### PR TITLE
remove service runtime filter from client

### DIFF
--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -45,9 +45,7 @@ func runList(dockerCli *command.DockerCli, opts listOptions) error {
 	ctx := context.Background()
 	client := dockerCli.Client()
 
-	serviceFilters := opts.filter.Value()
-	serviceFilters.Add("runtime", string(swarm.RuntimeContainer))
-	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: serviceFilters})
+	services, err := client.ServiceList(ctx, types.ServiceListOptions{})
 	if err != nil {
 		return err
 	}

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/command/task"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/opts"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -59,11 +58,8 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 	serviceIDFilter := filters.NewArgs()
 	serviceNameFilter := filters.NewArgs()
 	for _, service := range opts.services {
-		// default to container runtime
 		serviceIDFilter.Add("id", service)
-		serviceIDFilter.Add("runtime", string(swarmtypes.RuntimeContainer))
 		serviceNameFilter.Add("name", service)
-		serviceNameFilter.Add("runtime", string(swarmtypes.RuntimeContainer))
 	}
 	serviceByIDList, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: serviceIDFilter})
 	if err != nil {


### PR DESCRIPTION
it’s moving to the server.

Based on @ehazlett 's PR:
https://github.com/moby/moby/pull/32813/commits/e2d53387614f27782e905389f6f7a727dd21af05

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>