### PR TITLE
Less verbose fake cli

### DIFF
--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -1,7 +1,6 @@
 package checkpoint
 
 import (
-	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -37,9 +36,9 @@ func TestCheckpointCreateErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCliWithOutput(&fakeClient{
+		cli := test.NewFakeCli(&fakeClient{
 			checkpointCreateFunc: tc.checkpointCreateFunc,
-		}, &bytes.Buffer{})
+		})
 		cmd := newCreateCommand(cli)
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
@@ -50,8 +49,7 @@ func TestCheckpointCreateErrors(t *testing.T) {
 func TestCheckpointCreateWithOptions(t *testing.T) {
 	var containerID, checkpointID, checkpointDir string
 	var exit bool
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		checkpointCreateFunc: func(container string, options types.CheckpointCreateOptions) error {
 			containerID = container
 			checkpointID = options.CheckpointID
@@ -59,7 +57,7 @@ func TestCheckpointCreateWithOptions(t *testing.T) {
 			exit = options.Exit
 			return nil
 		},
-	}, buf)
+	})
 	cmd := newCreateCommand(cli)
 	checkpoint := "checkpoint-bar"
 	cmd.SetArgs([]string{"container-foo", checkpoint})
@@ -70,5 +68,5 @@ func TestCheckpointCreateWithOptions(t *testing.T) {
 	assert.Equal(t, checkpoint, checkpointID)
 	assert.Equal(t, "/dir/foo", checkpointDir)
 	assert.Equal(t, false, exit)
-	assert.Equal(t, checkpoint, strings.TrimSpace(buf.String()))
+	assert.Equal(t, checkpoint, strings.TrimSpace(cli.OutBuffer().String()))
 }

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -37,7 +37,7 @@ func TestCheckpointCreateErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			checkpointCreateFunc: tc.checkpointCreateFunc,
 		}, &bytes.Buffer{})
 		cmd := newCreateCommand(cli)
@@ -51,7 +51,7 @@ func TestCheckpointCreateWithOptions(t *testing.T) {
 	var containerID, checkpointID, checkpointDir string
 	var exit bool
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		checkpointCreateFunc: func(container string, options types.CheckpointCreateOptions) error {
 			containerID = container
 			checkpointID = options.CheckpointID

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -37,7 +37,7 @@ func TestCheckpointListErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			checkpointListFunc: tc.checkpointListFunc,
 		}, &bytes.Buffer{})
 		cmd := newListCommand(cli)
@@ -50,7 +50,7 @@ func TestCheckpointListErrors(t *testing.T) {
 func TestCheckpointListWithOptions(t *testing.T) {
 	var containerID, checkpointDir string
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		checkpointListFunc: func(container string, options types.CheckpointListOptions) ([]types.Checkpoint, error) {
 			containerID = container
 			checkpointDir = options.CheckpointDir

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -36,7 +36,7 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			checkpointDeleteFunc: tc.checkpointDeleteFunc,
 		}, &bytes.Buffer{})
 		cmd := newRemoveCommand(cli)
@@ -48,7 +48,7 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 
 func TestCheckpointRemoveWithOptions(t *testing.T) {
 	var containerID, checkpointID, checkpointDir string
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		checkpointDeleteFunc: func(container string, options types.CheckpointDeleteOptions) error {
 			containerID = container
 			checkpointID = options.CheckpointID

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -43,7 +43,7 @@ func TestConfigCreateErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigCreateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configCreateFunc: tc.configCreateFunc,
 			}, buf),
 		)
@@ -57,7 +57,7 @@ func TestConfigCreateWithName(t *testing.T) {
 	name := "foo"
 	buf := new(bytes.Buffer)
 	var actual []byte
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configCreateFunc: func(spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 			if spec.Name != name {
 				return types.ConfigCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
@@ -87,7 +87,7 @@ func TestConfigCreateWithLabels(t *testing.T) {
 	name := "foo"
 
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configCreateFunc: func(spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 			if spec.Name != name {
 				return types.ConfigCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -55,7 +55,7 @@ func TestConfigInspectErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configInspectFunc: tc.configInspectFunc,
 			}, buf),
 		)
@@ -97,7 +97,7 @@ func TestConfigInspectWithoutFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configInspectFunc: tc.configInspectFunc,
 			}, buf),
 		)
@@ -137,7 +137,7 @@ func TestConfigInspectWithFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configInspectFunc: tc.configInspectFunc,
 			}, buf),
 		)
@@ -174,7 +174,7 @@ func TestConfigInspectPretty(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configInspectFunc: tc.configInspectFunc,
 			}, buf))
 		cmd.SetArgs([]string{"configID"})

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -38,7 +38,7 @@ func TestConfigListErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigListCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configListFunc: tc.configListFunc,
 			}, buf),
 		)
