### PR TITLE
Add file completion to bash completion for `secret create`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1184,7 +1184,7 @@ _docker_config_create() {
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--label|-l')
-			if [ "$cword" -eq $((counter + 1)) ]; then
+			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi
 			;;
@@ -4158,6 +4158,12 @@ _docker_secret_create() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--label|-l')
+			if [ "$cword" -eq "$((counter + 1))" ]; then
+				_filedir
+			fi
 			;;
 	esac
 }


### PR DESCRIPTION
Like completion for `docker config create`, `docker secret create` should have file completion.
See https://github.com/docker/cli/pull/283#issuecomment-313638430.

Note: #266 changed all instances of `$((counter + 1))` to `"$((counter + 1))"`, so I fixed one instance that was introduced in a PR that was pending when #266 got merged.