### PR TITLE
Allow Proxy Configuration in config.json

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -290,7 +290,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		Dockerfile:     relDockerfile,
 		ShmSize:        options.shmSize.Value(),
 		Ulimits:        options.ulimits.GetList(),
-		BuildArgs:      opts.ConvertKVStringsToMapWithNil(options.buildArgs.GetAll()),
+		BuildArgs:      dockerCli.ConfigFile().ParseProxyConfig(dockerCli.Client().DaemonHost(), options.buildArgs.GetAll()),
 		AuthConfigs:    authConfigs,
 		Labels:         opts.ConvertKVStringsToMap(options.labels.GetAll()),
 		CacheFrom:      options.cacheFrom,

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -1,9 +1,11 @@
 package configfile
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEncodeAuth(t *testing.T) {
@@ -24,4 +26,119 @@ func TestEncodeAuth(t *testing.T) {
 	if authStr != "a2VuOnRlc3Q=" {
 		t.Fatal("AuthString encoding isn't correct.")
 	}
+}
+
+func TestProxyConfig(t *testing.T) {
+	httpProxy := "http://proxy.mycorp.com:3128"
+	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.com:21"
+	noProxy := "*.intra.mycorp.com"
+	defaultProxyConfig := ProxyConfig{
+		HTTPProxy:  httpProxy,
+		HTTPSProxy: httpsProxy,
+		FTPProxy:   ftpProxy,
+		NoProxy:    noProxy,
+	}
+
+	cfg := ConfigFile{
+		Proxies: map[string]ProxyConfig{
+			"default": defaultProxyConfig,
+		},
+	}
+
+	proxyConfig := cfg.ParseProxyConfig("/var/run/docker.sock", []string{})
+	expected := map[string]*string{
+		"HTTP_PROXY":  &httpProxy,
+		"http_proxy":  &httpProxy,
+		"HTTPS_PROXY": &httpsProxy,
+		"https_proxy": &httpsProxy,
+		"FTP_PROXY":   &ftpProxy,
+		"ftp_proxy":   &ftpProxy,
+		"NO_PROXY":    &noProxy,
+		"no_proxy":    &noProxy,
+	}
+	assert.Equal(t, expected, proxyConfig)
+}
+
+func TestProxyConfigOverride(t *testing.T) {
+	httpProxy := "http://proxy.mycorp.com:3128"
+	overrideHTTPProxy := "http://proxy.example.com:3128"
+	overrideNoProxy := ""
+	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.com:21"
+	noProxy := "*.intra.mycorp.com"
+	defaultProxyConfig := ProxyConfig{
+		HTTPProxy:  httpProxy,
+		HTTPSProxy: httpsProxy,
+		FTPProxy:   ftpProxy,
+		NoProxy:    noProxy,
+	}
+
+	cfg := ConfigFile{
+		Proxies: map[string]ProxyConfig{
+			"default": defaultProxyConfig,
+		},
+	}
+
+	ropts := []string{
+		fmt.Sprintf("HTTP_PROXY=%s", overrideHTTPProxy),
+		"NO_PROXY=",
+	}
+	proxyConfig := cfg.ParseProxyConfig("/var/run/docker.sock", ropts)
+	expected := map[string]*string{
+		"HTTP_PROXY":  &overrideHTTPProxy,
+		"http_proxy":  &httpProxy,
+		"HTTPS_PROXY": &httpsProxy,
+		"https_proxy": &httpsProxy,
+		"FTP_PROXY":   &ftpProxy,
+		"ftp_proxy":   &ftpProxy,
+		"NO_PROXY":    &overrideNoProxy,
+		"no_proxy":    &noProxy,
+	}
+	assert.Equal(t, expected, proxyConfig)
+}
+
+func TestProxyConfigPerHost(t *testing.T) {
+	httpProxy := "http://proxy.mycorp.com:3128"
+	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.com:21"
+	noProxy := "*.intra.mycorp.com"
+
+	extHTTPProxy := "http://proxy.example.com:3128"
+	extHTTPSProxy := "https://user:password@proxy.example.com:3129"
+	extFTPProxy := "http://ftpproxy.example.com:21"
+	extNoProxy := "*.intra.example.com"
+
+	defaultProxyConfig := ProxyConfig{
+		HTTPProxy:  httpProxy,
+		HTTPSProxy: httpsProxy,
+		FTPProxy:   ftpProxy,
+		NoProxy:    noProxy,
+	}
+	externalProxyConfig := ProxyConfig{
+		HTTPProxy:  extHTTPProxy,
+		HTTPSProxy: extHTTPSProxy,
+		FTPProxy:   extFTPProxy,
+		NoProxy:    extNoProxy,
+	}
+
+	cfg := ConfigFile{
+		Proxies: map[string]ProxyConfig{
+			"default":                       defaultProxyConfig,
+			"tcp://example.docker.com:2376": externalProxyConfig,
+		},
+	}
+
+	proxyConfig := cfg.ParseProxyConfig("tcp://example.docker.com:2376", []string{})
+	expected := map[string]*string{
+		"HTTP_PROXY":  &extHTTPProxy,
+		"http_proxy":  &extHTTPProxy,
+		"HTTPS_PROXY": &extHTTPSProxy,
+		"https_proxy": &extHTTPSProxy,
+		"FTP_PROXY":   &extFTPProxy,
+		"ftp_proxy":   &extFTPProxy,
+		"NO_PROXY":    &extNoProxy,
+		"no_proxy":    &extNoProxy,
+	}
+	assert.Equal(t, expected, proxyConfig)
 }


### PR DESCRIPTION
This is moby/moby#32966 re-openend against docker/cli
The above PR was a redux of moby/moby#30588 rebased and after the repo move!

**- What I did**

Added a mechanism to allow HTTP/HTTPS/FTP/NO proxy variables to be configured in `config.json`. These are then automatically populated in a `docker run` command as environment variables or as `build-args` in `docker build`!

This makes it easier for users suffering behind an HTTP Proxy as they only need to configure this once as opposed to creating custom aliases or forgetting the args and being denied buildage/runnage.

Updates #30323

**- How I did it**

Extended the `configfile` with some new proxy related variables.

These are scoped per Docker Host with a `default` catchall.

The config file is then read by the `build` or `run` command and the necessary variables are exported.

A `-e` flag or `--build-arg` provided on the CLI will override these default settings.

**- How to verify it**

1. Create a `config.json` with `{ "proxies" : { "httpProxy" : "http://127.0.0.1:3001" }`
2. Create a Dockerfile
```
FROM busybox
RUN echo $HTTP_PROXY
CMD echo $HTTP_PROXY
```
3. `docker --config /path/to/config build -t configtest .`
4. Verify that the `HTTP_PROXY` variable is as configured
5. `docker run --rm configtest env`
6. Verify that the HTTP_PROXY variable is as configured

**- Description for the changelog**

Added HTTP/HTTPS/FTP proxy configuration to `config.json`

**- A picture of a cute animal (not mandatory but encouraged)**

![](http://media-cache-ec0.pinimg.com/736x/e1/8c/21/e18c21aedb909d3553d4eae6e9c8961b.jpg)