### PR TITLE
Support running unit tests when files are saved

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ test:
 lint:
 	@gometalinter --config gometalinter.json ./...
 
-
 .PHONY: binary
 binary:
 	@./scripts/build/binary
@@ -32,6 +31,10 @@ cross:
 .PHONY: dynbinary
 dynbinary:
 	@./scripts/build/dynbinary
+
+.PHONY: watch
+watch:
+	@./scripts/test/watch
 
 # download dependencies (vendor/) listed in vendor.conf
 .PHONY: vendor

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Run all linting:
 ```
 $ make -f docker.Makefile lint
 ```
-`
 
 ### In-container development environment
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -46,6 +46,10 @@ test: build_docker_image
 cross: build_cross_image
 	@docker run --rm $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
 
+.PHONY: watch
+watch: build_docker_image
+	@docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make watch
+
 # start container in interactive mode for in-container development
 .PHONY: dev
 dev: build_docker_image

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -15,6 +15,10 @@ RUN     go get github.com/jteeuwen/go-bindata/go-bindata && \
         cp /go/bin/go-bindata /usr/bin && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
+RUN     go get github.com/dnephin/filewatcher && \
+        cp /go/bin/filewatcher /usr/bin/ && \
+        rm -rf /go/src/* /go/pkg/* /go/bin/*
+
 ENV     CGO_ENABLED=0
 WORKDIR /go/src/github.com/docker/cli
 CMD     sh

--- a/scripts/test/watch
+++ b/scripts/test/watch
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+filewatcher \
+    -L 5 \
+    -x '**/*.swp' \
+    -x .git \
+    -x build \
+    -x .idea \
+    -- \
+    sh -c 'go test -timeout 10s -v ./${dir} || ( echo; echo; exit 1 )'


### PR DESCRIPTION
This is a workflow that I've used for a long time. I think it works very well, and I'd like to include it as part of the build tools so that others can use it.

Here's how it works:

Start the watcher in one terminal 
```
make -f docker.Makefile watch
```

Make code changes in another terminal, editor, or IDE. Every time you save a file the unit tests for that package will run automatically.

Get (almost) instantaneous feedback on your code changes!
