### PR TITLE
Update codecov project threshold to 15%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: "0.05%"
+        threshold: "15%"
     changes: false
 ignore:
   - "**/internal/test"


### PR DESCRIPTION
That way, the build will fail less.

See https://github.com/docker/cli/pull/155#issuecomment-306597334

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
