### PR TITLE
Add 'build' to types.go

### DIFF
--- a/cli/compose/loader/full-example.yml
+++ b/cli/compose/loader/full-example.yml
@@ -2,6 +2,21 @@ version: "3.4"
 
 services:
   foo:
+
+    build:
+      context: ./dir
+      dockerfile: Dockerfile
+      args:
+        foo: bar
+      target: foo
+      network: foo
+      cache_from: 
+        - foo
+        - bar
+      labels: [FOO=BAR]
+
+
+    
     cap_add:
       - ALL
 

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -517,12 +517,14 @@ version: "3"
 services:
   web:
     image: web
-    build: ./web
+    build: 
+     context: ./web
     links:
       - bar
   db:
     image: db
-    build: ./db
+    build: 
+     context: ./db
 `))
 	assert.NoError(t, err)
 
@@ -686,6 +688,15 @@ func TestFullExample(t *testing.T) {
 	expectedServiceConfig := types.ServiceConfig{
 		Name: "foo",
 
+		Build: types.BuildConfig{
+			Context:    "./dir",
+			Dockerfile: "Dockerfile",
+			Args:       map[string]*string{"foo": strPtr("bar")},
+			Target:     "foo",
+			Network:    "foo",
+			CacheFrom:  []string{"foo", "bar"},
+			Labels:     map[string]string{"FOO": "BAR"},
+		},
 		CapAdd:        []string{"ALL"},
 		CapDrop:       []string{"NET_ADMIN", "SYS_ADMIN"},
 		CgroupParent:  "m-executor-abcd",

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -78,6 +78,7 @@ type Config struct {
 type ServiceConfig struct {
 	Name string
 
+	Build           BuildConfig
 	CapAdd          []string `mapstructure:"cap_add"`
 	CapDrop         []string `mapstructure:"cap_drop"`
 	CgroupParent    string   `mapstructure:"cgroup_parent"`
@@ -123,6 +124,18 @@ type ServiceConfig struct {
 	User            string
 	Volumes         []ServiceVolumeConfig
 	WorkingDir      string `mapstructure:"working_dir"`
+}
+
+// BuildConfig is a type for build
+// using the same format at libcompose: https://github.com/docker/libcompose/blob/master/yaml/build.go#L12
+type BuildConfig struct {
+	Context    string
+	Dockerfile string
+	Args       MappingWithEquals
+	Labels     Labels
+	CacheFrom  StringList `mapstructure:"cache_from"`
+	Network    string
+	Target     string
 }
 
 // ShellCommand is a string or list of string args


### PR DESCRIPTION
This adds 'build' to types.go in order for projects that use docker/cli
to parse Docker Compose files to correctly retrieve `build` keys.