### PR TITLE
Docs: update filter options for docker container ps

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -84,18 +84,19 @@ The currently supported filters are:
 
 | Filter                | Description                                                                                                                          |
 |:----------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| `id`                  | container's ID                                                                                                                       |
-| `name`                | container's name                                                                                                                     |
-| `label`               | An arbitrary string representing either a key or a key-value pair                                                                    |
+| `id`                  | Container's ID                                                                                                                       |
+| `name`                | Container's name                                                                                                                     |
+| `label`               | An arbitrary string representing either a key or a key-value pair. Expressed as `<key>` or `<key>=<value>`                           |
 | `exited`              | An integer representing the container's exit code. Only useful with `--all`.                                                         |
-| `status`              | One of `created|restarting|running|removing|paused|exited|dead`                                                                      |
+| `status`              | One of `created`, `restarting`, `running`, `removing`, `paused`, `exited`, or `dead`                                                 |
 | `ancestor`            | Filters containers which share a given image as an ancestor. Expressed as `<image-name>[:<tag>]`,  `<image id>`, or `<image@digest>` |
 | `before` or `since`   | Filters containers created before or after a given container ID or name                                                              |
 | `volume`              | Filters running containers which have mounted a given volume or bind mount.                                                          |
 | `network`             | Filters running containers connected to a given network.                                                                             |
-| `publish` or `expose` | Filters containers which publish or expose a given port.                                                                             |
-| `health`              | One of `starting|healthy|unhealthy|none`. Filters containers based on their healthcheck status.                                      |
-| `isolation`           | Windows daemon only. One of `default|process|hyperv`.                                                                                |
+| `publish` or `expose` | Filters containers which publish or expose a given port. Expressed as `<port>[/<proto>]` or `<startport-endport>/[<proto>]`          |
+| `health`              | Filters containers based on their healthcheck status. One of `starting`, `healthy`, `unhealthy` or `none`.                           |
+| `isolation`           | Windows daemon only. One of `default`, `process`, or `hyperv`.                                                                       |
+| `is-task`             | Filters containers that are a "task" for a service. Boolean option (`true` or `false`)                                               |
 
 
 #### label
@@ -208,11 +209,11 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 The `ancestor` filter matches containers based on its image or a descendant of
 it. The filter supports the following image representation:
 
-- image
-- image:tag
-- image:tag@digest
-- short-id
-- full-id
+- `image`
+- `image:tag`
+- `image:tag@digest`
+- `short-id`
+- `full-id`
 
 If you don't specify a `tag`, the `latest` tag is used. For example, to filter
 for containers that use the latest `ubuntu` image:

--- a/man/src/container/ls.md
+++ b/man/src/container/ls.md
@@ -4,39 +4,46 @@ the running containers.
 ## Filters
 
 Filter output based on these conditions:
-   - exited=<int> an exit code of <int>
-   - label=<key> or label=<key>=<value>
-   - status=(created|restarting|running|paused|exited|dead)
-   - name=<string> a container's name
-   - id=<ID> a container's ID
-   - is-task=(true|false) - containers that are a task (part of a service managed by swarm)
+   - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>)
+     containers created from an image or a descendant.
    - before=(<container-name>|<container-id>)
+   - expose=(<port>[/<proto>]|<startport-endport>/[<proto>])
+   - exited=<int> an exit code of <int>
+   - health=(starting|healthy|unhealthy|none)
+   - id=<ID> a container's ID
+   - isolation=(`default`|`process`|`hyperv`) (Windows daemon only)
+   - is-task=(true|false)
+   - label=<key> or label=<key>=<value>
+   - name=<string> a container's name
+   - network=(<network-id>|<network-name>)
+   - publish=(<port>[/<proto>]|<startport-endport>/[<proto>])
    - since=(<container-name>|<container-id>)
-   - ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - containers created from an image or a descendant.
-   - volume=(<volume-name>|<mount-point-destination>)
-   - network=(<network-name>|<network-id>) - containers connected to the provided network
-   - health=(starting|healthy|unhealthy|none) - filters containers based on healthcheck status
-   - publish=(<port>[/<proto>]|<startport-endport>/[<proto>]) - filters containers based on published ports
-   - expose=(<port>[/<proto>]|<startport-endport>/[<proto>]) - filters containers based on exposed ports
+   - status=(created|restarting|removing|running|paused|exited)
+   - volume=(<volume name>|<mount point destination>)
 
 ## Format
 
-   Pretty-print containers using a Go template.
-   Valid placeholders:
-      .ID - Container ID
-      .Image - Image ID
-      .Command - Quoted command
-      .CreatedAt - Time when the container was created.
-      .RunningFor - Elapsed time since the container was started.
-      .Ports - Exposed ports.
-      .Status - Container status.
-      .Size - Container disk size.
-      .Names - Container names.
-      .Labels - All labels assigned to the container.
-      .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
-      .Mounts - Names of the volumes mounted in this container.
+The formatting option (**--format**) pretty-prints container output
+using a Go template.
+
+Valid placeholders for the Go template are listed below:
+   - .ID           - Container ID.
+   - .Image        - Image ID.
+   - .Command      - Quoted command.
+   - .CreatedAt    - Time when the container was created.
+   - .RunningFor   - Elapsed time since the container was started.
+   - .Ports        - Exposed ports.
+   - .Status       - Container status.
+   - .Size         - Container disk size.
+   - .Names        - Container names.
+   - .Labels       - All labels assigned to the container.
+   - .Label        - Value of a specific label for this container.
+                     For example **'{{.Label "com.docker.swarm.cpu"}}'**.
+   - .Mounts       - Names of the volumes mounted in this container.
+   - .Networks     - Names of the networks attached to this container.
 
 # EXAMPLES
+
 ## Display all containers, including non-running
 
     $ docker container ls -a


### PR DESCRIPTION
The `is-task` filter was only documented in the usage
section, but this section is not used in the documentation.

This patch adds the missing filter, synchronises the
man page source, and does some slight rephrasing
and reformatting of the filters.

relates to https://github.com/moby/moby/pull/24411

ping @mstanleyjones @vdemeester PTAL