### PR TITLE
Fix prefix-matching for service ps

### DIFF
--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -69,29 +69,43 @@ func runPS(dockerCli command.Cli, options psOptions) error {
 		return err
 	}
 
+	var errs []string
+	serviceCount := 0
+loop:
+	// Match services by 1. Full ID, 2. Full name, 3. ID prefix. An error is returned if the ID-prefix match is ambiguous
 	for _, service := range options.services {
-		serviceCount := 0
-		// Lookup by ID/Prefix
-		for _, serviceEntry := range serviceByIDList {
-			if strings.HasPrefix(serviceEntry.ID, service) {
-				filter.Add("service", serviceEntry.ID)
+		for _, s := range serviceByIDList {
+			if s.ID == service {
+				filter.Add("service", s.ID)
 				serviceCount++
+				continue loop
 			}
 		}
-
-		// Lookup by Name/Prefix
-		for _, serviceEntry := range serviceByNameList {
-			if strings.HasPrefix(serviceEntry.Spec.Annotations.Name, service) {
-				filter.Add("service", serviceEntry.ID)
+		for _, s := range serviceByNameList {
+			if s.Spec.Annotations.Name == service {
+				filter.Add("service", s.ID)
 				serviceCount++
+				continue loop
 			}
 		}
-		// If nothing has been found, return immediately.
-		if serviceCount == 0 {
-			return errors.Errorf("no such services: %s", service)
+		found := false
+		for _, s := range serviceByIDList {
+			if strings.HasPrefix(s.ID, service) {
+				if found {
+					return errors.New("multiple services found with provided prefix: " + service)
+				}
+				filter.Add("service", s.ID)
+				serviceCount++
+				found = true
+			}
+		}
+		if !found {
+			errs = append(errs, "no such service: "+service)
 		}
 	}
-
+	if serviceCount == 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
 	if filter.Include("node") {
 		nodeFilters := filter.Get("node")
 		for _, nodeFilter := range nodeFilters {
@@ -117,6 +131,11 @@ func runPS(dockerCli command.Cli, options psOptions) error {
 			format = formatter.TableFormatKey
 		}
 	}
-
-	return task.Print(ctx, dockerCli, tasks, idresolver.New(client, options.noResolve), !options.noTrunc, options.quiet, format)
+	if err := task.Print(ctx, dockerCli, tasks, idresolver.New(client, options.noResolve), !options.noTrunc, options.quiet, format); err != nil {
+		return err
+	}
+	if len(errs) != 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
 }

--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"testing"
+
+	"bytes"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/cli/opts"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	serviceListFunc func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
+}
+
+func (f *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	if f.serviceListFunc != nil {
+		return f.serviceListFunc(ctx, options)
+	}
+	return nil, nil
+}
+
+func (f *fakeClient) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	return nil, nil
+}
+
+func newService(id string, name string) swarm.Service {
+	return swarm.Service{
+		ID:   id,
+		Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: name}},
+	}
+}
+
+func TestCreateFilter(t *testing.T) {
+	client := &fakeClient{
+		serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{
+				{ID: "idmatch"},
+				{ID: "idprefixmatch"},
+				newService("cccccccc", "namematch"),
+				newService("01010101", "notfoundprefix"),
+			}, nil
+		},
+	}
+
+	filter := opts.NewFilterOpt()
+	require.NoError(t, filter.Set("node=somenode"))
+	options := psOptions{
+		services: []string{"idmatch", "idprefix", "namematch", "notfound"},
+		filter:   filter,
+	}
+
+	actual, notfound, err := createFilter(context.Background(), client, options)
+	require.NoError(t, err)
+	assert.Equal(t, notfound, []string{"no such service: notfound"})
+
+	expected := filters.NewArgs()
+	expected.Add("service", "idmatch")
+	expected.Add("service", "idprefixmatch")
+	expected.Add("service", "cccccccc")
+	expected.Add("node", "somenode")
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateFilterWithAmbiguousIDPrefixError(t *testing.T) {
+	client := &fakeClient{
+		serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{
+				{ID: "aaaone"},
+				{ID: "aaatwo"},
+			}, nil
+		},
+	}
+	options := psOptions{
+		services: []string{"aaa"},
+		filter:   opts.NewFilterOpt(),
+	}
+	_, _, err := createFilter(context.Background(), client, options)
+	assert.EqualError(t, err, "multiple services found with provided prefix: aaa")
+}
+
+func TestCreateFilterNoneFound(t *testing.T) {
+	client := &fakeClient{}
+	options := psOptions{
+		services: []string{"foo", "notfound"},
+		filter:   opts.NewFilterOpt(),
+	}
+	_, _, err := createFilter(context.Background(), client, options)
+	assert.EqualError(t, err, "no such service: foo\nno such service: notfound")
+}
+
+func TestRunPSWarnsOnNotFound(t *testing.T) {
+	client := &fakeClient{
+		serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{
+				{ID: "foo"},
+			}, nil
+		},
+	}
+
+	out := new(bytes.Buffer)
+	cli := test.NewFakeCli(client, out)
+	options := psOptions{
+		services: []string{"foo", "bar"},
+		filter:   opts.NewFilterOpt(),
+		format:   "{{.ID}}",
+	}
+	err := runPS(cli, options)
+	assert.EqualError(t, err, "no such service: bar")
+}


### PR DESCRIPTION
The docker CLI matches objects either by ID _prefix_
or a full name match, but not partial name matches.

The correct order of resolution is;

- Full ID match (a name should not be able to mask an ID)
- Full name
- ID-prefix

This patch changes the way services are matched.

Also change to use the first matching service, if there's a
full match (by ID or Name) instead of continue looking for
other possible matches.

Error handling changed;

- Do not error early if multiple services were requested
  and one or more services were not found. Print the
  services that were not found after printing those that
  _were_ found instead
- Print an error if ID-prefix matching is ambiguous

This PR carries the CLI changes of https://github.com/moby/moby/pull/32800