### PR TITLE
Add bash completion for `docker config` command family

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4151,7 +4151,7 @@ _docker_secret_inspect() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help --pretty" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_secrets

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4195,6 +4195,10 @@ _docker_secret_ls() {
 }
 
 _docker_secret_remove() {
+	_docker_secret_rm
+}
+
+_docker_secret_rm() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
@@ -4203,10 +4207,6 @@ _docker_secret_remove() {
 			__docker_complete_secrets
 			;;
 	esac
-}
-
-_docker_secret_rm() {
-	_docker_secret_remove
 }
 
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -20,6 +20,7 @@
 # For several commands, the amount of completions can be configured by
 # setting environment variables.
 #
+# DOCKER_COMPLETION_SHOW_CONFIG_IDS
 # DOCKER_COMPLETION_SHOW_CONTAINER_IDS
 # DOCKER_COMPLETION_SHOW_NETWORK_IDS
 # DOCKER_COMPLETION_SHOW_NODE_IDS
@@ -59,6 +60,42 @@ shopt -s extglob
 
 __docker_q() {
 	docker ${host:+-H "$host"} ${config:+--config "$config"} 2>/dev/null "$@"
+}
+
+# __docker_configs returns a list of configs. Additional options to
+# `docker config ls` may be specified in order to filter the list, e.g.
+# `__docker_configs --filter label=stage=production`.
+# By default, only names are returned.
+# Set DOCKER_COMPLETION_SHOW_CONFIG_IDS=yes to also complete IDs.
+# An optional first option `--id|--name` may be used to limit the
+# output to the IDs or names of matching items. This setting takes
+# precedence over the environment setting.
+__docker_configs() {
+	local format
+	if [ "$1" = "--id" ] ; then
+		format='{{.ID}}'
+		shift
+	elif [ "$1" = "--name" ] ; then
+		format='{{.Name}}'
+		shift
+	elif [ "$DOCKER_COMPLETION_SHOW_CONFIG_IDS" = yes ] ; then
+		format='{{.ID}} {{.Name}}'
+	else
+		format='{{.Name}}'
+	fi
+
+	__docker_q config ls --format "$format" "$@"
+}
+
+# __docker_complete_configs applies completion of configs based on the current value
+# of `$cur` or the value of the optional first option `--cur`, if given.
+__docker_complete_configs() {
+	local current="$cur"
+	if [ "$1" = "--cur" ] ; then
+		current="$2"
+		shift 2
+	fi
+	COMPREPLY=( $(compgen -W "$(__docker_configs "$@")" -- "$current") )
 }
 
 # __docker_containers returns a list of containers. Additional options to
@@ -1091,6 +1128,117 @@ _docker_checkpoint_rm() {
 			elif [ $cword -eq $(($counter + 1)) ]; then
 				COMPREPLY=( $( compgen -W "$(__docker_q checkpoint ls "$prev" | sed 1d)" -- "$cur" ) )
 			fi
+			;;
+	esac
+}
+
+
+_docker_config() {
+	local subcommands="
+		create
+		inspect
+		ls
+		rm
+	"
+	local aliases="
+		list
+		remove
+	"
+	__docker_subcommands "$subcommands $aliases" && return
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_config_create() {
+	case "$prev" in
+		--label|-l)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--label|-l')
+			if [ $cword -eq $((counter + 1)) ]; then
+				_filedir
+			fi
+			;;
+	esac
+}
+
+_docker_config_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help --pretty" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_configs
+			;;
+	esac
+}
+
+_docker_config_list() {
+	_docker_config_ls
+}
+
+_docker_config_ls() {
+	local key=$(__docker_map_key_of_current_option '--filter|-f')
+	case "$key" in
+		id)
+			__docker_complete_configs --cur "${cur##*=}" --id
+			return
+			;;
+		name)
+			__docker_complete_configs --cur "${cur##*=}" --name
+			return
+			;;
+	esac
+
+	case "$prev" in
+		--filter|-f)
+			COMPREPLY=( $( compgen -S = -W "id label name" -- "$cur" ) )
+			__docker_nospace
+			return
+			;;
+		--format)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format --filter -f --help --quiet -q" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_config_remove() {
+	_docker_config_rm
+}
+
+_docker_config_rm() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_configs
 			;;
 	esac
 }
@@ -3146,6 +3294,7 @@ _docker_service_update_and_create() {
 
 	if [ "$subcommand" = "create" ] ; then
 		options_with_args="$options_with_args
+			--config
 			--constraint
 			--container-label
 			--dns
@@ -3162,6 +3311,10 @@ _docker_service_update_and_create() {
 		"
 
 		case "$prev" in
+			--config)
+				__docker_complete_configs
+				return
+				;;
 			--env-file)
 				_filedir
 				return
@@ -3196,6 +3349,8 @@ _docker_service_update_and_create() {
 	if [ "$subcommand" = "update" ] ; then
 		options_with_args="$options_with_args
 			--args
+			--config-add
+			--config-rm
 			--constraint-add
 			--constraint-rm
 			--container-label-add
@@ -3223,6 +3378,10 @@ _docker_service_update_and_create() {
 		"
 
 		case "$prev" in
+			--config-add|--config-rm)
+				__docker_complete_configs
+				return
+				;;
 			--group-add|--group-rm)
 				COMPREPLY=( $(compgen -g -- "$cur") )
 				return
@@ -4594,6 +4753,7 @@ _docker() {
 	shopt -s extglob
 
 	local management_commands=(
+		config
 		container
 		image
 		network


### PR DESCRIPTION
This adds bash completion for #45.
Ping @sdurrheimer for zsh completion

Additional commits add related functionality/refactorings:
- bash completion for `secret inspect --pretty` (Ref: #88)
- a minor refactoring in bash completion for `secret rm|remove`