### PR TITLE
Use golden files for tests that expect end-of-line whitespace

### DIFF
--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -230,10 +231,7 @@ size: 0B
 		// Special headers for customized table format
 		{
 			Context{Format: NewContainerFormat(`table {{truncate .ID 5}}\t{{json .Image}} {{.RunningFor}}/{{title .Status}}/{{pad .Ports 2 2}}.{{upper .Names}} {{lower .Status}}`, false, true)},
-			`CONTAINER ID        IMAGE CREATED/STATUS/  PORTS  .NAMES STATUS
-conta               "ubuntu" 24 hours ago//.FOOBAR_BAZ 
-conta               "ubuntu" 24 hours ago//.FOOBAR_BAR 
-`,
+			string(golden.Get(t, "container-context-write-special-headers.golden")),
 		},
 	}
 

--- a/cli/command/formatter/disk_usage_test.go
+++ b/cli/command/formatter/disk_usage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -83,12 +84,7 @@ Build Cache                                                 0B                  
 					Format: NewDiskUsageFormat("table {{.Type}}\t{{.Active}}"),
 				},
 			},
-			`TYPE                ACTIVE
-Images              0
-Containers          0
-Local Volumes       0
-Build Cache         
-`,
+			string(golden.Get(t, "disk-usage-context-write-custom.golden")),
 		},
 		// Raw Format
 		{
@@ -97,31 +93,7 @@ Build Cache
 					Format: NewDiskUsageFormat("raw"),
 				},
 			},
-			`type: Images
-total: 0
-active: 0
-size: 0B
-reclaimable: 0B
-
-type: Containers
-total: 0
-active: 0
-size: 0B
-reclaimable: 0B
-
-type: Local Volumes
-total: 0
-active: 0
-size: 0B
-reclaimable: 0B
-
-type: Build Cache
-total: 
-active: 
-size: 0B
-reclaimable: 0B
-
-`,
+			string(golden.Get(t, "disk-usage-raw-format.golden")),
 		},
 	}
 

--- a/cli/command/formatter/search_test.go
+++ b/cli/command/formatter/search_test.go
@@ -8,6 +8,7 @@ import (
 
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/stringutils"
+	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -120,10 +121,7 @@ func TestSearchContextWrite(t *testing.T) {
 		// Table format
 		{
 			Context{Format: NewSearchFormat("table")},
-			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
-result1             Official build      5000                [OK]                
-result2             Not official        5                                       [OK]
-`,
+			string(golden.Get(t, "search-context-write-table.golden")),
 		},
 		{
 			Context{Format: NewSearchFormat("table {{.Name}}")},
@@ -210,9 +208,7 @@ func TestSearchContextWriteStars(t *testing.T) {
 		// Table format
 		{
 			Context{Format: NewSearchFormat("table")},
-			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
-result1             Official build      5000                [OK]                
-`,
+			string(golden.Get(t, "search-context-write-stars-table.golden")),
 		},
 		{
 			Context{Format: NewSearchFormat("table {{.Name}}")},

--- a/cli/command/formatter/service_test.go
+++ b/cli/command/formatter/service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,21 +60,7 @@ bar
 		// Raw Format
 		{
 			Context{Format: NewServiceListFormat("raw", false)},
-			`id: id_baz
-name: baz
-mode: global
-replicas: 2/4
-image: 
-ports: *:80->8080/tcp
-
-id: id_bar
-name: bar
-mode: replicated
-replicas: 2/4
-image: 
-ports: *:80->8080/tcp
-
-`,
+			string(golden.Get(t, "service-context-write-raw.golden")),
 		},
 		{
 			Context{Format: NewServiceListFormat("raw", true)},

--- a/cli/command/formatter/task_test.go
+++ b/cli/command/formatter/task_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,10 +34,7 @@ taskID2
 		},
 		{
 			Context{Format: NewTaskFormat("table {{.Name}}\t{{.Node}}\t{{.Ports}}", false)},
-			`NAME                NODE                PORTS
-foobar_baz          foo1                
-foobar_bar          foo2                
-`,
+			string(golden.Get(t, "task-context-write-table-custom.golden")),
 		},
 		{
 			Context{Format: NewTaskFormat("table {{.Name}}", true)},

--- a/cli/command/formatter/testdata/container-context-write-special-headers.golden
+++ b/cli/command/formatter/testdata/container-context-write-special-headers.golden
@@ -1,0 +1,3 @@
+CONTAINER ID        IMAGE CREATED/STATUS/  PORTS  .NAMES STATUS
+conta               "ubuntu" 24 hours ago//.FOOBAR_BAZ 
+conta               "ubuntu" 24 hours ago//.FOOBAR_BAR 

--- a/cli/command/formatter/testdata/disk-usage-context-write-custom.golden
+++ b/cli/command/formatter/testdata/disk-usage-context-write-custom.golden
@@ -1,0 +1,5 @@
+TYPE                ACTIVE
+Images              0
+Containers          0
+Local Volumes       0
+Build Cache         

--- a/cli/command/formatter/testdata/disk-usage-raw-format.golden
+++ b/cli/command/formatter/testdata/disk-usage-raw-format.golden
@@ -1,0 +1,24 @@
+type: Images
+total: 0
+active: 0
+size: 0B
+reclaimable: 0B
+
+type: Containers
+total: 0
+active: 0
+size: 0B
+reclaimable: 0B
+
+type: Local Volumes
+total: 0
+active: 0
+size: 0B
+reclaimable: 0B
+
+type: Build Cache
+total: 
+active: 
+size: 0B
+reclaimable: 0B
+

--- a/cli/command/formatter/testdata/search-context-write-stars-table.golden
+++ b/cli/command/formatter/testdata/search-context-write-stars-table.golden
@@ -1,0 +1,2 @@
+NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
+result1             Official build      5000                [OK]                

--- a/cli/command/formatter/testdata/search-context-write-table.golden
+++ b/cli/command/formatter/testdata/search-context-write-table.golden
@@ -1,0 +1,3 @@
+NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
+result1             Official build      5000                [OK]                
+result2             Not official        5                                       [OK]

--- a/cli/command/formatter/testdata/service-context-write-raw.golden
+++ b/cli/command/formatter/testdata/service-context-write-raw.golden
@@ -1,0 +1,14 @@
+id: id_baz
+name: baz
+mode: global
+replicas: 2/4
+image: 
+ports: *:80->8080/tcp
+
+id: id_bar
+name: bar
+mode: replicated
+replicas: 2/4
+image: 
+ports: *:80->8080/tcp
+

--- a/cli/command/formatter/testdata/task-context-write-table-custom.golden
+++ b/cli/command/formatter/testdata/task-context-write-table-custom.golden
@@ -1,0 +1,3 @@
+NAME                NODE                PORTS
+foobar_baz          foo1                
+foobar_bar          foo2                

--- a/scripts/test/unit-with-coverage
+++ b/scripts/test/unit-with-coverage
@@ -11,7 +11,7 @@ for pkg in "$@"; do
         -coverprofile=profile.out \
         -covermode=atomic \
         "${pkg}"
-    
+
     if test -f profile.out; then
         cat profile.out >> coverage.txt
         rm profile.out


### PR DESCRIPTION
Many editors and git hooks will (correctly) strip end-of-line whitespace from `.go` files, however a few of our formatter tests expect trailing whitespace.

Move the expected values for those tests into golden files to preserve the whitespace.