### PR TITLE
Bump docker/docker to cd35e4beee13a7c193e2a89008cd87d38fcd0161

### DIFF
--- a/cli/command/image/build/context_test.go
+++ b/cli/command/image/build/context_test.go
@@ -266,3 +266,35 @@ func chdir(t *testing.T, dir string) func() {
 	require.NoError(t, os.Chdir(dir))
 	return func() { require.NoError(t, os.Chdir(workingDirectory)) }
 }
+
+func TestIsArchive(t *testing.T) {
+	var testcases = []struct {
+		doc      string
+		header   []byte
+		expected bool
+	}{
+		{
+			doc:      "nil is not a valid header",
+			header:   nil,
+			expected: false,
+		},
+		{
+			doc:      "invalid header bytes",
+			header:   []byte{0x00, 0x01, 0x02},
+			expected: false,
+		},
+		{
+			doc:      "header for bzip2 archive",
+			header:   []byte{0x42, 0x5A, 0x68},
+			expected: true,
+		},
+		{
+			doc:      "header for 7zip archive is not supported",
+			header:   []byte{0x50, 0x4b, 0x03, 0x04},
+			expected: false,
+		},
+	}
+	for _, testcase := range testcases {
+		assert.Equal(t, testcase.expected, IsArchive(testcase.header), testcase.doc)
+	}
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-github.com/docker/docker c8141a1fb1ff33b2bfab85a40e5da9a282f36cdc
+github.com/docker/docker cd35e4beee13a7c193e2a89008cd87d38fcd0161
 github.com/docker/docker-credential-helpers v0.5.1
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06 #?
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5

--- a/vendor/github.com/docker/docker/client/client.go
+++ b/vendor/github.com/docker/docker/client/client.go
@@ -216,9 +216,9 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	var apiPath string
 	if cli.version != "" {
 		v := strings.TrimPrefix(cli.version, "v")
-		apiPath = fmt.Sprintf("%s/v%s%s", cli.basePath, v, p)
+		apiPath = cli.basePath + "/v" + v + p
 	} else {
-		apiPath = fmt.Sprintf("%s%s", cli.basePath, p)
+		apiPath = cli.basePath + p
 	}
 
 	u := &url.URL{

--- a/vendor/github.com/docker/docker/client/container_copy.go
+++ b/vendor/github.com/docker/docker/client/container_copy.go
@@ -20,7 +20,7 @@ func (cli *Client) ContainerStatPath(ctx context.Context, containerID, path stri
 	query := url.Values{}
 	query.Set("path", filepath.ToSlash(path)) // Normalize the paths used in the API.
 
-	urlStr := fmt.Sprintf("/containers/%s/archive", containerID)
+	urlStr := "/containers/" + containerID + "/archive"
 	response, err := cli.head(ctx, urlStr, query, nil)
 	if err != nil {
 		return types.ContainerPathStat{}, err
@@ -42,7 +42,7 @@ func (cli *Client) CopyToContainer(ctx context.Context, container, path string, 
 		query.Set("copyUIDGID", "true")
 	}
 
-	apiPath := fmt.Sprintf("/containers/%s/archive", container)
+	apiPath := "/containers/" + container + "/archive"
 
 	response, err := cli.putRaw(ctx, apiPath, query, content, nil)
 	if err != nil {
@@ -63,7 +63,7 @@ func (cli *Client) CopyFromContainer(ctx context.Context, container, srcPath str
 	query := make(url.Values, 1)
 	query.Set("path", filepath.ToSlash(srcPath)) // Normalize the paths used in the API.
 
-	apiPath := fmt.Sprintf("/containers/%s/archive", container)
+	apiPath := "/containers/" + container + "/archive"
 	response, err := cli.get(ctx, apiPath, query, nil)
 	if err != nil {
 		return nil, types.ContainerPathStat{}, err

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
@@ -10,7 +8,7 @@ import (
 // Ping pings the server and returns the value of the "Docker-Experimental", "OS-Type" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
-	req, err := cli.buildRequest("GET", fmt.Sprintf("%s/_ping", cli.basePath), nil, nil)
+	req, err := cli.buildRequest("GET", cli.basePath+"/_ping", nil, nil)
 	if err != nil {
 		return ping, err
 	}

--- a/vendor/github.com/docker/docker/client/plugin_upgrade.go
+++ b/vendor/github.com/docker/docker/client/plugin_upgrade.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"io"
 	"net/url"
 
@@ -33,5 +32,5 @@ func (cli *Client) PluginUpgrade(ctx context.Context, name string, options types
 
 func (cli *Client) tryPluginUpgrade(ctx context.Context, query url.Values, privileges types.PluginPrivileges, name, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.post(ctx, fmt.Sprintf("/plugins/%s/upgrade", name), query, privileges, headers)
+	return cli.post(ctx, "/plugins/"+name+"/upgrade", query, privileges, headers)
 }

--- a/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_unix.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/system"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 )
@@ -72,13 +73,13 @@ func getInodeFromStat(stat interface{}) (inode uint64, err error) {
 	return
 }
 
-func getFileUIDGID(stat interface{}) (int, int, error) {
+func getFileUIDGID(stat interface{}) (idtools.IDPair, error) {
 	s, ok := stat.(*syscall.Stat_t)
 
 	if !ok {
-		return -1, -1, errors.New("cannot convert stat value to syscall.Stat_t")
+		return idtools.IDPair{}, errors.New("cannot convert stat value to syscall.Stat_t")
 	}
-	return int(s.Uid), int(s.Gid), nil
+	return idtools.IDPair{UID: int(s.Uid), GID: int(s.Gid)}, nil
 }
 
 func major(device uint64) uint64 {

--- a/vendor/github.com/docker/docker/pkg/archive/archive_windows.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_windows.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/longpath"
 )
 
@@ -72,7 +73,7 @@ func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
 	return nil
 }
 
-func getFileUIDGID(stat interface{}) (int, int, error) {
+func getFileUIDGID(stat interface{}) (idtools.IDPair, error) {
 	// no notion of file ownership mapping yet on Windows
-	return 0, 0, nil
+	return idtools.IDPair{0, 0}, nil
 }

--- a/vendor/github.com/docker/docker/pkg/archive/changes.go
+++ b/vendor/github.com/docker/docker/pkg/archive/changes.go
@@ -394,13 +394,8 @@ func ChangesSize(newDir string, changes []Change) int64 {
 func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMap) (io.ReadCloser, error) {
 	reader, writer := io.Pipe()
 	go func() {
-		ta := &tarAppender{
-			TarWriter: tar.NewWriter(writer),
-			Buffer:    pools.BufioWriter32KPool.Get(nil),
-			SeenFiles: make(map[uint64]string),
-			UIDMaps:   uidMaps,
-			GIDMaps:   gidMaps,
-		}
+		ta := newTarAppender(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer)
+
 		// this buffer is needed for the duration of this piped stream
 		defer pools.BufioWriter32KPool.Put(ta.Buffer)
 

--- a/vendor/github.com/docker/docker/pkg/archive/diff.go
+++ b/vendor/github.com/docker/docker/pkg/archive/diff.go
@@ -33,10 +33,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	if options.ExcludePatterns == nil {
 		options.ExcludePatterns = []string{}
 	}
-	remappedRootUID, remappedRootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
-	if err != nil {
-		return 0, err
-	}
+	idMappings := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
 
 	aufsTempdir := ""
 	aufsHardlinks := make(map[string]*tar.Header)
@@ -195,27 +192,10 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				srcData = tmpFile
 			}
 
-			// if the options contain a uid & gid maps, convert header uid/gid
-			// entries using the maps such that lchown sets the proper mapped
-			// uid/gid after writing the file. We only perform this mapping if
-			// the file isn't already owned by the remapped root UID or GID, as
-			// that specific uid/gid has no mapping from container -> host, and
-			// those files already have the proper ownership for inside the
-			// container.
-			if srcHdr.Uid != remappedRootUID {
-				xUID, err := idtools.ToHost(srcHdr.Uid, options.UIDMaps)
-				if err != nil {
-					return 0, err
-				}
-				srcHdr.Uid = xUID
+			if err := remapIDs(idMappings, srcHdr); err != nil {
+				return 0, err
 			}
-			if srcHdr.Gid != remappedRootGID {
-				xGID, err := idtools.ToHost(srcHdr.Gid, options.GIDMaps)
-				if err != nil {
-					return 0, err
-				}
-				srcHdr.Gid = xGID
-			}
+
 			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS); err != nil {
 				return 0, err
 			}

--- a/vendor/github.com/docker/docker/pkg/idtools/idtools_unix.go
+++ b/vendor/github.com/docker/docker/pkg/idtools/idtools_unix.go
@@ -69,15 +69,15 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 
 // CanAccess takes a valid (existing) directory and a uid, gid pair and determines
 // if that uid, gid pair has access (execute bit) to the directory
-func CanAccess(path string, uid, gid int) bool {
+func CanAccess(path string, pair IDPair) bool {
 	statInfo, err := system.Stat(path)
 	if err != nil {
 		return false
 	}
 	fileMode := os.FileMode(statInfo.Mode())
 	permBits := fileMode.Perm()
-	return accessible(statInfo.UID() == uint32(uid),
-		statInfo.GID() == uint32(gid), permBits)
+	return accessible(statInfo.UID() == uint32(pair.UID),
+		statInfo.GID() == uint32(pair.GID), permBits)
 }
 
 func accessible(isOwner, isGroup bool, perms os.FileMode) bool {

--- a/vendor/github.com/docker/docker/pkg/idtools/idtools_windows.go
+++ b/vendor/github.com/docker/docker/pkg/idtools/idtools_windows.go
@@ -20,6 +20,6 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 // CanAccess takes a valid (existing) directory and a uid, gid pair and determines
 // if that uid, gid pair has access (execute bit) to the directory
 // Windows does not require/support this function, so always return true
-func CanAccess(path string, uid, gid int) bool {
+func CanAccess(path string, pair IDPair) bool {
 	return true
 }

--- a/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
+++ b/vendor/github.com/docker/docker/pkg/term/termios_bsd.go
@@ -27,7 +27,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	newState := oldState.termios
 	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag |= unix.OPOST
+	newState.Oflag &^= unix.OPOST
 	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
 	newState.Cflag |= unix.CS8

--- a/vendor/github.com/docker/docker/pkg/term/termios_linux.go
+++ b/vendor/github.com/docker/docker/pkg/term/termios_linux.go
@@ -26,7 +26,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 	newState := oldState.termios
 
 	newState.Iflag &^= (unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON)
-	newState.Oflag |= unix.OPOST
+	newState.Oflag &^= unix.OPOST
 	newState.Lflag &^= (unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN)
 	newState.Cflag &^= (unix.CSIZE | unix.PARENB)
 	newState.Cflag |= unix.CS8

--- a/vendor/github.com/docker/docker/registry/session.go
+++ b/vendor/github.com/docker/docker/registry/session.go
@@ -757,19 +757,6 @@ func (r *Session) SearchRepositories(term string, limit int) (*registrytypes.Sea
 	return result, json.NewDecoder(res.Body).Decode(result)
 }
 
-// GetAuthConfig returns the authentication settings for a session
-// TODO(tiborvass): remove this once registry client v2 is vendored
-func (r *Session) GetAuthConfig(withPasswd bool) *types.AuthConfig {
-	password := ""
-	if withPasswd {
-		password = r.authConfig.Password
-	}
-	return &types.AuthConfig{
-		Username: r.authConfig.Username,
-		Password: password,
-	}
-}
-
 func isTimeout(err error) bool {
 	type timeout interface {
 		Timeout() bool

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -26,7 +26,7 @@ github.com/imdario/mergo 0.2.1
 golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
 
 #get libnetwork packages
-github.com/docker/libnetwork 83e1e49475b88a9f1f8ba89a690a7d5de42e24b9
+github.com/docker/libnetwork eb57059e91bc54c9da23c5a633b75b3faf910a68
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -38,7 +38,7 @@ github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
 github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
-github.com/vishvananda/netlink 1e86b2bee5b6a7d377e4c02bb7f98209d6a7297c
+github.com/vishvananda/netlink bd6d5de5ccef2d66b0a26177928d0d8895d7f969
 github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
@@ -61,7 +61,7 @@ google.golang.org/grpc v1.0.4
 github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
-github.com/opencontainers/runc 992a5be178a62e026f4069f443c6164912adbf09
+github.com/opencontainers/runc 2d41c047c83e09a6d61d464906feb2a2f3c52aa4 https://github.com/docker/runc
 github.com/opencontainers/image-spec f03dbe35d449c54915d235f1a3cf8f585a24babe
 github.com/opencontainers/runtime-spec d42f1eb741e6361e858d83fc75aa6893b66292c4 # specs
 

--- a/vendor/github.com/docker/docker/volume/volume.go
+++ b/vendor/github.com/docker/docker/volume/volume.go
@@ -149,7 +149,9 @@ func (m *MountPoint) Cleanup() error {
 
 // Setup sets up a mount point by either mounting the volume if it is
 // configured, or creating the source directory if supplied.
-func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string, err error) {
+// The, optional, checkFun parameter allows doing additional checking
+// before creating the source directory on the host.
+func (m *MountPoint) Setup(mountLabel string, rootIDs idtools.IDPair, checkFun func(m *MountPoint) error) (path string, err error) {
 	defer func() {
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
@@ -184,9 +186,17 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string
 
 	// system.MkdirAll() produces an error if m.Source exists and is a file (not a directory),
 	if m.Type == mounttypes.TypeBind {
+		// Before creating the source directory on the host, invoke checkFun if it's not nil. One of
+		// the use case is to forbid creating the daemon socket as a directory if the daemon is in
+		// the process of shutting down.
+		if checkFun != nil {
+			if err := checkFun(m); err != nil {
+				return "", err
+			}
+		}
 		// idtools.MkdirAllNewAs() produces an error if m.Source exists and is a file (not a directory)
 		// also, makes sure that if the directory is created, the correct remapped rootUID/rootGID will own it
-		if err := idtools.MkdirAllNewAs(m.Source, 0755, rootUID, rootGID); err != nil {
+		if err := idtools.MkdirAllAndChownNew(m.Source, 0755, rootIDs); err != nil {
 			if perr, ok := err.(*os.PathError); ok {
 				if perr.Err != syscall.ENOTDIR {
 					return "", errors.Wrapf(err, "error while creating mount source path '%s'", m.Source)


### PR DESCRIPTION
Reverts changes in pkg/term related to `OPOST` that pulled in through;
3574e6a674086a6d7fae9adbb17d5f80b2c0a714

And reverted upstream in;
https://github.com/moby/moby/commit/cd35e4beee13a7c193e2a89008cd87d38fcd0161 (https://github.com/moby/moby/pull/33577)

Full diff;
https://github.com/moby/moby/compare/c8141a1fb1ff33b2bfab85a40e5da9a282f36cdc...cd35e4beee13a7c193e2a89008cd87d38fcd0161


ping @crosbymichael @vieux 

