### PR TITLE
Add push-as flag to build command. Allow to build, tag then push in a single command

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -36,6 +36,7 @@ type buildOptions struct {
 	context        string
 	dockerfileName string
 	tags           opts.ListOpts
+	pushAs         string
 	labels         opts.ListOpts
 	buildArgs      opts.ListOpts
 	extraHosts     opts.ListOpts
@@ -100,6 +101,7 @@ func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
+	flags.StringVar(&options.pushAs, "push-as", "", "Tag and push image to a registry")
 	flags.Var(&options.buildArgs, "build-arg", "Set build-time variables")
 	flags.Var(options.ulimits, "ulimit", "Ulimit options")
 	flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
@@ -272,10 +274,14 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 	var body io.Reader = progress.NewProgressReader(buildCtx, progressOutput, 0, "", "Sending build context to Docker daemon")
 
 	authConfigs, _ := dockerCli.GetAllCredentials()
+	tags := options.tags.GetAll()
+	if options.pushAs != "" {
+		tags = append(tags, options.pushAs)
+	}
 	buildOptions := types.ImageBuildOptions{
 		Memory:         options.memory.Value(),
 		MemorySwap:     options.memorySwap.Value(),
-		Tags:           options.tags.GetAll(),
+		Tags:           tags,
 		SuppressOutput: options.quiet,
 		NoCache:        options.noCache,
 		Remove:         options.rm,
@@ -371,6 +377,9 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		}
 	}
 
+	if options.pushAs != "" {
+		return runPush(dockerCli, options.pushAs)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**- What I did**

I added a flag to the docker build command that push just after the build

**- How I did it**

With a new flag ```--push-as``` and re-using push command.

**- How to verify it**

```
$ docker build --push-as guillaumerose/foo .
Sending build context to Docker daemon  2.048kB
Step 1/2 : FROM alpine
 ---> a41a7446062d
Step 2/2 : CMD echo "Hello world"
 ---> Using cache
 ---> faa24c25dd9b
Successfully built faa24c25dd9b
Successfully tagged guillaumerose/foo:latest
The push refers to a repository [docker.io/guillaumerose/foo]
3fb66f713c9f: Layer already exists
latest: digest: sha256:42ca234f64d11fbd76d351141d5f3a4a72acec2f769e4720d0c5be76cec4fdff size: 528
3fb66f713c9f: Layer already exists
sample: digest: sha256:42ca234f64d11fbd76d351141d5f3a4a72acec2f769e4720d0c5be76cec4fdff size: 528
$ docker run guillaumerose/foo
Hello world
```

**- Description for the changelog**

Add push-as flag in build command.
