### PR TITLE
Add bash completion for `dockerd --network-control-plane-mtu`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2201,6 +2201,7 @@ _docker_daemon() {
 		--max-concurrent-uploads
 		--metrics-addr
 		--mtu
+		--network-control-plane-mtu
 		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror


### PR DESCRIPTION
This adds bash completion for https://github.com/moby/moby/pull/34103