### PR TITLE
progress: Show progress of replicated tasks before they are assigned

### DIFF
--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -275,7 +275,11 @@ func (u *replicatedProgressUpdater) update(service swarm.Service, tasks []swarm.
 				continue
 			}
 		}
-		if _, nodeActive := activeNodes[task.NodeID]; nodeActive {
+		if task.NodeID != "" {
+			if _, nodeActive := activeNodes[task.NodeID]; nodeActive {
+				tasksBySlot[task.Slot] = task
+			}
+		} else {
 			tasksBySlot[task.Slot] = task
 		}
 	}


### PR DESCRIPTION
This was only showing tasks that belong to nodes that are currently up,
so that tasks on down nodes don't appear to be stuck. But this
unintentionally excludes tasks that haven't been assigned yet, so if a
task is stuck before assignment, for example because no nodes meet its
constraints, a progress bar won't even be shown. The check should only
apply to tasks that have a node assignment.

Related to https://github.com/moby/moby/issues/33807

cc @thaJeztah