### PR TITLE
use latest golang:1.8 image to cross compile

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.1
+FROM    golang:1.8
 
 # allow replacing httpredir or deb mirror
 ARG     APT_MIRROR=deb.debian.org


### PR DESCRIPTION
Signed-off-by: Andrew Hsu <andrewhsu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Latest golang 1.8 version is 1.8.3. The cross compile Dockerfile locks it to 1.8.1. This PR will float the image version to latest of golang:1.8

**- How I did it**

Change FROM line.

**- How to verify it**

`$ make -f docker.Makefile cross`

And see that `Go version` is 1.8.3 with `docker.exe version`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* use latest golang when compiling

**- A picture of a cute animal (not mandatory but encouraged)**

🐌 