### PR TITLE
remove logging from service/inspect test case to clean up the output of running tests

### DIFF
--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -117,11 +117,7 @@ func TestJSONFormatWithNoUpdateConfig(t *testing.T) {
 	// s1: [{"ID":..}]
 	// s2: {"ID":..}
 	s1 := formatServiceInspect(t, formatter.NewServiceFormat(""), now)
-	t.Log("// s1")
-	t.Logf("%s", s1)
 	s2 := formatServiceInspect(t, formatter.NewServiceFormat("{{json .}}"), now)
-	t.Log("// s2")
-	t.Logf("%s", s2)
 	var m1Wrap []map[string]interface{}
 	if err := json.Unmarshal([]byte(s1), &m1Wrap); err != nil {
 		t.Fatal(err)
@@ -130,11 +126,9 @@ func TestJSONFormatWithNoUpdateConfig(t *testing.T) {
 		t.Fatalf("strange s1=%s", s1)
 	}
 	m1 := m1Wrap[0]
-	t.Logf("m1=%+v", m1)
 	var m2 map[string]interface{}
 	if err := json.Unmarshal([]byte(s2), &m2); err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("m2=%+v", m2)
 	assert.Equal(t, m1, m2)
 }


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Removed logging done by 'TestJSONFormatWithNoUpdateConfig' test of service/inspect, to clean up the output of running the test target

**- How I did it**
Removed the logging lines in service/inspect_test.go

**- How to verify it**
- Run the tests 'make -f docker.Makefile test'
- Without the proposed changes, the output will contain:
>=== RUN   TestJSONFormatWithNoUpdateConfig
>--- PASS: TestJSONFormatWithNoUpdateConfig (0.00s)
>        inspect_test.go:120: // s1
>        inspect_test.go:121: [
>                    {
>                        "ID": "de179gar9d0o7ltdybungplod",
>                        "Version": {
>                            "Index": 315
>                        },

...

>=== RUN   TestMemBytesString
>--- PASS: TestMemBytesString (0.00s)


- With this PR, the output will show:
>=== RUN   TestJSONFormatWithNoUpdateConfig
>--- PASS: TestJSONFormatWithNoUpdateConfig (0.00s)
>=== RUN   TestMemBytesString
>--- PASS: TestMemBytesString (0.00s)


**- Description for the changelog**
Removed logging from service/inspect test case to clean up output of running tests

**- A picture of a cute animal (not mandatory but encouraged)**