@@ -50,7 +50,7 @@ func TestConfigListErrors(t *testing.T) {
 
 func TestConfigList(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configListFunc: func(options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
 				*Config(ConfigID("ID-foo"),
@@ -79,7 +79,7 @@ func TestConfigList(t *testing.T) {
 
 func TestConfigListWithQuietOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configListFunc: func(options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
 				*Config(ConfigID("ID-foo"), ConfigName("foo")),
@@ -100,7 +100,7 @@ func TestConfigListWithQuietOption(t *testing.T) {
 
 func TestConfigListWithConfigFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configListFunc: func(options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
 				*Config(ConfigID("ID-foo"), ConfigName("foo")),
@@ -122,7 +122,7 @@ func TestConfigListWithConfigFormat(t *testing.T) {
 
 func TestConfigListWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configListFunc: func(options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
 				*Config(ConfigID("ID-foo"), ConfigName("foo")),
@@ -142,7 +142,7 @@ func TestConfigListWithFormat(t *testing.T) {
 
 func TestConfigListWithFilter(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configListFunc: func(options types.ConfigListOptions) ([]swarm.Config, error) {
 			assert.Equal(t, "foo", options.Filters.Get("name")[0])
 			assert.Equal(t, "lbl1=Label-bar", options.Filters.Get("label")[0])

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -68,7 +68,6 @@ func TestConfigList(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newConfigListCommand(cli)
 	cmd.SetOutput(buf)
 	assert.NoError(t, cmd.Execute())
@@ -89,7 +88,6 @@ func TestConfigListWithQuietOption(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newConfigListCommand(cli)
 	cmd.Flags().Set("quiet", "true")
 	assert.NoError(t, cmd.Execute())
@@ -110,7 +108,7 @@ func TestConfigListWithConfigFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		ConfigFormat: "{{ .Name }} {{ .Labels }}",
 	})
 	cmd := newConfigListCommand(cli)
@@ -162,7 +160,6 @@ func TestConfigListWithFilter(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newConfigListCommand(cli)
 	cmd.Flags().Set("filter", "name=foo")
 	cmd.Flags().Set("filter", "label=lbl1=Label-bar")

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -33,7 +33,7 @@ func TestConfigRemoveErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newConfigRemoveCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				configRemoveFunc: tc.configRemoveFunc,
 			}, buf),
 		)
@@ -47,7 +47,7 @@ func TestConfigRemoveWithName(t *testing.T) {
 	names := []string{"foo", "bar"}
 	buf := new(bytes.Buffer)
 	var removedConfigs []string
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configRemoveFunc: func(name string) error {
 			removedConfigs = append(removedConfigs, name)
 			return nil
@@ -65,7 +65,7 @@ func TestConfigRemoveContinueAfterError(t *testing.T) {
 	buf := new(bytes.Buffer)
 	var removedConfigs []string
 
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		configRemoveFunc: func(name string) error {
 			removedConfigs = append(removedConfigs, name)
 			if name == "foo" {

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -69,7 +69,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf))
+		cmd := NewAttachCommand(test.NewFakeCliWithOutput(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -68,8 +67,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cmd := NewAttachCommand(test.NewFakeCliWithOutput(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf))
+		cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{containerInspectFunc: tc.containerInspectFunc}))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -140,7 +140,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		conf := configfile.ConfigFile{}
-		cli := test.NewFakeCli(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf)
 		cli.SetConfigfile(&conf)
 		cmd := NewExecCommand(cli)
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -1,15 +1,14 @@
 package container
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 )
 
 type arguments struct {
@@ -79,9 +78,7 @@ func TestParseExec(t *testing.T) {
 
 	for valid, expectedExecConfig := range valids {
 		execConfig, err := parseExec(&valid.options, valid.execCmd)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		if !compareExecConfig(expectedExecConfig, execConfig) {
 			t.Fatalf("Expected [%v] for %v, got [%v]", expectedExecConfig, valid, execConfig)
 		}
@@ -138,10 +135,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		conf := configfile.ConfigFile{}
-		cli := test.NewFakeCliWithOutput(&fakeClient{containerInspectFunc: tc.containerInspectFunc}, buf)
-		cli.SetConfigfile(&conf)
+		cli := test.NewFakeCli(&fakeClient{containerInspectFunc: tc.containerInspectFunc})
 		cmd := NewExecCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -38,7 +38,7 @@ func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
 		return types.ImageBuildResponse{Body: ioutil.NopCloser(body)}, nil
 	}
 
-	cli := test.NewFakeCliWithOutput(&fakeClient{imageBuildFunc: fakeImageBuild}, ioutil.Discard)
+	cli := test.NewFakeCli(&fakeClient{imageBuildFunc: fakeImageBuild})
 	dockerfile := bytes.NewBufferString(`
 		FROM alpine:3.6
 		COPY foo /

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -38,7 +38,7 @@ func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
 		return types.ImageBuildResponse{Body: ioutil.NopCloser(body)}, nil
 	}
 
-	cli := test.NewFakeCli(&fakeClient{imageBuildFunc: fakeImageBuild}, ioutil.Discard)
+	cli := test.NewFakeCliWithOutput(&fakeClient{imageBuildFunc: fakeImageBuild}, ioutil.Discard)
 	dockerfile := bytes.NewBufferString(`
 		FROM alpine:3.6
 		COPY foo /

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -39,7 +39,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
+		cmd := NewHistoryCommand(test.NewFakeCliWithOutput(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -91,7 +91,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
+		cmd := NewHistoryCommand(test.NewFakeCliWithOutput(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -38,8 +37,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cmd := NewHistoryCommand(test.NewFakeCliWithOutput(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
+		cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -90,13 +88,13 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cmd := NewHistoryCommand(test.NewFakeCliWithOutput(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}, buf))
+		cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
+		cmd := NewHistoryCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NoError(t, err)
-		actual := buf.String()
+		actual := cli.OutBuffer().String()
 		if tc.outputRegex == "" {
 			expected := string(golden.Get(t, []byte(actual), fmt.Sprintf("history-command-success.%s.golden", tc.name))[:])
 			testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, expected)

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -37,7 +37,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}, buf))
+		cmd := NewImportCommand(test.NewFakeCliWithOutput(&fakeClient{imageImportFunc: tc.imageImportFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -45,7 +45,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 }
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
-	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
+	cmd := NewImportCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
 	testutil.ErrorContains(t, cmd.Execute(), "testdata/import-command-success.unexistent-file")
@@ -92,7 +92,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}, buf))
+		cmd := NewImportCommand(test.NewFakeCliWithOutput(&fakeClient{imageImportFunc: tc.imageImportFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NoError(t, cmd.Execute())

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -45,7 +45,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 }
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
-	cmd := NewImportCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
+	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
 	testutil.ErrorContains(t, cmd.Execute(), "testdata/import-command-success.unexistent-file")

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -27,7 +27,7 @@ func TestNewInspectCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := newInspectCommand(test.NewFakeCli(&fakeClient{}, buf))
+		cmd := newInspectCommand(test.NewFakeCliWithOutput(&fakeClient{}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -79,7 +79,7 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		imageInspectInvocationCount = 0
 		buf := new(bytes.Buffer)
-		cmd := newInspectCommand(test.NewFakeCli(&fakeClient{imageInspectFunc: tc.imageInspectFunc}, buf))
+		cmd := newInspectCommand(test.NewFakeCliWithOutput(&fakeClient{imageInspectFunc: tc.imageInspectFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewImagesCommand(test.NewFakeCliWithOutput(&fakeClient{imageListFunc: tc.imageListFunc}, new(bytes.Buffer)))
+		cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}, new(bytes.Buffer)))
+		cmd := NewImagesCommand(test.NewFakeCliWithOutput(&fakeClient{imageListFunc: tc.imageListFunc}, new(bytes.Buffer)))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -81,7 +81,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{imageListFunc: tc.imageListFunc}, buf)
 		cli.SetConfigfile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
 		cmd := NewImagesCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -95,7 +95,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 }
 
 func TestNewListCommandAlias(t *testing.T) {
-	cmd := newListCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
+	cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
 	assert.True(t, cmd.HasAlias("images"))
 	assert.True(t, cmd.HasAlias("list"))
 	assert.False(t, cmd.HasAlias("other"))

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -82,7 +82,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cli := test.NewFakeCliWithOutput(&fakeClient{imageListFunc: tc.imageListFunc}, buf)
-		cli.SetConfigfile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
+		cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
 		cmd := NewImagesCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
@@ -95,7 +95,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 }
 
 func TestNewListCommandAlias(t *testing.T) {
-	cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
+	cmd := newListCommand(test.NewFakeCli(&fakeClient{}))
 	assert.True(t, cmd.HasAlias("images"))
 	assert.True(t, cmd.HasAlias("list"))
 	assert.False(t, cmd.HasAlias("other"))

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -43,7 +43,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc}, new(bytes.Buffer))
+		cli := test.NewFakeCliWithOutput(&fakeClient{imageLoadFunc: tc.imageLoadFunc}, new(bytes.Buffer))
 		cli.In().SetIsTerminal(tc.isTerminalIn)
 		cmd := NewLoadCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -54,7 +54,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
-	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
+	cmd := NewLoadCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
 	err := cmd.Execute()
@@ -93,7 +93,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc}, buf))
+		cmd := NewLoadCommand(test.NewFakeCliWithOutput(&fakeClient{imageLoadFunc: tc.imageLoadFunc}, buf))
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -43,7 +43,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cli := test.NewFakeCliWithOutput(&fakeClient{imageLoadFunc: tc.imageLoadFunc}, new(bytes.Buffer))
+		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 		cli.In().SetIsTerminal(tc.isTerminalIn)
 		cmd := NewLoadCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -54,7 +54,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
-	cmd := NewLoadCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
+	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
 	err := cmd.Execute()

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -38,7 +38,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
+		cmd := NewPruneCommand(test.NewFakeCliWithOutput(&fakeClient{
 			imagesPruneFunc: tc.imagesPruneFunc,
 		}, buf))
 		cmd.SetOutput(ioutil.Discard)
@@ -86,7 +86,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
+		cmd := NewPruneCommand(test.NewFakeCliWithOutput(&fakeClient{
 			imagesPruneFunc: tc.imagesPruneFunc,
 		}, buf))
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -1,12 +1,10 @@
 package image
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"testing"
 
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/docker/pkg/testutil"
 	"github.com/docker/docker/pkg/testutil/golden"
@@ -41,9 +39,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
-		cli.SetConfigfile(configfile.New("filename"))
+		cli := test.NewFakeCli(&fakeClient{})
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
@@ -66,15 +62,13 @@ func TestNewPullCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
-		cli.SetConfigfile(configfile.New("filename"))
+		cli := test.NewFakeCli(&fakeClient{})
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NoError(t, err)
-		actual := buf.String()
+		actual := cli.OutBuffer().String()
 		expected := string(golden.Get(t, []byte(actual), fmt.Sprintf("pull-command-success.%s.golden", tc.name))[:])
 		testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, expected)
 	}

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -42,7 +42,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
 		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -67,7 +67,7 @@ func TestNewPullCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
 		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPullCommand(cli)
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -1,13 +1,11 @@
 package image
 
 import (
-	"bytes"
 	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/testutil"
@@ -47,9 +45,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf)
-		cli.SetConfigfile(configfile.New("filename"))
+		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
 		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)
@@ -68,13 +64,11 @@ func TestNewPushCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{
+		cli := test.NewFakeCli(&fakeClient{
 			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
-		}, buf)
-		cli.SetConfigfile(configfile.New("filename"))
+		})
 		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		cmd.SetArgs(tc.args)

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -48,7 +48,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{imagePushFunc: tc.imagePushFunc}, buf)
 		cli.SetConfigfile(configfile.New("filename"))
 		cmd := NewPushCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -69,7 +69,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewRemoveCommandAlias(t *testing.T) {
-	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}, new(bytes.Buffer)))
+	cmd := newRemoveCommand(test.NewFakeCliWithOutput(&fakeClient{}, new(bytes.Buffer)))
 	assert.True(t, cmd.HasAlias("rmi"))
 	assert.True(t, cmd.HasAlias("remove"))
 	assert.False(t, cmd.HasAlias("other"))
@@ -44,7 +44,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
+		cmd := NewRemoveCommand(test.NewFakeCliWithOutput(&fakeClient{
 			imageRemoveFunc: tc.imageRemoveFunc,
 		}, new(bytes.Buffer)))
 		cmd.SetOutput(ioutil.Discard)
@@ -99,7 +99,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		errBuf := new(bytes.Buffer)
-		fakeCli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc}, buf)
+		fakeCli := test.NewFakeCliWithOutput(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc}, buf)
 		fakeCli.SetErr(errBuf)
 		cmd := NewRemoveCommand(fakeCli)
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -45,7 +45,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc}, new(bytes.Buffer))
+		cli := test.NewFakeCliWithOutput(&fakeClient{imageSaveFunc: tc.imageSaveFunc}, new(bytes.Buffer))
 		cli.Out().SetIsTerminal(tc.isTerminal)
 		cmd := NewSaveCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
@@ -85,7 +85,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
+		cmd := NewSaveCommand(test.NewFakeCliWithOutput(&fakeClient{
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -45,7 +45,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cli := test.NewFakeCliWithOutput(&fakeClient{imageSaveFunc: tc.imageSaveFunc}, new(bytes.Buffer))
+		cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 		cli.Out().SetIsTerminal(tc.isTerminal)
 		cmd := NewSaveCommand(cli)
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -19,7 +19,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 	expectedError := "\"tag\" requires exactly 2 argument(s)."
 	buf := new(bytes.Buffer)
 	for _, args := range testCases {
-		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}, buf))
+		cmd := NewTagCommand(test.NewFakeCliWithOutput(&fakeClient{}, buf))
 		cmd.SetArgs(args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), expectedError)
@@ -29,7 +29,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 func TestCliNewTagCommand(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := NewTagCommand(
-		test.NewFakeCli(&fakeClient{
+		test.NewFakeCliWithOutput(&fakeClient{
 			imageTagFunc: func(image string, ref string) error {
 				assert.Equal(t, "image1", image)
 				assert.Equal(t, "image2", ref)

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -17,9 +16,8 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 		{"image1", "image2", "image3"},
 	}
 	expectedError := "\"tag\" requires exactly 2 argument(s)."
-	buf := new(bytes.Buffer)
 	for _, args := range testCases {
-		cmd := NewTagCommand(test.NewFakeCliWithOutput(&fakeClient{}, buf))
+		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), expectedError)
@@ -27,15 +25,14 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 }
 
 func TestCliNewTagCommand(t *testing.T) {
-	buf := new(bytes.Buffer)
 	cmd := NewTagCommand(
-		test.NewFakeCliWithOutput(&fakeClient{
+		test.NewFakeCli(&fakeClient{
 			imageTagFunc: func(image string, ref string) error {
 				assert.Equal(t, "image1", image)
 				assert.Equal(t, "image2", ref)
 				return nil
 			},
-		}, buf))
+		}))
 	cmd.SetArgs([]string{"image1", "image2"})
 	cmd.SetOutput(ioutil.Discard)
 	assert.NoError(t, cmd.Execute())

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -130,11 +129,10 @@ func TestNetworkCreateErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newCreateCommand(
 			test.NewFakeCli(&fakeClient{
 				networkCreateFunc: tc.networkCreateFunc,
-			}, buf),
+			}),
 		)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
@@ -155,7 +153,6 @@ func TestNetworkCreateWithFlags(t *testing.T) {
 			map[string]string{},
 		},
 	}
-	buf := new(bytes.Buffer)
 	cli := test.NewFakeCli(&fakeClient{
 		networkCreateFunc: func(ctx context.Context, name string, createBody types.NetworkCreate) (types.NetworkCreateResponse, error) {
 			assert.Equal(t, expectedDriver, createBody.Driver, "not expected driver error")
@@ -164,7 +161,7 @@ func TestNetworkCreateWithFlags(t *testing.T) {
 				ID: name,
 			}, nil
 		},
-	}, buf)
+	})
 	args := []string{"banana"}
 	cmd := newCreateCommand(cli)
 
@@ -174,5 +171,5 @@ func TestNetworkCreateWithFlags(t *testing.T) {
 	cmd.Flags().Set("gateway", "192.168.4.1/24")
 	cmd.Flags().Set("subnet", "192.168.4.0/24")
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "banana", strings.TrimSpace(buf.String()))
+	assert.Equal(t, "banana", strings.TrimSpace(cli.OutBuffer().String()))
 }

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -42,7 +42,7 @@ func TestNodeDemoteErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newDemoteCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}, buf))
@@ -55,7 +55,7 @@ func TestNodeDemoteErrors(t *testing.T) {
 func TestNodeDemoteNoChange(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := newDemoteCommand(
-		test.NewFakeCli(&fakeClient{
+		test.NewFakeCliWithOutput(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(), []byte{}, nil
 			},
@@ -73,7 +73,7 @@ func TestNodeDemoteNoChange(t *testing.T) {
 func TestNodeDemoteMultipleNode(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := newDemoteCommand(
-		test.NewFakeCli(&fakeClient{
+		test.NewFakeCliWithOutput(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(Manager()), []byte{}, nil
 			},

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -40,12 +39,11 @@ func TestNodeDemoteErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newDemoteCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -53,9 +51,8 @@ func TestNodeDemoteErrors(t *testing.T) {
 }
 
 func TestNodeDemoteNoChange(t *testing.T) {
-	buf := new(bytes.Buffer)
 	cmd := newDemoteCommand(
-		test.NewFakeCliWithOutput(&fakeClient{
+		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(), []byte{}, nil
 			},
@@ -65,15 +62,14 @@ func TestNodeDemoteNoChange(t *testing.T) {
 				}
 				return nil
 			},
-		}, buf))
+		}))
 	cmd.SetArgs([]string{"nodeID"})
 	assert.NoError(t, cmd.Execute())
 }
 
 func TestNodeDemoteMultipleNode(t *testing.T) {
-	buf := new(bytes.Buffer)
 	cmd := newDemoteCommand(
-		test.NewFakeCliWithOutput(&fakeClient{
+		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(Manager()), []byte{}, nil
 			},
@@ -83,7 +79,7 @@ func TestNodeDemoteMultipleNode(t *testing.T) {
 				}
 				return nil
 			},
-		}, buf))
+		}))
 	cmd.SetArgs([]string{"nodeID1", "nodeID2"})
 	assert.NoError(t, cmd.Execute())
 }

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -69,7 +69,7 @@ func TestNodeInspectErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				infoFunc:        tc.infoFunc,
 			}, buf))
