### PR TITLE
Adding csv format parameters to network option in service create/update

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -396,17 +396,16 @@ func (c *credentialSpecOpt) Value() *swarm.CredentialSpec {
 	return c.value
 }
 
-func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, networks []string) ([]swarm.NetworkAttachmentConfig, error) {
-	nets := []swarm.NetworkAttachmentConfig{}
-	for _, networkIDOrName := range networks {
-		network, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
+func verifyNetworks(ctx context.Context, apiClient client.NetworkAPIClient, networks opts.NetworkOpt) ([]swarm.NetworkAttachmentConfig, error) {
+	for _, netAttach := range networks.Value() {
+		networkIDOrName := netAttach.Target
+		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
 		if err != nil {
 			return nil, err
 		}
-		nets = append(nets, swarm.NetworkAttachmentConfig{Target: network.ID})
 	}
-	sort.Sort(byNetworkTarget(nets))
-	return nets, nil
+	sort.Sort(byNetworkTarget(networks.Value()))
+	return networks.Value(), nil
 }
 
 type endpointOptions struct {
@@ -539,7 +538,7 @@ type serviceOptions struct {
 	placementPrefs placementPrefOpts
 	update         updateOptions
 	rollback       updateOptions
-	networks       opts.ListOpts
+	networks       opts.NetworkOpt
 	endpoint       endpointOptions
 
 	registryAuth bool
@@ -563,7 +562,6 @@ func newServiceOptions() *serviceOptions {
 		dnsOption:       opts.NewListOpts(nil),
 		dnsSearch:       opts.NewListOpts(opts.ValidateDNSSearch),
 		hosts:           opts.NewListOpts(opts.ValidateExtraHost),
-		networks:        opts.NewListOpts(nil),
 	}
 }
 
@@ -625,7 +623,7 @@ func (opts *serviceOptions) ToService(ctx context.Context, apiClient client.Netw
 		return service, err
 	}
 
-	networks, err := convertNetworks(ctx, apiClient, opts.networks.GetAll())
+	networks, err := verifyNetworks(ctx, apiClient, opts.networks)
 	if err != nil {
 		return service, err
 	}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -219,7 +219,6 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 			*field, _ = flags.GetString(flag)
 		}
 	}
-
 	updateInt64Value := func(flag string, field *int64) {
 		if flags.Changed(flag) {
 			*field = flags.Lookup(flag).Value.(int64Value).Value()
@@ -989,8 +988,8 @@ func updateNetworks(ctx context.Context, apiClient client.NetworkAPIClient, flag
 	}
 
 	if flags.Changed(flagNetworkAdd) {
-		values := flags.Lookup(flagNetworkAdd).Value.(*opts.ListOpts).GetAll()
-		networks, err := convertNetworks(ctx, apiClient, values)
+		values := flags.Lookup(flagNetworkAdd).Value.(*opts.NetworkOpt)
+		networks, err := verifyNetworks(ctx, apiClient, *values)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry-picked from https://github.com/moby/moby/pull/32975

**- What I did**
Added capability to service create/update  to accept network option in csv format and add test case to verify the same.

**- How I did it**
Changed `--network` , `--network-add` options to accept csv format key/value by create a new network option type. 

**- How to verify it**

```
docker service create --name web --network name=docknet,alias=web1,alias=web2 nginx
docker service create --name web --network docknet nginx
docker service update web --network-add name=docknet,alias=web1
docker service update web --network-rm docknet
```


TODO:
- [ ] Get ~~https://github.com/moby/moby/pull/32975~~ https://github.com/moby/moby/pull/33130 merged, to vendor `opts` package.