### PR TITLE
Silent login: use credentials from cred store to login

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/client"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -47,10 +50,7 @@ func NewLoginCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runLogin(dockerCli command.Cli, opts loginOptions) error {
-	ctx := context.Background()
-	clnt := dockerCli.Client()
-
+func verifyloginOptions(dockerCli command.Cli, opts *loginOptions) error {
 	if opts.password != "" {
 		fmt.Fprintln(dockerCli.Err(), "WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
 		if opts.passwordStdin {
@@ -71,7 +71,15 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error {
 		opts.password = strings.TrimSuffix(string(contents), "\n")
 		opts.password = strings.TrimSuffix(opts.password, "\r")
 	}
+	return nil
+}
 
+func runLogin(dockerCli command.Cli, opts loginOptions) error {
+	ctx := context.Background()
+	clnt := dockerCli.Client()
+	if err := verifyloginOptions(dockerCli, &opts); err != nil {
+		return err
+	}
 	var (
 		serverAddress string
 		authServer    = command.ElectAuthServer(ctx, dockerCli)
@@ -82,21 +90,30 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error {
 		serverAddress = authServer
 	}
 
+	var err error
+	var authConfig *types.AuthConfig
+	var response registrytypes.AuthenticateOKBody
 	isDefaultRegistry := serverAddress == authServer
-
-	authConfig, err := command.ConfigureAuth(dockerCli, opts.user, opts.password, serverAddress, isDefaultRegistry)
-	if err != nil {
-		return err
+	authConfig, err = command.GetDefaultAuthConfig(dockerCli, opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
+	if err == nil && authConfig.Username != "" && authConfig.Password != "" {
+		response, err = loginWithCredStoreCreds(ctx, dockerCli, authConfig)
 	}
-	response, err := clnt.RegistryLogin(ctx, authConfig)
-	if err != nil {
-		return err
+	if err != nil || authConfig.Username == "" || authConfig.Password == "" {
+		err = command.ConfigureAuth(dockerCli, opts.user, opts.password, authConfig, isDefaultRegistry)
+		if err != nil {
+			return err
+		}
+
+		response, err = clnt.RegistryLogin(ctx, *authConfig)
+		if err != nil {
+			return err
+		}
 	}
 	if response.IdentityToken != "" {
 		authConfig.Password = ""
 		authConfig.IdentityToken = response.IdentityToken
 	}
-	if err := dockerCli.ConfigFile().GetCredentialsStore(serverAddress).Store(authConfig); err != nil {
+	if err := dockerCli.ConfigFile().GetCredentialsStore(serverAddress).Store(*authConfig); err != nil {
 		return errors.Errorf("Error saving credentials: %v", err)
 	}
 
@@ -104,4 +121,18 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error {
 		fmt.Fprintln(dockerCli.Out(), response.Status)
 	}
 	return nil
+}
+
+func loginWithCredStoreCreds(ctx context.Context, dockerCli command.Cli, authConfig *types.AuthConfig) (registrytypes.AuthenticateOKBody, error) {
+	fmt.Fprintf(dockerCli.Out(), "Authenticating with existing credentials...\n")
+	cliClient := dockerCli.Client()
+	response, err := cliClient.RegistryLogin(ctx, *authConfig)
+	if err != nil {
+		if client.IsErrUnauthorized(err) {
+			fmt.Fprintf(dockerCli.Err(), "Stored credentials invalid or expired\n")
+		} else {
+			fmt.Fprintf(dockerCli.Err(), "Login did not succeed, error: %s\n", err)
+		}
+	}
+	return response, err
 }

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -1,0 +1,151 @@
+package registry
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+)
+
+const userErr = "userunknownError"
+const testAuthErrMsg = "UNKNOWN_ERR"
+
+var testAuthErrors = map[string]error{
+	userErr: fmt.Errorf(testAuthErrMsg),
+}
+
+var expiredPassword = "I_M_EXPIRED"
+
+type fakeClient struct {
+	client.Client
+}
+
+// nolint: unparam
+func (c fakeClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registrytypes.AuthenticateOKBody, error) {
+	if auth.Password == expiredPassword {
+		return registrytypes.AuthenticateOKBody{}, fmt.Errorf("Invalid Username or Password")
+	}
+	err := testAuthErrors[auth.Username]
+	return registrytypes.AuthenticateOKBody{}, err
+}
+
+func TestLoginWithCredStoreCreds(t *testing.T) {
+	testCases := []struct {
+		inputAuthConfig types.AuthConfig
+		expectedMsg     string
+		expectedErr     string
+	}{
+		{
+			inputAuthConfig: types.AuthConfig{},
+			expectedMsg:     "Authenticating with existing credentials...\n",
+		},
+		{
+			inputAuthConfig: types.AuthConfig{
+				Username: userErr,
+			},
+			expectedMsg: "Authenticating with existing credentials...\n",
+			expectedErr: fmt.Sprintf("Login did not succeed, error: %s\n", testAuthErrMsg),
+		},
+		// can't easily test the 401 case because client.IsErrUnauthorized(err) involving
+		// creating an error of a private type
+	}
+	ctx := context.Background()
+	for _, tc := range testCases {
+		cli := (*test.FakeCli)(test.NewFakeCli(&fakeClient{}))
+		errBuf := new(bytes.Buffer)
+		cli.SetErr(errBuf)
+		loginWithCredStoreCreds(ctx, cli, &tc.inputAuthConfig)
+		outputString := cli.OutBuffer().String()
+		assert.Equal(t, tc.expectedMsg, outputString)
+		errorString := errBuf.String()
+		assert.Equal(t, tc.expectedErr, errorString)
+	}
+}
+
+func TestRunLogin(t *testing.T) {
+	const storedServerAddress = "reg1"
+	const validUsername = "u1"
+	const validPassword = "p1"
+	const validPassword2 = "p2"
+
+	validAuthConfig := types.AuthConfig{
+		ServerAddress: storedServerAddress,
+		Username:      validUsername,
+		Password:      validPassword,
+	}
+	expiredAuthConfig := types.AuthConfig{
+		ServerAddress: storedServerAddress,
+		Username:      validUsername,
+		Password:      expiredPassword,
+	}
+	testCases := []struct {
+		inputLoginOption  loginOptions
+		inputStoredCred   *types.AuthConfig
+		expectedErr       string
+		expectedSavedCred types.AuthConfig
+	}{
+		{
+			inputLoginOption: loginOptions{
+				serverAddress: storedServerAddress,
+			},
+			inputStoredCred:   &validAuthConfig,
+			expectedErr:       "",
+			expectedSavedCred: validAuthConfig,
+		},
+		{
+			inputLoginOption: loginOptions{
+				serverAddress: storedServerAddress,
+			},
+			inputStoredCred: &expiredAuthConfig,
+			expectedErr:     "Error: Cannot perform an interactive login from a non TTY device",
+		},
+		{
+			inputLoginOption: loginOptions{
+				serverAddress: storedServerAddress,
+				user:          validUsername,
+				password:      validPassword2,
+			},
+			inputStoredCred: &validAuthConfig,
+			expectedErr:     "",
+			expectedSavedCred: types.AuthConfig{
+				ServerAddress: storedServerAddress,
+				Username:      validUsername,
+				Password:      validPassword2,
+			},
+		},
+		{
+			inputLoginOption: loginOptions{
+				serverAddress: storedServerAddress,
+				user:          userErr,
+				password:      validPassword,
+			},
+			inputStoredCred: &validAuthConfig,
+			expectedErr:     testAuthErrMsg,
+		},
+	}
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{})
+		errBuf := new(bytes.Buffer)
+		cli.SetErr(errBuf)
+		if tc.inputStoredCred != nil {
+			cred := *tc.inputStoredCred
+			cli.ConfigFile().GetCredentialsStore(cred.ServerAddress).Store(cred)
+		}
+		loginErr := runLogin(cli, tc.inputLoginOption)
+		if tc.expectedErr != "" {
+			assert.Equal(t, tc.expectedErr, loginErr.Error())
+		} else {
+			assert.Nil(t, loginErr)
+			savedCred, credStoreErr := cli.ConfigFile().GetCredentialsStore(tc.inputStoredCred.ServerAddress).Get(tc.inputStoredCred.ServerAddress)
+			assert.Nil(t, credStoreErr)
+			assert.Equal(t, tc.expectedSavedCred, savedCred)
+		}
+	}
+}

--- a/internal/test/store.go
+++ b/internal/test/store.go
@@ -5,8 +5,8 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// fake store implements a credentials.Store that only acts as an in memory map
-type fakeStore struct {
+// FakeStore implements a credentials.Store that only acts as an in memory map
+type FakeStore struct {
 	store      map[string]types.AuthConfig
 	eraseFunc  func(serverAddress string) error
 	getFunc    func(serverAddress string) (types.AuthConfig, error)
@@ -16,31 +16,36 @@ type fakeStore struct {
 
 // NewFakeStore creates a new file credentials store.
 func NewFakeStore() credentials.Store {
-	return &fakeStore{store: map[string]types.AuthConfig{}}
+	return &FakeStore{store: map[string]types.AuthConfig{}}
 }
 
-func (c *fakeStore) SetStore(store map[string]types.AuthConfig) {
+// SetStore is used to overrides Set function
+func (c *FakeStore) SetStore(store map[string]types.AuthConfig) {
 	c.store = store
 }
 
-func (c *fakeStore) SetEraseFunc(eraseFunc func(string) error) {
+// SetEraseFunc is used to overrides Erase function
+func (c *FakeStore) SetEraseFunc(eraseFunc func(string) error) {
 	c.eraseFunc = eraseFunc
 }
 
-func (c *fakeStore) SetGetFunc(getFunc func(string) (types.AuthConfig, error)) {
+// SetGetFunc is used to overrides Get function
+func (c *FakeStore) SetGetFunc(getFunc func(string) (types.AuthConfig, error)) {
 	c.getFunc = getFunc
 }
 
-func (c *fakeStore) SetGetAllFunc(getAllFunc func() (map[string]types.AuthConfig, error)) {
+// SetGetAllFunc is used to  overrides GetAll function
+func (c *FakeStore) SetGetAllFunc(getAllFunc func() (map[string]types.AuthConfig, error)) {
 	c.getAllFunc = getAllFunc
 }
 
-func (c *fakeStore) SetStoreFunc(storeFunc func(types.AuthConfig) error) {
+// SetStoreFunc is used to override Store function
+func (c *FakeStore) SetStoreFunc(storeFunc func(types.AuthConfig) error) {
 	c.storeFunc = storeFunc
 }
 
 // Erase removes the given credentials from the map store
-func (c *fakeStore) Erase(serverAddress string) error {
+func (c *FakeStore) Erase(serverAddress string) error {
 	if c.eraseFunc != nil {
 		return c.eraseFunc(serverAddress)
 	}
@@ -49,14 +54,15 @@ func (c *fakeStore) Erase(serverAddress string) error {
 }
 
 // Get retrieves credentials for a specific server from the map store.
-func (c *fakeStore) Get(serverAddress string) (types.AuthConfig, error) {
+func (c *FakeStore) Get(serverAddress string) (types.AuthConfig, error) {
 	if c.getFunc != nil {
 		return c.getFunc(serverAddress)
 	}
 	return c.store[serverAddress], nil
 }
 
-func (c *fakeStore) GetAll() (map[string]types.AuthConfig, error) {
+// GetAll returns the key value pairs of ServerAddress => Username
+func (c *FakeStore) GetAll() (map[string]types.AuthConfig, error) {
 	if c.getAllFunc != nil {
 		return c.getAllFunc()
 	}
@@ -64,7 +70,7 @@ func (c *fakeStore) GetAll() (map[string]types.AuthConfig, error) {
 }
 
 // Store saves the given credentials in the map store.
-func (c *fakeStore) Store(authConfig types.AuthConfig) error {
+func (c *FakeStore) Store(authConfig types.AuthConfig) error {
 	if c.storeFunc != nil {
 		return c.storeFunc(authConfig)
 	}


### PR DESCRIPTION
**- What I did**
As discussed in https://github.com/docker/cli/issues/130#issuecomment-304921964, Azure Container Registry wants a way for `docker login <registry>` to proceed to log in if the credential store returns username and password.

This is a minor behavior change for `docker login` command scenario. In particular: when user call `docker login` without `-p` and `-u`, it used to be that the user would be prompted for new username and password interactively in all situations.

The new behavior would be a lot like `docker pull`. `docker login`. With this change, docker would now try to find credentials in the cred store first and try to login with it. Only if it fails with 401 status would docker cli prompt for new username and password.

**- How I did it**
The surface area of this code change was a little bigger than expected because of some refactoring. Functionality changes are mostly in [cli/command/registry/login.go](cli/command/registry/login.go). There are some refactoring going on mainly in [cli/command/registry.go](cli/command/registry.go) because I didn't want to call `cli.CredentialsStore(serverAddress).Get(serverAddress)` twice in the scenario where docker is prompting for credentials interactively and looking for existing username in the cred store as default parameters.

I actually think the refactor may be useful as I can see similar changes being done to refactor `pull`, `push`, etc to save a call to CredentialsStore.Get in similar situation. 

**- How to verify it**

Manually ran `docker login` with or without `-p`, `-u` with default registry. Observed expected behavior change:
- Login prompt occurs as normal if the user wasn't logged in.
- Login prompt would be omitted if the user was already logged in
- Login prompt would occur if cred store credential is incorrect (simulate a credential expired scenario)

Manually ran `docker login <registry>` on Azure Container Registry
- Login prompt is shown as expected, cred store is updated only after login

Manually ran `docker pull <registry>` without logging in and trigger a login
- Login prompt is shown as expected, pull proceeded only after login
