### PR TITLE
Singularize / pluralize "argument(s)" in error message

### DIFF
--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -20,11 +20,11 @@ func TestCheckpointCreateErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{"too-few-arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args:          []string{"too", "many", "arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"foo", "bar"},

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -20,11 +20,11 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{"too-few-arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args:          []string{"too", "many", "arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"foo", "bar"},

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -26,10 +26,10 @@ func TestConfigCreateErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{"too_few"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{args: []string{"too", "many", "arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"name", filepath.Join("testdata", configDataFile)},

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -20,7 +20,7 @@ func TestConfigRemoveErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{},
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			args: []string{"foo"},

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -25,7 +25,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires exactly 1 argument(s).",
+			expectedError: "requires exactly 1 argument.",
 		},
 		{
 			name:          "client-error",

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -24,7 +24,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			name:          "import-failed",

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -22,7 +22,7 @@ func TestNewInspectCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 	}
 	for _, tc := range testCases {

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -25,7 +25,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{"arg1", "arg2"},
-			expectedError: "requires at most 1 argument(s).",
+			expectedError: "requires at most 1 argument.",
 		},
 		{
 			name:          "failed-list",

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -27,7 +27,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{"arg"},
-			expectedError: "accepts no argument(s).",
+			expectedError: "accepts no arguments.",
 		},
 		{
 			name:          "input-to-terminal",

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -25,7 +25,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{"something"},
-			expectedError: "accepts no argument(s).",
+			expectedError: "accepts no arguments.",
 		},
 		{
 			name:          "prune-error",

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -19,7 +19,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	}{
 		{
 			name:          "wrong-args",
-			expectedError: "requires exactly 1 argument(s).",
+			expectedError: "requires exactly 1 argument.",
 			args:          []string{},
 		},
 		{

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -23,7 +23,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires exactly 1 argument(s).",
+			expectedError: "requires exactly 1 argument.",
 		},
 		{
 			name:          "invalid-name",

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -29,7 +29,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 	}{
 		{
 			name:          "wrong args",
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			name:          "ImageRemove fail",

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -26,7 +26,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		{
 			name:          "wrong args",
 			args:          []string{},
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			name:          "output to terminal",

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -15,7 +15,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 		{"image1"},
 		{"image1", "image2", "image3"},
 	}
-	expectedError := "\"tag\" requires exactly 2 argument(s)."
+	expectedError := "\"tag\" requires exactly 2 arguments."
 	for _, args := range testCases {
 		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -19,7 +19,7 @@ func TestNetworkConnectErrors(t *testing.T) {
 		expectedError      string
 	}{
 		{
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"toto", "titi"},

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -17,7 +17,7 @@ func TestNetworkDisconnectErrors(t *testing.T) {
 		expectedError         string
 	}{
 		{
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"toto", "titi"},

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -27,10 +27,10 @@ func TestSecretCreateErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{"too_few"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{args: []string{"too", "many", "arguments"},
-			expectedError: "requires exactly 2 argument(s)",
+			expectedError: "requires exactly 2 arguments",
 		},
 		{
 			args: []string{"name", filepath.Join("testdata", secretDataFile)},

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -20,7 +20,7 @@ func TestSecretRemoveErrors(t *testing.T) {
 	}{
 		{
 			args:          []string{},
-			expectedError: "requires at least 1 argument(s).",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			args: []string{"foo"},

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -21,7 +21,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 		{
 			name:          "too-many-args",
 			args:          []string{"foo"},
-			expectedError: "accepts no argument(s)",
+			expectedError: "accepts no arguments",
 		},
 		{
 			name: "leave-failed",

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -29,7 +29,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 		{
 			name:          "too-many-args",
 			args:          []string{"foo"},
-			expectedError: "accepts no argument(s)",
+			expectedError: "accepts no arguments",
 		},
 		{
 			name: "swarm-inspect-rotate-failed",

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -25,7 +25,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 		{
 			name:          "too-many-args",
 			args:          []string{"foo"},
-			expectedError: "accepts no argument(s)",
+			expectedError: "accepts no arguments",
 		},
 		{
 			name: "is-not-part-of-a-swarm",

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -30,7 +30,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 		{
 			name:          "too-many-args",
 			args:          []string{"foo"},
-			expectedError: "accepts no argument(s)",
+			expectedError: "accepts no arguments",
 		},
 		{
 			name: "swarm-inspect-error",

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -31,7 +31,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 		},
 		{
 			args:          []string{"too", "many"},
-			expectedError: "requires at most 1 argument(s)",
+			expectedError: "requires at most 1 argument",
 		},
 		{
 			volumeCreateFunc: func(createBody volumetypes.VolumesCreateBody) (types.Volume, error) {

--- a/cli/required.go
+++ b/cli/required.go
@@ -18,7 +18,7 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	return errors.Errorf(
-		"\"%s\" accepts no argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+		"%q accepts no arguments.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 		cmd.CommandPath(),
 		cmd.CommandPath(),
 		cmd.UseLine(),
@@ -33,9 +33,10 @@ func RequiresMinArgs(min int) cobra.PositionalArgs {
 			return nil
 		}
 		return errors.Errorf(
-			"\"%s\" requires at least %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+			"%q requires at least %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			min,
+			pluralize("argument", min),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
@@ -50,9 +51,10 @@ func RequiresMaxArgs(max int) cobra.PositionalArgs {
 			return nil
 		}
 		return errors.Errorf(
-			"\"%s\" requires at most %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+			"%q requires at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			max,
+			pluralize("argument", max),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
@@ -67,10 +69,11 @@ func RequiresRangeArgs(min int, max int) cobra.PositionalArgs {
 			return nil
 		}
 		return errors.Errorf(
-			"\"%s\" requires at least %d and at most %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+			"%q requires at least %d and at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			min,
 			max,
+			pluralize("argument", max),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
@@ -85,12 +88,20 @@ func ExactArgs(number int) cobra.PositionalArgs {
 			return nil
 		}
 		return errors.Errorf(
-			"\"%s\" requires exactly %d argument(s).\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
+			"%q requires exactly %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
 			number,
+			pluralize("argument", number),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
 		)
 	}
+}
+
+func pluralize(word string, number int) string {
+	if number == 1 {
+		return word
+	}
+	return word + "s"
 }

--- a/cli/required_test.go
+++ b/cli/required_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiresNoArgs(t *testing.T) {
+	testCases := []testCase{
+		{
+			validateFunc:  NoArgs,
+			expectedError: "no error",
+		},
+		{
+			args:          []string{"foo"},
+			validateFunc:  NoArgs,
+			expectedError: "accepts no arguments.",
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+func TestRequiresMinArgs(t *testing.T) {
+	testCases := []testCase{
+		{
+			validateFunc:  RequiresMinArgs(0),
+			expectedError: "no error",
+		},
+		{
+			validateFunc:  RequiresMinArgs(1),
+			expectedError: "at least 1 argument.",
+		},
+		{
+			args:          []string{"foo"},
+			validateFunc:  RequiresMinArgs(2),
+			expectedError: "at least 2 arguments.",
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+func TestRequiresMaxArgs(t *testing.T) {
+	testCases := []testCase{
+		{
+			validateFunc:  RequiresMaxArgs(0),
+			expectedError: "no error",
+		},
+		{
+			args:          []string{"foo", "bar"},
+			validateFunc:  RequiresMaxArgs(1),
+			expectedError: "at most 1 argument.",
+		},
+		{
+			args:          []string{"foo", "bar", "baz"},
+			validateFunc:  RequiresMaxArgs(2),
+			expectedError: "at most 2 arguments.",
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+func TestRequiresRangeArgs(t *testing.T) {
+	testCases := []testCase{
+		{
+			validateFunc:  RequiresRangeArgs(0, 0),
+			expectedError: "no error",
+		},
+		{
+			validateFunc:  RequiresRangeArgs(0, 1),
+			expectedError: "no error",
+		},
+		{
+			args:          []string{"foo", "bar"},
+			validateFunc:  RequiresRangeArgs(0, 1),
+			expectedError: "at most 1 argument.",
+		},
+		{
+			args:          []string{"foo", "bar", "baz"},
+			validateFunc:  RequiresRangeArgs(0, 2),
+			expectedError: "at most 2 arguments.",
+		},
+		{
+			validateFunc:  RequiresRangeArgs(1, 2),
+			expectedError: "at least 1 ",
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+func TestExactArgs(t *testing.T) {
+	testCases := []testCase{
+		{
+			validateFunc:  ExactArgs(0),
+			expectedError: "no error",
+		},
+		{
+			validateFunc:  ExactArgs(1),
+			expectedError: "exactly 1 argument.",
+		},
+		{
+			validateFunc:  ExactArgs(2),
+			expectedError: "exactly 2 arguments.",
+		},
+	}
+	runTestCases(t, testCases)
+}
+
+type testCase struct {
+	args          []string
+	validateFunc  cobra.PositionalArgs
+	expectedError string
+}
+
+func runTestCases(t *testing.T, testCases []testCase) {
+	for _, tc := range testCases {
+		cmd := newDummyCommand(tc.validateFunc)
+		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
+
+		err := cmd.Execute()
+
+		require.Error(t, err, "Expected an error: %s", tc.expectedError)
+		assert.Contains(t, err.Error(), tc.expectedError)
+	}
+}
+
+func newDummyCommand(validationFunc cobra.PositionalArgs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "dummy",
+		Args: validationFunc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("no error")
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Found some note I made following https://github.com/moby/moby/pull/23241#r65784758, so made this change :smile:

The validation functions to test for the number of passed arguments did not pluralize `argument(s)`, and used `argument(s)` in all cases.

**- What I did**

This patch adds a simple `pluralize()` helper to improve this.

Before this change, `argument(s)` was used in all cases:

```bash
$ docker container ls foobar
"docker container ls" accepts no argument(s).

$ docker network create one two
"docker network create" requires exactly 1 argument(s).

$ docker network connect
"docker network connect" requires exactly 2 argument(s).

$ docker volume create one two
"docker volume create" requires at most 1 argument(s).
```


After this change, `argument(s)` is properly singularized or plurarized:

```bash
$ docker container ls foobar
"docker container ls" accepts no arguments.

$ docker network create one two
"docker network create" requires exactly 1 argument.

$ docker network connect
"docker network connect" requires exactly 2 arguments.

$ docker volume create one two
"docker volume create" requires at most 1 argument.
```

Test cases were updated accordingly.

**- Description for the changelog**

    Improved error messages for number of arguments passed to commands.

**- A picture of a cute animal (not mandatory but encouraged)**
![8850638-guinea-pig-hd](https://user-images.githubusercontent.com/1804568/29242373-736bb620-7f8c-11e7-8253-4baa70948c6c.jpg)


(image: http://www.milles.nl/author/admin/page/2/)