### PR TITLE
Provide examples for multiple uses of the same flag

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -167,6 +167,8 @@ $ docker service create --name redis \
 4cdgfyky7ozwh3htjfw0d12qv
 ```
 
+To grant a service access to multiple secrets, use multiple `--secret` flags.
+
 Secrets are located in `/run/secrets` in the container.  If no target is
 specified, the name of the secret will be used as the in memory file in the
 container.  If a target is specified, that will be the filename.  In the
@@ -191,10 +193,26 @@ tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
 ### Set environment variables (-e, --env)
 
-This sets environmental variables for all tasks in a service. For example:
+This sets an environmental variable for all tasks in a service. For example:
 
 ```bash
-$ docker service create --name redis_2 --replicas 5 --env MYVAR=foo redis:3.0.6
+$ docker service create \
+  --name redis_2 \
+  --replicas 5 \
+  --env MYVAR=foo \
+  redis:3.0.6
+```
+
+To specify multiple environment variables, specify multiple `--env` flags, each
+with a separate key-value pair.
+
+```bash
+$ docker service create \
+  --name redis_2 \
+  --replicas 5 \
+  --env MYVAR=foo \
+  --env MYVAR2=bar \
+  redis:3.0.6
 ```
 
 ### Create a service with specific hostname (--hostname)


### PR DESCRIPTION
This is an attempt to clear up some confusion a user encountered about specifying multiple `--env` flags. It's not completely systematic (more examples in this file probably could have been modified) but I think it's a start.

Fixes https://github.com/docker/docker.github.io/issues/3718

![koala and shoe](http://cdn4.teen.com/wp-content/gallery/baby-koala-pictures/baby-koala-1.jpg)