### PR TITLE
Documentation: Make the example match the documentation table

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -211,7 +211,7 @@ is also available when creating the ingress network, besides the `--attachable` 
 $ docker network create -d overlay \
   --subnet=10.11.0.0/16 \
   --ingress \
-  --opt com.docker.network.mtu=9216 \
+  --opt com.docker.network.driver.mtu=9216 \
   --opt encrypted=true \
   my-ingress-network
 ```


### PR DESCRIPTION
the missing `driver` made my bridge not have the correct MTU when i copied from the example and not the doc table.  Brings them into alignment.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute animal](http://i.imgur.com/1hl94tm.jpg)
