### PR TITLE
Add a restarting check to runAttach

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -34,11 +34,12 @@ func inspectContainerAndCheckState(ctx context.Context, cli client.APIClient, ar
 	if c.State.Paused {
 		return nil, errors.New("You cannot attach to a paused container, unpause it first")
 	}
+
 	return &c, nil
 }
 
 // NewAttachCommand creates a new cobra.Command for `docker attach`
-func NewAttachCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewAttachCommand(dockerCli command.Cli) *cobra.Command {
 	var opts attachOptions
 
 	cmd := &cobra.Command{
@@ -58,7 +59,7 @@ func NewAttachCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runAttach(dockerCli *command.DockerCli, opts *attachOptions) error {
+func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 	ctx := context.Background()
 	client := dockerCli.Client()
 

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -34,6 +34,9 @@ func inspectContainerAndCheckState(ctx context.Context, cli client.APIClient, ar
 	if c.State.Paused {
 		return nil, errors.New("You cannot attach to a paused container, unpause it first")
 	}
+	if c.State.Restarting {
+		return nil, errors.New("You cannot attach to a restarting container, wait until it is running")
+	}
 
 	return &c, nil
 }

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -51,6 +51,21 @@ func TestNewAttachCommandErrors(t *testing.T) {
 				return c, nil
 			},
 		},
+		{
+			name:          "client-restarting",
+			args:          []string{"5cb5bb5e4a3b"},
+			expectedError: "You cannot attach to a restarting container",
+			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
+				c := types.ContainerJSON{}
+				c.ContainerJSONBase = &types.ContainerJSONBase{}
+				c.ContainerJSONBase.State = &types.ContainerState{
+					Running:    true,
+					Paused:     false,
+					Restarting: true,
+				}
+				return c, nil
+			},
+		},
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,0 +1,62 @@
+package container
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/pkg/errors"
+)
+
+func TestNewAttachCommandErrors(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		args                 []string
+		expectedError        string
+		containerInspectFunc func(img string) (types.ContainerJSON, error)
+	}{
+		{
+			name:          "client-error",
+			args:          []string{"5cb5bb5e4a3b"},
+			expectedError: "something went wrong",
+			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
+				return types.ContainerJSON{}, errors.Errorf("something went wrong")
+			},
+		},
+		{
+			name:          "client-stopped",
+			args:          []string{"5cb5bb5e4a3b"},
+			expectedError: "You cannot attach to a stopped container",
+			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
+				c := types.ContainerJSON{}
+				c.ContainerJSONBase = &types.ContainerJSONBase{}
+				c.ContainerJSONBase.State = &types.ContainerState{Running: false}
+				return c, nil
+			},
+		},
+		{
+			name:          "client-paused",
+			args:          []string{"5cb5bb5e4a3b"},
+			expectedError: "You cannot attach to a paused container",
+			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
+				c := types.ContainerJSON{}
+				c.ContainerJSONBase = &types.ContainerJSONBase{}
+				c.ContainerJSONBase.State = &types.ContainerState{
+					Running: true,
+					Paused:  true,
+				}
+				return c, nil
+			},
+		},
+	}
+	for _, tc := range testCases {
+		buf := new(bytes.Buffer)
+		cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf))
+		cmd.SetOutput(ioutil.Discard)
+		cmd.SetArgs(tc.args)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}

--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -1,0 +1,19 @@
+package container
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	containerInspectFunc func(string) (types.ContainerJSON, error)
+}
+
+func (cli *fakeClient) ContainerInspect(_ context.Context, containerID string) (types.ContainerJSON, error) {
+	if cli.containerInspectFunc != nil {
+		return cli.containerInspectFunc(containerID)
+	}
+	return types.ContainerJSON{}, nil
+}

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -33,7 +33,7 @@ func newExecOptions() *execOptions {
 }
 
 // NewExecCommand creates a new cobra.Command for `docker exec`
-func NewExecCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 	options := newExecOptions()
 
 	cmd := &cobra.Command{
@@ -63,7 +63,7 @@ func NewExecCommand(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 // nolint: gocyclo
-func runExec(dockerCli *command.DockerCli, options *execOptions, container string, execCmd []string) error {
+func runExec(dockerCli command.Cli, options *execOptions, container string, execCmd []string) error {
 	execConfig, err := parseExec(options, execCmd)
 	// just in case the ParseExec does not exit
 	if container == "" || err != nil {

--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -39,7 +39,7 @@ func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id strin
 }
 
 // MonitorTtySize updates the container tty size when the terminal tty changes size
-func MonitorTtySize(ctx context.Context, cli *command.DockerCli, id string, isExec bool) error {
+func MonitorTtySize(ctx context.Context, cli command.Cli, id string, isExec bool) error {
 	resizeTty := func() {
 		height, width := cli.Out().GetTtySize()
 		resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
@@ -74,7 +74,7 @@ func MonitorTtySize(ctx context.Context, cli *command.DockerCli, id string, isEx
 }
 
 // ForwardAllSignals forwards signals to the container
-func ForwardAllSignals(ctx context.Context, cli *command.DockerCli, cid string) chan os.Signal {
+func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string) chan os.Signal {
 	sigc := make(chan os.Signal, 128)
 	signal.CatchAll(sigc)
 	go func() {

--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -127,7 +127,7 @@ func legacyWaitExitOrRemoved(ctx context.Context, dockerCli *command.DockerCli, 
 
 // getExitCode performs an inspect on the container. It returns
 // the running state and the exit code.
-func getExitCode(ctx context.Context, dockerCli *command.DockerCli, containerID string) (bool, int, error) {
+func getExitCode(ctx context.Context, dockerCli command.Cli, containerID string) (bool, int, error) {
 	c, err := dockerCli.Client().ContainerInspect(ctx, containerID)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.


### PR DESCRIPTION
Signed-off-by: yangshukui <yangshukui@huawei.com>

part carried from https://github.com/moby/moby/pull/32137

**- What I did**
Add a restarting check to runAttach

**- How I did it**

**- How to verify it**
terminal 1,
```
docker run -d --restart=always busybox
3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
sleep 5
docker attach 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
terminal 2,
```
docker stop 3664ae34b27306711b55a4cbf1802d1a027b3ab33ef7fe7789c1aefb0268c928
```
and then docker attach maybe block.

