### PR TITLE
Use an image with git and ssh for circleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ jobs:
 
   lint:
     working_directory: /work
-    docker: [{image: 'docker:17.05'}]
+    docker: [{image: 'docker:17.05-git'}]
     steps:
       - checkout
       - setup_remote_docker
@@ -20,7 +20,7 @@ jobs:
 
   cross:
     working_directory: /work
-    docker: [{image: 'docker:17.05'}]
+    docker: [{image: 'docker:17.05-git'}]
     steps:
       - checkout
       - setup_remote_docker
@@ -37,7 +37,7 @@ jobs:
 
   test:
     working_directory: /work
-    docker: [{image: 'docker:17.05'}]
+    docker: [{image: 'docker:17.05-git'}]
     steps:
       - checkout
       - setup_remote_docker
@@ -58,7 +58,7 @@ jobs:
 
   validate:
     working_directory: /work
-    docker: [{image: 'docker:17.05'}]
+    docker: [{image: 'docker:17.05-git'}]
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Without git we get this warning:

> Warning: Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but this is still an experiment feature. We highly recommend using an image that has official git and ssh installed.

I believe https://circleci.com/gh/docker/cli/888 shows an error caused by the experimental client. I ssh'ed into the node and saw that the files were correct, but `HEAD` was pointing at master, so our vendor check fails.