@@ -111,7 +111,7 @@ func TestNodeInspectPretty(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 			}, buf))
 		cmd.SetArgs([]string{"nodeID"})

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -43,7 +43,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			nodeListFunc: tc.nodeListFunc,
 			infoFunc:     tc.infoFunc,
 		}, buf)
@@ -56,7 +56,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 
 func TestNodeList(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
 				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),
@@ -82,7 +82,7 @@ func TestNodeList(t *testing.T) {
 
 func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
 				*Node(),
@@ -99,7 +99,7 @@ func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
 // Test case for #24090
 func TestNodeListContainsHostname(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{}, buf)
+	cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
 	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newListCommand(cli)
 	assert.NoError(t, cmd.Execute())
@@ -108,7 +108,7 @@ func TestNodeListContainsHostname(t *testing.T) {
 
 func TestNodeListDefaultFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
 				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),
@@ -136,7 +136,7 @@ func TestNodeListDefaultFormat(t *testing.T) {
 
 func TestNodeListFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
 				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -42,12 +42,10 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{
+		cli := test.NewFakeCli(&fakeClient{
 			nodeListFunc: tc.nodeListFunc,
 			infoFunc:     tc.infoFunc,
-		}, buf)
-		cli.SetConfigfile(&configfile.ConfigFile{})
+		})
 		cmd := newListCommand(cli)
 		cmd.SetOutput(ioutil.Discard)
 		assert.EqualError(t, cmd.Execute(), tc.expectedError)
@@ -55,8 +53,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 }
 
 func TestNodeList(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
 				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),
