### PR TITLE
Show images digests when "{{.Digest}}" is in format

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -79,6 +79,11 @@ func ImageWrite(ctx ImageContext, images []types.ImageSummary) error {
 	return ctx.Write(newImageContext(), render)
 }
 
+// needDigest determines whether the image digest should be ignored or not when writing image context
+func needDigest(ctx ImageContext) bool {
+	return ctx.Digest || ctx.Format.Contains("{{.Digest}}")
+}
+
 func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subContext subContext) error) error {
 	for _, image := range images {
 		images := []*imageContext{}
@@ -121,7 +126,7 @@ func imageFormat(ctx ImageContext, images []types.ImageSummary, format func(subC
 				// Do not display digests as their own row
 				delete(repoDigests, repo)
 
-				if !ctx.Digest {
+				if !needDigest(ctx) {
 					// Ignore digest references, just show tag once
 					digests = nil
 				}

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -140,6 +140,14 @@ image               <none>
 		{
 			ImageContext{
 				Context: Context{
+					Format: NewImageFormat("table {{.Digest}}", true, false),
+				},
+			},
+			"DIGEST\nsha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf\n<none>\n<none>\n",
+		},
+		{
+			ImageContext{
+				Context: Context{
 					Format: NewImageFormat("table", true, false),
 				},
 			},


### PR DESCRIPTION

**- What I did**

This patch fixes the following bug #435:

Running "docker image ls --digests" will add images digests
to the image table. However, when using "format" to display
images digests all of them are "<none>".


**- How I did it**

In `cli/command/formatter/image.go` if either `--digests` is `true` or `{{.Digest}}` is in `--format` then display the image digest. Otherwise, set it to `nil`.

**- How to verify it**

Run unit-tests

**- Description for the changelog**
Fix #435 

**- A picture of a cute animal (not mandatory but encouraged)**

