### PR TITLE
Return an error instead of an `*InvalidTemplateError`

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -39,11 +39,15 @@ func interpolateSectionItem(
 
 	for key, value := range item {
 		interpolatedValue, err := recursiveInterpolate(value, mapping)
-		if err != nil {
+		switch err := err.(type) {
+		case nil:
+		case *template.InvalidTemplateError:
 			return nil, errors.Errorf(
 				"Invalid interpolation format for %#v option in %s %#v: %#v. You may need to escape any $ with another $.",
 				key, section, name, err.Template,
 			)
+		default:
+			return nil, errors.Wrapf(err, "error while interpolating %s in %s %s", key, section, name)
 		}
 		out[key] = interpolatedValue
 	}
@@ -55,7 +59,7 @@ func interpolateSectionItem(
 func recursiveInterpolate(
 	value interface{},
 	mapping template.Mapping,
-) (interface{}, *template.InvalidTemplateError) {
+) (interface{}, error) {
 
 	switch value := value.(type) {
 

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -33,8 +33,9 @@ func (e InvalidTemplateError) Error() string {
 type Mapping func(string) (string, bool)
 
 // Substitute variables in the string with their values
-func Substitute(template string, mapping Mapping) (result string, err *InvalidTemplateError) {
-	result = pattern.ReplaceAllStringFunc(template, func(substring string) string {
+func Substitute(template string, mapping Mapping) (string, error) {
+	var err error
+	result := pattern.ReplaceAllStringFunc(template, func(substring string) string {
 		matches := pattern.FindStringSubmatch(substring)
 		groups := make(map[string]string)
 		for i, name := range pattern.SubexpNames() {


### PR DESCRIPTION
This mess things up using the `Substitute` method from outside (i.e. the error is nil but not nil kinda).

Signed-off-by: Vincent Demeester <vincent@sbr.pm>