### PR TITLE
Unexport subcommands

### DIFF
--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -18,8 +18,8 @@ func NewSystemCommand(dockerCli *command.DockerCli) *cobra.Command {
 	cmd.AddCommand(
 		NewEventsCommand(dockerCli),
 		NewInfoCommand(dockerCli),
-		NewDiskUsageCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newDiskUsageCommand(dockerCli),
+		newPruneCommand(dockerCli),
 	)
 
 	return cmd

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -15,8 +15,8 @@ type diskUsageOptions struct {
 	format  string
 }
 
-// NewDiskUsageCommand creates a new cobra.Command for `docker df`
-func NewDiskUsageCommand(dockerCli *command.DockerCli) *cobra.Command {
+// newDiskUsageCommand creates a new cobra.Command for `docker df`
+func newDiskUsageCommand(dockerCli *command.DockerCli) *cobra.Command {
 	var opts diskUsageOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -26,8 +26,8 @@ type pruneOptions struct {
 	filter          opts.FilterOpt
 }
 
-// NewPruneCommand creates a new cobra.Command for `docker prune`
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+// newPruneCommand creates a new cobra.Command for `docker prune`
+func newPruneCommand(dockerCli command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt(), pruneBuildCache: true}
 
 	cmd := &cobra.Command{

--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPrunePromptPre131(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{version: "1.30"})
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	assert.NoError(t, cmd.Execute())
 	assert.NotContains(t, cli.OutBuffer().String(), "all build cache")
 }


### PR DESCRIPTION
These commands were only used as subcommands, so did
not have to be exported.

**- A picture of a cute animal (not mandatory but encouraged)**

![dog-gets-stunned-by-a-mouse-resizecrop--](https://user-images.githubusercontent.com/1804568/28319337-73375204-6b82-11e7-9605-d70604c66333.jpg)

(image: http://www.perfectlytimedpics.com/dog-gets-stunned-by-a-mouse/)