### PR TITLE
[docs] Fix typo in configration.

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -279,7 +279,7 @@ The following values are accepted:
 | "host"                     | Use the host system's IPC namespace.                                              |
 
 If not specified, daemon default is used, which can either be `"private"`
-or `"shareable"`, depending on the daemon version and configration.
+or `"shareable"`, depending on the daemon version and configuration.
 
 IPC (POSIX/SysV IPC) namespace provides separation of named shared memory
 segments, semaphores and message queues.


### PR DESCRIPTION
Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>

**- What I did**

Fixed a little typo.

**- A picture of a cute animal (not mandatory but encouraged)**

![cb7b8d297a6ea229bc7f42ee891a2304](https://user-images.githubusercontent.com/432791/30253066-eb84a0b0-967d-11e7-8199-78bb44bd4d68.jpg)

