### PR TITLE
pin vndr to 9909bb2b8a0b7ea464527b376dc50389c90df587

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -3,8 +3,11 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git make bash coreutils
 
-RUN     go get github.com/LK4D4/vndr && \
-        cp /go/bin/vndr /usr/bin && \
+ARG     VNDR_COMMIT=9909bb2b8a0b7ea464527b376dc50389c90df587
+RUN     git clone https://github.com/LK4D4/vndr.git "/go/src/github.com/LK4D4/vndr" && \
+        cd "/go/src/github.com/LK4D4/vndr" && \
+        git checkout -q "$VNDR_COMMIT" && \
+        go build -v -o /usr/bin/vndr . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 RUN     go get github.com/jteeuwen/go-bindata/go-bindata && \


### PR DESCRIPTION
This make updating vndr a deliberate action, and prevents updates to vndr from making the vendor validation fail in CI.

Pinning to 9909bb2b8a0b7ea464527b376dc50389c90df587, which is current "master", and the same version as is used in https://github.com/moby/moby/pull/34047

ping @tonistiigi @tiborvass @dnephin PTAL