### PR TITLE
fix the issue `--help` doesn't work if daemon is not available

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -202,6 +202,9 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 		if versions.LessThan(ping.APIVersion, cli.client.ClientVersion()) {
 			cli.client.UpdateClientVersion(ping.APIVersion)
 		}
+	} else {
+		// Default to true if we fail to connect to daemon
+		cli.server = ServerInfo{HasExperimental: true}
 	}
 
 	return nil


### PR DESCRIPTION
Hi,

fixes #114 

- What I did

Let `--help` be available even is the daemon is not running
Then I add a condition to show an error message in case the daemon is not running

- How I did it
1. For now I just added a comment to the return in the `setHelpFunc` function ligne 95 
2. In the `isSupported` function I added an if statement. Because hasExperimental is false it means the daemon is off. 
Then I suggested a customized error message (line 250)

- How to verify it
1. run the "make -f docker.Makefile cross" command
2. go to the folder build and build with the "deploy --help" (In my case for mac ./docker-darwin-amd64 deploy --help )
3. Verify the normal behaviour , help visible and message if experimental features not enabled
4. Stop Docker 
5 run ./docker-darwin-amd64 deploy --help again 
6. Check if the help is shown with the new error message : 
"Can't connect to Docker daemon.
Docker deploy is only supported on a Docker daemon running and with experimental features enabled"

- Description for the changelog
Make `--help` available even if the daemon is not available, add a custom error message

![simonscat](https://user-images.githubusercontent.com/13678978/27155621-ed556c94-5159-11e7-9a6a-5f7cac8d00b5.jpg)
