### PR TITLE
progress: Show success message when finished counting down

### DIFF
--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -129,6 +129,11 @@ func ServiceProgress(ctx context.Context, client client.APIClient, serviceID str
 			}
 		}
 		if converged && time.Since(convergedAt) >= monitor {
+			progressOut.WriteProgress(progress.Progress{
+				ID:     "verify",
+				Action: "Service converged",
+			})
+
 			return nil
 		}
 


### PR DESCRIPTION
This avoids leaving a message on the terminal saying there's 1 second remaining. See https://github.com/docker/cli/pull/237#issuecomment-310810162.

Open to suggestions on the wording.

cc @thaJeztah