### PR TITLE
fix the output leak from error test case for config/remove

### DIFF
--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -77,6 +77,7 @@ func TestConfigRemoveContinueAfterError(t *testing.T) {
 
 	cmd := newConfigRemoveCommand(cli)
 	cmd.SetArgs(names)
+	cmd.SetOutput(ioutil.Discard)
 	assert.EqualError(t, cmd.Execute(), "error removing config: foo")
 	assert.Equal(t, names, removedConfigs)
 }


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
The 'TestConfigRemoveContinueAfterError' test for the config/remove command leaks an error message from an error test case to the output. This PR is to fix the leak to remove noise from the output when running the tests.

**- How I did it**
Redirected the output of the command for the specific test to ioutil/Discard

**- How to verify it**
- Run the tests (make -f docker.Makefile test)
- Without the proposed fix, the output will show the following:
>=== RUN   TestConfigRemoveContinueAfterError
>Error: error removing config: foo
>Usage:
>  rm CONFIG [CONFIG...] [flags]
>
>Aliases:
>  rm, remove
>
>
>--- PASS: TestConfigRemoveContinueAfterError (0.00s)

- With the proposed fix, the output will not contain the error message from the error test case:
>=== RUN   TestConfigRemoveContinueAfterError
>--- PASS: TestConfigRemoveContinueAfterError (0.00s)

**- Description for the changelog**
Removed the message leaked from error test case for config/remove command.

**- A picture of a cute animal (not mandatory but encouraged)**

