### PR TITLE
Remove bash completion for `stack ps --all|-a`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4407,7 +4407,7 @@ _docker_stack_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--filter|-f')


### PR DESCRIPTION
This option was removed in https://github.com/moby/moby/pull/28885 due to shared code.
Bash completion was only updated for `service ps`, in that PR, though.

See https://github.com/moby/moby/pull/29716 for the corresponding docs change.