### PR TITLE
Add support for redirections in bash completion for `docker save|load`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2579,7 +2579,7 @@ _docker_image_inspect() {
 
 _docker_image_load() {
 	case "$prev" in
-		--input|-i)
+		--input|-i|"<")
 			_filedir
 			return
 			;;
@@ -2710,7 +2710,7 @@ _docker_image_rmi() {
 
 _docker_image_save() {
 	case "$prev" in
-		--output|-o)
+		--output|-o|">")
 			_filedir
 			return
 			;;


### PR DESCRIPTION
Turns out that it's up to the completion scripts to deal with redirection characters. They do not split commands, instead they show up as ordinary words in `$COMP_WORDS`.

Without this PR
- `docker save my-image > ` would complete images instead of file names.
- `docker load < ` wouldn't complete anything