### PR TITLE
Dropped hyphen in bind mount where appropriate

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -135,19 +135,19 @@ func TestParseRunVolumes(t *testing.T) {
 		t.Fatalf("Error parsing volume flags, %s is missing from volumes. Received %v", arr[1], config.Volumes)
 	}
 
-	// A single bind-mount
+	// A single bind mount
 	arr, tryit = setupPlatformVolume([]string{`/hostTmp:/containerTmp`}, []string{os.Getenv("TEMP") + `:c:\containerTmp`})
 	if config, hostConfig := mustParse(t, tryit); hostConfig.Binds == nil || hostConfig.Binds[0] != arr[0] {
 		t.Fatalf("Error parsing volume flags, %q should mount-bind the path before the colon into the path after the colon. Received %v %v", arr[0], hostConfig.Binds, config.Volumes)
 	}
 
-	// Two bind-mounts.
+	// Two bind mounts.
 	arr, tryit = setupPlatformVolume([]string{`/hostTmp:/containerTmp`, `/hostVar:/containerVar`}, []string{os.Getenv("ProgramData") + `:c:\ContainerPD`, os.Getenv("TEMP") + `:c:\containerTmp`})
 	if _, hostConfig := mustParse(t, tryit); hostConfig.Binds == nil || compareRandomizedStrings(hostConfig.Binds[0], hostConfig.Binds[1], arr[0], arr[1]) != nil {
 		t.Fatalf("Error parsing volume flags, `%s and %s` did not mount-bind correctly. Received %v", arr[0], arr[1], hostConfig.Binds)
 	}
 
