### PR TITLE
Add support for `read_only` services in stack deploy

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -129,6 +129,7 @@ func convertService(
 				TTY:             service.Tty,
 				OpenStdin:       service.StdinOpen,
 				Secrets:         secrets,
+				ReadOnly:        service.ReadOnly,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -18,7 +18,6 @@ var UnsupportedProperties = []string{
 	"mac_address",
 	"network_mode",
 	"privileged",
-	"read_only",
 	"restart",
 	"security_opt",
 	"shm_size",


### PR DESCRIPTION
The `read_only` key in a composefile is not taken into account right
now. Now that services support `--read-only`, so should `stack deploy`

Ref: moby/moby#32994

🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
