### PR TITLE
Update gometalinter

### DIFF
--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -2,7 +2,7 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git
 
-ARG     GOMETALINTER_SHA=b4ebfc554d8f36bfef1f180ad0aaaaac99b430d5
+ARG     GOMETALINTER_SHA=4306381615a2ba2a207f8fcea02c08c6b2b0803f
 RUN     go get github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \
         git checkout -q "$GOMETALINTER_SHA" && \


### PR DESCRIPTION
Another fix for master.

There was a bug in `b4ebfc554d8f36bfef1f180ad0aaaaac99b430d` (the old pinned commit) where it was importing a package that it wasn't vendoring. That import was removed, which means that `go get` doesn't download it anymore. This is causing the lint to fail on master because it's no longer possible to build `b4ebfc554d8f36bfef1f180ad0aaaaac99b430d` now that `gometalinter` master has removed the dependency.

