### PR TITLE
update service create and update options in commandline documentation

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -21,9 +21,10 @@ Usage:  docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
 Create a new service
 
 Options:
+      --config config                      Specify configurations to expose to the service
       --constraint list                    Placement constraints
       --container-label list               Container labels
-      --credential-spec                    Credential spec for managed service account (Windows only)
+      --credential-spec credential-spec    Credential spec for managed service account (Windows only)
   -d, --detach                             Exit immediately instead of waiting for the service to converge (default true)
       --dns list                           Set custom DNS servers
       --dns-option list                    Set DNS options
@@ -49,8 +50,9 @@ Options:
       --mode string                        Service mode (replicated or global) (default "replicated")
       --mount mount                        Attach a filesystem mount to the service
       --name string                        Service name
-      --network list                       Network attachments
+      --network network                    Network attachments
       --no-healthcheck                     Disable any container-specified HEALTHCHECK
+      --no-resolve-image                   Do not query the registry to resolve image digest and supported platforms
       --placement-pref pref                Add a placement preference
   -p, --publish port                       Publish a port as a node port
   -q, --quiet                              Suppress progress output

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -22,11 +22,13 @@ Update a service
 
 Options:
       --args command                       Service command args
+      --config-add config                  Add or update a config file on a service
+      --config-rm list                     Remove a configuration file
       --constraint-add list                Add or update a placement constraint
       --constraint-rm list                 Remove a constraint
       --container-label-add list           Add or update a container label
       --container-label-rm list            Remove a container label by its key
-      --credential-spec                    Credential spec for managed service account (Windows only)
+      --credential-spec credential-spec    Credential spec for managed service account (Windows only)
   -d, --detach                             Exit immediately instead of waiting for the service to converge (default true)
       --dns-add list                       Add or update a custom DNS server
       --dns-option-add list                Add or update a DNS option
@@ -59,9 +61,10 @@ Options:
       --log-opt list                       Logging driver options
       --mount-add mount                    Add or update a mount on a service
       --mount-rm list                      Remove a mount by its target path
-      --network-add list                   Add a network
+      --network-add network                Add a network
       --network-rm list                    Remove a network
       --no-healthcheck                     Disable any container-specified HEALTHCHECK
+      --no-resolve-image                   Do not query the registry to resolve image digest and supported platforms
       --placement-pref-add pref            Add a placement preference
       --placement-pref-rm pref             Remove a placement preference
       --publish-add port                   Add or update a published port
@@ -80,7 +83,7 @@ Options:
       --rollback-failure-action string     Action on rollback failure ("pause"|"continue")
       --rollback-max-failure-ratio float   Failure rate to tolerate during a rollback
       --rollback-monitor duration          Duration after each task rollback to monitor for failure (ns|us|ms|s|m|h)
-      --rollback-order string              Rollback order ("start-first"|"stop-first") (default "stop-first")
+      --rollback-order string              Rollback order ("start-first"|"stop-first")
       --rollback-parallelism uint          Maximum number of tasks rolled back simultaneously (0 to roll back all at once)
       --secret-add secret                  Add or update a secret on a service
       --secret-rm list                     Remove a secret


### PR DESCRIPTION
Fix issue #159 
Signed-off-by: zebrilee <zebrilee@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
`--config`was not up to date in service_create.md and service_update.md so I checked if it was the only one and updated all options' part for both of those files

PS : the actual PR #205 will also modify those files by adding a `[service rollback](service_rollback.md)`at the end

**- How I did it**
Copy paste `docker service update --help` and `docker service create --help` results in their own .md files 

**- How to verify it**
The documentation and the result of the commandline `docker service update` and `docker service create --help` must be the same

(did a `make -f docker.Makefile` too)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Update the docker service create and update commandline documentation 

**- A picture of a cute animal (not mandatory but encouraged)**

