### PR TITLE
expose config credentials without needing the Cli

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -156,7 +155,7 @@ func getConfiguredCredentialStore(c *configfile.ConfigFile, serverAddress string
 // Initialize the dockerCli runs initialization that must happen after command
 // line flags are parsed.
 func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
-	cli.configFile = LoadDefaultConfigFile(cli.err)
+	cli.configFile = cliconfig.LoadDefaultConfigFile(cli.err)
 
 	var err error
 	cli.client, err = NewAPIClientFromFlags(opts.Common, cli.configFile)
@@ -211,19 +210,6 @@ type ServerInfo struct {
 // NewDockerCli returns a DockerCli instance with IO output and error streams set by in, out and err.
 func NewDockerCli(in io.ReadCloser, out, err io.Writer) *DockerCli {
 	return &DockerCli{in: NewInStream(in), out: NewOutStream(out), err: err}
-}
-
-// LoadDefaultConfigFile attempts to load the default config file and returns
-// an initialized ConfigFile struct if none is found.
-func LoadDefaultConfigFile(err io.Writer) *configfile.ConfigFile {
-	configFile, e := cliconfig.Load(cliconfig.Dir())
-	if e != nil {
-		fmt.Fprintf(err, "WARNING: Error loading config file:%v\n", e)
-	}
-	if !configFile.ContainsAuth() {
-		credentials.DetectDefaultStore(configFile)
-	}
-	return configFile
 }
 
 // NewAPIClientFromFlags creates a new APIClient from command line flags

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -36,6 +36,7 @@ type Cli interface {
 	In() *InStream
 	SetIn(in *InStream)
 	ConfigFile() *configfile.ConfigFile
+	ServerInfo() ServerInfo
 }
 
 // DockerCli is an instance the docker command line client.

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -78,7 +78,7 @@ func (o buildOptions) contextFromStdin() bool {
 }
 
 // NewBuildCommand creates a new `docker build` command
-func NewBuildCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	ulimits := make(map[string]*units.Ulimit)
 	options := buildOptions{
 		tags:       opts.NewListOpts(validateTag),
@@ -159,7 +159,7 @@ func (out *lastProgressOutput) WriteProgress(prog progress.Progress) error {
 }
 
 // nolint: gocyclo
-func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
+func runBuild(dockerCli command.Cli, options buildOptions) error {
 	var (
 		buildCtx      io.ReadCloser
 		dockerfileCtx io.ReadCloser
@@ -336,7 +336,8 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		body = buildCtx
 	}
 
-	authConfigs, _ := dockerCli.GetAllCredentials()
+	configFile := dockerCli.ConfigFile()
+	authConfigs, _ := configFile.GetAllCredentials()
 	buildOptions := types.ImageBuildOptions{
 		Memory:         options.memory.Value(),
 		MemorySwap:     options.memorySwap.Value(),
@@ -356,7 +357,7 @@ func runBuild(dockerCli *command.DockerCli, options buildOptions) error {
 		Dockerfile:     relDockerfile,
 		ShmSize:        options.shmSize.Value(),
 		Ulimits:        options.ulimits.GetList(),
-		BuildArgs:      dockerCli.ConfigFile().ParseProxyConfig(dockerCli.Client().DaemonHost(), options.buildArgs.GetAll()),
+		BuildArgs:      configFile.ParseProxyConfig(dockerCli.Client().DaemonHost(), options.buildArgs.GetAll()),
 		AuthConfigs:    authConfigs,
 		Labels:         opts.ConvertKVStringsToMap(options.labels.GetAll()),
 		CacheFrom:      options.cacheFrom,

--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -26,11 +26,11 @@ import (
 
 const clientSessionRemote = "client-session"
 
-func isSessionSupported(dockerCli *command.DockerCli) bool {
+func isSessionSupported(dockerCli command.Cli) bool {
 	return dockerCli.ServerInfo().HasExperimental && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.31")
 }
 
-func trySession(dockerCli *command.DockerCli, contextDir string) (*session.Session, error) {
+func trySession(dockerCli command.Cli, contextDir string) (*session.Session, error) {
 	var s *session.Session
 	if isSessionSupported(dockerCli) {
 		sharedKey, err := getBuildSharedKey(contextDir)

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -8,8 +8,7 @@ import (
 )
 
 // NewImageCommand returns a cobra command for `image` subcommands
-// nolint: interfacer
-func NewImageCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewImageCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Manage images",

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -43,7 +43,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cli := test.NewFakeCli(&fakeClient{}, buf)
-		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
@@ -68,7 +68,7 @@ func TestNewPullCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cli := test.NewFakeCli(&fakeClient{}, buf)
-		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/docker/pkg/testutil/golden"
@@ -41,7 +42,9 @@ func TestNewPullCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPullCommand(test.NewFakeCli(&fakeClient{}, buf))
+		cli := test.NewFakeCli(&fakeClient{}, buf)
+		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -64,7 +67,9 @@ func TestNewPullCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPullCommand(test.NewFakeCli(&fakeClient{}, buf))
+		cli := test.NewFakeCli(&fakeClient{}, buf)
+		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -49,7 +49,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf)
-		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
@@ -74,7 +74,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		}, buf)
-		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/testutil"
@@ -47,7 +48,9 @@ func TestNewPushCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPushCommand(test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf))
+		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf)
+		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -66,11 +69,13 @@ func TestNewPushCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPushCommand(test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCli(&fakeClient{
 			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
-		}, buf))
+		}, buf)
+		cli.SetConfigfile(configfile.NewConfigFile("filename"))
+		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NoError(t, cmd.Execute())

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -70,7 +70,7 @@ func ResolveAuthConfig(ctx context.Context, cli Cli, index *registrytypes.IndexI
 		configKey = ElectAuthServer(ctx, cli)
 	}
 
-	a, _ := cli.CredentialsStore(configKey).Get(configKey)
+	a, _ := cli.ConfigFile().GetAuthConfig(configKey)
 	return a
 }
 
@@ -85,7 +85,7 @@ func ConfigureAuth(cli Cli, flUser, flPassword, serverAddress string, isDefaultR
 		serverAddress = registry.ConvertToHostname(serverAddress)
 	}
 
-	authconfig, err := cli.CredentialsStore(serverAddress).Get(serverAddress)
+	authconfig, err := cli.ConfigFile().GetAuthConfig(serverAddress)
 	if err != nil {
 		return authconfig, err
 	}

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -71,7 +71,7 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error {
 		authConfig.Password = ""
 		authConfig.IdentityToken = response.IdentityToken
 	}
-	if err := dockerCli.CredentialsStore(serverAddress).Store(authConfig); err != nil {
+	if err := dockerCli.ConfigFile().GetCredentialsStore(serverAddress).Store(authConfig); err != nil {
 		return errors.Errorf("Error saving credentials: %v", err)
 	}
 

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -68,7 +68,7 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 
 	fmt.Fprintf(dockerCli.Out(), "Removing login credentials for %s\n", hostnameAddress)
 	for _, r := range regsToLogout {
-		if err := dockerCli.CredentialsStore(r).Erase(r); err != nil {
+		if err := dockerCli.ConfigFile().GetCredentialsStore(r).Erase(r); err != nil {
 			fmt.Fprintf(dockerCli.Err(), "WARNING: could not erase credentials: %v\n", err)
 		}
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -120,7 +120,7 @@ func LoadDefaultConfigFile(err io.Writer) *configfile.ConfigFile {
 		fmt.Fprintf(err, "WARNING: Error loading config file:%v\n", e)
 	}
 	if !configFile.ContainsAuth() {
-		credentials.DetectDefaultStore(configFile)
+		configFile.CredentialsStore = credentials.DetectDefaultStore(configFile.CredentialsStore)
 	}
 	return configFile
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -114,10 +114,10 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 
 // LoadDefaultConfigFile attempts to load the default config file and returns
 // an initialized ConfigFile struct if none is found.
-func LoadDefaultConfigFile(err io.Writer) *configfile.ConfigFile {
-	configFile, e := Load(Dir())
-	if e != nil {
-		fmt.Fprintf(err, "WARNING: Error loading config file:%v\n", e)
+func LoadDefaultConfigFile(stderr io.Writer) *configfile.ConfigFile {
+	configFile, err := Load(Dir())
+	if err != nil {
+		fmt.Fprintf(stderr, "WARNING: Error loading config file: %v\n", err)
 	}
 	if !configFile.ContainsAuth() {
 		configFile.CredentialsStore = credentials.DetectDefaultStore(configFile.CredentialsStore)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -69,7 +69,7 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 
 	filename := filepath.Join(configDir, ConfigFileName)
-	configFile := configfile.NewConfigFile(filename)
+	configFile := configfile.New(filename)
 
 	// Try happy path first - latest config file
 	if _, err := os.Stat(filename); err == nil {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -484,15 +484,6 @@ func TestConfigDir(t *testing.T) {
 	}
 }
 
-func TestConfigFile(t *testing.T) {
-	configFilename := "configFilename"
-	configFile := NewConfigFile(configFilename)
-
-	if configFile.Filename != configFilename {
-		t.Fatalf("Expected %s, got %s", configFilename, configFile.Filename)
-	}
-}
-
 func TestJSONReaderNoFile(t *testing.T) {
 	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } } }`
 

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -540,7 +540,7 @@ func TestLoadDefaultConfigFile(t *testing.T) {
 
 	configFile := LoadDefaultConfigFile(buffer)
 	credStore := credentials.DetectDefaultStore("")
-	expected := configfile.NewConfigFile(filename)
+	expected := configfile.New(filename)
 	expected.CredentialsStore = credStore
 	expected.PsFormat = "format"
 

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -54,8 +54,8 @@ type ProxyConfig struct {
 	FTPProxy   string `json:"ftpProxy,omitempty"`
 }
 
-// NewConfigFile initializes an empty configuration file for the given filename 'fn'
-func NewConfigFile(fn string) *ConfigFile {
+// New initializes an empty configuration file for the given filename 'fn'
+func New(fn string) *ConfigFile {
 	return &ConfigFile{
 		AuthConfigs: make(map[string]types.AuthConfig),
 		HTTPHeaders: make(map[string]string),

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -53,6 +53,15 @@ type ProxyConfig struct {
 	FTPProxy   string `json:"ftpProxy,omitempty"`
 }
 
+// NewConfigFile initializes an empty configuration file for the given filename 'fn'
+func NewConfigFile(fn string) *ConfigFile {
+	return &ConfigFile{
+		AuthConfigs: make(map[string]types.AuthConfig),
+		HTTPHeaders: make(map[string]string),
+		Filename:    fn,
+	}
+}
+
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the
 // auth config information with given directory and populates the receiver object
 func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -127,6 +127,11 @@ func (configFile *ConfigFile) ContainsAuth() bool {
 		len(configFile.AuthConfigs) > 0
 }
 
+// GetAuthConfigs returns the mapping of repo to auth configuration
+func (configFile *ConfigFile) GetAuthConfigs() map[string]types.AuthConfig {
+	return configFile.AuthConfigs
+}
+
 // SaveToWriter encodes and writes out all the authorization information to
 // the given writer
 func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -142,3 +142,10 @@ func TestProxyConfigPerHost(t *testing.T) {
 	}
 	assert.Equal(t, expected, proxyConfig)
 }
+
+func TestConfigFile(t *testing.T) {
+	configFilename := "configFilename"
+	configFile := NewConfigFile(configFilename)
+
+	assert.Equal(t, configFilename, configFile.Filename)
+}

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -137,13 +137,13 @@ func TestProxyConfigPerHost(t *testing.T) {
 
 func TestConfigFile(t *testing.T) {
 	configFilename := "configFilename"
-	configFile := NewConfigFile(configFilename)
+	configFile := New(configFilename)
 
 	assert.Equal(t, configFilename, configFile.Filename)
 }
 
 func TestGetAllCredentials(t *testing.T) {
-	configFile := NewConfigFile("filename")
+	configFile := New("filename")
 	exampleAuth := types.AuthConfig{
 		Username: "user",
 		Password: "pass",

--- a/cli/config/credentials/default_store.go
+++ b/cli/config/credentials/default_store.go
@@ -2,21 +2,18 @@ package credentials
 
 import (
 	"os/exec"
-
-	"github.com/docker/cli/cli/config/configfile"
 )
 
-// DetectDefaultStore sets the default credentials store
-// if the host includes the default store helper program.
-func DetectDefaultStore(c *configfile.ConfigFile) {
-	if c.CredentialsStore != "" {
-		// user defined
-		return
+// DetectDefaultStore return the default credentials store for the platform if
+// the store executable is available.
+func DetectDefaultStore(store string) string {
+	// user defined or no default for platform
+	if store != "" || defaultCredentialsStore == "" {
+		return store
 	}
 
-	if defaultCredentialsStore != "" {
-		if _, err := exec.LookPath(remoteCredentialsPrefix + defaultCredentialsStore); err == nil {
-			c.CredentialsStore = defaultCredentialsStore
-		}
+	if _, err := exec.LookPath(remoteCredentialsPrefix + defaultCredentialsStore); err == nil {
+		return defaultCredentialsStore
 	}
+	return ""
 }

--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -1,37 +1,39 @@
 package credentials
 
 import (
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/registry"
 )
 
+type store interface {
+	Save() error
+	GetAuthConfigs() map[string]types.AuthConfig
+}
+
 // fileStore implements a credentials store using
 // the docker configuration file to keep the credentials in plain text.
 type fileStore struct {
-	file *configfile.ConfigFile
+	file store
 }
 
 // NewFileStore creates a new file credentials store.
-func NewFileStore(file *configfile.ConfigFile) Store {
-	return &fileStore{
-		file: file,
-	}
+func NewFileStore(file store) Store {
+	return &fileStore{file: file}
 }
 
 // Erase removes the given credentials from the file store.
 func (c *fileStore) Erase(serverAddress string) error {
-	delete(c.file.AuthConfigs, serverAddress)
+	delete(c.file.GetAuthConfigs(), serverAddress)
 	return c.file.Save()
 }
 
 // Get retrieves credentials for a specific server from the file store.
 func (c *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
-	authConfig, ok := c.file.AuthConfigs[serverAddress]
+	authConfig, ok := c.file.GetAuthConfigs()[serverAddress]
 	if !ok {
 		// Maybe they have a legacy config file, we will iterate the keys converting
 		// them to the new format and testing
-		for r, ac := range c.file.AuthConfigs {
+		for r, ac := range c.file.GetAuthConfigs() {
 			if serverAddress == registry.ConvertToHostname(r) {
 				return ac, nil
 			}
@@ -43,11 +45,11 @@ func (c *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
 }
 
 func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
-	return c.file.AuthConfigs, nil
+	return c.file.GetAuthConfigs(), nil
 }
 
 // Store saves the given credentials in the file store.
 func (c *fileStore) Store(authConfig types.AuthConfig) error {
-	c.file.AuthConfigs[authConfig.ServerAddress] = authConfig
+	c.file.GetAuthConfigs()[authConfig.ServerAddress] = authConfig
 	return c.file.Save()
 }

--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/api/types"
 )
@@ -14,7 +13,7 @@ func newConfigFile(auths map[string]types.AuthConfig) *configfile.ConfigFile {
 	name := tmp.Name()
 	tmp.Close()
 
-	c := cliconfig.NewConfigFile(name)
+	c := configfile.NewConfigFile(name)
 	c.AuthConfigs = auths
 	return c
 }

--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -1,7 +1,6 @@
 package credentials
 
 import (
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/docker/docker/api/types"
@@ -22,7 +21,7 @@ type nativeStore struct {
 
 // NewNativeStore creates a new native store that
 // uses a remote helper program to manage credentials.
-func NewNativeStore(file *configfile.ConfigFile, helperSuffix string) Store {
+func NewNativeStore(file store, helperSuffix string) Store {
 	name := remoteCredentialsPrefix + helperSuffix
 	return &nativeStore{
 		programFunc: client.NewShellProgramFunc(name),

--- a/cli/internal/test/cli.go
+++ b/cli/internal/test/cli.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/docker/client"
 )
 
@@ -19,7 +18,6 @@ type FakeCli struct {
 	out        *command.OutStream
 	err        io.Writer
 	in         *command.InStream
-	store      credentials.Store
 }
 
 // NewFakeCli returns a Cli backed by the fakeCli

--- a/cli/internal/test/cli.go
+++ b/cli/internal/test/cli.go
@@ -71,11 +71,3 @@ func (c *FakeCli) In() *command.InStream {
 func (c *FakeCli) ConfigFile() *configfile.ConfigFile {
 	return c.configfile
 }
-
-// CredentialsStore returns the fake store the cli will use
-func (c *FakeCli) CredentialsStore(serverAddress string) credentials.Store {
-	if c.store == nil {
-		c.store = NewFakeStore()
-	}
-	return c.store
-}


### PR DESCRIPTION
Related to moby/moby#30817

Move `GetAllCredentials()`, and `CredentialsStore()` from the `DockerCli` to the `ConfigFile` struct, so that are easier to use externally.