### PR TITLE
Use native formatting in bash completion of nodes

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -441,18 +441,23 @@ __docker_complete_stacks() {
 # precedence over the environment setting.
 # Completions may be added with `--add`, e.g. `--add self`.
 __docker_nodes() {
+	local format
+	if [ "$DOCKER_COMPLETION_SHOW_NODE_IDS" = yes ] ; then
+		format='{{.ID}} {{.Hostname}}'
+	else
+		format='{{.Hostname}}'
+	fi
+
 	local add=()
-	local fields='$2'  # default: node name only
-	[ "${DOCKER_COMPLETION_SHOW_NODE_IDS}" = yes ] && fields='$1,$2' # ID and name
 
 	while true ; do
 		case "$1" in
 			--id)
-				fields='$1' # IDs only
+				format='{{.ID}}'
 				shift
 				;;
 			--name)
-				fields='$2' # names only
+				format='{{.Hostname}}'
 				shift
 				;;
 			--add)
@@ -465,7 +470,7 @@ __docker_nodes() {
 		esac
 	done
 
-	echo "$(__docker_q node ls "$@" | tr -d '*' | awk "NR>1 {print $fields}")" "${add[@]}"
+	echo "$(__docker_q node ls --format "$format" "$@")" "${add[@]}"
 }
 
 # __docker_complete_nodes applies completion of nodes based on the current


### PR DESCRIPTION
Completion of nodes now uses native Docker commands that were not available when this function was created.

Hint for reviewers: `__docker_nodes` can be called directly, which makes testing the effect of `$DOCKER_COMPLETION_SHOW_NODE_IDS` and its options easier, e.g.
```bash
DOCKER_COMPLETION_SHOW_NODE_IDS=yes __docker_nodes --name --add hugo
```