### PR TITLE
Fix false Liquid errors

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -216,6 +216,7 @@ attach`, `docker exec`, `docker run` or `docker start` command.
 Following is a sample `config.json` file:
 
 ```json
+{% raw %}
 {
   "HttpHeaders": {
     "MyHeader": "MyValue"
@@ -236,6 +237,7 @@ Following is a sample `config.json` file:
     "unicorn.example.com": "vcbait"
   }
 }
+{% endraw %}
 ```
 
 ### Notary


### PR DESCRIPTION
The double brackets in this block of JSON code are breaking the docs import when we import the `cli.md`. This fixes that. Needs to be cherry-picked into 17.06 please, ASAP.