### PR TITLE
Add support for stop-signal in stack command

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -142,6 +142,7 @@ func Service(
 				User:            service.User,
 				Mounts:          mounts,
 				StopGracePeriod: service.StopGracePeriod,
+				StopSignal:      service.StopSignal,
 				TTY:             service.Tty,
 				OpenStdin:       service.StdinOpen,
 				Secrets:         secrets,

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -21,7 +21,6 @@ var UnsupportedProperties = []string{
 	"restart",
 	"security_opt",
 	"shm_size",
-	"stop_signal",
 	"sysctls",
 	"tmpfs",
 	"userns_mode",


### PR DESCRIPTION
**- What I did**

Fixes #370 by passing `StopSignal` to the container spec when doing a deploy.

**- How I did it**

Passed `StopSignal` and removed `stop_signal` from unsupported keys.

**- How to verify it**

Create a small `docker-compose` file with a service defining a stop signal, deploy using `docker stack deploy -c file.yml stack_name` then inspect one of the created containers.

**- Description for the changelog**

Added support for `stop_signal` when deploying a compose file through docker stack.

**- A picture of a cute animal (not mandatory but encouraged)**

![otter_madness](https://user-images.githubusercontent.com/308493/28654156-1326a91c-72cd-11e7-811b-485a41a28dcc.gif)
