### PR TITLE
Add metric plugins to bash completion for `plugin ls --filter capability`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3762,7 +3762,7 @@ _docker_plugin_ls() {
 	local key=$(__docker_map_key_of_current_option '--filter|-f')
 	case "$key" in
 		capability)
-			COMPREPLY=( $( compgen -W "authz ipamdriver networkdriver volumedriver" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "authz ipamdriver logdriver metricscollector networkdriver volumedriver" -- "${cur##*=}" ) )
 			return
 			;;
 		enabled)


### PR DESCRIPTION
This adds bash completion for https://github.com/moby/moby/pull/32874.
Ping @sdurrheimer for zsh completion