### PR TITLE
Add bash completion for `label` filter of `prune` commands

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1413,7 +1413,7 @@ _docker_container_port() {
 _docker_container_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -2428,7 +2428,7 @@ _docker_image_ls() {
 _docker_image_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -2806,7 +2806,7 @@ _docker_network_ls() {
 _docker_network_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -4314,7 +4314,7 @@ _docker_system_info() {
 _docker_system_prune() {
 	case "$prev" in
 		--filter)
-			COMPREPLY=( $( compgen -W "until" -S = -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "label label! until" -S = -- "$cur" ) )
 			__docker_nospace
 			return
 			;;
@@ -4433,9 +4433,17 @@ _docker_volume_ls() {
 }
 
 _docker_volume_prune() {
+	case "$prev" in
+		--filter)
+			COMPREPLY=( $( compgen -W "label label!" -S = -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+	esac
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force -f --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter --force -f --help" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This adds bash completion for `docker container|image|network|system|volume prune --filter label|label!`
Ref: https://github.com/moby/moby/pull/30740