### PR TITLE
If `docker swarm ca` is not called with the `--rotate` flag, warn if other flags are passed

### DIFF
--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -61,6 +61,11 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 	}
 
 	if !opts.rotate {
+		for _, f := range []string{flagCACert, flagCAKey, flagCACert, flagExternalCA} {
+			if flags.Changed(f) {
+				return fmt.Errorf("`--%s` flag requires the `--rotate` flag to update the CA", f)
+			}
+		}
 		if swarmInspect.ClusterInfo.TLSInfo.TrustRoot == "" {
 			fmt.Fprintln(dockerCli.Out(), "No CA information available")
 		} else {
@@ -71,7 +76,7 @@ func runRotateCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) er
 
 	genRootCA := true
 	spec := &swarmInspect.Spec
-	opts.mergeSwarmSpec(spec, flags)
+	opts.mergeSwarmSpec(spec, flags) // updates the spec given the cert expiry or external CA flag
 	if flags.Changed(flagCACert) {
 		spec.CAConfig.SigningCACert = opts.rootCACert.Contents()
 		genRootCA = false


### PR DESCRIPTION
If `docker swarm ca` is not called with the `--rotate` flag, the other flags, including cert expiry, will be ignored, so warn if a user attempts to use `docker swarm ca --cert-expiry` or something.

See https://github.com/docker/cli/pull/48#issuecomment-309448046.

![image](https://cdn.pixabay.com/photo/2016/02/22/10/06/hedgehog-1215140_960_720.jpg)