### PR TITLE
fixed the output leak from the error test case for secret/remove command

### DIFF
--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -76,6 +76,7 @@ func TestSecretRemoveContinueAfterError(t *testing.T) {
 	}, buf)
 
 	cmd := newSecretRemoveCommand(cli)
+	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs(names)
 	assert.EqualError(t, cmd.Execute(), "error removing secret: foo")
 	assert.Equal(t, names, removedSecrets)


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The 'TestSecretRemoveContinueAfterError' test for the secret/remove command leaks an error message from an error test case to the output. This PR is to fix the leak to remove noise from output when running the tests. 

**- How I did it**
Redirected the output of the command for the specific test to ioutil/discard

**- How to verify it**
- Run the tests (make -f docker.Makefile test)
- Without the proposed fix, the output will show the following:
>=== RUN   TestSecretRemoveContinueAfterError
>Error: error removing secret: foo
>Usage:
>  rm SECRET [SECRET...] [flags]
>
>  Aliases:
>    rm, remove
>
>
>--- PASS: TestSecretRemoveContinueAfterError (0.00s)

- With the proposed fix, the output will not contain the error message from the error test case:
>=== RUN   TestSecretRemoveContinueAfterError
>--- PASS: TestSecretRemoveContinueAfterError (0.00s)

**- Description for the changelog**
Removed the message leaked from error test case for secret/remove command.

**- A picture of a cute animal (not mandatory but encouraged)**

