### PR TITLE
Run docs and man generation in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,14 +42,14 @@ jobs:
             apk add -U bash curl
             curl -s https://codecov.io/bash | bash
       - run:
-          name: "Validate Vendor and Code Generation"
+          name: "Validate Vendor, Docs, and Code Generation"
           command: |
             if [ "$CIRCLE_NODE_INDEX" != "3" ]; then exit; fi
             dockerfile=dockerfiles/Dockerfile.dev
             echo "COPY . ." >> $dockerfile
             rm -f .dockerignore # include .git
             docker build -f $dockerfile --tag cli-builder .
-            docker run cli-builder make -B vendor compose-jsonschema
+            docker run cli-builder make -B vendor compose-jsonschema manpages yamldocs
 
       - store_artifacts:
           path: /work/build

--- a/man/import.go
+++ b/man/import.go
@@ -1,0 +1,7 @@
+// +build never
+
+package main
+
+// Not used, but required for generating other man pages.
+// Import it here so that the package is included by vndr.
+import _ "github.com/cpuguy83/go-md2man"

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -1,25 +1,14 @@
 #!/usr/bin/env bash
-#
-# Generate man pages for docker/docker
-#
-
-set -eu
+# Generate man pages for docker/cli
+set -eu -o pipefail
 
 mkdir -p ./man/man1
 
-MD2MAN_REPO=github.com/cpuguy83/go-md2man
-MD2MAN_COMMIT=$(grep -F "$MD2MAN_REPO" vendor.conf | cut -d' ' -f2)
-
-(
-	go get -d "$MD2MAN_REPO"
-	cd "$GOPATH"/src/"$MD2MAN_REPO"
-	git checkout "$MD2MAN_COMMIT" &> /dev/null
-	go install "$MD2MAN_REPO"
-)
+go install ./vendor/github.com/cpuguy83/go-md2man
 
 # Generate man pages from cobra commands
 go build -o /tmp/gen-manpages github.com/docker/cli/man
-/tmp/gen-manpages --root . --target ./man/man1
+/tmp/gen-manpages --root $(pwd) --target $(pwd)/man/man1
 
 # Generate legacy pages from markdown
 ./man/md2man-all.sh -q

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -1,5 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# Generate yaml for docker/cli reference docs
+set -eu -o pipefail
+
+mkdir -p docs/yaml/gen
 
 go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
-mkdir docs/yaml/gen
 build/yaml-docs-generator --root $(pwd) --target $(pwd)/docs/yaml/gen

--- a/vendor/github.com/cpuguy83/go-md2man/md2man.go
+++ b/vendor/github.com/cpuguy83/go-md2man/md2man.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/cpuguy83/go-md2man/md2man"
+)
+
+var inFilePath = flag.String("in", "", "Path to file to be processed (default: stdin)")
+var outFilePath = flag.String("out", "", "Path to output processed file (default: stdout)")
+
+func main() {
+	var err error
+	flag.Parse()
+
+	inFile := os.Stdin
+	if *inFilePath != "" {
+		inFile, err = os.Open(*inFilePath)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	defer inFile.Close()
+
+	doc, err := ioutil.ReadAll(inFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	out := md2man.Render(doc)
+
+	outFile := os.Stdout
+	if *outFilePath != "" {
+		outFile, err = os.Create(*outFilePath)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		defer outFile.Close()
+	}
+	_, err = outFile.Write(out)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This way if we make changes to the scripts, or a docs change is invalid somehow we might be able to catch that problem in CI. We could probably do a little more validation on the output, but this is better than nothing.

Also cleanup the scripts a bit to be more consistent, and fail on errors.