### PR TITLE
Speed up testing with coverage

### DIFF
--- a/scripts/test/unit-with-coverage
+++ b/scripts/test/unit-with-coverage
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
+# install test dependencies once before running tests for each package. This
+# reduces the runtime from 200s down to 23s
+go test -i $@
+
 for pkg in $@; do
     ./scripts/test/unit \
         -cover \


### PR DESCRIPTION
By running a `go test -i` on all the packages first the overall run time is significantly
decreased.

On my desktop this reduces the run time from 200s to 34s.
On circleCI this reduces the run time (which includes building an image) from 9 minutes to under 2 minutes.