### PR TITLE
[WIP] `docker project` subcommands

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -202,7 +202,7 @@ func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.
 
 	var httpClient *http.Client
 	if project.IsInProject() {
-		httpClient, err = project.GetCurrentProject().NewScopedHttpClient(host, verStr)
+		httpClient, err = project.GetCurrentProject().NewScopedHTTPClient(host, verStr)
 		if err != nil {
 			return &client.Client{}, err
 		}

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/command/network"
 	"github.com/docker/cli/cli/command/node"
 	"github.com/docker/cli/cli/command/plugin"
+	"github.com/docker/cli/cli/command/project"
 	"github.com/docker/cli/cli/command/registry"
 	"github.com/docker/cli/cli/command/secret"
 	"github.com/docker/cli/cli/command/service"
@@ -48,6 +49,9 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		// plugin
 		plugin.NewPluginCommand(dockerCli),
 
+		// project
+		project.NewProjectCommand(dockerCli),
+
 		// registry
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
@@ -77,6 +81,7 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		volume.NewVolumeCommand(dockerCli),
 
 		// legacy commands may be hidden
+		hide(project.NewInitCommand(dockerCli)),
 		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInfoCommand(dockerCli)),
 		hide(system.NewInspectCommand(dockerCli)),

--- a/cli/command/formatter/project.go
+++ b/cli/command/formatter/project.go
@@ -1,0 +1,63 @@
+package formatter
+
+import "github.com/docker/cli/project"
+
+const (
+	defaultProjectQuietFormat = "{{.RootDir}}"
+	defaultProjectTableFormat = "table {{.RootDir}}\t{{.ID}}"
+	projectRootDirHeader      = "ROOT DIRECTORY"
+	projectIDHeader           = "ID"
+)
+
+// NewProjectFormat returns a format for use with a project Context
+func NewProjectFormat(source string, quiet bool) Format {
+	switch source {
+	case TableFormatKey:
+		if quiet {
+			return defaultProjectQuietFormat
+		}
+		return defaultProjectTableFormat
+	}
+	return Format(source)
+}
+
+// ProjectWrite writes formatted projects using the Context
+func ProjectWrite(ctx Context, projects []project.Project) error {
+	render := func(format func(subContext subContext) error) error {
+		for _, p := range projects {
+			if err := format(&projectContext{v: p}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return ctx.Write(newProjectContext(), render)
+}
+
+type projectHeaderContext map[string]string
+
+type projectContext struct {
+	HeaderContext
+	v project.Project
+}
+
+func newProjectContext() *projectContext {
+	projectCtx := projectContext{}
+	projectCtx.header = projectHeaderContext{
+		"RootDir": projectRootDirHeader,
+		"ID":      projectIDHeader,
+	}
+	return &projectCtx
+}
+
+func (c *projectContext) MarshalJSON() ([]byte, error) {
+	return marshalJSON(c)
+}
+
+func (c *projectContext) RootDir() string {
+	return c.v.RootDir()
+}
+
+func (c *projectContext) ID() string {
+	return c.v.ID()
+}

--- a/cli/command/project/cmd.go
+++ b/cli/command/project/cmd.go
@@ -1,0 +1,25 @@
+package project
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+// NewProjectCommand returns a cobra command struct for the `project` subcommand
+func NewProjectCommand(dockerCli *command.DockerCli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage projects",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		NewInitCommand(dockerCli),
+		NewJoinCommand(dockerCli),
+		NewLsCommand(dockerCli),
+		NewLeaveCommand(dockerCli),
+		NewIDCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/project/id.go
+++ b/cli/command/project/id.go
@@ -1,0 +1,60 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	project "github.com/docker/cli/project/impl"
+	"github.com/spf13/cobra"
+)
+
+type idOptions struct {
+	projectDir string
+}
+
+// NewIDCommand returns a command that can be used to display current project id
+func NewIDCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts idOptions
+
+	cmd := &cobra.Command{
+		Use:   "id",
+		Short: "Display Docker project ID",
+		Args:  cli.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runID(dockerCli, &opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.projectDir, "dir", "d", "", "Target directory (default is current directory)")
+
+	return cmd
+}
+
+func runID(dockerCli *command.DockerCli, opts *idOptions) error {
+	// directory from where project should be left
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if opts.projectDir != "" {
+		if filepath.IsAbs(opts.projectDir) {
+			dir = opts.projectDir
+		} else {
+			dir = filepath.Clean(filepath.Join(dir, opts.projectDir))
+		}
+	}
+	proj, err := project.Load(dir)
+	if err != nil {
+		return err
+	}
+	if proj == nil {
+		fmt.Fprintf(dockerCli.Out(), "no project found at %s\n", dir)
+		return nil
+	}
+	fmt.Fprintf(dockerCli.Out(), "%s\n", proj.ID())
+	return nil
+}

--- a/cli/command/project/init.go
+++ b/cli/command/project/init.go
@@ -1,0 +1,73 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	project "github.com/docker/cli/project/impl"
+	projectutil "github.com/docker/cli/project/util"
+	"github.com/spf13/cobra"
+)
+
+type initOptions struct {
+	projectDir string
+	force      bool
+}
+
+// NewInitCommand creates a new cobra.Command for `docker project init`
+func NewInitCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts initOptions
+
+	cmd := &cobra.Command{
+		Use:   "init [ID]",
+		Short: "Initiate Docker project",
+		Args:  cli.RequiresMaxArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ID := ""
+			if len(args) == 1 {
+				ID = args[0]
+			}
+			return runInit(dockerCli, &opts, ID)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.projectDir, "dir", "d", "", "Target directory (default is current directory)")
+	flags.BoolVarP(&opts.force, "force", "f", false, "Force initialization over existing project")
+
+	return cmd
+}
+
+func runInit(dockerCli *command.DockerCli, opts *initOptions, ID string) error {
+
+	// directory where project should be initiated
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if opts.projectDir != "" {
+		if filepath.IsAbs(opts.projectDir) {
+			dir = opts.projectDir
+		} else {
+			dir = filepath.Clean(filepath.Join(dir, opts.projectDir))
+		}
+	}
+
+	proj, err := project.Init(dir, ID, opts.force)
+	if err != nil {
+		return err
+	}
+
+	err = projectutil.SaveInRecentProjects(proj)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(dockerCli.Out(), "project created at %s\n", dir)
+	fmt.Fprintf(dockerCli.Out(), "to join the project: `docker project join %s`\n", proj.ID())
+
+	return nil
+}

--- a/cli/command/project/join.go
+++ b/cli/command/project/join.go
@@ -1,0 +1,66 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	project "github.com/docker/cli/project/impl"
+	projectutil "github.com/docker/cli/project/util"
+	"github.com/spf13/cobra"
+)
+
+type joinOptions struct {
+	projectDir string
+}
+
+// NewJoinCommand creates a new cobra.Command for `docker project join`
+func NewJoinCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts joinOptions
+
+	cmd := &cobra.Command{
+		Use:   "join ID",
+		Short: "Join a Docker project",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runJoin(dockerCli, &opts, args[0])
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.projectDir, "dir", "d", "", "Target directory (default is current directory)")
+
+	return cmd
+}
+
+func runJoin(dockerCli *command.DockerCli, opts *joinOptions, ID string) error {
+
+	// directory where project should be initiated
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if opts.projectDir != "" {
+		if filepath.IsAbs(opts.projectDir) {
+			dir = opts.projectDir
+		} else {
+			dir = filepath.Clean(filepath.Join(dir, opts.projectDir))
+		}
+	}
+
+	proj, err := project.Init(dir, ID, false)
+	if err != nil {
+		return err
+	}
+
+	err = projectutil.SaveInRecentProjects(proj)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(dockerCli.Out(), "joined project %s!\n", proj.ID())
+
+	return nil
+}

--- a/cli/command/project/leave.go
+++ b/cli/command/project/leave.go
@@ -1,0 +1,81 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	project "github.com/docker/cli/project/impl"
+	projectutil "github.com/docker/cli/project/util"
+	"github.com/spf13/cobra"
+)
+
+type leaveOptions struct {
+	projectDir string
+}
+
+// NewLeaveCommand removes the project id
+func NewLeaveCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts leaveOptions
+
+	cmd := &cobra.Command{
+		Use:   "leave",
+		Short: "Leave a Docker project",
+		Args:  cli.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLeave(dockerCli, &opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.projectDir, "dir", "d", "", "Target directory (default is current directory)")
+
+	return cmd
+}
+
+func runLeave(dockerCli *command.DockerCli, opts *leaveOptions) error {
+	// directory from where project should be left
+	dir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if opts.projectDir != "" {
+		if filepath.IsAbs(opts.projectDir) {
+			dir = opts.projectDir
+		} else {
+			dir = filepath.Clean(filepath.Join(dir, opts.projectDir))
+		}
+	}
+
+	proj, err := project.Load(dir)
+	if err != nil {
+		return err
+	}
+
+	if proj == nil {
+		fmt.Fprintf(dockerCli.Out(), "no project found at %s\n", dir)
+		// still try to remove it from recent projects considering given
+		// dir as project root directory
+		err = projectutil.RemoveFromRecentProjects(dir)
+		if err == nil {
+			fmt.Fprintf(dockerCli.Out(), "(removed from recent projects though)\n")
+		}
+		// don't do anything is err != nil
+		return nil
+	}
+
+	_ = projectutil.RemoveFromRecentProjects(proj.RootDir())
+
+	projectID := proj.ID()
+
+	err = proj.Leave()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(dockerCli.Out(), "left project %s\n", projectID)
+
+	return nil
+}

--- a/cli/command/project/list.go
+++ b/cli/command/project/list.go
@@ -14,7 +14,7 @@ type lsOptions struct {
 	format string
 }
 
-// NewInitCommand creates a new cobra.Command for `docker project init`
+// NewLsCommand creates a new cobra.Command for `docker project ls`
 func NewLsCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts lsOptions
 
@@ -32,12 +32,6 @@ func NewLsCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&opts.format, "format", "", "Pretty-print volumes using a Go template")
 
 	return cmd
-}
-
-type projectForJson struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-	Root string `json:"root"`
 }
 
 func runLs(dockerCli *command.DockerCli, opts *lsOptions) error {

--- a/cli/command/project/list.go
+++ b/cli/command/project/list.go
@@ -1,0 +1,63 @@
+package project
+
+import (
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/formatter"
+	projectutil "github.com/docker/cli/project/util"
+	"github.com/spf13/cobra"
+)
+
+type lsOptions struct {
+	json   bool
+	quiet  bool
+	format string
+}
+
+// NewInitCommand creates a new cobra.Command for `docker project init`
+func NewLsCommand(dockerCli *command.DockerCli) *cobra.Command {
+	var opts lsOptions
+
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List recent projects",
+		Args:  cli.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLs(dockerCli, &opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display volume names")
+	flags.StringVar(&opts.format, "format", "", "Pretty-print volumes using a Go template")
+
+	return cmd
+}
+
+type projectForJson struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+	Root string `json:"root"`
+}
+
+func runLs(dockerCli *command.DockerCli, opts *lsOptions) error {
+	projects := projectutil.GetRecentProjects()
+
+	format := opts.format
+	if len(format) == 0 {
+		// TODO: allow project ls format to be defined in config
+
+		// if len(dockerCli.ConfigFile().VolumesFormat) > 0 && !opts.quiet {
+		// 	format = dockerCli.ConfigFile().VolumesFormat
+		// } else {
+		format = formatter.TableFormatKey
+		// }
+	}
+
+	projectCtx := formatter.Context{
+		Output: dockerCli.Out(),
+		Format: formatter.NewProjectFormat(format, opts.quiet),
+	}
+
+	return formatter.ProjectWrite(projectCtx, projects)
+}

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/system"
 )
 
@@ -113,6 +115,24 @@ func PruneFilters(dockerCli Cli, pruneFilters filters.Args) filters.Args {
 			}
 		}
 		pruneFilters.Add(parts[0], parts[1])
+	}
+
+	// Server APIs older than 1.29 will just ignore label filters.
+	// It's dangerous because a command like:
+	// `docker container prune --filter label=foo=bar`
+	// would just remove all stopped containers without considering the label
+	// The remote API should reject requests using unknown filters.
+	if pruneFilters.Get("label") != nil {
+		serverVersion, err := dockerCli.Client().ServerVersion(context.Background())
+		if err != nil {
+			fmt.Fprintf(dockerCli.Err(), "server API can't be verified\n")
+			os.Exit(1)
+		}
+		minimumVersion := "1.29"
+		if versions.LessThan(serverVersion.APIVersion, minimumVersion) {
+			fmt.Fprintf(dockerCli.Err(), "server API version: %s, %s required to filter on label\n", serverVersion.APIVersion, minimumVersion)
+			os.Exit(1)
+		}
 	}
 
 	return pruneFilters

--- a/project/impl/project.go
+++ b/project/impl/project.go
@@ -123,9 +123,9 @@ func (p *Project) Dial() (net.Conn, error) {
 	return fakeListener.DialContext(nil, "", "")
 }
 
