### PR TITLE
Fix image resolve detection

### DIFF
--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -34,10 +34,13 @@ type fakeClient struct {
 	nodeListFunc       func(options types.NodeListOptions) ([]swarm.Node, error)
 	taskListFunc       func(options types.TaskListOptions) ([]swarm.Task, error)
 	nodeInspectWithRaw func(ref string) (swarm.Node, []byte, error)
-	serviceRemoveFunc  func(serviceID string) error
-	networkRemoveFunc  func(networkID string) error
-	secretRemoveFunc   func(secretID string) error
-	configRemoveFunc   func(configID string) error
+
+	serviceUpdateFunc func(serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error)
+
+	serviceRemoveFunc func(serviceID string) error
+	networkRemoveFunc func(networkID string) error
+	secretRemoveFunc  func(secretID string) error
+	configRemoveFunc  func(configID string) error
 }
 
 func (cli *fakeClient) ServerVersion(ctx context.Context) (types.Version, error) {
@@ -130,6 +133,14 @@ func (cli *fakeClient) NodeInspectWithRaw(ctx context.Context, ref string) (swar
 		return cli.nodeInspectWithRaw(ref)
 	}
 	return swarm.Node{}, nil, nil
+}
+
+func (cli *fakeClient) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
+	if cli.serviceUpdateFunc != nil {
+		return cli.serviceUpdateFunc(serviceID, version, service, options)
+	}
+
+	return types.ServiceUpdateResponse{}, nil
 }
 
 func (cli *fakeClient) ServiceRemove(ctx context.Context, serviceID string) error {

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/docker/cli/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -21,4 +23,81 @@ func TestPruneServices(t *testing.T) {
 
 	pruneServices(ctx, dockerCli, namespace, services)
 	assert.Equal(t, buildObjectIDs([]string{objectName("foo", "remove")}), client.removedServices)
+}
+
+// TestServiceUpdateResolveImageChanged tests that the service's
+// image digest is preserved if the image did not change in the compose file
+func TestServiceUpdateResolveImageChanged(t *testing.T) {
+	namespace := convert.NewNamespace("mystack")
+
+	var (
+		receivedOptions types.ServiceUpdateOptions
+		receivedService swarm.ServiceSpec
+	)
+
+	client := test.NewFakeCli(&fakeClient{
+		serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{
+				{
+					Spec: swarm.ServiceSpec{
+						Annotations: swarm.Annotations{
+							Name:   namespace.Name() + "_myservice",
+							Labels: map[string]string{"com.docker.stack.image": "foobar:1.2.3"},
+						},
+						TaskTemplate: swarm.TaskSpec{
+							ContainerSpec: swarm.ContainerSpec{
+								Image: "foobar:1.2.3@sha256:deadbeef",
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		serviceUpdateFunc: func(serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
+			receivedOptions = options
+			receivedService = service
+			return types.ServiceUpdateResponse{}, nil
+		},
+	})
+
+	var testcases = []struct {
+		image                 string
+		expectedQueryRegistry bool
+		expectedImage         string
+	}{
+		// Image not changed
+		{
+			image: "foobar:1.2.3",
+			expectedQueryRegistry: false,
+			expectedImage:         "foobar:1.2.3@sha256:deadbeef",
+		},
+		// Image changed
+		{
+			image: "foobar:1.2.4",
+			expectedQueryRegistry: true,
+			expectedImage:         "foobar:1.2.4",
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, testcase := range testcases {
+		t.Logf("Testing image %q", testcase.image)
+		spec := map[string]swarm.ServiceSpec{
+			"myservice": {
+				TaskTemplate: swarm.TaskSpec{
+					ContainerSpec: swarm.ContainerSpec{
+						Image: testcase.image,
+					},
+				},
+			},
+		}
+		err := deployServices(ctx, client, spec, namespace, false, resolveImageChanged)
+		assert.NoError(t, err)
+		assert.Equal(t, testcase.expectedQueryRegistry, receivedOptions.QueryRegistry)
+		assert.Equal(t, testcase.expectedImage, receivedService.TaskTemplate.ContainerSpec.Image)
+
+		receivedService = swarm.ServiceSpec{}
+		receivedOptions = types.ServiceUpdateOptions{}
+	}
 }


### PR DESCRIPTION
When using `--resolve-image change`, the image that was resolved during deploy, as well as `Platform` information were overwritten by the image specified in the docker-compose.yaml.  As a result, services were always re-deployed.

fixes https://github.com/moby/moby/issues/34242

**- What I did**

If `QueryRegistry` is "false", preserve the `image` and `Platform` information from the existing service.

**UPDATE:**
removed preserving the platform information, as is discussed in https://github.com/moby/moby/issues/34268

**- How to verify it**

```bash
cat > docker-compose.yml <<"EOF"
version: "3.3"
services:
    redis:
        image: redis:3.2.8
EOF

docker stack deploy -c docker-compose.yml repro \
&& docker service inspect repro_redis -f '{{json .Spec}}' | jq . > before.json \
&& docker stack deploy -c docker-compose.yml --resolve-image changed repro \
&& docker service inspect repro_redis -f '{{json .Spec}}' | jq . > after.json \
&& docker stack rm repro
```

The diff should be empty:

```
git diff --no-index before.json after.json
```


Before this change, the diff would show:

```patch
diff --git a/before.json b/after.json
index f65ecfff..0eecbc51 100644
--- a/before.json
+++ b/after.json
@@ -23,14 +23,7 @@
       "Delay": 5000000000,
       "MaxAttempts": 0
     },
-    "Placement": {
-      "Platforms": [
-        {
-          "Architecture": "amd64",
-          "OS": "linux"
-        }
-      ]
-    },
+    "Placement": {},
     "Networks": [
       {
         "Target": "njp31bnesn79ojar7vj34saqc",
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


ping @aaronlehmann @nishanttotla @dnephin PTAL