### PR TITLE
Add --init option to `docker service create`

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -85,6 +85,9 @@ ContainerSpec:
 {{- if .ContainerWorkDir }}
  Dir:		{{ .ContainerWorkDir }}
 {{- end -}}
+{{- if .HasContainerInit }}
+ Init:		{{ .ContainerInit }}
+{{- end -}}
 {{- if .ContainerUser }}
  User: {{ .ContainerUser }}
 {{- end }}
@@ -370,6 +373,14 @@ func (ctx *serviceInspectContext) ContainerWorkDir() string {
 
 func (ctx *serviceInspectContext) ContainerUser() string {
 	return ctx.Service.Spec.TaskTemplate.ContainerSpec.User
+}
+
+func (ctx *serviceInspectContext) HasContainerInit() bool {
+	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Init != nil
+}
+
+func (ctx *serviceInspectContext) ContainerInit() bool {
+	return *ctx.Service.Spec.TaskTemplate.ContainerSpec.Init
 }
 
 func (ctx *serviceInspectContext) ContainerMounts() []mounttypes.Mount {

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -58,6 +58,8 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagDNSSearch, "version", []string{"1.25"})
 	flags.Var(&opts.hosts, flagHost, "Set one or more custom host-to-IP mappings (host:ip)")
 	flags.SetAnnotation(flagHost, "version", []string{"1.25"})
+	flags.BoolVar(&opts.init, flagInit, false, "Use an init inside each service container to forward signals and reap processes")
+	flags.SetAnnotation(flagInit, "version", []string{"1.37"})
 
 	flags.Var(cliopts.NewListOptsRef(&opts.resources.resGenericResources, ValidateSingleGenericResource), "generic-resource", "User defined resources")
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.32"})

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -480,6 +480,7 @@ type serviceOptions struct {
 	user            string
 	groups          opts.ListOpts
 	credentialSpec  credentialSpecOpt
+	init            bool
 	stopSignal      string
 	tty             bool
 	readOnly        bool
@@ -624,6 +625,7 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				TTY:        options.tty,
 				ReadOnly:   options.readOnly,
 				Mounts:     options.mounts.Value(),
+				Init:       &options.init,
 				DNSConfig: &swarm.DNSConfig{
 					Nameservers: options.dns.GetAll(),
 					Search:      options.dnsSearch.GetAll(),
@@ -875,6 +877,7 @@ const (
 	flagRollbackMonitor         = "rollback-monitor"
 	flagRollbackOrder           = "rollback-order"
 	flagRollbackParallelism     = "rollback-parallelism"
+	flagInit                    = "init"
 	flagStopGracePeriod         = "stop-grace-period"
 	flagStopSignal              = "stop-signal"
 	flagTTY                     = "tty"

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -547,6 +547,32 @@ func TestUpdateReadOnly(t *testing.T) {
 	assert.Check(t, !cspec.ReadOnly)
 }
 
+func TestUpdateInit(t *testing.T) {
+	spec := &swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{},
+		},
+	}
+	cspec := spec.TaskTemplate.ContainerSpec
+
+	// Update with --init=true
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("init", "true")
+	updateService(nil, nil, flags, spec)
+	assert.Check(t, is.Equal(true, *cspec.Init))
+
+	// Update without --init, no change
+	flags = newUpdateCommand(nil).Flags()
+	updateService(nil, nil, flags, spec)
+	assert.Check(t, is.Equal(true, *cspec.Init))
+
+	// Update with --init=false
+	flags = newUpdateCommand(nil).Flags()
+	flags.Set("init", "false")
+	updateService(nil, nil, flags, spec)
+	assert.Check(t, is.Equal(false, *cspec.Init))
+}
+
 func TestUpdateStopSignal(t *testing.T) {
 	spec := &swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -43,6 +43,7 @@ Options:
       --help                               Print usage
       --host list                          Set one or more custom host-to-IP mappings (host:ip)
       --hostname string                    Container hostname
+      --init bool                          Use an init inside each service container to forward signals and reap processes
       --isolation string                   Service container isolation mode
   -l, --label list                         Service labels
       --limit-cpu decimal                  Limit CPUs

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -54,6 +54,7 @@ Options:
       --host-add list                      Add a custom host-to-IP mapping (host:ip)
       --host-rm list                       Remove a custom host-to-IP mapping (host:ip)
       --hostname string                    Container hostname
+      --init bool                          Use an init inside each service container to forward signals and reap processes
       --image string                       Service image tag
       --isolation string                   Service container isolation mode
       --label-add list                     Add or update a service label


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Helps https://github.com/docker/cli/issues/51, but requires more work to add stack/compose v3 file support.
See https://github.com/docker/swarmkit/pull/2350, and https://github.com/moby/moby/issues/34529. We've got it all set in swarmkit, this should finish the CLI, and we're waiting on the final pieces in moby.

**- What I did**
Added a `--init` option to `docker service create`
**- How I did it**
Added an options string (`flagInit`), the swarm api field in `opts.ToService()`, and a boolean flag in `newCreateCommand()`

I also changed a line in the vendor code to add the `Init` option to the swarm container api. I understand I'm not supposed to do this, but I'll wait till they get a PR into moby/moby, and then do the vendoring properly.

**- How to verify it**
Run the tests for the `service` subcommand. Since the daemon doesn't support `init` for swarm yet, it won't actually do anything.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add --init option to `docker service create`

Waiting for the following PR to get merged
- [x] https://github.com/docker/swarmkit/pull/2652
- [x] https://github.com/moby/moby/pull/36895
- [x] https://github.com/moby/moby/pull/37183
- [x] https://github.com/docker/cli/pull/1116