### PR TITLE
update makefiles: add “vendor” target in docker.Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,36 @@
 # github.com/docker/cli 
 #
 
-.PHONY: build clean test lint cross
-
 # build the CLI
+.PHONY: build
 build: clean
 	@go build -o ./build/docker github.com/docker/cli/cmd/docker
 
 # remove build artifacts
+.PHONY: clean
 clean:
 	@rm -rf ./build/*
 
 # run go test
 # the "-tags daemon" part is temporary
+.PHONY: test
 test:
 	@go test -tags daemon -v $(shell go list ./... | grep -v /vendor/)
 
 # run linters
+.PHONY: lint
 lint:
 	@gometalinter --config gometalinter.json ./...
 
 # build the CLI for multiple architectures
+.PHONY: cross
 cross: clean
 	@gox -output build/docker-{{.OS}}-{{.Arch}} \
 		 -osarch="linux/arm linux/amd64 darwin/amd64 windows/amd64" \
 		 github.com/docker/cli/cmd/docker
 
+# download dependencies (vendor/) listed in vendor.conf
+.PHONY: vendor
 vendor: vendor.conf
 	@vndr 2> /dev/null
 	@if [ "`git status --porcelain -- vendor 2>/dev/null`" ]; then \

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -4,41 +4,52 @@
 # Makefile for developing using Docker
 #
 
-+.PHONY: build_docker_image build_linter_image build clean test cross dev lint
-
 DEV_DOCKER_IMAGE_NAME = docker-cli-dev
 LINTER_IMAGE_NAME = docker-cli-lint
 MOUNTS = -v `pwd`:/go/src/github.com/docker/cli
 
 # build docker image (dockerfiles/Dockerfile.build)
+.PHONY: build_docker_image
 build_docker_image:
 	@docker build -q -t $(DEV_DOCKER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.build .
 
-.PHONY: builder_linter_image
+# build docker image having the linting tools (dockerfiles/Dockerfile.lint)
+.PHONY: build_linter_image
 build_linter_image:
 	@docker build -q -t $(LINTER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.lint .
 
 # build executable using a container
+.PHONY: build
 build: build_docker_image
 	@echo "WARNING: this will drop a Linux executable on your host (not a macOS of Windows one)"
 	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make build
 
 # clean build artifacts using a container
+.PHONY: clean
 clean: build_docker_image
 	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
 
 # run go test
+.PHONY: test
 test: build_docker_image
 	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test
 
 # build the CLI for multiple architectures using a container
+.PHONY: cross
 cross: build_docker_image
 	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make cross
 
 # start container in interactive mode for in-container development
+.PHONY: dev
 dev: build_docker_image
 	@docker run -ti $(MOUNTS) -v /var/run/docker.sock:/var/run/docker.sock $(DEV_DOCKER_IMAGE_NAME) ash
 
 # run linters in a container
+.PHONY: lint
 lint: build_linter_image
 	@docker run -ti $(MOUNTS) $(LINTER_IMAGE_NAME)
+
+# download dependencies (vendor/) listed in vendor.conf, using a container
+.PHONY: vendor
+vendor: build_docker_image vendor.conf
+	@docker run -ti --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make vendor

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,4 +43,3 @@ golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb
 google.golang.org/grpc v1.0.4
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
-


### PR DESCRIPTION
**- What I did**

Add `vendor` target in docker.Makefile,
so that contributors don’t need “vndr” on their laptop.

Now, they can do:

```
$ make -f docker.Makefile vendor
```

**- A picture of a cute animal (not mandatory but encouraged)**

![giant-mantis-wallpaper-2](https://cloud.githubusercontent.com/assets/939999/25873697/5734afba-34c4-11e7-85ca-2cdf590ab0da.jpg)

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>