### PR TITLE
removed the output leaked from stack remove error test case

### DIFF
--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"bytes"
 	"errors"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -116,6 +117,7 @@ func TestContinueAfterError(t *testing.T) {
 		},
 	}
 	cmd := newRemoveCommand(test.NewFakeCli(cli, &bytes.Buffer{}))
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.EqualError(t, cmd.Execute(), "Failed to remove some resources from stack: foo")


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The 'TestContinueAfterError' test for the stack/remove command leaks an error message from an error test case to the output. This PR is to fix the leak to remove noise from output when running the tests.

**- How I did it**
Redirected the output of the command for the specific test to ioutil/discard

**- How to verify it**
- Run the tests (make -f docker.Makefile test)
- Without the proposed fix, the output will show the following:

> === RUN   TestContinueAfterError
>Error: Failed to remove some resources from stack: foo
>Usage:
>  rm STACK [STACK...] [flags]
>
>Aliases:
>  rm, remove, down
>
>--- PASS: TestContinueAfterError (0.00s)

- With the proposed fix, the output will not contain the error message from the error test case:
>=== RUN   TestContinueAfterError
>--- PASS: TestContinueAfterError (0.00s)
>PASS


**- Description for the changelog**
Removed the message leaked from error test case for stack remove 

**- A picture of a cute animal (not mandatory but encouraged)**

