### PR TITLE
prune commands : make sure label filters are considered

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -34,7 +34,9 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images not just dangling ones")
-	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'until=<timestamp>')")
+	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'label=<key>=<value>')")
+	// "filter" flag is available in 1.28 (docker 17.04) and up
+	flags.SetAnnotation("filter", "version", []string{"1.28"})
 
 	return cmd
 }


### PR DESCRIPTION
Fixes #17 

Related to https://github.com/moby/moby/pull/33023

Checking server API version is at least 1.29 to accept prune commands with label filters.

Signed-off-by: Adrien Duermael <adrien@duermael.com>