### PR TITLE
Use scope=swarm for service related network inspect and revendor docker/docker

### DIFF
--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/inspect"
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,7 @@ func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	ctx := context.Background()
 
 	getNetFunc := func(name string) (interface{}, []byte, error) {
-		return client.NetworkInspectWithRaw(ctx, name, opts.verbose)
+		return client.NetworkInspectWithRaw(ctx, name, types.NetworkInspectOptions{Verbose: opts.verbose})
 	}
 
 	return inspect.Inspect(dockerCli.Out(), opts.names, opts.format, getNetFunc)

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -33,7 +34,7 @@ func runRemove(dockerCli *command.DockerCli, networks []string) error {
 	status := 0
 
 	for _, name := range networks {
-		if nw, _, err := client.NetworkInspectWithRaw(ctx, name, false); err == nil &&
+		if nw, _, err := client.NetworkInspectWithRaw(ctx, name, types.NetworkInspectOptions{}); err == nil &&
 			nw.Ingress &&
 			!command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), ingressWarning) {
 			continue

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -61,7 +61,7 @@ func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	}
 
 	getNetwork := func(ref string) (interface{}, []byte, error) {
-		network, _, err := client.NetworkInspectWithRaw(ctx, ref, false)
+		network, _, err := client.NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{Scope: "swarm"})
 		if err == nil || !apiclient.IsErrNetworkNotFound(err) {
 			return network, nil, err
 		}

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/opts"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
@@ -349,7 +350,7 @@ func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, net
 	var netAttach []swarm.NetworkAttachmentConfig
 	for _, net := range networks.Value() {
 		networkIDOrName := net.Target
-		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
+		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
 		if err != nil {
 			return nil, err
 		}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1008,7 +1008,7 @@ func updateNetworks(ctx context.Context, apiClient client.NetworkAPIClient, flag
 	toRemove := buildToRemoveSet(flags, flagNetworkRemove)
 	idsToRemove := make(map[string]struct{})
 	for networkIDOrName := range toRemove {
-		network, err := apiClient.NetworkInspect(ctx, networkIDOrName, false)
+		network, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
 		if err != nil {
 			return err
 		}

--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -174,7 +174,7 @@ func validateExternalNetworks(
 	externalNetworks []string,
 ) error {
 	for _, networkName := range externalNetworks {
-		network, err := client.NetworkInspect(ctx, networkName, false)
+		network, err := client.NetworkInspect(ctx, networkName, types.NetworkInspectOptions{})
 		switch {
 		case dockerclient.IsErrNotFound(err):
 			return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)

--- a/cli/command/stack/deploy_composefile_test.go
+++ b/cli/command/stack/deploy_composefile_test.go
@@ -70,7 +70,7 @@ func TestValidateExternalNetworks(t *testing.T) {
 
 	for _, testcase := range testcases {
 		fakeClient := &network.FakeClient{
-			NetworkInspectFunc: func(_ context.Context, _ string, _ bool) (types.NetworkResource, error) {
+			NetworkInspectFunc: func(_ context.Context, _ string, _ types.NetworkInspectOptions) (types.NetworkResource, error) {
 				return testcase.inspectResponse, testcase.inspectError
 			},
 		}

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -68,7 +68,7 @@ func inspectImages(ctx context.Context, dockerCli *command.DockerCli) inspect.Ge
 
 func inspectNetwork(ctx context.Context, dockerCli *command.DockerCli) inspect.GetRefFunc {
 	return func(ref string) (interface{}, []byte, error) {
-		return dockerCli.Client().NetworkInspectWithRaw(ctx, ref, false)
+		return dockerCli.Client().NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{})
 	}
 }
 

--- a/cli/internal/test/network/client.go
+++ b/cli/internal/test/network/client.go
@@ -9,7 +9,7 @@ import (
 
 // FakeClient is a fake NetworkAPIClient
 type FakeClient struct {
-	NetworkInspectFunc func(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
+	NetworkInspectFunc func(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
 }
 
 // NetworkConnect fakes connecting to a network
@@ -28,15 +28,15 @@ func (c *FakeClient) NetworkDisconnect(ctx context.Context, networkID, container
 }
 
 // NetworkInspect fakes inspecting a network
-func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
+func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error) {
 	if c.NetworkInspectFunc != nil {
-		return c.NetworkInspectFunc(ctx, networkID, verbose)
+		return c.NetworkInspectFunc(ctx, networkID, options)
 	}
 	return types.NetworkResource{}, nil
 }
 
 // NetworkInspectWithRaw fakes inspecting a network with a raw response
-func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error) {
+func (c *FakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
 	return types.NetworkResource{}, nil, nil
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
-github.com/docker/docker cd35e4beee13a7c193e2a89008cd87d38fcd0161
+github.com/docker/docker 4310f7da7e6bcd8185bf05e032f9b7321cfa6ea2
 github.com/docker/docker-credential-helpers v0.5.1
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06 #?
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5

--- a/vendor/github.com/docker/docker/api/common.go
+++ b/vendor/github.com/docker/docker/api/common.go
@@ -21,7 +21,7 @@ import (
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.30"
+	DefaultVersion string = "1.31"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -468,6 +468,12 @@ type NetworkDisconnect struct {
 	Force     bool
 }
 
+// NetworkInspectOptions holds parameters to inspect network
+type NetworkInspectOptions struct {
+	Scope   string
+	Verbose bool
+}
+
 // Checkpoint represents the details of a checkpoint
 type Checkpoint struct {
 	Name string // Name is the name of the checkpoint

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -99,8 +99,8 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 	NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error
-	NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error)
-	NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error)
+	NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
+	NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error)

--- a/vendor/github.com/docker/docker/client/network_inspect.go
+++ b/vendor/github.com/docker/docker/client/network_inspect.go
@@ -12,21 +12,24 @@ import (
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, error) {
-	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, verbose)
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error) {
+	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, verbose bool) (types.NetworkResource, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, []byte, error) {
 	var (
 		networkResource types.NetworkResource
 		resp            serverResponse
 		err             error
 	)
 	query := url.Values{}
-	if verbose {
+	if options.Verbose {
 		query.Set("verbose", "true")
+	}
+	if options.Scope != "" {
+		query.Set("scope", options.Scope)
 	}
 	resp, err = cli.get(ctx, "/networks/"+networkID, query, nil)
 	if err != nil {

--- a/vendor/github.com/docker/docker/pkg/pools/pools.go
+++ b/vendor/github.com/docker/docker/pkg/pools/pools.go
@@ -17,14 +17,15 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 )
 
+const buffer32K = 32 * 1024
+
 var (
 	// BufioReader32KPool is a pool which returns bufio.Reader with a 32K buffer.
 	BufioReader32KPool = newBufioReaderPoolWithSize(buffer32K)
 	// BufioWriter32KPool is a pool which returns bufio.Writer with a 32K buffer.
 	BufioWriter32KPool = newBufioWriterPoolWithSize(buffer32K)
+	buffer32KPool      = newBufferPoolWithSize(buffer32K)
 )
-
-const buffer32K = 32 * 1024
 
 // BufioReaderPool is a bufio reader that uses sync.Pool.
 type BufioReaderPool struct {
@@ -54,11 +55,31 @@ func (bufPool *BufioReaderPool) Put(b *bufio.Reader) {
 	bufPool.pool.Put(b)
 }
 
+type bufferPool struct {
+	pool sync.Pool
+}
+
+func newBufferPoolWithSize(size int) *bufferPool {
+	return &bufferPool{
+		pool: sync.Pool{
+			New: func() interface{} { return make([]byte, size) },
+		},
+	}
+}
+
+func (bp *bufferPool) Get() []byte {
+	return bp.pool.Get().([]byte)
+}
+
+func (bp *bufferPool) Put(b []byte) {
+	bp.pool.Put(b)
+}
+
 // Copy is a convenience wrapper which uses a buffer to avoid allocation in io.Copy.
 func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
-	buf := BufioReader32KPool.Get(src)
-	written, err = io.Copy(dst, buf)
-	BufioReader32KPool.Put(buf)
+	buf := buffer32KPool.Get()
+	written, err = io.CopyBuffer(dst, src, buf)
+	buffer32KPool.Put(buf)
 	return
 }
 

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	ntuserApiset      = syscall.NewLazyDLL("ext-ms-win-ntuser-window-l1-1-0")
-	procGetVersionExW = modkernel32.NewProc("GetVersionExW")
+	ntuserApiset       = syscall.NewLazyDLL("ext-ms-win-ntuser-window-l1-1-0")
+	procGetVersionExW  = modkernel32.NewProc("GetVersionExW")
+	procGetProductInfo = modkernel32.NewProc("GetProductInfo")
 )
 
 // OSVersion is a wrapper for Windows version information
@@ -64,6 +65,22 @@ func IsWindowsClient() bool {
 	}
 	const verNTWorkstation = 0x00000001
 	return osviex.ProductType == verNTWorkstation
+}
+
+// IsIoTCore returns true if the currently running image is based off of
+// Windows 10 IoT Core.
+// @engine maintainers - this function should not be removed or modified as it
+// is used to enforce licensing restrictions on Windows.
+func IsIoTCore() bool {
+	var returnedProductType uint32
+	r1, _, err := procGetProductInfo.Call(6, 1, 0, 0, uintptr(unsafe.Pointer(&returnedProductType)))
+	if r1 == 0 {
+		logrus.Warnf("GetProductInfo failed - assuming this is not IoT: %v", err)
+		return false
+	}
+	const productIoTUAP = 0x0000007B
+	const productIoTUAPCommercial = 0x00000083
+	return returnedProductType == productIoTUAP || returnedProductType == productIoTUAPCommercial
 }
 
 // Unmount is a platform-specific helper function to call

--- a/vendor/github.com/docker/docker/registry/config_unix.go
+++ b/vendor/github.com/docker/docker/registry/config_unix.go
@@ -21,5 +21,5 @@ func cleanPath(s string) string {
 
 // installCliPlatformFlags handles any platform specific flags for the service.
 func (options *ServiceOptions) installCliPlatformFlags(flags *pflag.FlagSet) {
-	flags.BoolVar(&options.V2Only, "disable-legacy-registry", false, "Disable contacting legacy registries")
+	flags.BoolVar(&options.V2Only, "disable-legacy-registry", true, "Disable contacting legacy registries")
 }

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -13,7 +13,7 @@ github.com/mattn/go-shellwords v1.0.3
 github.com/tchap/go-patricia v2.2.6
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
-golang.org/x/net c427ad74c6d7a814201695e9ffde0c5d400a7674
+golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/go-connections e15c02316c12de00874640cd76311849de2aeed5
@@ -26,7 +26,7 @@ github.com/imdario/mergo 0.2.1
 golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
 
 #get libnetwork packages
-github.com/docker/libnetwork eb57059e91bc54c9da23c5a633b75b3faf910a68
+github.com/docker/libnetwork f4a15a0890383619ad797b3bd2481cc6f46a978d
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -57,7 +57,7 @@ github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 github.com/mistifyio/go-zfs 22c9b32c84eb0d0c6f4043b6e90fc94073de92fa
 github.com/pborman/uuid v1.0
 
-google.golang.org/grpc v1.0.4
+google.golang.org/grpc v1.3.0
 github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
@@ -71,7 +71,7 @@ github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 github.com/coreos/go-systemd v4
 github.com/godbus/dbus v4.0.0
 github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
-github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
+github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 
 # gelf logging driver deps
 github.com/Graylog2/go-gelf 7029da823dad4ef3a876df61065156acb703b2ea
@@ -97,14 +97,14 @@ golang.org/x/oauth2 96382aa079b72d8c014eb0c50f6c223d1e6a2de0
 google.golang.org/api 3cc2e591b550923a2c5f0ab5a803feda924d5823
 cloud.google.com/go 9d965e63e8cceb1b5d7977a202f0fcb8866d6525
 github.com/googleapis/gax-go da06d194a00e19ce00d9011a13931c3f6f6887c7
-google.golang.org/genproto b3e7c2fb04031add52c4817f53f43757ccbf9c18
+google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 
 # containerd
 github.com/containerd/containerd 3addd840653146c90a254301d6c3a663c7fd6429
 github.com/tonistiigi/fifo 1405643975692217d6720f8b54aeee1bf2cd5cf4
 
 # cluster
-github.com/docker/swarmkit eb07af52aa2216100cff1ad0b13df48daa8914bf
+github.com/docker/swarmkit a4bf0135f63fb60f0e76ae81579cde87f580db6e
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e


### PR DESCRIPTION
This fix updates docker/docker to 4310f7da7e6bcd8185bf05e032f9b7321cfa6ea2 and use `scope=swarm` for service related network inspect.

This fix use `scope=swarm` for service related network inspect. The purpose is that, in case multiple networks with the same name exist in different scopes, it is still possible to obtain the network for services.

This fix is related to  docker/cli#167, moby/moby#30897, moby/moby#33561, moby/moby#30242
