### PR TITLE
Add .exe extensions to .gitignore for local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cli/winresources/rsrc_amd64.syso
 /docs/yaml/gen/
 coverage.txt
 profile.out
+*.exe
+*.exe~


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Same as for moby/moby, adds the .exe extensions to .gitignore for when doing local builds