### PR TITLE
Fix .github/CODEOWNERS patterns

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Github code owners
 # See https://github.com/blog/2392-introducing-code-owners
 
-cli/compose/*              @dnephin @vdemeester
-contrib/completion/bash/*  @albers
-contrib/completion/zsh/*   @sdurrheimer
-docs/*                     @mstanleyjones @vdemeester @thaJeztah
-scripts/*                  @dnephin
+cli/compose/**              @dnephin @vdemeester
+contrib/completion/bash/**  @albers
+contrib/completion/zsh/**   @sdurrheimer
+docs/**                     @mstanleyjones @vdemeester @thaJeztah
+scripts/**                  @dnephin


### PR DESCRIPTION
Apparently they use https://git-scm.com/docs/gitignore#_pattern_format

I'm not sure if these `**` are necessary, the doc suggests that just a `/` might work.

I tried testing these against my fork, but nothing works there. I also tried testing by modifying files in this PR, which also doesn't work. I'm guessing it has to be in master.