-// NewScopedHttpClient ...
-func (p *Project) NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error) {
-	// creates a docker API client that will be used internally by the proxy
+// NewScopedHTTPClient creates a docker API client used internally by the proxy
+func (p *Project) NewScopedHTTPClient(backendAddr, apiVersion string) (*http.Client, error) {
+	//
 	dockerClient, err := client.NewClient(backendAddr, apiVersion, nil, nil)
 	if err != nil {
 		return nil, err

--- a/project/impl/project.go
+++ b/project/impl/project.go
@@ -1,0 +1,235 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	projectUtil "github.com/docker/cli/project/util"
+	"github.com/docker/distribution/uuid"
+	"github.com/docker/docker/client"
+	proxyFakes "github.com/docker/engine-api-proxy/fakes"
+	proxyNamespace "github.com/docker/engine-api-proxy/namespace"
+	"github.com/docker/engine-api-proxy/proxy"
+)
+
+const (
+	// ProjectDir describes where the project stores configuration
+	ProjectDir = ".git/.docker"
+	// ProjectIDFile is the name of the file storing project's id
+	ProjectIDFile = "id"
+)
+
+// Project defines a Docker project.
+// It implements the "github.com/docker/cli/proj".Project interface.
+type Project struct {
+	rootDir string
+	proxy   *proxy.Proxy
+}
+
+// Init initiates a new project
+func Init(dir, id string, force bool) (*Project, error) {
+	if force == false && isProjectRoot(dir) {
+		return nil, fmt.Errorf("target directory already is the root of a Docker project")
+	}
+
+	if id == "" {
+		id = uuid.Generate().String()
+	}
+
+	if err := validateProjectID(id); err != nil {
+		return nil, err
+	}
+
+	// write id file
+	IDFile := filepath.Join(dir, ProjectDir, ProjectIDFile)
+	err := os.MkdirAll(ProjectDir, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile(IDFile, []byte(id), 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	proj, err := Load(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return proj, nil
+}
+
+// isProjectRoot looks for a project configuration file at a given path.
+func isProjectRoot(dirPath string) (found bool) {
+	found = false
+	IDFile := filepath.Join(dirPath, ProjectDir, ProjectIDFile)
+	fileInfo, err := os.Stat(IDFile)
+	if os.IsNotExist(err) {
+		return
+	}
+	if fileInfo.IsDir() {
+		return
+	}
+	found = true
+	return
+}
+
+// FindProjectRoot looks in current directory and parents until
+// it finds a project config file. It then returns the parent
+// of that directory, the root of the Docker project.
+func FindProjectRoot(path string) (projectRootPath string, err error) {
+	path = filepath.Clean(path)
+	for {
+		if isProjectRoot(path) {
+			return path, nil
+		}
+		// break after / has been tested
+		if path == filepath.Dir(path) {
+			break
+		}
+		path = filepath.Dir(path)
+	}
+	return "", errors.New("can't find project root directory")
+}
+
+// RootDir returns project's root directory
+func (p *Project) RootDir() string {
+	return p.rootDir
+}
+
+// ID returns project's ID
+func (p *Project) ID() string {
+	id, err := p.getProjectID()
+	if err != nil {
+		log.Fatalln(err.Error())
+	}
+	return id
+}
+
+// Dial connects to the remote API through in-memory proxy to deal with
+// labels and names.
+func (p *Project) Dial() (net.Conn, error) {
+	fakeListener, ok := p.proxy.GetListener().(*proxyFakes.FakeListener)
+	if ok == false {
+		return nil, errors.New("listener is not a fake listener")
+	}
+	return fakeListener.DialContext(nil, "", "")
+}
+
+// NewScopedHttpClient ...
+func (p *Project) NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error) {
+	// creates a docker API client that will be used internally by the proxy
+	dockerClient, err := client.NewClient(backendAddr, apiVersion, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	// obtain proxy routes
+	proxyRoutes := proxyNamespace.MiddlewareRoutes(dockerClient, func() proxyNamespace.Scoper {
+		return proxyNamespace.NewProjectScoper(p.ID())
+	})
+	// construct proxy options struct
+	proxyOpts := proxy.Options{
+		Listen:      "",
+		Backend:     backendAddr,
+		SocketGroup: "",
+		Routes:      proxyRoutes,
+	}
+	// create in-memory proxy
+	p.proxy, err = proxy.NewInMemoryProxy(proxyOpts)
+	if err != nil {
+		return nil, err
+	}
+	// start proxy server goroutine
+	go p.proxy.Start()
+
+	// get FakeListener from proxy
+	fakeListener, ok := p.proxy.GetListener().(*proxyFakes.FakeListener)
+	if ok == false {
+		return nil, errors.New("listener is not a fake listener")
+	}
+
+	transport := &http.Transport{}
+	transport.DialContext = fakeListener.DialContext
+
+	return &http.Client{
+		Transport: transport,
+	}, nil
+}
+
+// Leave deletes the file used to store project ID. That is a sufficient
+// condition to stop working in the scope of a project.
+func (p *Project) Leave() error {
+	IDFilePath := filepath.Join(p.RootDir(), ProjectDir, ProjectIDFile)
+	return os.Remove(IDFilePath)
+}
+
+// Load returns project for a given path.
+// The configuration file can be in a parent directory, so we have to test all
+// the way up to the root directory. If no configuration file is found then
+// nil,nil is returned (no error)
+func Load(path string) (*Project, error) {
+
+	projectRootDirPath, err := FindProjectRoot(path)
+	if err != nil {
+		// TODO: gdevillele: handle actual errors, for now we suppose no project is found
+		return nil, nil
+	}
+
+	// create project struct
+	p := &Project{
+		rootDir: projectRootDirPath,
+	}
+
+	// go to project root dir
+	previousWorkDir, err := projectUtil.ChRootDir(p)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Chdir(previousWorkDir)
+
+	// validate project ID
+	_, err = p.getProjectID()
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// LoadForWd returns project for current working directory
+func LoadForWd() (*Project, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	return Load(wd)
+}
+
+// getProjectID retrieves the ID of the project
+// and validates it (it cannot contain any '.' for example)
+func (p *Project) getProjectID() (string, error) {
+	IDBytes, err := ioutil.ReadFile(filepath.Join(p.RootDir(), ProjectDir, ProjectIDFile))
+	if err != nil {
+		return "", errors.New("can't read project id")
+	}
+	ID := string(IDBytes)
+	if err := validateProjectID(ID); err != nil {
+		return "", err
+	}
+	return ID, nil
+}
+
+func validateProjectID(id string) error {
+	rgxp := regexp.MustCompilePOSIX("^[0-9a-zA-Z_-]+$")
+	if rgxp.MatchString(id) == false {
+		return errors.New("invalid project id")
+	}
+	return nil
+}

--- a/project/project.go
+++ b/project/project.go
@@ -1,0 +1,49 @@
+package project
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	// CurrentProject is used to store loaded project
+	currentProject Project
+)
+
+// Project is the interface used by the cli package
+type Project interface {
+	RootDir() string         // returns the project root directory's path
+	ID() string              // returns project id
+	Dial() (net.Conn, error) // returns conn to proxy
+	NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error)
+}
+
+// IsInProject indicates whether we are in the context of a project
+func IsInProject() bool {
+	return GetCurrentProject() != nil
+}
+
+func GetCurrentProject() Project {
+	if isProjectIgnored() {
+		return nil
+	}
+	return currentProject
+}
+
+func SetCurrentProject(p Project) {
+	currentProject = p
+}
+
+func isProjectIgnored() bool {
+	var ignoreProjectFlag bool = false
+	f := pflag.NewFlagSet("", pflag.ContinueOnError)
+	f.SetOutput(ioutil.Discard)
+	f.BoolVar(&ignoreProjectFlag, "ignore-project", false, "disables project scoping")
+	_ = f.Parse(os.Args[1:])
+	return ignoreProjectFlag
+}

--- a/project/project.go
+++ b/project/project.go
@@ -20,7 +20,7 @@ type Project interface {
 	RootDir() string         // returns the project root directory's path
 	ID() string              // returns project id
 	Dial() (net.Conn, error) // returns conn to proxy
-	NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error)
+	NewScopedHTTPClient(backendAddr, apiVersion string) (*http.Client, error)
 }
 
 // IsInProject indicates whether we are in the context of a project
@@ -28,6 +28,7 @@ func IsInProject() bool {
 	return GetCurrentProject() != nil
 }
 
+// GetCurrentProject returns the project that is currently active
 func GetCurrentProject() Project {
 	if isProjectIgnored() {
 		return nil
@@ -35,12 +36,13 @@ func GetCurrentProject() Project {
 	return currentProject
 }
 
+// SetCurrentProject sets active project
 func SetCurrentProject(p Project) {
 	currentProject = p
 }
 
 func isProjectIgnored() bool {
-	var ignoreProjectFlag bool = false
+	ignoreProjectFlag := false
 	f := pflag.NewFlagSet("", pflag.ContinueOnError)
 	f.SetOutput(ioutil.Discard)
 	f.BoolVar(&ignoreProjectFlag, "ignore-project", false, "disables project scoping")

--- a/project/util/util.go
+++ b/project/util/util.go
@@ -1,0 +1,184 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/project"
+)
+
+const (
+	recentProjectsFileName = ".recentProjects.json"
+)
+
+func ChRootDir(p project.Project) (previousWorkDir string, err error) {
+	previousWorkDir, err = os.Getwd()
+	if err != nil {
+		return
+	}
+	err = os.Chdir(p.RootDir())
+	if err != nil {
+		return
+	}
+	return
+}
+
+type recentProject struct {
+	IDVal      string `json:"id"`
+	RootDirVal string `json:"root"`
+	Timestamp  int    `json:"t"`
+}
+
+// Project interface implementation
+func (rp *recentProject) RootDir() string {
+	return rp.RootDirVal
+}
+func (rp *recentProject) ID() string {
+	return rp.IDVal
+}
+func (rp *recentProject) Dial() (net.Conn, error) {
+	return nil, nil
+}
+func (rp *recentProject) NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error) {
+	return nil, nil
+}
+
+type recentProjects []*recentProject
+
+func (a recentProjects) Len() int           { return len(a) }
+func (a recentProjects) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a recentProjects) Less(i, j int) bool { return a[i].Timestamp > a[j].Timestamp }
+
+// SaveInRecentProjects inserts project or updates existing entry in the
+// file storing recent projects
+func SaveInRecentProjects(p project.Project) error {
+	rProjects := getRecentProjects()
+	inserted := false
+
+	rp := &recentProject{
+		IDVal:      p.ID(),
+		RootDirVal: p.RootDir(),
+		Timestamp:  int(time.Now().Unix()),
+	}
+
+	for i, rProject := range rProjects {
+		if rProject.IDVal == rp.IDVal {
+			rProjects[i] = rp
+			inserted = true
+			break
+		}
+	}
+
+	if !inserted {
+		rProjects = append(rProjects, rp)
+	}
+
+	err := saveRecentProjects(rProjects)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RemoveFromRecentProjects removes project at given root dir path from
+// recent project. Using a string parameter instead of project.Project
+// because the actual directory may have been removed manually while the
+// user still wants to remove the project from the list...
+func RemoveFromRecentProjects(rootDir string) error {
+	rProjects := getRecentProjects()
+	removed := false
+
+	for i, rProject := range rProjects {
+		if rProject.RootDir() == rootDir {
+			// last element
+			if i == len(rProjects)-1 {
+				rProjects = rProjects[:i]
+			} else {
+				rProjects = append(rProjects[:i], rProjects[i+1:]...)
+			}
+			removed = true
+			break
+		}
+	}
+
+	if !removed {
+		return errors.New("can't remove from recent project (not found)")
+	}
+
+	err := saveRecentProjects(rProjects)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetRecentProjects returns the ordered list of recent projects.
+func GetRecentProjects() []project.Project {
+	rp := getRecentProjects()
+	resp := make([]project.Project, len(rp))
+	for i, p := range rp {
+		resp[i] = p
+	}
+	return resp
+}
+
+func getRecentProjects() recentProjects {
+	rProjects := make(recentProjects, 0)
+	jsonBytes, err := ioutil.ReadFile(recentProjectsFile())
+	if err == nil {
+		err := json.Unmarshal(jsonBytes, &rProjects)
+		if err != nil {
+			return make(recentProjects, 0)
+		}
+	}
+	return rProjects
+}
+
+func recentProjectsFile() string {
+	return filepath.Join(cliconfig.Dir(), recentProjectsFileName)
+}
+
+func saveRecentProjects(rProjects recentProjects) error {
+	// filter to enforce only one project per location
+	locationFilter := make(map[string]*recentProject)
+
+	for _, rProject := range rProjects {
+		if p, exists := locationFilter[rProject.RootDir()]; exists {
+			// keep most recent
+			if p.Timestamp > rProject.Timestamp {
+				continue
+			}
+		}
+		locationFilter[rProject.RootDir()] = rProject
+	}
+
+	filteredRecentProjects := make(recentProjects, len(locationFilter))
+
+	i := 0
+	for _, filteredProject := range locationFilter {
+		filteredRecentProjects[i] = filteredProject
+		i++
+	}
+
+	sort.Sort(filteredRecentProjects)
+
+	jsonBytes, err := json.Marshal(filteredRecentProjects)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(recentProjectsFile(), jsonBytes, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/project/util/util.go
+++ b/project/util/util.go
@@ -19,6 +19,7 @@ const (
 	recentProjectsFileName = ".recentProjects.json"
 )
 
+// ChRootDir changes the current working directory to project's root directory
 func ChRootDir(p project.Project) (previousWorkDir string, err error) {
 	previousWorkDir, err = os.Getwd()
 	if err != nil {
@@ -47,7 +48,7 @@ func (rp *recentProject) ID() string {
 func (rp *recentProject) Dial() (net.Conn, error) {
 	return nil, nil
 }
-func (rp *recentProject) NewScopedHttpClient(backendAddr, apiVersion string) (*http.Client, error) {
+func (rp *recentProject) NewScopedHTTPClient(backendAddr, apiVersion string) (*http.Client, error) {
 	return nil, nil
 }
 

--- a/project/util/util.go
+++ b/project/util/util.go
@@ -135,7 +135,7 @@ func GetRecentProjects() []project.Project {
 
 func getRecentProjects() recentProjects {
 	rProjects := make(recentProjects, 0)
-	jsonBytes, err := ioutil.ReadFile(recentProjectsFile())
+	jsonBytes, err := ioutil.ReadFile(recentProjectsFilePath())
 	if err == nil {
 		err := json.Unmarshal(jsonBytes, &rProjects)
 		if err != nil {
@@ -145,7 +145,7 @@ func getRecentProjects() recentProjects {
 	return rProjects
 }
 
-func recentProjectsFile() string {
+func recentProjectsFilePath() string {
 	return filepath.Join(cliconfig.Dir(), recentProjectsFileName)
 }
 
@@ -177,7 +177,15 @@ func saveRecentProjects(rProjects recentProjects) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(recentProjectsFile(), jsonBytes, 0644)
+	// update recent projects JSON file on disc
+	// automatically create parent directories if they don't exist
+	filePath := recentProjectsFilePath()
+	parentDirPath := filepath.Dir(filePath)
+	err = os.MkdirAll(parentDirPath, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(filePath, jsonBytes, 0644)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/dnephin/go-os-user/LICENSE
+++ b/vendor/github.com/dnephin/go-os-user/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2014 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/dnephin/go-os-user/lookup.go
+++ b/vendor/github.com/dnephin/go-os-user/lookup.go
@@ -1,0 +1,110 @@
+package user
+
+import (
+	"errors"
+	"syscall"
+)
+
+var (
+	// The current operating system does not provide the required data for user lookups.
+	ErrUnsupported = errors.New("user lookup: operating system does not provide passwd-formatted data")
+	// No matching entries found in file.
+	ErrNoPasswdEntries = errors.New("no matching entries in passwd file")
+	ErrNoGroupEntries  = errors.New("no matching entries in group file")
+)
+
+func lookupUser(filter func(u User) bool) (User, error) {
+	// Get operating system-specific passwd reader-closer.
+	passwd, err := GetPasswd()
+	if err != nil {
+		return User{}, err
+	}
+	defer passwd.Close()
+
+	// Get the users.
+	users, err := ParsePasswdFilter(passwd, filter)
+	if err != nil {
+		return User{}, err
+	}
+
+	// No user entries found.
+	if len(users) == 0 {
+		return User{}, ErrNoPasswdEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return users[0], nil
+}
+
+// CurrentUser looks up the current user by their user id in /etc/passwd. If the
+// user cannot be found (or there is no /etc/passwd file on the filesystem),
+// then CurrentUser returns an error.
+func CurrentUser() (User, error) {
+	return LookupUid(syscall.Getuid())
+}
+
+// LookupUser looks up a user by their username in /etc/passwd. If the user
+// cannot be found (or there is no /etc/passwd file on the filesystem), then
+// LookupUser returns an error.
+func LookupUser(username string) (User, error) {
+	return lookupUser(func(u User) bool {
+		return u.Name == username
+	})
+}
+
+// LookupUid looks up a user by their user id in /etc/passwd. If the user cannot
+// be found (or there is no /etc/passwd file on the filesystem), then LookupId
+// returns an error.
+func LookupUid(uid int) (User, error) {
+	return lookupUser(func(u User) bool {
+		return u.Uid == uid
+	})
+}
+
+func lookupGroup(filter func(g Group) bool) (Group, error) {
+	// Get operating system-specific group reader-closer.
+	group, err := GetGroup()
+	if err != nil {
+		return Group{}, err
+	}
+	defer group.Close()
+
+	// Get the users.
+	groups, err := ParseGroupFilter(group, filter)
+	if err != nil {
+		return Group{}, err
+	}
+
+	// No user entries found.
+	if len(groups) == 0 {
+		return Group{}, ErrNoGroupEntries
+	}
+
+	// Assume the first entry is the "correct" one.
+	return groups[0], nil
+}
+
+// CurrentGroup looks up the current user's group by their primary group id's
+// entry in /etc/passwd. If the group cannot be found (or there is no
+// /etc/group file on the filesystem), then CurrentGroup returns an error.
+func CurrentGroup() (Group, error) {
+	return LookupGid(syscall.Getgid())
+}
+
+// LookupGroup looks up a group by its name in /etc/group. If the group cannot
+// be found (or there is no /etc/group file on the filesystem), then LookupGroup
+// returns an error.
+func LookupGroup(groupname string) (Group, error) {
+	return lookupGroup(func(g Group) bool {
+		return g.Name == groupname
+	})
+}
+
+// LookupGid looks up a group by its group id in /etc/group. If the group cannot
+// be found (or there is no /etc/group file on the filesystem), then LookupGid
+// returns an error.
+func LookupGid(gid int) (Group, error) {
+	return lookupGroup(func(g Group) bool {
+		return g.Gid == gid
+	})
+}

--- a/vendor/github.com/dnephin/go-os-user/lookup_unix.go
+++ b/vendor/github.com/dnephin/go-os-user/lookup_unix.go
@@ -1,0 +1,30 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package user
+
+import (
+	"io"
+	"os"
+)
+
+// Unix-specific path to the passwd and group formatted files.
+const (
+	unixPasswdPath = "/etc/passwd"
+	unixGroupPath  = "/etc/group"
+)
+
+func GetPasswdPath() (string, error) {
+	return unixPasswdPath, nil
+}
+
+func GetPasswd() (io.ReadCloser, error) {
+	return os.Open(unixPasswdPath)
+}
+
+func GetGroupPath() (string, error) {
+	return unixGroupPath, nil
+}
+
+func GetGroup() (io.ReadCloser, error) {
+	return os.Open(unixGroupPath)
+}

--- a/vendor/github.com/dnephin/go-os-user/lookup_unsupported.go
+++ b/vendor/github.com/dnephin/go-os-user/lookup_unsupported.go
@@ -1,0 +1,21 @@
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+package user
+
+import "io"
+
+func GetPasswdPath() (string, error) {
+	return "", ErrUnsupported
+}
+
+func GetPasswd() (io.ReadCloser, error) {
+	return nil, ErrUnsupported
+}
+
+func GetGroupPath() (string, error) {
+	return "", ErrUnsupported
+}
+
+func GetGroup() (io.ReadCloser, error) {
+	return nil, ErrUnsupported
+}

--- a/vendor/github.com/dnephin/go-os-user/user.go
+++ b/vendor/github.com/dnephin/go-os-user/user.go
@@ -1,0 +1,441 @@
+package user
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	minId = 0
+	maxId = 1<<31 - 1 //for 32-bit systems compatibility
+)
+
+var (
+	ErrRange = fmt.Errorf("uids and gids must be in range %d-%d", minId, maxId)
+)
+
+type User struct {
+	Name  string
+	Pass  string
+	Uid   int
+	Gid   int
+	Gecos string
+	Home  string
+	Shell string
+}
+
+type Group struct {
+	Name string
+	Pass string
+	Gid  int
+	List []string
+}
+
+func parseLine(line string, v ...interface{}) {
+	if line == "" {
+		return
+	}
+
+	parts := strings.Split(line, ":")
+	for i, p := range parts {
+		// Ignore cases where we don't have enough fields to populate the arguments.
+		// Some configuration files like to misbehave.
+		if len(v) <= i {
+			break
+		}
+
+		// Use the type of the argument to figure out how to parse it, scanf() style.
+		// This is legit.
+		switch e := v[i].(type) {
+		case *string:
+			*e = p
+		case *int:
+			// "numbers", with conversion errors ignored because of some misbehaving configuration files.
+			*e, _ = strconv.Atoi(p)
+		case *[]string:
+			// Comma-separated lists.
+			if p != "" {
+				*e = strings.Split(p, ",")
+			} else {
+				*e = []string{}
+			}
+		default:
+			// Someone goof'd when writing code using this function. Scream so they can hear us.
+			panic(fmt.Sprintf("parseLine only accepts {*string, *int, *[]string} as arguments! %#v is not a pointer!", e))
+		}
+	}
+}
+
+func ParsePasswdFile(path string) ([]User, error) {
+	passwd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer passwd.Close()
+	return ParsePasswd(passwd)
+}
+
+func ParsePasswd(passwd io.Reader) ([]User, error) {
+	return ParsePasswdFilter(passwd, nil)
+}
+
+func ParsePasswdFileFilter(path string, filter func(User) bool) ([]User, error) {
+	passwd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer passwd.Close()
+	return ParsePasswdFilter(passwd, filter)
+}
+
+func ParsePasswdFilter(r io.Reader, filter func(User) bool) ([]User, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil source for passwd-formatted data")
+	}
+
+	var (
+		s   = bufio.NewScanner(r)
+		out = []User{}
+	)
+
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		// see: man 5 passwd
+		//  name:password:UID:GID:GECOS:directory:shell
+		// Name:Pass:Uid:Gid:Gecos:Home:Shell
+		//  root:x:0:0:root:/root:/bin/bash
+		//  adm:x:3:4:adm:/var/adm:/bin/false
+		p := User{}
+		parseLine(line, &p.Name, &p.Pass, &p.Uid, &p.Gid, &p.Gecos, &p.Home, &p.Shell)
+
+		if filter == nil || filter(p) {
+			out = append(out, p)
+		}
+	}
+
+	return out, nil
+}
+
+func ParseGroupFile(path string) ([]Group, error) {
+	group, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer group.Close()
+	return ParseGroup(group)
+}
+
+func ParseGroup(group io.Reader) ([]Group, error) {
+	return ParseGroupFilter(group, nil)
+}
+
+func ParseGroupFileFilter(path string, filter func(Group) bool) ([]Group, error) {
+	group, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer group.Close()
+	return ParseGroupFilter(group, filter)
+}
+
+func ParseGroupFilter(r io.Reader, filter func(Group) bool) ([]Group, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil source for group-formatted data")
+	}
+
+	var (
+		s   = bufio.NewScanner(r)
+		out = []Group{}
+	)
+
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+
+		text := s.Text()
+		if text == "" {
+			continue
+		}
+
+		// see: man 5 group
+		//  group_name:password:GID:user_list
+		// Name:Pass:Gid:List
+		//  root:x:0:root
+		//  adm:x:4:root,adm,daemon
+		p := Group{}
+		parseLine(text, &p.Name, &p.Pass, &p.Gid, &p.List)
+
+		if filter == nil || filter(p) {
+			out = append(out, p)
+		}
+	}
+
+	return out, nil
+}
+
+type ExecUser struct {
+	Uid   int
+	Gid   int
+	Sgids []int
+	Home  string
+}
+
+// GetExecUserPath is a wrapper for GetExecUser. It reads data from each of the
+// given file paths and uses that data as the arguments to GetExecUser. If the
+// files cannot be opened for any reason, the error is ignored and a nil
+// io.Reader is passed instead.
+func GetExecUserPath(userSpec string, defaults *ExecUser, passwdPath, groupPath string) (*ExecUser, error) {
+	passwd, err := os.Open(passwdPath)
+	if err != nil {
+		passwd = nil
+	} else {
+		defer passwd.Close()
+	}
+
+	group, err := os.Open(groupPath)
+	if err != nil {
+		group = nil
+	} else {
+		defer group.Close()
+	}
+
+	return GetExecUser(userSpec, defaults, passwd, group)
+}
+
+// GetExecUser parses a user specification string (using the passwd and group
+// readers as sources for /etc/passwd and /etc/group data, respectively). In
+// the case of blank fields or missing data from the sources, the values in
+// defaults is used.
+//
+// GetExecUser will return an error if a user or group literal could not be
+// found in any entry in passwd and group respectively.
+//
+// Examples of valid user specifications are:
+//     * ""
+//     * "user"
+//     * "uid"
+//     * "user:group"
+//     * "uid:gid
+//     * "user:gid"
+//     * "uid:group"
+//
+// It should be noted that if you specify a numeric user or group id, they will
+// not be evaluated as usernames (only the metadata will be filled). So attempting
+// to parse a user with user.Name = "1337" will produce the user with a UID of
+// 1337.
+func GetExecUser(userSpec string, defaults *ExecUser, passwd, group io.Reader) (*ExecUser, error) {
+	if defaults == nil {
+		defaults = new(ExecUser)
+	}
+
+	// Copy over defaults.
+	user := &ExecUser{
+		Uid:   defaults.Uid,
+		Gid:   defaults.Gid,
+		Sgids: defaults.Sgids,
+		Home:  defaults.Home,
+	}
+
+	// Sgids slice *cannot* be nil.
+	if user.Sgids == nil {
+		user.Sgids = []int{}
+	}
+
+	// Allow for userArg to have either "user" syntax, or optionally "user:group" syntax
+	var userArg, groupArg string
+	parseLine(userSpec, &userArg, &groupArg)
+
+	// Convert userArg and groupArg to be numeric, so we don't have to execute
+	// Atoi *twice* for each iteration over lines.
+	uidArg, uidErr := strconv.Atoi(userArg)
+	gidArg, gidErr := strconv.Atoi(groupArg)
+
+	// Find the matching user.
+	users, err := ParsePasswdFilter(passwd, func(u User) bool {
+		if userArg == "" {
+			// Default to current state of the user.
+			return u.Uid == user.Uid
+		}
+
+		if uidErr == nil {
+			// If the userArg is numeric, always treat it as a UID.
+			return uidArg == u.Uid
+		}
+
+		return u.Name == userArg
+	})
+
+	// If we can't find the user, we have to bail.
+	if err != nil && passwd != nil {
+		if userArg == "" {
+			userArg = strconv.Itoa(user.Uid)
+		}
+		return nil, fmt.Errorf("unable to find user %s: %v", userArg, err)
+	}
+
+	var matchedUserName string
+	if len(users) > 0 {
+		// First match wins, even if there's more than one matching entry.
+		matchedUserName = users[0].Name
+		user.Uid = users[0].Uid
+		user.Gid = users[0].Gid
+		user.Home = users[0].Home
+	} else if userArg != "" {
+		// If we can't find a user with the given username, the only other valid
+		// option is if it's a numeric username with no associated entry in passwd.
+
+		if uidErr != nil {
+			// Not numeric.
+			return nil, fmt.Errorf("unable to find user %s: %v", userArg, ErrNoPasswdEntries)
+		}
+		user.Uid = uidArg
+
+		// Must be inside valid uid range.
+		if user.Uid < minId || user.Uid > maxId {
+			return nil, ErrRange
+		}
+
+		// Okay, so it's numeric. We can just roll with this.
+	}
+
+	// On to the groups. If we matched a username, we need to do this because of
+	// the supplementary group IDs.
+	if groupArg != "" || matchedUserName != "" {
+		groups, err := ParseGroupFilter(group, func(g Group) bool {
+			// If the group argument isn't explicit, we'll just search for it.
+			if groupArg == "" {
+				// Check if user is a member of this group.
+				for _, u := range g.List {
+					if u == matchedUserName {
+						return true
+					}
+				}
+				return false
+			}
+
+			if gidErr == nil {
+				// If the groupArg is numeric, always treat it as a GID.
+				return gidArg == g.Gid
+			}
+
+			return g.Name == groupArg
+		})
+		if err != nil && group != nil {
+			return nil, fmt.Errorf("unable to find groups for spec %v: %v", matchedUserName, err)
+		}
+
+		// Only start modifying user.Gid if it is in explicit form.
+		if groupArg != "" {
+			if len(groups) > 0 {
+				// First match wins, even if there's more than one matching entry.
+				user.Gid = groups[0].Gid
+			} else if groupArg != "" {
+				// If we can't find a group with the given name, the only other valid
+				// option is if it's a numeric group name with no associated entry in group.
+
+				if gidErr != nil {
+					// Not numeric.
+					return nil, fmt.Errorf("unable to find group %s: %v", groupArg, ErrNoGroupEntries)
+				}
+				user.Gid = gidArg
+
+				// Must be inside valid gid range.
+				if user.Gid < minId || user.Gid > maxId {
+					return nil, ErrRange
+				}
+
+				// Okay, so it's numeric. We can just roll with this.
+			}
+		} else if len(groups) > 0 {
+			// Supplementary group ids only make sense if in the implicit form.
+			user.Sgids = make([]int, len(groups))
+			for i, group := range groups {
+				user.Sgids[i] = group.Gid
+			}
+		}
+	}
+
+	return user, nil
+}
+
+// GetAdditionalGroups looks up a list of groups by name or group id
+// against the given /etc/group formatted data. If a group name cannot
+// be found, an error will be returned. If a group id cannot be found,
+// or the given group data is nil, the id will be returned as-is
+// provided it is in the legal range.
+func GetAdditionalGroups(additionalGroups []string, group io.Reader) ([]int, error) {
+	var groups = []Group{}
+	if group != nil {
+		var err error
+		groups, err = ParseGroupFilter(group, func(g Group) bool {
+			for _, ag := range additionalGroups {
+				if g.Name == ag || strconv.Itoa(g.Gid) == ag {
+					return true
+				}
+			}
+			return false
+		})
+		if err != nil {
+			return nil, fmt.Errorf("Unable to find additional groups %v: %v", additionalGroups, err)
+		}
+	}
+
+	gidMap := make(map[int]struct{})
+	for _, ag := range additionalGroups {
+		var found bool
+		for _, g := range groups {
+			// if we found a matched group either by name or gid, take the
+			// first matched as correct
+			if g.Name == ag || strconv.Itoa(g.Gid) == ag {
+				if _, ok := gidMap[g.Gid]; !ok {
+					gidMap[g.Gid] = struct{}{}
+					found = true
+					break
+				}
+			}
+		}
+		// we asked for a group but didn't find it. let's check to see
+		// if we wanted a numeric group
+		if !found {
+			gid, err := strconv.Atoi(ag)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to find group %s", ag)
+			}
+			// Ensure gid is inside gid range.
+			if gid < minId || gid > maxId {
+				return nil, ErrRange
+			}
+			gidMap[gid] = struct{}{}
+		}
+	}
+	gids := []int{}
+	for gid := range gidMap {
+		gids = append(gids, gid)
+	}
+	return gids, nil
+}
+
+// GetAdditionalGroupsPath is a wrapper around GetAdditionalGroups
+// that opens the groupPath given and gives it as an argument to
+// GetAdditionalGroups.
+func GetAdditionalGroupsPath(additionalGroups []string, groupPath string) ([]int, error) {
+	group, err := os.Open(groupPath)
+	if err == nil {
+		defer group.Close()
+	}
+	return GetAdditionalGroups(additionalGroups, group)
+}

--- a/vendor/github.com/docker/engine-api-proxy/README.md
+++ b/vendor/github.com/docker/engine-api-proxy/README.md
@@ -1,0 +1,6 @@
+# Proxy server for Docker Engine API
+
+An HTTP Proxy that listens on one socket, and forwards requests to
+a Docker Engine API socket. The proxy can be configured with middleware which
+may modify the the request and the response as it passes through the proxy.
+

--- a/vendor/github.com/docker/engine-api-proxy/dobi.yaml
+++ b/vendor/github.com/docker/engine-api-proxy/dobi.yaml
@@ -1,0 +1,51 @@
+
+meta:
+  project: docker_proxy
+
+mount=source:
+  bind: .
+  path: /go/src/github.com/docker/engine-api-proxy
+
+image=builder:
+  image: docker-proxy-dev
+  context: dobifiles/builder/
+  dockerfile: Dockerfile
+
+image=linter:
+  image: msoap/golang-checks
+  tags: [alpine]
+  pull: "48h"
+
+job=deps:
+  use: builder
+  mounts: [source]
+  command: 'glide install -v'
+
+job=shell:
+  use: builder
+  mounts: [source]
+  interactive: true
+  provide-docker: true
+  command: sh
+
+job=watch:
+  use: builder
+  mounts: [source]
+  interactive: true
+  command: script/watch
+
+job=binary:
+  use: builder
+  mounts: [source]
+  command: script/binary
+
+job=lint:
+  use: linter
+  mounts: [source]
+  working-dir: /go/src/github.com/docker/engine-api-proxy
+  command: gometalinter
+
+job=test-unit:
+  use: builder
+  mounts: [source]
+  command: "bash -c 'go test -v $(glide nv)'"

--- a/vendor/github.com/docker/engine-api-proxy/dobifiles/builder/Dockerfile
+++ b/vendor/github.com/docker/engine-api-proxy/dobifiles/builder/Dockerfile
@@ -1,0 +1,21 @@
+
+FROM    golang:1.7.5-alpine3.5
+
+RUN     apk add -U git bash curl tree
+RUN     git config --global http.https://gopkg.in.followRedirects true
+
+RUN     export GLIDE=v0.12.3; \
+        export SRC=https://github.com/Masterminds/glide/releases/download/; \
+        curl -sL ${SRC}/${GLIDE}/glide-${GLIDE}-linux-amd64.tar.gz | \
+        tar -xz linux-amd64/glide && \
+        mv linux-amd64/glide /usr/bin/glide && \
+        chmod +x /usr/bin/glide
+
+RUN     go get github.com/dnephin/filewatcher && \
+        cp /go/bin/filewatcher /usr/bin/ && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
+WORKDIR /go/src/github.com/docker/engine-api-proxy
+RUN     addgroup docker # used for pinata tests
+ENV     PS1="# "
+ENV     CGO_ENABLED=0

--- a/vendor/github.com/docker/engine-api-proxy/errors/http.go
+++ b/vendor/github.com/docker/engine-api-proxy/errors/http.go
@@ -1,0 +1,35 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// For now, this is used when the proxy directly replies to the client
+// with an error, whithout even proxying the request.
+
+// HTTPError is an error that can be used as a response to an HTTP request.
+// It contains an error message and an HTTP status code.
+type HTTPError struct {
+	HttpStatusCode int
+	ErrorMessage   string
+}
+
+// NewHTTPError returns a newly created HTTPError containing
+// the http status code and error message provided
+func NewHTTPError(httpCode int, errorMsg string) *HTTPError {
+	return &HTTPError{
+		HttpStatusCode: httpCode,
+		ErrorMessage:   errorMsg,
+	}
+}
+
+// Error returns a string representing the error
+func (h *HTTPError) Error() string {
+	return fmt.Sprintf("%v: %s", h.HttpStatusCode, h.ErrorMessage)
+}
+
+// Write writes the error in a http.ResponseWriter
+func (h *HTTPError) Write(w http.ResponseWriter) {
+	http.Error(w, h.ErrorMessage, h.HttpStatusCode)
+}

--- a/vendor/github.com/docker/engine-api-proxy/fakes/net.go
+++ b/vendor/github.com/docker/engine-api-proxy/fakes/net.go
@@ -1,0 +1,208 @@
+package fakes
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	"github.com/docker/engine-api-proxy/types"
+)
+
+// make sure interfaces are properly implemented
+var (
+	_ net.Listener                    = &FakeListener{}
+	_ net.Addr                        = fakeAddr{}
+	_ net.Addr                        = connAddr{}
+	_ net.Conn                        = &Conn{}
+	_ types.CloseWriter               = &Conn{}
+	_ types.ReadWriteCloseCloseWriter = &Conn{}
+)
+
+// FakeListener allows for in-memory, in-process proxying.
+// It is the link between the CLI's http client and the proxy server.
+// How it works:
+// - each in-memory/in-process proxy has a FakeListener
+// - clients obtain connections by calling DialContext()
+// - this creates two net.Conn, that are linked together
+// - one is returned to the client, the other is pushed in a queue
+// - server obtains connections from the queue by calling Accept()
+type FakeListener struct {
+	queue chan net.Conn
+}
+
+// NewListener creates a new FakeListener and returns a pointer to it
+func NewListener() *FakeListener {
+	return &FakeListener{queue: make(chan net.Conn)}
+}
+
+// Accept returns the next connection in the queue.
+// This function is intended to be used by the in-memory proxy server.
+func (f *FakeListener) Accept() (net.Conn, error) {
+	select {
+	case newConnection := <-f.queue:
+		return newConnection, nil
+	}
+}
+
+// Close ...
+func (f *FakeListener) Close() error {
+	return nil
+}
+
+// Addr ...
+func (f *FakeListener) Addr() net.Addr {
+	return fakeAddr{}
+}
+
+// DialContext returns client connection to the caller.
+func (f *FakeListener) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	serverConn, clientConn := Pipe()
+	f.queue <- serverConn
+	return clientConn, nil
+}
+
+// Pipe creates and return to connected Conn structs
+// (like the net.Pipe() function)
+func Pipe() (*Conn, *Conn) {
+	a1, a2 := net.Pipe()
+	b1, b2 := net.Pipe()
+
+	p1r := &pipe{
+		reader: a1,
+		writer: nil,
+	}
+	p1w := &pipe{
+		reader: nil,
+		writer: b1,
+	}
+
+	p2r := &pipe{
+		reader: b2,
+		writer: nil,
+	}
+	p2w := &pipe{
+		reader: nil,
+		writer: a2,
+	}
+
+	conn1 := &Conn{
+		reader: p1r,
+		writer: p1w,
+	}
+	conn2 := &Conn{
+		reader: p2r,
+		writer: p2w,
+	}
+
+	return conn1, conn2
+}
+
+// Types
+
+type fakeAddr struct{}
+
+func (a fakeAddr) Network() string {
+	return "memory"
+}
+
+func (a fakeAddr) String() string {
+	return "fake"
+}
+
+// Conn implements the net.Conn interface,
+// but also the CloseWriter and CloseReader interfaces.
+// That means it is possible to close each connection way (read or write) separately
+type Conn struct {
+	reader *pipe
+	writer *pipe
+}
+
+func (c *Conn) Read(b []byte) (n int, err error) {
+	return c.reader.Read(b)
+}
+
+func (c *Conn) Write(b []byte) (n int, err error) {
+	return c.writer.Write(b)
+}
+
+func (c *Conn) Close() error {
+	err := c.reader.Close()
+	err1 := c.writer.Close()
+	if err == nil {
+		err = err1
+	}
+	return err
+}
+
+func (c *Conn) LocalAddr() net.Addr {
+	return connAddr{}
+}
+
+func (c *Conn) RemoteAddr() net.Addr {
+	return connAddr{}
+}
+
+func (c *Conn) SetDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "fakeconn", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "fakeconn", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return &net.OpError{Op: "set", Net: "fakeconn", Source: nil, Addr: nil, Err: errors.New("deadline not supported")}
+}
+
+// CloseWrite is the implementation of the CloseWriter interface
+func (c *Conn) CloseWrite() error {
+	return c.writer.Close()
+}
+
+// CloseRead is the implementation of the CloseReader interface
+func (c *Conn) CloseRead() error {
+	return c.reader.Close()
+}
+
+/////
+
+type connAddr struct{}
+
+func (connAddr) Network() string {
+	return "fakeconn"
+}
+
+func (connAddr) String() string {
+	return "fakeconn"
+}
+
+/////
+
+type pipe struct {
+	reader net.Conn
+	writer net.Conn
+}
+
+func (p *pipe) Read(b []byte) (n int, err error) {
+	return p.reader.Read(b)
+}
+
+func (p *pipe) Write(b []byte) (n int, err error) {
+	return p.writer.Write(b)
+}
+
+func (p *pipe) Close() error {
+	var err error
+	if p.reader != nil {
+		err = p.reader.Close()
+	}
+	var err1 error
+	if p.writer != nil {
+		err1 = p.writer.Close()
+	}
+	if err == nil {
+		err = err1
+	}
+	return err
+}

--- a/vendor/github.com/docker/engine-api-proxy/glide.lock
+++ b/vendor/github.com/docker/engine-api-proxy/glide.lock
@@ -1,0 +1,114 @@
+hash: 3d1275539423a8a4ff1f31c242c36b1a62ade5727a5df060f6e2107298ef3c4b
+updated: 2017-05-09T21:20:15.65011855Z
+imports:
+- name: github.com/dnephin/go-os-user
+  version: 44e2994deb1ed3c8bf21e28cbd5d2e3107b35e0b
+- name: github.com/docker/distribution
+  version: 0700fa570d7bcc1b3e46ee127c4489fd25f4daa3
+  subpackages:
+  - digestset
+  - reference
+- name: github.com/docker/docker
+  version: 1a6f8a92b2c5912058828d560f52281ba0424472
+  repo: https://github.com/moby/moby
+  subpackages:
+  - api
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/image
+  - api/types/mount
+  - api/types/network
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/time
+  - api/types/versions
+  - api/types/volume
+  - client
+  - pkg/idtools
+  - pkg/ioutils
+  - pkg/longpath
+  - pkg/parsers
+  - pkg/random
+  - pkg/stringid
+  - pkg/sysinfo
+  - pkg/system
+  - pkg/tlsconfig
+  - runconfig
+  - volume
+- name: github.com/docker/go-connections
+  version: a2afab9802043837035592f1c24827fb70766de9
+  subpackages:
+  - nat
+  - sockets
+  - tlsconfig
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/docker/libtrust
+  version: aabc10ec26b754e797f9028f4589c5b7bd90dc20
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/mux
+  version: e6d8883c5d26ee0e6146b7ea7793a131fcf551f2
+  repo: https://github.com/dnephin/mux
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/Microsoft/go-winio
+  version: fff283ad5116362ca252298cfc9b95828956d85d
+- name: github.com/opencontainers/go-digest
+  version: aa2ec055abd10d26d539eb630a92241b781ce4bc
+- name: github.com/opencontainers/runc
+  version: ef9a4b315558d31eae520725ff67383c2f79c3cb
+  subpackages:
+  - libcontainer/cgroups
+  - libcontainer/configs
+  - libcontainer/user
+- name: github.com/opencontainers/runtime-spec
+  version: e659613ba5a720bcc11afa54461970a6eec163a7
+  subpackages:
+  - specs-go
+- name: github.com/opencontainers/selinux
+  version: 63bd19516561f1973f86c9f777b263ee1e0db140
+  subpackages:
+  - go-selinux
+  - go-selinux/label
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/rneugeba/virtsock
+  version: 6b4dec728264e07c41e108caebd6bc2b72559a5f
+  subpackages:
+  - pkg/hvsock
+- name: github.com/Sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
+- name: github.com/spf13/cobra
+  version: 7be4beda01ec05d0b93d80b3facd2b6f44080d94
+- name: github.com/spf13/pflag
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require
+- name: golang.org/x/net
+  version: a6577fac2d73be281a500b310739095313165611
+  subpackages:
+  - context
+  - context/ctxhttp
+  - proxy
+- name: golang.org/x/sys
+  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  subpackages:
+  - unix
+  - windows
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/vendor/github.com/docker/engine-api-proxy/glide.yaml
+++ b/vendor/github.com/docker/engine-api-proxy/glide.yaml
@@ -1,0 +1,22 @@
+package: github.com/docker/engine-api-proxy
+import:
+- package: github.com/spf13/cobra
+- package: github.com/Sirupsen/logrus
+  version: ~0.11.5
+- package: github.com/pkg/errors
+  version: ^0.8.0
+- package: github.com/gorilla/mux
+  repo: https://github.com/dnephin/mux
+- package: github.com/docker/go-connections
+  subpackages:
+  - sockets
+- package: github.com/docker/docker
+  repo: https://github.com/moby/moby
+  subpackages:
+  - api/types
+  - client
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+- package: github.com/dnephin/go-os-user

--- a/vendor/github.com/docker/engine-api-proxy/httputils/httputils.go
+++ b/vendor/github.com/docker/engine-api-proxy/httputils/httputils.go
@@ -1,0 +1,42 @@
+package httputils
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/docker/docker/api"
+)
+
+// Copied from github.com/docker/docker/api/server/httputils/httputils.go
+// without the nasty dependency graph
+
+// CheckForJSON makes sure that the request's Content-Type is application/json.
+func CheckForJSON(r *http.Request) error {
+	ct := r.Header.Get("Content-Type")
+
+	// No Content-Type header is ok as long as there's no Body
+	if ct == "" {
+		if r.Body == nil || r.ContentLength == 0 {
+			return nil
+		}
+	}
+
+	// Otherwise it better be json
+	if api.MatchesContentType(ct, "application/json") {
+		return nil
+	}
+	return fmt.Errorf("Content-Type specified (%s) must be 'application/json'", ct)
+}
+
+// ParseForm ensures the request form is parsed even with invalid content types.
+// If we don't do this, POST method without Content-type (even with empty body) will fail.
+func ParseForm(r *http.Request) error {
+	if r == nil {
+		return nil
+	}
+	if err := r.ParseForm(); err != nil && !strings.HasPrefix(err.Error(), "mime:") {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/container.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/container.go
@@ -1,0 +1,51 @@
+package json
+
+import (
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/runconfig"
+)
+
+type ContainerCreateBody struct {
+	*container.Config
+	HostConfig       *container.HostConfig
+	NetworkingConfig *network.NetworkingConfig
+}
+
+// DecodeContainers decodes a json request body and returns a list of container
+// summaries
+func DecodeContainers(body io.Reader) ([]types.Container, error) {
+	var cs []types.Container
+	return cs, decode(body, &cs)
+}
+
+// DecodeContainer decodes a json request body and returns a container object
+func DecodeContainerCreate(body io.Reader) (ContainerCreateBody, error) {
+	var container ContainerCreateBody
+	return container, decode(body, &container)
+}
+
+// DecodeContainer decodes a json request body and returns a container object
+func DecodeContainer(body io.Reader) (types.ContainerJSON, error) {
+	var container types.ContainerJSON
+	return container, decode(body, &container)
+}
+
+// DecodeContainerStart decodes a json request body and returns a
+// ContainerConfigWrapper. The body may be either an a legacy body with a JSON config,
+// or docker-compose passing {} instead of the empty body.
+func DecodeContainerStart(body io.Reader) (*runconfig.ContainerConfigWrapper, error) {
+	var wrapper runconfig.ContainerConfigWrapper
+	err := decode(body, &wrapper)
+	switch err {
+	case io.EOF:
+		return nil, nil
+	case nil:
+		return &wrapper, nil
+	default:
+		return nil, err
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/json.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/json.go
@@ -1,0 +1,85 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+)
+
+// Encode json encodes obj and returns it as a ReadCloser
+func Encode(obj interface{}) (int, io.ReadCloser, error) {
+	var b bytes.Buffer
+	if obj == nil {
+		return 0, ioutil.NopCloser(&b), nil
+	}
+
+	encoder := json.NewEncoder(&b)
+	if err := encoder.Encode(&obj); err != nil {
+		log.Warnf("Failed to re-encode %T: %s\n", obj, err)
+		return -1, nil, err
+	}
+	return b.Len(), ioutil.NopCloser(&b), nil
+}
+
+// EncodeBody json encodes obj and returns a request with the object in the body
+func EncodeBody(obj interface{}, req *http.Request) (*http.Request, error) {
+	var size int
+	var err error
+	size, req.Body, err = Encode(obj)
+	req.ContentLength = int64(size)
+	return req, err
+}
+
+func decode(body io.Reader, obj interface{}) error {
+	decoder := json.NewDecoder(body)
+	if err := decoder.Decode(obj); err != nil {
+		log.Warnf("Failed to decode %T: %s\n", obj, err)
+		return err
+	}
+	return nil
+}
+
+type namedFields struct {
+	Name   string
+	Labels map[string]string
+}
+
+// Named objects are used to partially decode a json object that has a name and
+// labels. The rest of the structure is untouched.
+type Named struct {
+	namedFields
+	raw map[string]interface{}
+}
+
+func (n *Named) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &n.namedFields); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal Named")
+	}
+	return json.Unmarshal(data, &n.raw)
+}
+
+func (n *Named) MarshalJSON() ([]byte, error) {
+	asMap := map[string]interface{}(n.raw)
+	asMap["Name"] = n.Name
+	asMap["Labels"] = n.Labels
+	return json.Marshal(&asMap)
+}
+
+// DecodeNamedObject decodes a json request body and returns a list of Named
+// objects. Both Volumes and Networks can be decoded this way.
+func DecodeNameds(body io.Reader) ([]Named, error) {
+	var named []Named
+	return named, decode(body, &named)
+}
+
+// DecodeNamedObject decodes a json request body and returns a Named object.
+// Both Volumes and Networks can be decoded this way.
+func DecodeNamed(body io.Reader) (Named, error) {
+	var named Named
+	return named, decode(body, &named)
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/json_test.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/json_test.go
@@ -1,0 +1,36 @@
+package json
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Stub struct {
+	Foo string
+}
+
+func TestEncodeObject(t *testing.T) {
+	stub := Stub{Foo: "ok"}
+	expectedSize := 13
+
+	size, reader, err := Encode(&stub)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSize, size)
+
+	buf, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSize, len(buf))
+	assert.Equal(t, `{"Foo":"ok"}`+"\n", string(buf))
+}
+
+func TestEncodeWithNil(t *testing.T) {
+	size, reader, err := Encode(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, size, 0)
+
+	buf, err := ioutil.ReadAll(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(buf))
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/network.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/network.go
@@ -1,0 +1,39 @@
+package json
+
+import (
+	"io"
+
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+type connectedFields struct {
+	Container string
+}
+
+// Connected objects are used to partially decode a json object that has a
+// container name and other fields
+type Connected struct {
+	connectedFields
+	raw map[string]interface{}
+}
+
+func (n *Connected) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &n.connectedFields); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal Connected")
+	}
+	return json.Unmarshal(data, &n.raw)
+}
+
+func (n *Connected) MarshalJSON() ([]byte, error) {
+	asMap := map[string]interface{}(n.raw)
+	asMap["Container"] = n.Container
+	return json.Marshal(&asMap)
+}
+
+// DecodeNetworkConnect decodes a json request body and returns a network
+// connect body
+func DecodeNetworkConnect(body io.Reader) (Connected, error) {
+	var net Connected
+	return net, decode(body, &net)
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/service.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/service.go
@@ -1,0 +1,13 @@
+package json
+
+import (
+	"io"
+
+	"github.com/docker/docker/api/types/swarm"
+)
+
+func DecodeServiceCreate(body io.Reader) (swarm.ServiceSpec, error) {
+	var service swarm.ServiceSpec
+	err := decode(body, &service)
+	return service, err
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/speced.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/speced.go
@@ -1,0 +1,54 @@
+package json
+
+import (
+	"io"
+
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+type specedFields struct {
+	Spec namedFields
+}
+
+// Speced objects are used to partially decode a json object that has a Spec with
+// a name and labels. The rest of the structure is untouched.
+type Speced struct {
+	specedFields
+	raw map[string]interface{}
+}
+
+func (n *Speced) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &n.specedFields); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal Speced")
+	}
+	return json.Unmarshal(data, &n.raw)
+}
+
+func (n *Speced) MarshalJSON() ([]byte, error) {
+	asMap := map[string]interface{}(n.raw)
+	if asMap["Spec"] == nil {
+		asMap["Spec"] = make(map[string]interface{})
+	}
+	innerMap, ok := asMap["Spec"].(map[string]interface{})
+	if !ok {
+		return nil, errors.Errorf("unexpected Spec format")
+	}
+	innerMap["Name"] = n.Spec.Name
+	innerMap["Labels"] = n.Spec.Labels
+	return json.Marshal(&asMap)
+}
+
+// DecodeSpecedObject decodes a json request body and returns a list of Speced
+// objects. Both Volumes and Networks can be decoded this way.
+func DecodeSpeceds(body io.Reader) ([]Speced, error) {
+	var speced []Speced
+	return speced, decode(body, &speced)
+}
+
+// DecodeSpecedObject decodes a json request body and returns a Speced object.
+// Both Volumes and Networks can be decoded this way.
+func DecodeSpeced(body io.Reader) (Speced, error) {
+	var speced Speced
+	return speced, decode(body, &speced)
+}

--- a/vendor/github.com/docker/engine-api-proxy/json/volume.go
+++ b/vendor/github.com/docker/engine-api-proxy/json/volume.go
@@ -1,0 +1,14 @@
+package json
+
+import (
+	"io"
+
+	"github.com/docker/docker/api/types/volume"
+)
+
+// DecodeVolumeList decodes a json request body and returns a list of volumes
+// summaries
+func DecodeVolumeList(body io.Reader) (volume.VolumesListOKBody, error) {
+	var parsedBody volume.VolumesListOKBody
+	return parsedBody, decode(body, &parsedBody)
+}

--- a/vendor/github.com/docker/engine-api-proxy/main.go
+++ b/vendor/github.com/docker/engine-api-proxy/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api"
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/pipeline"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	backend  string
+	listen   string
+	logLevel string
+	scope    string
+	group    string
+}
+
+func newMainCommand() *cobra.Command {
+	opts := options{}
+	cmd := &cobra.Command{
+		Use:           "proxy",
+		Short:         "Proxy the engine API",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("no args allowed")
+			}
+			return runMain(opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.backend, "backend", "b", "unix:///var/run/docker.sock",
+		"Socket or host:port of the engine API to proxy")
+	flags.StringVarP(&opts.listen, "listen", "l", "unix:///var/run/docker-proxy.sock",
+		"Socket or port to listen on")
+	flags.StringVar(&opts.logLevel, "log-level", "INFO", "Log level")
+	flags.StringVar(&opts.scope, "scope", "", "Name of project or pipeline scope")
+	flags.StringVar(&opts.group, "group", "docker", "Group of the listen socket")
+	return cmd
+}
+
+func runMain(opts options) error {
+	if err := setupLogging(opts.logLevel); err != nil {
+		return errors.Wrap(err, "failed to configure logging")
+	}
+
+	client, err := NewClient(opts.backend)
+	if err != nil {
+		return errors.Wrap(err, "failed to create backend client")
+	}
+
+	routes, err := setupDemoMiddleware(opts, client)
+	if err != nil {
+		return err
+	}
+
+	apiProxy, err := proxy.NewProxy(proxy.Options{
+		Listen:      opts.listen,
+		Backend:     opts.backend,
+		SocketGroup: opts.group,
+		Routes:      routes,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to create proxy")
+	}
+	return apiProxy.Start()
+}
+
+// NewClient creates a new Docker API client
+// TODO: move this
+func NewClient(addr string) (client.APIClient, error) {
+	return client.NewClient(addr, api.DefaultVersion, nil, nil)
+}
+
+func setupDemoMiddleware(opts options, client client.APIClient) ([]proxy.MiddlewareRoute, error) {
+	switch {
+	case opts.scope != "":
+		lookup := func() pipeline.Scoper {
+			return pipeline.NewPipelineScoper(opts.scope)
+		}
+		return pipeline.MiddlewareRoutes(client, lookup), nil
+	default:
+		return nil, errors.New("this demo requires --scope")
+	}
+}
+
+func setupLogging(level string) error {
+	logLevel, err := log.ParseLevel(level)
+	log.SetLevel(logLevel)
+	return err
+}
+
+func main() {
+	if err := newMainCommand().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
+		os.Exit(-1)
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/common.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/common.go
@@ -1,0 +1,241 @@
+package pipeline
+
+import (
+	"io"
+	"net/http"
+
+	"fmt"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/errors"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+)
+
+func reqWithLookup(
+	lookup LookupScope,
+	handler func(LookupScope, *mux.Route, *http.Request) (*http.Request, error),
+) proxy.RequestHandler {
+	return func(route *mux.Route, req *http.Request) (*http.Request, error) {
+		return handler(lookup, route, req)
+	}
+}
+
+func respWithLookup(
+	lookup LookupScope,
+	handler func(LookupScope, *http.Response, io.ReadCloser) (int, io.ReadCloser, error),
+) proxy.ResponseHandler {
+	return func(resp *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+		return handler(lookup, resp, body)
+	}
+}
+
+func newObjectListRoute(route *routes.Route, lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           route,
+		RequestHandler:  reqWithLookup(lookup, objectListRequest),
+		ResponseHandler: respWithLookup(lookup, objectListResponse),
+	}
+}
+
+func objectListRequest(lookup LookupScope, _ *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+
+	if err := req.ParseForm(); err != nil {
+		return nil, err
+	}
+	query := req.Form
+	reqFilters, err := filters.FromParam(query.Get("filters"))
+	if err != nil {
+		return nil, err
+	}
+
+	scope.UpdateFilter(reqFilters)
+	filterJSON, err := filters.ToParam(reqFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	query.Set("filters", filterJSON)
+	req.URL.RawQuery = query.Encode()
+	return req, nil
+}
+
+func objectListResponse(lookup LookupScope, _ *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	scope := lookup()
+	nameds, err := json.DecodeNameds(body)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	for i, named := range nameds {
+		nameds[i].Name = scope.DescopeName(named.Name)
+	}
+	return json.Encode(nameds)
+}
+
+type scopePathFunc func(lookup LookupScope, client client.APIClient) *scopePath
+
+func newObjectInspectRoute(
+	route *routes.Route,
+	scopePathFunc scopePathFunc,
+	lookup LookupScope,
+	client client.APIClient,
+) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           route,
+		RequestHandler:  scopePathFunc(lookup, client).request,
+		ResponseHandler: respWithLookup(lookup, objectInspectResponse),
+	}
+}
+
+func objectInspectResponse(lookup LookupScope, resp *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusAlreadyReported {
+		return -1, body, nil
+	}
+
+	scope := lookup()
+	obj, err := json.DecodeNamed(body)
+	if err != nil {
+		return -1, nil, err
+	}
+	obj.Name = scope.DescopeName(obj.Name)
+	return json.Encode(&obj)
+}
+
+func objectCreateRequest(lookup LookupScope, _ *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+
+	named, err := json.DecodeNamed(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	named.Name = scope.ScopeName(named.Name)
+	if named.Labels == nil {
+		named.Labels = make(map[string]string)
+	}
+	scope.AddLabels(named.Labels)
+	return json.EncodeBody(&named, req)
+}
+
+func newObjectUpdateRoute(route *routes.Route, lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          route,
+		RequestHandler: reqWithLookup(lookup, newObjectUpdateRequest),
+	}
+}
+
+func newObjectUpdateRequest(lookup LookupScope, _ *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+
+	named, err := json.DecodeNamed(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	named.Name = scope.ScopeName(named.Name)
+	return json.EncodeBody(&named, req)
+}
+
+func newScopeObjectPath(
+	route *routes.Route,
+	scopePathFunc scopePathFunc,
+	lookup LookupScope,
+	client client.APIClient,
+) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          route,
+		RequestHandler: scopePathFunc(lookup, client).request,
+	}
+}
+
+// inspector is the common interface for all client inspect methods
+type inspector func(ctx context.Context, nameOrID string) (*labeled, error)
+
+type labeled struct {
+	ID     string
+	Labels map[string]string
+}
+
+type scopePath struct {
+	lookup    LookupScope
+	inspector inspector
+	// getVars is a shim for testing, could be removed with a patch to
+	// gorilla/mux to allow setting the relevant context values
+	getVars func(req *http.Request) map[string]string
+}
+
+func (n *scopePath) request(route *mux.Route, req *http.Request) (*http.Request, error) {
+	if n.getVars == nil {
+		n.getVars = mux.Vars
+	}
+	nameOrID := n.getVars(req)["name"]
+	version := n.getVars(req)["version"]
+	scope := n.lookup()
+
+	// TODO: maybe cache these lookups?
+	scoped, err := n.scope(req.Context(), nameOrID, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := route.URL("name", scoped, "version", version)
+	url.RawQuery = req.URL.RawQuery
+	req.URL = url
+
+	return req, err
+}
+
+// needsScoping determines whether a docker object identifier (id or name) needs
+// to be scoped (prefixed) before the request is sent to the actual Docker daemon.
+// This function is used in the request handler of the proxy.
+func (n *scopePath) needsScoping(ctx context.Context, nameOrID string, scope Scoper) (bool, error) {
+	obj, err := n.inspector(ctx, nameOrID)
+	switch {
+	case err == nil:
+		// nameOrID matched either an id, or a name (prefixed or not).
+		// Only return the request unmodified if it's an id or
+		// the container name isn't already scoped.
+		if scope.IsInScope(obj.Labels) && isUnscopedName(nameOrID, scope) {
+			return false, nil
+		}
+	case client.IsErrNotFound(err):
+		// nothing found with that nameOrID, so mutate the name
+	default:
+		return false, err
+	}
+	return true, nil
+}
+
+// scope returns scoped name, or an error if the scoped name matches
+// an object that is out of scope
+func (n *scopePath) scope(ctx context.Context, nameOrID string, scope Scoper) (string, error) {
+	needs, err := n.needsScoping(ctx, nameOrID, scope)
+	switch {
+	case err != nil:
+		return "", err
+	case !needs:
+		return nameOrID, err
+	}
+
+	scoped := scope.ScopeName(nameOrID)
+	obj, err := n.inspector(ctx, scoped)
+	switch {
+	case err == nil:
+		if !scope.IsInScope(obj.Labels) {
+			return "", errors.NewHTTPError(
+				http.StatusNotFound, fmt.Sprintf("%q not found", nameOrID))
+		}
+	case client.IsErrNotFound(err):
+	default:
+		return "", err
+	}
+	return scoped, nil
+}
+
+func isUnscopedName(nameOrID string, scope Scoper) bool {
+	return nameOrID == scope.DescopeName(nameOrID)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/common_test.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/common_test.go
@@ -1,0 +1,289 @@
+package pipeline
+
+import (
+	gojson "encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func defaultLookup() Scoper {
+	return NewProjectScoper("myproject")
+}
+
+type argsBuilder struct {
+	args filters.Args
+}
+
+func newArgs() argsBuilder {
+	return argsBuilder{args: filters.NewArgs()}
+}
+
+func (a argsBuilder) add(key, value string) argsBuilder {
+	a.args.Add(key, value)
+	return a
+}
+
+func (a argsBuilder) values(t *testing.T) url.Values {
+	values := url.Values{}
+	encoded, err := filters.ToParam(a.args)
+	assert.NoError(t, err)
+	values.Add("filters", encoded)
+	return values
+}
+
+func TestObjectListRequest(t *testing.T) {
+	expectedLabel := func() argsBuilder {
+		return newArgs().add("label", projectLabel+"=myproject")
+	}
+
+	var cases = []struct {
+		doc      string
+		filters  argsBuilder
+		expected argsBuilder
+	}{
+		{
+			doc:      "No Filters",
+			expected: expectedLabel(),
+		},
+		{
+			doc:      "Filter by name",
+			filters:  newArgs().add("name", "foo"),
+			expected: expectedLabel().add("name", "myproject_foo"),
+		},
+		{
+			doc: "Filter by labels and a name",
+			filters: newArgs().add(
+				"name", "foo").add(
+				"label", "com.example=zoom"),
+			expected: expectedLabel().add(
+				"label", "com.example=zoom").add(
+				"name", "myproject_foo"),
+		},
+	}
+
+	for _, testcase := range cases {
+		query := testcase.filters.values(t).Encode()
+		input, err := http.NewRequest("GET", "/containers?"+query, nil)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+
+		req, err := objectListRequest(defaultLookup, nil, input)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+		if !assert.NoError(t, req.ParseForm(), testcase.doc) {
+			continue
+		}
+		assert.Equal(t, testcase.expected.values(t), req.Form, testcase.doc)
+	}
+}
+
+func TestObjectListResponse(t *testing.T) {
+	volumes := []types.Volume{{Name: "myproject_foo", Scope: "local"}}
+	expected := []types.Volume{{Name: "foo", Scope: "local"}}
+	_, encoded, err := json.Encode(volumes)
+	require.NoError(t, err)
+
+	size, reader, err := objectListResponse(defaultLookup, nil, encoded)
+	require.NoError(t, err)
+	assert.Equal(t, 90, size)
+	actual := []types.Volume{}
+	err = gojson.NewDecoder(reader).Decode(&actual)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestObjectInspectResponse(t *testing.T) {
+	volume := types.Volume{Name: "myproject_foo", Scope: "local"}
+	expected := types.Volume{Name: "foo", Scope: "local"}
+	_, encoded, err := json.Encode(volume)
+	require.NoError(t, err)
+
+	resp := &http.Response{StatusCode: http.StatusOK}
+	size, reader, err := objectInspectResponse(defaultLookup, resp, encoded)
+	require.NoError(t, err)
+	assert.Equal(t, 88, size)
+	actual := types.Volume{}
+	err = gojson.NewDecoder(reader).Decode(&actual)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestObjectCreateRequest(t *testing.T) {
+	var cases = []struct {
+		doc          string
+		name         string
+		expectedName string
+		labels       map[string]string
+	}{
+		{
+			doc: "No name, no labels",
+		},
+		{
+			doc:          "With a name",
+			name:         "foo",
+			expectedName: "myproject_foo",
+		},
+		{
+			doc:    "With labels",
+			labels: map[string]string{"something": "else"},
+		},
+	}
+
+	for _, testcase := range cases {
+		network := types.NetworkCreateRequest{
+			Name:          testcase.name,
+			NetworkCreate: types.NetworkCreate{Labels: testcase.labels},
+		}
+		labels := copyLabels(testcase.labels)
+		labels[projectLabel] = "myproject"
+		expected := types.NetworkCreateRequest{
+			Name:          testcase.expectedName,
+			NetworkCreate: types.NetworkCreate{Labels: labels},
+		}
+
+		_, body, err := json.Encode(network)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		input, err := http.NewRequest("GET", "/network/create", body)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+		req, err := objectCreateRequest(defaultLookup, nil, input)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+		actual := types.NetworkCreateRequest{}
+		err = gojson.NewDecoder(req.Body).Decode(&actual)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+		assert.Equal(t, expected, actual)
+	}
+}
+
+func copyLabels(source map[string]string) map[string]string {
+	result := map[string]string{}
+	if source == nil {
+		return result
+	}
+	for k, v := range source {
+		result[k] = v
+	}
+	return result
+}
+
+func TestScopePathRequest(t *testing.T) {
+	scopeLabels := map[string]string{projectLabel: "myproject"}
+	var cases = []struct {
+		doc           string
+		nameOrID      string
+		labeled       *labeled
+		verifyLabeled *labeled
+		expected      string
+		query         string
+		expectError   string
+	}{
+		{
+			doc:      "Scoped name should get double scoped",
+			nameOrID: "myproject_gibs",
+			labeled:  &labeled{ID: "aaaaaaa", Labels: scopeLabels},
+			expected: "/containers/myproject_myproject_gibs",
+		},
+		{
+			doc:      "ID should not be scoped",
+			nameOrID: "aaaaaaa",
+			labeled:  &labeled{ID: "aaaaaaa", Labels: scopeLabels},
+			expected: "/containers/aaaaaaa",
+		},
+		{
+			doc:      "Unscoped name should be scoped",
+			nameOrID: "gibs",
+			expected: "/containers/myproject_gibs?foo=zoom",
+			query:    "?foo=zoom",
+		},
+		{
+			doc:      "Unscoped name matches an unscoped object, needs to be scoped",
+			nameOrID: "gibs",
+			labeled:  &labeled{ID: "aaaaaaa", Labels: map[string]string{}},
+			expected: "/containers/myproject_gibs",
+		},
+		{
+			doc:      "Unscoped name is already in scope, should not be scoped",
+			nameOrID: "random_name",
+			labeled:  &labeled{ID: "aaaaaaa", Labels: scopeLabels},
+			expected: "/containers/random_name?foo=zoom",
+			query:    "?foo=zoom",
+		},
+		{
+			doc:           "Scoped name matches an object that is out of scope",
+			nameOrID:      "name",
+			verifyLabeled: &labeled{ID: "aaaaaaa", Labels: map[string]string{}},
+			expectError:   "\"name\" not found",
+		},
+	}
+
+	for _, testcase := range cases {
+		path := scopePath{
+			lookup:    defaultLookup,
+			inspector: newMockInspector(testcase.labeled, testcase.verifyLabeled),
+			getVars: func(_ *http.Request) map[string]string {
+				return map[string]string{
+					"name":    testcase.nameOrID,
+					"version": "v1.42",
+				}
+			},
+		}
+		route := routes.ContainerRemove.AsMuxRoute()
+		urlStr := "/containers/" + testcase.nameOrID + testcase.query
+		input, err := http.NewRequest("DELETE", urlStr, nil)
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+
+		req, err := path.request(route, input)
+		if testcase.expectError != "" {
+			if !assert.Error(t, err, testcase.doc) {
+				continue
+			}
+			assert.Contains(t, err.Error(), testcase.expectError, testcase.doc)
+			continue
+		}
+
+		if !assert.NoError(t, err, testcase.doc) {
+			continue
+		}
+		assert.Equal(t, testcase.expected, req.URL.String(), testcase.doc)
+	}
+}
+
+func newMockInspector(labeleds ...*labeled) inspector {
+	index := 0
+	return func(ctx context.Context, nameOrID string) (*labeled, error) {
+		if index >= len(labeleds) {
+			panic("MockInspector is out of labeled")
+		}
+		result := labeleds[index]
+		index++
+		if result == nil {
+			return nil, notFound{}
+		}
+		return result, nil
+	}
+}
+
+type notFound struct{}
+
+func (n notFound) NotFound() bool { return true }
+func (n notFound) Error() string  { return "oops" }

--- a/vendor/github.com/docker/engine-api-proxy/namespace/container.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/container.go
@@ -1,0 +1,161 @@
+package pipeline
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	json "github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+)
+
+func newContainerCreateRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          routes.ContainerCreate,
+		RequestHandler: reqWithLookup(lookup, containerCreateRequest),
+	}
+}
+
+func newContainerCommitRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          routes.ContainerCommit,
+		RequestHandler: reqWithLookup(lookup, containerCommitRequest),
+	}
+}
+
+func containerCreateRequest(lookup LookupScope, _ *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+
+	query := req.URL.Query()
+	// add prefix to container name when receiving a user-defined container name
+	if name := query.Get("name"); name != "" {
+		query.Set("name", scope.ScopeName(name))
+	}
+	req.URL.RawQuery = query.Encode()
+
+	// decode request body
+	body, err := json.DecodeContainerCreate(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// add container labels
+	if body.Config.Labels == nil {
+		body.Config.Labels = make(map[string]string)
+	}
+	scope.AddLabels(body.Config.Labels)
+
+	// scope network names
+	hostConfig := body.HostConfig
+	if hostConfig.NetworkMode.IsUserDefined() {
+		v := hostConfig.NetworkMode.UserDefined()
+		hostConfig.NetworkMode = container.NetworkMode(scope.ScopeName(v))
+	}
+	if body.NetworkingConfig != nil {
+		var newEndpointsConfig map[string]*network.EndpointSettings = make(map[string]*network.EndpointSettings)
+		for key, _ := range body.NetworkingConfig.EndpointsConfig {
+			scopedKey := scope.ScopeName(key)
+			newEndpointsConfig[scopedKey] = body.NetworkingConfig.EndpointsConfig[key]
+		}
+		body.NetworkingConfig.EndpointsConfig = newEndpointsConfig
+	}
+
+	return json.EncodeBody(&body, req)
+}
+
+// containerCommitRequest is the request handler for the /commit path.
+// ($ docker container commit)
+func containerCommitRequest(lookup LookupScope, route *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+	query := req.URL.Query()
+	containerName := query.Get("container")
+	if containerName != "" {
+		query.Set("container", scope.ScopeName(containerName))
+	}
+	req.URL.RawQuery = query.Encode()
+	return req, nil
+}
+
+func newScopeContainerPath(route *routes.Route, lookup LookupScope, client client.APIClient) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          route,
+		RequestHandler: newContainerScopePath(lookup, client).request,
+	}
+}
+
+// newConatinerInspectRoute returns a route which scopes the inspect response.
+// The request is scoped by scopePath.
+func newContainerInspectRoute(lookup LookupScope, client client.APIClient) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.ContainerInspect,
+		RequestHandler:  newContainerScopePath(lookup, client).request,
+		ResponseHandler: respWithLookup(lookup, containerInspectResponse),
+	}
+}
+
+func newContainerScopePath(lookup LookupScope, client client.APIClient) *scopePath {
+	inspector := func(ctx context.Context, nameOrID string) (*labeled, error) {
+		container, _, err := client.ContainerInspectWithRaw(ctx, nameOrID, false)
+		if err != nil {
+			return nil, err
+		}
+		return &labeled{ID: container.ID, Labels: container.Config.Labels}, nil
+	}
+	return &scopePath{lookup: lookup, inspector: inspector}
+}
+
+func containerInspectResponse(lookup LookupScope, resp *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	if resp.StatusCode != http.StatusOK {
+		return -1, body, nil
+	}
+
+	scope := lookup()
+	container, err := json.DecodeContainer(body)
+	if err != nil {
+		return -1, nil, err
+	}
+	container.Name = descopeContainerName(scope, container.Name)
+	// TODO: descope any references to scoped resources
+	return json.Encode(&container)
+}
+
+func newContainerListRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.ContainerList,
+		RequestHandler:  reqWithLookup(lookup, objectListRequest),
+		ResponseHandler: respWithLookup(lookup, containerListResponse),
+	}
+}
+
+func containerListResponse(lookup LookupScope, _ *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	scope := lookup()
+	containers, err := json.DecodeContainers(body)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	for i, container := range containers {
+		// TODO: does this need to descope image, volume, network name as well?
+		containers[i].Names = descopeNames(scope, container.Names)
+	}
+
+	return json.Encode(&containers)
+}
+
+func descopeNames(scope Scoper, names []string) []string {
+	result := []string{}
+	for _, name := range names {
+		result = append(result, descopeContainerName(scope, name))
+	}
+	return result
+}
+
+func descopeContainerName(scope Scoper, name string) string {
+	return "/" + scope.DescopeName(strings.TrimPrefix(name, "/"))
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/container_test.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/container_test.go
@@ -1,0 +1,25 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerListResponse(t *testing.T) {
+	containers := []types.Container{{Names: []string{"/myproject_foo"}}}
+	expected := []types.Container{{Names: []string{"/foo"}}}
+	_, encoded, err := json.Encode(containers)
+	require.NoError(t, err)
+
+	size, reader, err := containerListResponse(defaultLookup, nil, encoded)
+
+	require.NoError(t, err)
+	assert.Equal(t, 181, size)
+	actual, err := json.DecodeContainers(reader)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/network.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/network.go
@@ -1,0 +1,63 @@
+package pipeline
+
+import (
+	"net/http"
+
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+)
+
+func newNetworkScopePath(lookup LookupScope, client client.APIClient) *scopePath {
+	inspector := func(ctx context.Context, nameOrID string) (*labeled, error) {
+		network, _, err := client.NetworkInspectWithRaw(ctx, nameOrID, false)
+		if err != nil {
+			return nil, err
+		}
+		return &labeled{ID: network.ID, Labels: network.Labels}, nil
+	}
+	return &scopePath{lookup: lookup, inspector: inspector}
+}
+
+func newNetworkCreateRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          routes.NetworkCreate,
+		RequestHandler: reqWithLookup(lookup, objectCreateRequest),
+	}
+}
+
+func newNetworkConnectRoute(route *routes.Route, lookup LookupScope, client client.APIClient) proxy.MiddlewareRoute {
+	containerScopePath := newContainerScopePath(lookup, client)
+	connect := &networkConnectRoute{
+		containerScopePath: containerScopePath,
+		lookup:             lookup,
+	}
+	return proxy.MiddlewareRoute{
+		Route:          route,
+		RequestHandler: connect.request,
+	}
+}
+
+type networkConnectRoute struct {
+	containerScopePath *scopePath
+	lookup             LookupScope
+}
+
+func (n *networkConnectRoute) request(route *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := n.lookup()
+
+	net, err := json.DecodeNetworkConnect(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	scoped, err := n.containerScopePath.scope(req.Context(), net.Container, scope)
+	if err != nil {
+		return nil, err
+	}
+	net.Container = scoped
+	return json.EncodeBody(&net, req)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/network_test.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/network_test.go
@@ -1,0 +1,42 @@
+package pipeline
+
+import (
+	gojson "encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkConnectRequest(t *testing.T) {
+	path := &scopePath{
+		inspector: newMockInspector(&labeled{ID: "aaaaaa"}, nil),
+	}
+	route := &networkConnectRoute{
+		lookup:             defaultLookup,
+		containerScopePath: path,
+	}
+	network := types.NetworkDisconnect{
+		Container: "gibs",
+		Force:     true,
+	}
+	expected := types.NetworkDisconnect{
+		Container: "myproject_gibs",
+		Force:     true,
+	}
+
+	_, body, err := json.Encode(network)
+	require.NoError(t, err)
+	input, err := http.NewRequest("POST", "/network/foo", body)
+
+	req, err := route.request(nil, input)
+	require.NoError(t, err)
+
+	actual := types.NetworkDisconnect{}
+	err = gojson.NewDecoder(req.Body).Decode(&actual)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/routes.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/routes.go
@@ -1,0 +1,77 @@
+package pipeline
+
+import (
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+)
+
+// MiddlewareRoutes returns the pipeline middleware routes.
+func MiddlewareRoutes(client client.APIClient, lookup LookupScope) []proxy.MiddlewareRoute {
+	scopedContainerRoute := func(route *routes.Route) proxy.MiddlewareRoute {
+		return newScopeContainerPath(route, lookup, client)
+	}
+
+	return []proxy.MiddlewareRoute{
+		// Container routes
+		newContainerCreateRoute(lookup),
+		newContainerListRoute(lookup),
+		newContainerInspectRoute(lookup, client),
+		newContainerCommitRoute(lookup),
+		scopedContainerRoute(routes.ContainerArchiveGet),
+		scopedContainerRoute(routes.ContainerArchiveHead),
+		scopedContainerRoute(routes.ContainerArchivePut),
+		scopedContainerRoute(routes.ContainerAttach),
+		scopedContainerRoute(routes.ContainerAttachWS),
+		scopedContainerRoute(routes.ContainerRemove),
+		scopedContainerRoute(routes.ContainerKill),
+		scopedContainerRoute(routes.ContainerPause),
+		scopedContainerRoute(routes.ContainerRename),
+		scopedContainerRoute(routes.ContainerResize),
+		scopedContainerRoute(routes.ContainerRestart),
+		scopedContainerRoute(routes.ContainerStart),
+		scopedContainerRoute(routes.ContainerStats),
+		scopedContainerRoute(routes.ContainerStop),
+		scopedContainerRoute(routes.ContainerTop),
+		scopedContainerRoute(routes.ContainerUnpause),
+		scopedContainerRoute(routes.ContainerUpdate),
+		scopedContainerRoute(routes.ContainerWait),
+		scopedContainerRoute(routes.ContainerLogs),
+		scopedContainerRoute(routes.ContainerChanges),
+		scopedContainerRoute(routes.ContainerExport),
+		scopedContainerRoute(routes.ContainerExecCreate),
+
+		// Volume routes
+		newVolumeListRoute(lookup),
+		newObjectInspectRoute(routes.VolumeInspect, newVolumeScopePath, lookup, client),
+		newVolumeCreateRoute(lookup),
+		newScopeObjectPath(routes.VolumeRemove, newVolumeScopePath, lookup, client),
+
+		// Network routes
+		newObjectListRoute(routes.NetworkList, lookup),
+		newObjectInspectRoute(routes.NetworkInspect, newNetworkScopePath, lookup, client),
+		newNetworkCreateRoute(lookup),
+		newScopeObjectPath(routes.NetworkRemove, newNetworkScopePath, lookup, client),
+		newScopeObjectPath(routes.NetworkConnect, newNetworkScopePath, lookup, client),
+		newNetworkConnectRoute(routes.NetworkConnect, lookup, client),
+		newScopeObjectPath(routes.NetworkDisconnect, newNetworkScopePath, lookup, client),
+		newNetworkConnectRoute(routes.NetworkDisconnect, lookup, client),
+
+		// Service routes
+		newServiceListRoute(lookup),
+		newServiceCreateRoute(lookup),
+		newServiceInspectRoute(lookup, client),
+		newScopeObjectPath(routes.ServiceRemove, newServiceScopePath, lookup, client),
+		newScopeObjectPath(routes.ServiceUpdate, newServiceScopePath, lookup, client),
+		newObjectUpdateRoute(routes.ServiceUpdate, lookup),
+		newScopeObjectPath(routes.ServiceLogs, newServiceScopePath, lookup, client),
+
+		// Secret routes
+		newSecretInspectRoute(lookup, client),
+		newSecretCreateRoute(lookup),
+		newSecretListRoute(lookup),
+		newScopeObjectPath(routes.SecretRemove, newSecretScopePath, lookup, client),
+		newScopeObjectPath(routes.SecretUpdate, newSecretScopePath, lookup, client),
+		newObjectUpdateRoute(routes.SecretUpdate, lookup),
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/scope.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/scope.go
@@ -1,0 +1,95 @@
+package pipeline
+
+import (
+	"strings"
+
+	"github.com/docker/docker/api/types/filters"
+)
+
+const (
+	pipelineLabel = "com.docker.pipeline.scope"
+	projectLabel  = "com.docker.project.id"
+	// projectNameLabel = "com.docker.project.name"
+)
+
+// Namespace mangles names by prepending the name
+type Namespace struct {
+	label string
+	name  string
+}
+
+// Scope prepends the namespace to a name
+func (n Namespace) ScopeName(name string) string {
+	if name == "" {
+		return ""
+	}
+	return n.name + "_" + name
+}
+
+// Descope returns the name without the namespace prefix
+func (n Namespace) DescopeName(name string) string {
+	return strings.TrimPrefix(name, n.name+"_")
+}
+
+// Name returns the name of the namespace
+func (n Namespace) Name() string {
+	return n.name
+}
+
+func (n Namespace) IsInScope(labels map[string]string) bool {
+	scope, ok := labels[n.label]
+	return ok && n.name == scope
+}
+
+func (n Namespace) UpdateFilter(reqFilters filters.Args) {
+	reqFilters.Add("label", n.label+"="+n.Name())
+	for _, nameFilter := range reqFilters.Get("name") {
+		reqFilters.Del("name", nameFilter)
+		reqFilters.Add("name", n.ScopeName(nameFilter))
+	}
+}
+
+// NewNamespace returns a new Namespace for scoping of names
+func NewNamespace(name, label string) Namespace {
+	return Namespace{name: name, label: label}
+}
+
+// LookupScope is a function which returns a ScopeInfo
+type LookupScope func() Scoper
+
+// Scoper provides scoping to middleware
+type Scoper interface {
+	ScopeName(string) string
+	DescopeName(string) string
+	AddLabels(map[string]string)
+	UpdateFilter(filters.Args)
+	IsInScope(map[string]string) bool
+}
+
+type pipelineScoper struct {
+	Namespace
+}
+
+func (s *pipelineScoper) AddLabels(labels map[string]string) {
+	labels[s.Namespace.label] = s.Namespace.Name()
+}
+
+func NewPipelineScoper(name string) Scoper {
+	return &pipelineScoper{Namespace: NewNamespace(name, pipelineLabel)}
+}
+
+type projectScoper struct {
+	Namespace
+	humanName string
+}
+
+func (s *projectScoper) AddLabels(labels map[string]string) {
+	labels[projectLabel] = s.Namespace.Name()
+	// labels[projectNameLabel] = s.humanName
+}
+
+func NewProjectScoper(id string) Scoper {
+	return &projectScoper{
+		Namespace: NewNamespace(id, projectLabel),
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/secret.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/secret.go
@@ -1,0 +1,42 @@
+package pipeline
+
+import (
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"golang.org/x/net/context"
+)
+
+func newSecretScopePath(lookup LookupScope, client client.APIClient) *scopePath {
+	inspector := func(ctx context.Context, nameOrID string) (*labeled, error) {
+		secret, _, err := client.SecretInspectWithRaw(ctx, nameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return &labeled{ID: secret.ID, Labels: secret.Spec.Labels}, nil
+	}
+	return &scopePath{lookup: lookup, inspector: inspector}
+}
+
+func newSecretCreateRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          routes.SecretCreate,
+		RequestHandler: reqWithLookup(lookup, objectCreateRequest),
+	}
+}
+
+func newSecretInspectRoute(lookup LookupScope, client client.APIClient) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.SecretInspect,
+		RequestHandler:  newSecretScopePath(lookup, client).request,
+		ResponseHandler: respWithLookup(lookup, specedInspectResponse),
+	}
+}
+
+func newSecretListRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.SecretList,
+		RequestHandler:  reqWithLookup(lookup, objectListRequest),
+		ResponseHandler: respWithLookup(lookup, specedListResponse),
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/service.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/service.go
@@ -1,0 +1,125 @@
+package pipeline
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
+)
+
+func newServiceListRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.ServiceList,
+		RequestHandler:  reqWithLookup(lookup, objectListRequest),
+		ResponseHandler: respWithLookup(lookup, specedListResponse),
+	}
+}
+
+func specedListResponse(lookup LookupScope, _ *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	scope := lookup()
+	services, err := json.DecodeSpeceds(body)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	for i, service := range services {
+		// TODO: does this need to descope image, volume, network name as well?
+		services[i].Spec.Name = scope.DescopeName(service.Spec.Name)
+	}
+	return json.Encode(&services)
+}
+
+func newServiceCreateRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:          routes.ServiceCreate,
+		RequestHandler: reqWithLookup(lookup, serviceCreateRequest),
+	}
+}
+
+func serviceCreateRequest(lookup LookupScope, _ *mux.Route, req *http.Request) (*http.Request, error) {
+	scope := lookup()
+
+	// decode request
+	body, err := json.DecodeServiceCreate(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// scope name
+	if body.Name != "" {
+		body.Name = scope.ScopeName(body.Name)
+	}
+
+	// add labels
+	if body.Labels == nil {
+		body.Labels = make(map[string]string)
+	}
+	scope.AddLabels(body.Labels)
+
+	// scope network names
+	// NOTHING TO DO APPARENTLY
+
+	// scope secret names
+	for i, _ := range body.TaskTemplate.ContainerSpec.Secrets {
+		body.TaskTemplate.ContainerSpec.Secrets[i].SecretName = scope.ScopeName(body.TaskTemplate.ContainerSpec.Secrets[i].SecretName)
+	}
+
+	// scope volume names
+	for i, m := range body.TaskTemplate.ContainerSpec.Mounts {
+		// volumes types:
+		//	- volume
+		// 	- bind
+		// 	- tmpfs
+
+		// ONLY SUPPORT NAMED VOLUMES FOR NOW
+		if m.Type == mount.TypeVolume {
+			body.TaskTemplate.ContainerSpec.Mounts[i].Source = scope.ScopeName(body.TaskTemplate.ContainerSpec.Mounts[i].Source)
+		}
+	}
+
+	return json.EncodeBody(&body, req)
+}
+
+func newServiceInspectRoute(lookup LookupScope, client client.APIClient) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.ServiceInspect,
+		RequestHandler:  newServiceScopePath(lookup, client).request,
+		ResponseHandler: respWithLookup(lookup, specedInspectResponse),
+	}
+}
+
+func newServiceScopePath(lookup LookupScope, client client.APIClient) *scopePath {
+	inspector := func(ctx context.Context, nameOrID string) (*labeled, error) {
+		serviceInspectOpts := types.ServiceInspectOptions{
+			InsertDefaults: true,
+		}
+		service, _, err := client.ServiceInspectWithRaw(ctx, nameOrID, serviceInspectOpts)
+		if err != nil {
+			return nil, err
+		}
+		return &labeled{ID: service.ID, Labels: service.Spec.Labels}, nil
+	}
+	return &scopePath{lookup: lookup, inspector: inspector}
+}
+
+func specedInspectResponse(lookup LookupScope, resp *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	if resp.StatusCode != http.StatusOK {
+		return -1, body, nil
+	}
+
+	scope := lookup()
+	service, err := json.DecodeSpeced(body)
+	if err != nil {
+		return -1, nil, err
+	}
+	service.Spec.Name = scope.DescopeName(service.Spec.Name)
+	// TODO: descope any references to scoped resources
+	return json.Encode(&service)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/service_test.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/service_test.go
@@ -1,0 +1,83 @@
+package pipeline
+
+import (
+	gojson "encoding/json"
+	"net/http"
+	"testing"
+
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/engine-api-proxy/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// utcZero is necessary because json encode/decoded adds the UTC location
+// to all time fields. This causes reflect.DeepEqual() to return false because
+// the time fields are utcZero, instead of time.Time{}
+var utcZero = time.Time{}.UTC()
+var metaZero = swarm.Meta{CreatedAt: utcZero, UpdatedAt: utcZero}
+
+func TestSpecedListResponse(t *testing.T) {
+	secrets := []swarm.Secret{
+		{
+			ID: "abcd",
+			Spec: swarm.SecretSpec{
+				Annotations: swarm.Annotations{Name: "myproject_foo"},
+				Data:        []byte("password"),
+			},
+		},
+	}
+	expected := []swarm.Secret{
+		{
+			ID: "abcd",
+			Spec: swarm.SecretSpec{
+				Annotations: swarm.Annotations{Name: "foo"},
+				Data:        []byte("password"),
+			},
+			Meta: metaZero,
+		},
+	}
+	_, encoded, err := json.Encode(secrets)
+	require.NoError(t, err)
+
+	_, reader, err := specedListResponse(defaultLookup, nil, encoded)
+	require.NoError(t, err)
+
+	actual := []swarm.Secret{}
+	err = gojson.NewDecoder(reader).Decode(&actual)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestSpecedInspectResponse(t *testing.T) {
+	service := swarm.Service{
+		ID: "abcd",
+		Spec: swarm.ServiceSpec{
+			Annotations:  swarm.Annotations{Name: "myproject_foo"},
+			UpdateConfig: &swarm.UpdateConfig{Parallelism: 2},
+		},
+	}
+	expected := swarm.Service{
+		ID: "abcd",
+		Spec: swarm.ServiceSpec{
+			Annotations:  swarm.Annotations{Name: "foo"},
+			UpdateConfig: &swarm.UpdateConfig{Parallelism: 2},
+		},
+		Meta: metaZero,
+	}
+
+	_, encoded, err := json.Encode(service)
+	require.NoError(t, err)
+
+	resp := &http.Response{StatusCode: http.StatusOK}
+	_, reader, err := specedInspectResponse(defaultLookup, resp, encoded)
+	require.NoError(t, err)
+
+	actual := swarm.Service{}
+	err = gojson.NewDecoder(reader).Decode(&actual)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, actual)
+}

--- a/vendor/github.com/docker/engine-api-proxy/namespace/volume.go
+++ b/vendor/github.com/docker/engine-api-proxy/namespace/volume.go
@@ -1,0 +1,56 @@
+package pipeline
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/docker/docker/client"
+	json "github.com/docker/engine-api-proxy/json"
+	"github.com/docker/engine-api-proxy/proxy"
+	"github.com/docker/engine-api-proxy/routes"
+	"golang.org/x/net/context"
+)
+
+// newVolumeListRoute creates the /volumes route, for `docker volume ls`
+func newVolumeListRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.VolumeList,
+		RequestHandler:  reqWithLookup(lookup, objectListRequest),
+		ResponseHandler: respWithLookup(lookup, volumeListResponse),
+	}
+}
+
+// volumeListResponse handles "/volumes" route's response
+func volumeListResponse(lookup LookupScope, _ *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	scope := lookup()
+
+	volumeListBody, err := json.DecodeVolumeList(body)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	for i, volume := range volumeListBody.Volumes {
+		volumeListBody.Volumes[i].Name = scope.DescopeName(volume.Name)
+	}
+
+	return json.Encode(&volumeListBody)
+}
+
+func newVolumeScopePath(lookup LookupScope, client client.APIClient) *scopePath {
+	inspector := func(ctx context.Context, nameOrID string) (*labeled, error) {
+		volume, _, err := client.VolumeInspectWithRaw(ctx, nameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return &labeled{Labels: volume.Labels}, nil
+	}
+	return &scopePath{lookup: lookup, inspector: inspector}
+}
+
+func newVolumeCreateRoute(lookup LookupScope) proxy.MiddlewareRoute {
+	return proxy.MiddlewareRoute{
+		Route:           routes.VolumeCreate,
+		RequestHandler:  reqWithLookup(lookup, objectCreateRequest),
+		ResponseHandler: respWithLookup(lookup, objectInspectResponse),
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/logging.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/logging.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/engine-api-proxy/types"
+)
+
+// check that withLogging is a types.ReadWriteCloseCloseWriter
+var _ types.ReadWriteCloseCloseWriter = &withLogging{}
+
+// A ReadWriteCloseCloseWriter that decorates an underlying ReadWriteWriteCloser and
+// logs all reads and writes.
+type withLogging struct {
+	label      string
+	underlying types.ReadWriteCloseCloseWriter
+}
+
+func (t *withLogging) Read(buf []byte) (int, error) {
+	count, err := t.underlying.Read(buf)
+	log.Debugf("proxy %s -> %s\n", t.label, buf[:count])
+	if err != nil {
+		log.Debugf("proxy %s -> %s\n", t.label, err)
+	}
+	return count, err
+}
+
+func (t *withLogging) Write(buf []byte) (int, error) {
+	log.Debugf("proxy %s <- %s\n", t.label, buf)
+	return t.underlying.Write(buf)
+}
+
+func (t *withLogging) Close() error {
+	log.Debugf("proxy %s <- EOF\n", t.label)
+	return t.underlying.Close()
+}
+
+func (t *withLogging) CloseWrite() error {
+	return t.underlying.CloseWrite()
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/middleware.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/middleware.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/engine-api-proxy/errors"
+	"github.com/docker/engine-api-proxy/routes"
+	"github.com/gorilla/mux"
+)
+
+// MiddlewareRoute is the definition of a route with handlers for modifying the
+// request and the response that match the route.
+type MiddlewareRoute struct {
+	Route           *routes.Route
+	RequestHandler  RequestHandler
+	ResponseHandler ResponseHandler
+}
+
+// RequestHandler accepts a request, and the route that was matched, and returns
+// a new request object. The new request will be made against the backend.
+type RequestHandler func(*mux.Route, *http.Request) (*http.Request, error)
+
+// ResponseHandler accepts a response and the body of a response, and returns a
+// new body for the response
+type ResponseHandler func(*http.Response, io.ReadCloser) (int, io.ReadCloser, error)
+
+type routeHandler struct {
+	routes      []MiddlewareRoute
+	passthru    *passthru
+	cancellable bool
+	route       *mux.Route
+}
+
+func newRouteHandler(route *mux.Route, routes []MiddlewareRoute, passthru *passthru, cancellable bool) *routeHandler {
+	return &routeHandler{
+		routes:      routes,
+		passthru:    passthru,
+		cancellable: cancellable,
+		route:       route,
+	}
+}
+
+func (m *routeHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	req, err := m.wrapRequest(req)
+	if err != nil {
+		if httperror, ok := err.(*errors.HTTPError); ok {
+			httperror.Write(writer)
+			return
+		}
+		writeProxyError(writer)
+		return
+	}
+
+	if err := m.passthru.Passthru(writer, req, m, m.cancellable); err != nil {
+		log.Warn(err)
+		writeProxyError(writer)
+	}
+}
+
+func (m *routeHandler) wrapRequest(req *http.Request) (*http.Request, error) {
+	var err error
+	for _, route := range m.routes {
+		if route.RequestHandler == nil {
+			continue
+		}
+		req, err = route.RequestHandler(m.route, req)
+		if err != nil {
+			log.Warnf("Error in handler %s", err)
+			return nil, err
+		}
+	}
+	return req, nil
+}
+
+func (m *routeHandler) RewriteBody(resp *http.Response, body io.ReadCloser) (int, io.ReadCloser, error) {
+	var size = -1
+	var err error
+	// apply the rewriters in reverse order
+	for i := len(m.routes) - 1; i >= 0; i-- {
+		if m.routes[i].ResponseHandler == nil {
+			continue
+		}
+		size, body, err = m.routes[i].ResponseHandler(resp, body)
+		if err != nil {
+			return -1, nil, err
+		}
+	}
+	return size, body, nil
+}
+
+func newHandlerFromMiddleware(middlewareRoutes []MiddlewareRoute, dailer BackendDialer) (http.Handler, error) {
+	mapping := map[*routes.Route][]MiddlewareRoute{}
+	for _, route := range middlewareRoutes {
+		mapping[route.Route] = append(mapping[route.Route], route)
+	}
+
+	// Add defaults for cancellable routes
+	for route := range cancellableRoutes {
+		if _, exists := mapping[route]; exists {
+			continue
+		}
+		mapping[route] = []MiddlewareRoute{}
+	}
+
+	router := mux.NewRouter()
+	passthru := newPassthru(dailer)
+
+	// TODO: what if order of routes matters? Order routes using constants
+	for route, chain := range mapping {
+		cancellable := cancellableRoutes[route]
+
+		log.Debugf("Adding route %s", route)
+		muxRoute := route.AsMuxRoute()
+		handler := newRouteHandler(muxRoute, chain, passthru, cancellable)
+		router.AddRoute(muxRoute.Handler(handler))
+
+		versioned := route.Versioned()
+		log.Debugf("Adding route %s", versioned)
+		muxRoute = versioned.AsMuxRoute()
+		handler = newRouteHandler(muxRoute, chain, passthru, cancellable)
+		router.AddRoute(muxRoute.Handler(handler))
+	}
+	router.Handle("/{any:.*}", newRouteHandler(&mux.Route{}, nil, passthru, false))
+	return router, nil
+}
+
+var cancellableRoutes = map[*routes.Route]bool{
+	routes.PluginPull:     true,
+	routes.PluginPush:     true,
+	routes.ImageBuild:     true,
+	routes.ImageCreate:    true,
+	routes.ImagePush:      true,
+	routes.Events:         true,
+	routes.ContainerLogs:  true,
+	routes.ContainerStats: true,
+	routes.ServiceLogs:    true,
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/passthru.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/passthru.go
@@ -1,0 +1,254 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/docker/engine-api-proxy/types"
+)
+
+// ResponseRewriter is an interface that can be implemented by Middleware to
+// modifying the response body
+type ResponseRewriter interface {
+	RewriteBody(*http.Response, io.ReadCloser) (int, io.ReadCloser, error)
+}
+
+// NopRewriter implements the ResponseRewriter interface but takes no action
+type NopRewriter struct{}
+
+// RewriteBody does nothing
+func (n NopRewriter) RewriteBody(resp *http.Response, body io.ReadCloser) (int, io.ReadCloser) {
+	return -1, body
+}
+
+// BackendDialer is an interface which provides a connection to a backend
+type BackendDialer interface {
+	Dial() (types.ReadWriteCloseCloseWriter, error)
+}
+
+// WriteFlusher extends the io.Writer interface with http.Flusher
+type WriteFlusher interface {
+	io.Writer
+	http.Flusher
+}
+
+type writeFlusher struct {
+	writer WriteFlusher
+}
+
+func (t *writeFlusher) Write(buf []byte) (int, error) {
+	count, err := t.writer.Write(buf)
+	t.writer.Flush()
+	return count, err
+}
+
+func IsRawStreamUpgrade(resp *http.Response) bool {
+	return (resp.StatusCode == 101 && resp.Header.Get("Upgrade") == "tcp") ||
+		resp.Header.Get("Content-Type") == "application/vnd.docker.raw-stream"
+}
+
+func writeProxyError(writer http.ResponseWriter) {
+	http.Error(writer, "Bad response from Docker Engine", 502)
+}
+
+type passthru struct {
+	backendDialer BackendDialer
+}
+
+func newPassthru(backendDialer BackendDialer) *passthru {
+	return &passthru{backendDialer: backendDialer}
+}
+
+func (p *passthru) Passthru(writer http.ResponseWriter, req *http.Request, rewriter ResponseRewriter, cancellable bool) error {
+	log.Debugf("proxy >> %s %s\n", req.Method, AnonymizeURL(req.URL))
+
+	// Connect to underlying service
+	var underlying types.ReadWriteCloseCloseWriter
+	underlying, err := p.backendDialer.Dial()
+	if err != nil {
+		return err
+	}
+	defer underlying.Close()
+
+	if cancellable {
+		if notifier, ok := writer.(http.CloseNotifier); ok {
+			notify := notifier.CloseNotify()
+			finished := make(chan struct{})
+			defer close(finished)
+			go func() {
+				select {
+				case <-notify:
+					log.Debug("Cancel connection...")
+					underlying.CloseWrite()
+				case <-finished:
+				}
+			}()
+		}
+	}
+
+	return p.doHandleHTTP(underlying, writer, req, rewriter)
+}
+
+func (p *passthru) doHandleHTTP(underlying types.ReadWriteCloseCloseWriter, writer http.ResponseWriter, req *http.Request, rewriter ResponseRewriter) error {
+	underlying = &withLogging{label: "underlying", underlying: underlying}
+
+	// Forward request to underlying
+	requestErrors := make(chan error)
+	go func() {
+		requestErrors <- req.Write(underlying)
+	}()
+
+	// Read response
+	resp, err := http.ReadResponse(bufio.NewReader(underlying), req)
+	if err != nil {
+		log.Warnf("error reading response from Docker: %s", err)
+		writeProxyError(writer)
+		return nil // ??
+	}
+
+	// Forward response to client
+	isRaw := IsRawStreamUpgrade(resp)
+	copyHeaders(writer.Header(), resp.Header)
+	if isRaw {
+		// Stop Go adding a chunked encoding header
+		writer.Header().Set("Transfer-Encoding", "identity")
+		writer.WriteHeader(resp.StatusCode)
+		writer.(http.Flusher).Flush()
+
+		// Attach console - hijack connection
+		err := upgradeToRaw(writer, underlying)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Regular HTTP response
+		newContentLength, body, err := rewriter.RewriteBody(resp, resp.Body)
+		switch {
+		case err != nil:
+			writeProxyError(writer)
+			return nil
+		case newContentLength >= 0:
+			writer.Header().Set(http.CanonicalHeaderKey("content-length"), fmt.Sprintf("%d", newContentLength))
+		}
+		writer.WriteHeader(resp.StatusCode)
+		writer.(http.Flusher).Flush()
+
+		_, err = io.Copy(&writeFlusher{writer: writer.(WriteFlusher)}, body)
+		if err != nil {
+			log.Warnf("error copying response body from Docker: %s", err)
+		}
+		err = resp.Body.Close()
+		if err != nil {
+			log.Warnf("error closing response body from Docker: %s", err)
+		}
+	}
+
+	// Wait for request thread to finish if it's still going
+	err = <-requestErrors
+	if err != nil {
+		log.Warnf("error forwarding client's request to Docker: %s", err)
+	}
+	log.Debugf("proxy << %s %s\n", req.Method, AnonymizeURL(req.URL))
+
+	return nil
+}
+
+func upgradeToRaw(writer http.ResponseWriter, underlying io.ReadWriteCloser) error {
+	log.Debug("Upgrading to raw stream")
+	hj, ok := writer.(http.Hijacker)
+	if !ok {
+		panic("BUG: webserver doesn't support hijacking")
+	}
+
+	conn, bufrw, err := hj.Hijack()
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close()
+	bufrw.Flush()
+	done := make(chan bool)
+
+	// Stream underlying -> conn
+	go func() {
+		var err error
+		n := bufrw.Reader.Buffered()
+		if n > 0 {
+			buf := make([]byte, n)
+			n, err := bufrw.Read(buf)
+			if err != nil {
+				panic(err)
+			}
+			_, err = conn.Write(buf[0:n])
+		}
+		if err != nil {
+			log.Warnf("Error draining buffer: %s", err)
+		} else {
+			_, err := io.Copy(conn, underlying)
+			if err != nil {
+				log.Warnf("Error forwarding raw stream from container: %s", err)
+			}
+			connCloseWriter, ok := conn.(types.CloseWriter)
+			if ok {
+				err = connCloseWriter.CloseWrite()
+				if err != nil {
+					log.Warnf("Error closing raw stream from container: %s", err)
+				}
+			} else {
+				log.Errorln("client connection is not a CloseWriter")
+			}
+		}
+		done <- true
+	}()
+
+	// Stream underlying <- conn
+	_, err = io.Copy(underlying, conn)
+	if err != nil {
+		log.Warnf("Error forwarding raw stream to container: %s", err)
+	}
+
+	underlyingCloseWriter, ok := underlying.(types.CloseWriter)
+	if ok {
+		err = underlyingCloseWriter.CloseWrite()
+		if err != nil {
+			log.Warnf("Error closing raw stream to container: %s", err)
+		}
+	} else {
+		log.Errorln("underlying connection is not a CloseWriter")
+	}
+	<-done
+
+	return nil
+}
+
+// Make dst have the same contents as src
+func copyHeaders(dst, src http.Header) {
+	// http://stackoverflow.com/questions/13812121/how-to-clear-a-map-in-go
+	for k := range dst {
+		delete(dst, k)
+	}
+
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+// AnonymizeURL searches for `username` or `password` in the query string. If any
+// of those is found, the whole query string is redacted.
+// We could be nore precise but since the urls are only printed for debug purpose,
+// it's ok.
+func AnonymizeURL(u *url.URL) string {
+	url := u.String()
+
+	if strings.Contains(u.RawQuery, "username") || strings.Contains(u.RawQuery, "password") {
+		return url[0:strings.Index(url, "?")] + "?[REDACTED]"
+	}
+
+	return url
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/proxy.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/proxy.go
@@ -1,0 +1,124 @@
+/* The Proxy package proxies HTTP and streaming requests to the Engine API.
+
+The proxy listens for requests, runs any transformations that are configured
+for the url and then passes the request along to the backend.
+*/
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/client"
+	"github.com/docker/engine-api-proxy/fakes"
+	"github.com/docker/engine-api-proxy/types"
+	"github.com/docker/go-connections/sockets"
+	"github.com/pkg/errors"
+)
+
+// Options accepted by NewProxy for creating a proxy
+type Options struct {
+	Listen      string
+	Backend     string
+	SocketGroup string
+	Routes      []MiddlewareRoute
+}
+
+// Proxy server which accepts requests and forwards them to a backend
+type Proxy struct {
+	listener net.Listener
+	handler  http.Handler
+}
+
+// GetListener returns the proxy's listener.
+// This is to be used when doing "in-process" proxying.
+func (p *Proxy) GetListener() net.Listener {
+	return p.listener
+}
+
+// NewInMemoryProxy creates an in-memory proxy for "in-process" use
+func NewInMemoryProxy(opts Options) (*Proxy, error) {
+	listener := fakes.NewListener()
+	handler, err := newDefaultHandler(opts.Backend, opts.Routes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create handler")
+	}
+	return &Proxy{listener: listener, handler: handler}, nil
+}
+
+func NewProxy(opts Options) (*Proxy, error) {
+	listener, err := newListener(opts.Listen, opts.SocketGroup)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create listener")
+	}
+	handler, err := newDefaultHandler(opts.Backend, opts.Routes)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create handler")
+	}
+	return &Proxy{listener: listener, handler: handler}, nil
+}
+
+func (p *Proxy) Start() error {
+	log.Debugf("Proxy listening on %s", p.listener.Addr())
+	return http.Serve(p.listener, p.handler)
+}
+
+func newDefaultHandler(addr string, routes []MiddlewareRoute) (http.Handler, error) {
+	dialer, err := newBackendDialer(addr)
+	if err != nil {
+		return nil, err
+	}
+	return newHandlerFromMiddleware(routes, dialer)
+}
+
+func newBackendDialer(host string) (*backendDialer, error) {
+	proto, addr, _, err := client.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+	return &backendDialer{proto: proto, addr: addr}, nil
+}
+
+// TODO: move to new module
+type backendDialer struct {
+	proto string
+	addr  string
+}
+
+// TODO: configurable timeout
+func (s *backendDialer) Dial() (types.ReadWriteCloseCloseWriter, error) {
+	// support Windows named-pipes
+	if s.proto == "npipe" {
+		conn, err := sockets.DialPipe(s.addr, 32*time.Second)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to connect to backend npipe socket")
+		}
+		resultConn, ok := conn.(types.ReadWriteCloseCloseWriter)
+		if !ok {
+			return nil, errors.Wrapf(err, "backend net.Conn does not implement the ReadWriteCloseCloseWriter interface")
+		}
+		return resultConn, nil
+	}
+
+	conn, err := net.DialTimeout(s.proto, s.addr, 32*time.Second)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to connect to backend socket")
+	}
+
+	// when the backend dialer is connected to the actual Docker daemon
+	// using a TCP connection, be sure to send keep-alive messages so
+	// the connection doesn't timeout when no bytes are sent or received
+	// for long periods of time.
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetKeepAlive(true)
+		tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	}
+
+	resultConn, ok := conn.(types.ReadWriteCloseCloseWriter)
+	if !ok {
+		return nil, errors.Wrapf(err, "backend net.Conn does not implement the ReadWriteCloseCloseWriter interface")
+	}
+	return resultConn, nil
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/proxy_others.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/proxy_others.go
@@ -1,0 +1,32 @@
+// +build !windows
+
+package proxy
+
+import (
+	"net"
+
+	user "github.com/dnephin/go-os-user"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/sockets"
+	"github.com/pkg/errors"
+)
+
+func newListener(host, groupname string) (net.Listener, error) {
+	proto, addr, _, err := client.ParseHost(host)
+	if err != nil {
+		return nil, err
+	}
+	switch proto {
+	case "unix":
+		group, err := user.LookupGroup(groupname)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid group %q", groupname)
+		}
+		return sockets.NewUnixSocket(addr, group.Gid)
+	case "tcp", "http":
+		// TODO: support https/tls
+		return net.Listen("tcp", addr)
+	default:
+		return nil, errors.Errorf("unsupported protocol in %s", host)
+	}
+}

