### PR TITLE
Fix error variable being overwritten

### DIFF
--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -97,14 +97,15 @@ func removeServices(
 	dockerCli command.Cli,
 	services []swarm.Service,
 ) bool {
-	var err error
+	var hasError bool
 	for _, service := range services {
 		fmt.Fprintf(dockerCli.Err(), "Removing service %s\n", service.Spec.Name)
-		if err = dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
+		if err := dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove service %s: %s", service.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeNetworks(
@@ -112,14 +113,15 @@ func removeNetworks(
 	dockerCli command.Cli,
 	networks []types.NetworkResource,
 ) bool {
-	var err error
+	var hasError bool
 	for _, network := range networks {
 		fmt.Fprintf(dockerCli.Err(), "Removing network %s\n", network.Name)
-		if err = dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+		if err := dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeSecrets(
@@ -127,14 +129,15 @@ func removeSecrets(
 	dockerCli command.Cli,
 	secrets []swarm.Secret,
 ) bool {
-	var err error
+	var hasError bool
 	for _, secret := range secrets {
 		fmt.Fprintf(dockerCli.Err(), "Removing secret %s\n", secret.Spec.Name)
-		if err = dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
+		if err := dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove secret %s: %s", secret.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeConfigs(
@@ -142,12 +145,13 @@ func removeConfigs(
 	dockerCli command.Cli,
 	configs []swarm.Config,
 ) bool {
-	var err error
+	var hasError bool
 	for _, config := range configs {
 		fmt.Fprintf(dockerCli.Err(), "Removing config %s\n", config.Spec.Name)
-		if err = dockerCli.Client().ConfigRemove(ctx, config.ID); err != nil {
+		if err := dockerCli.Client().ConfigRemove(ctx, config.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove config %s: %s", config.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }


### PR DESCRIPTION
The `err` variable was set in a loop, so only the last result was taken into account to return "success" or not.

ping @dnephin @vdemeester PTAL
