### PR TITLE
login: print a big warning when using --password

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -47,6 +47,10 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error {
 	ctx := context.Background()
 	clnt := dockerCli.Client()
 
+	if opts.password != "" {
+		fmt.Fprintln(dockerCli.Err(), "WARNING! Using --password via the CLI is insecure.")
+	}
+
 	var (
 		serverAddress string
 		authServer    = command.ElectAuthServer(ctx, dockerCli)


### PR DESCRIPTION
Task command lines are world readable via /proc/pid/cmdline, so this isn't
safe.