--- a/vendor/github.com/docker/engine-api-proxy/proxy/proxy_windows.go
+++ b/vendor/github.com/docker/engine-api-proxy/proxy/proxy_windows.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package proxy
+
+import (
+	"errors"
+	"log"
+	"net"
+)
+
+func newListener(host, groupname string) (net.Listener, error) {
+	log.Fatalln("NOT IMPLEMENTED FOR THIS PLATFORM")
+	return nil, errors.New("NOT IMPLEMENTED FOR THIS PLATFORM")
+}

--- a/vendor/github.com/docker/engine-api-proxy/routes/routes.go
+++ b/vendor/github.com/docker/engine-api-proxy/routes/routes.go
@@ -1,0 +1,101 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+var (
+	ContainerArchiveGet  = New(http.MethodGet, "/containers/{name:.*}/archive")
+	ContainerArchiveHead = New(http.MethodHead, "/containers/{name:.*}/archive")
+	ContainerArchivePut  = New(http.MethodPut, "/containers/{name:.*}/archive")
+	ContainerAttach      = New(http.MethodPost, "/containers/{name:.*}/attach")
+	ContainerAttachWS    = New(http.MethodGet, "/containers/{name:.*}/attach/ws")
+	ContainerChanges     = New(http.MethodGet, "/containers/{name:.*}/changes")
+	ContainerCommit      = New(http.MethodPost, "/commit")
+	ContainerCreate      = New(http.MethodPost, "/containers/create")
+	ContainerExec        = New(http.MethodGet, "/exec/{id:.*}/json")
+	ContainerExecCreate  = New(http.MethodPost, "/containers/{name:.*}/exec")
+	ContainerExecResize  = New(http.MethodPost, "/exec/{id:.*}/resize")
+	ContainerExecStart   = New(http.MethodPost, "/exec/{id:.*}/start")
+	ContainerExport      = New(http.MethodGet, "/containers/{name:.*}/export")
+	ContainerInspect     = New(http.MethodGet, "/containers/{name:.*}/json")
+	ContainerKill        = New(http.MethodPost, "/containers/{name:.*}/kill")
+	ContainerList        = New(http.MethodGet, "/containers/json")
+	ContainerLogs        = New(http.MethodGet, "/containers/{name:.*}/logs")
+	ContainerPause       = New(http.MethodPost, "/containers/{name:.*}/pause")
+	ContainerPrune       = New(http.MethodPost, "/containers/prune")
+	ContainerRemove      = New(http.MethodDelete, "/containers/{name:.*}")
+	ContainerRename      = New(http.MethodPost, "/containers/{name:.*}/rename")
+	ContainerResize      = New(http.MethodPost, "/containers/{name:.*}/resize")
+	ContainerRestart     = New(http.MethodPost, "/containers/{name:.*}/restart")
+	ContainerStart       = New(http.MethodPost, "/containers/{name:.*}/start")
+	ContainerStats       = New(http.MethodGet, "/containers/{name:.*}/stats")
+	ContainerStop        = New(http.MethodPost, "/containers/{name:.*}/stop")
+	ContainerTop         = New(http.MethodGet, "/containers/{name:.*}/top")
+	ContainerUnpause     = New(http.MethodPost, "/containers/{name:.*}/unpause")
+	ContainerUpdate      = New(http.MethodPost, "/containers/{name:.*}/update")
+	ContainerWait        = New(http.MethodPost, "/containers/{name:.*}/wait")
+
+	VolumeList    = New(http.MethodGet, "/volumes")
+	VolumeInspect = New(http.MethodGet, "/volumes/{name:.*}")
+	VolumeCreate  = New(http.MethodPost, "/volumes/create")
+	VolumeRemove  = New(http.MethodDelete, "/volumes/{name:.*}")
+
+	NetworkList       = New(http.MethodGet, "/networks")
+	NetworkInspect    = New(http.MethodGet, "/networks/{name:.*}")
+	NetworkCreate     = New(http.MethodPost, "/networks/create")
+	NetworkRemove     = New(http.MethodDelete, "/networks/{name:.*}")
+	NetworkConnect    = New(http.MethodPost, "/networks/{name:.*}/connect")
+	NetworkDisconnect = New(http.MethodPost, "/networks/{name:.*}/disconnect")
+
+	Events      = New(http.MethodGet, "/events")
+	ImageBuild  = New(http.MethodPost, "/build")
+	ImageCreate = New(http.MethodPost, "/images/create")
+	ImagePush   = New(http.MethodPost, "/images/{name:.*}/push")
+	PluginPull  = New(http.MethodPost, "/plugins/pull")
+	PluginPush  = New(http.MethodPost, "/plugins/{name:.*}/push")
+
+	ServiceList    = New(http.MethodGet, "/services")
+	ServiceCreate  = New(http.MethodPost, "/services/create")
+	ServiceInspect = New(http.MethodGet, "/services/{name:.*}")
+	ServiceRemove  = New(http.MethodDelete, "/services/{name:.*}")
+	ServiceUpdate  = New(http.MethodPost, "/services/{name:.*}/update")
+	ServiceLogs    = New(http.MethodGet, "/services/{name:.*}/logs")
+
+	SecretList    = New(http.MethodGet, "/secrets")
+	SecretCreate  = New(http.MethodPost, "/secrets/create")
+	SecretInspect = New(http.MethodGet, "/secrets/{name:.*}")
+	SecretRemove  = New(http.MethodDelete, "/secrets/{name:.*}")
+	SecretUpdate  = New(http.MethodPost, "/secrets/{name:.*}/update")
+)
+
+// Route is a data object which holds details about a route
+type Route struct {
+	Method string
+	Path   string
+}
+
+// AsMuxRoute returns a mux.Route from the values set in this route
+func (r *Route) AsMuxRoute() *mux.Route {
+	route := &mux.Route{}
+	return route.Methods(r.Method).Path(r.Path)
+}
+
+// Versioned returns a copy of this Route with a version prefixed Path
+func (r *Route) Versioned() *Route {
+	newRoute := *r
+	newRoute.Path = "/v{version:[0-9.]+}" + r.Path
+	return &newRoute
+}
+
+func (r *Route) String() string {
+	return fmt.Sprintf("%s %s", r.Method, r.Path)
+}
+
+// New creates a new route from an HTTP method and a path
+func New(method string, path string) *Route {
+	return &Route{Method: method, Path: path}
+}

