### PR TITLE
Spelling

### DIFF
--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -163,7 +163,7 @@ func (h *hijackedIOStreamer) beginInputStream(restoreInput func()) (doneC <-chan
 			if err != nil {
 				// This error will also occur on the receive
 				// side (from stdout) where it will be
-				// propogated back to the caller.
+				// propagated back to the caller.
 				logrus.Debugf("Error sendStdin: %s", err)
 			}
 		}

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -146,12 +146,12 @@ func runStart(dockerCli *command.DockerCli, opts *startOptions) error {
 				fmt.Fprintln(dockerCli.Err(), "Error monitoring TTY size:", err)
 			}
 		}
-		if attchErr := <-cErr; attchErr != nil {
+		if attachErr := <-cErr; attachErr != nil {
 			if _, ok := err.(term.EscapeError); ok {
 				// The user entered the detach escape sequence.
 				return nil
 			}
-			return attchErr
+			return attachErr
 		}
 
 		if status := <-statusChan; status != 0 {

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -226,7 +226,7 @@ size: 0B
 			Context{Format: NewContainerFormat("{{.Image}}", false, true)},
 			"ubuntu\nubuntu\n",
 		},
-		// Special headers for customerized table format
+		// Special headers for customized table format
 		{
 			Context{Format: NewContainerFormat(`table {{truncate .ID 5}}\t{{json .Image}} {{.RunningFor}}/{{title .Status}}/{{pad .Ports 2 2}}.{{upper .Names}} {{lower .Status}}`, false, true)},
 			`CONTAINER ID        IMAGE CREATED/STATUS/  PORTS  .NAMES STATUS

--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // waitOnService waits for the service to converge. It outputs a progress bar,
-// if appopriate based on the CLI flags.
+// if appropriate based on the CLI flags.
 func waitOnService(ctx context.Context, dockerCli *command.DockerCli, serviceID string, opts *serviceOptions) error {
 	errChan := make(chan error, 1)
 	pipeReader, pipeWriter := io.Pipe()

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -237,7 +237,7 @@ type logWriter struct {
 func (lw *logWriter) Write(buf []byte) (int, error) {
 	// this works but ONLY because stdcopy calls write a whole line at a time.
 	// if this ends up horribly broken or panics, check to see if stdcopy has
-	// reneged on that asssumption. (@god forgive me)
+	// reneged on that assumption. (@god forgive me)
 	// also this only works because the logs format is, like, barely parsable.
 	// if something changes in the logs format, this is gonna break
 

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -233,7 +233,7 @@ func writeOverallProgress(progressOut progress.Output, numerator, denominator in
 type replicatedProgressUpdater struct {
 	progressOut progress.Output
 
-	// used for maping slots to a contiguous space
+	// used for mapping slots to a contiguous space
 	// this also causes progress bars to appear in order
 	slotMap map[int]int
 

--- a/dockerfiles/osx-cross.sh
+++ b/dockerfiles/osx-cross.sh
@@ -25,5 +25,5 @@ echo "Downloading OSX SDK"
 time curl -sSL https://s3.dockerproject.org/darwin/v2/${OSX_SDK}.tar.xz \
     -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz"
 
-echo "Buidling osxcross"
+echo "Building osxcross"
 UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh > /dev/null

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -158,7 +158,7 @@ func TestValidateDNSSearch(t *testing.T) {
 		`foo.bar-.baz`,
 		`foo.-bar`,
 		`foo.-bar.baz`,
-		`foo.bar.baz.this.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbethis.should.fail.on.long.name.beause.it.is.longer.thanisshouldbe`,
+		`foo.bar.baz.this.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbe`,
 	}
 
 	for _, domain := range valid {


### PR DESCRIPTION
I'm going to actively ignore your submission guidelines.
As a general rule, whenever I submit large changesets to large projects, people insist on changes. As such, there's no point in me signing a submission at this time.
The current summary of each changeset represents a distinct word family misspelling. Sometimes projects have a preferred language family (en-US/en-GB being the most common), as such it's handy to be able to easily drop changesets. It's also not uncommon for some changes to need to be split out into special PRs (e.g. if they would constitute an API change).

I'm happy to squash and sign a single commit once someone agrees it's ready.
I'd appreciate it if someone proposed the commit message. I am not eager to have to sign the commit a second time because someone objects to my chosen commit message.

**- What I did**
I spellchecked the docker/cli repository

**- How I did it**
I used my own personal tool to generate a list of tokens not found in `/usr/share/dict/words` -- I then manually consider each remaining token. Typically I'll let Google Suggest suggest replacement words.

**- How to verify it**
Review the diff.

**- Description for the changelog**
9 word families were corrected across:
 9 files changed, 17 insertions(+), 17 deletions(-)

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://cloud.githubusercontent.com/assets/2119212/26288409/c30602da-3e5f-11e7-87e4-f571c5de29a4.png)