@@ -71,13 +68,14 @@ func TestNodeList(t *testing.T) {
 				},
 			}, nil
 		},
-	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
+	})
+
 	cmd := newListCommand(cli)
 	assert.NoError(t, cmd.Execute())
-	assert.Contains(t, buf.String(), `nodeID1 *           nodeHostname1       Ready               Active              Leader`)
-	assert.Contains(t, buf.String(), `nodeID2             nodeHostname2       Ready               Active              Reachable`)
-	assert.Contains(t, buf.String(), `nodeID3             nodeHostname3       Ready               Active`)
+	out := cli.OutBuffer().String()
+	assert.Contains(t, out, `nodeID1 *           nodeHostname1       Ready               Active              Leader`)
+	assert.Contains(t, out, `nodeID2             nodeHostname2       Ready               Active              Reachable`)
+	assert.Contains(t, out, `nodeID3             nodeHostname3       Ready               Active`)
 }
 
 func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
@@ -89,7 +87,6 @@ func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newListCommand(cli)
 	cmd.Flags().Set("quiet", "true")
 	assert.NoError(t, cmd.Execute())
@@ -100,7 +97,6 @@ func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
 func TestNodeListContainsHostname(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cli := test.NewFakeCliWithOutput(&fakeClient{}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newListCommand(cli)
 	assert.NoError(t, cmd.Execute())
 	assert.Contains(t, buf.String(), "HOSTNAME")
@@ -124,7 +120,7 @@ func TestNodeListDefaultFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		NodesFormat: "{{.ID}}: {{.Hostname}} {{.Status}}/{{.ManagerStatus}}",
 	})
 	cmd := newListCommand(cli)
@@ -151,7 +147,7 @@ func TestNodeListFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		NodesFormat: "{{.ID}}: {{.Hostname}} {{.Status}}/{{.ManagerStatus}}",
 	})
 	cmd := newListCommand(cli)

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -42,7 +42,7 @@ func TestNodePromoteErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newPromoteCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}, buf))
@@ -55,7 +55,7 @@ func TestNodePromoteErrors(t *testing.T) {
 func TestNodePromoteNoChange(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := newPromoteCommand(
-		test.NewFakeCli(&fakeClient{
+		test.NewFakeCliWithOutput(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(Manager()), []byte{}, nil
 			},
@@ -73,7 +73,7 @@ func TestNodePromoteNoChange(t *testing.T) {
 func TestNodePromoteMultipleNode(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := newPromoteCommand(
-		test.NewFakeCli(&fakeClient{
+		test.NewFakeCliWithOutput(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
 				return *Node(), []byte{}, nil
 			},

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -52,7 +52,7 @@ func TestNodePsErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newPsCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				infoFunc:        tc.infoFunc,
 				nodeInspectFunc: tc.nodeInspectFunc,
 				taskInspectFunc: tc.taskInspectFunc,
@@ -116,7 +116,7 @@ func TestNodePs(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newPsCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				infoFunc:        tc.infoFunc,
 				nodeInspectFunc: tc.nodeInspectFunc,
 				taskInspectFunc: tc.taskInspectFunc,

--- a/cli/command/node/remove_test.go
+++ b/cli/command/node/remove_test.go
@@ -31,7 +31,7 @@ func TestNodeRemoveErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newRemoveCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeRemoveFunc: tc.nodeRemoveFunc,
 			}, buf))
 		cmd.SetArgs(tc.args)
@@ -42,7 +42,7 @@ func TestNodeRemoveErrors(t *testing.T) {
 
 func TestNodeRemoveMultiple(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}, buf))
+	cmd := newRemoveCommand(test.NewFakeCliWithOutput(&fakeClient{}, buf))
 	cmd.SetArgs([]string{"nodeID1", "nodeID2"})
 	assert.NoError(t, cmd.Execute())
 }

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -59,7 +59,7 @@ func TestNodeUpdateErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}, buf))
@@ -160,7 +160,7 @@ func TestNodeUpdate(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}, buf))

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -57,12 +56,11 @@ func TestNodeUpdateErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
@@ -158,12 +156,11 @@ func TestNodeUpdate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -64,7 +64,7 @@ func TestElectAuthServer(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{infoFunc: tc.infoFunc}, buf)
+		cli := test.NewFakeCliWithOutput(&fakeClient{infoFunc: tc.infoFunc}, buf)
 		errBuf := new(bytes.Buffer)
 		cli.SetErr(errBuf)
 		server := ElectAuthServer(context.Background(), cli)

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -1,7 +1,6 @@
 package command_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -63,13 +62,10 @@ func TestElectAuthServer(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cli := test.NewFakeCliWithOutput(&fakeClient{infoFunc: tc.infoFunc}, buf)
-		errBuf := new(bytes.Buffer)
-		cli.SetErr(errBuf)
+		cli := test.NewFakeCli(&fakeClient{infoFunc: tc.infoFunc})
 		server := ElectAuthServer(context.Background(), cli)
 		assert.Equal(t, tc.expectedAuthServer, server)
-		actual := errBuf.String()
+		actual := cli.ErrBuffer().String()
 		if tc.expectedWarning == "" {
 			assert.Empty(t, actual)
 		} else {

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -43,7 +43,7 @@ func TestSecretCreateErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretCreateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretCreateFunc: tc.secretCreateFunc,
 			}, buf),
 		)
@@ -57,7 +57,7 @@ func TestSecretCreateWithName(t *testing.T) {
 	name := "foo"
 	buf := new(bytes.Buffer)
 	var actual []byte
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretCreateFunc: func(spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if spec.Name != name {
 				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
@@ -87,7 +87,7 @@ func TestSecretCreateWithLabels(t *testing.T) {
 	name := "foo"
 
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretCreateFunc: func(spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if spec.Name != name {
 				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -41,11 +41,10 @@ func TestSecretCreateErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newSecretCreateCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				secretCreateFunc: tc.secretCreateFunc,
-			}, buf),
+			}),
 		)
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -55,7 +55,7 @@ func TestSecretInspectErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,
 			}, buf),
 		)
@@ -97,7 +97,7 @@ func TestSecretInspectWithoutFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,
 			}, buf),
 		)
@@ -137,7 +137,7 @@ func TestSecretInspectWithFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,
 			}, buf),
 		)
@@ -173,7 +173,7 @@ func TestSecretInspectPretty(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,
 			}, buf))
 		cmd.SetArgs([]string{"secretID"})

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -38,7 +38,7 @@ func TestSecretListErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretListCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretListFunc: tc.secretListFunc,
 			}, buf),
 		)
