### PR TITLE
Docs fixups for password stdin

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2684,7 +2684,7 @@ _docker_login() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --password -p --username -u" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --password --password-stdin -p --username -u" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -229,6 +229,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from load' -s i -l input -d 
 complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Log in to a Docker registry server'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s p -l password -d 'Password'
+complete -c docker -A -f -n '__fish_seen_subcommand_from login' -l password-stdin -d 'Read password from stdin'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s u -l username -d 'Username'
 
 # logout

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2761,6 +2761,7 @@ __docker_subcommand() {
             _arguments $(__docker_arguments) -A '-*' \
                 $opts_help \
                 "($help -p --password)"{-p=,--password=}"[Password]:password: " \
+                "($help)--password-stdin[Read password from stdin]" \
                 "($help -u --user)"{-u=,--user=}"[Username]:username: " \
                 "($help -)1:server: " && ret=0
             ;;

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -22,9 +22,10 @@ Log in to a Docker registry.
 If no server is specified, the default is defined by the daemon.
 
 Options:
-      --help              Print usage
-  -p, --password string   Password
-  -u, --username string   Username
+      --help                    Print usage
+  -p, --password       string   Password
+      --password-stdin          Read password from stdin
+  -u, --username       string   Username
 ```
 
 ## Description
@@ -38,6 +39,20 @@ adding the server name.
 
 ```bash
 $ docker login localhost:8080
+```
+
+### Provide a password using STDIN
+
+To run the `docker login` command non-interactively, you can set the
+`--password-stdin` flag to provide a password through `STDIN`. Using
+`STDIN` prevents the password from ending up in the shell's history,
+or log-files.
+
+The following example reads a password from a file, and passes it to the
+`docker login` command using `STDIN`:
+
+```bash
+$ cat ~/my_password.txt | docker login --username foo --password-stdin
 ```
 
 ### Privileged user requirement


### PR DESCRIPTION
Add various documentation (--help output, man page, etc) notes about the new `--password-stdin`. Also add things to the shell completion profiles.

cc @thaJeztah 