### PR TITLE
service: Avoid underflow in logs padding calculation

### DIFF
--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -204,8 +204,12 @@ func (f *taskFormatter) format(ctx context.Context, logCtx logContext) (string, 
 		}
 	}
 
-	padding := strings.Repeat(" ", f.padding-getMaxLength(task.Slot))
-	formatted := fmt.Sprintf("%s@%s%s", taskName, nodeName, padding)
+	paddingCount := f.padding - getMaxLength(task.Slot)
+	padding := ""
+	if paddingCount > 0 {
+		padding = strings.Repeat(" ", paddingCount)
+	}
+	formatted := taskName + "@" + nodeName + padding
 	f.cache[logCtx] = formatted
 	return formatted, nil
 }


### PR DESCRIPTION
This command inserts a variable amount of padding in the log line:

    padding := strings.Repeat(" ", f.padding-getMaxLength(task.Slot))

If the service is scaled up, or the slot numbers are noncontiguous, the
subtraction can underflow, causing a crash.

See https://github.com/moby/moby/issues/33222

cc @dperny