### PR TITLE
Fix presentation of published "random" host ports

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -518,11 +518,11 @@ func (c *serviceContext) Image() string {
 }
 
 func (c *serviceContext) Ports() string {
-	if c.service.Spec.EndpointSpec == nil || c.service.Spec.EndpointSpec.Ports == nil {
+	if c.service.Endpoint.Ports == nil {
 		return ""
 	}
 	ports := []string{}
-	for _, pConfig := range c.service.Spec.EndpointSpec.Ports {
+	for _, pConfig := range c.service.Endpoint.Ports {
 		if pConfig.PublishMode == swarm.PortConfigPublishModeIngress {
 			ports = append(ports, fmt.Sprintf("*:%d->%d/%s",
 				pConfig.PublishedPort,

--- a/cli/command/formatter/service_test.go
+++ b/cli/command/formatter/service_test.go
@@ -96,14 +96,14 @@ bar
 				ID: "id_baz",
 				Spec: swarm.ServiceSpec{
 					Annotations: swarm.Annotations{Name: "baz"},
-					EndpointSpec: &swarm.EndpointSpec{
-						Ports: []swarm.PortConfig{
-							{
-								PublishMode:   "ingress",
-								PublishedPort: 80,
-								TargetPort:    8080,
-								Protocol:      "tcp",
-							},
+				},
+				Endpoint: swarm.Endpoint{
+					Ports: []swarm.PortConfig{
+						{
+							PublishMode:   "ingress",
+							PublishedPort: 80,
+							TargetPort:    8080,
+							Protocol:      "tcp",
 						},
 					},
 				},
@@ -112,14 +112,14 @@ bar
 				ID: "id_bar",
 				Spec: swarm.ServiceSpec{
 					Annotations: swarm.Annotations{Name: "bar"},
-					EndpointSpec: &swarm.EndpointSpec{
-						Ports: []swarm.PortConfig{
-							{
-								PublishMode:   "ingress",
-								PublishedPort: 80,
-								TargetPort:    8080,
-								Protocol:      "tcp",
-							},
+				},
+				Endpoint: swarm.Endpoint{
+					Ports: []swarm.PortConfig{
+						{
+							PublishMode:   "ingress",
+							PublishedPort: 80,
+							TargetPort:    8080,
+							Protocol:      "tcp",
 						},
 					},
 				},
@@ -152,14 +152,14 @@ func TestServiceContextWriteJSON(t *testing.T) {
 			ID: "id_baz",
 			Spec: swarm.ServiceSpec{
 				Annotations: swarm.Annotations{Name: "baz"},
-				EndpointSpec: &swarm.EndpointSpec{
-					Ports: []swarm.PortConfig{
-						{
-							PublishMode:   "ingress",
-							PublishedPort: 80,
-							TargetPort:    8080,
-							Protocol:      "tcp",
-						},
+			},
+			Endpoint: swarm.Endpoint{
+				Ports: []swarm.PortConfig{
+					{
+						PublishMode:   "ingress",
+						PublishedPort: 80,
+						TargetPort:    8080,
+						Protocol:      "tcp",
 					},
 				},
 			},
@@ -168,14 +168,14 @@ func TestServiceContextWriteJSON(t *testing.T) {
 			ID: "id_bar",
 			Spec: swarm.ServiceSpec{
 				Annotations: swarm.Annotations{Name: "bar"},
-				EndpointSpec: &swarm.EndpointSpec{
-					Ports: []swarm.PortConfig{
-						{
-							PublishMode:   "ingress",
-							PublishedPort: 80,
-							TargetPort:    8080,
-							Protocol:      "tcp",
-						},
+			},
+			Endpoint: swarm.Endpoint{
+				Ports: []swarm.PortConfig{
+					{
+						PublishMode:   "ingress",
+						PublishedPort: 80,
+						TargetPort:    8080,
+						Protocol:      "tcp",
 					},
 				},
 			},

--- a/cli/command/stack/testdata/stack-services-without-format.golden
+++ b/cli/command/stack/testdata/stack-services-without-format.golden
@@ -1,2 +1,2 @@
 ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
-id-foo              name-foo            replicated          0/2                 busybox:latest      *:0->3232/tcp
+id-foo              name-foo            replicated          0/2                 busybox:latest      *:30000->3232/tcp

--- a/cli/internal/test/builders/service.go
+++ b/cli/internal/test/builders/service.go
@@ -64,5 +64,11 @@ func ServiceImage(image string) func(*swarm.Service) {
 func ServicePort(port swarm.PortConfig) func(*swarm.Service) {
 	return func(service *swarm.Service) {
 		service.Spec.EndpointSpec.Ports = append(service.Spec.EndpointSpec.Ports, port)
+
+		assignedPort := port
+		if assignedPort.PublishedPort == 0 {
+			assignedPort.PublishedPort = 30000
+		}
+		service.Endpoint.Ports = append(service.Endpoint.Ports, assignedPort)
 	}
 }


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/402

Ports that were picked from the ephemeral port range were presented as `*:0->80/tcp`.

This patch changes the presentation to use the actually assigned port, instead of the port specified in `Endpoint.Spec` (which is always empty/zero (`0`))

Before this change;

    ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
    5d44i665qj66        with-random-port    replicated          1/1                 nginx:alpine        *:0->80/tcp

After this change;

    ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
    5d44i665qj66        with-random-port    replicated          1/1                 nginx:alpine        *:30000->80/tcp

