### PR TITLE
Use version in VERSION file instead `unknown-version` when build cli

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-VERSION=${VERSION:-"unknown-version"}
+VERSION=${VERSION:-$(cat VERSION)}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 BUILDTIME=${BUILDTIME:-$(date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')}
 


### PR DESCRIPTION
when build cli, the version of the `docker version` is `unknown-version`,
we should use the version in the `VERSION` file.

Signed-off-by: Lei Jitang <leijitang@huawei.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
