### PR TITLE
Moving docker service digest pinning to client side

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -106,7 +107,10 @@ func runCreate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *service
 		createOpts.EncodedRegistryAuth = encodedAuth
 	}
 
-	createOpts.QueryRegistry = true
+	// query registry if flag disabling it was not set
+	if !opts.noResolveImage && versions.GreaterThanOrEqualTo(apiClient.ClientVersion(), "1.30") {
+		createOpts.QueryRegistry = true
+	}
 
 	response, err := apiClient.ServiceCreate(ctx, service, createOpts)
 	if err != nil {

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -92,7 +92,7 @@ func runCreate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *service
 		service.TaskTemplate.ContainerSpec.Configs = configs
 	}
 
-	if err := resolveServiceImageDigest(dockerCli, &service); err != nil {
+	if err := resolveServiceImageDigestContentTrust(dockerCli, &service); err != nil {
 		return err
 	}
 
@@ -105,6 +105,8 @@ func runCreate(dockerCli *command.DockerCli, flags *pflag.FlagSet, opts *service
 		}
 		createOpts.EncodedRegistryAuth = encodedAuth
 	}
+
+	createOpts.QueryRegistry = true
 
 	response, err := apiClient.ServiceCreate(ctx, service, createOpts)
 	if err != nil {

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -542,7 +542,8 @@ type serviceOptions struct {
 	networks       opts.ListOpts
 	endpoint       endpointOptions
 
-	registryAuth bool
+	registryAuth   bool
+	noResolveImage bool
 
 	logDriver logDriverOptions
 
@@ -797,6 +798,8 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 	flags.StringVar(&opts.endpoint.mode, flagEndpointMode, defaultFlagValues.getString(flagEndpointMode), "Endpoint mode (vip or dnsrr)")
 
 	flags.BoolVar(&opts.registryAuth, flagRegistryAuth, false, "Send registry authentication details to swarm agents")
+	flags.BoolVar(&opts.noResolveImage, flagNoResolveImage, false, "Do not query the registry to resolve image digest and supported platforms")
+	flags.SetAnnotation(flagNoResolveImage, "version", []string{"1.30"})
 
 	flags.StringVar(&opts.logDriver.name, flagLogDriver, "", "Logging driver for service")
 	flags.Var(&opts.logDriver.opts, flagLogOpt, "Logging driver options")
@@ -899,6 +902,7 @@ const (
 	flagUser                    = "user"
 	flagWorkdir                 = "workdir"
 	flagRegistryAuth            = "with-registry-auth"
+	flagNoResolveImage          = "no-resolve-image"
 	flagLogDriver               = "log-driver"
 	flagLogOpt                  = "log-opt"
 	flagHealthCmd               = "health-cmd"

--- a/cli/command/service/trust.go
+++ b/cli/command/service/trust.go
@@ -15,10 +15,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-func resolveServiceImageDigest(dockerCli command.Cli, service *swarm.ServiceSpec) error {
+func resolveServiceImageDigestContentTrust(dockerCli command.Cli, service *swarm.ServiceSpec) error {
 	if !command.IsTrusted() {
-		// Digests are resolved by the daemon when not using content
-		// trust.
+		// When not using content trust, digest resolution happens later when
+		// contacting the registry to retrieve image information.
 		return nil
 	}
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -167,7 +167,9 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, options *serv
 		if err := resolveServiceImageDigestContentTrust(dockerCli, spec); err != nil {
 			return err
 		}
-		updateOpts.QueryRegistry = true
+		if !options.noResolveImage && versions.GreaterThanOrEqualTo(apiClient.ClientVersion(), "1.30") {
+			updateOpts.QueryRegistry = true
+		}
 	}
 
 	updatedSecrets, err := getUpdatedSecrets(apiClient, flags, spec.TaskTemplate.ContainerSpec.Secrets)

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -164,9 +164,10 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, options *serv
 	}
 
 	if flags.Changed("image") {
-		if err := resolveServiceImageDigest(dockerCli, spec); err != nil {
+		if err := resolveServiceImageDigestContentTrust(dockerCli, spec); err != nil {
 			return err
 		}
+		updateOpts.QueryRegistry = true
 	}
 
 	updatedSecrets, err := getUpdatedSecrets(apiClient, flags, spec.TaskTemplate.ContainerSpec.Secrets)


### PR DESCRIPTION
These are some minor changes that were originally part of this PR: https://github.com/moby/moby/pull/32388

For the flag, the default should be `opts.noResolveImage = false`, and if `--no-resolve-image` is passed, then `opts.noResolveImage` should be set to `true`.
When `opts.noResolveImage = false`, it sets `QueryRegistry` in the service create/update options to `true`, so that the registry will be looked up to resolve digest and platform information. When `opts.noResolveImage = true`, then `QueryRegistry` is set to `false`. The former case should be the default, and relevant for most users.


They must be moved here now that the CLI is separate.

(Part of the multi-arch support effort in https://github.com/moby/moby/issues/31348)

Ping @tiborvass @thaJeztah 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>