### PR TITLE
Add "build" dir to PATH in dev-container

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -24,6 +24,7 @@ RUN     go get -d github.com/dnephin/filewatcher && \
         go build -v -o /usr/bin/filewatcher . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ENV     CGO_ENABLED=0
+ENV     CGO_ENABLED=0 \
+        PATH=$PATH:/go/src/github.com/docker/cli/build
 WORKDIR /go/src/github.com/docker/cli
 CMD     sh


### PR DESCRIPTION
This makes running the client easier inside
the container; allowing to use just `docker`
instead of `build/docker`.


**- What I did**

**- How I did it**

**- How to verify it**

```bash
$ make -f docker.Makefile binary shell
$ docker version
```
