### PR TITLE
Fix some problems with image force remove

### DIFF
--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -59,9 +59,6 @@ func runRemove(dockerCli command.Cli, opts removeOptions, images []string) error
 	for _, img := range images {
 		dels, err := client.ImageRemove(ctx, img, options)
 		if err != nil {
-			if opts.force {
-				fmt.Fprintf(dockerCli.Out(), "NotFound: %s\n", img)
-			}
 			errs = append(errs, err.Error())
 		} else {
 			for _, del := range dels {
@@ -74,8 +71,12 @@ func runRemove(dockerCli command.Cli, opts removeOptions, images []string) error
 		}
 	}
 
-	if !opts.force && len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+	if len(errs) > 0 {
+		msg := strings.Join(errs, "\n")
+		if !opts.force {
+			return errors.New(msg)
+		}
+		fmt.Fprintf(dockerCli.Err(), msg)
 	}
 	return nil
 }

--- a/cli/command/image/testdata/remove-command-success.Image Deleted with force option.golden
+++ b/cli/command/image/testdata/remove-command-success.Image Deleted with force option.golden
@@ -1,1 +1,0 @@
-NotFound:image1


### PR DESCRIPTION
Sorry, I didn't notice these until #160 was merged.

* the warning should go to stderr
* the warning message should not say "NotFound". The err could be anything, "not found" is just one option (also camel case for user errors is not great)
* fix the code so that `opts.force` doesn't have to be checked twice.


@thaJeztah @vdemeester