### PR TITLE
Added docker events example with until option to documentation

### DIFF
--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -275,6 +275,12 @@ $ docker events --since '10m'
 2017-01-05T00:36:09.840186338+08:00 container die 0fdb...ff37 (exitCode=143, image=alpine:latest, name=test)
 2017-01-05T00:36:09.880113663+08:00 network disconnect e2e...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
 2017-01-05T00:36:09.890214053+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
+
+$ docker events --since '2017-01-05T00:35:30' --until '2017-01-05T00:36:05'
+2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
+2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
+2017-01-05T00:36:04.703631903+08:00 network connect e2e1...29e2 (container=0fdb...ff37, name=bridge, type=bridge)
+2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)
 ```
 
 ### Filter events by criteria


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/34475

The docs lead to some confusion about the use of the `--until` option for `docker events`. I've added an example that shows how to use it. As it's meant to be used together with `--since`, I did not include an example of `--until` alone.

