### PR TITLE
Add ulimits to unsupported compose fields

### DIFF
--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -23,6 +23,7 @@ var UnsupportedProperties = []string{
 	"shm_size",
 	"sysctls",
 	"tmpfs",
+	"ulimits",
 	"userns_mode",
 }
 


### PR DESCRIPTION
Fixes https://github.com/docker/for-linux/issues/88