### PR TITLE
Add bash completion for `search --format`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4287,14 +4287,14 @@ _docker_search() {
 			__docker_nospace
 			return
 			;;
-		--limit)
+		--format|--limit)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter --help --limit --no-trunc" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --format --help --limit --no-trunc" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This adds bash completion for #440.
Also adds support for missing short form `-f` for `--filter`.