### PR TITLE
Add more lint checks

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -62,6 +62,7 @@ func NewExecCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
+// nolint: gocyclo
 func runExec(dockerCli *command.DockerCli, opts *execOptions, container string, execCmd []string) error {
 	execConfig, err := parseExec(opts, execCmd)
 	// just in case the ParseExec does not exit

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -38,7 +38,7 @@ func NewExportCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 func runExport(dockerCli *command.DockerCli, opts exportOptions) error {
 	if opts.output == "" && dockerCli.Out().IsTerminal() {
-		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
+		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}
 
 	clnt := dockerCli.Client()

--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -14,6 +14,7 @@ import (
 
 // holdHijackedConnection handles copying input to and output from streams to the
 // connection
+// nolint: gocyclo
 func holdHijackedConnection(ctx context.Context, streams command.Streams, tty bool, inputStream io.ReadCloser, outputStream, errorStream io.Writer, resp types.HijackedResponse) error {
 	var (
 		err         error

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -298,6 +298,7 @@ type containerConfig struct {
 // parse parses the args for the specified command and generates a Config,
 // a HostConfig and returns them with the specified command.
 // If the specified args are not valid, it will return an error.
+// nolint: gocyclo
 func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, error) {
 	var (
 		attachStdin  = copts.attach.Get("stdin")

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -86,6 +86,7 @@ func TestParseRunLinks(t *testing.T) {
 	}
 }
 
+// nolint: gocyclo
 func TestParseRunAttach(t *testing.T) {
 	if config, _ := mustParse(t, "-a stdin"); !config.AttachStdin || config.AttachStdout || config.AttachStderr {
 		t.Fatalf("Error parsing attach flags. Expect only Stdin enabled. Received: in: %v, out: %v, err: %v", config.AttachStdin, config.AttachStdout, config.AttachStderr)
@@ -129,6 +130,7 @@ func TestParseRunAttach(t *testing.T) {
 	}
 }
 
+// nolint: gocyclo
 func TestParseRunVolumes(t *testing.T) {
 
 	// A single volume
@@ -614,6 +616,7 @@ func TestParseEntryPoint(t *testing.T) {
 
 // This tests the cases for binds which are generated through
 // DecodeContainerConfig rather than Parse()
+// nolint: gocyclo
 func TestDecodeContainerConfigVolumes(t *testing.T) {
 
 	// Root to root

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -93,6 +93,7 @@ func runRun(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *runOptions
 	return runContainer(dockerCli, opts, copts, containerConfig)
 }
 
+// nolint: gocyclo
 func runContainer(dockerCli *command.DockerCli, opts *runOptions, copts *containerOptions, containerConfig *containerConfig) error {
 	config := containerConfig.Config
 	hostConfig := containerConfig.HostConfig

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -52,6 +52,7 @@ func NewStartCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
+// nolint: gocyclo
 func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 	ctx, cancelFun := context.WithCancel(context.Background())
 

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -59,7 +59,7 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 		// We're going to attach to a container.
 		// 1. Ensure we only have one container.
 		if len(opts.containers) > 1 {
-			return errors.New("You cannot start and attach multiple containers at once.")
+			return errors.New("you cannot start and attach multiple containers at once")
 		}
 
 		// 2. Attach to the container.
@@ -143,7 +143,7 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 		}
 	} else if opts.checkpoint != "" {
 		if len(opts.containers) > 1 {
-			return errors.New("You cannot restore multiple containers at once.")
+			return errors.New("you cannot restore multiple containers at once")
 		}
 		container := opts.containers[0]
 		startOptions := types.ContainerStartOptions{

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -48,6 +48,7 @@ func NewStatsCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 // runStats displays a live stream of resource usage statistics for one or more containers.
 // This shows real-time information on CPU usage, memory usage, and network I/O.
+// nolint: gocyclo
 func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 	showAll := len(opts.containers) == 0
 	closeChan := make(chan error)

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -77,7 +77,7 @@ func runUpdate(dockerCli *command.DockerCli, opts *updateOptions) error {
 	var err error
 
 	if opts.nFlag == 0 {
-		return errors.New("You must provide one or more flags when using this command.")
+		return errors.New("you must provide one or more flags when using this command")
 	}
 
 	var restartPolicy containertypes.RestartPolicy

--- a/cli/command/events_utils.go
+++ b/cli/command/events_utils.go
@@ -7,8 +7,6 @@ import (
 	eventtypes "github.com/docker/docker/api/types/events"
 )
 
-type eventProcessor func(eventtypes.Message, error) error
-
 // EventHandler is abstract interface for user to customize
 // own handle functions of each type of events
 type EventHandler interface {

--- a/cli/command/formatter/history.go
+++ b/cli/command/formatter/history.go
@@ -99,13 +99,10 @@ func (c *historyContext) CreatedBy() string {
 }
 
 func (c *historyContext) Size() string {
-	size := ""
 	if c.human {
-		size = units.HumanSizeWithPrecision(float64(c.h.Size), 3)
-	} else {
-		size = strconv.FormatInt(c.h.Size, 10)
+		return units.HumanSizeWithPrecision(float64(c.h.Size), 3)
 	}
-	return size
+	return strconv.FormatInt(c.h.Size, 10)
 }
 
 func (c *historyContext) Comment() string {

--- a/cli/command/formatter/history_test.go
+++ b/cli/command/formatter/history_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"bytes"
+
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/stringutils"

--- a/cli/command/formatter/secret.go
+++ b/cli/command/formatter/secret.go
@@ -12,7 +12,6 @@ import (
 const (
 	defaultSecretTableFormat = "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}\t{{.UpdatedAt}}"
 	secretIDHeader           = "ID"
-	secretNameHeader         = "NAME"
 	secretCreatedHeader      = "CREATED"
 	secretUpdatedHeader      = "UPDATED"
 )

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -143,6 +143,7 @@ func (out *lastProgressOutput) WriteProgress(prog progress.Progress) error {
 	return out.output.WriteProgress(prog)
 }
 
+// nolint: gocyclo
 func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	var (
 		buildCtx      io.ReadCloser

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -38,7 +38,7 @@ func NewSaveCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 func runSave(dockerCli *command.DockerCli, opts saveOptions) error {
 	if opts.output == "" && dockerCli.Out().IsTerminal() {
-		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
+		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}
 
 	responseBody, err := dockerCli.Client().ImageSave(context.Background(), opts.images)

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -41,6 +41,7 @@ func trustedPush(ctx context.Context, cli *command.DockerCli, repoInfo *registry
 }
 
 // PushTrustedReference pushes a canonical reference to the trust server.
+// nolint: gocyclo
 func PushTrustedReference(cli *command.DockerCli, repoInfo *registry.RepositoryInfo, ref reference.Named, authConfig types.AuthConfig, in io.Reader) error {
 	// If it is a trusted push we would like to find the target entry which match the
 	// tag provided in the function and then do an AddTarget later.

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -113,6 +113,7 @@ func runCreate(dockerCli *command.DockerCli, opts createOptions) error {
 // possible to correlate the various related parameters and consolidate them.
 // consolidateIpam consolidates subnets, ip-ranges, gateways and auxiliary addresses into
 // structured ipam data.
+// nolint: gocyclo
 func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]string) ([]network.IPAMConfig, error) {
 	if len(subnets) < len(ranges) || len(subnets) < len(gateways) {
 		return nil, errors.Errorf("every ip-range or gateway must have a corresponding subnet")

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -96,7 +96,7 @@ func runPs(dockerCli command.Cli, opts psOptions) error {
 	}
 
 	if len(errs) == 0 || len(tasks) != 0 {
-		if err := task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format); err != nil {
+		if err := task.Print(ctx, dockerCli, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -92,7 +92,7 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 		if !client.IsErrServiceNotFound(err) {
 			return err
 		}
-		task, _, err := cli.TaskInspectWithRaw(ctx, opts.target)
+		task, _, _ := cli.TaskInspectWithRaw(ctx, opts.target)
 		tty = task.Spec.ContainerSpec.TTY
 		// TODO(dperny) hot fix until we get a nice details system squared away,
 		// ignores details (including task context) if we have a TTY log
@@ -112,7 +112,7 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 			return err
 		}
 		maxLength = getMaxLength(task.Slot)
-		responseBody, err = cli.TaskLogs(ctx, opts.target, options)
+		responseBody, _ = cli.TaskLogs(ctx, opts.target, options)
 	} else {
 		tty = service.Spec.TaskTemplate.ContainerSpec.TTY
 		// TODO(dperny) hot fix until we get a nice details system squared away,

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -59,6 +59,7 @@ func stateToProgress(state swarm.TaskState, rollback bool) int64 {
 }
 
 // ServiceProgress outputs progress information for convergence of a service.
+// nolint: gocyclo
 func ServiceProgress(ctx context.Context, client client.APIClient, serviceID string, progressWriter io.WriteCloser) error {
 	defer progressWriter.Close()
 
@@ -240,6 +241,7 @@ type replicatedProgressUpdater struct {
 	done        bool
 }
 
+// nolint: gocyclo
 func (u *replicatedProgressUpdater) update(service swarm.Service, tasks []swarm.Task, activeNodes map[string]swarm.Node, rollback bool) (bool, error) {
 	if service.Spec.Mode.Replicated == nil || service.Spec.Mode.Replicated.Replicas == nil {
 		return false, errors.New("no replica count")

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -119,5 +119,5 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 		}
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format)
+	return task.Print(ctx, dockerCli, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format)
 }

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/opts"
 	runconfigopts "github.com/docker/docker/runconfig/opts"
-	"github.com/docker/go-connections/nat"
 	"github.com/docker/swarmkit/api/defaults"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -585,10 +584,6 @@ func envKey(value string) string {
 	return kv[0]
 }
 
-func itemKey(value string) string {
-	return value
-}
-
 func buildToRemoveSet(flags *pflag.FlagSet, flag string) map[string]struct{} {
 	var empty struct{}
 	toRemove := make(map[string]struct{})
@@ -824,11 +819,6 @@ func equalPublishMode(mode1, mode2 swarm.PortConfigPublishMode) bool {
 	return mode1 == mode2 ||
 		(mode1 == swarm.PortConfigPublishMode("") && mode2 == swarm.PortConfigPublishModeIngress) ||
 		(mode2 == swarm.PortConfigPublishMode("") && mode1 == swarm.PortConfigPublishModeIngress)
-}
-
-func equalPort(targetPort nat.Port, port swarm.PortConfig) bool {
-	return (string(port.Protocol) == targetPort.Proto() &&
-		port.TargetPort == uint32(targetPort.Int()))
 }
 
 func updateReplicas(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -97,6 +97,7 @@ func newListOptsVar() *opts.ListOpts {
 	return opts.NewListOptsRef(&[]string{}, nil)
 }
 
+// nolint: gocyclo
 func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *serviceOptions, serviceID string) error {
 	apiClient := dockerCli.Client()
 	ctx := context.Background()
@@ -211,6 +212,7 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *service
 	return waitOnService(ctx, dockerCli, serviceID, opts)
 }
 
+// nolint: gocyclo
 func updateService(ctx context.Context, apiClient client.APIClient, flags *pflag.FlagSet, spec *swarm.ServiceSpec) error {
 	updateString := func(flag string, field *string) {
 		if flags.Changed(flag) {

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -72,7 +72,7 @@ func checkDaemonIsSwarmManager(ctx context.Context, dockerCli *command.DockerCli
 		return err
 	}
 	if !info.Swarm.ControlAvailable {
-		return errors.New("This node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again.")
+		return errors.New("this node is not a swarm manager. Use \"docker swarm init\" or \"docker swarm join\" to connect this node to swarm and try again")
 	}
 	return nil
 }

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -72,5 +72,5 @@ func runPS(dockerCli *command.DockerCli, opts psOptions) error {
 		}
 	}
 
-	return task.Print(dockerCli, ctx, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format)
+	return task.Print(ctx, dockerCli, tasks, idresolver.New(client, opts.noResolve), !opts.noTrunc, opts.quiet, format)
 }

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -26,7 +26,6 @@ const (
 	flagExternalCA          = "external-ca"
 	flagMaxSnapshots        = "max-snapshots"
 	flagSnapshotInterval    = "snapshot-interval"
-	flagLockKey             = "lock-key"
 	flagAutolock            = "autolock"
 	flagAvailability        = "availability"
 )

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -54,6 +54,7 @@ func runInfo(dockerCli *command.DockerCli, opts *infoOptions) error {
 	return formatInfo(dockerCli, info, opts.format)
 }
 
+// nolint: gocyclo
 func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 	fmt.Fprintf(dockerCli.Out(), "Containers: %d\n", info.Containers)
 	fmt.Fprintf(dockerCli.Out(), " Running: %d\n", info.ContainersRunning)

--- a/cli/command/task/print.go
+++ b/cli/command/task/print.go
@@ -35,7 +35,7 @@ func (t tasksBySlot) Less(i, j int) bool {
 // Print task information in a format.
 // Besides this, command `docker node ps <node>`
 // and `docker stack ps` will call this, too.
-func Print(dockerCli command.Cli, ctx context.Context, tasks []swarm.Task, resolver *idresolver.IDResolver, trunc, quiet bool, format string) error {
+func Print(ctx context.Context, dockerCli command.Cli, tasks []swarm.Task, resolver *idresolver.IDResolver, trunc, quiet bool, format string) error {
 	sort.Stable(tasksBySlot(tasks))
 
 	names := map[string]string{}

--- a/cli/command/task/print.go
+++ b/cli/command/task/print.go
@@ -59,7 +59,7 @@ func Print(ctx context.Context, dockerCli command.Cli, tasks []swarm.Task, resol
 			return err
 		}
 
-		name := ""
+		var name string
 		if task.Slot != 0 {
 			name = fmt.Sprintf("%v.%v", serviceName, task.Slot)
 		} else {

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 	"reflect"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -21,10 +20,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
-)
-
-var (
-	fieldNameRegexp = regexp.MustCompile("[A-Z][a-z0-9]+")
 )
 
 // ParseYAML reads the bytes from a file, parses the bytes into a mapping

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/pkg/homedir"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmptyConfigDir(t *testing.T) {
@@ -543,6 +544,7 @@ func TestJSONSaveWithNoFile(t *testing.T) {
 		"psFormat": "table {{.ID}}\\t{{.Label \"com.docker.label.cpu\"}}"
 }`
 	config, err := LoadFromReader(strings.NewReader(js))
+	require.NoError(t, err)
 	err = config.Save()
 	if err == nil {
 		t.Fatalf("Expected error. File should not have been able to save with no file name.")
@@ -583,6 +585,7 @@ func TestLegacyJSONSaveWithNoFile(t *testing.T) {
 
 	js := `{"https://index.docker.io/v1/":{"auth":"am9lam9lOmhlbGxv","email":"user@example.com"}}`
 	config, err := LegacyLoadFromReader(strings.NewReader(js))
+	require.NoError(t, err)
 	err = config.Save()
 	if err == nil {
 		t.Fatalf("Expected error. File should not have been able to save with no file name.")

--- a/client/client_mock_test.go
+++ b/client/client_mock_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// transportFunc allows us to inject a mock transport for testing. We define it
+// here so we can detect the tlsconfig and return nil for only this type.
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return tf(req)
+}
+
 func newMockClient(doer func(*http.Request) (*http.Response, error)) *http.Client {
 	return &http.Client{
 		Transport: transportFunc(doer),

--- a/client/image_search_test.go
+++ b/client/image_search_test.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 
 	"encoding/json"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/registry"

--- a/client/request.go
+++ b/client/request.go
@@ -121,6 +121,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	return cli.doRequest(ctx, req)
 }
 
+// nolint: gocyclo
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {
 	serverResp := serverResponse{statusCode: -1}
 

--- a/client/transport.go
+++ b/client/transport.go
@@ -5,14 +5,6 @@ import (
 	"net/http"
 )
 
-// transportFunc allows us to inject a mock transport for testing. We define it
-// here so we can detect the tlsconfig and return nil for only this type.
-type transportFunc func(*http.Request) (*http.Response, error)
-
-func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return tf(req)
-}
-
 // resolveTLSConfig attempts to resolve the TLS configuration from the
 // RoundTripper.
 func resolveTLSConfig(transport http.RoundTripper) *tls.Config {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"github.com/docker/docker/api/types/filters"
 	"net/url"
 	"regexp"
+
+	"github.com/docker/docker/api/types/filters"
 )
 
 var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -4,5 +4,11 @@
   "Exclude": ["cli/compose/schema/bindata.go"],
 
   "DisableAll": true,
-  "Enable": ["gofmt", "vet", "golint", "goimports"]
+  "Enable": [
+    "gofmt",
+    "vet",
+    "golint",
+    "goimports",
+    "deadcode"
+  ]
 }

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -5,12 +5,13 @@
 
   "DisableAll": true,
   "Enable": [
-    "gofmt",
-    "vet",
-    "golint",
-    "goimports",
     "deadcode",
-    "gocyclo"
+    "gocyclo",
+    "gofmt",
+    "goimports",
+    "golint",
+    "ineffassign",
+    "vet"
   ],
 
   "Cyclo": 19

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -9,6 +9,9 @@
     "vet",
     "golint",
     "goimports",
-    "deadcode"
-  ]
+    "deadcode",
+    "gocyclo"
+  ],
+
+  "Cyclo": 19
 }

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,8 +1,8 @@
 {
   "Vendor": true,
-  "Sort": ["linter", "severity"],
+  "Sort": ["linter", "severity", "path"],
   "Exclude": ["cli/compose/schema/bindata.go"],
 
   "DisableAll": true,
-  "Enable": ["gofmt", "vet"]
+  "Enable": ["gofmt", "vet", "golint"]
 }

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -4,5 +4,5 @@
   "Exclude": ["cli/compose/schema/bindata.go"],
 
   "DisableAll": true,
-  "Enable": ["gofmt", "vet", "golint"]
+  "Enable": ["gofmt", "vet", "golint", "goimports"]
 }


### PR DESCRIPTION
These are split into separate commits so that you can see which changes were made for which linter. I can squash it before we merge if you want.

Adds 5 new linters and fixes some errors they uncovered.

`gocycle` has to ignore a few functions, and currently has an extremely high limit. I'd like to eventually get that down to much closer to 10, and work on fixing some of the whitelisted offenders.