### PR TITLE
Compose: Improve error messages when resource create/update fails

### DIFF
--- a/cli/compose/loader/volume.go
+++ b/cli/compose/loader/volume.go
@@ -114,8 +114,5 @@ func isFilePath(source string) bool {
 
 	// Windows absolute path
 	first, next := utf8.DecodeRuneInString(source)
-	if unicode.IsLetter(first) && source[next] == ':' {
-		return true
-	}
-	return false
+	return unicode.IsLetter(first) && source[next] == ':'
 }


### PR DESCRIPTION
Previously secret update errors looked like this:

> Error response from daemon: rpc error: code = 3 desc = only updates to Labels are allowed

which do not provide enough details for a user to understand what failed.

Also removes some unnecessary conditions in `deployServices()`