### PR TITLE
Fix: skip build-cache prune on unsupported versions

### DIFF
--- a/cli/command/system/client_test.go
+++ b/cli/command/system/client_test.go
@@ -1,0 +1,15 @@
+package system
+
+import (
+	"github.com/docker/docker/client"
+)
+
+type fakeClient struct {
+	client.Client
+
+	version string
+}
+
+func (cli *fakeClient) ClientVersion() string {
+	return cli.version
+}

--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -1,0 +1,15 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrunePromptPre131(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{version: "1.30"})
+	cmd := NewPruneCommand(cli)
+	assert.NoError(t, cmd.Execute())
+	assert.NotContains(t, cli.OutBuffer().String(), "all build cache")
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Disabled "build-cache prune" on older daemons

**- How I did it**

**- How to verify it**

Running system prune against an older daemon should not print "build cache" in the confirmation message, and should not print a "version" error when running

```bash
DOCKER_API_VERSION=1.30 docker system prune
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

