### PR TITLE
Vendor docker/docker to eb36d6021618f788012c166a533f1b321cda9695

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,7 @@ github.com/agl/ed25519 d2b94fd789ea21d12fac1a4443dd3a3f79cda72c
 github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-github.com/docker/docker f02a5b50c407bdb087388e18e1ac619f2788dd8d
+github.com/docker/docker eb36d6021618f788012c166a533f1b321cda9695
 github.com/docker/docker-credential-helpers v0.5.0
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5


### PR DESCRIPTION
To compile docker/cli in Go1.8 docker/docker has to be bumped
to eb36d6021618f788012c166a533f1b321cda9695.

Read more here:
https://github.com/golang/go/issues/18347
https://github.com/moby/moby/issues/29602
https://github.com/moby/moby/pull/29030
https://github.com/moby/moby/pull/32127

closes #64 