### PR TITLE
New linters

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -111,12 +111,7 @@ func runExec(dockerCli command.Cli, options *execOptions, container string, exec
 			Tty:    execConfig.Tty,
 		}
 
-		if err := client.ContainerExecStart(ctx, execID, execStartCheck); err != nil {
-			return err
-		}
-		// For now don't print this - wait for when we support exec wait()
-		// fmt.Fprintf(dockerCli.Out(), "%s\n", execID)
-		return nil
+		return client.ContainerExecStart(ctx, execID, execStartCheck)
 	}
 
 	// Interactive exec requested.

--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -110,7 +110,7 @@ func (h *hijackedIOStreamer) setupInput() (restore func(), err error) {
 
 func (h *hijackedIOStreamer) beginOutputStream(restoreInput func()) <-chan error {
 	if h.outputStream == nil && h.errorStream == nil {
-		// Ther is no need to copy output.
+		// There is no need to copy output.
 		return nil
 	}
 

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	deviceCgroupRuleRegexp = regexp.MustCompile("^[acb] ([0-9]+|\\*):([0-9]+|\\*) [rwm]{1,3}$")
+	deviceCgroupRuleRegexp = regexp.MustCompile(`^[acb] ([0-9]+|\*):([0-9]+|\*) [rwm]{1,3}$`)
 )
 
 // containerOptions is a data object with all the options for creating a container

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -106,7 +106,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 			closeChan <- err
 		}
 		for _, container := range cs {
-			s := formatter.NewContainerStats(container.ID[:12], daemonOSType)
+			s := formatter.NewContainerStats(container.ID[:12])
 			if cStats.add(s) {
 				waitFirst.Add(1)
 				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
@@ -123,7 +123,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		eh := command.InitEventHandler()
 		eh.Handle("create", func(e events.Message) {
 			if opts.all {
-				s := formatter.NewContainerStats(e.ID[:12], daemonOSType)
+				s := formatter.NewContainerStats(e.ID[:12])
 				if cStats.add(s) {
 					waitFirst.Add(1)
 					go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
@@ -132,7 +132,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		})
 
 		eh.Handle("start", func(e events.Message) {
-			s := formatter.NewContainerStats(e.ID[:12], daemonOSType)
+			s := formatter.NewContainerStats(e.ID[:12])
 			if cStats.add(s) {
 				waitFirst.Add(1)
 				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)
@@ -158,7 +158,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 		// Artificially send creation events for the containers we were asked to
 		// monitor (same code path than we use when monitoring all containers).
 		for _, name := range opts.containers {
-			s := formatter.NewContainerStats(name, daemonOSType)
+			s := formatter.NewContainerStats(name)
 			if cStats.add(s) {
 				waitFirst.Add(1)
 				go collect(ctx, s, dockerCli.Client(), !opts.noStream, waitFirst)

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -16,9 +16,8 @@ import (
 )
 
 type stats struct {
-	ostype string
-	mu     sync.Mutex
-	cs     []*formatter.ContainerStats
+	mu sync.Mutex
+	cs []*formatter.ContainerStats
 }
 
 // daemonOSType is set once we have at least one stat for a container

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -171,11 +171,11 @@ func (c *containerContext) Command() string {
 }
 
 func (c *containerContext) CreatedAt() string {
-	return time.Unix(int64(c.c.Created), 0).String()
+	return time.Unix(c.c.Created, 0).String()
 }
 
 func (c *containerContext) RunningFor() string {
-	createdAt := time.Unix(int64(c.c.Created), 0)
+	createdAt := time.Unix(c.c.Created, 0)
 	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 }
 

--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -234,7 +234,6 @@ func (c *diskUsageImagesContext) Reclaimable() string {
 
 type diskUsageContainersContext struct {
 	HeaderContext
-	verbose    bool
 	containers []*types.Container
 }
 
@@ -297,7 +296,6 @@ func (c *diskUsageContainersContext) Reclaimable() string {
 
 type diskUsageVolumesContext struct {
 	HeaderContext
-	verbose bool
 	volumes []*types.Volume
 }
 

--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -65,7 +65,7 @@ reclaimable: {{.Reclaimable}}
 }
 
 func (ctx *DiskUsageContext) Write() (err error) {
-	if ctx.Verbose == false {
+	if !ctx.Verbose {
 		ctx.buffer = bytes.NewBufferString("")
 		ctx.preFormat()
 

--- a/cli/command/formatter/history.go
+++ b/cli/command/formatter/history.go
@@ -79,21 +79,18 @@ func (c *historyContext) ID() string {
 }
 
 func (c *historyContext) CreatedAt() string {
-	var created string
-	created = units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(c.h.Created), 0)))
-	return created
+	return units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
 }
 
 func (c *historyContext) CreatedSince() string {
-	var created string
-	created = units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(c.h.Created), 0)))
+	created := units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
 	return created + " ago"
 }
 
 func (c *historyContext) CreatedBy() string {
 	createdBy := strings.Replace(c.h.CreatedBy, "\t", " ", -1)
 	if c.trunc {
-		createdBy = stringutils.Ellipsis(createdBy, 45)
+		return stringutils.Ellipsis(createdBy, 45)
 	}
 	return createdBy
 }

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -234,12 +234,12 @@ func (c *imageContext) Digest() string {
 }
 
 func (c *imageContext) CreatedSince() string {
-	createdAt := time.Unix(int64(c.i.Created), 0)
+	createdAt := time.Unix(c.i.Created, 0)
 	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 }
 
 func (c *imageContext) CreatedAt() string {
-	return time.Unix(int64(c.i.Created), 0).String()
+	return time.Unix(c.i.Created, 0).String()
 }
 
 func (c *imageContext) Size() string {

--- a/cli/command/formatter/reflect_test.go
+++ b/cli/command/formatter/reflect_test.go
@@ -12,7 +12,7 @@ func (d *dummy) Func1() string {
 	return "Func1"
 }
 
-func (d *dummy) func2() string {
+func (d *dummy) func2() string { // nolint: unused
 	return "func2(should not be marshalled)"
 }
 

--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -109,10 +109,8 @@ func NewStatsFormat(source, osType string) Format {
 }
 
 // NewContainerStats returns a new ContainerStats entity and sets in it the given name
-func NewContainerStats(container, osType string) *ContainerStats {
-	return &ContainerStats{
-		StatsEntry: StatsEntry{Container: container},
-	}
+func NewContainerStats(container string) *ContainerStats {
+	return &ContainerStats{StatsEntry: StatsEntry{Container: container}}
 }
 
 // ContainerStatsWrite renders the context for a list of containers statistics

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -6,24 +6,17 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/internal/test"
-	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/docker/pkg/testutil/golden"
-	"github.com/docker/docker/registry"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestNewPullCommandErrors(t *testing.T) {
 	testCases := []struct {
-		name            string
-		args            []string
-		expectedError   string
-		trustedPullFunc func(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo, ref reference.Named,
-			authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error
+		name          string
+		args          []string
+		expectedError string
 	}{
 		{
 			name:          "wrong-args",
@@ -57,10 +50,8 @@ func TestNewPullCommandErrors(t *testing.T) {
 
 func TestNewPullCommandSuccess(t *testing.T) {
 	testCases := []struct {
-		name            string
-		args            []string
-		trustedPullFunc func(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo, ref reference.Named,
-			authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error
+		name string
+		args []string
 	}{
 		{
 			name: "simple",

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -7,15 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/internal/test"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/testutil"
-	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestNewPushCommandErrors(t *testing.T) {
@@ -60,11 +56,8 @@ func TestNewPushCommandErrors(t *testing.T) {
 
 func TestNewPushCommandSuccess(t *testing.T) {
 	testCases := []struct {
-		name            string
-		args            []string
-		trustedPushFunc func(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo,
-			ref reference.Named, authConfig types.AuthConfig,
-			requestPrivilege types.RequestPrivilegeFunc) error
+		name string
+		args []string
 	}{
 		{
 			name: "simple",

--- a/cli/command/node/opts.go
+++ b/cli/command/node/opts.go
@@ -11,7 +11,6 @@ type nodeOptions struct {
 }
 
 type annotations struct {
-	name   string
 	labels opts.ListOpts
 }
 

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -16,7 +16,6 @@ type loginOptions struct {
 	serverAddress string
 	user          string
 	password      string
-	email         string
 }
 
 // NewLoginCommand creates a new `docker login` command

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -164,7 +164,7 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 
 // getMaxLength gets the maximum length of the number in base 10
 func getMaxLength(i int) int {
-	return len(strconv.FormatInt(int64(i), 10))
+	return len(strconv.Itoa(i))
 }
 
 type taskFormatter struct {

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -354,7 +354,7 @@ func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, net
 		if err != nil {
 			return nil, err
 		}
-		netAttach = append(netAttach, swarm.NetworkAttachmentConfig{Target: net.Target, Aliases: net.Aliases, DriverOpts: net.DriverOpts})
+		netAttach = append(netAttach, swarm.NetworkAttachmentConfig(net))
 	}
 	sort.Sort(byNetworkTarget(netAttach))
 	return netAttach, nil

--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -134,10 +134,7 @@ func getConfigDetails(composefile string) (composetypes.ConfigDetails, error) {
 	// TODO: support multiple files
 	details.ConfigFiles = []composetypes.ConfigFile{*configFile}
 	details.Environment, err = buildEnvironment(os.Environ())
-	if err != nil {
-		return details, err
-	}
-	return details, nil
+	return details, err
 }
 
 func buildEnvironment(env []string) (map[string]string, error) {

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -69,7 +69,7 @@ func getStacks(ctx context.Context, apiclient client.APIClient) ([]*formatter.St
 	if err != nil {
 		return nil, err
 	}
-	m := make(map[string]*formatter.Stack, 0)
+	m := make(map[string]*formatter.Stack)
 	for _, service := range services {
 		labels := service.Spec.Labels
 		name, ok := labels[convert.LabelNamespace]

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -92,7 +92,7 @@ func runInit(dockerCli command.Cli, flags *pflag.FlagSet, opts initOptions) erro
 		if err != nil {
 			return errors.Wrap(err, "could not fetch unlock key")
 		}
-		printUnlockCommand(ctx, dockerCli, unlockKeyResp.UnlockKey)
+		printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
 	}
 
 	return nil

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -217,13 +217,13 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 }
 
 func addSwarmCAFlags(flags *pflag.FlagSet, opts *swarmOptions) {
-	flags.DurationVar(&opts.nodeCertExpiry, flagCertExpiry, time.Duration(90*24*time.Hour), "Validity period for node certificates (ns|us|ms|s|m|h)")
+	flags.DurationVar(&opts.nodeCertExpiry, flagCertExpiry, 90*24*time.Hour, "Validity period for node certificates (ns|us|ms|s|m|h)")
 	flags.Var(&opts.externalCA, flagExternalCA, "Specifications of one or more certificate signing endpoints")
 }
 
 func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	flags.Int64Var(&opts.taskHistoryLimit, flagTaskHistoryLimit, 5, "Task history retention limit")
-	flags.DurationVar(&opts.dispatcherHeartbeat, flagDispatcherHeartbeat, time.Duration(5*time.Second), "Dispatcher heartbeat period (ns|us|ms|s|m|h)")
+	flags.DurationVar(&opts.dispatcherHeartbeat, flagDispatcherHeartbeat, 5*time.Second, "Dispatcher heartbeat period (ns|us|ms|s|m|h)")
 	flags.Uint64Var(&opts.maxSnapshots, flagMaxSnapshots, 0, "Number of additional Raft snapshots to retain")
 	flags.SetAnnotation(flagMaxSnapshots, "version", []string{"1.25"})
 	flags.Uint64Var(&opts.snapshotInterval, flagSnapshotInterval, 10000, "Number of log entries between Raft snapshots")

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -74,16 +75,15 @@ func runUnlockKey(dockerCli command.Cli, opts unlockKeyOptions) error {
 		return nil
 	}
 
-	printUnlockCommand(ctx, dockerCli, unlockKeyResp.UnlockKey)
+	printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
 	return nil
 }
 
-func printUnlockCommand(ctx context.Context, dockerCli command.Cli, unlockKey string) {
+func printUnlockCommand(out io.Writer, unlockKey string) {
 	if len(unlockKey) > 0 {
-		fmt.Fprintf(dockerCli.Out(), "To unlock a swarm manager after it restarts, "+
+		fmt.Fprintf(out, "To unlock a swarm manager after it restarts, "+
 			"run the `docker swarm unlock`\ncommand and provide the following key:\n\n    %s\n\n"+
 			"Please remember to store this key in a password manager, since without it you\n"+
 			"will not be able to restart the manager.\n", unlockKey)
 	}
-	return
 }

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -19,7 +19,6 @@ func TestSwarmUnlockErrors(t *testing.T) {
 	testCases := []struct {
 		name            string
 		args            []string
-		input           string
 		swarmUnlockFunc func(req swarm.UnlockRequest) error
 		infoFunc        func() (types.Info, error)
 		expectedError   string

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -65,7 +65,7 @@ func runUpdate(dockerCli command.Cli, flags *pflag.FlagSet, opts swarmOptions) e
 		if err != nil {
 			return errors.Wrap(err, "could not fetch unlock key")
 		}
-		printUnlockCommand(ctx, dockerCli, unlockKeyResp.UnlockKey)
+		printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
 	}
 
 	return nil

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -120,7 +119,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Tick: %d\n", info.Swarm.Cluster.Spec.Raft.HeartbeatTick)
 			fmt.Fprintf(dockerCli.Out(), "  Election Tick: %d\n", info.Swarm.Cluster.Spec.Raft.ElectionTick)
 			fmt.Fprintf(dockerCli.Out(), " Dispatcher:\n")
-			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Period: %s\n", units.HumanDuration(time.Duration(info.Swarm.Cluster.Spec.Dispatcher.HeartbeatPeriod)))
+			fmt.Fprintf(dockerCli.Out(), "  Heartbeat Period: %s\n", units.HumanDuration(info.Swarm.Cluster.Spec.Dispatcher.HeartbeatPeriod))
 			fmt.Fprintf(dockerCli.Out(), " CA Configuration:\n")
 			fmt.Fprintf(dockerCli.Out(), "  Expiry Duration: %s\n", units.HumanDuration(info.Swarm.Cluster.Spec.CAConfig.NodeCertExpiry))
 			fmt.Fprintf(dockerCli.Out(), "  Force Rotate: %d\n", info.Swarm.Cluster.Spec.CAConfig.ForceRotate)

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -263,7 +263,7 @@ func prettyPrintInfo(dockerCli *command.DockerCli, info types.Info) error {
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
 		fmt.Fprintln(dockerCli.Out(), "Insecure Registries:")
 		for _, registry := range info.RegistryConfig.IndexConfigs {
-			if registry.Secure == false {
+			if !registry.Secure {
 				fmt.Fprintf(dockerCli.Out(), " %s\n", registry.Name)
 			}
 		}

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -563,9 +563,6 @@ func convertCredentialSpec(spec composetypes.CredentialSpecConfig) (*swarm.Crede
 	if spec.File != "" && spec.Registry != "" {
 		return nil, errors.New("Invalid credential spec - must provide one of `File` or `Registry`")
 	}
-
-	return &swarm.CredentialSpec{
-		File:     spec.File,
-		Registry: spec.Registry,
-	}, nil
+	swarmCredSpec := swarm.CredentialSpec(spec)
+	return &swarmCredSpec, nil
 }

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -632,10 +632,6 @@ func durationPtr(value time.Duration) *time.Duration {
 	return &value
 }
 
-func int64Ptr(value int64) *int64 {
-	return &value
-}
-
 func uint64Ptr(value uint64) *uint64 {
 	return &value
 }

--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -73,7 +73,7 @@ func (c *nativeStore) GetAll() (map[string]types.AuthConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		ac, _ := fileConfigs[registry] // might contain Email
+		ac := fileConfigs[registry] // might contain Email
 		ac.Username = creds.Username
 		ac.Password = creds.Password
 		ac.IdentityToken = creds.IdentityToken

--- a/cli/internal/test/network/client.go
+++ b/cli/internal/test/network/client.go
@@ -18,11 +18,11 @@ func (c *FakeClient) NetworkConnect(ctx context.Context, networkID, container st
 }
 
 // NetworkCreate fakes creating a network
-func (c *FakeClient) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+func (c *FakeClient) NetworkCreate(_ context.Context, _ string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
 	return types.NetworkCreateResponse{}, nil
 }
 
-// NetworkDisconnect fakes disconencting from a network
+// NetworkDisconnect fakes disconnecting from a network
 func (c *FakeClient) NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error {
 	return nil
 }
@@ -36,12 +36,12 @@ func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, optio
 }
 
 // NetworkInspectWithRaw fakes inspecting a network with a raw response
-func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
+func (c *FakeClient) NetworkInspectWithRaw(_ context.Context, _ string, _ types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
 	return types.NetworkResource{}, nil, nil
 }
 
 // NetworkList fakes listing networks
-func (c *FakeClient) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
+func (c *FakeClient) NetworkList(_ context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	return nil, nil
 }
 
@@ -51,6 +51,6 @@ func (c *FakeClient) NetworkRemove(ctx context.Context, networkID string) error 
 }
 
 // NetworksPrune fakes pruning networks
-func (c *FakeClient) NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error) {
+func (c *FakeClient) NetworksPrune(_ context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error) {
 	return types.NetworksPruneReport{}, nil
 }

--- a/cli/internal/test/store.go
+++ b/cli/internal/test/store.go
@@ -53,8 +53,7 @@ func (c *fakeStore) Get(serverAddress string) (types.AuthConfig, error) {
 	if c.getFunc != nil {
 		return c.getFunc(serverAddress)
 	}
-	authConfig, _ := c.store[serverAddress]
-	return authConfig, nil
+	return c.store[serverAddress], nil
 }
 
 func (c *fakeStore) GetAll() (map[string]types.AuthConfig, error) {

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -161,7 +161,7 @@ func GetNotaryRepository(streams command.Streams, repoInfo *registry.RepositoryI
 	}
 	tokenHandler := auth.NewTokenHandlerWithOptions(tokenHandlerOptions)
 	basicHandler := auth.NewBasicHandler(creds)
-	modifiers = append(modifiers, transport.RequestModifier(auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)))
+	modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
 	tr := transport.NewTransport(base, modifiers...)
 
 	return client.NewNotaryRepository(

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -2,7 +2,7 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git
 
-RUN     go get -u gopkg.in/alecthomas/gometalinter.v1 && \
+RUN     go get -u gopkg.in/dnephin/gometalinter.v1 && \
         mv /go/bin/gometalinter.v1 /usr/local/bin/gometalinter && \
         gometalinter --install
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -7,5 +7,6 @@ RUN     go get -u gopkg.in/alecthomas/gometalinter.v1 && \
         gometalinter --install
 
 WORKDIR /go/src/github.com/docker/cli
+ENV     CGO_ENABLED=0
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
-CMD ["--config=gometalinter.json", "./..."]
+CMD     ["--config=gometalinter.json", "./..."]

--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -66,14 +66,14 @@ func GenYamlTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandle
 	if _, err := io.WriteString(f, filePrepender(filename)); err != nil {
 		return err
 	}
-	if err := GenYamlCustom(cmd, f, linkHandler); err != nil {
+	if err := GenYamlCustom(cmd, f); err != nil {
 		return err
 	}
 	return nil
 }
 
 // GenYamlCustom creates custom yaml output
-func GenYamlCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string) string) error {
+func GenYamlCustom(cmd *cobra.Command, w io.Writer) error {
 	cliDoc := cmdDoc{}
 	cliDoc.Name = cmd.CommandPath()
 

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,6 +1,6 @@
 {
   "Vendor": true,
-  "Deadline": "3m",
+  "Deadline": "5m",
   "Sort": ["linter", "severity", "path"],
   "Exclude": ["cli/compose/schema/bindata.go"],
 
@@ -16,6 +16,7 @@
     "lll",
     "misspell",
     "unconvert",
+    "unparam",
     "unused",
     "vet"
   ],

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,6 +1,6 @@
 {
   "Vendor": true,
-  "Deadline": "8m",
+  "Deadline": "2m",
   "Sort": ["linter", "severity", "path"],
   "Exclude": ["cli/compose/schema/bindata.go"],
 

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,6 +1,6 @@
 {
   "Vendor": true,
-  "Deadline": "5m",
+  "Deadline": "8m",
   "Sort": ["linter", "severity", "path"],
   "Exclude": ["cli/compose/schema/bindata.go"],
 
@@ -11,6 +11,7 @@
     "gofmt",
     "goimports",
     "golint",
+    "gosimple",
     "ineffassign",
     "interfacer",
     "lll",

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -15,6 +15,7 @@
     "interfacer",
     "lll",
     "misspell",
+    "unconvert",
     "unused",
     "vet"
   ],

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -14,6 +14,7 @@
     "ineffassign",
     "interfacer",
     "lll",
+    "misspell",
     "unused",
     "vet"
   ],

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,6 +1,6 @@
 {
   "Vendor": true,
-  "Deadline": "2m",
+  "Deadline": "3m",
   "Sort": ["linter", "severity", "path"],
   "Exclude": ["cli/compose/schema/bindata.go"],
 
@@ -14,6 +14,7 @@
     "ineffassign",
     "interfacer",
     "lll",
+    "unused",
     "vet"
   ],
 

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -179,7 +179,7 @@ func (opts *MapOpts) GetAll() map[string]string {
 }
 
 func (opts *MapOpts) String() string {
-	return fmt.Sprintf("%v", map[string]string((opts.values)))
+	return fmt.Sprintf("%v", opts.values)
 }
 
 // Type returns a string name for this Option type

--- a/opts/quotedstring.go
+++ b/opts/quotedstring.go
@@ -18,7 +18,7 @@ func (s *QuotedString) Type() string {
 }
 
 func (s *QuotedString) String() string {
-	return string(*s.value)
+	return *s.value
 }
 
 func trimQuotes(value string) string {

--- a/opts/throttledevice.go
+++ b/opts/throttledevice.go
@@ -52,10 +52,7 @@ func ValidateThrottleIOpsDevice(val string) (*blkiodev.ThrottleDevice, error) {
 		return nil, fmt.Errorf("invalid rate for device: %s. The correct format is <device-path>:<number>. Number must be a positive integer", val)
 	}
 
-	return &blkiodev.ThrottleDevice{
-		Path: split[0],
-		Rate: uint64(rate),
-	}, nil
+	return &blkiodev.ThrottleDevice{Path: split[0], Rate: rate}, nil
 }
 
 // ThrottledeviceOpt defines a map of ThrottleDevices

--- a/opts/weightdevice.go
+++ b/opts/weightdevice.go
@@ -75,12 +75,7 @@ func (opt *WeightdeviceOpt) String() string {
 
 // GetList returns a slice of pointers to WeightDevices.
 func (opt *WeightdeviceOpt) GetList() []*blkiodev.WeightDevice {
-	var weightdevice []*blkiodev.WeightDevice
-	for _, v := range opt.values {
-		weightdevice = append(weightdevice, v)
-	}
-
-	return weightdevice
+	return opt.values
 }
 
 // Type returns the option type


### PR DESCRIPTION
Some of these linters didn't work on the first pass. I realized it was because `CGO_ENABLED=0` wasn't set.

Adds:
* `unused` - finds unused variables
* `misspell` - finds common spelling mistakes
* `unconvert` - finds unnecessary type convertions
* `unparam` - finds unused parameters (`_` is automatically ignored so functions that have extra params for interfaces are not errors)
* `gosimple` finds code simplifications

Right now this is a bit slower than I'd like it to be. I might look at https://github.com/alecthomas/gometalinter/issues/167 to see if it improves things. 

I suspect running things in-process would be much faster (instead of having to re-parse the AST each time), but that would be a much larger change.