### PR TITLE
Fix loader error with different build syntax

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -221,6 +221,7 @@ func createTransformHook() mapstructure.DecodeHookFuncType {
 		reflect.TypeOf(types.Labels{}):                           transformMappingOrListFunc("=", false),
 		reflect.TypeOf(types.MappingWithColon{}):                 transformMappingOrListFunc(":", false),
 		reflect.TypeOf(types.ServiceVolumeConfig{}):              transformServiceVolumeConfig,
+		reflect.TypeOf(types.BuildConfig{}):                      transformBuildConfig,
 	}
 
 	return func(_ reflect.Type, target reflect.Type, data interface{}) (interface{}, error) {
@@ -560,6 +561,17 @@ func transformStringSourceMap(data interface{}) (interface{}, error) {
 		return data, nil
 	default:
 		return data, errors.Errorf("invalid type %T for secret", value)
+	}
+}
+
+func transformBuildConfig(data interface{}) (interface{}, error) {
+	switch value := data.(type) {
+	case string:
+		return map[string]interface{}{"context": value}, nil
+	case map[string]interface{}:
+		return data, nil
+	default:
+		return data, errors.Errorf("invalid type %T for service build", value)
 	}
 }
 

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -528,6 +528,26 @@ services:
 	assert.Equal(t, []string{"build", "links"}, unsupported)
 }
 
+func TestBuildProperties(t *testing.T) {
+	dict, err := ParseYAML([]byte(`
+version: "3"
+services:
+  web:
+    image: web
+    build: .
+    links:
+      - bar
+  db:
+    image: db
+    build:
+     context: ./db
+`))
+	require.NoError(t, err)
+	configDetails := buildConfigDetails(dict, nil)
+	_, err = Load(configDetails)
+	require.NoError(t, err)
+}
+
 func TestDeprecatedProperties(t *testing.T) {
 	dict, err := ParseYAML([]byte(`
 version: "3"


### PR DESCRIPTION
`build: .` was not working anymore. Fixing this by adding a new
tranform function for BuildConfig.

/cc @cdrage 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>