### PR TITLE
Misc cleanup of dockerfiles and circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ jobs:
 
   lint:
     working_directory: /work
-    docker: [{image: 'docker:17.05-git'}]
+    docker: [{image: 'docker:17.06-git'}]
     steps:
       - checkout
       - setup_remote_docker:
@@ -22,7 +22,7 @@ jobs:
 
   cross:
     working_directory: /work
-    docker: [{image: 'docker:17.05-git'}]
+    docker: [{image: 'docker:17.06-git'}]
     parallelism: 3
     steps:
       - checkout
@@ -48,7 +48,7 @@ jobs:
 
   test:
     working_directory: /work
-    docker: [{image: 'docker:17.05-git'}]
+    docker: [{image: 'docker:17.06-git'}]
     steps:
       - checkout
       - setup_remote_docker:
@@ -75,9 +75,8 @@ jobs:
 
   validate:
     working_directory: /work
-    docker: [{image: 'docker:17.05-git'}]
+    docker: [{image: 'docker:17.06-git'}]
     steps:
-      - run: apk add -U git openssh
       - checkout
       - setup_remote_docker:
             reusable: true
@@ -93,7 +92,7 @@ jobs:
                 make -B vendor compose-jsonschema manpages yamldocs
   shellcheck:
     working_directory: /work
-    docker: [{image: 'docker:17.05-git'}]
+    docker: [{image: 'docker:17.06-git'}]
     steps:
       - checkout
       - setup_remote_docker

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -57,26 +57,6 @@ const confirmationTemplate = `WARNING! This will remove:
 {{- end }}
 Are you sure you want to continue?`
 
-// runContainerPrune executes a prune command for containers
-func runContainerPrune(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error) {
-	return container.RunPrune(dockerCli, filter)
-}
-
-// runNetworkPrune executes a prune command for networks
-func runNetworkPrune(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error) {
-	return network.RunPrune(dockerCli, filter)
-}
-
-// runVolumePrune executes a prune command for volumes
-func runVolumePrune(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error) {
-	return volume.RunPrune(dockerCli, filter)
-}
-
-// runImagePrune executes a prune command for images
-func runImagePrune(dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
-	return image.RunPrune(dockerCli, all, filter)
-}
-
 // runBuildCachePrune executes a prune command for build cache
 func runBuildCachePrune(dockerCli command.Cli, _ opts.FilterOpt) (uint64, string, error) {
 	report, err := dockerCli.Client().BuildCachePrune(context.Background())
@@ -94,14 +74,14 @@ func runPrune(dockerCli command.Cli, options pruneOptions) error {
 		return nil
 	}
 	imagePrune := func(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error) {
-		return runImagePrune(dockerCli, options.all, options.filter)
+		return image.RunPrune(dockerCli, options.all, options.filter)
 	}
 	pruneFuncs := []func(dockerCli command.Cli, filter opts.FilterOpt) (uint64, string, error){
-		runContainerPrune,
-		runNetworkPrune,
+		container.RunPrune,
+		network.RunPrune,
 	}
 	if options.pruneVolumes {
-		pruneFuncs = append(pruneFuncs, runVolumePrune)
+		pruneFuncs = append(pruneFuncs, volume.RunPrune)
 	}
 	pruneFuncs = append(pruneFuncs, imagePrune)
 	if options.pruneBuildCache {

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -4,21 +4,21 @@ FROM    golang:1.8.3-alpine
 RUN     apk add -U git make bash coreutils
 
 ARG     VNDR_SHA=9909bb2b8a0b7ea464527b376dc50389c90df587
-RUN     go get github.com/LK4D4/vndr && \
+RUN     go get -d github.com/LK4D4/vndr && \
         cd /go/src/github.com/LK4D4/vndr && \
         git checkout -q "$VNDR_SHA" && \
         go build -v -o /usr/bin/vndr . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 ARG     BINDATA_SHA=a0ff2567cfb70903282db057e799fd826784d41d
-RUN     go get github.com/jteeuwen/go-bindata/go-bindata && \
+RUN     go get -d github.com/jteeuwen/go-bindata/go-bindata && \
         cd /go/src/github.com/jteeuwen/go-bindata/go-bindata && \
         git checkout -q "$BINDATA_SHA" && \
         go build -v -o /usr/bin/go-bindata . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 ARG     FILEWATCHER_SHA=2e12ea42f6c8c089b19e992145bb94e8adaecedb
-RUN     go get github.com/dnephin/filewatcher && \
+RUN     go get -d github.com/dnephin/filewatcher && \
         cd /go/src/github.com/dnephin/filewatcher && \
         git checkout -q "$FILEWATCHER_SHA" && \
         go build -v -o /usr/bin/filewatcher . && \

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -3,7 +3,7 @@ FROM    golang:1.8.3-alpine
 RUN     apk add -U git
 
 ARG     GOMETALINTER_SHA=4306381615a2ba2a207f8fcea02c08c6b2b0803f
-RUN     go get github.com/alecthomas/gometalinter && \
+RUN     go get -d github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \
         git checkout -q "$GOMETALINTER_SHA" && \
         go build -v -o /usr/local/bin/gometalinter . && \ 


### PR DESCRIPTION
Plus remove unnecessary prune function aliases.

Add `-d` to `go get` so we don't waste time building a binary before we change to the correct git sha. This was an even bigger problem with `gometalinter` because we don't remove `/go/bin` so we are actually running the unpinned master version.

Remove an unnecessary `apk add` from circle.yml. This package is already in the base image now.

Upgrade base images since the `17.05` tag is not supported anymore according to hub.