### PR TITLE
Do not call the config endpoint if API is lower than 1.30

### DIFF
--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/compose/convert"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
@@ -32,6 +33,13 @@ type fakeClient struct {
 	networkRemoveFunc func(networkID string) error
 	secretRemoveFunc  func(secretID string) error
 	configRemoveFunc  func(configID string) error
+}
+
+func (cli *fakeClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	return types.Version{
+		Version:    "docker-dev",
+		APIVersion: api.DefaultVersion,
+	}, nil
 }
 
 func (cli *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {


### PR DESCRIPTION
Another would be to handle `Page not found` error in those cases 👼
(and https://github.com/moby/moby/pull/33571 could help too 👼)

Fix #180 

/cc @mavenugo @friism 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
