### PR TITLE
Fix mounts for directories with weird chars

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -7,7 +7,7 @@
 DEV_DOCKER_IMAGE_NAME = docker-cli-dev
 LINTER_IMAGE_NAME = docker-cli-lint
 CROSS_IMAGE_NAME = docker-cli-cross
-MOUNTS = -v `pwd`:/go/src/github.com/docker/cli
+MOUNTS = -v "$(CURDIR)":/go/src/github.com/docker/cli
 VERSION = $(shell cat VERSION)
 ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT
 


### PR DESCRIPTION


When directories have characters like `&&` they must be wrapped in
quotes or else the docker run command will fail.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes:
`make -f docker.Makefile binary` when running in directories like `/src/when && where/cli`

**- How I did it**
Just replaced:
```
`pwd`
```
With:
```
"$(CURDIR)"
```

**- How to verify it**
Running:
`make -f docker.Makefile binary` when running in directories like `/src/when && where/cli`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
Change `pwd` -> `"CURDIR"` in docker.Makefile
```

**- A picture of a cute animal (not mandatory but encouraged)**
![e6ey0tj](https://user-images.githubusercontent.com/1700823/27412590-7d338666-56aa-11e7-82dd-9daa2684cadf.jpg)

