### PR TITLE
Add note about joining through a load balancer

### DIFF
--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -94,7 +94,10 @@ for example `--advertise-addr eth0:2377`.
 Specifying a port is optional. If the value is a bare IP address, or interface
 name, the default port 2377 will be used.
 
-This flag is generally not necessary when joining an existing swarm.
+This flag is generally not necessary when joining an existing swarm. If
+you're joining new nodes through a load balancer, you should use this flag to
+ensure the node advertises its IP address and not the IP address of the load
+balancer.
 
 ### `--data-path-addr`
 


### PR DESCRIPTION
Signed-off-by: Joao Fernandes <joao.fernandes@docker.com>

I've added a note to the docs of `swarm-join --advertise-addr` to make it clear that you should use that flag when joining nodes through a load balancer.

If you're joining nodes through a load balancer, instead of running `docker swarm join --token xxxx <ip>` with the IP of a manager node, you use the IP of a load balancer that balances between all manager nodes. But if you do this, you need to include `--advertise-addr <ip>` with the IP of the node, otherwise the node might be registered with the load balancer's IP.

This disclaimer is relevant to users trying to do a production-grade deployment of Docker, and the feedback came from internal doogfooding initiatives from our infrastructure team.