### PR TITLE
add unit tests to checkpoint package

### DIFF
--- a/cli/command/checkpoint/client_test.go
+++ b/cli/command/checkpoint/client_test.go
@@ -1,0 +1,35 @@
+package checkpoint
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	checkpointCreateFunc func(container string, options types.CheckpointCreateOptions) error
+	checkpointDeleteFunc func(container string, options types.CheckpointDeleteOptions) error
+	checkpointListFunc   func(container string, options types.CheckpointListOptions) ([]types.Checkpoint, error)
+}
+
+func (cli *fakeClient) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
+	if cli.checkpointCreateFunc != nil {
+		return cli.checkpointCreateFunc(container, options)
+	}
+	return nil
+}
+
+func (cli *fakeClient) CheckpointDelete(ctx context.Context, container string, options types.CheckpointDeleteOptions) error {
+	if cli.checkpointDeleteFunc != nil {
+		return cli.checkpointDeleteFunc(container, options)
+	}
+	return nil
+}
+
+func (cli *fakeClient) CheckpointList(ctx context.Context, container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
+	if cli.checkpointListFunc != nil {
+		return cli.checkpointListFunc(container, options)
+	}
+	return []types.Checkpoint{}, nil
+}

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -1,0 +1,74 @@
+package checkpoint
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointCreateErrors(t *testing.T) {
+	testCases := []struct {
+		args                 []string
+		checkpointCreateFunc func(container string, options types.CheckpointCreateOptions) error
+		expectedError        string
+	}{
+		{
+			args:          []string{"too-few-arguments"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			args:          []string{"too", "many", "arguments"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			args: []string{"foo", "bar"},
+			checkpointCreateFunc: func(container string, options types.CheckpointCreateOptions) error {
+				return errors.Errorf("error creating checkpoint for container foo")
+			},
+			expectedError: "error creating checkpoint for container foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{
+			checkpointCreateFunc: tc.checkpointCreateFunc,
+		}, &bytes.Buffer{})
+		cmd := newCreateCommand(cli)
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}
+
+func TestCheckpointCreateWithOptions(t *testing.T) {
+	var containerID, checkpointID, checkpointDir string
+	var exit bool
+	buf := new(bytes.Buffer)
+	cli := test.NewFakeCli(&fakeClient{
+		checkpointCreateFunc: func(container string, options types.CheckpointCreateOptions) error {
+			containerID = container
+			checkpointID = options.CheckpointID
+			checkpointDir = options.CheckpointDir
+			exit = options.Exit
+			return nil
+		},
+	}, buf)
+	cmd := newCreateCommand(cli)
+	checkpoint := "checkpoint-bar"
+	cmd.SetArgs([]string{"container-foo", checkpoint})
+	cmd.Flags().Set("leave-running", "true")
+	cmd.Flags().Set("checkpoint-dir", "/dir/foo")
+	assert.NoError(t, cmd.Execute())
+	assert.Equal(t, "container-foo", containerID)
+	assert.Equal(t, checkpoint, checkpointID)
+	assert.Equal(t, "/dir/foo", checkpointDir)
+	assert.Equal(t, false, exit)
+	assert.Equal(t, checkpoint, strings.TrimSpace(buf.String()))
+}

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -1,0 +1,71 @@
+package checkpoint
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/docker/docker/pkg/testutil/golden"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointListErrors(t *testing.T) {
+	testCases := []struct {
+		args               []string
+		checkpointListFunc func(container string, options types.CheckpointListOptions) ([]types.Checkpoint, error)
+		expectedError      string
+	}{
+		{
+			args:          []string{},
+			expectedError: "requires exactly 1 argument",
+		},
+		{
+			args:          []string{"too", "many", "arguments"},
+			expectedError: "requires exactly 1 argument",
+		},
+		{
+			args: []string{"foo"},
+			checkpointListFunc: func(container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
+				return []types.Checkpoint{}, errors.Errorf("error getting checkpoints for container foo")
+			},
+			expectedError: "error getting checkpoints for container foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{
+			checkpointListFunc: tc.checkpointListFunc,
+		}, &bytes.Buffer{})
+		cmd := newListCommand(cli)
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}
+
+func TestCheckpointListWithOptions(t *testing.T) {
+	var containerID, checkpointDir string
+	buf := new(bytes.Buffer)
+	cli := test.NewFakeCli(&fakeClient{
+		checkpointListFunc: func(container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
+			containerID = container
+			checkpointDir = options.CheckpointDir
+			return []types.Checkpoint{
+				{Name: "checkpoint-foo"},
+			}, nil
+		},
+	}, buf)
+	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{"container-foo"})
+	cmd.Flags().Set("checkpoint-dir", "/dir/foo")
+	assert.NoError(t, cmd.Execute())
+	assert.Equal(t, "container-foo", containerID)
+	assert.Equal(t, "/dir/foo", checkpointDir)
+	actual := buf.String()
+	expected := golden.Get(t, []byte(actual), "checkpoint-list-with-options.golden")
+	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
+}

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -1,0 +1,66 @@
+package checkpoint
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointRemoveErrors(t *testing.T) {
+	testCases := []struct {
+		args                 []string
+		checkpointDeleteFunc func(container string, options types.CheckpointDeleteOptions) error
+		expectedError        string
+	}{
+		{
+			args:          []string{"too-few-arguments"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			args:          []string{"too", "many", "arguments"},
+			expectedError: "requires exactly 2 argument(s)",
+		},
+		{
+			args: []string{"foo", "bar"},
+			checkpointDeleteFunc: func(container string, options types.CheckpointDeleteOptions) error {
+				return errors.Errorf("error deleting checkpoint")
+			},
+			expectedError: "error deleting checkpoint",
+		},
+	}
+
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{
+			checkpointDeleteFunc: tc.checkpointDeleteFunc,
+		}, &bytes.Buffer{})
+		cmd := newRemoveCommand(cli)
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+	}
+}
+
+func TestCheckpointRemoveWithOptions(t *testing.T) {
+	var containerID, checkpointID, checkpointDir string
+	cli := test.NewFakeCli(&fakeClient{
+		checkpointDeleteFunc: func(container string, options types.CheckpointDeleteOptions) error {
+			containerID = container
+			checkpointID = options.CheckpointID
+			checkpointDir = options.CheckpointDir
+			return nil
+		},
+	}, &bytes.Buffer{})
+	cmd := newRemoveCommand(cli)
+	cmd.SetArgs([]string{"container-foo", "checkpoint-bar"})
+	cmd.Flags().Set("checkpoint-dir", "/dir/foo")
+	assert.NoError(t, cmd.Execute())
+	assert.Equal(t, "container-foo", containerID)
+	assert.Equal(t, "checkpoint-bar", checkpointID)
+	assert.Equal(t, "/dir/foo", checkpointDir)
+}

--- a/cli/command/checkpoint/testdata/checkpoint-list-with-options.golden
+++ b/cli/command/checkpoint/testdata/checkpoint-list-with-options.golden
@@ -1,0 +1,2 @@
+CHECKPOINT NAME
+checkpoint-foo


### PR DESCRIPTION
Add unit tests to cli/command/checkpoint package. Part of work on #37.

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>


**- What I did**
Added unit tests to the checkpoint package.

**- How I did it**
Added test files and testdata to the cli/command/checkpoint package.

**- How to verify it**
Run the tests (make -f docker.Makefile test)

**- Description for the changelog**
Added unit tests to cli/command/checkpoint package.

**- A picture of a cute animal (not mandatory but encouraged)**