--- a/vendor/github.com/docker/engine-api-proxy/script/binary
+++ b/vendor/github.com/docker/engine-api-proxy/script/binary
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+mkdir -p dist
+go build -o dist/proxy .

--- a/vendor/github.com/docker/engine-api-proxy/script/watch
+++ b/vendor/github.com/docker/engine-api-proxy/script/watch
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+exec filewatcher \
+    -x '.git' \
+    -x '.dobi' \
+    -x '.glide' \
+    -x 'vendor' \
+    -x '**/*.swp' \
+    -x 'dist' \
+    -x 'script' \
+    -x 'dobifiles' \
+    -x '.idea' \
+    -- \
+    bash -c 'go test -timeout 20s -v ./${dir} || ( echo; echo; echo; echo; exit 1 )'

--- a/vendor/github.com/docker/engine-api-proxy/types/types.go
+++ b/vendor/github.com/docker/engine-api-proxy/types/types.go
@@ -1,0 +1,14 @@
+package types
+
+import "io"
+
+// CloseWriter allows for a write to be closed
+type CloseWriter interface {
+	CloseWrite() error
+}
+
+// ReadWriteCloseCloseWriter extends io.ReadWriteCloser with CloseWriter
+type ReadWriteCloseCloseWriter interface {
+	io.ReadWriteCloser
+	CloseWriter
+}

