### PR TITLE
allow override of git hash when building binary

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -9,6 +9,7 @@ LINTER_IMAGE_NAME = docker-cli-lint
 CROSS_IMAGE_NAME = docker-cli-cross
 MOUNTS = -v `pwd`:/go/src/github.com/docker/cli
 VERSION = $(shell cat VERSION)
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
@@ -27,7 +28,7 @@ build_cross_image:
 
 # build executable using a container
 binary: build_docker_image
-	docker run --rm -e VERSION=$(VERSION) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
+	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
 
 build: binary
 
@@ -44,7 +45,7 @@ test: build_docker_image
 # build the CLI for multiple architectures using a container
 .PHONY: cross
 cross: build_cross_image
-	docker run --rm -e VERSION=$(VERSION) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
+	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
 
 .PHONY: watch
 watch: build_docker_image
@@ -68,4 +69,4 @@ vendor: build_docker_image vendor.conf
 	docker run -ti --rm $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make vendor
 
 dynbinary: build_cross_image
-	docker run -ti --rm $(MOUNTS) $(CROSS_IMAGE_NAME) make dynbinary
+	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make dynbinary


### PR DESCRIPTION
Signed-off-by: Andrew Hsu <andrewhsu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Have `docker.Makefile` accept optional parameter `GITCOMMIT` to set the git hash in the output of the final binary's `docker --version`.

This is useful in the situation of having the source code of the repo, but no `.git` directory for the `git rev-parse` command to get the git hash. The optional parameter will allow override of the git hash in this case.

**- How I did it**

With my fingers.

**- How to verify it**

```
$ make -f docker.Makefile GITCOMMIT=deadbee binary
$ build/docker --version
Docker version 17.06.0-dev, build deadbee
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* allow override of git hash when building binary

**- A picture of a cute animal (not mandatory but encouraged)**

🐝 