### PR TITLE
Fix "liquid" warning on logging plugins page

### DIFF
--- a/docs/extend/plugins_logging.md
+++ b/docs/extend/plugins_logging.md
@@ -213,7 +213,7 @@ to determine what set of logs to read.
 
 **Response**:
 ```
-{{ log stream }}
+{% raw %}{{ log stream }}{% endraw %}
 ```
 
 The response should be the encoded log message using the same format as the


### PR DESCRIPTION
Noticed this warning in the documentation CI:

    Liquid Warning: Liquid syntax error (line 210): Expected end_of_string but found id in "{{ log stream }}" in engine/extend/plugins_logging.md


ping @vdemeester @mstanleyjones PTAL