@@ -50,7 +50,7 @@ func TestSecretListErrors(t *testing.T) {
 
 func TestSecretList(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretListFunc: func(options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
 				*Secret(SecretID("ID-foo"),
@@ -79,7 +79,7 @@ func TestSecretList(t *testing.T) {
 
 func TestSecretListWithQuietOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretListFunc: func(options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
 				*Secret(SecretID("ID-foo"), SecretName("foo")),
@@ -100,7 +100,7 @@ func TestSecretListWithQuietOption(t *testing.T) {
 
 func TestSecretListWithConfigFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretListFunc: func(options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
 				*Secret(SecretID("ID-foo"), SecretName("foo")),
@@ -122,7 +122,7 @@ func TestSecretListWithConfigFormat(t *testing.T) {
 
 func TestSecretListWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretListFunc: func(options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
 				*Secret(SecretID("ID-foo"), SecretName("foo")),
@@ -142,7 +142,7 @@ func TestSecretListWithFormat(t *testing.T) {
 
 func TestSecretListWithFilter(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretListFunc: func(options types.SecretListOptions) ([]swarm.Secret, error) {
 			assert.Equal(t, "foo", options.Filters.Get("name")[0], "foo")
 			assert.Equal(t, "lbl1=Label-bar", options.Filters.Get("label")[0])

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -68,7 +68,6 @@ func TestSecretList(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newSecretListCommand(cli)
 	cmd.SetOutput(buf)
 	assert.NoError(t, cmd.Execute())
@@ -89,7 +88,6 @@ func TestSecretListWithQuietOption(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newSecretListCommand(cli)
 	cmd.Flags().Set("quiet", "true")
 	assert.NoError(t, cmd.Execute())
@@ -110,7 +108,7 @@ func TestSecretListWithConfigFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		SecretFormat: "{{ .Name }} {{ .Labels }}",
 	})
 	cmd := newSecretListCommand(cli)
@@ -162,7 +160,6 @@ func TestSecretListWithFilter(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newSecretListCommand(cli)
 	cmd.Flags().Set("filter", "name=foo")
 	cmd.Flags().Set("filter", "label=lbl1=Label-bar")

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -33,7 +33,7 @@ func TestSecretRemoveErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newSecretRemoveCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				secretRemoveFunc: tc.secretRemoveFunc,
 			}, buf),
 		)
@@ -47,7 +47,7 @@ func TestSecretRemoveWithName(t *testing.T) {
 	names := []string{"foo", "bar"}
 	buf := new(bytes.Buffer)
 	var removedSecrets []string
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretRemoveFunc: func(name string) error {
 			removedSecrets = append(removedSecrets, name)
 			return nil
@@ -65,7 +65,7 @@ func TestSecretRemoveContinueAfterError(t *testing.T) {
 	buf := new(bytes.Buffer)
 	var removedSecrets []string
 
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		secretRemoveFunc: func(name string) error {
 			removedSecrets = append(removedSecrets, name)
 			if name == "foo" {

--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -107,7 +107,7 @@ func TestRunPSWarnsOnNotFound(t *testing.T) {
 	}
 
 	out := new(bytes.Buffer)
-	cli := test.NewFakeCli(client, out)
+	cli := test.NewFakeCliWithOutput(client, out)
 	options := psOptions{
 		services: []string{"foo", "bar"},
 		filter:   opts.NewFilterOpt(),

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -18,7 +18,7 @@ func TestPruneServices(t *testing.T) {
 		"keep": {},
 	}
 	client := &fakeClient{services: []string{objectName("foo", "keep"), objectName("foo", "remove")}}
-	dockerCli := test.NewFakeCli(client, &bytes.Buffer{})
+	dockerCli := test.NewFakeCliWithOutput(client, &bytes.Buffer{})
 	dockerCli.SetErr(&bytes.Buffer{})
 
 	pruneServices(ctx, dockerCli, namespace, services)

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -1,7 +1,6 @@
 package stack
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/docker/cli/cli/compose/convert"
@@ -18,10 +17,8 @@ func TestPruneServices(t *testing.T) {
 		"keep": {},
 	}
 	client := &fakeClient{services: []string{objectName("foo", "keep"), objectName("foo", "remove")}}
-	dockerCli := test.NewFakeCliWithOutput(client, &bytes.Buffer{})
-	dockerCli.SetErr(&bytes.Buffer{})
+	dockerCli := test.NewFakeCli(client)
 
 	pruneServices(ctx, dockerCli, namespace, services)
-
 	assert.Equal(t, buildObjectIDs([]string{objectName("foo", "remove")}), client.removedServices)
 }

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -48,7 +48,7 @@ func TestListErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := newListCommand(test.NewFakeCli(&fakeClient{
+		cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{
 			serviceListFunc: tc.serviceListFunc,
 		}, &bytes.Buffer{}))
 		cmd.SetArgs(tc.args)
@@ -62,7 +62,7 @@ func TestListErrors(t *testing.T) {
 
 func TestListWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cmd := newListCommand(test.NewFakeCli(&fakeClient{
+	cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(
@@ -81,7 +81,7 @@ func TestListWithFormat(t *testing.T) {
 
 func TestListWithoutFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cmd := newListCommand(test.NewFakeCli(&fakeClient{
+	cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(
@@ -99,7 +99,7 @@ func TestListWithoutFormat(t *testing.T) {
 
 func TestListOrder(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cmd := newListCommand(test.NewFakeCli(&fakeClient{
+	cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -48,9 +48,9 @@ func TestListErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := newListCommand(test.NewFakeCliWithOutput(&fakeClient{
+		cmd := newListCommand(test.NewFakeCli(&fakeClient{
 			serviceListFunc: tc.serviceListFunc,
-		}, &bytes.Buffer{}))
+		}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
 		for key, value := range tc.flags {

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -1,7 +1,6 @@
 package stack
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -43,9 +42,9 @@ func TestStackPsErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := newPsCommand(test.NewFakeCliWithOutput(&fakeClient{
+		cmd := newPsCommand(test.NewFakeCli(&fakeClient{
 			taskListFunc: tc.taskListFunc,
-		}, &bytes.Buffer{}))
+		}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -67,42 +66,39 @@ func TestStackPsEmptyStack(t *testing.T) {
 }
 
 func TestStackPsWithQuietOption(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskID("id-foo"))}, nil
 		},
-	}, buf)
+	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("quiet", "true")
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-with-quiet-option.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 
 }
 
 func TestStackPsWithNoTruncOption(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskID("xn4cypcov06f2w8gsbaf2lst3"))}, nil
 		},
-	}, buf)
+	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("no-trunc", "true")
 	cmd.Flags().Set("format", "{{ .ID }}")
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-with-no-trunc-option.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackPsWithNoResolveOption(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(
 				TaskNodeID("id-node-foo"),
@@ -111,54 +107,51 @@ func TestStackPsWithNoResolveOption(t *testing.T) {
 		nodeInspectWithRaw: func(ref string) (swarm.Node, []byte, error) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
-	}, buf)
+	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("no-resolve", "true")
 	cmd.Flags().Set("format", "{{ .Node }}")
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-with-no-resolve-option.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackPsWithFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
-	}, buf)
+	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("format", "{{ .Name }}")
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-with-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackPsWithConfigFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
-	}, buf)
+	})
 	cli.SetConfigFile(&configfile.ConfigFile{
 		TasksFormat: "{{ .Name }}",
 	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-with-config-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackPsWithoutFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(
 				TaskID("id-foo"),
@@ -172,11 +165,11 @@ func TestStackPsWithoutFormat(t *testing.T) {
 		nodeInspectWithRaw: func(ref string) (swarm.Node, []byte, error) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
-	}, buf)
+	})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-ps-without-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -73,7 +73,6 @@ func TestStackPsWithQuietOption(t *testing.T) {
 			return []swarm.Task{*Task(TaskID("id-foo"))}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("quiet", "true")
@@ -91,7 +90,6 @@ func TestStackPsWithNoTruncOption(t *testing.T) {
 			return []swarm.Task{*Task(TaskID("xn4cypcov06f2w8gsbaf2lst3"))}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("no-trunc", "true")
@@ -114,7 +112,6 @@ func TestStackPsWithNoResolveOption(t *testing.T) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("no-resolve", "true")
@@ -132,7 +129,6 @@ func TestStackPsWithFormat(t *testing.T) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("format", "{{ .Name }}")
@@ -149,7 +145,7 @@ func TestStackPsWithConfigFormat(t *testing.T) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		TasksFormat: "{{ .Name }}",
 	})
 	cmd := newPsCommand(cli)
@@ -177,7 +173,6 @@ func TestStackPsWithoutFormat(t *testing.T) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newPsCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -43,7 +43,7 @@ func TestStackPsErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cmd := newPsCommand(test.NewFakeCli(&fakeClient{
+		cmd := newPsCommand(test.NewFakeCliWithOutput(&fakeClient{
 			taskListFunc: tc.taskListFunc,
 		}, &bytes.Buffer{}))
 		cmd.SetArgs(tc.args)
@@ -53,25 +53,22 @@ func TestStackPsErrors(t *testing.T) {
 }
 
 func TestStackPsEmptyStack(t *testing.T) {
-	out := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
 	fakeCli := test.NewFakeCli(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{}, nil
 		},
-	}, out)
-	fakeCli.SetErr(stderr)
+	})
 	cmd := newPsCommand(fakeCli)
 	cmd.SetArgs([]string{"foo"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "", out.String())
-	assert.Equal(t, "Nothing found in stack: foo\n", stderr.String())
+	assert.Equal(t, "", fakeCli.OutBuffer().String())
+	assert.Equal(t, "Nothing found in stack: foo\n", fakeCli.ErrBuffer().String())
 }
 
 func TestStackPsWithQuietOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskID("id-foo"))}, nil
 		},
@@ -89,7 +86,7 @@ func TestStackPsWithQuietOption(t *testing.T) {
 
 func TestStackPsWithNoTruncOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskID("xn4cypcov06f2w8gsbaf2lst3"))}, nil
 		},
@@ -107,7 +104,7 @@ func TestStackPsWithNoTruncOption(t *testing.T) {
 
 func TestStackPsWithNoResolveOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(
 				TaskNodeID("id-node-foo"),
@@ -130,7 +127,7 @@ func TestStackPsWithNoResolveOption(t *testing.T) {
 
 func TestStackPsWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
@@ -147,7 +144,7 @@ func TestStackPsWithFormat(t *testing.T) {
 
 func TestStackPsWithConfigFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
 		},
@@ -165,7 +162,7 @@ func TestStackPsWithConfigFormat(t *testing.T) {
 
 func TestStackPsWithoutFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 			return []swarm.Task{*Task(
 				TaskID("id-foo"),

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -46,7 +46,7 @@ func TestRemoveStack(t *testing.T) {
 		secrets:  allSecrets,
 		configs:  allConfigs,
 	}
-	cmd := newRemoveCommand(test.NewFakeCli(cli, &bytes.Buffer{}))
+	cmd := newRemoveCommand(test.NewFakeCliWithOutput(cli, &bytes.Buffer{}))
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
@@ -57,8 +57,6 @@ func TestRemoveStack(t *testing.T) {
 }
 
 func TestRemoveStackSkipEmpty(t *testing.T) {
-	out := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
 	allServices := []string{objectName("bar", "service1"), objectName("bar", "service2")}
 	allServiceIDs := buildObjectIDs(allServices)
 
@@ -77,14 +75,13 @@ func TestRemoveStackSkipEmpty(t *testing.T) {
 		secrets:  allSecrets,
 		configs:  allConfigs,
 	}
-	fakeCli := test.NewFakeCli(fakeClient, out)
-	fakeCli.SetErr(stderr)
+	fakeCli := test.NewFakeCli(fakeClient)
 	cmd := newRemoveCommand(fakeCli)
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "", out.String())
-	assert.Contains(t, stderr.String(), "Nothing found in stack: foo\n")
+	assert.Equal(t, "", fakeCli.OutBuffer().String())
+	assert.Contains(t, fakeCli.ErrBuffer().String(), "Nothing found in stack: foo\n")
 	assert.Equal(t, allServiceIDs, fakeClient.removedServices)
 	assert.Equal(t, allNetworkIDs, fakeClient.removedNetworks)
 	assert.Equal(t, allSecretIDs, fakeClient.removedSecrets)
@@ -120,7 +117,7 @@ func TestRemoveContinueAfterError(t *testing.T) {
 			return nil
 		},
 	}
-	cmd := newRemoveCommand(test.NewFakeCli(cli, &bytes.Buffer{}))
+	cmd := newRemoveCommand(test.NewFakeCliWithOutput(cli, &bytes.Buffer{}))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -1,7 +1,6 @@
 package stack
 
 import (
-	"bytes"
 	"errors"
 	"io/ioutil"
 	"strings"
@@ -46,7 +45,7 @@ func TestRemoveStack(t *testing.T) {
 		secrets:  allSecrets,
 		configs:  allConfigs,
 	}
-	cmd := newRemoveCommand(test.NewFakeCliWithOutput(cli, &bytes.Buffer{}))
+	cmd := newRemoveCommand(test.NewFakeCli(cli))
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
@@ -117,7 +116,7 @@ func TestRemoveContinueAfterError(t *testing.T) {
 			return nil
 		},
 	}
-	cmd := newRemoveCommand(test.NewFakeCliWithOutput(cli, &bytes.Buffer{}))
+	cmd := newRemoveCommand(test.NewFakeCli(cli))
 	cmd.SetOutput(ioutil.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -66,7 +66,7 @@ func TestStackServicesErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			serviceListFunc: tc.serviceListFunc,
 			nodeListFunc:    tc.nodeListFunc,
 			taskListFunc:    tc.taskListFunc,
@@ -83,24 +83,21 @@ func TestStackServicesErrors(t *testing.T) {
 }
 
 func TestStackServicesEmptyServiceList(t *testing.T) {
-	out := new(bytes.Buffer)
-	stderr := new(bytes.Buffer)
 	fakeCli := test.NewFakeCli(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{}, nil
 		},
-	}, out)
-	fakeCli.SetErr(stderr)
+	})
 	cmd := newServicesCommand(fakeCli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "", out.String())
-	assert.Equal(t, "Nothing found in stack: foo\n", stderr.String())
+	assert.Equal(t, "", fakeCli.OutBuffer().String())
+	assert.Equal(t, "Nothing found in stack: foo\n", fakeCli.ErrBuffer().String())
 }
 
 func TestStackServicesWithQuietOption(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{*Service(ServiceID("id-foo"))}, nil
 		},
@@ -117,7 +114,7 @@ func TestStackServicesWithQuietOption(t *testing.T) {
 
 func TestStackServicesWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(ServiceName("service-name-foo")),
@@ -136,7 +133,7 @@ func TestStackServicesWithFormat(t *testing.T) {
 
 func TestStackServicesWithConfigFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(ServiceName("service-name-foo")),
@@ -156,7 +153,7 @@ func TestStackServicesWithConfigFormat(t *testing.T) {
 
 func TestStackServicesWithoutFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{*Service(
 				ServiceName("name-foo"),

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -1,7 +1,6 @@
 package stack
 
 import (
-	"bytes"
 	"io/ioutil"
 	"testing"
 
@@ -95,62 +94,58 @@ func TestStackServicesEmptyServiceList(t *testing.T) {
 }
 
 func TestStackServicesWithQuietOption(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{*Service(ServiceID("id-foo"))}, nil
 		},
-	}, buf)
+	})
 	cmd := newServicesCommand(cli)
 	cmd.Flags().Set("quiet", "true")
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-services-with-quiet-option.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackServicesWithFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(ServiceName("service-name-foo")),
 			}, nil
 		},
-	}, buf)
+	})
 	cmd := newServicesCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("format", "{{ .Name }}")
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-services-with-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackServicesWithConfigFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{
 				*Service(ServiceName("service-name-foo")),
 			}, nil
 		},
-	}, buf)
+	})
 	cli.SetConfigFile(&configfile.ConfigFile{
 		ServicesFormat: "{{ .Name }}",
 	})
 	cmd := newServicesCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-services-with-config-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }
 
 func TestStackServicesWithoutFormat(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cli := test.NewFakeCliWithOutput(&fakeClient{
+	cli := test.NewFakeCli(&fakeClient{
 		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 			return []swarm.Service{*Service(
 				ServiceName("name-foo"),
@@ -165,11 +160,11 @@ func TestStackServicesWithoutFormat(t *testing.T) {
 				}),
 			)}, nil
 		},
-	}, buf)
+	})
 	cmd := newServicesCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
+	actual := cli.OutBuffer().String()
 	expected := golden.Get(t, []byte(actual), "stack-services-without-format.golden")
 	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 }

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -66,12 +66,11 @@ func TestStackServicesErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		cli := test.NewFakeCliWithOutput(&fakeClient{
+		cli := test.NewFakeCli(&fakeClient{
 			serviceListFunc: tc.serviceListFunc,
 			nodeListFunc:    tc.nodeListFunc,
 			taskListFunc:    tc.taskListFunc,
-		}, &bytes.Buffer{})
-		cli.SetConfigfile(&configfile.ConfigFile{})
+		})
 		cmd := newServicesCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
@@ -102,7 +101,6 @@ func TestStackServicesWithQuietOption(t *testing.T) {
 			return []swarm.Service{*Service(ServiceID("id-foo"))}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newServicesCommand(cli)
 	cmd.Flags().Set("quiet", "true")
 	cmd.SetArgs([]string{"foo"})
@@ -121,7 +119,6 @@ func TestStackServicesWithFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newServicesCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	cmd.Flags().Set("format", "{{ .Name }}")
@@ -140,7 +137,7 @@ func TestStackServicesWithConfigFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		ServicesFormat: "{{ .Name }}",
 	})
 	cmd := newServicesCommand(cli)
@@ -169,7 +166,6 @@ func TestStackServicesWithoutFormat(t *testing.T) {
 			)}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newServicesCommand(cli)
 	cmd.SetArgs([]string{"foo"})
 	assert.NoError(t, cmd.Execute())

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -67,7 +67,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInitCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInitFunc:         tc.swarmInitFunc,
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
@@ -114,7 +114,7 @@ func TestSwarmInit(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInitCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInitFunc:         tc.swarmInitFunc,
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -51,7 +51,7 @@ func TestSwarmJoinErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newJoinCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmJoinFunc: tc.swarmJoinFunc,
 				infoFunc:      tc.infoFunc,
 			}, buf))
@@ -93,7 +93,7 @@ func TestSwarmJoin(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newJoinCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				infoFunc: tc.infoFunc,
 			}, buf))
 		cmd.SetArgs([]string{"remote"})

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -92,7 +92,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newJoinTokenCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc: tc.swarmInspectFunc,
 				swarmUpdateFunc:  tc.swarmUpdateFunc,
 				infoFunc:         tc.infoFunc,
@@ -200,7 +200,7 @@ func TestSwarmJoinToken(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newJoinTokenCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc: tc.swarmInspectFunc,
 				infoFunc:         tc.infoFunc,
 				nodeInspectFunc:  tc.nodeInspectFunc,

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -33,11 +32,10 @@ func TestSwarmLeaveErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newLeaveCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				swarmLeaveFunc: tc.swarmLeaveFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -45,9 +43,8 @@ func TestSwarmLeaveErrors(t *testing.T) {
 }
 
 func TestSwarmLeave(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cmd := newLeaveCommand(
-		test.NewFakeCliWithOutput(&fakeClient{}, buf))
+	cli := test.NewFakeCli(&fakeClient{})
+	cmd := newLeaveCommand(cli)
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "Node left the swarm.", strings.TrimSpace(buf.String()))
+	assert.Equal(t, "Node left the swarm.", strings.TrimSpace(cli.OutBuffer().String()))
 }

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -35,7 +35,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newLeaveCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmLeaveFunc: tc.swarmLeaveFunc,
 			}, buf))
 		cmd.SetArgs(tc.args)
