### PR TITLE
Fix warning in docker CLI when `swarm ca` is called with flags other than `--rotate`

### DIFF
--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -60,7 +60,7 @@ func runCA(dockerCli command.Cli, flags *pflag.FlagSet, opts caOptions) error {
 	}
 
 	if !opts.rotate {
-		for _, f := range []string{flagCACert, flagCAKey, flagCACert, flagExternalCA} {
+		for _, f := range []string{flagCACert, flagCAKey, flagCertExpiry, flagExternalCA} {
 			if flags.Changed(f) {
 				return fmt.Errorf("`--%s` flag requires the `--rotate` flag to update the CA", f)
 			}


### PR DESCRIPTION
As @albers pointed out in https://github.com/docker/cli/pull/207/files#r125589944, the `flagCACert` var was duplicated.  Fixed this to be `flagCertExpiry` instead, and added a test for the invalid flags.

![image](https://s-media-cache-ak0.pinimg.com/736x/63/bb/61/63bb616a33fc209cd3a48795c981f46d--mini-husky-alaskan-klee-kai.jpg)

cc @dnephin @thaJeztah