### PR TITLE
Add bash completion for `service create --detach`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3078,6 +3078,7 @@ _docker_service_update_and_create() {
 	"
 
 	local boolean_options="
+		--detach -d
 		--help
 		--no-healthcheck
 		--read-only


### PR DESCRIPTION
Ref: https://github.com/moby/moby/pull/31144, https://github.com/moby/moby/pull/32516.
Ping @sdurrheimer for zsh completion