### PR TITLE
improve speed of "go build" as well as "docker build"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-/build
+build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 # build the CLI
 build: clean
-	@go build -o ./build/docker ./cmd/docker
+	@go build -o ./build/docker github.com/docker/cli/cmd/docker
 
 # remove build artifacts
 clean:
@@ -16,4 +16,4 @@ clean:
 cross: clean
 	@gox -output build/docker-{{.OS}}-{{.Arch}} \
 		 -osarch="linux/arm linux/amd64 darwin/amd64 windows/amd64" \
-		 ./cmd/docker
+		 github.com/docker/cli/cmd/docker

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,7 +10,7 @@ DEV_DOCKER_IMAGE_NAME = docker_cli_dev
 
 # build docker image (dockerfiles/Dockerfile.build)
 build_docker_image:
-	@docker build -t $(DEV_DOCKER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.build . > /dev/null
+	@docker build -q -t $(DEV_DOCKER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.build .
 
 # build executable using a container
 build: build_docker_image


### PR DESCRIPTION
- add a .dockerignore to reduce the size of the build context (from ~600MB to ~15MB)
- take advantage of `go build`'s caching