### PR TITLE
Enable client side digest pinning for stack deploy

### DIFF
--- a/cli/command/stack/deploy_bundlefile.go
+++ b/cli/command/stack/deploy_bundlefile.go
@@ -87,5 +87,5 @@ func deployBundle(ctx context.Context, dockerCli command.Cli, opts deployOptions
 	if err := createNetworks(ctx, dockerCli, namespace, networks); err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
 }

--- a/cli/command/stack/deploy_bundlefile.go
+++ b/cli/command/stack/deploy_bundlefile.go
@@ -87,5 +87,5 @@ func deployBundle(ctx context.Context, dockerCli command.Cli, opts deployOptions
 	if err := createNetworks(ctx, dockerCli, namespace, networks); err != nil {
 		return err
 	}
-	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.noResolveImage)
+	return deployServices(ctx, dockerCli, services, namespace, opts.sendRegistryAuth, opts.resolveImage)
 }

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -17,7 +17,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultNetwork = "default"
+const (
+	defaultNetwork = "default"
+	// LabelImage is the label used to store image name provided in the compose file
+	LabelImage = "com.docker.stack.image"
+)
 
 // Services from compose-file types to engine API types
 func Services(
@@ -45,12 +49,6 @@ func Services(
 		if err != nil {
 			return nil, errors.Wrapf(err, "service %s", service.Name)
 		}
-		// add an image label to serviceSpec
-		if serviceSpec.Labels == nil {
-			serviceSpec.Labels = make(map[string]string)
-		}
-		serviceSpec.Labels["com.docker.stack.image"] = service.Image
-
 		result[service.Name] = serviceSpec
 	}
 
@@ -162,6 +160,9 @@ func convertService(
 		Mode:         mode,
 		UpdateConfig: convertUpdateConfig(service.Deploy.UpdateConfig),
 	}
+
+	// add an image label to serviceSpec
+	serviceSpec.Labels[LabelImage] = service.Image
 
 	// ServiceSpec.Networks is deprecated and should not have been used by
 	// this package. It is possible to update TaskTemplate.Networks, but it

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -45,6 +45,12 @@ func Services(
 		if err != nil {
 			return nil, errors.Wrapf(err, "service %s", service.Name)
 		}
+		// add an image label to serviceSpec
+		if serviceSpec.Labels == nil {
+			serviceSpec.Labels = make(map[string]string)
+		}
+		serviceSpec.Labels["com.docker.stack.image"] = service.Image
+
 		result[service.Name] = serviceSpec
 	}
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/docker/cli/pull/30.

It also adds a `--no-resolve-image` flag to `stack deploy` to disable digest pinning if required.

I'm not sure if we want to do this for 17.06, but it seems like all the required functionality exists, and it would be useful to have consistency.

cc @dnephin @tiborvass  @thaJeztah 