### PR TITLE
Remove bash completion for `service update --network`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3107,7 +3107,6 @@ _docker_service_update_and_create() {
 		--log-driver
 		--log-opt
 		--mount
-		--network
 		--replicas
 		--reserve-cpu
 		--reserve-memory
@@ -3156,6 +3155,7 @@ _docker_service_update_and_create() {
 			--host
 			--mode
 			--name
+			--network
 			--placement-pref
 			--publish -p
 			--secret


### PR DESCRIPTION
The `--network` option is only valid for `docker service create`.
This PR removes it from bash completion for `docker service update` (which has `--network-add` and `--network-rm` instead).