### PR TITLE
increase gometalinter deadline from 30s to 120s

### DIFF
--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -9,4 +9,4 @@ RUN     go get -u gopkg.in/alecthomas/gometalinter.v1 && \
 WORKDIR /go/src/github.com/docker/cli
 COPY . .
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
-CMD ["--config=gometalinter.json", "./..."]
+CMD ["--config=gometalinter.json", "./...", "--deadline=120s"]


### PR DESCRIPTION
so it doesn’t timeout when running in Docker for Mac

```
$ make -f docker.Makefile lint
```
was failing on my Mac.

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>