### PR TITLE
Re-adds test target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ clean: ## remove build artifacts
 test-unit: ## run unit test
 	./scripts/test/unit $(shell go list ./... | grep -vE '/vendor/|/e2e/')
 
+.PHONY: test
+test: test-unit ## run tests
+
 .PHONY: test-coverage
 test-coverage: ## run test coverage
 	./scripts/test/unit-with-coverage $(shell go list ./... | grep -vE '/vendor/|/e2e/')

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -46,6 +46,9 @@ clean: build_docker_image
 test-unit: build_docker_image
 	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test-unit
 
+.PHONY: test
+test: test-unit test-e2e
+
 # build the CLI for multiple architectures using a container
 .PHONY: cross
 cross: build_cross_image


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The test target existed before, this is to provide a legacy interface to
allow easy testing for downstream Docker CE.

Without this we would need separate Makefiles/Jenkinsfiles for releases
past 17.07. Later on this target could also be used to test both unit
tests and integration tests at the same time.

**- How I did it**
Re-added the target, it's basically an alias now.

**- How to verify it**
* `make test`
* `make -f docker.Makefile test`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Re-added `test` target to the Makefile and docker.Makefile

**- A picture of a cute animal (not mandatory but encouraged)**
![Are you not entertained](http://cdn77.sadanduseless.com/wp-content/uploads/2014/05/bird-with-arms21.jpg)
