### PR TITLE
Print timestamp when --human=true

### DIFF
--- a/cli/command/formatter/history.go
+++ b/cli/command/formatter/history.go
@@ -79,10 +79,13 @@ func (c *historyContext) ID() string {
 }
 
 func (c *historyContext) CreatedAt() string {
-	return units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
+	return time.Unix(c.h.Created, 0).Format(time.RFC3339)
 }
 
 func (c *historyContext) CreatedSince() string {
+	if !c.human {
+		return c.CreatedAt()
+	}
 	created := units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
 	return created + " ago"
 }

--- a/cli/command/formatter/history_test.go
+++ b/cli/command/formatter/history_test.go
@@ -51,17 +51,21 @@ func TestHistoryContext_ID(t *testing.T) {
 }
 
 func TestHistoryContext_CreatedSince(t *testing.T) {
-	unixTime := time.Now().AddDate(0, 0, -7).Unix()
-	expected := "7 days ago"
-
 	var ctx historyContext
 	cases := []historyCase{
 		{
 			historyContext{
-				h:     image.HistoryResponseItem{Created: unixTime},
+				h:     image.HistoryResponseItem{Created: time.Now().AddDate(0, 0, -7).Unix()},
 				trunc: false,
 				human: true,
-			}, expected, ctx.CreatedSince,
+			}, "7 days ago", ctx.CreatedSince,
+		},
+		{
+			historyContext{
+				h:     image.HistoryResponseItem{Created: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()},
+				trunc: false,
+				human: false,
+			}, "2009-11-10T23:00:00Z", ctx.CreatedSince,
 		},
 	}
 


### PR DESCRIPTION
This PR closes #437

**- What I did**

* Setting `--human=true` changes `CreatedSince` format
* `CreatedAt` now displays the creation timestamp as specified in the documents

**- How I did it**

* Updated `historyContext.CreatedSince` and `historyContext.CreatedAt` in `cli/command/formatter/history.go`
* Added a test-case to `cli/command/formatter/history_test.go`

**- How to verify it**

Run unit tests

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

