### PR TITLE
Add bash completion for `docker build --target`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2439,6 +2439,7 @@ _docker_image_build() {
 		--network
 		--shm-size
 		--tag -t
+		--target
 		--ulimit
 	"
 	__docker_daemon_os_is windows && options_with_args+="
@@ -2503,6 +2504,19 @@ _docker_image_build() {
 			;;
 		--tag|-t)
 			__docker_complete_image_repos_and_tags
+			return
+			;;
+		--target)
+			local context_pos=$( __docker_pos_first_nonflag "$( __docker_to_alternatives "$options_with_args" )" )
+			local context="${words[$context_pos]}"
+			context="${context:-.}"
+
+			local file="$( __docker_value_of_option '--file|f' )"
+			local default_file="${context%/}/Dockerfile"
+			local dockerfile="${file:-$default_file}"
+
+			local targets="$( sed -n 's/^FROM .\+ AS \(.\+\)/\1/p' "$dockerfile" 2>/dev/null )"
+			COMPREPLY=( $( compgen -W "$targets" -- "$cur" ) )
 			return
 			;;
 		$(__docker_to_extglob "$options_with_args") )


### PR DESCRIPTION
This adds bash completion for https://github.com/moby/moby/pull/32496.

`--target` is completed with targets that are extracted from the dockerfile.

This does not always work, though. According to the syntax of `docker build`,

    Usage:  docker build [OPTIONS] PATH | URL | -

`PATH` should be the last argument and therefore won't be available for calculation of the dockerfile location during completion of `--target`.

But `docker build . --target` also works, so `--file` and `PATH` are honored if they are specified before `--target`. As the default value for the dockerfile `./Dockerfile` is assumed.