### PR TITLE
Synchronous CLI command for root CA rotation

### DIFF
--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"io"
+	"io/ioutil"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service/progress"
@@ -20,14 +21,7 @@ func waitOnService(ctx context.Context, dockerCli *command.DockerCli, serviceID 
 	}()
 
 	if opts.quiet {
-		go func() {
-			for {
-				var buf [1024]byte
-				if _, err := pipeReader.Read(buf[:]); err != nil {
-					return
-				}
-			}
-		}()
+		go io.Copy(ioutil.Discard, pipeReader)
 		return <-errChan
 	}
 

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -102,13 +102,7 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 	}()
 
 	if opts.quiet {
-		go func() {
-			for {
-				if _, err := io.Copy(ioutil.Discard, pipeReader); err != nil {
-					return
-				}
-			}
-		}()
+		go io.Copy(ioutil.Discard, pipeReader)
 		return <-errChan
 	}
 

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -1,0 +1,134 @@
+package swarm
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"io/ioutil"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/swarm/progress"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type caOptions struct {
+	swarmOptions
+	rootCACert PEMFile
+	rootCAKey  PEMFile
+	rotate     bool
+	detach     bool
+	quiet      bool
+}
+
+func newRotateCACommand(dockerCli command.Cli) *cobra.Command {
+	opts := caOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "ca [OPTIONS]",
+		Short: "Manage root CA",
+		Args:  cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRotateCA(dockerCli, cmd.Flags(), opts)
+		},
+		Tags: map[string]string{"version": "1.30"},
+	}
+
+	flags := cmd.Flags()
+	addSwarmCAFlags(flags, &opts.swarmOptions)
+	flags.BoolVar(&opts.rotate, flagRotate, false, "Rotate the swarm CA - if no certificate or key are provided, new ones will be generated")
+	flags.Var(&opts.rootCACert, flagCACert, "Path to the PEM-formatted root CA certificate to use for the new cluster")
+	flags.Var(&opts.rootCAKey, flagCAKey, "Path to the PEM-formatted root CA key to use for the new cluster")
+
+	flags.BoolVarP(&opts.detach, "detach", "d", false, "Exit immediately instead of waiting for the root rotation to converge")
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress progress output")
+	return cmd
+}
+
+func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) error {
+	client := dockerCli.Client()
+	ctx := context.Background()
+
+	swarmInspect, err := client.SwarmInspect(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !opts.rotate {
+		if swarmInspect.ClusterInfo.TLSInfo.TrustRoot == "" {
+			fmt.Fprintln(dockerCli.Out(), "No CA information available")
+		} else {
+			fmt.Fprintln(dockerCli.Out(), strings.TrimSpace(swarmInspect.ClusterInfo.TLSInfo.TrustRoot))
+		}
+		return nil
+	}
+
+	genRootCA := true
+	spec := &swarmInspect.Spec
+	opts.mergeSwarmSpec(spec, flags)
+	if flags.Changed(flagCACert) {
+		spec.CAConfig.SigningCACert = opts.rootCACert.Contents()
+		genRootCA = false
+	}
+	if flags.Changed(flagCAKey) {
+		spec.CAConfig.SigningCAKey = opts.rootCAKey.Contents()
+		genRootCA = false
+	}
+	if genRootCA {
+		spec.CAConfig.ForceRotate++
+		spec.CAConfig.SigningCACert = ""
+		spec.CAConfig.SigningCAKey = ""
+	}
+
+	if err := client.SwarmUpdate(ctx, swarmInspect.Version, swarmInspect.Spec, swarm.UpdateFlags{}); err != nil {
+		return err
+	}
+
+	if opts.detach {
+		return nil
+	}
+
+	errChan := make(chan error, 1)
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		errChan <- progress.RootRotationProgress(ctx, client, pipeWriter)
+	}()
+
+	if opts.quiet {
+		go func() {
+			for {
+				if _, err := io.Copy(ioutil.Discard, pipeReader); err != nil {
+					return
+				}
+			}
+		}()
+		return <-errChan
+	}
+
+	err = jsonmessage.DisplayJSONMessagesToStream(pipeReader, dockerCli.Out(), nil)
+	if err == nil {
+		err = <-errChan
+	}
+	if err != nil {
+		return err
+	}
+
+	swarmInspect, err = client.SwarmInspect(ctx)
+	if err != nil {
+		return err
+	}
+
+	if swarmInspect.ClusterInfo.TLSInfo.TrustRoot == "" {
+		fmt.Fprintln(dockerCli.Out(), "No CA information available")
+	} else {
+		fmt.Fprintln(dockerCli.Out(), strings.TrimSpace(swarmInspect.ClusterInfo.TLSInfo.TrustRoot))
+	}
+	return nil
+}

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -25,6 +25,7 @@ func NewSwarmCommand(dockerCli command.Cli) *cobra.Command {
 		newUpdateCommand(dockerCli),
 		newLeaveCommand(dockerCli),
 		newUnlockCommand(dockerCli),
+		newRotateCACommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/swarm/progress/root_rotation.go
+++ b/cli/command/swarm/progress/root_rotation.go
@@ -1,0 +1,121 @@
+package progress
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/signal"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	certsRotatedStr = "  rotated TLS certificates"
+	rootsRotatedStr = "  rotated CA certificates"
+	// rootsAction has a single space because rootsRotatedStr is one character shorter than certsRotatedStr.
+	// This makes sure the progress bar are aligned.
+	certsAction = ""
+	rootsAction = " "
+)
+
+// RootRotationProgress outputs progress information for convergence of a root rotation.
+func RootRotationProgress(ctx context.Context, dclient client.APIClient, progressWriter io.WriteCloser) error {
+	defer progressWriter.Close()
+
+	progressOut := streamformatter.NewJSONProgressOutput(progressWriter, false)
+
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+	defer signal.Stop(sigint)
+
+	// draw 2 progress bars, 1 for nodes with the correct cert, 1 for nodes with the correct trust root
+	progress.Update(progressOut, "desired root digest", "")
+	progress.Update(progressOut, certsRotatedStr, certsAction)
+	progress.Update(progressOut, rootsRotatedStr, rootsAction)
+
+	var done bool
+
+	for {
+		info, err := dclient.SwarmInspect(ctx)
+		if err != nil {
+			return err
+		}
+
+		if done {
+			return nil
+		}
+
+		nodes, err := dclient.NodeList(ctx, types.NodeListOptions{})
+		if err != nil {
+			return err
+		}
+
+		done = updateProgress(progressOut, info.ClusterInfo.TLSInfo, nodes, info.ClusterInfo.RootRotationInProgress)
+
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-sigint:
+			if !done {
+				progress.Message(progressOut, "", "Operation continuing in background.")
+				progress.Message(progressOut, "", "Use `swarmctl cluster inspect default` to check progress.")
+			}
+			return nil
+		}
+	}
+}
+
+func updateProgress(progressOut progress.Output, desiredTLSInfo swarm.TLSInfo, nodes []swarm.Node, rootRotationInProgress bool) bool {
+	// write the current desired root cert's digest, because the desired root certs might be too long
+	progressOut.WriteProgress(progress.Progress{
+		ID:     "desired root digest",
+		Action: digest.FromBytes([]byte(desiredTLSInfo.TrustRoot)).String(),
+	})
+
+	// If we had reached a converged state, check if we are still converged.
+	var certsRight, trustRootsRight int64
+	for _, n := range nodes {
+		if bytes.Equal(n.Description.TLSInfo.CertIssuerPublicKey, desiredTLSInfo.CertIssuerPublicKey) &&
+			bytes.Equal(n.Description.TLSInfo.CertIssuerSubject, desiredTLSInfo.CertIssuerSubject) {
+			certsRight++
+		}
+
+		if n.Description.TLSInfo.TrustRoot == desiredTLSInfo.TrustRoot {
+			trustRootsRight++
+		}
+	}
+
+	total := int64(len(nodes))
+	progressOut.WriteProgress(progress.Progress{
+		ID:      certsRotatedStr,
+		Action:  certsAction,
+		Current: certsRight,
+		Total:   total,
+		Units:   "nodes",
+	})
+
+	rootsProgress := progress.Progress{
+		ID:      rootsRotatedStr,
+		Action:  rootsAction,
+		Current: trustRootsRight,
+		Total:   total,
+		Units:   "nodes",
+	}
+
+	if certsRight == total && !rootRotationInProgress {
+		progressOut.WriteProgress(rootsProgress)
+		return certsRight == total && trustRootsRight == total
+	}
+
+	// we still have certs that need renewing, so display that there are zero roots rotated yet
+	rootsProgress.Current = 0
+	progressOut.WriteProgress(rootsProgress)
+	return false
+}

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -123,6 +123,8 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Period: %s\n", units.HumanDuration(time.Duration(info.Swarm.Cluster.Spec.Dispatcher.HeartbeatPeriod)))
 			fmt.Fprintf(dockerCli.Out(), " CA Configuration:\n")
 			fmt.Fprintf(dockerCli.Out(), "  Expiry Duration: %s\n", units.HumanDuration(info.Swarm.Cluster.Spec.CAConfig.NodeCertExpiry))
