### PR TITLE
Improve bash completion for `stack deploy`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4331,6 +4331,12 @@ _docker_stack_deploy() {
 			__docker_daemon_is_experimental && options+=" --bundle-file"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag '--compose-file|-c|--bundle-file')
+			if [ "$cword" -eq "$counter" ]; then
+				__docker_complete_stacks
+			fi
+			;;
 	esac
 }
 
@@ -4408,6 +4414,7 @@ _docker_stack_rm() {
 			;;
 		*)
 			__docker_complete_stacks
+			;;
 	esac
 }
 


### PR DESCRIPTION
This adds completion of stack names, which is very useful when updating existing stacks.