### PR TITLE
bash completion for `service ps` supports multiple services

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3242,10 +3242,7 @@ _docker_service_ps() {
 			COMPREPLY=( $( compgen -W "--filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f')
-			if [ "$cword" -eq "$counter" ]; then
-				__docker_complete_services
-			fi
+			__docker_complete_services
 			;;
 	esac
 }


### PR DESCRIPTION
`docker service ps` was changed to support multiple services in https://github.com/moby/moby/pull/25234.
Ping @sdurrheimer for zsh completion