### PR TITLE
Add bash completion for `service create|update --network-(add|rm)`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3154,6 +3154,8 @@ _docker_service_update_and_create() {
 			--host-add
 			--host-rm
 			--image
+			--network-add
+			--network-rm
 			--placement-pref-add
 			--placement-pref-rm
 			--publish-add
@@ -3178,6 +3180,10 @@ _docker_service_update_and_create() {
 				;;
 			--image)
 				__docker_complete_image_repos_and_tags
+				return
+				;;
+			--network-add|--network-rm)
+				__docker_complete_networks
 				return
 				;;
 			--placement-pref-add|--placement-pref-rm)


### PR DESCRIPTION
This adds bash completion for https://github.com/moby/moby/pull/32062.
Ping @sdurrheimer for zsh completion

Note: In the completion for `docker service update --network-rm`, it would be nice to only complete networks that are actually connected to the service. Sadly, at this point of typing, the service is not known yet - it's the last argument. So I have to complete _all_ networks here.