### PR TITLE
remove redundant code in update action in api call

### DIFF
--- a/client/node_update.go
+++ b/client/node_update.go
@@ -12,7 +12,6 @@ import (
 func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
-	ensureReaderClosed(resp)
+	_, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
 	return err
 }

--- a/client/secret_update.go
+++ b/client/secret_update.go
@@ -8,11 +8,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SecretUpdate attempts to updates a Secret
+// SecretUpdate attempts to update a Secret
 func (cli *Client) SecretUpdate(ctx context.Context, id string, version swarm.Version, secret swarm.SecretSpec) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))
-	resp, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
-	ensureReaderClosed(resp)
+	_, err := cli.post(ctx, "/secrets/"+id+"/update", query, secret, nil)
 	return err
 }

--- a/client/swarm_update.go
+++ b/client/swarm_update.go
@@ -16,7 +16,6 @@ func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm
 	query.Set("rotateWorkerToken", fmt.Sprintf("%v", flags.RotateWorkerToken))
 	query.Set("rotateManagerToken", fmt.Sprintf("%v", flags.RotateManagerToken))
 	query.Set("rotateManagerUnlockKey", fmt.Sprintf("%v", flags.RotateManagerUnlockKey))
-	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
-	ensureReaderClosed(resp)
+	_, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
 	return err
 }


### PR DESCRIPTION
remove redundant code in update action in api call

Signed-off-by: allencloud <allen.sun@daocloud.io>