### PR TITLE
fix docker/docker/cli path in comment

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -28,7 +28,7 @@ func SetupRootCommand(rootCmd *cobra.Command) {
 }
 
 // FlagErrorFunc prints an error message which matches the format of the
-// docker/docker/cli error messages
+// docker/cli/cli error messages
 func FlagErrorFunc(cmd *cobra.Command, err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Fixes path in comment: `docker/docker/cli` -> `docker/cli/cli`

Signed-off-by: Adrien Duermael <adrien@duermael.com>