### PR TITLE
Support parsing of named pipes for compose volumes

### DIFF
--- a/cli/compose/loader/volume.go
+++ b/cli/compose/loader/volume.go
@@ -112,6 +112,11 @@ func isFilePath(source string) bool {
 		return true
 	}
 
+	// windows named pipes
+	if strings.HasPrefix(source, `\\`) {
+		return true
+	}
+
 	first, nextIndex := utf8.DecodeRuneInString(source)
 	return isWindowsDrive([]rune{first}, rune(source[nextIndex]))
 }

--- a/cli/compose/loader/volume_test.go
+++ b/cli/compose/loader/volume_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/cli/cli/compose/types"
 	"github.com/docker/cli/internal/test/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseVolumeAnonymousVolume(t *testing.T) {
@@ -147,6 +148,17 @@ func TestParseVolumeWithRW(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expected, volume)
 	}
+}
+
+func TestParseVolumeWindowsNamedPipe(t *testing.T) {
+	volume, err := ParseVolume(`\\.\pipe\docker_engine:\\.\pipe\inside`)
+	require.NoError(t, err)
+	expected := types.ServiceVolumeConfig{
+		Type:   "bind",
+		Source: `\\.\pipe\docker_engine`,
+		Target: `\\.\pipe\inside`,
+	}
+	assert.Equal(t, expected, volume)
 }
 
 func TestIsFilePath(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/moby/moby/issues/34795

Fixes the client side parsing of volume specs to support windows named pipes.