### PR TITLE
Add new CLI option for --until

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -20,6 +20,7 @@ type fakeClient struct {
 	infoFunc              func() (types.Info, error)
 	containerStatPathFunc func(container, path string) (types.ContainerPathStat, error)
 	containerCopyFromFunc func(container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	logFunc               func(string, types.ContainerLogsOptions) (io.ReadCloser, error)
 }
 
 func (f *fakeClient) ContainerInspect(_ context.Context, containerID string) (types.ContainerJSON, error) {
@@ -86,4 +87,11 @@ func (f *fakeClient) CopyFromContainer(_ context.Context, container, srcPath str
 		return f.containerCopyFromFunc(container, srcPath)
 	}
 	return nil, types.ContainerPathStat{}, nil
+}
+
+func (f *fakeClient) ContainerLogs(_ context.Context, container string, options types.ContainerLogsOptions) (io.ReadCloser, error) {
+	if f.logFunc != nil {
+		return f.logFunc(container, options)
+	}
+	return nil, nil
 }

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -14,6 +14,7 @@ import (
 type logsOptions struct {
 	follow     bool
 	since      string
+	until      string
 	timestamps bool
 	details    bool
 	tail       string
@@ -38,6 +39,8 @@ func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.follow, "follow", "f", false, "Follow log output")
 	flags.StringVar(&opts.since, "since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
+	flags.StringVar(&opts.until, "until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)")
+	flags.SetAnnotation("until", "version", []string{"1.35"})
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps")
 	flags.BoolVar(&opts.details, "details", false, "Show extra details provided to logs")
 	flags.StringVar(&opts.tail, "tail", "all", "Number of lines to show from the end of the logs")
@@ -51,6 +54,7 @@ func runLogs(dockerCli command.Cli, opts *logsOptions) error {
 		ShowStdout: true,
 		ShowStderr: true,
 		Since:      opts.since,
+		Until:      opts.until,
 		Timestamps: opts.timestamps,
 		Follow:     opts.follow,
 		Tail:       opts.tail,

--- a/cli/command/container/logs_test.go
+++ b/cli/command/container/logs_test.go
@@ -1,0 +1,62 @@
+package container
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/cli/internal/test/testutil"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunLogs(t *testing.T) {
+	inspectFn := func(containerID string) (types.ContainerJSON, error) {
+		return types.ContainerJSON{
+			Config:            &container.Config{Tty: true},
+			ContainerJSONBase: &types.ContainerJSONBase{State: &types.ContainerState{Running: false}},
+		}, nil
+	}
+
+	logFn := func(expectedOut string) func(string, types.ContainerLogsOptions) (io.ReadCloser, error) {
+		return func(container string, opts types.ContainerLogsOptions) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader(expectedOut)), nil
+		}
+	}
+
+	var testcases = []struct {
+		doc           string
+		options       *logsOptions
+		client        fakeClient
+		expectedError string
+		expectedOut   string
+		expectedErr   string
+	}{
+		{
+			doc:         "successful logs",
+			expectedOut: "foo",
+			options:     &logsOptions{},
+			client:      fakeClient{logFunc: logFn("foo"), inspectFunc: inspectFn},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.doc, func(t *testing.T) {
+			cli := test.NewFakeCli(&testcase.client)
+
+			err := runLogs(cli, testcase.options)
+			if testcase.expectedError != "" {
+				testutil.ErrorContains(t, err, testcase.expectedError)
+			} else {
+				if !assert.NoError(t, err) {
+					return
+				}
+			}
+			assert.Equal(t, testcase.expectedOut, cli.OutBuffer().String())
+			assert.Equal(t, testcase.expectedErr, cli.ErrBuffer().String())
+		})
+	}
+}

--- a/cli/command/container/logs_test.go
+++ b/cli/command/container/logs_test.go
@@ -13,18 +13,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var logFn = func(expectedOut string) func(string, types.ContainerLogsOptions) (io.ReadCloser, error) {
+	return func(container string, opts types.ContainerLogsOptions) (io.ReadCloser, error) {
+		return ioutil.NopCloser(strings.NewReader(expectedOut)), nil
+	}
+}
+
 func TestRunLogs(t *testing.T) {
 	inspectFn := func(containerID string) (types.ContainerJSON, error) {
 		return types.ContainerJSON{
 			Config:            &container.Config{Tty: true},
 			ContainerJSONBase: &types.ContainerJSONBase{State: &types.ContainerState{Running: false}},
 		}, nil
-	}
-
-	logFn := func(expectedOut string) func(string, types.ContainerLogsOptions) (io.ReadCloser, error) {
-		return func(container string, opts types.ContainerLogsOptions) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader(expectedOut)), nil
-		}
 	}
 
 	var testcases = []struct {

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -25,6 +25,7 @@ Options:
   -f, --follow         Follow log output
       --help           Print usage
       --since string   Show logs since timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
+      --until string   Show logs before timestamp (e.g. 2013-01-02T13:23:37) or relative (e.g. 42m for 42 minutes)
       --tail string    Number of lines to show from the end of the logs (default "all")
   -t, --timestamps     Show timestamps
 ```
@@ -66,3 +67,19 @@ that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
 seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
 fraction of a second no more than nine digits long. You can combine the
 `--since` option with either or both of the `--follow` or `--tail` options.
+
+## Examples
+
+### Retrieve logs until a specific point in time
+
+In order to retrieve logs before a specific point in time, run:
+
+```bash
+$ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
+$ date
+Tue 14 Nov 2017 16:40:00 CET
+$ docker logs -f --until=2s
+Tue 14 Nov 2017 16:40:00 CET
+Tue 14 Nov 2017 16:40:01 CET
+Tue 14 Nov 2017 16:40:02 CET
+```

--- a/man/src/container/logs.md
+++ b/man/src/container/logs.md
@@ -10,8 +10,8 @@ then continue streaming new output from the container's stdout and stderr.
 **Warning**: This command works only for the **json-file** or **journald**
 logging drivers.
 
-The `--since` option can be Unix timestamps, date formatted timestamps, or Go
-duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine's
+The `--since` and `--until` options can be Unix timestamps, date formatted timestamps, 
+or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the client machine's
 time. Supported formats for date formatted time stamps include RFC3339Nano,
 RFC3339, `2006-01-02T15:04:05`, `2006-01-02T15:04:05.999999999`,
 `2006-01-02Z07:00`, and `2006-01-02`. The local timezone on the client will be
@@ -20,9 +20,21 @@ end of the timestamp.  When providing Unix timestamps enter
 seconds[.nanoseconds], where seconds is the number of seconds that have elapsed
 since January 1, 1970 (midnight UTC/GMT), not counting leap  seconds (aka Unix
 epoch or Unix time), and the optional .nanoseconds field is a fraction of a
-second no more than nine digits long. You can combine the `--since` option with
-either or both of the `--follow` or `--tail` options.
+second no more than nine digits long. You can combine the `--since` or `--until` 
+options with either or both of the `--follow` or `--tail` options.
 
 The `docker container logs --details` command will add on extra attributes, such as
 environment variables and labels, provided to `--log-opt` when creating the
 container.
+
+In order to retrieve logs before a specific point in time, run:
+
+```bash
+$ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
+$ date
+Tue 14 Nov 2017 16:40:00 CET
+$ docker logs -f --until=2s
+Tue 14 Nov 2017 16:40:00 CET
+Tue 14 Nov 2017 16:40:01 CET
+Tue 14 Nov 2017 16:40:02 CET
+```


### PR DESCRIPTION
**- What I did**

Added an --until flag for docker logs in line with #32807.

**- How I did it**

Adapted CLI pkg.

**- How to verify it**

Run unit/integration tests. One caveat is that we don't have any integration tests for any of the logger adaptors at the moment (e.g. loggerd), so I was not able to verify the changes to this.

**- Description for the changelog**
```
docker logs now supports --until
```

