### PR TITLE
Add test-coverage & codecov target and update circleci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /build/
 cli/winresources/rsrc_386.syso
 cli/winresources/rsrc_amd64.syso
+coverage.txt
+profile.out

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,11 @@ clean:
 # the "-tags daemon" part is temporary
 .PHONY: test
 test:
-	go test -tags daemon -v $(shell go list ./... | grep -v /vendor/)
+	./scripts/test/unit $(shell go list ./... | grep -v /vendor/)
 
 .PHONY: test-coverage
 test-coverage:
-	for pkg in $(shell go list ./... | grep -v /vendor/); do \
-		go test -tags daemon -v -cover -parallel 8 -coverprofile=profile.out -covermode=atomic $${pkg} || exit 1; \
-		if test -f profile.out; then \
-			cat profile.out >> coverage.txt && rm profile.out; \
-		fi; \
-	done
-
-.PHONY: codecov
-codecov:
-	$(shell curl -s https://codecov.io/bash | bash)
+	./scripts/test/unit-with-coverage
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,19 @@ clean:
 test:
 	go test -tags daemon -v $(shell go list ./... | grep -v /vendor/)
 
+.PHONY: test-coverage
+test-coverage:
+	for pkg in $(shell go list ./... | grep -v /vendor/); do \
+		go test -tags daemon -v -cover -parallel 8 -coverprofile=profile.out -covermode=atomic $${pkg} || exit 1; \
+		if test -f profile.out; then \
+			cat profile.out >> coverage.txt && rm profile.out; \
+		fi; \
+	done
+
+.PHONY: codecov
+codecov:
+	$(shell curl -s https://codecov.io/bash | bash)
+
 .PHONY: lint
 lint:
 	gometalinter --config gometalinter.json ./...

--- a/circle.yml
+++ b/circle.yml
@@ -29,13 +29,16 @@ jobs:
             docker run --name cross cli-builder make cross
             docker cp cross:/go/src/github.com/docker/cli/build /work/build
       - run:
-          name: "Unit Test"
+          name: "Unit Test with Coverage"
           command: |
             if [ "$CIRCLE_NODE_INDEX" != "2" ]; then exit; fi
             dockerfile=dockerfiles/Dockerfile.dev
             echo "COPY . ." >> $dockerfile
             docker build -f $dockerfile --tag cli-builder .
-            docker run cli-builder make test-coverage codecov
+            docker run --name test cli-builder make test-coverage
+            docker cp test:/go/src/github.com/docker/cli/coverage.txt coverage.txt
+            apk add -U bash curl
+            curl -s https://codecov.io/bash | bash
       - run:
           name: "Validate Vendor and Code Generation"
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ jobs:
             dockerfile=dockerfiles/Dockerfile.dev
             echo "COPY . ." >> $dockerfile
             docker build -f $dockerfile --tag cli-builder .
-            docker run cli-builder make test
+            docker run cli-builder make test-coverage codecov
       - run:
           name: "Validate Vendor and Code Generation"
           command: |

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,7 +1,7 @@
 
 FROM    golang:1.8-alpine
 
-RUN     apk add -U git make bash coreutils curl
+RUN     apk add -U git make bash coreutils
 
 RUN     go get github.com/LK4D4/vndr && \
         cp /go/bin/vndr /usr/bin && \

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,7 +1,7 @@
 
 FROM    golang:1.8-alpine
 
-RUN     apk add -U git make bash coreutils
+RUN     apk add -U git make bash coreutils curl
 
 RUN     go get github.com/LK4D4/vndr && \
         cp /go/bin/vndr /usr/bin && \

--- a/scripts/test/unit
+++ b/scripts/test/unit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+go test -tags daemon -v $@

--- a/scripts/test/unit-with-coverage
+++ b/scripts/test/unit-with-coverage
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+for pkg in $(go list ./... | grep -v /vendor/); do
+    ./scripts/test/unit \
+        -cover \
+        -coverprofile=profile.out \
+        -covermode=atomic \
+        ${pkg}
+    
+    if test -f profile.out; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done


### PR DESCRIPTION
This is more or less what we used on some other docker project.

- Not sure if `test-coverage` should be on his own or be just `test`
- @dnephin I added `parellel` here too 👼 
- @nandhini915 the codecov token is set on circleci I guess ? 👼 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
