### PR TITLE
removed logging from command/formatter package tests

### DIFF
--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContainerPsContext(t *testing.T) {
@@ -357,12 +358,11 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, expectedJSONs[i], m)
+		err := json.Unmarshal([]byte(line), &m)
+		require.NoError(t, err, msg)
+		assert.Equal(t, expectedJSONs[i], m, msg)
 	}
 }
 
@@ -377,12 +377,11 @@ func TestContainerContextWriteJSONField(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var s string
-		if err := json.Unmarshal([]byte(line), &s); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, containers[i].ID, s)
+		err := json.Unmarshal([]byte(line), &s)
+		require.NoError(t, err, msg)
+		assert.Equal(t, containers[i].ID, s, msg)
 	}
 }
 

--- a/cli/command/formatter/network_test.go
+++ b/cli/command/formatter/network_test.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNetworkContext(t *testing.T) {
@@ -183,12 +185,11 @@ func TestNetworkContextWriteJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, expectedJSONs[i], m)
+		err := json.Unmarshal([]byte(line), &m)
+		require.NoError(t, err, msg)
+		assert.Equal(t, expectedJSONs[i], m, msg)
 	}
 }
 
@@ -203,11 +204,10 @@ func TestNetworkContextWriteJSONField(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var s string
-		if err := json.Unmarshal([]byte(line), &s); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, networks[i].ID, s)
+		err := json.Unmarshal([]byte(line), &s)
+		require.NoError(t, err, msg)
+		assert.Equal(t, networks[i].ID, s, msg)
 	}
 }

--- a/cli/command/formatter/node_test.go
+++ b/cli/command/formatter/node_test.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNodeContext(t *testing.T) {
@@ -248,12 +250,11 @@ func TestNodeContextWriteJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 		for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-			t.Logf("Output: line %d: %s", i, line)
+			msg := fmt.Sprintf("Output: line %d: %s", i, line)
 			var m map[string]interface{}
-			if err := json.Unmarshal([]byte(line), &m); err != nil {
-				t.Fatal(err)
-			}
-			assert.Equal(t, testcase.expected[i], m)
+			err := json.Unmarshal([]byte(line), &m)
+			require.NoError(t, err, msg)
+			assert.Equal(t, testcase.expected[i], m, msg)
 		}
 	}
 }
@@ -269,12 +270,11 @@ func TestNodeContextWriteJSONField(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var s string
-		if err := json.Unmarshal([]byte(line), &s); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, nodes[i].ID, s)
+		err := json.Unmarshal([]byte(line), &s)
+		require.NoError(t, err, msg)
+		assert.Equal(t, nodes[i].ID, s, msg)
 	}
 }
 

--- a/cli/command/formatter/service_test.go
+++ b/cli/command/formatter/service_test.go
@@ -3,11 +3,13 @@ package formatter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceContextWrite(t *testing.T) {
@@ -200,12 +202,11 @@ func TestServiceContextWriteJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, expectedJSONs[i], m)
+		err := json.Unmarshal([]byte(line), &m)
+		require.NoError(t, err, msg)
+		assert.Equal(t, expectedJSONs[i], m, msg)
 	}
 }
 func TestServiceContextWriteJSONField(t *testing.T) {
@@ -229,11 +230,10 @@ func TestServiceContextWriteJSONField(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var s string
-		if err := json.Unmarshal([]byte(line), &s); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, services[i].Spec.Name, s)
+		err := json.Unmarshal([]byte(line), &s)
+		require.NoError(t, err, msg)
+		assert.Equal(t, services[i].Spec.Name, s, msg)
 	}
 }

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -3,12 +3,14 @@ package formatter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVolumeContext(t *testing.T) {
@@ -153,12 +155,11 @@ func TestVolumeContextWriteJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &m); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, expectedJSONs[i], m)
+		err := json.Unmarshal([]byte(line), &m)
+		require.NoError(t, err, msg)
+		assert.Equal(t, expectedJSONs[i], m, msg)
 	}
 }
 
@@ -173,11 +174,10 @@ func TestVolumeContextWriteJSONField(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
-		t.Logf("Output: line %d: %s", i, line)
+		msg := fmt.Sprintf("Output: line %d: %s", i, line)
 		var s string
-		if err := json.Unmarshal([]byte(line), &s); err != nil {
-			t.Fatal(err)
-		}
-		assert.Equal(t, volumes[i].Name, s)
+		err := json.Unmarshal([]byte(line), &s)
+		require.NoError(t, err, msg)
+		assert.Equal(t, volumes[i].Name, s, msg)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Removed logging from the tests in command/formatter package (for container, network, node, service, and volume commands tests)

**- How I did it**
Removed the Logf calls when there are no errors.

**- How to verify it**
- Run the tests (make -f docker.Makefile test)
- Output on the master branch (only shown for volume command tests, others are similar):

>=== RUN   TestVolumeContextWriteJSON
>--- PASS: TestVolumeContextWriteJSON (0.00s)
>        volume_test.go:156: Output: line 0: {"Driver":"foo","Labels":"","Links":"N/A","Mountpoint":"","Name":"foobar_baz","Scope
":"","Size":"N/A"}
>        volume_test.go:156: Output: line 1: {"Driver":"bar","Labels":"","Links":"N/A","Mountpoint":"","Name":"foobar_bar","Scope
":"","Size":"N/A"}
>=== RUN   TestVolumeContextWriteJSONField
>--- PASS: TestVolumeContextWriteJSONField (0.00s)
>        volume_test.go:176: Output: line 0: "foobar_baz"
>        volume_test.go:176: Output: line 1: "foobar_bar"


- Output with the changes in this PR:
>=== RUN   TestVolumeContextWriteJSON
>--- PASS: TestVolumeContextWriteJSON (0.00s)
>=== RUN   TestVolumeContextWriteJSONField
>--- PASS: TestVolumeContextWriteJSONField (0.00s)



**- Description for the changelog**
Removed logging from command/formatter package tests


**- A picture of a cute animal (not mandatory but encouraged)**

