### PR TITLE
Fix service ls/ps truncated display when image has no tag

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -511,9 +511,12 @@ func (c *serviceContext) Image() string {
 			if namedTagged, err := reference.WithTag(reference.TrimNamed(nt), nt.Tag()); err == nil {
 				image = reference.FamiliarString(namedTagged)
 			}
+		} else {
+			// when a tag is not provided
+			named := reference.TrimNamed(ref)
+			image = reference.FamiliarString(named)
 		}
 	}
-
 	return image
 }
 

--- a/cli/command/formatter/task.go
+++ b/cli/command/formatter/task.go
@@ -94,13 +94,16 @@ func (c *taskContext) Name() string {
 func (c *taskContext) Image() string {
 	image := c.task.Spec.ContainerSpec.Image
 	if c.trunc {
-		ref, err := reference.ParseNormalizedNamed(image)
-		if err == nil {
+		if ref, err := reference.ParseNormalizedNamed(image); err == nil {
 			// update image string for display, (strips any digest)
 			if nt, ok := ref.(reference.NamedTagged); ok {
 				if namedTagged, err := reference.WithTag(reference.TrimNamed(nt), nt.Tag()); err == nil {
 					image = reference.FamiliarString(namedTagged)
 				}
+			} else {
+				// when a tag is not provided
+				named := reference.TrimNamed(ref)
+				image = reference.FamiliarString(named)
 			}
 		}
 	}


### PR DESCRIPTION
In the case when an image didn't contain a tag, `ref.(reference.NamedTagged)` errors out, and the final result is that the digest gets printed even when `--no-trunc` is not specified.

This PR adds an extra case to fix that.

Fix https://github.com/docker/cli/issues/79.

cc @dmcgowan @aaronlehmann 