### PR TITLE
Allow --detach and --quiet flags when using --rollback

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -131,7 +131,7 @@ func runUpdate(dockerCli *command.DockerCli, flags *pflag.FlagSet, options *serv
 		// Rollback can't be combined with other flags.
 		otherFlagsPassed := false
 		flags.VisitAll(func(f *pflag.Flag) {
-			if f.Name == "rollback" {
+			if f.Name == "rollback" || f.Name == "detach" || f.Name == "quiet" {
 				return
 			}
 			if flags.Changed(f.Name) {


### PR DESCRIPTION
Commit 78c204ef798c7380e11ba26e5cd231e04fc6efe4 (https://github.com/moby/moby/pull/31108/commits/f9bd8ec8b268581f93095c5a80679f0a8ff498bf /  https://github.com/moby/moby/pull/31108 in the moby repo) added a validation to prevent `--rollback` from being used in combination with other flags that update the service spec.

This validation was not taking into account that some flags only affect the CLI behavior, and are okay to be used when rolling back.

This patch updates the validation, and adds `--quiet` and `--detach` to the list of allowed flags.

relates to https://github.com/moby/moby/issues/33444#issuecomment-305420378