### PR TITLE
Refactor and UI changes to `swarm ca` command

### DIFF
--- a/cli/command/swarm/ca_test.go
+++ b/cli/command/swarm/ca_test.go
@@ -1,0 +1,88 @@
+package swarm
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func swarmSpecWithFullCAConfig() *swarm.Spec {
+	return &swarm.Spec{
+		CAConfig: swarm.CAConfig{
+			SigningCACert:  "cacert",
+			SigningCAKey:   "cakey",
+			ForceRotate:    1,
+			NodeCertExpiry: time.Duration(200),
+			ExternalCAs: []*swarm.ExternalCA{
+				{
+					URL:      "https://example.com/ca",
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					CACert:   "excacert",
+				},
+			},
+		},
+	}
+}
+
+func TestDisplayTrustRootNoRoot(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	err := displayTrustRoot(buffer, swarm.Swarm{})
+	assert.EqualError(t, err, "No CA information available")
+}
+
+func TestDisplayTrustRoot(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	trustRoot := "trustme"
+	err := displayTrustRoot(buffer, swarm.Swarm{
+		ClusterInfo: swarm.ClusterInfo{
+			TLSInfo: swarm.TLSInfo{TrustRoot: trustRoot},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, trustRoot+"\n", buffer.String())
+}
+
+func TestUpdateSwarmSpecDefaultRotate(t *testing.T) {
+	spec := swarmSpecWithFullCAConfig()
+	flags := newCACommand(nil).Flags()
+	updateSwarmSpec(spec, flags, caOptions{})
+
+	expected := swarmSpecWithFullCAConfig()
+	expected.CAConfig.ForceRotate = 2
+	expected.CAConfig.SigningCACert = ""
+	expected.CAConfig.SigningCAKey = ""
+	assert.Equal(t, expected, spec)
+}
+
+func TestUpdateSwarmSpecPartial(t *testing.T) {
+	spec := swarmSpecWithFullCAConfig()
+	flags := newCACommand(nil).Flags()
+	updateSwarmSpec(spec, flags, caOptions{
+		rootCACert: PEMFile{contents: "cacert"},
+	})
+
+	expected := swarmSpecWithFullCAConfig()
+	expected.CAConfig.SigningCACert = "cacert"
+	assert.Equal(t, expected, spec)
+}
+
+func TestUpdateSwarmSpecFullFlags(t *testing.T) {
+	flags := newCACommand(nil).Flags()
+	flags.Lookup(flagCertExpiry).Changed = true
+	spec := swarmSpecWithFullCAConfig()
+	updateSwarmSpec(spec, flags, caOptions{
+		rootCACert:     PEMFile{contents: "cacert"},
+		rootCAKey:      PEMFile{contents: "cakey"},
+		swarmCAOptions: swarmCAOptions{nodeCertExpiry: 3 * time.Minute},
+	})
+
+	expected := swarmSpecWithFullCAConfig()
+	expected.CAConfig.SigningCACert = "cacert"
+	expected.CAConfig.SigningCAKey = "cakey"
+	expected.CAConfig.NodeCertExpiry = 3 * time.Minute
+	assert.Equal(t, expected, spec)
+}

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -25,7 +25,7 @@ func NewSwarmCommand(dockerCli command.Cli) *cobra.Command {
 		newUpdateCommand(dockerCli),
 		newLeaveCommand(dockerCli),
 		newUnlockCommand(dockerCli),
-		newRotateCACommand(dockerCli),
+		newCACommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -36,10 +36,9 @@ const (
 )
 
 type swarmOptions struct {
+	swarmCAOptions
 	taskHistoryLimit    int64
 	dispatcherHeartbeat time.Duration
-	nodeCertExpiry      time.Duration
-	externalCA          ExternalCAOption
 	maxSnapshots        uint64
 	snapshotInterval    uint64
 	autolock            bool
@@ -216,7 +215,7 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 	return &externalCA, nil
 }
 
-func addSwarmCAFlags(flags *pflag.FlagSet, opts *swarmOptions) {
+func addSwarmCAFlags(flags *pflag.FlagSet, opts *swarmCAOptions) {
 	flags.DurationVar(&opts.nodeCertExpiry, flagCertExpiry, 90*24*time.Hour, "Validity period for node certificates (ns|us|ms|s|m|h)")
 	flags.Var(&opts.externalCA, flagExternalCA, "Specifications of one or more certificate signing endpoints")
 }
@@ -228,7 +227,7 @@ func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	flags.SetAnnotation(flagMaxSnapshots, "version", []string{"1.25"})
 	flags.Uint64Var(&opts.snapshotInterval, flagSnapshotInterval, 10000, "Number of log entries between Raft snapshots")
 	flags.SetAnnotation(flagSnapshotInterval, "version", []string{"1.25"})
-	addSwarmCAFlags(flags, opts)
+	addSwarmCAFlags(flags, &opts.swarmCAOptions)
 }
 
 func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet) {
@@ -238,12 +237,6 @@ func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet)
 	if flags.Changed(flagDispatcherHeartbeat) {
 		spec.Dispatcher.HeartbeatPeriod = opts.dispatcherHeartbeat
 	}
-	if flags.Changed(flagCertExpiry) {
-		spec.CAConfig.NodeCertExpiry = opts.nodeCertExpiry
-	}
-	if flags.Changed(flagExternalCA) {
-		spec.CAConfig.ExternalCAs = opts.externalCA.Value()
-	}
 	if flags.Changed(flagMaxSnapshots) {
 		spec.Raft.KeepOldSnapshots = &opts.maxSnapshots
 	}
@@ -252,6 +245,21 @@ func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet)
 	}
 	if flags.Changed(flagAutolock) {
 		spec.EncryptionConfig.AutoLockManagers = opts.autolock
+	}
+	opts.mergeSwarmSpecCAFlags(spec, flags)
+}
+
+type swarmCAOptions struct {
+	nodeCertExpiry time.Duration
+	externalCA     ExternalCAOption
+}
+
+func (opts *swarmCAOptions) mergeSwarmSpecCAFlags(spec *swarm.Spec, flags *pflag.FlagSet) {
+	if flags.Changed(flagCertExpiry) {
+		spec.CAConfig.NodeCertExpiry = opts.nodeCertExpiry
+	}
+	if flags.Changed(flagExternalCA) {
+		spec.CAConfig.ExternalCAs = opts.externalCA.Value()
 	}
 }
 


### PR DESCRIPTION
Split out a `swarmCAOptions` struct for options that are shared between the ca and update commands. Previously only 2 fields from the `swarmOptions` struct were being used by `CACommand`. 

Updated the usage string to better reflect the functionality provided by the command.

Change the "no trust root" message to an error. With this change the message will be displayed on `stderr` and the exit code will be non-zero. I believe this case should be an error because the intent of the command was to print some information, but the result was the information was not available to print. Also moved those lines to a new function, since they were duplicated.

Add some unit tests. for the new functions.

cc @cyli @aaronlehmann 