-	// Two bind-mounts, first read-only, second read-write.
+	// Two bind mounts, first read-only, second read-write.
 	// TODO Windows: The Windows version uses read-write as that's the only mode it supports. Can change this post TP4
 	arr, tryit = setupPlatformVolume(
 		[]string{`/hostTmp:/containerTmp:ro`, `/hostVar:/containerVar:rw`},

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -302,7 +302,7 @@ Contents of file
 ```
 
 The following examples will fail when using Windows-based containers, as the
-destination of a volume or bind-mount inside the container must be one of:
+destination of a volume or bind mount inside the container must be one of:
 a non-existing or empty directory; or a drive other than C:. Further, the source
 of a bind mount must be a local directory, not a file.
 
@@ -318,7 +318,7 @@ docker run -v c:\foo:c:\existing-directory-with-contents ...
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/engine/tutorials/dockervolumes/)
 
 
-### Add bind-mounts or volumes using the --mount flag
+### Add bind mounts or volumes using the --mount flag
 
 The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
 mounts in a container.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -243,19 +243,19 @@ $ docker service create \
 For more information about labels, refer to [apply custom
 metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
 
-### Add bind-mounts, volumes or memory filesystems
+### Add bind mounts, volumes or memory filesystems
 
 Docker supports three different kinds of mounts, which allow containers to read
 from or write to files or directories, either on the host operating system, or
 on memory filesystems. These types are _data volumes_ (often referred to simply
-as volumes), _bind-mounts_, and _tmpfs_.
+as volumes), _bind mounts_, and _tmpfs_.
 
-A **bind-mount** makes a file or directory on the host available to the
-container it is mounted within. A bind-mount may be either read-only or
+A **bind mount** makes a file or directory on the host available to the
+container it is mounted within. A bind mount may be either read-only or
 read-write. For example, a container might share its host's DNS information by
-means of a bind-mount of the host's `/etc/resolv.conf` or a container might
+means of a bind mount of the host's `/etc/resolv.conf` or a container might
 write logs to its host's `/var/log/myContainerLogs` directory. If you use
-bind-mounts and your host and containers have different notions of permissions,
+bind mounts and your host and containers have different notions of permissions,
 access controls, or other such details, you will run into portability issues.
 
 A **named volume** is a mechanism for decoupling persistent data needed by your
@@ -279,7 +279,7 @@ update the named volume.
 For more information about named volumes, see
 [Data Volumes](https://docs.docker.com/engine/tutorials/dockervolumes/).
 
-The following table describes options which apply to both bind-mounts and named
+The following table describes options which apply to both bind mounts and named
 volumes in a service:
 
 <table>
@@ -328,7 +328,7 @@ volumes in a service:
     <td>
       <p>Mount path inside the container, for example <tt>/some/path/in/container/</tt>.
       If the path does not exist in the container's filesystem, the Engine creates
-      a directory at the specified location before mounting the volume or bind-mount.</p>
+      a directory at the specified location before mounting the volume or bind mount.</p>
     </td>
   </tr>
   <tr>
@@ -362,15 +362,15 @@ volumes in a service:
 #### Bind Propagation
 
 Bind propagation refers to whether or not mounts created within a given
-bind-mount or named volume can be propagated to replicas of that mount. Consider
+bind mount or named volume can be propagated to replicas of that mount. Consider
 a mount point `/mnt`, which is also mounted on `/tmp`. The propation settings
 control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
 propagation setting has a recursive counterpoint. In the case of recursion,
 consider that `/tmp/a` is also mounted as `/foo`. The propagation settings
 control whether `/mnt/a` and/or `/tmp/a` would exist.
 
-The `bind-propagation` option defaults to `rprivate` for both bind-mounts and
-volume mounts, and is only configurable for bind-mounts. In other words, named
+The `bind-propagation` option defaults to `rprivate` for both bind mounts and
+volume mounts, and is only configurable for bind mounts. In other words, named
 volumes do not support bind propagation.
 
 - **`shared`**: Sub-mounts of the original mount are exposed to replica mounts,

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -136,7 +136,7 @@ that the rolling restart happens gradually.
 
 ### Add or remove mounts
 
-Use the `--mount-add` or `--mount-rm` options add or remove a service's bind-mounts
+Use the `--mount-add` or `--mount-rm` options add or remove a service's bind mounts
 or volumes.
 
 The following example creates a service which mounts the `test-data` volume to
@@ -147,7 +147,7 @@ service name.
 
 - The `--mount-add` flag takes the same parameters as the `--mount` flag on
   `service create`. Refer to the [volumes and
-  bind-mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
+  bind mounts](service_create.md#volumes-and-bind-mounts-mount) section in the
   `service create` reference for details.
 
 - The `--mount-rm` flag takes the `target` path of the mount.

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1577,7 +1577,7 @@ followed by `a-z0-9`, `_` (underscore), `.` (period) or `-` (hyphen).
 An absolute path starts with a `/` (forward slash).
 
 For example, you can specify either `/foo` or `foo` for a `host-src` value.
-If you supply the `/foo` value, Docker creates a bind-mount. If you supply
+If you supply the `/foo` value, Docker creates a bind mount. If you supply
 the `foo` specification, Docker creates a named volume.
 
 ### USER

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -671,14 +671,14 @@ alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or
 If you supply a `HOST-DIR` that is an absolute path,  Docker bind-mounts to the
 path you specify. If you supply a `name`, Docker creates a named volume by that
 `name`. For example, you can specify either `/foo` or `foo` for a `HOST-DIR`
-value. If you supply the `/foo` value, Docker creates a bind-mount. If you
+value. If you supply the `/foo` value, Docker creates a bind mount. If you
 supply the `foo` specification, Docker creates a named volume.
 
 You can specify multiple  **-v** options to mount one or more mounts to a
 container. To use these same mounts in other containers, specify the
 **--volumes-from** option also.
 
-You can supply additional options for each bind-mount following an additional
+You can supply additional options for each bind mount following an additional
 colon.  A `:ro` or `:rw` suffix mounts a volume in read-only or read-write
 mode, respectively. By default, volumes are mounted in read-write mode.
 You can also specify the consistency requirement for the mount, either

--- a/man/src/container/create.md
+++ b/man/src/container/create.md
@@ -16,14 +16,14 @@ alphanumeric character, followed by `a-z0-9`, `_` (underscore), `.` (period) or
 If you supply a `HOST-DIR` that is an absolute path,  Docker bind-mounts to the
 path you specify. If you supply a `name`, Docker creates a named volume by that
 `name`. For example, you can specify either `/foo` or `foo` for a `HOST-DIR`
-value. If you supply the `/foo` value, Docker creates a bind-mount. If you
+value. If you supply the `/foo` value, Docker creates a bind mount. If you
 supply the `foo` specification, Docker creates a named volume.
 
 You can specify multiple  **-v** options to mount one or more mounts to a
 container. To use these same mounts in other containers, specify the
 **--volumes-from** option also.
 
-You can supply additional options for each bind-mount following an additional
+You can supply additional options for each bind mount following an additional
 colon.  A `:ro` or `:rw` suffix mounts a volume in read-only or read-write
 mode, respectively. By default, volumes are mounted in read-write mode.  
 You can also specify the consistency requirement for the mount, either


### PR DESCRIPTION
Signed-off-by: Christophe Vidal <kriss@krizalys.com>

**- What I did**

Dropped the hyphen in `bind mount` where appropriate (when **not** used as an option, a verb, a past participate, in a dependency repository, etc...).

This was suggested previously by @mstanleyjones in https://github.com/docker/cli/pull/446.

Related to https://github.com/moby/moby/pull/34572.

