### PR TITLE
build: follow up fixes for build stream

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 
@@ -264,7 +265,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 	// if streaming and dockerfile was not from stdin then read from file
 	// to the same reader that is usually stdin
 	if options.stream && dockerfileCtx == nil {
-		dockerfileCtx, err = os.Open(relDockerfile)
+		dockerfileCtx, err = os.Open(filepath.Join(contextDir, relDockerfile))
 		if err != nil {
 			return errors.Wrapf(err, "failed to open %s", relDockerfile)
 		}


### PR DESCRIPTION
Addresses the follow-up comments in https://github.com/docker/cli/pull/231#pullrequestreview-47914776

For the content-trust update, I have no idea why the `FROM` images should be retagged by the builder. I would argue that this is wrong but made it match the non-stream behavior.

@dnephin 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>

