### PR TITLE
Fast fail when save directory does not exist

### DIFF
--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -43,6 +43,11 @@ func TestNewSaveCommandErrors(t *testing.T) {
 				return ioutil.NopCloser(strings.NewReader("")), errors.Errorf("error saving image")
 			},
 		},
+		{
+			name:          "output directory does not exist",
+			args:          []string{"-o", "fakedir/out.tar", "arg1"},
+			expectedError: "failed to save image: unable to validate output path: directory \"fakedir\" does not exist",
+		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})


### PR DESCRIPTION
Signed-off-by: Darren Stahl <darst@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

When using `docker save -o foo/bar.tar`, if the directory foo does not exist, the client currently calls into the daemon to save the image, sends the entire tar stream to the client just to fail to create the file. This problem exists on both Windows and Linux.

This PR adds a fast fail check prior to calling the daemon to ensure the directory exists.

**- How I did it**

Check if the containing directory exists prior to starting the save.

**- How to verify it**

```
PS > .\docker.exe save microsoft/nanoserver -o c:\fakedir\out.tar
unable to save to c:\fakedir\out.tar: directory does not exist
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Save now fast fails when the directory does not exist.


**- A picture of a cute animal (not mandatory but encouraged)**

![](https://s-media-cache-ak0.pinimg.com/originals/be/65/bc/be65bc5832b1497e62f305f022972176.jpg)


