### PR TITLE
Add bash completion for plugin events

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4230,13 +4230,16 @@ _docker_system_events() {
 				destroy
 				detach
 				die
+				disable
 				disconnect
+				enable
 				exec_create
 				exec_detach
 				exec_start
 				export
 				health_status
 				import
+				install
 				kill
 				load
 				mount
@@ -4245,6 +4248,7 @@ _docker_system_events() {
 				pull
 				push
 				reload
+				remove
 				rename
 				resize
 				restart
@@ -4270,7 +4274,7 @@ _docker_system_events() {
 			return
 			;;
 		type)
-			COMPREPLY=( $( compgen -W "container daemon image network volume" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "container daemon image network plugin volume" -- "${cur##*=}" ) )
 			return
 			;;
 		volume)


### PR DESCRIPTION
This adds support for the `type=plugin` filter and the plugin events.
ping @sdurrheimer for zsh completion