### PR TITLE
Fix lint errors merged while new lint branch was in PR

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -354,7 +354,11 @@ func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, net
 		if err != nil {
 			return nil, err
 		}
-		netAttach = append(netAttach, swarm.NetworkAttachmentConfig(net))
+		netAttach = append(netAttach, swarm.NetworkAttachmentConfig{ // nolint: gosimple
+			Target:     net.Target,
+			Aliases:    net.Aliases,
+			DriverOpts: net.DriverOpts,
+		})
 	}
 	sort.Sort(byNetworkTarget(netAttach))
 	return netAttach, nil

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -503,9 +503,8 @@ func updatePlacementPreferences(flags *pflag.FlagSet, placement *swarm.Placement
 	}
 
 	if flags.Changed(flagPlacementPrefAdd) {
-		for _, addition := range flags.Lookup(flagPlacementPrefAdd).Value.(*placementPrefOpts).prefs {
-			newPrefs = append(newPrefs, addition)
-		}
+		newPrefs = append(newPrefs,
+			flags.Lookup(flagPlacementPrefAdd).Value.(*placementPrefOpts).prefs...)
 	}
 
 	placement.Preferences = newPrefs

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -173,7 +173,7 @@ func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts []string) ma
 		cfgKey = host
 	}
 
-	config, _ := configFile.Proxies[cfgKey]
+	config := configFile.Proxies[cfgKey]
 	permitted := map[string]*string{
 		"HTTP_PROXY":  &config.HTTPProxy,
 		"HTTPS_PROXY": &config.HTTPSProxy,


### PR DESCRIPTION

There was a panic in `gosimple` which is why the `newAttach` change is being reverted and whitelisted for now. It was fixed in https://github.com/dominikh/go-tools/commit/769824fffc0626f9febdcdeb1c80d3644c12e788 so we just have to pickup that fix in gometalinters vendored copy. I will do that tomorrow.

The other 2 were from PRs that were merged at the same time as the new linter PR, so the new linters had never run on them.