### PR TITLE
Add metric plugins to zsh completion for `plugin ls --filter capability`

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1521,7 +1521,7 @@ __docker_plugin_complete_ls_filters() {
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
             (capability)
-                opts=('authz' 'ipamdriver' 'networkdriver' 'volumedriver')
+                opts=('authz' 'ipamdriver' 'logdriver' 'metricscollector' 'networkdriver' 'volumedriver')
                 _describe -t capability-opts "capability options" opts && ret=0
                 ;;
             (enabled)


### PR DESCRIPTION
This is the zsh equivalent of #281 for moby/moby#32874

Signed-off-by: Jean-Pierre Huynh <jean-pierre.huynh@ounet.fr>