@@ -47,7 +47,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 func TestSwarmLeave(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cmd := newLeaveCommand(
-		test.NewFakeCli(&fakeClient{}, buf))
+		test.NewFakeCliWithOutput(&fakeClient{}, buf))
 	assert.NoError(t, cmd.Execute())
 	assert.Equal(t, "Node left the swarm.", strings.TrimSpace(buf.String()))
 }

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"testing"
@@ -83,13 +82,12 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newUnlockKeyCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmUpdateFunc:       tc.swarmUpdateFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
@@ -158,19 +156,18 @@ func TestSwarmUnlockKey(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
-		cmd := newUnlockKeyCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
-				swarmInspectFunc:      tc.swarmInspectFunc,
-				swarmUpdateFunc:       tc.swarmUpdateFunc,
-				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
-			}, buf))
+		cli := test.NewFakeCli(&fakeClient{
+			swarmInspectFunc:      tc.swarmInspectFunc,
+			swarmUpdateFunc:       tc.swarmUpdateFunc,
+			swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
+		})
+		cmd := newUnlockKeyCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
 		assert.NoError(t, cmd.Execute())
-		actual := buf.String()
+		actual := cli.OutBuffer().String()
 		expected := golden.Get(t, []byte(actual), fmt.Sprintf("unlockkeys-%s.golden", tc.name))
 		testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
 	}

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -85,7 +85,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUnlockKeyCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmUpdateFunc:       tc.swarmUpdateFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
@@ -160,7 +160,7 @@ func TestSwarmUnlockKey(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUnlockKeyCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmUpdateFunc:       tc.swarmUpdateFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"bytes"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -66,12 +65,11 @@ func TestSwarmUnlockErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newUnlockCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				infoFunc:        tc.infoFunc,
 				swarmUnlockFunc: tc.swarmUnlockFunc,
-			}, buf))
+			}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOutput(ioutil.Discard)
 		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -80,8 +78,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 
 func TestSwarmUnlock(t *testing.T) {
 	input := "unlockKey"
-	buf := new(bytes.Buffer)
-	dockerCli := test.NewFakeCliWithOutput(&fakeClient{
+	dockerCli := test.NewFakeCli(&fakeClient{
 		infoFunc: func() (types.Info, error) {
 			return types.Info{
 				Swarm: swarm.Info{
@@ -95,7 +92,7 @@ func TestSwarmUnlock(t *testing.T) {
 			}
 			return nil
 		},
-	}, buf)
+	})
 	dockerCli.SetIn(command.NewInStream(ioutil.NopCloser(strings.NewReader(input))))
 	cmd := newUnlockCommand(dockerCli)
 	assert.NoError(t, cmd.Execute())

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -68,7 +68,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUnlockCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				infoFunc:        tc.infoFunc,
 				swarmUnlockFunc: tc.swarmUnlockFunc,
 			}, buf))
