### PR TITLE
Add scripts folder to shellcheck

### DIFF
--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -11,4 +11,4 @@ echo "Building statically linked $TARGET"
 export CGO_ENABLED=0
 go build -o "${TARGET}" --ldflags "${LDFLAGS}" "${SOURCE}"
 
-ln -sf "$(basename ${TARGET})" build/docker
+ln -sf "$(basename "${TARGET}")" build/docker

--- a/scripts/build/cross
+++ b/scripts/build/cross
@@ -18,7 +18,7 @@ jobs=(
 )
 
 # Outside of circleCI run all at once. On circleCI run two at a time because
-# each continer has access to two cores.
+# each container has access to two cores.
 group=${CROSS_GROUP-"all"}
 
 if [ "$group" == "all" ]; then
@@ -29,5 +29,5 @@ if [ "$group" == "all" ]; then
 
 fi
 
-declare -i start=$group*2
+declare -i start="$group*2"
 parallel ::: "${jobs[@]:$start:2}"

--- a/scripts/build/dynbinary
+++ b/scripts/build/dynbinary
@@ -11,4 +11,4 @@ echo "Building dynamically linked $TARGET"
 export CGO_ENABLED=1
 go build -o "${TARGET}" -tags pkcs11 --ldflags "${LDFLAGS}" "${SOURCE}"
 
-ln -sf "$(basename ${TARGET})" build/docker
+ln -sf "$(basename "${TARGET}")" build/docker

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -8,7 +8,7 @@ go install ./vendor/github.com/cpuguy83/go-md2man
 
 # Generate man pages from cobra commands
 go build -o /tmp/gen-manpages github.com/docker/cli/man
-/tmp/gen-manpages --root $(pwd) --target $(pwd)/man/man1
+/tmp/gen-manpages --root "$(pwd)" --target "$(pwd)/man/man1"
 
 # Generate legacy pages from markdown
 ./man/md2man-all.sh -q

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -5,4 +5,4 @@ set -eu -o pipefail
 mkdir -p docs/yaml/gen
 
 go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
-build/yaml-docs-generator --root $(pwd) --target $(pwd)/docs/yaml/gen
+build/yaml-docs-generator --root "$(pwd)" --target "$(pwd)/docs/yaml/gen"

--- a/scripts/gen/windows-resources
+++ b/scripts/gen/windows-resources
@@ -6,6 +6,7 @@
 set -eu -o pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=/go/src/github.com/docker/cli/scripts/build/.variables
 source $SCRIPTDIR/../build/.variables
 
 RESOURCES=$SCRIPTDIR/../winresources
@@ -15,30 +16,28 @@ trap 'rm -rf $TEMPDIR' EXIT
 
 if [ "$(go env GOHOSTOS)" == "windows" ]; then
 	WINDRES=windres
-	WINDMC=windmc
 else
 	# Cross compiling
 	WINDRES=x86_64-w64-mingw32-windres
-	WINDMC=x86_64-w64-mingw32-windmc
 fi
 
 # Generate a Windows file version of the form major,minor,patch,build (with any part optional)
-VERSION_QUAD=$(echo -n $VERSION | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
+VERSION_QUAD=$(echo -n "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
 
 # Pass version and commit information into the resource compiler
 defs=
-[ ! -z $VERSION ]      && defs="$defs -D DOCKER_VERSION=\"$VERSION\""
-[ ! -z $VERSION_QUAD ] && defs="$defs -D DOCKER_VERSION_QUAD=$VERSION_QUAD"
-[ ! -z $GITCOMMIT ]    && defs="$defs -D DOCKER_COMMIT=\"$GITCOMMIT\""
+[ ! -z "$VERSION" ]      && defs+=( "-D DOCKER_VERSION=\"$VERSION\"")
+[ ! -z "$VERSION_QUAD" ] && defs+=( "-D DOCKER_VERSION_QUAD=$VERSION_QUAD")
+[ ! -z "$GITCOMMIT" ]    && defs+=( "-D DOCKER_COMMIT=\"$GITCOMMIT\"")
 
 function makeres {
-	$WINDRES \
-		-i $RESOURCES/$1 \
-		-o $3 \
-		-F $2 \
+	"$WINDRES" \
+		-i "$RESOURCES/$1" \
+		-o "$3" \
+		-F "$2" \
 		--use-temp-file \
-		-I $TEMPDIR \
-		$defs
+		-I "$TEMPDIR" \
+		${defs[*]}
 }
 
 makeres docker.rc pe-x86-64 rsrc_amd64.syso

--- a/scripts/test/unit
+++ b/scripts/test/unit
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-go test -tags daemon -v $@
+go test -tags daemon -v "$@"

--- a/scripts/test/unit-with-coverage
+++ b/scripts/test/unit-with-coverage
@@ -3,14 +3,14 @@ set -eu -o pipefail
 
 # install test dependencies once before running tests for each package. This
 # reduces the runtime from 200s down to 23s
-go test -i $@
+go test -i "$@"
 
-for pkg in $@; do
+for pkg in "$@"; do
     ./scripts/test/unit \
         -cover \
         -coverprofile=profile.out \
         -covermode=atomic \
-        ${pkg}
+        "${pkg}"
     
     if test -f profile.out; then
         cat profile.out >> coverage.txt

--- a/scripts/test/watch
+++ b/scripts/test/watch
@@ -1,2 +1,3 @@
 #!/bin/sh
+# shellcheck disable=SC2016
 exec filewatcher -L 6 -x build -x script go test -timeout 10s -v './${dir}'

--- a/scripts/validate/check-git-diff
+++ b/scripts/validate/check-git-diff
@@ -3,13 +3,13 @@
 set -eu
 
 DIFF_PATH=$1
-DIFF=$(git status --porcelain -- $DIFF_PATH)
+DIFF=$(git status --porcelain -- "$DIFF_PATH")
 
 if [ "$DIFF" ]; then
     echo
     echo "These files were changed:"
     echo
-    echo $DIFF
+    echo "$DIFF"
     echo
     exit 1
 else

--- a/scripts/validate/shellcheck
+++ b/scripts/validate/shellcheck
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -eo pipefail
 
-# Maintain an array of files to shellcheck not the best solution but will do for the time being
-FILES=()
-FILES+=("contrib/completion/bash/docker")
-FILES+=("scripts/validate/shellcheck")
-
-for f in "${FILES[@]}"; do
-    shellcheck "$f"
-done
+shellcheck contrib/completion/bash/docker
+find scripts/ -type f | grep -v scripts/winresources | xargs shellcheck


### PR DESCRIPTION
Is `scripts/gen/windows-resources` still used? I didn't change it as it looks like it's not used anymore.

Signed-off-by: Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
