### PR TITLE
Fix e2e test by using a pinned version of alpine

### DIFF
--- a/e2e/container/testdata/run-attached-from-remote-and-remove.golden
+++ b/e2e/container/testdata/run-attached-from-remote-and-remove.golden
@@ -1,4 +1,4 @@
 Unable to find image 'registry:5000/alpine:test-run-pulls' locally
 test-run-pulls: Pulling from alpine
-Digest: sha256:0930dd4cc97ed5771ebe9be9caf3e8dc5341e0b5e32e8fb143394d7dfdfa100e
+Digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
 Status: Downloaded newer image for registry:5000/alpine:test-run-pulls

--- a/scripts/test/e2e/load-alpine
+++ b/scripts/test/e2e/load-alpine
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-src=alpine:3.6
+src=alpine@sha256:f006ecbb824d87947d0b51ab8488634bf69fe4094959d935c0c103f4820a417d
 dest=registry:5000/alpine:3.6
 docker pull $src
 docker tag $src $dest


### PR DESCRIPTION
Fixes this test failure on master, caused by a repin of `alpine:3.6`. This is now using a digest to pull a specific version of alpine so we shouldn't run in to this problem again.

```
22:44:11 === RUN   TestRunAttachedFromRemoteImageAndRemove
22:44:11 --- FAIL: TestRunAttachedFromRemoteImageAndRemove (0.72s)
22:44:11 		
	            	-Digest: sha256:0930dd4cc97ed5771ebe9be9caf3e8dc5341e0b5e32e8fb143394d7dfdfa100e
22:44:11 		
	            	+Digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
22:44:11 		
	            	 Status: Downloaded newer image for registry:5000/alpine:test-run-pulls
22:44:11 		
22:44:11 FAIL
22:44:11 FAIL	github.com/docker/cli/e2e/container	0.721s
```