### PR TITLE
Move output of stack rm to stdout

### DIFF
--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -103,7 +103,7 @@ func removeServices(
 	var hasError bool
 	sort.Slice(services, sortServiceByName(services))
 	for _, service := range services {
-		fmt.Fprintf(dockerCli.Err(), "Removing service %s\n", service.Spec.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing service %s\n", service.Spec.Name)
 		if err := dockerCli.Client().ServiceRemove(ctx, service.ID); err != nil {
 			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove service %s: %s", service.ID, err)
@@ -119,7 +119,7 @@ func removeNetworks(
 ) bool {
 	var hasError bool
 	for _, network := range networks {
-		fmt.Fprintf(dockerCli.Err(), "Removing network %s\n", network.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing network %s\n", network.Name)
 		if err := dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
 			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
@@ -135,7 +135,7 @@ func removeSecrets(
 ) bool {
 	var hasError bool
 	for _, secret := range secrets {
-		fmt.Fprintf(dockerCli.Err(), "Removing secret %s\n", secret.Spec.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing secret %s\n", secret.Spec.Name)
 		if err := dockerCli.Client().SecretRemove(ctx, secret.ID); err != nil {
 			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove secret %s: %s", secret.ID, err)
@@ -151,7 +151,7 @@ func removeConfigs(
 ) bool {
 	var hasError bool
 	for _, config := range configs {
-		fmt.Fprintf(dockerCli.Err(), "Removing config %s\n", config.Spec.Name)
+		fmt.Fprintf(dockerCli.Out(), "Removing config %s\n", config.Spec.Name)
 		if err := dockerCli.Client().ConfigRemove(ctx, config.ID); err != nil {
 			hasError = true
 			fmt.Fprintf(dockerCli.Err(), "Failed to remove config %s: %s", config.ID, err)

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -101,7 +101,13 @@ func TestRemoveStackSkipEmpty(t *testing.T) {
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "", fakeCli.OutBuffer().String())
+	expectedList := []string{"Removing service bar_service1",
+		"Removing service bar_service2",
+		"Removing secret bar_secret1",
+		"Removing config bar_config1",
+		"Removing network bar_network1\n",
+	}
+	assert.Equal(t, strings.Join(expectedList, "\n"), fakeCli.OutBuffer().String())
 	assert.Contains(t, fakeCli.ErrBuffer().String(), "Nothing found in stack: foo\n")
 	assert.Equal(t, allServiceIDs, fakeClient.removedServices)
 	assert.Equal(t, allNetworkIDs, fakeClient.removedNetworks)

--- a/e2e/stack/remove_test.go
+++ b/e2e/stack/remove_test.go
@@ -19,8 +19,8 @@ func TestRemove(t *testing.T) {
 
 	result := icmd.RunCmd(shell(t, "docker stack rm %s", stackname))
 
-	result.Assert(t, icmd.Expected{Out: icmd.None})
-	golden.Assert(t, result.Stderr(), "stack-remove-success.golden")
+	result.Assert(t, icmd.Expected{Err: icmd.None})
+	golden.Assert(t, result.Stdout(), "stack-remove-success.golden")
 }
 
 func deployFullStack(t *testing.T, stackname string) {


### PR DESCRIPTION
**- What I did**
Updated the output of `docker stack rm` to be sent to stdout.

Fixes https://github.com/docker/cli/issues/490

**- How I did it**
`s/Err/Out`

**- How to verify it**
With no errors, doing `docker stack rm nginx 1>stdout.log 2>stderr.log` should show all output in `stdout`

**- Description for the changelog**
`docker stack rm` now sends info messages to Stdout


**- A picture of a cute animal (not mandatory but encouraged)**
![doge](https://media.giphy.com/media/oYmYj4FUVZPlS/giphy.gif)
