### PR TITLE
Add gometalinter to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # github.com/docker/cli 
 #
 
-.PHONY: build clean cross
+.PHONY: build clean cross test lint
 
 # build the CLI
 build: clean
@@ -16,6 +16,9 @@ clean:
 # the "-tags daemon" part is temporary
 test:
 	@go test -tags daemon -v $(shell go list ./... | grep -v /vendor/)
+
+lint:
+	@gometalinter --config gometalinter.json ./...
 
 # build the CLI for multiple architectures
 cross: clean

--- a/circle.yml
+++ b/circle.yml
@@ -7,4 +7,11 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: docker build -f dockerfiles/Dockerfile.ci .
+      - run: 
+          name: "Lint"          
+          command: |
+            docker build -f dockerfiles/Dockerfile.lint --tag cli-linter .
+            docker run cli-linter
+      - run:
+          name: "Build and Unit Test"
+          command: docker build -f dockerfiles/Dockerfile.ci .

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -13,21 +13,21 @@ type arguments struct {
 
 func TestParseExec(t *testing.T) {
 	valids := map[*arguments]*types.ExecConfig{
-		&arguments{
+		{
 			execCmd: []string{"command"},
 		}: {
 			Cmd:          []string{"command"},
 			AttachStdout: true,
 			AttachStderr: true,
 		},
-		&arguments{
+		{
 			execCmd: []string{"command1", "command2"},
 		}: {
 			Cmd:          []string{"command1", "command2"},
 			AttachStdout: true,
 			AttachStderr: true,
 		},
-		&arguments{
+		{
 			options: execOptions{
 				interactive: true,
 				tty:         true,
@@ -42,7 +42,7 @@ func TestParseExec(t *testing.T) {
 			Tty:          true,
 			Cmd:          []string{"command"},
 		},
-		&arguments{
+		{
 			options: execOptions{
 				detach: true,
 			},
@@ -54,7 +54,7 @@ func TestParseExec(t *testing.T) {
 			Detach:       true,
 			Cmd:          []string{"command"},
 		},
-		&arguments{
+		{
 			options: execOptions{
 				tty:         true,
 				interactive: true,

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -6,29 +6,38 @@
 
 +.PHONY: build_docker_image build clean cross dev
 
-DEV_DOCKER_IMAGE_NAME = docker_cli_dev
+DEV_DOCKER_IMAGE_NAME = docker-cli-dev
+LINTER_IMAGE_NAME = docker-cli-lint
+MOUNTS = -v `pwd`:/go/src/github.com/docker/cli
 
 # build docker image (dockerfiles/Dockerfile.build)
 build_docker_image:
 	@docker build -q -t $(DEV_DOCKER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.build .
 
+.PHONY: builder_linter_image
+build_linter_image:
+	@docker build -q -t $(LINTER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.lint .
+
 # build executable using a container
 build: build_docker_image
 	@echo "WARNING: this will drop a Linux executable on your host (not a macOS of Windows one)"
-	@docker run --rm -v `pwd`:/go/src/github.com/docker/cli $(DEV_DOCKER_IMAGE_NAME) make build
+	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make build
 
 # clean build artifacts using a container
 clean: build_docker_image
-	@docker run --rm -v `pwd`:/go/src/github.com/docker/cli $(DEV_DOCKER_IMAGE_NAME) make clean
+	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
 
 # run go test
 test: build_docker_image
-	@docker run --rm -v `pwd`:/go/src/github.com/docker/cli $(DEV_DOCKER_IMAGE_NAME) make test
+	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test
 
 # build the CLI for multiple architectures using a container
 cross: build_docker_image
-	@docker run --rm -v `pwd`:/go/src/github.com/docker/cli $(DEV_DOCKER_IMAGE_NAME) make cross
+	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make cross
 
 # start container in interactive mode for in-container development
 dev: build_docker_image
-	@docker run -ti -v `pwd`:/go/src/github.com/docker/cli $(DEV_DOCKER_IMAGE_NAME) ash
+	@docker run -ti $(MOUNTS)  $(DEV_DOCKER_IMAGE_NAME) ash
+
+lint: build_linter_image
+	@docker run -ti $(MOUNTS) $(LINTER_IMAGE_NAME)

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,0 +1,12 @@
+FROM    golang:1.8-alpine
+
+RUN     apk add -U git
+
+RUN     go get -u gopkg.in/alecthomas/gometalinter.v1 && \
+        mv /go/bin/gometalinter.v1 /usr/local/bin/gometalinter && \
+        gometalinter --install
+
+WORKDIR /go/src/github.com/docker/cli
+COPY . .
+ENTRYPOINT ["/usr/local/bin/gometalinter"]
+CMD ["--config=gometalinter.json", "./..."]

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,0 +1,8 @@
+{
+  "Vendor": true,
+  "Sort": ["linter", "severity"],
+  "Exclude": ["cli/compose/schema/bindata.go"],
+
+  "DisableAll": true,
+  "Enable": ["gofmt", "vet"]
+}


### PR DESCRIPTION
Adding a Dockerfile, makefile target and config for gometalinter.

Enable `gofmt` and `vet` for now, and fix the one file with an error.

I'd like to enable more linters after this, but I'm adding these for now.

Also changed the circle config to use nice names for each step