### PR TITLE
Ignore codecov upload failures in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -71,7 +71,8 @@ jobs:
                 test-$CIRCLE_BUILD_NUM:/go/src/github.com/docker/cli/coverage.txt \
                 coverage.txt
             apk add -U bash curl
-            curl -s https://codecov.io/bash | bash
+            curl -s https://codecov.io/bash | bash || \
+                echo 'Codecov failed to upload'
 
   validate:
     working_directory: /work


### PR DESCRIPTION
Codecov report upload has been failing for a couple days now.

According to the https://docs.codecov.io/v4.3.6/docs/about-the-codecov-bash-uploader#section-uploading-process it's recommended that we ignore the failure. 