### PR TITLE
Fix test and lint failures on master

### DIFF
--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -10,85 +10,70 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRemoveStack(t *testing.T) {
+func fakeClientForRemoveStackTest(version string) *fakeClient {
 	allServices := []string{
 		objectName("foo", "service1"),
 		objectName("foo", "service2"),
 		objectName("bar", "service1"),
 		objectName("bar", "service2"),
 	}
-	allServiceIDs := buildObjectIDs(allServices)
-
 	allNetworks := []string{
 		objectName("foo", "network1"),
 		objectName("bar", "network1"),
 	}
-	allNetworkIDs := buildObjectIDs(allNetworks)
-
 	allSecrets := []string{
 		objectName("foo", "secret1"),
 		objectName("foo", "secret2"),
 		objectName("bar", "secret1"),
 	}
-	allSecretIDs := buildObjectIDs(allSecrets)
-
 	allConfigs := []string{
 		objectName("foo", "config1"),
 		objectName("foo", "config2"),
 		objectName("bar", "config1"),
 	}
-	allConfigIDs := buildObjectIDs(allConfigs)
-
-	// Using API 1.24; removes services, networks, but doesn't remove configs and secrets
-	cli := &fakeClient{
-		version:  "1.24",
+	return &fakeClient{
+		version:  version,
 		services: allServices,
 		networks: allNetworks,
 		secrets:  allSecrets,
 		configs:  allConfigs,
 	}
-	cmd := newRemoveCommand(test.NewFakeCli(cli))
+}
+
+func TestRemoveStackVersion124DoesNotRemoveConfigsOrSecrets(t *testing.T) {
+	client := fakeClientForRemoveStackTest("1.24")
+	cmd := newRemoveCommand(test.NewFakeCli(client))
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, allServiceIDs, cli.removedServices)
-	assert.Equal(t, allNetworkIDs, cli.removedNetworks)
-	assert.Nil(t, cli.removedSecrets)
-	assert.Nil(t, cli.removedConfigs)
+	assert.Equal(t, buildObjectIDs(client.services), client.removedServices)
+	assert.Equal(t, buildObjectIDs(client.networks), client.removedNetworks)
+	assert.Nil(t, client.removedSecrets)
+	assert.Nil(t, client.removedConfigs)
+}
 
-	// Using API 1.25; removes services, networks, but doesn't remove configs
-	cli = &fakeClient{
-		version:  "1.25",
-		services: allServices,
-		networks: allNetworks,
-		secrets:  allSecrets,
-		configs:  allConfigs,
-	}
-	cmd = newRemoveCommand(test.NewFakeCli(cli, &bytes.Buffer{}))
+func TestRemoveStackVersion125DoesNotRemoveConfigs(t *testing.T) {
+	client := fakeClientForRemoveStackTest("1.25")
+	cmd := newRemoveCommand(test.NewFakeCli(client))
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, allServiceIDs, cli.removedServices)
-	assert.Equal(t, allNetworkIDs, cli.removedNetworks)
-	assert.Equal(t, allSecretIDs, cli.removedSecrets)
-	assert.Nil(t, cli.removedConfigs)
+	assert.Equal(t, buildObjectIDs(client.services), client.removedServices)
+	assert.Equal(t, buildObjectIDs(client.networks), client.removedNetworks)
+	assert.Equal(t, buildObjectIDs(client.secrets), client.removedSecrets)
+	assert.Nil(t, client.removedConfigs)
+}
 
-	// Using API 1.30; removes services, networks, configs, and secrets
-	cli = &fakeClient{
-		version:  "1.30",
-		services: allServices,
-		networks: allNetworks,
-		secrets:  allSecrets,
-		configs:  allConfigs,
-	}
-	cmd = newRemoveCommand(test.NewFakeCli(cli, &bytes.Buffer{}))
+func TestRemoveStackVersion130RemovesEverything(t *testing.T) {
+	client := fakeClientForRemoveStackTest("1.30")
+	cmd := newRemoveCommand(test.NewFakeCli(client))
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, allServiceIDs, cli.removedServices)
-	assert.Equal(t, allNetworkIDs, cli.removedNetworks)
-	assert.Equal(t, allSecretIDs, cli.removedSecrets)
-	assert.Equal(t, allConfigIDs, cli.removedConfigs)
+	assert.Equal(t, buildObjectIDs(client.services), client.removedServices)
+	assert.Equal(t, buildObjectIDs(client.networks), client.removedNetworks)
+	assert.Equal(t, buildObjectIDs(client.secrets), client.removedSecrets)
+	assert.Equal(t, buildObjectIDs(client.configs), client.removedConfigs)
 }
 
 func TestRemoveStackSkipEmpty(t *testing.T) {


### PR DESCRIPTION
Fix the conflict between the changes in #299 and #277, which just merged together.

Also split up the test cases from #277