### PR TITLE
[system/prune] make pruneFuncs an array

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -66,7 +66,7 @@ func runPrune(dockerCli command.Cli, options pruneOptions) error {
 
 	var spaceReclaimed uint64
 
-	for _, pruneFn := range []func(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error){
+	for _, pruneFn := range [3]func(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error){
 		prune.RunContainerPrune,
 		prune.RunVolumePrune,
 		prune.RunNetworkPrune,


### PR DESCRIPTION
From the looks of it, the pruneFuncs slice does not need to be a slice since the elements inside of it are fixed. 

Probably more of an OCD optimization 😄 but i think it also reads better.

Signed-off-by: Marwan Sulaiman <marwan.sulaiman@work.co>