### PR TITLE
Host and Bridge network support in docker stack deploy

### DIFF
--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/compose/loader"
 	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	apiclient "github.com/docker/docker/client"
 	dockerclient "github.com/docker/docker/client"
@@ -177,11 +178,11 @@ func validateExternalNetworks(
 		network, err := client.NetworkInspect(ctx, networkName, false)
 		if err != nil {
 			if dockerclient.IsErrNetworkNotFound(err) {
-				return errors.Errorf("network %q is declared as external, but could not be found. You need to create the network before the stack is deployed (with overlay driver)", networkName)
+				return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)
 			}
 			return err
 		}
-		if network.Scope != "swarm" {
+		if container.NetworkMode(networkName).IsUserDefined() && network.Scope != "swarm" {
 			return errors.Errorf("network %q is declared as external, but it is not in the right scope: %q instead of %q", networkName, network.Scope, "swarm")
 		}
 	}

--- a/cli/command/stack/deploy_composefile_test.go
+++ b/cli/command/stack/deploy_composefile_test.go
@@ -5,9 +5,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/cli/cli/internal/test/network"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/docker/pkg/testutil/tempfile"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestGetConfigDetails(t *testing.T) {
@@ -25,4 +30,56 @@ services:
 	assert.Equal(t, filepath.Dir(file.Name()), details.WorkingDir)
 	assert.Len(t, details.ConfigFiles, 1)
 	assert.Len(t, details.Environment, len(os.Environ()))
+}
+
+type notFound struct {
+	error
+}
+
+func (n notFound) NotFound() bool {
+	return true
+}
+
+func TestValidateExternalNetworks(t *testing.T) {
+	var testcases = []struct {
+		inspectResponse types.NetworkResource
+		inspectError    error
+		expectedMsg     string
+		network         string
+	}{
+		{
+			inspectError: notFound{},
+			expectedMsg:  "could not be found. You need to create a swarm-scoped network",
+		},
+		{
+			inspectError: errors.New("Unexpected"),
+			expectedMsg:  "Unexpected",
+		},
+		{
+			network: "host",
+		},
+		{
+			network:     "user",
+			expectedMsg: "is not in the right scope",
+		},
+		{
+			network:         "user",
+			inspectResponse: types.NetworkResource{Scope: "swarm"},
+		},
+	}
+
+	for _, testcase := range testcases {
+		fakeClient := &network.FakeClient{
+			NetworkInspectFunc: func(_ context.Context, _ string, _ bool) (types.NetworkResource, error) {
+				return testcase.inspectResponse, testcase.inspectError
+			},
+		}
+		networks := []string{testcase.network}
+		err := validateExternalNetworks(context.Background(), fakeClient, networks)
+		if testcase.expectedMsg == "" {
+			assert.NoError(t, err)
+		} else {
+			testutil.ErrorContains(t, err, testcase.expectedMsg)
+		}
+	}
 }

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -214,18 +214,21 @@ func convertServiceNetworks(
 		if !ok && networkName != defaultNetwork {
 			return nil, errors.Errorf("undefined network %q", networkName)
 		}
-		var aliases []string
-		if network != nil {
-			aliases = network.Aliases
-		}
 		target := namespace.Scope(networkName)
 		if networkConfig.External.External {
 			target = networkConfig.External.Name
 		}
-		nets = append(nets, swarm.NetworkAttachmentConfig{
-			Target:  target,
-			Aliases: append(aliases, name),
-		})
+		netAttachConfig := swarm.NetworkAttachmentConfig{
+			Target: target,
+		}
+		if container.NetworkMode(target).IsUserDefined() {
+			var aliases []string
+			if network != nil {
+				aliases = network.Aliases
+			}
+			netAttachConfig.Aliases = append(aliases, name)
+		}
+		nets = append(nets, netAttachConfig)
 	}
 
 	sort.Sort(byNetworkTarget(nets))

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -214,19 +214,22 @@ func convertServiceNetworks(
 		if !ok && networkName != defaultNetwork {
 			return nil, errors.Errorf("undefined network %q", networkName)
 		}
+		var aliases []string
+		if network != nil {
+			aliases = network.Aliases
+		}
 		target := namespace.Scope(networkName)
 		if networkConfig.External.External {
 			target = networkConfig.External.Name
 		}
 		netAttachConfig := swarm.NetworkAttachmentConfig{
-			Target: target,
+			Target:  target,
+			Aliases: aliases,
 		}
+		// Only add default aliases to user defined networks. Other networks do
+		// not support aliases.
 		if container.NetworkMode(target).IsUserDefined() {
-			var aliases []string
-			if network != nil {
-				aliases = network.Aliases
-			}
-			netAttachConfig.Aliases = append(aliases, name)
+			netAttachConfig.Aliases = append(netAttachConfig.Aliases, name)
 		}
 		nets = append(nets, netAttachConfig)
 	}

--- a/cli/internal/test/network/client.go
+++ b/cli/internal/test/network/client.go
@@ -1,0 +1,56 @@
+package network
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"golang.org/x/net/context"
+)
+
+// FakeClient is a fake NetworkAPIClient
+type FakeClient struct {
+	NetworkInspectFunc func(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
+}
+
+// NetworkConnect fakes connecting to a network
+func (c *FakeClient) NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error {
+	return nil
+}
+
+// NetworkCreate fakes creating a network
+func (c *FakeClient) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	return types.NetworkCreateResponse{}, nil
+}
+
+// NetworkDisconnect fakes disconencting from a network
+func (c *FakeClient) NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error {
+	return nil
+}
+
+// NetworkInspect fakes inspecting a network
+func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
+	if c.NetworkInspectFunc != nil {
+		return c.NetworkInspectFunc(ctx, networkID, verbose)
+	}
+	return types.NetworkResource{}, nil
+}
+
+// NetworkInspectWithRaw fakes inspecting a network with a raw response
+func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error) {
+	return types.NetworkResource{}, nil, nil
+}
+
+// NetworkList fakes listing networks
+func (c *FakeClient) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
+	return nil, nil
+}
+
+// NetworkRemove fakes removing networks
+func (c *FakeClient) NetworkRemove(ctx context.Context, networkID string) error {
+	return nil
+}
+
+// NetworksPrune fakes pruning networks
+func (c *FakeClient) NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error) {
+	return types.NetworksPruneReport{}, nil
+}

--- a/scripts/test/watch
+++ b/scripts/test/watch
@@ -3,7 +3,7 @@
 set -e
 
 filewatcher \
-    -L 5 \
+    -L 6 \
     -x '**/*.swp' \
     -x .git \
     -x build \


### PR DESCRIPTION
With the introduction of node-local network support, docker services can
be attached to special networks such as host and bridge. This fix brings
in the required changes to make sure the stack file accepts these
networks as well.

Fixes https://github.com/docker/cli/issues/131

Signed-off-by: Madhu Venugopal <madhu@docker.com>