@@ -81,7 +81,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 func TestSwarmUnlock(t *testing.T) {
 	input := "unlockKey"
 	buf := new(bytes.Buffer)
-	dockerCli := test.NewFakeCli(&fakeClient{
+	dockerCli := test.NewFakeCliWithOutput(&fakeClient{
 		infoFunc: func() (types.Info, error) {
 			return types.Info{
 				Swarm: swarm.Info{

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -70,7 +70,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmUpdateFunc:       tc.swarmUpdateFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,
@@ -166,7 +166,7 @@ func TestSwarmUpdate(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newUpdateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,
 				swarmUpdateFunc:       tc.swarmUpdateFunc,
 				swarmGetUnlockKeyFunc: tc.swarmGetUnlockKeyFunc,

--- a/cli/command/task/print_test.go
+++ b/cli/command/task/print_test.go
@@ -24,7 +24,7 @@ func TestTaskPrintWithQuietOption(t *testing.T) {
 	noResolve := true
 	buf := new(bytes.Buffer)
 	apiClient := &fakeClient{}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(TaskID("id-foo")),
 	}
@@ -41,7 +41,7 @@ func TestTaskPrintWithNoTruncOption(t *testing.T) {
 	noResolve := true
 	buf := new(bytes.Buffer)
 	apiClient := &fakeClient{}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(TaskID("id-foo-yov6omdek8fg3k5stosyp2m50")),
 	}
@@ -58,7 +58,7 @@ func TestTaskPrintWithGlobalService(t *testing.T) {
 	noResolve := true
 	buf := new(bytes.Buffer)
 	apiClient := &fakeClient{}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(TaskServiceID("service-id-foo"), TaskNodeID("node-id-bar"), TaskSlot(0)),
 	}
@@ -75,7 +75,7 @@ func TestTaskPrintWithReplicatedService(t *testing.T) {
 	noResolve := true
 	buf := new(bytes.Buffer)
 	apiClient := &fakeClient{}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(TaskServiceID("service-id-foo"), TaskSlot(1)),
 	}
@@ -99,7 +99,7 @@ func TestTaskPrintWithIndentation(t *testing.T) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
 	}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(
 			TaskID("id-foo"),
@@ -138,7 +138,7 @@ func TestTaskPrintWithResolution(t *testing.T) {
 			return *Node(NodeName("node-name-bar")), nil, nil
 		},
 	}
-	cli := test.NewFakeCli(apiClient, buf)
+	cli := test.NewFakeCliWithOutput(apiClient, buf)
 	tasks := []swarm.Task{
 		*Task(TaskServiceID("service-id-foo"), TaskSlot(1)),
 	}

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -43,7 +43,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newCreateCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeCreateFunc: tc.volumeCreateFunc,
 			}, buf),
 		)
@@ -59,7 +59,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 func TestVolumeCreateWithName(t *testing.T) {
 	name := "foo"
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		volumeCreateFunc: func(body volumetypes.VolumesCreateBody) (types.Volume, error) {
 			if body.Name != name {
 				return types.Volume{}, errors.Errorf("expected name %q, got %q", name, body.Name)
@@ -97,7 +97,7 @@ func TestVolumeCreateWithFlags(t *testing.T) {
 	name := "banana"
 
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		volumeCreateFunc: func(body volumetypes.VolumesCreateBody) (types.Volume, error) {
 			if body.Name != "" {
 				return types.Volume{}, errors.Errorf("expected empty name, got %q", body.Name)

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -41,11 +41,10 @@ func TestVolumeCreateErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		buf := new(bytes.Buffer)
 		cmd := newCreateCommand(
-			test.NewFakeCliWithOutput(&fakeClient{
+			test.NewFakeCli(&fakeClient{
 				volumeCreateFunc: tc.volumeCreateFunc,
-			}, buf),
+			}),
 		)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -56,7 +56,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeInspectFunc: tc.volumeInspectFunc,
 			}, buf),
 		)
@@ -98,7 +98,7 @@ func TestVolumeInspectWithoutFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeInspectFunc: tc.volumeInspectFunc,
 			}, buf),
 		)
@@ -138,7 +138,7 @@ func TestVolumeInspectWithFormat(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newInspectCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeInspectFunc: tc.volumeInspectFunc,
 			}, buf),
 		)

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -39,7 +39,7 @@ func TestVolumeListErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newListCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeListFunc: tc.volumeListFunc,
 			}, buf),
 		)
