### PR TITLE
docs/reference/builder.md: mention that USER directive also allows to specify a user group

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1306,11 +1306,18 @@ Keep the following things in mind about volumes in the `Dockerfile`.
 
 ## USER
 
-    USER daemon
+    USER <user>[:<group>]
+or
+    USER <UID>[:<GID>]
 
-The `USER` instruction sets the user name or UID to use when running the image
-and for any `RUN`, `CMD` and `ENTRYPOINT` instructions that follow it in the
-`Dockerfile`.
+The `USER` instruction sets the user name (or UID) and optionally the user
+group (or GID) to use when running the image and for any `RUN`, `CMD` and
+`ENTRYPOINT` instructions that follow it in the `Dockerfile`.
+
+> **Warning**:
+> When the user does doesn't have a primary group then the image (or the next
+> instructions) will be run with the `root` group.
+
 
 ## WORKDIR
 


### PR DESCRIPTION
When `USER 1000` is specified in the `Dockerfile` and doesn't have a primary group, the resulted image will be run with an UID=1000 and GID=0 (root):
```sh
$ docker build -t test-uid .
Sending build context to Docker daemon 13.82 kB
Step 1/2 : FROM centos:latest
 ---> 3bee3060bfc8
Step 2/2 : USER 1000
 ---> Running in 18b73f17a670
 ---> eef2fb2ad150
Removing intermediate container 18b73f17a670
Successfully built eef2fb2ad150
$ docker run --rm -it test-uid id
uid=1000 gid=0(root) groups=0(root)
```

Such behavior is unexpected (and also insecure) and it's possible to set a GID explicitly by using `USER uid:gid` syntax:
```sh
$ docker build -t test-uid .
Sending build context to Docker daemon 13.82 kB
Step 1/2 : FROM centos:latest
 ---> 3bee3060bfc8
Step 2/2 : USER 1000:1000
 ---> Running in b8c31413f969
 ---> dc0154009df7
Removing intermediate container b8c31413f969
Successfully built dc0154009df7
$ docker run --rm -it test-uid id
uid=1000 gid=1000 groups=1000
```

But this syntax is undocumented and many developers (including me until today) don't know about it.

**- What I did**
I've updated documentation to reflect the current state.

**- Description for the changelog**
Document that the `USER` directive also allows to specify a user group.

**- A picture of a cute animal (not mandatory but encouraged)**
🐈 

CC @mfojtik

This is the issue https://github.com/moby/moby/pull/33573 but opened here because documentation were moved to this repository.