### PR TITLE
Sort services names in a natural order

### DIFF
--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"golang.org/x/net/context"
+)
+
+type fakeClient struct {
+	client.Client
+	serviceListFunc func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
+}
+
+func (f *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	if f.serviceListFunc != nil {
+		return f.serviceListFunc(ctx, options)
+	}
+	return nil, nil
+}
+
+func (f *fakeClient) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	return nil, nil
+}
+
+func (f *fakeClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+	return nil, nil
+}
+
+func newService(id string, name string) swarm.Service {
+	return swarm.Service{
+		ID:   id,
+		Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: name}},
+	}
+}

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/pkg/testutil"
+	"github.com/docker/docker/pkg/testutil/golden"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceListOrder(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{
+				newService("a57dbe8", "service-1-foo"),
+				newService("a57dbdd", "service-10-foo"),
+				newService("aaaaaaa", "service-2-foo"),
+			}, nil
+		},
+	})
+	cmd := newListCommand(cli)
+	cmd.Flags().Set("format", "{{.Name}}")
+	assert.NoError(t, cmd.Execute())
+	actual := cli.OutBuffer().String()
+	expected := golden.Get(t, []byte(actual), "service-list-sort.golden")
+	testutil.EqualNormalizedString(t, testutil.RemoveSpace, actual, string(expected))
+}

--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -10,34 +10,10 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
-
-type fakeClient struct {
-	client.Client
-	serviceListFunc func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
-}
-
-func (f *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
-	if f.serviceListFunc != nil {
-		return f.serviceListFunc(ctx, options)
-	}
-	return nil, nil
-}
-
-func (f *fakeClient) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
-	return nil, nil
-}
-
-func newService(id string, name string) swarm.Service {
-	return swarm.Service{
-		ID:   id,
-		Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: name}},
-	}
-}
 
 func TestCreateFilter(t *testing.T) {
 	client := &fakeClient{

--- a/cli/command/service/testdata/service-list-sort.golden
+++ b/cli/command/service/testdata/service-list-sort.golden
@@ -1,0 +1,3 @@
+service-1-foo
+service-2-foo
+service-10-foo


### PR DESCRIPTION
Follow-up to #315 

@aaronlehmann Let me know if there are other resources that need to be natural-sorted.

**- What I did**

Use natural sorting to display swarm services

**- How I did it**

Using the `sortorder.NaturalLess` function and the `Sort` interface

**- How to verify it**

```
$ TESTDIR='cli/command/service' go test -v
```
