### PR TITLE
Use v1.0.0 tag for go-difflib

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,7 @@ github.com/opencontainers/image-spec f03dbe35d449c54915d235f1a3cf8f585a24babe
 github.com/opencontainers/runc 9c2d8d184e5da67c95d601382adf14862e4f2228 https://github.com/docker/runc.git
 github.com/opencontainers/selinux v1.0.0-rc1
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
-github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
+github.com/pmezard/go-difflib v1.0.0
 github.com/russross/blackfriday 1d6b8e9301e720b08a8938b8c25c018285885438
 github.com/shurcooL/sanitized_anchor_name 10ef21a441db47d8b13ebcc5fd2310f636973c77
 github.com/spf13/cobra v1.5.1 https://github.com/dnephin/cobra.git


### PR DESCRIPTION
just a nit; use the v1.0.0 tag (which corresponds to this commit), so that this matches what's used in the moby/moby vendor.conf;
https://github.com/moby/moby/blob/master/vendor.conf#L22

Alternatively, I can update moby/moby to use a commit as well