### PR TITLE
Sort swarm services using natural sorting

### DIFF
--- a/cli/command/network/client_test.go
+++ b/cli/command/network/client_test.go
@@ -1,0 +1,19 @@
+package network
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	networkCreateFunc func(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
+}
+
+func (c *fakeClient) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	if c.networkCreateFunc != nil {
+		return c.networkCreateFunc(ctx, name, options)
+	}
+	return types.NetworkCreateResponse{}, nil
+}

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -8,8 +8,7 @@ import (
 )
 
 // NewNetworkCommand returns a cobra command for `network` subcommands
-// nolint: interfacer
-func NewNetworkCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewNetworkCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "network",
 		Short: "Manage networks",

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -19,7 +19,7 @@ type connectOptions struct {
 	linklocalips []string
 }
 
-func newConnectCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newConnectCommand(dockerCli command.Cli) *cobra.Command {
 	options := connectOptions{
 		links: opts.NewListOpts(opts.ValidateLink),
 	}
@@ -45,7 +45,7 @@ func newConnectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runConnect(dockerCli *command.DockerCli, options connectOptions) error {
+func runConnect(dockerCli command.Cli, options connectOptions) error {
 	client := dockerCli.Client()
 
 	epConfig := &network.EndpointSettings{

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -36,7 +36,7 @@ type createOptions struct {
 	ipamOpt     opts.MapOpts
 }
 
-func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	options := createOptions{
 		driverOpts: *opts.NewMapOpts(nil, nil),
 		labels:     opts.NewListOpts(opts.ValidateEnv),
@@ -82,7 +82,7 @@ func newCreateCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runCreate(dockerCli *command.DockerCli, options createOptions) error {
+func runCreate(dockerCli command.Cli, options createOptions) error {
 	client := dockerCli.Client()
 
 	ipamCfg, err := consolidateIpam(options.ipamSubnet, options.ipamIPRange, options.ipamGateway, options.ipamAux.GetAll())
@@ -232,13 +232,13 @@ func subnetMatches(subnet, data string) (bool, error) {
 
 	_, s, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return false, errors.Errorf("Invalid subnet %s : %v", s, err)
+		return false, errors.Wrap(err, "invalid subnet")
 	}
 
 	if strings.Contains(data, "/") {
 		ip, _, err = net.ParseCIDR(data)
 		if err != nil {
-			return false, errors.Errorf("Invalid cidr %s : %v", data, err)
+			return false, err
 		}
 	} else {
 		ip = net.ParseIP(data)

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -1,0 +1,178 @@
+package network
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestNetworkCreateErrors(t *testing.T) {
+	testCases := []struct {
+		args              []string
+		flags             map[string]string
+		networkCreateFunc func(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
+		expectedError     string
+	}{
+		{
+			expectedError: "exactly 1 argument",
+		},
+		{
+			args: []string{"toto"},
+			networkCreateFunc: func(ctx context.Context, name string, createBody types.NetworkCreate) (types.NetworkCreateResponse, error) {
+				return types.NetworkCreateResponse{}, errors.Errorf("error creating network")
+			},
+			expectedError: "error creating network",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.255.0.0/24",
+				"gateway":  "255.0.255.0/24",
+				"subnet":   "10.1.2.0.30.50",
+			},
+			expectedError: "invalid CIDR address: 10.1.2.0.30.50",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.255.0.0.30/24",
+				"gateway":  "255.0.255.0/24",
+				"subnet":   "255.0.0.0/24",
+			},
+			expectedError: "invalid CIDR address: 255.255.0.0.30/24",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"gateway": "255.0.0.0/24",
+			},
+			expectedError: "every ip-range or gateway must have a corresponding subnet",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.0.0.0/24",
+			},
+			expectedError: "every ip-range or gateway must have a corresponding subnet",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.0.0.0/24",
+				"gateway":  "255.0.0.0/24",
+			},
+			expectedError: "every ip-range or gateway must have a corresponding subnet",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.255.0.0/24",
+				"gateway":  "255.0.255.0/24",
+				"subnet":   "10.1.2.0/23,10.1.3.248/30",
+			},
+			expectedError: "multiple overlapping subnet configuration is not supported",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "192.168.1.0/24,192.168.1.200/24",
+				"gateway":  "192.168.1.1,192.168.1.4",
+				"subnet":   "192.168.2.0/24,192.168.1.250/24",
+			},
+			expectedError: "cannot configure multiple ranges (192.168.1.200/24, 192.168.1.0/24) on the same subnet (192.168.1.250/24)",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "255.255.200.0/24,255.255.120.0/24",
+				"gateway":  "255.0.255.0/24",
+				"subnet":   "255.255.255.0/24,255.255.0.255/24",
+			},
+			expectedError: "no matching subnet for range 255.255.200.0/24",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "192.168.1.0/24",
+				"gateway":  "192.168.1.1,192.168.1.4",
+				"subnet":   "192.168.2.0/24,192.168.1.250/24",
+			},
+			expectedError: "cannot configure multiple gateways (192.168.1.4, 192.168.1.1) for the same subnet (192.168.1.250/24)",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "192.168.1.0/24",
+				"gateway":  "192.168.4.1,192.168.5.4",
+				"subnet":   "192.168.2.0/24,192.168.1.250/24",
+			},
+			expectedError: "no matching subnet for gateway 192.168.4.1",
+		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"gateway":     "255.255.0.0/24",
+				"subnet":      "255.255.0.0/24",
+				"aux-address": "255.255.0.30/24",
+			},
+			expectedError: "no matching subnet for aux-address",
+		},
+	}
+
+	for _, tc := range testCases {
+		buf := new(bytes.Buffer)
+		cmd := newCreateCommand(
+			test.NewFakeCli(&fakeClient{
+				networkCreateFunc: tc.networkCreateFunc,
+			}, buf),
+		)
+		cmd.SetArgs(tc.args)
+		for key, value := range tc.flags {
+			require.NoError(t, cmd.Flags().Set(key, value))
+		}
+		cmd.SetOutput(ioutil.Discard)
+		testutil.ErrorContains(t, cmd.Execute(), tc.expectedError)
+
+	}
+}
+func TestNetworkCreateWithFlags(t *testing.T) {
+	expectedDriver := "foo"
+	expectedOpts := []network.IPAMConfig{
+		{
+			"192.168.4.0/24",
+			"192.168.4.0/24",
+			"192.168.4.1/24",
+			map[string]string{},
+		},
+	}
+	buf := new(bytes.Buffer)
+	cli := test.NewFakeCli(&fakeClient{
+		networkCreateFunc: func(ctx context.Context, name string, createBody types.NetworkCreate) (types.NetworkCreateResponse, error) {
+			assert.Equal(t, expectedDriver, createBody.Driver, "not expected driver error")
+			assert.Equal(t, expectedOpts, createBody.IPAM.Config, "not expected driver error")
+			return types.NetworkCreateResponse{
+				ID: name,
+			}, nil
+		},
+	}, buf)
+	args := []string{"banana"}
+	cmd := newCreateCommand(cli)
+
+	cmd.SetArgs(args)
+	cmd.Flags().Set("driver", "foo")
+	cmd.Flags().Set("ip-range", "192.168.4.0/24")
+	cmd.Flags().Set("gateway", "192.168.4.1/24")
+	cmd.Flags().Set("subnet", "192.168.4.0/24")
+	assert.NoError(t, cmd.Execute())
+	assert.Equal(t, "banana", strings.TrimSpace(buf.String()))
+}

