### PR TITLE
Clarify docker/go package

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,10 @@ github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker 050c1bb17bd033e909cb653f5449b683608293d6
 github.com/docker/docker-credential-helpers v0.5.1
-github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06 #?
+
+# the docker/go package contains a customized version of canonical/json
+# and is used by Notary. The package is periodically rebased on current Go versions.
+github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 github.com/docker/go-events 18b43f1bc85d9cdd42c05a6cd2d444c7a200a894
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1


### PR DESCRIPTION
This package is used by Notary. Add a comment to the vendor.conf file to explain what it contains
and what it's used for.

e.g.,  see https://github.com/docker/notary/blob/37073310d40204d9e3344253afa5ece7bc42fbbb/tuf/data/serializer.go#L3

ping @cyli @riyazdf @vdemeester PTAL