### PR TITLE
Update golang 1.8.3

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.1
+FROM    golang:1.8.3
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8-alpine
+FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git make bash coreutils
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.8-alpine
+FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <scherer_stefan@icloud.com>

**- What I did**

I installed the static Windows binaries 17.06.0-ce-rc2 and found out that the docker cli is compiled with go1.8.1 

```
PS C:\Users\stefan> docker version
Client:
 Version:      17.06.0-ce-rc2
 API version:  1.30
 Go version:   go1.8.1
 Git commit:   402dd4a
 Built:        Thu Jun  8 02:36:20 2017
 OS/Arch:      windows/amd64

Server:
 Version:      17.06.0-ce-rc2
 API version:  1.30 (minimum version 1.24)
 Go version:   go1.8.3
 Git commit:   402dd4a
 Built:        Thu Jun  8 02:47:18 2017
 OS/Arch:      windows/amd64
 Experimental: false
```

So I think this Dockerfile to cross-compile the docker cli should be updated as well as the release notes show us an explicit update to Go 1.8.3 https://github.com/moby/moby/pull/33387

**- How I did it**

Just updating the Dockerfile.cross

**- How to verify it**

Good question, a how-to guide for the community would help me verify the whole build. To build the Windows ZIP I use docker/docker-ce repo. So how to test my pull request in docker/cli repo to build the ZIP in docker/docker-ce repo? I don't have a best practise for that right now.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
