### PR TITLE
When nothing found in stack exit with exit code 1

### DIFF
--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -57,8 +57,7 @@ func runPS(dockerCli command.Cli, options psOptions) error {
 	}
 
 	if len(tasks) == 0 {
-		fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", namespace)
-		return nil
+		return fmt.Errorf("nothing found in stack: %s", namespace)
 	}
 
 	format := options.format

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -60,9 +60,9 @@ func TestStackPsEmptyStack(t *testing.T) {
 	cmd := newPsCommand(fakeCli)
 	cmd.SetArgs([]string{"foo"})
 
-	assert.NoError(t, cmd.Execute())
+	assert.Error(t, cmd.Execute())
+	assert.EqualError(t, cmd.Execute(), "nothing found in stack: foo")
 	assert.Equal(t, "", fakeCli.OutBuffer().String())
-	assert.Equal(t, "Nothing found in stack: foo\n", fakeCli.ErrBuffer().String())
 }
 
 func TestStackPsWithQuietOption(t *testing.T) {


### PR DESCRIPTION
**- What I did**

close #478 

To keep on a consistent behaviour such as in docker-service-ps
if docker-stack-ps didn't find a given stack, the command line
should exit with exit code 1.

**- How I did it**

Instead of printing the error to `stdout`, return it.
This will automatically exit with error code 1.

**- How to verify it**

Run unit tests.

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

