### PR TITLE
Add --pretty option to "secret inspect" and "config inspect"

### DIFF
--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/inspect"
+	"github.com/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 )
@@ -11,6 +14,7 @@ import (
 type inspectOptions struct {
 	names  []string
 	format string
+	pretty bool
 }
 
 func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
@@ -26,6 +30,7 @@ func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", "Format the output using the given Go template")
+	cmd.Flags().BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
 	return cmd
 }
 
@@ -33,9 +38,29 @@ func runConfigInspect(dockerCli command.Cli, opts inspectOptions) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 
+	if opts.pretty {
+		opts.format = "pretty"
+	}
+
 	getRef := func(id string) (interface{}, []byte, error) {
 		return client.ConfigInspectWithRaw(ctx, id)
 	}
+	f := opts.format
 
-	return inspect.Inspect(dockerCli.Out(), opts.names, opts.format, getRef)
+	// check if the user is trying to apply a template to the pretty format, which
+	// is not supported
+	if strings.HasPrefix(f, "pretty") && f != "pretty" {
+		return fmt.Errorf("Cannot supply extra formatting options to the pretty template")
+	}
+
+	configCtx := formatter.Context{
+		Output: dockerCli.Out(),
+		Format: formatter.NewConfigFormat(f, false),
+	}
+
+	if err := formatter.ConfigInspectWrite(configCtx, opts.names, getRef); err != nil {
+		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+	}
+	return nil
+
 }

--- a/cli/command/config/testdata/config-inspect-pretty.simple.golden
+++ b/cli/command/config/testdata/config-inspect-pretty.simple.golden
@@ -1,0 +1,8 @@
+ID: configID
+Name: configName
+Labels:
+	- lbl1=value1
+Created at: 0001-01-01 00:00:00+0000 utc
+Updated at: 0001-01-01 00:00:00+0000 utc
+Data:
+payload here

--- a/cli/command/formatter/node.go
+++ b/cli/command/formatter/node.go
@@ -69,8 +69,7 @@ TLS Info:
 {{.TLSInfoTrustRoot}}
  Issuer Subject:	{{.TLSInfoCertIssuerSubject}}
  Issuer Public Key:	{{.TLSInfoCertIssuerPublicKey}}
-{{- end}}
-`
+{{- end}}`
 	nodeIDHeader        = "ID"
 	selfHeader          = ""
 	hostnameHeader      = "HOSTNAME"
@@ -177,7 +176,7 @@ func (c *nodeContext) TLSStatus() string {
 	return "Needs Rotation"
 }
 
-// NodeInspectWrite renders the context for a list of services
+// NodeInspectWrite renders the context for a list of nodes
 func NodeInspectWrite(ctx Context, refs []string, getRef inspect.GetRefFunc) error {
 	if ctx.Format != nodeInspectPrettyTemplate {
 		return inspect.Inspect(ctx.Output, refs, string(ctx.Format), getRef)

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -341,7 +341,6 @@ data
 
  Issuer Subject:	c3ViamVjdA==
  Issuer Public Key:	cHViS2V5
-
 `
 	assert.Equal(t, expected, out.String())
 }

--- a/cli/command/secret/testdata/secret-inspect-pretty.simple.golden
+++ b/cli/command/secret/testdata/secret-inspect-pretty.simple.golden
@@ -1,0 +1,6 @@
+ID: secretID
+Name: secretName
+Labels:
+	- lbl1=value1
+Created at: 0001-01-01 00:00:00+0000 utc
+Updated at: 0001-01-01 00:00:00+0000 utc

--- a/cli/internal/test/builders/config.go
+++ b/cli/internal/test/builders/config.go
@@ -59,3 +59,10 @@ func ConfigUpdatedAt(t time.Time) func(*swarm.Config) {
 		config.UpdatedAt = t
 	}
 }
+
+// ConfigData sets the config payload.
+func ConfigData(data []byte) func(*swarm.Config) {
+	return func(config *swarm.Config) {
+		config.Spec.Data = data
+	}
+}


### PR DESCRIPTION
This adds a pretty template for both inspect subcommands. For configs,
it's particularly useful because it's a way to expose the config payload
in the CLI in a non-base64-encoded way.

Fixes #88

cc @dhiltgen