### PR TITLE
Plugable secrets backend

### DIFF
--- a/cli/command/formatter/secret.go
+++ b/cli/command/formatter/secret.go
@@ -12,19 +12,20 @@ import (
 )
 
 const (
-	defaultSecretTableFormat           = "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}\t{{.UpdatedAt}}"
+	defaultSecretTableFormat           = "table {{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.CreatedAt}}\t{{.UpdatedAt}}"
 	secretIDHeader                     = "ID"
 	secretCreatedHeader                = "CREATED"
 	secretUpdatedHeader                = "UPDATED"
-	secretInspectPrettyTemplate Format = `ID:			{{.ID}}
-Name:			{{.Name}}
+	secretInspectPrettyTemplate Format = `ID:              {{.ID}}
+Name:              {{.Name}}
 {{- if .Labels }}
 Labels:
 {{- range $k, $v := .Labels }}
  - {{ $k }}{{if $v }}={{ $v }}{{ end }}
 {{- end }}{{ end }}
-Created at:            	{{.CreatedAt}}
-Updated at:            	{{.UpdatedAt}}`
+Driver:            {{.Driver}}
+Created at:        {{.CreatedAt}}
+Updated at:        {{.UpdatedAt}}`
 )
 
 // NewSecretFormat returns a Format for rendering using a secret Context
@@ -61,6 +62,7 @@ func newSecretContext() *secretContext {
 	sCtx.header = map[string]string{
 		"ID":        secretIDHeader,
 		"Name":      nameHeader,
+		"Driver":    driverHeader,
 		"CreatedAt": secretCreatedHeader,
 		"UpdatedAt": secretUpdatedHeader,
 		"Labels":    labelsHeader,
@@ -87,6 +89,13 @@ func (c *secretContext) Name() string {
 
 func (c *secretContext) CreatedAt() string {
 	return units.HumanDuration(time.Now().UTC().Sub(c.s.Meta.CreatedAt)) + " ago"
+}
+
+func (c *secretContext) Driver() string {
+	if c.s.Spec.Driver == nil {
+		return ""
+	}
+	return c.s.Spec.Driver.Name
 }
 
 func (c *secretContext) UpdatedAt() string {
@@ -151,6 +160,13 @@ func (ctx *secretInspectContext) Name() string {
 
 func (ctx *secretInspectContext) Labels() map[string]string {
 	return ctx.Secret.Spec.Labels
+}
+
+func (ctx *secretInspectContext) Driver() string {
+	if ctx.Secret.Spec.Driver == nil {
+		return ""
+	}
+	return ctx.Secret.Spec.Driver.Name
 }
 
 func (ctx *secretInspectContext) CreatedAt() string {

--- a/cli/command/formatter/secret_test.go
+++ b/cli/command/formatter/secret_test.go
@@ -28,9 +28,9 @@ func TestSecretContextFormatWrite(t *testing.T) {
 		},
 		// Table format
 		{Context{Format: NewSecretFormat("table", false)},
-			`ID                  NAME                CREATED                  UPDATED
-1                   passwords           Less than a second ago   Less than a second ago
-2                   id_rsa              Less than a second ago   Less than a second ago
+			`ID                  NAME                DRIVER              CREATED                  UPDATED
+1                   passwords                               Less than a second ago   Less than a second ago
+2                   id_rsa                                  Less than a second ago   Less than a second ago
 `},
 		{Context{Format: NewSecretFormat("table {{.Name}}", true)},
 			`NAME

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -154,6 +154,7 @@ func TestSecretInspectPretty(t *testing.T) {
 					}),
 					SecretID("secretID"),
 					SecretName("secretName"),
+					SecretDriver("driver"),
 					SecretCreatedAt(time.Time{}),
 					SecretUpdatedAt(time.Time{}),
 				), []byte{}, nil

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -63,6 +63,7 @@ func TestSecretList(t *testing.T) {
 					SecretVersion(swarm.Version{Index: 11}),
 					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
 					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+					SecretDriver("driver"),
 				),
 			}, nil
 		},

--- a/cli/command/secret/testdata/secret-inspect-pretty.simple.golden
+++ b/cli/command/secret/testdata/secret-inspect-pretty.simple.golden
@@ -1,6 +1,7 @@
-ID:			secretID
-Name:			secretName
+ID:              secretID
+Name:              secretName
 Labels:
  - lbl1=value1
-Created at:            	0001-01-01 00:00:00 +0000 utc
-Updated at:            	0001-01-01 00:00:00 +0000 utc
+Driver:            driver
+Created at:        0001-01-01 00:00:00 +0000 utc
+Updated at:        0001-01-01 00:00:00 +0000 utc

--- a/cli/command/secret/testdata/secret-list-with-filter.golden
+++ b/cli/command/secret/testdata/secret-list-with-filter.golden
@@ -1,3 +1,3 @@
-ID                  NAME                CREATED             UPDATED
-ID-foo              foo                 2 hours ago         About an hour ago
-ID-bar              bar                 2 hours ago         About an hour ago
+ID                  NAME                DRIVER              CREATED             UPDATED
+ID-foo              foo                                     2 hours ago         About an hour ago
+ID-bar              bar                                     2 hours ago         About an hour ago

--- a/cli/command/secret/testdata/secret-list.golden
+++ b/cli/command/secret/testdata/secret-list.golden
@@ -1,3 +1,3 @@
-ID                  NAME                CREATED             UPDATED
-ID-foo              foo                 2 hours ago         About an hour ago
-ID-bar              bar                 2 hours ago         About an hour ago
+ID                  NAME                DRIVER              CREATED             UPDATED
+ID-foo              foo                                     2 hours ago         About an hour ago
+ID-bar              bar                 driver              2 hours ago         About an hour ago

--- a/internal/test/builders/secret.go
+++ b/internal/test/builders/secret.go
@@ -32,6 +32,15 @@ func SecretName(name string) func(secret *swarm.Secret) {
 	}
 }
 
+// SecretDriver sets the secret's driver name
+func SecretDriver(driver string) func(secret *swarm.Secret) {
+	return func(secret *swarm.Secret) {
+		secret.Spec.Driver = &swarm.Driver{
+			Name: driver,
+		}
+	}
+}
+
 // SecretID sets the secret's ID
 func SecretID(ID string) func(secret *swarm.Secret) {
 	return func(secret *swarm.Secret) {


### PR DESCRIPTION
This commit extends SwarmKit secret management with pluggable secret
backends support.
Following previous commits:
1. docker/swarmkit@eebac27434d34708fac993f9f5181d106c5c2fae
2. docker/docker@08f7cf05268782a0dd8e4c41a4cc65fdf78d09f2

Added driver parameter to `docker secret` command.
Specifically:

1. `docker secret create [secret_name] --driver [driver_name]`
2.  Displaying the driver in
```
    $ docker secret ls
    $ docker secret inspect [secret_name]
    $ docker secret inspect [secret_name] -pretty
```

Signed-off-by: Liron Levin <liron@twistlock.com>