--- a/vendor/github.com/gorilla/mux/README.md
+++ b/vendor/github.com/gorilla/mux/README.md
@@ -1,19 +1,45 @@
-mux
+gorilla/mux
 ===
 [![GoDoc](https://godoc.org/github.com/gorilla/mux?status.svg)](https://godoc.org/github.com/gorilla/mux)
 [![Build Status](https://travis-ci.org/gorilla/mux.svg?branch=master)](https://travis-ci.org/gorilla/mux)
+[![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
+
+![Gorilla Logo](http://www.gorillatoolkit.org/static/images/gorilla-icon-64.png)
 
 http://www.gorillatoolkit.org/pkg/mux
 
-Package `gorilla/mux` implements a request router and dispatcher.
+Package `gorilla/mux` implements a request router and dispatcher for matching incoming requests to
+their respective handler.
 
 The name mux stands for "HTTP request multiplexer". Like the standard `http.ServeMux`, `mux.Router` matches incoming requests against a list of registered routes and calls a handler for the route that matches the URL or other conditions. The main features are:
 
+* It implements the `http.Handler` interface so it is compatible with the standard `http.ServeMux`.
 * Requests can be matched based on URL host, path, path prefix, schemes, header and query values, HTTP methods or using custom matchers.
 * URL hosts and paths can have variables with an optional regular expression.
 * Registered URLs can be built, or "reversed", which helps maintaining references to resources.
 * Routes can be used as subrouters: nested routes are only tested if the parent route matches. This is useful to define groups of routes that share common conditions like a host, a path prefix or other repeated attributes. As a bonus, this optimizes request matching.
-* It implements the `http.Handler` interface so it is compatible with the standard `http.ServeMux`.
+
+---
+
+* [Install](#install)
+* [Examples](#examples)
+* [Matching Routes](#matching-routes)
+* [Listing Routes](#listing-routes)
+* [Static Files](#static-files)
+* [Registered URLs](#registered-urls)
+* [Full Example](#full-example)
+
+---
+
+## Install
+
+With a [correctly configured](https://golang.org/doc/install#testing) Go toolchain:
+
+```sh
+go get -u github.com/gorilla/mux
+```
+
+## Examples
 
 Let's start registering a couple of URL paths and handlers:
 
@@ -41,11 +67,16 @@ r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
 The names are used to create a map of route variables which can be retrieved calling `mux.Vars()`:
 
 ```go
-vars := mux.Vars(request)
-category := vars["category"]
+func ArticlesCategoryHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "Category: %v\n", vars["category"])
+}
 ```
 
 And this is all you need to know about the basic usage. More advanced options are explained below.
+
+### Matching Routes
 
 Routes can also be restricted to a domain or subdomain. Just define a host pattern to be matched. They can also have variables:
 
@@ -118,7 +149,7 @@ Then register routes in the subrouter:
 ```go
 s.HandleFunc("/products/", ProductsHandler)
 s.HandleFunc("/products/{key}", ProductHandler)
-s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
+s.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
 ```
 
 The three URL paths we registered above will only be tested if the domain is `www.example.com`, because the subrouter is tested first. This is not only convenient, but also optimizes request matching. You can create subrouters combining any attribute matchers accepted by a route.
@@ -137,6 +168,73 @@ s.HandleFunc("/{key}/", ProductHandler)
 // "/products/{key}/details"
 s.HandleFunc("/{key}/details", ProductDetailsHandler)
 ```
+
+### Listing Routes
+
+Routes on a mux can be listed using the Router.Walk method—useful for generating documentation:
+
+```go
+package main
+
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/gorilla/mux"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    return
+}
+
+func main() {
+    r := mux.NewRouter()
+    r.HandleFunc("/", handler)
+    r.HandleFunc("/products", handler)
+    r.HandleFunc("/articles", handler)
+    r.HandleFunc("/articles/{id}", handler)
+    r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+        t, err := route.GetPathTemplate()
+        if err != nil {
+            return err
+        }
+        fmt.Println(t)
+        return nil
+    })
+    http.Handle("/", r)
+}
+```
+
+### Static Files
+
+Note that the path provided to `PathPrefix()` represents a "wildcard": calling
+`PathPrefix("/static/").Handler(...)` means that the handler will be passed any
+request that matches "/static/*". This makes it easy to serve static files with mux:
+
+```go
+func main() {
+	var dir string
+
+	flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
+	flag.Parse()
+	r := mux.NewRouter()
+
+	// This will serve files under http://localhost:8000/static/<filename>
+	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+
+	srv := &http.Server{
+		Handler:      r,
+		Addr:         "127.0.0.1:8000",
+		// Good practice: enforce timeouts for servers you create!
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+
+	log.Fatal(srv.ListenAndServe())
+}
+```
+
+### Registered URLs
 
 Now let's see how to build registered URLs.
 
@@ -219,7 +317,7 @@ package main
 
 import (
 	"net/http"
-
+	"log"
 	"github.com/gorilla/mux"
 )
 
@@ -233,7 +331,7 @@ func main() {
 	r.HandleFunc("/", YourHandler)
 
 	// Bind to a port and pass our router in
-	http.ListenAndServe(":8000", r)
+	log.Fatal(http.ListenAndServe(":8000", r))
 }
 ```
 

--- a/vendor/github.com/gorilla/mux/context_gorilla.go
+++ b/vendor/github.com/gorilla/mux/context_gorilla.go
@@ -1,0 +1,26 @@
+// +build !go1.7
+
+package mux
+
+import (
+	"net/http"
+
+	"github.com/gorilla/context"
+)
+
+func contextGet(r *http.Request, key interface{}) interface{} {
+	return context.Get(r, key)
+}
+
+func contextSet(r *http.Request, key, val interface{}) *http.Request {
+	if val == nil {
+		return r
+	}
+
+	context.Set(r, key, val)
+	return r
+}
+
+func contextClear(r *http.Request) {
+	context.Clear(r)
+}

--- a/vendor/github.com/gorilla/mux/context_native.go
+++ b/vendor/github.com/gorilla/mux/context_native.go
@@ -1,0 +1,24 @@
+// +build go1.7
+
+package mux
+
+import (
+	"context"
+	"net/http"
+)
+
+func contextGet(r *http.Request, key interface{}) interface{} {
+	return r.Context().Value(key)
+}
+
+func contextSet(r *http.Request, key, val interface{}) *http.Request {
+	if val == nil {
+		return r
+	}
+
+	return r.WithContext(context.WithValue(r.Context(), key, val))
+}
+
+func contextClear(r *http.Request) {
+	return
+}

--- a/vendor/github.com/gorilla/mux/doc.go
+++ b/vendor/github.com/gorilla/mux/doc.go
@@ -47,11 +47,20 @@ variable will be anything until the next slash. For example:
 	r.HandleFunc("/articles/{category}/", ArticlesCategoryHandler)
 	r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
 
+Groups can be used inside patterns, as long as they are non-capturing (?:re). For example:
+
+	r.HandleFunc("/articles/{category}/{sort:(?:asc|desc|new)}", ArticlesCategoryHandler)
+
 The names are used to create a map of route variables which can be retrieved
 calling mux.Vars():
 
 	vars := mux.Vars(request)
 	category := vars["category"]
+
+Note that if any capturing groups are present, mux will panic() during parsing. To prevent
+this, convert any capturing groups to non-capturing, e.g. change "/{sort:(asc|desc)}" to
+"/{sort:(?:asc|desc)}". This is a change from prior versions which behaved unpredictably
+when capturing groups were present.
 
 And this is all you need to know about the basic usage. More advanced options
 are explained below.
@@ -135,6 +144,31 @@ the inner routes use it as base for their paths:
 	s.HandleFunc("/{key}/", ProductHandler)
 	// "/products/{key}/details"
 	s.HandleFunc("/{key}/details", ProductDetailsHandler)
+
+Note that the path provided to PathPrefix() represents a "wildcard": calling
+PathPrefix("/static/").Handler(...) means that the handler will be passed any
+request that matches "/static/*". This makes it easy to serve static files with mux:
+
+	func main() {
+		var dir string
+
+		flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
+		flag.Parse()
+		r := mux.NewRouter()
+
+		// This will serve files under http://localhost:8000/static/<filename>
+		r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+
+		srv := &http.Server{
+			Handler:      r,
+			Addr:         "127.0.0.1:8000",
+			// Good practice: enforce timeouts for servers you create!
+			WriteTimeout: 15 * time.Second,
+			ReadTimeout:  15 * time.Second,
+		}
+
+		log.Fatal(srv.ListenAndServe())
+	}
 
 Now let's see how to build registered URLs.
 

--- a/vendor/github.com/gorilla/mux/mux.go
+++ b/vendor/github.com/gorilla/mux/mux.go
@@ -10,8 +10,7 @@ import (
 	"net/http"
 	"path"
 	"regexp"
-
-	"github.com/gorilla/context"
+	"strings"
 )
 
 // NewRouter returns a new router instance.
@@ -48,8 +47,14 @@ type Router struct {
 	namedRoutes map[string]*Route
 	// See Router.StrictSlash(). This defines the flag for new routes.
 	strictSlash bool
-	// If true, do not clear the request context after handling the request
+	// See Router.SkipClean(). This defines the flag for new routes.
+	skipClean bool
+	// If true, do not clear the request context after handling the request.
+	// This has no effect when go1.7+ is used, since the context is stored
+	// on the request itself.
 	KeepContext bool
+	// see Router.UseEncodedPath(). This defines a flag for all routes.
+	useEncodedPath bool
 }
 
 // Match matches registered routes against the request.
@@ -73,32 +78,38 @@ func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
 // When there is a match, the route variables can be retrieved calling
 // mux.Vars(request).
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// Clean path to canonical form and redirect.
-	if p := cleanPath(req.URL.Path); p != req.URL.Path {
+	if !r.skipClean {
+		path := req.URL.Path
+		if r.useEncodedPath {
+			path = getPath(req)
+		}
+		// Clean path to canonical form and redirect.
+		if p := cleanPath(path); p != path {
 
-		// Added 3 lines (Philip Schlump) - It was dropping the query string and #whatever from query.
-		// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
-		// http://code.google.com/p/go/issues/detail?id=5252
-		url := *req.URL
-		url.Path = p
-		p = url.String()
+			// Added 3 lines (Philip Schlump) - It was dropping the query string and #whatever from query.
+			// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
+			// http://code.google.com/p/go/issues/detail?id=5252
+			url := *req.URL
+			url.Path = p
+			p = url.String()
 
-		w.Header().Set("Location", p)
-		w.WriteHeader(http.StatusMovedPermanently)
-		return
+			w.Header().Set("Location", p)
+			w.WriteHeader(http.StatusMovedPermanently)
+			return
+		}
 	}
 	var match RouteMatch
 	var handler http.Handler
 	if r.Match(req, &match) {
 		handler = match.Handler
-		setVars(req, match.Vars)
-		setCurrentRoute(req, match.Route)
+		req = setVars(req, match.Vars)
+		req = setCurrentRoute(req, match.Route)
 	}
 	if handler == nil {
 		handler = http.NotFoundHandler()
 	}
 	if !r.KeepContext {
-		defer context.Clear(req)
+		defer contextClear(req)
 	}
 	handler.ServeHTTP(w, req)
 }
@@ -130,6 +141,34 @@ func (r *Router) GetRoute(name string) *Route {
 // route inherit the original StrictSlash setting.
 func (r *Router) StrictSlash(value bool) *Router {
 	r.strictSlash = value
+	return r
+}
+
+// SkipClean defines the path cleaning behaviour for new routes. The initial
+// value is false. Users should be careful about which routes are not cleaned
+//
+// When true, if the route path is "/path//to", it will remain with the double
+// slash. This is helpful if you have a route like: /fetch/http://xkcd.com/534/
+//
+// When false, the path will be cleaned, so /fetch/http://xkcd.com/534/ will
+// become /fetch/http/xkcd.com/534
+func (r *Router) SkipClean(value bool) *Router {
+	r.skipClean = value
+	return r
+}
+
+// UseEncodedPath tells the router to match the encoded original path
+// to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/{var}/to".
+// This behavior has the drawback of needing to match routes against
+// r.RequestURI instead of r.URL.Path. Any modifications (such as http.StripPrefix)
+// to r.URL.Path will not affect routing when this flag is on and thus may
+// induce unintended behavior.
+//
+// If not called, the router will match the unencoded path to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/foo/bar/to"
+func (r *Router) UseEncodedPath() *Router {
+	r.useEncodedPath = true
 	return r
 }
 
@@ -170,9 +209,18 @@ func (r *Router) buildVars(m map[string]string) map[string]string {
 
 // NewRoute registers an empty route.
 func (r *Router) NewRoute() *Route {
-	route := &Route{parent: r, strictSlash: r.strictSlash}
-	r.routes = append(r.routes, route)
+	route := &Route{}
+	r.AddRoute(route)
 	return route
+}
+
+// AddRoute registers a route
+func (r *Router) AddRoute(route *Route) {
+	route.parent = r
+	route.strictSlash = r.strictSlash
+	route.skipClean = r.skipClean
+	route.useEncodedPath = r.useEncodedPath
+	r.routes = append(r.routes, route)
 }
 
 // Handle registers a new route with a matcher for the URL path.
@@ -268,6 +316,9 @@ func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
 		if err == SkipRouter {
 			continue
 		}
+		if err != nil {
+			return err
+		}
 		for _, sr := range t.matchers {
 			if h, ok := sr.(*Router); ok {
 				err := h.walk(walkFn, ancestors)
@@ -308,7 +359,7 @@ const (
 
 // Vars returns the route variables for the current request, if any.
 func Vars(r *http.Request) map[string]string {
-	if rv := context.Get(r, varsKey); rv != nil {
+	if rv := contextGet(r, varsKey); rv != nil {
 		return rv.(map[string]string)
 	}
 	return nil
@@ -320,27 +371,45 @@ func Vars(r *http.Request) map[string]string {
 // after the handler returns, unless the KeepContext option is set on the
 // Router.
 func CurrentRoute(r *http.Request) *Route {
-	if rv := context.Get(r, routeKey); rv != nil {
+	if rv := contextGet(r, routeKey); rv != nil {
 		return rv.(*Route)
 	}
 	return nil
 }
 
-func setVars(r *http.Request, val interface{}) {
-	if val != nil {
-		context.Set(r, varsKey, val)
-	}
+func setVars(r *http.Request, val interface{}) *http.Request {
+	return contextSet(r, varsKey, val)
 }
 
-func setCurrentRoute(r *http.Request, val interface{}) {
-	if val != nil {
-		context.Set(r, routeKey, val)
-	}
+func setCurrentRoute(r *http.Request, val interface{}) *http.Request {
+	return contextSet(r, routeKey, val)
 }
 
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
+
+// getPath returns the escaped path if possible; doing what URL.EscapedPath()
+// which was added in go1.5 does
+func getPath(req *http.Request) string {
+	if req.RequestURI != "" {
+		// Extract the path from RequestURI (which is escaped unlike URL.Path)
+		// as detailed here as detailed in https://golang.org/pkg/net/url/#URL
+		// for < 1.5 server side workaround
+		// http://localhost/path/here?v=1 -> /path/here
+		path := req.RequestURI
+		path = strings.TrimPrefix(path, req.URL.Scheme+`://`)
+		path = strings.TrimPrefix(path, req.URL.Host)
+		if i := strings.LastIndex(path, "?"); i > -1 {
+			path = path[:i]
+		}
+		if i := strings.LastIndex(path, "#"); i > -1 {
+			path = path[:i]
+		}
+		return path
+	}
+	return req.URL.Path
+}
 
 // cleanPath returns the canonical path for p, eliminating . and .. elements.
 // Borrowed from the net/http package.
@@ -357,6 +426,7 @@ func cleanPath(p string) string {
 	if p[len(p)-1] == '/' && np != "/" {
 		np += "/"
 	}
+
 	return np
 }
 

--- a/vendor/github.com/gorilla/mux/regexp.go
+++ b/vendor/github.com/gorilla/mux/regexp.go
@@ -24,7 +24,7 @@ import (
 // Previously we accepted only Python-like identifiers for variable
 // names ([a-zA-Z_][a-zA-Z0-9_]*), but currently the only restriction is that
 // name and pattern can't be empty, and names can't contain a colon.
-func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash bool) (*routeRegexp, error) {
+func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash, useEncodedPath bool) (*routeRegexp, error) {
 	// Check if it is well-formed.
 	idxs, errBraces := braceIndices(tpl)
 	if errBraces != nil {
@@ -109,16 +109,24 @@ func newRouteRegexp(tpl string, matchHost, matchPrefix, matchQuery, strictSlash 
 	if errCompile != nil {
 		return nil, errCompile
 	}
+
+	// Check for capturing groups which used to work in older versions
+	if reg.NumSubexp() != len(idxs)/2 {
+		panic(fmt.Sprintf("route %s contains capture groups in its regexp. ", template) +
+			"Only non-capturing groups are accepted: e.g. (?:pattern) instead of (pattern)")
+	}
+
 	// Done!
 	return &routeRegexp{
-		template:    template,
-		matchHost:   matchHost,
-		matchQuery:  matchQuery,
-		strictSlash: strictSlash,
-		regexp:      reg,
-		reverse:     reverse.String(),
-		varsN:       varsN,
-		varsR:       varsR,
+		template:       template,
+		matchHost:      matchHost,
+		matchQuery:     matchQuery,
+		strictSlash:    strictSlash,
+		useEncodedPath: useEncodedPath,
+		regexp:         reg,
+		reverse:        reverse.String(),
+		varsN:          varsN,
+		varsR:          varsR,
 	}, nil
 }
 
@@ -133,6 +141,9 @@ type routeRegexp struct {
 	matchQuery bool
 	// The strictSlash value defined on the route, but disabled if PathPrefix was used.
 	strictSlash bool
+	// Determines whether to use encoded path from getPath function or unencoded
+	// req.URL.Path for path matching
+	useEncodedPath bool
 	// Expanded regexp.
 	regexp *regexp.Regexp
 	// Reverse template.
@@ -149,8 +160,11 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 		if r.matchQuery {
 			return r.matchQueryString(req)
 		}
-
-		return r.regexp.MatchString(req.URL.Path)
+		path := req.URL.Path
+		if r.useEncodedPath {
+			path = getPath(req)
+		}
+		return r.regexp.MatchString(path)
 	}
 
 	return r.regexp.MatchString(getHost(req))
@@ -253,14 +267,18 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 			extractVars(host, matches, v.host.varsN, m.Vars)
 		}
 	}
+	path := req.URL.Path
+	if r.useEncodedPath {
+		path = getPath(req)
+	}
 	// Store path variables.
 	if v.path != nil {
-		matches := v.path.regexp.FindStringSubmatchIndex(req.URL.Path)
+		matches := v.path.regexp.FindStringSubmatchIndex(path)
 		if len(matches) > 0 {
-			extractVars(req.URL.Path, matches, v.path.varsN, m.Vars)
+			extractVars(path, matches, v.path.varsN, m.Vars)
 			// Check if we should redirect.
 			if v.path.strictSlash {
-				p1 := strings.HasSuffix(req.URL.Path, "/")
+				p1 := strings.HasSuffix(path, "/")
 				p2 := strings.HasSuffix(v.path.template, "/")
 				if p1 != p2 {
 					u, _ := url.Parse(req.URL.String())
@@ -299,14 +317,7 @@ func getHost(r *http.Request) string {
 }
 
 func extractVars(input string, matches []int, names []string, output map[string]string) {
-	matchesCount := 0
-	prevEnd := -1
-	for i := 2; i < len(matches) && matchesCount < len(names); i += 2 {
-		if prevEnd < matches[i+1] {
-			value := input[matches[i]:matches[i+1]]
-			output[names[matchesCount]] = value
-			prevEnd = matches[i+1]
-			matchesCount++
-		}
+	for i, name := range names {
+		output[name] = input[matches[2*i+2]:matches[2*i+3]]
 	}
 }

--- a/vendor/github.com/gorilla/mux/route.go
+++ b/vendor/github.com/gorilla/mux/route.go
@@ -26,6 +26,11 @@ type Route struct {
 	// If true, when the path pattern is "/path/", accessing "/path" will
 	// redirect to the former and vice versa.
 	strictSlash bool
+	// If true, when the path pattern is "/path//to", accessing "/path//to"
+	// will not redirect
+	skipClean bool
+	// If true, "/path/foo%2Fbar/to" will match the path "/path/{var}/to"
+	useEncodedPath bool
 	// If true, this route never matches: it is only used to build URLs.
 	buildOnly bool
 	// The name used to build URLs.
@@ -34,6 +39,10 @@ type Route struct {
 	err error
 
 	buildVarsFunc BuildVarsFunc
+}
+
+func (r *Route) SkipClean() bool {
+	return r.skipClean
 }
 
 // Match matches the route against the request.
@@ -144,14 +153,14 @@ func (r *Route) addRegexpMatcher(tpl string, matchHost, matchPrefix, matchQuery 
 	}
 	r.regexp = r.getRegexpGroup()
 	if !matchHost && !matchQuery {
-		if len(tpl) == 0 || tpl[0] != '/' {
+		if len(tpl) > 0 && tpl[0] != '/' {
 			return fmt.Errorf("mux: path must start with a slash, got %q", tpl)
 		}
 		if r.regexp.path != nil {
 			tpl = strings.TrimRight(r.regexp.path.template, "/") + tpl
 		}
 	}
-	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, r.strictSlash)
+	rr, err := newRouteRegexp(tpl, matchHost, matchPrefix, matchQuery, r.strictSlash, r.useEncodedPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Add project subcommands

**Proposal:** `project` subcommands can be used as a way to put containers, volumes, networks, services, secrets & stacks in the context of a project.

⚠️ The pull request is not ready to be merged (see checklist below). But the feature is mature enough to be tested, please send your feedback! 🙂

Command output:

```shell
$ docker project

Usage:	docker project COMMAND

Manage projects

Options:
      --help   Print usage

Commands:
  id          Display Docker project ID
  init        Initiate Docker project
  join        Join a Docker project
  leave       Leave a Docker project
  ls          List recent projects
```

## How to install it 📦

Check out changes and run:

```shell
make -f docker.Makefile cross
```

Then depending on your platform, use the binary that's been built. On a Mac for example:

```shell
# don't worry, /usr/local/bin/docker is just a symlink
# restart Docker for Mac to go back to original CLI
rm /usr/local/bin/docker && ln -s `pwd`/build/docker-darwin-amd64 /usr/local/bin/docker
```

## How to use it 🚀

From within a directory, use `docker init [PROJECT_ID]` (random ID is generated if not provided):

```shell
$ cd /proj
# `docker ps -a` lists all containers
$ docker ps -a --format {{.ID}}
384c6fe92217
004e39638126
d8a8cb780ccb
ca2fdc22f56d
# init project in /proj
$ docker init abcde
project created at /proj
to join the project: `docker project join abcde`
# run container
$ docker run -d redis
cc740b6ff1f0f6199b8cbdc6a1fdac7d288bf8d38c410b1e68e17adc601d7f17
# now `docker ps -a` only lists containers that belong to the project
$ docker ps -a --format {{.ID}}
cc740b6ff1f0
```

From within `/proj` directory, new Docker entities will be created in the context of the project, and only scoped entities will be listed when using commands like `docker volume ls`, `docker container ls`, etc.

You can join a common project from different locations. It's useful if you have different repositories involved in one single application:

```shell
$ cd /dir1
$ docker init abcde
project created at /dir1
to join the project: `docker project join abcde`
$ cd /dir2
$ docker project join abcde
joined project abcde!
$ docker project join -d /dir3 abcde
joined project abcde!
```

`--ignore-project` option can be used with all docker commands to bypass project scoping.

## How it works ⚙️

The project ID is stored in `/PATH/TO/DIR/.git/.docker/id`.

We're using an in-memory proxy (when in the context of a project) to catch and modify requests sent to the Docker remote API. The code of the proxy can be found in this dedicated repository: [docker/engine-api-proxy](https://github.com/docker/engine-api-proxy).

Basically, the proxy adds this label: `com.docker.project.id=PROJECT_ID` to all containers, volumes, networks, services, secrets & stacks created within the context of a project. It also mangle names when necessary to avoid collisions:

```shell
# within project context:
$ docker run -d --name db redis
$ docker ps --format "table {{.ID}}\t{{.Names}}"
CONTAINER ID        NAMES
0959db1494f2        db
# move out from project context
$ cd ..
$ docker ps --format "table {{.ID}}\t{{.Names}}"
CONTAINER ID        NAMES
0959db1494f2        abcde_db

```

## Checklist ✅

- [ ] unit tests
- [ ] functional tests
- [ ] open https://github.com/docker/engine-api-proxy and include in vendor.conf (cc @dnephin)
- [ ] fix workflow to store & list recent projects (we shouldn't enforce unique IDs)

Thanks!

-- @gdevillele & @aduermael

cc @aluzzardi, @tiborvass, @thaJeztah, @dhiltgen