### PR TITLE
Explain `stack deploy` with multiple Compose files

### DIFF
--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -40,7 +40,7 @@ has to be run targeting a manager node.
 
 ### Compose file
 
-The `deploy` command supports compose file version `3.0` and above."
+The `deploy` command supports compose file version `3.0` and above.
 
 ```bash
 $ docker stack deploy --compose-file docker-compose.yml vossibility
@@ -57,7 +57,28 @@ Creating service vossibility_ghollector
 Creating service vossibility_lookupd
 ```
 
-You can verify that the services were correctly created
+Only a single Compose file is accepted. If your configuration is split between
+multiple Compose files, e.g. a base configuration and environment-specific overrides,
+you can combine these by passing them to `docker-compose config` with the `-f` option
+and redirecting the merged output into a new file.
+
+```bash
+$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml config > docker-stack.yml
+$ docker stack deploy --compose-file docker-stack.yml vossibility
+
+Ignoring unsupported options: links
+
+Creating network vossibility_vossibility
+Creating network vossibility_default
+Creating service vossibility_nsqd
+Creating service vossibility_logstash
+Creating service vossibility_elasticsearch
+Creating service vossibility_kibana
+Creating service vossibility_ghollector
+Creating service vossibility_lookupd
+```
+
+You can verify that the services were correctly created:
 
 ```bash
 $ docker service ls


### PR DESCRIPTION
The Docker Compose docs suggest using a separate override
configuration file for production-specific settings, but
it is not obvious how to feed this to `docker stack deploy`,
which only supports a single Compose file as input. Thus,
we now describe how to do this by merging the configuration
files with `docker-compose config`.

carry of https://github.com/moby/moby/pull/33290 (thanks @denisw!)