### PR TITLE
Add bash completion for `service create|update --entrypoint`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3039,6 +3039,7 @@ _docker_service_update() {
 _docker_service_update_and_create() {
 	local options_with_args="
 		--endpoint-mode
+		--entrypoint
 		--env -e
 		--force
 		--health-cmd
@@ -3138,7 +3139,7 @@ _docker_service_update_and_create() {
 	fi
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
-			--arg
+			--args
 			--constraint-add
 			--constraint-rm
 			--container-label-add


### PR DESCRIPTION
This adds bash completion for https://github.com/moby/moby/pull/29228.
Also fixes a wrong option: `service update --arg` should be `--args`.

ping @sdurrheimer for zsh completion