### PR TITLE
Fix check-git-diff in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,6 +45,7 @@ jobs:
             if [ "$CIRCLE_NODE_INDEX" != "3" ]; then exit; fi
             dockerfile=dockerfiles/Dockerfile.dev
             echo "COPY . ." >> $dockerfile
+            rm -f .dockerignore # include .git
             docker build -f $dockerfile --tag cli-builder .
             docker run cli-builder make -B vendor compose-jsonschema
 

--- a/scripts/validate/check-git-diff
+++ b/scripts/validate/check-git-diff
@@ -3,12 +3,13 @@
 set -eu
 
 DIFF_PATH=$1
+DIFF=$(git status --porcelain -- $DIFF_PATH)
 
-if [ "`git status --porcelain -- $DIFF_PATH 2>/dev/null`" ]; then
+if [ "$DIFF" ]; then
     echo
     echo "These files were changed:"
     echo
-    git status --porcelain -- $DIFF_PATH 2>/dev/null
+    echo $DIFF
     echo
     exit 1
 else


### PR DESCRIPTION
The vendor and compose-jsonschema checks were not failing in CI because `.git` is in `.dockerignore` (https://circleci.com/gh/docker/cli/552#queue-placeholder/containers/3)

This PR fixes the issue (see example run https://circleci.com/gh/docker/cli/557#queue-placeholder/containers/3).

`scripts/validate/check-git-diff` now errors properly when there is no `.git`, and `.git` is included in the image for this build.