### PR TITLE
Fix sort order of options in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2851,7 +2851,7 @@ _docker_login() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --password --password-stdin -p --username -u" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --password -p --password-stdin --username -u" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This is a follow-up on https://github.com/docker/cli/pull/332/files#diff-754420541b12dbcbbea00825942a4635. No functional changes.