### PR TITLE
Pin all tools used in the Dockerfiles

### DIFF
--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -243,7 +243,7 @@ func (c *diskUsageImagesContext) Reclaimable() string {
 	if c.totalSize > 0 {
 		return fmt.Sprintf("%s (%v%%)", units.HumanSize(float64(reclaimable)), (reclaimable*100)/c.totalSize)
 	}
-	return fmt.Sprintf("%s", units.HumanSize(float64(reclaimable)))
+	return units.HumanSize(float64(reclaimable))
 }
 
 type diskUsageContainersContext struct {
@@ -305,7 +305,7 @@ func (c *diskUsageContainersContext) Reclaimable() string {
 		return fmt.Sprintf("%s (%v%%)", units.HumanSize(float64(reclaimable)), (reclaimable*100)/totalSize)
 	}
 
-	return fmt.Sprintf("%s", units.HumanSize(float64(reclaimable)))
+	return units.HumanSize(float64(reclaimable))
 }
 
 type diskUsageVolumesContext struct {
@@ -366,7 +366,7 @@ func (c *diskUsageVolumesContext) Reclaimable() string {
 		return fmt.Sprintf("%s (%v%%)", units.HumanSize(float64(reclaimable)), (reclaimable*100)/totalSize)
 	}
 
-	return fmt.Sprintf("%s", units.HumanSize(float64(reclaimable)))
+	return units.HumanSize(float64(reclaimable))
 }
 
 type diskUsageBuilderContext struct {

--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -184,7 +184,7 @@ func (c *containerStatsContext) MemUsage() string {
 		return fmt.Sprintf("-- / --")
 	}
 	if c.os == winOSType {
-		return fmt.Sprintf("%s", units.BytesSize(c.s.Memory))
+		return units.BytesSize(c.s.Memory)
 	}
 	return fmt.Sprintf("%s / %s", units.BytesSize(c.s.Memory), units.BytesSize(c.s.MemoryLimit))
 }

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -3,19 +3,25 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git make bash coreutils
 
-ARG     VNDR_COMMIT=9909bb2b8a0b7ea464527b376dc50389c90df587
-RUN     git clone https://github.com/LK4D4/vndr.git "/go/src/github.com/LK4D4/vndr" && \
-        cd "/go/src/github.com/LK4D4/vndr" && \
-        git checkout -q "$VNDR_COMMIT" && \
+ARG     VNDR_SHA=9909bb2b8a0b7ea464527b376dc50389c90df587
+RUN     go get github.com/LK4D4/vndr && \
+        cd /go/src/github.com/LK4D4/vndr && \
+        git checkout -q "$VNDR_SHA" && \
         go build -v -o /usr/bin/vndr . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
+ARG     BINDATA_SHA=a0ff2567cfb70903282db057e799fd826784d41d
 RUN     go get github.com/jteeuwen/go-bindata/go-bindata && \
-        cp /go/bin/go-bindata /usr/bin && \
+        cd /go/src/github.com/jteeuwen/go-bindata/go-bindata && \
+        git checkout -q "$BINDATA_SHA" && \
+        go build -v -o /usr/bin/go-bindata . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
+ARG     FILEWATCHER_SHA=2e12ea42f6c8c089b19e992145bb94e8adaecedb
 RUN     go get github.com/dnephin/filewatcher && \
-        cp /go/bin/filewatcher /usr/bin/ && \
+        cd /go/src/github.com/dnephin/filewatcher && \
+        git checkout -q "$FILEWATCHER_SHA" && \
+        go build -v -o /usr/bin/filewatcher . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 ENV     CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -2,9 +2,13 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git
 
-RUN     go get -u gopkg.in/dnephin/gometalinter.v1 && \
-        mv /go/bin/gometalinter.v1 /usr/local/bin/gometalinter && \
-        gometalinter --install
+ARG     GOMETALINTER_SHA=b4ebfc554d8f36bfef1f180ad0aaaaac99b430d5
+RUN     go get github.com/alecthomas/gometalinter && \
+        cd /go/src/github.com/alecthomas/gometalinter && \
+        git checkout -q "$GOMETALINTER_SHA" && \
+        go build -v -o /usr/local/bin/gometalinter . && \ 
+        gometalinter --install && \
+        rm -rf /go/src/* /go/pkg/*
 
 WORKDIR /go/src/github.com/docker/cli
 ENV     CGO_ENABLED=0

--- a/scripts/test/watch
+++ b/scripts/test/watch
@@ -1,12 +1,2 @@
 #!/bin/sh
-
-set -e
-
-filewatcher \
-    -L 6 \
-    -x '**/*.swp' \
-    -x .git \
-    -x build \
-    -x .idea \
-    -- \
-    sh -c 'go test -timeout 10s -v ./${dir} || ( echo; echo; exit 1 )'
+exec filewatcher -L 6 -x build -x script go test -timeout 10s -v './${dir}'


### PR DESCRIPTION
Also update `gometalinter` to use the official version instead of my fork, now that the official version has accepted my PRs. The latest version includes some updates to linters, which found some new gosimple errors. This PR includes the fixes.