### PR TITLE
Create docker ps --name

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -33,8 +33,13 @@ func NewContainerFormat(source string, quiet bool, size bool) Format {
 	switch source {
 	case TableFormatKey:
 		if quiet {
-			return defaultQuietFormat
+			if QuietFormat == "" {
+				return defaultQuietFormat
+			} else {
+				return Format(QuietFormat)
+			}
 		}
+
 		format := defaultContainerTableFormat
 		if size {
 			format += `\t{{.Size}}`

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -23,6 +23,8 @@ const (
 // Format is the format string rendered using the Context
 type Format string
 
+var QuietFormat string
+
 // IsTable returns true if the format is a table-type format
 func (f Format) IsTable() bool {
 	return strings.HasPrefix(string(f), TableFormatKey)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1571,7 +1571,7 @@ _docker_container_ls() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --filter -f --format --help --last -n --latest -l --no-trunc --quiet -q --size -s" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --filter -f --format --help --last -n --name --latest -l --no-trunc --quiet -q --size -s" -- "$cur" ) )
 			;;
 	esac
 }

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -43,6 +43,7 @@ Options:
       --help            Print usage
   -n, --last int        Show n last created containers (includes all states) (default -1)
   -l, --latest          Show the latest created container (includes all states)
+      --name            Only display Names
       --no-trunc        Don't truncate output
   -q, --quiet           Only display numeric IDs
   -s, --size            Display total file sizes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This PR is a feature request about `docker ps --name`.  
`docker ps --name` displays to list only container names.

exmaple

```
$ ./build/docker-linux-amd64 ps -a --name
elegant_mahavira
confident_ardinghelli
silly_thompson
keen_fermi
wizardly_brattain
```

In order to make it same way without `docker ps --name`, I had to write next annoying code.

```
for id in `docker ps -q`; do
  name=`docker inspect -f='{{.Name}}' ${id}`
  name=$(basename ${name})
done
```


**- How I did it**
`docker ps --name` lists {{.Names}} likes as `docker ps -q`.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

