### PR TITLE
Don't sleep in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,10 @@ cli/compose/schema/bindata.go: cli/compose/schema/data/*.json
 
 compose-jsonschema: cli/compose/schema/bindata.go
 	scripts/validate/check-git-diff cli/compose/schema/bindata.go
+
+.PHONY: ci-validate
+ci-validate:
+	time make -B vendor
+	time make -B compose-jsonschema
+	time make manpages
+	time make yamldocs

--- a/circle.yml
+++ b/circle.yml
@@ -90,7 +90,7 @@ jobs:
             rm -f .dockerignore # include .git
             docker build -f $dockerfile --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
             docker run --rm cli-builder-with-git:$CIRCLE_BUILD_NUM \
-                make -B vendor compose-jsonschema manpages yamldocs
+                make ci-validate
   shellcheck:
     working_directory: /work
     docker: [{image: 'docker:17.06-git'}]
@@ -104,7 +104,7 @@ jobs:
             echo "COPY . ." >> $dockerfile
             docker build -f $dockerfile --tag cli-validator:$CIRCLE_BUILD_NUM .
             docker run --rm cli-validator:$CIRCLE_BUILD_NUM \
-                make -B shellcheck
+                make shellcheck
 workflows:
   version: 2
   ci:

--- a/circle.yml
+++ b/circle.yml
@@ -71,7 +71,8 @@ jobs:
                 test-$CIRCLE_BUILD_NUM:/go/src/github.com/docker/cli/coverage.txt \
                 coverage.txt
             apk add -U bash curl
-            curl -s https://codecov.io/bash | bash
+            curl -s https://codecov.io/bash | bash || \
+                echo 'Codecov failed to upload'
 
   validate:
     working_directory: /work

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,7 +10,7 @@ CROSS_IMAGE_NAME = docker-cli-cross
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate
 MOUNTS = -v "$(CURDIR)":/go/src/github.com/docker/cli
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e DISABLE_WARN_OUTSIDE_CONTAINER=1
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,2 +1,3 @@
 FROM    dockercore/golang-cross@sha256:d24e7affa3a85d460d2303c2549f03fc866f2b97d771ccf07b0e6e2b411dd207
+ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -25,6 +25,7 @@ RUN     go get -d github.com/dnephin/filewatcher && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
 ENV     CGO_ENABLED=0 \
-        PATH=$PATH:/go/src/github.com/docker/cli/build
+        PATH=$PATH:/go/src/github.com/docker/cli/build \
+        DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 CMD     sh

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -12,5 +12,6 @@ RUN     go get -d github.com/alecthomas/gometalinter && \
 
 WORKDIR /go/src/github.com/docker/cli
 ENV     CGO_ENABLED=0
+ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
 CMD     ["--config=gometalinter.json", "./..."]

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,9 +1,9 @@
-FROM debian:stretch-slim
+FROM    debian:stretch-slim
 
-RUN apt-get update && \
-    apt-get -y install make shellcheck && \
-    apt-get clean
+RUN     apt-get update && \
+        apt-get -y install make shellcheck && \
+        apt-get clean
 
 WORKDIR /go/src/github.com/docker/cli
-
-CMD bash
+ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
+CMD     bash


### PR DESCRIPTION
Set  DISABLE_WARN_OUTSIDE_CONTAINER so we don't sleep

Now that `validate` is the slowest build, add `time` to each step so we can see what's taking longer. I think using `dep` will speed this up a lot because it uses a cache, and circle-ci supports saving a cache between builds. 


