### PR TITLE
push multiple docker images with `docker push`

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -39,7 +39,7 @@ func pushImages(dockerCli command.Cli, args []string) error {
 	ctx := context.Background()
 
 	for _, remote := range args {
-		if err := runPush(dockerCli, remote, ctx); err != nil {
+		if err := runPush(ctx, dockerCli, remote); err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}
@@ -54,7 +54,7 @@ func pushImages(dockerCli command.Cli, args []string) error {
 	return nil
 }
 
-func runPush(dockerCli command.Cli, remote string, ctx context.Context) error {
+func runPush(ctx context.Context, dockerCli command.Cli, remote string) error {
 
 	ref, err := reference.ParseNormalizedNamed(remote)
 	if err != nil {

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -36,8 +36,10 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 func pushImages(dockerCli command.Cli, args []string) error {
 	var errs []string
 
+	ctx := context.Background()
+
 	for _, remote := range args {
-		if err := runPush(dockerCli, remote); err != nil {
+		if err := runPush(dockerCli, remote, ctx); err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}
@@ -52,7 +54,7 @@ func pushImages(dockerCli command.Cli, args []string) error {
 	return nil
 }
 
-func runPush(dockerCli command.Cli, remote string) error {
+func runPush(dockerCli command.Cli, remote string, ctx context.Context) error {
 
 	ref, err := reference.ParseNormalizedNamed(remote)
 	if err != nil {
@@ -64,8 +66,6 @@ func runPush(dockerCli command.Cli, remote string) error {
 	if err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	// Resolve the Auth config relevant for this server
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -11,9 +11,8 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
-	"github.com/spf13/cobra"
 	"github.com/pkg/errors"
-
+	"github.com/spf13/cobra"
 )
 
 // NewPushCommand creates a new `docker push` command
@@ -23,7 +22,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Push an image or a repository to a registry",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-				return pushImages(dockerCli, args)
+			return pushImages(dockerCli, args)
 		},
 	}
 

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -23,7 +23,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires exactly 1 argument.",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			name:          "invalid-name",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed `docker push` to be able to push multiple images.

feature request for: https://github.com/docker/cli/issues/267

**- How I did it**
I created a new function that looped runPush with the variable arguments passed into `docker push`. Changed `ExactArgs` to `RequireMinArgs` to support multiple images.

**- How to verify it**
You can run something like:
```
docker push glyif/valid_image:latest glyif/invalid_image:latest glyif/another_valid_image:latest
```

It will push the 2 valid images and return the error that glyif/invlid_image was unable to be pushed.

**- Description for the changelog**
ability to push multiple docker images with `docker push`


**- A picture of a cute animal (not mandatory but encouraged)**
My dogs again :)

![20170813_161337](https://user-images.githubusercontent.com/25441110/29482721-cddc3fa8-844b-11e7-8a33-4c5e12c84c1a.jpg)


