### PR TITLE
Fix bash completion for `service create|update --detach|-d`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3081,7 +3081,7 @@ _docker_service_update_and_create() {
 	"
 
 	local boolean_options="
-		--detach -d
+		--detach=false -d=false
 		--help
 		--no-healthcheck
 		--read-only


### PR DESCRIPTION
In #250, I overlooked that the default value for this option is `true`.

I think this I was thrown back into the dark times when such options were reported like (_help output from Docker 1.11.2_):
```bash
  --disable-content-trust=true    Skip image verification
```

Anyway, this PR adapts this completion to the default behavior for boolean options that default to `true`:
append the `=false` suffix because that is the only syntax that really changes behavior.
