### PR TITLE
Remove duplicate publish option in docker service create/update

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1960,7 +1960,6 @@ __docker_service_subcommand() {
         "($help)*--mount=[Attach a filesystem mount to the service]:mount: "
         "($help)*--network=[Network attachments]:network: "
         "($help)--no-healthcheck[Disable any container-specified HEALTHCHECK]"
-        "($help)*"{-p=,--publish=}"[Publish a port as a node port]:port: "
         "($help)--read-only[Mount the container's root filesystem as read only]"
         "($help)--replicas=[Number of tasks]:replicas: "
         "($help)--reserve-cpu=[Reserve CPUs]:value: "
@@ -2001,7 +2000,7 @@ __docker_service_subcommand() {
                 "($help)--mode=[Service Mode]:mode:(global replicated)" \
                 "($help)--name=[Service name]:name: " \
                 "($help)*--placement-pref=[Add a placement preference]:pref:__docker_service_complete_placement_pref" \
-                "($help)*--publish=[Publish a port]:port: " \
+                "($help)*"{-p=,--publish=}"[Publish a port as a node port]:port: " \
                 "($help -): :__docker_complete_images" \
                 "($help -):command: _command_names -e" \
                 "($help -)*::arguments: _normal" && ret=0


### PR DESCRIPTION
The publish option was showing twice. The fix has been made to be compliant with [docker service create](https://docs.docker.com/engine/reference/commandline/service_create/) and [docker service update](https://docs.docker.com/engine/reference/commandline/service_update/)

![screen shot 2017-07-21 at 09 49 08](https://user-images.githubusercontent.com/2276335/28456615-ded7a700-6dfa-11e7-99d2-9a31e4bf62de.png)

Note: The whole `create_update` option list is really outdated. I'm planning on doing am update. Would you recommend everything in a single PR or multiple small ones?
