### PR TITLE
Add a way to just build windows and osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ binary: ## build executable for Linux
 cross: ## build executable for macOS and Windows
 	./scripts/build/cross
 
+.PHONY: binary-windows
+binary-windows: ## build executable for Windows
+	./scripts/build/windows
+
+.PHONY: binary-osx
+binary-osx: ## build executable for macOS
+	./scripts/build/osx
+
 .PHONY: dynbinary
 dynbinary: ## build dynamically linked binary
 	./scripts/build/dynbinary

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -54,6 +54,14 @@ test: test-unit test-e2e
 cross: build_cross_image
 	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
 
+.PHONY: binary-windows
+binary-windows: build_cross_image
+	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+
+.PHONY: binary-osx
+binary-osx: build_cross_image
+	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+
 .PHONY: watch
 watch: build_docker_image
 	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make watch


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added 2 targets for `binary-windows` and `binary-osx` to build them separately from the `cross` target.

This is useful for builds (like master.dockerproject.org) that don't necessarily care about
getting full binaries for multiarch but do care about Windows. This cuts time needed for
compiling just Windows binaries by more than half

With `cross`:
```
make -f docker.Makefile cross  0.19s user 0.14s system 0% cpu 1:50.96 total
```

With just `windows`:
```
make -f docker.Makefile binary-windows  0.21s user 0.15s system 1% cpu 27.269 total
```

**- How I did it**
Added make targets that correspond to their respective scripts in `scripts/build/$@`

**- How to verify it**
```shell
make -f docker.Makefile binary-windows
make -f docker.Makefile binary-osx
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Added targets to cross compile for just windows and osx


**- A picture of a cute animal (not mandatory but encouraged)**

![](http://www.iywib.com/birds_with_arms9999991.jpg)