### PR TITLE
update circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,12 @@ jobs:
   build:
     working_directory: ~/cli
     docker:
-      - image: docker:17.04
+      - image: docker:17.05
     steps:
+      - run:
+          name: "Install Git and SSH"
+          command: |
+            apk add -U git openssh
       - checkout
       - setup_remote_docker
       - run:


### PR DESCRIPTION
- update from `docker:17.04` to `docker:17.05`
- install git and ssh to suppress CircleCI warning

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>