### PR TITLE
Stop disabling Windows LF -> CRLF translation

### DIFF
--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -179,10 +179,7 @@ func (h *hijackedIOStreamer) beginInputStream(restoreInput func()) (doneC <-chan
 }
 
 func setRawTerminal(streams command.Streams) error {
-	if err := streams.In().SetRawTerminal(); err != nil {
-		return err
-	}
-	return streams.Out().SetRawTerminal()
+	return streams.In().SetRawTerminal()
 }
 
 func restoreTerminal(streams command.Streams, in io.Closer) error {

--- a/cli/command/out.go
+++ b/cli/command/out.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"io"
-	"os"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/term"
@@ -17,15 +16,6 @@ type OutStream struct {
 
 func (o *OutStream) Write(p []byte) (int, error) {
 	return o.out.Write(p)
-}
-
-// SetRawTerminal sets raw mode on the input terminal
-func (o *OutStream) SetRawTerminal() (err error) {
-	if os.Getenv("NORAW") != "" || !o.CommonStream.isTerminal {
-		return nil
-	}
-	o.CommonStream.state, err = term.SetRawTerminalOutput(o.CommonStream.fd)
-	return err
 }
 
 // GetTtySize returns the height and width in characters of the tty


### PR DESCRIPTION
Signed-off-by: John Stephens <johnstep@docker.com>

runc was changed to remove the `unix.ONLCR` terminal flag in opencontainers/runc#1146, which stops the translation of LF to CRLF. The Windows console should keep its default behavior of converting LF to CRLF.

@jhowardmsft