### PR TITLE
Add more event filters in doc: config, node, secret and service

### DIFF
--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -175,14 +175,18 @@ container container 588a23dac085 *AND* the event type is *start*
 
 The currently supported filters are:
 
+* config (`config=<name or id>`)
 * container (`container=<name or id>`)
 * daemon (`daemon=<name or id>`)
 * event (`event=<event action>`)
 * image (`image=<tag or id>`)
 * label (`label=<key>` or `label=<key>=<value>`)
 * network (`network=<name or id>`)
+* node (`node=<id>`)
 * plugin (`plugin=<name or id>`)
 * scope (`scope=<local or swarm>`)
+* secret (`secret=<name or id>`)
+* service (`service=<name or id>`)
 * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
 * volume (`volume=<name>`)
 


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

Add some event validate type in commandline docs, since the coming merge PR https://github.com/moby/moby/pull/34952.

**- What I did**
1. add more event filters in doc: config, node, secret and service

This is waiting for the PR above to be merged. So I add a `DO-NOT-MERGE`.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