--- a/cli/command/network/disconnect.go
+++ b/cli/command/network/disconnect.go
@@ -14,7 +14,7 @@ type disconnectOptions struct {
 	force     bool
 }
 
-func newDisconnectCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newDisconnectCommand(dockerCli command.Cli) *cobra.Command {
 	opts := disconnectOptions{}
 
 	cmd := &cobra.Command{
@@ -34,7 +34,7 @@ func newDisconnectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runDisconnect(dockerCli *command.DockerCli, opts disconnectOptions) error {
+func runDisconnect(dockerCli command.Cli, opts disconnectOptions) error {
 	client := dockerCli.Client()
 
 	return client.NetworkDisconnect(context.Background(), opts.network, opts.container, opts.force)

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -16,7 +16,7 @@ type inspectOptions struct {
 	verbose bool
 }
 
-func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -35,7 +35,7 @@ func newInspectCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
+func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 	client := dockerCli.Client()
 
 	ctx := context.Background()

--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -25,7 +25,7 @@ type listOptions struct {
 	filter  opts.FilterOpt
 }
 
-func newListCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newListCommand(dockerCli command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -47,7 +47,7 @@ func newListCommand(dockerCli *command.DockerCli) *cobra.Command {
 	return cmd
 }
 
-func runList(dockerCli *command.DockerCli, options listOptions) error {
+func runList(dockerCli command.Cli, options listOptions) error {
 	client := dockerCli.Client()
 	listOptions := types.NetworkListOptions{Filters: options.filter.Value()}
 	networkResources, err := client.NetworkList(context.Background(), listOptions)

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRemoveCommand(dockerCli *command.DockerCli) *cobra.Command {
+func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm NETWORK [NETWORK...]",
 		Aliases: []string{"remove"},
@@ -28,7 +28,7 @@ const ingressWarning = "WARNING! Before removing the routing-mesh network, " +
 	"Otherwise, removal may not be effective and functionality of newly create " +
 	"ingress networks will be impaired.\nAre you sure you want to continue?"
 
-func runRemove(dockerCli *command.DockerCli, networks []string) error {
+func runRemove(dockerCli command.Cli, networks []string) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 	status := 0

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -1,14 +1,26 @@
 package node
 
 import (
+	"sort"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
+	"vbom.ml/util/sortorder"
 )
+
+type byHostname []swarm.Node
+
+func (n byHostname) Len() int      { return len(n) }
+func (n byHostname) Swap(i, j int) { n[i], n[j] = n[j], n[i] }
+func (n byHostname) Less(i, j int) bool {
+	return sortorder.NaturalLess(n[i].Description.Hostname, n[j].Description.Hostname)
+}
 
 type listOptions struct {
 	quiet  bool
@@ -68,5 +80,6 @@ func runList(dockerCli command.Cli, options listOptions) error {
 		Output: dockerCli.Out(),
 		Format: formatter.NewNodeFormat(format, options.quiet),
 	}
+	sort.Sort(byHostname(nodes))
 	return formatter.NodeWrite(nodesCtx, nodes, info)
 }

--- a/cli/command/node/testdata/node-list-sort.golden
+++ b/cli/command/node/testdata/node-list-sort.golden
@@ -1,0 +1,3 @@
+node-1-foo:
+node-2-foo: Leader
+node-10-foo: Reachable

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
+	"vbom.ml/util/sortorder"
 )
 
 type listOptions struct {
@@ -60,7 +61,7 @@ type byName []*formatter.Stack
 
 func (n byName) Len() int           { return len(n) }
 func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
-func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+func (n byName) Less(i, j int) bool { return sortorder.NaturalLess(n[i].Name, n[j].Name) }
 
 func getStacks(ctx context.Context, apiclient client.APIClient) ([]*formatter.Stack, error) {
 	services, err := apiclient.ServiceList(

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -98,10 +98,13 @@ func TestListWithoutFormat(t *testing.T) {
 }
 
 func TestListOrder(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cmd := newListCommand(test.NewFakeCli(&fakeClient{
-		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
-			return []swarm.Service{
+	usecases := []struct {
+		golden        string
+		swarmServices []swarm.Service
+	}{
+		{
+			golden: "stack-list-sort.golden",
+			swarmServices: []swarm.Service{
 				*Service(
 					ServiceLabels(map[string]string{
 						"com.docker.stack.namespace": "service-name-foo",
@@ -112,11 +115,40 @@ func TestListOrder(t *testing.T) {
 						"com.docker.stack.namespace": "service-name-bar",
 					}),
 				),
-			}, nil
+			},
 		},
-	}, buf))
-	assert.NoError(t, cmd.Execute())
-	actual := buf.String()
-	expected := golden.Get(t, []byte(actual), "stack-list-sort.golden")
-	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
+		{
+			golden: "stack-list-sort-natural.golden",
+			swarmServices: []swarm.Service{
+				*Service(
+					ServiceLabels(map[string]string{
+						"com.docker.stack.namespace": "service-name-1-foo",
+					}),
+				),
+				*Service(
+					ServiceLabels(map[string]string{
+						"com.docker.stack.namespace": "service-name-10-foo",
+					}),
+				),
+				*Service(
+					ServiceLabels(map[string]string{
+						"com.docker.stack.namespace": "service-name-2-foo",
+					}),
+				),
+			},
+		},
+	}
+
+	for _, uc := range usecases {
+		buf := new(bytes.Buffer)
+		cmd := newListCommand(test.NewFakeCli(&fakeClient{
+			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
+				return uc.swarmServices, nil
+			},
+		}, buf))
+		assert.NoError(t, cmd.Execute())
+		actual := buf.String()
+		expected := golden.Get(t, []byte(actual), uc.golden)
+		testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
+	}
 }

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -97,14 +97,15 @@ func removeServices(
 	dockerCli command.Cli,
 	services []swarm.Service,
 ) bool {
-	var err error
+	var hasError bool
 	for _, service := range services {
 		fmt.Fprintf(dockerCli.Err(), "Removing service %s\n", service.Spec.Name)
-		if err = dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
+		if err := dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove service %s: %s", service.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeNetworks(
@@ -112,14 +113,15 @@ func removeNetworks(
 	dockerCli command.Cli,
 	networks []types.NetworkResource,
 ) bool {
-	var err error
+	var hasError bool
 	for _, network := range networks {
 		fmt.Fprintf(dockerCli.Err(), "Removing network %s\n", network.Name)
-		if err = dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+		if err := dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeSecrets(
@@ -127,14 +129,15 @@ func removeSecrets(
 	dockerCli command.Cli,
 	secrets []swarm.Secret,
 ) bool {
-	var err error
+	var hasError bool
 	for _, secret := range secrets {
 		fmt.Fprintf(dockerCli.Err(), "Removing secret %s\n", secret.Spec.Name)
-		if err = dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
+		if err := dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove secret %s: %s", secret.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }
 
 func removeConfigs(
@@ -142,12 +145,13 @@ func removeConfigs(
 	dockerCli command.Cli,
 	configs []swarm.Config,
 ) bool {
-	var err error
+	var hasError bool
 	for _, config := range configs {
 		fmt.Fprintf(dockerCli.Err(), "Removing config %s\n", config.Spec.Name)
-		if err = dockerCli.Client().ConfigRemove(ctx, config.ID); err != nil {
+		if err := dockerCli.Client().ConfigRemove(ctx, config.ID); err != nil {
+			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove config %s: %s", config.ID, err)
 		}
 	}
-	return err != nil
+	return hasError
 }

--- a/cli/command/stack/testdata/stack-list-sort-natural.golden
+++ b/cli/command/stack/testdata/stack-list-sort-natural.golden
@@ -1,0 +1,4 @@
+NAME                   SERVICES
+service-name-1-foo     1
+service-name-2-foo     1
+service-name-10-foo    1

--- a/vendor.conf
+++ b/vendor.conf
@@ -52,3 +52,4 @@ gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 github.com/tonistiigi/fsutil 0ac4c11b053b9c5c7c47558f81f96c7100ce50fb
 github.com/stevvooe/continuity cd7a8e21e2b6f84799f5dd4b65faf49c8d3ee02d
 golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
+vbom.ml/util 928aaa586d7718c70f4090ddf83f2b34c16fdc8d

--- a/vendor/vbom.ml/util/LICENSE
+++ b/vendor/vbom.ml/util/LICENSE
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) 2015 Frits van Bommel
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/vbom.ml/util/README.md
+++ b/vendor/vbom.ml/util/README.md
@@ -1,0 +1,5 @@
+## util [![GoDoc](https://godoc.org/vbom.ml/util?status.svg)](https://godoc.org/vbom.ml/util)
+
+    import "vbom.ml/util"
+
+Go utility packages.

--- a/vendor/vbom.ml/util/sortorder/README.md
+++ b/vendor/vbom.ml/util/sortorder/README.md
@@ -1,0 +1,5 @@
+## sortorder [![GoDoc](https://godoc.org/vbom.ml/util/sortorder?status.svg)](https://godoc.org/vbom.ml/util/sortorder)
+
+    import "vbom.ml/util/sortorder"
+
+Sort orders and comparison functions.

--- a/vendor/vbom.ml/util/sortorder/doc.go
+++ b/vendor/vbom.ml/util/sortorder/doc.go
@@ -1,0 +1,5 @@
+// Package sortorder implements sort orders and comparison functions.
+//
+// Currently, it only implements so-called "natural order", where integers
+// embedded in strings are compared by value.
+package sortorder // import "vbom.ml/util/sortorder"

--- a/vendor/vbom.ml/util/sortorder/natsort.go
+++ b/vendor/vbom.ml/util/sortorder/natsort.go
@@ -1,0 +1,76 @@
+package sortorder
+
+// Natural implements sort.Interface to sort strings in natural order. This
+// means that e.g. "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+type Natural []string
+
+func (n Natural) Len() int           { return len(n) }
+func (n Natural) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+func (n Natural) Less(i, j int) bool { return NaturalLess(n[i], n[j]) }
+
+func isdigit(b byte) bool { return '0' <= b && b <= '9' }
+
+// NaturalLess compares two strings using natural ordering. This means that e.g.
+// "abc2" < "abc12".
+//
+// Non-digit sequences and numbers are compared separately. The former are
+// compared bytewise, while the latter are compared numerically (except that
+// the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
+//
+// Limitation: only ASCII digits (0-9) are considered.
+func NaturalLess(str1, str2 string) bool {
+	idx1, idx2 := 0, 0
+	for idx1 < len(str1) && idx2 < len(str2) {
+		c1, c2 := str1[idx1], str2[idx2]
+		dig1, dig2 := isdigit(c1), isdigit(c2)
+		switch {
+		case dig1 != dig2: // Digits before other characters.
+			return dig1 // True if LHS is a digit, false if the RHS is one.
+		case !dig1: // && !dig2, because dig1 == dig2
+			// UTF-8 compares bytewise-lexicographically, no need to decode
+			// codepoints.
+			if c1 != c2 {
+				return c1 < c2
+			}
+			idx1++
+			idx2++
+		default: // Digits
+			// Eat zeros.
+			for ; idx1 < len(str1) && str1[idx1] == '0'; idx1++ {
+			}
+			for ; idx2 < len(str2) && str2[idx2] == '0'; idx2++ {
+			}
+			// Eat all digits.
+			nonZero1, nonZero2 := idx1, idx2
+			for ; idx1 < len(str1) && isdigit(str1[idx1]); idx1++ {
+			}
+			for ; idx2 < len(str2) && isdigit(str2[idx2]); idx2++ {
+			}
+			// If lengths of numbers with non-zero prefix differ, the shorter
+			// one is less.
+			if len1, len2 := idx1-nonZero1, idx2-nonZero2; len1 != len2 {
+				return len1 < len2
+			}
+			// If they're not equal, string comparison is correct.
+			if nr1, nr2 := str1[nonZero1:idx1], str2[nonZero2:idx2]; nr1 != nr2 {
+				return nr1 < nr2
+			}
+			// Otherwise, the one with less zeros is less.
+			// Because everything up to the number is equal, comparing the index
+			// after the zeros is sufficient.
+			if nonZero1 != nonZero2 {
+				return nonZero1 < nonZero2
+			}
+		}
+		// They're identical so far, so continue comparing.
+	}
+	// So far they are identical. At least one is ended. If the other continues,
+	// it sorts last.
+	return len(str1) < len(str2)
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/moby/moby/pull/31638

**- What I did**

Use natural sorting to display swarm services in `docker stack ls`.

**- How I did it**

Import `vbom.ml/util/sortorder` and update `Less(i, j int) bool` 

**- How to verify it**

Run unit test

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