@@ -54,7 +54,7 @@ func TestVolumeListErrors(t *testing.T) {
 
 func TestVolumeListWithoutFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volumetypes.VolumesListOKBody, error) {
 			return volumetypes.VolumesListOKBody{
 				Volumes: []*types.Volume{
@@ -77,7 +77,7 @@ func TestVolumeListWithoutFormat(t *testing.T) {
 
 func TestVolumeListWithConfigFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volumetypes.VolumesListOKBody, error) {
 			return volumetypes.VolumesListOKBody{
 				Volumes: []*types.Volume{
@@ -102,7 +102,7 @@ func TestVolumeListWithConfigFormat(t *testing.T) {
 
 func TestVolumeListWithFormat(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cli := test.NewFakeCli(&fakeClient{
+	cli := test.NewFakeCliWithOutput(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volumetypes.VolumesListOKBody, error) {
 			return volumetypes.VolumesListOKBody{
 				Volumes: []*types.Volume{

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -67,7 +67,6 @@ func TestVolumeListWithoutFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newListCommand(cli)
 	assert.NoError(t, cmd.Execute())
 	actual := buf.String()
@@ -90,7 +89,7 @@ func TestVolumeListWithConfigFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{
+	cli.SetConfigFile(&configfile.ConfigFile{
 		VolumesFormat: "{{ .Name }} {{ .Driver }} {{ .Labels }}",
 	})
 	cmd := newListCommand(cli)
@@ -115,7 +114,6 @@ func TestVolumeListWithFormat(t *testing.T) {
 			}, nil
 		},
 	}, buf)
-	cli.SetConfigfile(&configfile.ConfigFile{})
 	cmd := newListCommand(cli)
 	cmd.Flags().Set("format", "{{ .Name }} {{ .Driver }} {{ .Labels }}")
 	assert.NoError(t, cmd.Execute())

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -41,7 +41,7 @@ func TestVolumePruneErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewPruneCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumePruneFunc: tc.volumePruneFunc,
 			}, ioutil.Discard),
 		)
@@ -70,7 +70,7 @@ func TestVolumePruneForce(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := NewPruneCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumePruneFunc: tc.volumePruneFunc,
 			}, buf),
 		)
@@ -88,7 +88,7 @@ func TestVolumePrunePromptYes(t *testing.T) {
 	}
 	for _, input := range []string{"y", "Y"} {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			volumePruneFunc: simplePruneFunc,
 		}, buf)
 
@@ -110,7 +110,7 @@ func TestVolumePrunePromptNo(t *testing.T) {
 	}
 	for _, input := range []string{"n", "N", "no", "anything", "really"} {
 		buf := new(bytes.Buffer)
-		cli := test.NewFakeCli(&fakeClient{
+		cli := test.NewFakeCliWithOutput(&fakeClient{
 			volumePruneFunc: simplePruneFunc,
 		}, buf)
 

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -31,7 +31,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 	for _, tc := range testCases {
 		buf := new(bytes.Buffer)
 		cmd := newRemoveCommand(
-			test.NewFakeCli(&fakeClient{
+			test.NewFakeCliWithOutput(&fakeClient{
 				volumeRemoveFunc: tc.volumeRemoveFunc,
 			}, buf))
 		cmd.SetArgs(tc.args)
@@ -42,7 +42,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 
 func TestNodeRemoveMultiple(t *testing.T) {
 	buf := new(bytes.Buffer)
-	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}, buf))
+	cmd := newRemoveCommand(test.NewFakeCliWithOutput(&fakeClient{}, buf))
 	cmd.SetArgs([]string{"volume1", "volume2"})
 	assert.NoError(t, cmd.Execute())
 }

--- a/cli/internal/test/cli.go
+++ b/cli/internal/test/cli.go
@@ -55,8 +55,8 @@ func (c *FakeCli) SetErr(err *bytes.Buffer) {
 	c.err = err
 }
 
-// SetConfigfile sets the "fake" config file
-func (c *FakeCli) SetConfigfile(configfile *configfile.ConfigFile) {
+// SetConfigFile sets the "fake" config file
+func (c *FakeCli) SetConfigFile(configfile *configfile.ConfigFile) {
 	c.configfile = configfile
 }
 


### PR DESCRIPTION
Almost every use of `FakeCli` uses a `bytes.Buffer` for stdout/stderr. Instead of having the caller setup these buffers every time we can default to using a buffer.

I updated some tests to remove unnecessary calls to `SetErr()` and `SetConfigFile()`, and a few tests to use the new `NewFakeCli()`. I've deprecated the only one.