### PR TITLE
Makefile: on clean, delete files in the build folder, but not the folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: clean
 
 # remove build artifacts
 clean:
-	@rm -rf ./build
+	@rm -rf ./build/*
 
 # run go test
 # the "-tags daemon" part is temporary


### PR DESCRIPTION
This is useful when doing iterative development on moby/moby with `DOCKER_CLI_PATH=...`.