### PR TITLE
allow version number to be set in builds

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,6 +8,7 @@ DEV_DOCKER_IMAGE_NAME = docker-cli-dev
 LINTER_IMAGE_NAME = docker-cli-lint
 CROSS_IMAGE_NAME = docker-cli-cross
 MOUNTS = -v `pwd`:/go/src/github.com/docker/cli
+VERSION = $(shell cat VERSION)
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
@@ -26,7 +27,7 @@ build_cross_image:
 
 # build executable using a container
 binary: build_docker_image
-	docker run --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
+	docker run --rm -e VERSION=$(VERSION) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
 
 build: binary
 
@@ -43,7 +44,7 @@ test: build_docker_image
 # build the CLI for multiple architectures using a container
 .PHONY: cross
 cross: build_cross_image
-	docker run --rm $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
+	docker run --rm -e VERSION=$(VERSION) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
 
 .PHONY: watch
 watch: build_docker_image

--- a/scripts/build/osx
+++ b/scripts/build/osx
@@ -11,7 +11,7 @@ export CGO_ENABLED=1
 export GOOS=darwin
 export GOARCH=amd64
 export CC=o64-clang
-export LDFLAGS='-linkmode external -s'
+export LDFLAGS="$LDFLAGS -linkmode external -s"
 export LDFLAGS_STATIC_DOCKER='-extld='${CC}
 
 # Override TARGET


### PR DESCRIPTION
Signed-off-by: Andrew Hsu <andrewhsu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Pass version number into build scripts so binary can display version number. Without this PR, the version number will not be set in the final build artifact:

**- How I did it**

Update `Makefile` to pass value into docker container that does the build.

**- How to verify it**

```
$ make -f docker.Makefile binary
$ build/docker --version
Docker version 17.06.0-dev, build 883d28c
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* set version number based on `VERSION` file

**- A picture of a cute animal (not mandatory but encouraged)**

🐈 
