### PR TITLE
 Reset uid/gid to 0 in build context to fix cache busting issues on ADD/COPY

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -243,6 +244,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		excludes = build.TrimBuildFilesFromExcludes(excludes, relDockerfile, options.dockerfileFromStdin())
 		buildCtx, err = archive.TarWithOptions(contextDir, &archive.TarOptions{
 			ExcludePatterns: excludes,
+			ChownOpts:       &idtools.IDPair{UID: 0, GID: 0},
 		})
 		if err != nil {
 			return err

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -6,18 +6,57 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"syscall"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/gotestyourself/gotestyourself/skip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
+func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
+	skip.IfCondition(t, runtime.GOOS == "windows", "uid and gid not relevant on windows")
+	dest := fs.NewDir(t, "test-build-context-dest")
+	defer dest.Remove()
+
+	fakeImageBuild := func(_ context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+		assert.NoError(t, archive.Untar(context, dest.Path(), nil))
+
+		body := new(bytes.Buffer)
+		return types.ImageBuildResponse{Body: ioutil.NopCloser(body)}, nil
+	}
+	cli := test.NewFakeCli(&fakeClient{imageBuildFunc: fakeImageBuild})
+
+	dir := fs.NewDir(t, "test-build-context",
+		fs.WithFile("foo", "some content", fs.AsUser(65534, 65534)),
+		fs.WithFile("Dockerfile", `
+			FROM alpine:3.6
+			COPY foo bar /
+		`),
+	)
+	defer dir.Remove()
+
+	options := newBuildOptions()
+	options.context = dir.Path()
+
+	err := runBuild(cli, options)
+	require.NoError(t, err)
+
+	files, err := ioutil.ReadDir(dest.Path())
+	require.NoError(t, err)
+	for _, fileInfo := range files {
+		assert.Equal(t, uint32(0), fileInfo.Sys().(*syscall.Stat_t).Uid)
+		assert.Equal(t, uint32(0), fileInfo.Sys().(*syscall.Stat_t).Gid)
+	}
+}
 func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
 	dest, err := ioutil.TempDir("", "test-build-compress-dest")
 	require.NoError(t, err)

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v0.4
 github.com/golang/protobuf 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/gotestyourself/gotestyourself v1.1.0
+github.com/gotestyourself/gotestyourself v1.2.0
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/mattn/go-shellwords v1.0.3
 github.com/Microsoft/go-winio v0.4.4
@@ -28,7 +28,7 @@ github.com/miekg/pkcs11 df8ae6ca730422dba20c768ff38ef7d79077a59f
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715
 github.com/moby/buildkit da2b9dc7dab99e824b2b1067ad7d0523e32dd2d9 https://github.com/dmcgowan/buildkit.git
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
-github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448 
+github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.0
 github.com/opencontainers/runc d40db12e72a40109dfcf28539f5ee0930d2f0277
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9

--- a/vendor/github.com/gotestyourself/gotestyourself/skip/skip_go18.go
+++ b/vendor/github.com/gotestyourself/gotestyourself/skip/skip_go18.go
@@ -1,0 +1,17 @@
+// +build !go1.9,!go.10,!go.11,!go1.12
+
+package skip
+
+import "strings"
+
+func getSourceLinesRange(line int, _ int) (int, int) {
+	firstLine := line - maxContextLines
+	if firstLine < 0 {
+		firstLine = 0
+	}
+	return firstLine, line
+}
+
+func getSource(lines []string, i int) string {
+	return strings.Join(lines[len(lines)-i-1:], "\n")
+}

--- a/vendor/github.com/gotestyourself/gotestyourself/skip/skip_go19.go
+++ b/vendor/github.com/gotestyourself/gotestyourself/skip/skip_go19.go
@@ -1,0 +1,17 @@
+// +build go1.9
+
+package skip
+
+import "strings"
+
+func getSourceLinesRange(line int, lines int) (int, int) {
+	lastLine := line + maxContextLines
+	if lastLine > lines {
+		lastLine = lines
+	}
+	return line - 1, lastLine
+}
+
+func getSource(lines []string, i int) string {
+	return strings.Join(lines[:i], "\n")
+}


### PR DESCRIPTION
**- What I did**

Fix of https://github.com/moby/moby/issues/32816

**- How I did it**

By resetting uid/gid to 0/0 in the build context. Prior to that, made possible by adding chownOpts in pkg/archive tarWithOption https://github.com/moby/moby/pull/34590

**- How to verify it**

`go test -v ./cli/command/image -run TestRunBuildResetsUidAndGidInContext`

**- Description for the changelog**

Reset uid/gid to 0 in build context to fix cache busting issues on ADD/COPY

**- A picture of a cute animal (not mandatory but encouraged)**

![133-insolite-25](https://user-images.githubusercontent.com/54712/30224976-0d316634-94d1-11e7-8042-ff1a94ce522f.jpg)