### PR TITLE
Fix invalid plugin references in docs

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -189,13 +189,13 @@ Stdout of a plugin is redirected to dockerd logs. Such entries have a
 corresponding log entries in the docker daemon logs.
 
 ```bash
-$ docker plugin install tiborvass/sample-volume-plugins
+$ docker plugin install tiborvass/sample-volume-plugin
 
 INFO[0036] Starting...       Found 0 volumes on startup  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
 ```
 
 ```bash
-$ docker volume create -d tiborvass/sample-volume-plugins samplevol
+$ docker volume create -d tiborvass/sample-volume-plugin samplevol
 
 INFO[0193] Create Called...  Ensuring directory /data/samplevol exists on host...  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
 INFO[0193] open /var/lib/docker/plugin-data/local-persist.json: no such file or directory  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -68,9 +68,9 @@ might have multiple capabilities. Currently `volumedriver`, `networkdriver`,
 `ipamdriver`, `logdriver`, `metricscollector`, and `authz` are supported capabilities.
 
 ```bash
-$ docker plugin install --disable tiborvass/no-remove
+$ docker plugin install --disable vieux/sshfs
 
-tiborvass/no-remove
+Installed plugin vieux/sshfs
 
 $ docker plugin ls --filter enabled=true
 
@@ -102,7 +102,7 @@ The following example uses a template without headers and outputs the
 ```bash
 $ docker plugin ls --format "{{.ID}}: {{.Name}}"
 
-4be01827a72e: tiborvass/no-remove
+4be01827a72e: vieux/sshfs:latest
 ```
 
 ## Related commands


### PR DESCRIPTION
The plugins `tiborvass/sample-volume-plugins` and `tiborvass/no-remove`
do not exist, see also https://github.com/moby/moby/issues/29886:

```bash
$ docker plugin install tiborvass/sample-volume-plugins
docker plugin install tiborvass/sample-volume-plugins
Error response from daemon: pull access denied for tiborvass/sample-volume-plugins, repository does not exist or may require 'docker login'
```
```bash
$ docker plugin install tiborvass/no-remove
Error response from daemon: Encountered remote "application/vnd.docker.plugin.v0+json"(unknown) when fetching
```
- `tiborvass/no-remove` was only used as an example for `docker plugin ls`, so this could easisly be replaced with any plugin.
- `tiborvass/sample-volume-plugins` was replaced by `tiborvass/sample-volume-plugin`. I verified that this plugin works as described in the document.