### PR TITLE
Error if "until" filter is combined with "--volumes" on system prune

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -67,6 +67,10 @@ func runBuildCachePrune(dockerCli command.Cli, _ opts.FilterOpt) (uint64, string
 }
 
 func runPrune(dockerCli command.Cli, options pruneOptions) error {
+	// TODO version this once "until" filter is supported for volumes
+	if options.pruneVolumes && options.filter.Value().Include("until") {
+		return fmt.Errorf(`ERROR: The "until" filter is not supported with "--volumes"`)
+	}
 	if versions.LessThan(dockerCli.Client().ClientVersion(), "1.31") {
 		options.pruneBuildCache = false
 	}


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/310
relates to https://github.com/moby/moby/issues/31122#issuecomment-313872632

The "until" filter is supported by all object types, except for
volumes.

Before this patch, the "until" filter would attempted to be used for the volume
prune endpoint, resulting in an error being returned by the daemon, and
further prune endpoints (networks, images) to be skipped.

```bash
$ docker system prune --filter until=24h --filter label=label.foo=bar

WARNING! This will remove:
        - all stopped containers
        - all volumes not used by at least one container
        - all networks not used by at least one container
        - all dangling images
Are you sure you want to continue? [y/N] y
Error response from daemon: Invalid filter 'until'
```

    Calling POST /v1.30/containers/prune?filters=%7B%22label%22%3A%7B%22label.foo%3D%3Dbar%22%3Atrue%7D%2C%22until%22%3A%7B%2224h%22%3Atrue%7D%7D
    Calling POST /v1.30/volumes/prune?filters=%7B%22label%22%3A%7B%22label.foo%3D%3Dbar%22%3Atrue%7D%2C%22until%22%3A%7B%2224h%22%3Atrue%7D%7D
    Handler for POST /v1.30/volumes/prune returned error: Invalid filter 'until'
    Error response from daemon: Invalid filter 'until'

With this patch, an error is produced instead, preventing "partial" prune.

```bash
$ docker system prune --filter until=24h --filter label=foo==bar --volumes
ERROR: The "until" filter is not supported with "--volumes"
```

Note that `docker volume prune` does not have this problem, and produces an
error if the `until` filter is used;

```bash
$ docker volume prune --filter until=24h

WARNING! This will remove all volumes not used by at least one container.
Are you sure you want to continue? [y/N] y
Error response from daemon: Invalid filter 'until'
```