+			fmt.Fprintf(dockerCli.Out(), "  Force Rotate: %d\n", info.Swarm.Cluster.Spec.CAConfig.ForceRotate)
+			fprintfIfNotEmpty(dockerCli.Out(), "  Signing CA Certificate: \n%s\n\n", strings.TrimSpace(info.Swarm.Cluster.Spec.CAConfig.SigningCACert))
 			if len(info.Swarm.Cluster.Spec.CAConfig.ExternalCAs) > 0 {
 				fmt.Fprintf(dockerCli.Out(), "  External CAs:\n")
 				for _, entry := range info.Swarm.Cluster.Spec.CAConfig.ExternalCAs {

--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-github.com/docker/docker 69c35dad8e7ec21de32d42b9dd606d3416ae1566
+github.com/docker/docker eb8abc95985bf3882a4a177c409a96e36e25f5b7
 github.com/docker/docker-credential-helpers v0.5.0
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5

--- a/vendor/github.com/docker/docker/api/types/swarm/swarm.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/swarm.go
@@ -109,6 +109,16 @@ type CAConfig struct {
 	// ExternalCAs is a list of CAs to which a manager node will make
 	// certificate signing requests for node certificates.
 	ExternalCAs []*ExternalCA `json:",omitempty"`
+
+	// SigningCACert and SigningCAKey specify the desired signing root CA and
+	// root CA key for the swarm.  When inspecting the cluster, the key will
+	// be redacted.
+	SigningCACert string `json:",omitempty"`
+	SigningCAKey  string `json:",omitempty"`
+
+	// If this value changes, and there is no specified signing cert and key,
+	// then the swarm is forced to generate a new root certificate ane key.
+	ForceRotate uint64 `json:",omitempty"`
 }
 
 // ExternalCAProtocol represents type of external CA.

--- a/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
@@ -36,7 +36,8 @@ type JSONProgress struct {
 	Total      int64 `json:"total,omitempty"`
 	Start      int64 `json:"start,omitempty"`
 	// If true, don't show xB/yB
-	HideCounts bool `json:"hidecounts,omitempty"`
+	HideCounts bool   `json:"hidecounts,omitempty"`
+	Units      string `json:"units,omitempty"`
 }
 
 func (p *JSONProgress) String() string {
@@ -55,11 +56,16 @@ func (p *JSONProgress) String() string {
 	if p.Current <= 0 && p.Total <= 0 {
 		return ""
 	}
-	current := units.HumanSize(float64(p.Current))
 	if p.Total <= 0 {
-		return fmt.Sprintf("%8v", current)
+		switch p.Units {
+		case "":
+			current := units.HumanSize(float64(p.Current))
+			return fmt.Sprintf("%8v", current)
+		default:
+			return fmt.Sprintf("%d %s", p.Current, p.Units)
+		}
 	}
-	total := units.HumanSize(float64(p.Total))
+
 	percentage := int(float64(p.Current)/float64(p.Total)*100) / 2
 	if percentage > 50 {
 		percentage = 50
@@ -73,12 +79,24 @@ func (p *JSONProgress) String() string {
 		pbBox = fmt.Sprintf("[%s>%s] ", strings.Repeat("=", percentage), strings.Repeat(" ", numSpaces))
 	}
 
-	if !p.HideCounts {
+	switch {
+	case p.HideCounts:
+	case p.Units == "": // no units, use bytes
+		current := units.HumanSize(float64(p.Current))
+		total := units.HumanSize(float64(p.Total))
+
 		numbersBox = fmt.Sprintf("%8v/%v", current, total)
 
 		if p.Current > p.Total {
 			// remove total display if the reported current is wonky.
 			numbersBox = fmt.Sprintf("%8v", current)
+		}
+	default:
+		numbersBox = fmt.Sprintf("%d/%d %s", p.Current, p.Total, p.Units)
+
+		if p.Current > p.Total {
+			// remove total display if the reported current is wonky.
+			numbersBox = fmt.Sprintf("%d %s", p.Current, p.Units)
 		}
 	}
 

--- a/vendor/github.com/docker/docker/pkg/progress/progress.go
+++ b/vendor/github.com/docker/docker/pkg/progress/progress.go
@@ -18,6 +18,8 @@ type Progress struct {
 
 	// If true, don't show xB/yB
 	HideCounts bool
+	// If not empty, use units instead of bytes for counts
+	Units string
 
 	// Aux contains extra information not presented to the user, such as
 	// digests for push signing.

--- a/vendor/github.com/docker/docker/pkg/streamformatter/streamformatter.go
+++ b/vendor/github.com/docker/docker/pkg/streamformatter/streamformatter.go
@@ -117,7 +117,7 @@ func (out *progressOutput) WriteProgress(prog progress.Progress) error {
 	if prog.Message != "" {
 		formatted = out.sf.formatStatus(prog.ID, prog.Message)
 	} else {
-		jsonProgress := jsonmessage.JSONProgress{Current: prog.Current, Total: prog.Total, HideCounts: prog.HideCounts}
+		jsonProgress := jsonmessage.JSONProgress{Current: prog.Current, Total: prog.Total, HideCounts: prog.HideCounts, Units: prog.Units}
 		formatted = out.sf.formatProgress(prog.ID, prog.Action, &jsonProgress, prog.Aux)
 	}
 	_, err := out.out.Write(formatted)


### PR DESCRIPTION
Provide command line tool to view and rotate swarm's currently CA root certificate.

Signed-off-by: Ying Li <ying.li@docker.com>

This code was originally in https://github.com/moby/moby/pull/32993.

```
root@ubuntu:~#  docker swarm ca
-----BEGIN CERTIFICATE-----
MIIBazCCARCgAwIBAgIUJPzo67QC7g8Ebg2ansjkZ8CbmaswCgYIKoZIzj0EAwIw
EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAzMTcxMDAwWhcNMzcwNDI4MTcx
MDAwWjATMREwDwYDVQQDEwhzd2FybS1jYTBZMBMGByqGSM49AgEGCCqGSM49AwEH
A0IABKL6/C0sihYEb935wVPRA8MqzPLn3jzou0OJRXHsCLcVExigrMdgmLCC+Va4
+sJ+SLVO1eQbvLHH8uuDdF/QOU6jQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMB
Af8EBTADAQH/MB0GA1UdDgQWBBSfUy5bjUnBAx/B0GkOBKp91XvxzjAKBggqhkjO
PQQDAgNJADBGAiEAnbvh0puOS5R/qvy1PMHY1iksYKh2acsGLtL/jAIvO4ACIQCi
lIwQqLkJ48SQqCjG1DBTSBsHmMSRT+6mE2My+Z3GKA==
-----END CERTIFICATE-----

root@ubuntu:~# docker swarm ca --help

Usage:	docker swarm ca [OPTIONS]

Manage root CA

Options:
      --ca-cert pem-file          Path to the PEM-formatted root CA certificate to use for the new cluster
      --ca-key pem-file           Path to the PEM-formatted root CA key to use for the new cluster
      --cert-expiry duration      Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
  -d, --detach                    Exit immediately instead of waiting for the root rotation to converge
      --external-ca external-ca   Specifications of one or more certificate signing endpoints
      --help                      Print usage
  -q, --quiet                     Suppress progress output
      --rotate                    Rotate the swarm CA - if no certificate or key are provided, new ones will be generated
```

Sample progress bar here, copied styling from the synchronous service create progress bar:  https://asciinema.org/a/2em3i7y1u50ajeut13es5m6uh

Note:  I originally thought about just doing `docker swarm update --rotate-ca cert=/path/...,key=/path/...` but I wasn't sure how to also do tell the CLI to just generate a cert and key - it'd probably have to look like `docker swarm update --rotate-ca ""` which seems weird, hence the new command.

Also a suggestion from @NathanMcCauley:  if we have service identities, and those could be rotated, do we want to use the same CLI command to view/rotate those as well?