### PR TITLE
fixed output leak from daemon unit tests

### DIFF
--- a/cmd/docker/daemon_unit_test.go
+++ b/cmd/docker/daemon_unit_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ func TestDaemonCommandHelp(t *testing.T) {
 	cmd := newDaemonCommand()
 	cmd.RunE = stubRun
 	cmd.SetArgs([]string{"--help"})
+	cmd.SetOutput(ioutil.Discard)
 	err := cmd.Execute()
 	assert.NoError(t, err)
 }
@@ -25,6 +27,7 @@ func TestDaemonCommand(t *testing.T) {
 	cmd := newDaemonCommand()
 	cmd.RunE = stubRun
 	cmd.SetArgs([]string{"--containerd", "/foo"})
+	cmd.SetOutput(ioutil.Discard)
 	err := cmd.Execute()
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Fixed the output leaked from daemon unit tests (cmd/docker package) to clean up the output of running tests.

**- How I did it**
Redirected the output from the unit tests.

**- How to verify it**
- Run the tests (make -f docker.Makefile test)
- Output from the master branch includes:
>=== RUN   TestDaemonCommandHelp
>Command "daemon" is deprecated, and will be removed in Docker 17.12. Please run `dockerd` directly.
>--- PASS: TestDaemonCommandHelp (0.00s)
>=== RUN   TestDaemonCommand
>Command "daemon" is deprecated, and will be removed in Docker 17.12. Please run `dockerd` directly.
>--- PASS: TestDaemonCommand (0.00s)


- With this PR, the output shows:
>=== RUN   TestDaemonCommandHelp
>--- PASS: TestDaemonCommandHelp (0.00s)
>=== RUN   TestDaemonCommand
>--- PASS: TestDaemonCommand (0.00s)


**- Description for the changelog**
Fixed output leak from daemon unit tests

**- A picture of a cute animal (not mandatory but encouraged)**

