### PR TITLE
Update gometalinter

### DIFF
--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -185,6 +185,7 @@ func setRawTerminal(streams command.Streams) error {
 	return streams.Out().SetRawTerminal()
 }
 
+// nolint: unparam
 func restoreTerminal(streams command.Streams, in io.Closer) error {
 	streams.In().RestoreTerminal()
 	streams.Out().RestoreTerminal()

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -43,6 +43,7 @@ func TestValidateAttach(t *testing.T) {
 	}
 }
 
+// nolint: unparam
 func parseRun(args []string) (*container.Config, *container.HostConfig, *networktypes.NetworkingConfig, error) {
 	flags := pflag.NewFlagSet("run", pflag.ContinueOnError)
 	flags.SetOutput(ioutil.Discard)

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -40,11 +40,14 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runPull(dockerCli command.Cli, opts pullOptions) error {
-	distributionRef, err := reference.ParseNormalizedNamed(opts.remote)
+func runPull(cli command.Cli, opts pullOptions) error {
+	ctx := context.Background()
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(cli), opts.remote)
 	if err != nil {
 		return err
 	}
+
+	distributionRef := imgRefAndAuth.Reference()
 	if opts.all && !reference.IsNameOnly(distributionRef) {
 		return errors.New("tag can't be used with --all-tags/-a")
 	}
@@ -52,27 +55,16 @@ func runPull(dockerCli command.Cli, opts pullOptions) error {
 	if !opts.all && reference.IsNameOnly(distributionRef) {
 		distributionRef = reference.TagNameOnly(distributionRef)
 		if tagged, ok := distributionRef.(reference.Tagged); ok {
-			fmt.Fprintf(dockerCli.Out(), "Using default tag: %s\n", tagged.Tag())
+			fmt.Fprintf(cli.Out(), "Using default tag: %s\n", tagged.Tag())
 		}
 	}
-
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := registry.ParseRepositoryInfo(distributionRef)
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-
-	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, "pull")
 
 	// Check if reference has a digest
 	_, isCanonical := distributionRef.(reference.Canonical)
 	if command.IsTrusted() && !isCanonical {
-		err = trustedPull(ctx, dockerCli, repoInfo, distributionRef, authConfig, requestPrivilege)
+		err = trustedPull(ctx, cli, imgRefAndAuth)
 	} else {
-		err = imagePullPrivileged(ctx, dockerCli, authConfig, reference.FamiliarString(distributionRef), requestPrivilege, opts.all)
+		err = imagePullPrivileged(ctx, cli, imgRefAndAuth, opts.all)
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "when fetching 'plugin'") {
@@ -80,6 +72,5 @@ func runPull(dockerCli command.Cli, opts pullOptions) error {
 		}
 		return err
 	}
-
 	return nil
 }

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -32,11 +32,6 @@ func TestNewPullCommandErrors(t *testing.T) {
 			expectedError: "tag can't be used with --all-tags/-a",
 			args:          []string{"--all-tags", "image:tag"},
 		},
-		{
-			name:          "pull-error",
-			args:          []string{"--disable-content-trust=false", "image:tag"},
-			expectedError: "you are not authorized to perform this operation: server returned 401.",
-		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})

--- a/cli/command/image/trust_test.go
+++ b/cli/command/image/trust_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustpinning"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func unsetENV() {
@@ -67,6 +68,7 @@ func TestAddTargetToAllSignableRolesError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	require.NoError(t, err)
 	target := client.Target{}
 	err = AddTargetToAllSignableRoles(notaryRepo, &target)
 	assert.EqualError(t, err, "client is offline")

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -104,13 +104,12 @@ func checkDaemonIsSwarmManager(ctx context.Context, dockerCli command.Cli) error
 }
 
 // pruneServices removes services that are no longer referenced in the source
-func pruneServices(ctx context.Context, dockerCli command.Cli, namespace convert.Namespace, services map[string]struct{}) bool {
+func pruneServices(ctx context.Context, dockerCli command.Cli, namespace convert.Namespace, services map[string]struct{}) {
 	client := dockerCli.Client()
 
 	oldServices, err := getServices(ctx, client, namespace.Name())
 	if err != nil {
 		fmt.Fprintf(dockerCli.Err(), "Failed to list services: %s", err)
-		return true
 	}
 
 	pruneServices := []swarm.Service{}
@@ -119,5 +118,5 @@ func pruneServices(ctx context.Context, dockerCli command.Cli, namespace convert
 			pruneServices = append(pruneServices, service)
 		}
 	}
-	return removeServices(ctx, dockerCli, pruneServices)
+	removeServices(ctx, dockerCli, pruneServices)
 }

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -59,6 +59,7 @@ func TestStackPsEmptyStack(t *testing.T) {
 	})
 	cmd := newPsCommand(fakeCli)
 	cmd.SetArgs([]string{"foo"})
+	cmd.SetOutput(ioutil.Discard)
 
 	assert.Error(t, cmd.Execute())
 	assert.EqualError(t, cmd.Execute(), "nothing found in stack: foo")

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -15,24 +15,20 @@ import (
 	"golang.org/x/net/context"
 )
 
-type unlockOptions struct{}
-
 func newUnlockCommand(dockerCli command.Cli) *cobra.Command {
-	opts := unlockOptions{}
-
 	cmd := &cobra.Command{
 		Use:   "unlock",
 		Short: "Unlock swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUnlock(dockerCli, opts)
+			return runUnlock(dockerCli)
 		},
 	}
 
 	return cmd
 }
 
-func runUnlock(dockerCli command.Cli, opts unlockOptions) error {
+func runUnlock(dockerCli command.Cli) error {
 	client := dockerCli.Client()
 	ctx := context.Background()
 

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
 	"github.com/pkg/errors"
-
-	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/trust"
 	"github.com/spf13/cobra"
 )
 
@@ -38,10 +36,7 @@ func newRevokeCommand(dockerCli command.Cli) *cobra.Command {
 
 func revokeTrust(cli command.Cli, remote string, options revokeOptions) error {
 	ctx := context.Background()
-	authResolver := func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
-		return command.ResolveAuthConfig(ctx, cli, index)
-	}
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver, remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
 	if err != nil {
 		return err
 	}
@@ -57,7 +52,7 @@ func revokeTrust(cli command.Cli, remote string, options revokeOptions) error {
 		}
 	}
 
-	notaryRepo, err := cli.NotaryClient(*imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := cli.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/revoke_test.go
+++ b/cli/command/trust/revoke_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/notary/passphrase"
 	"github.com/docker/notary/trustpinning"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTrustRevokeCommandErrors(t *testing.T) {
@@ -140,6 +141,7 @@ func TestGetSignableRolesForTargetAndRemoveError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	require.NoError(t, err)
 	target := client.Target{}
 	err = getSignableRolesForTargetAndRemove(target, notaryRepo)
 	assert.EqualError(t, err, "client is offline")

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/notary/trustpinning"
 	"github.com/docker/notary/tuf/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const passwd = "password"
@@ -151,6 +152,7 @@ func TestAddStageSigners(t *testing.T) {
 		NewThreshold: notary.MinThreshold,
 		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
 	})
+	require.NoError(t, err)
 	expectedChange := changelist.NewTUFChange(
 		changelist.ActionCreate,
 		userRole,
@@ -165,6 +167,7 @@ func TestAddStageSigners(t *testing.T) {
 	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
 		AddPaths: []string{""},
 	})
+	require.NoError(t, err)
 	expectedChange = changelist.NewTUFChange(
 		changelist.ActionCreate,
 		userRole,
@@ -182,6 +185,7 @@ func TestAddStageSigners(t *testing.T) {
 		NewThreshold: notary.MinThreshold,
 		AddKeys:      data.KeyList([]data.PublicKey{userKey}),
 	})
+	require.NoError(t, err)
 	expectedChange = changelist.NewTUFChange(
 		changelist.ActionCreate,
 		releasesRole,
@@ -196,6 +200,7 @@ func TestAddStageSigners(t *testing.T) {
 	expectedJSON, err = json.Marshal(&changelist.TUFDelegation{
 		AddPaths: []string{""},
 	})
+	require.NoError(t, err)
 	expectedChange = changelist.NewTUFChange(
 		changelist.ActionCreate,
 		releasesRole,
@@ -268,18 +273,24 @@ func TestPrettyPrintExistingSignatureInfo(t *testing.T) {
 	assert.Contains(t, fakeCli.OutBuffer().String(), "Existing signatures for tag tagName digest abc123 from:\nAlice, Bob, Carol")
 }
 
-func TestChangeList(t *testing.T) {
+func TestSignCommandChangeListIsCleanedOnError(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
+
 	config.SetDir(tmpDir)
-	cmd := newSignCommand(
-		test.NewFakeCli(&fakeClient{}))
+	cli := test.NewFakeCli(&fakeClient{})
+	cli.SetNotaryClient(getLoadedNotaryRepository)
+	cmd := newSignCommand(cli)
 	cmd.SetArgs([]string{"ubuntu:latest"})
 	cmd.SetOutput(ioutil.Discard)
+
 	err = cmd.Execute()
+	require.Error(t, err)
+
 	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "docker.io/library/ubuntu", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	assert.NoError(t, err)
 	cl, err := notaryRepo.GetChangelist()
+	require.NoError(t, err)
 	assert.Equal(t, len(cl.List()), 0)
 }

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"bytes"
+
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/test"
@@ -264,13 +266,12 @@ func TestGetExistingSignatureInfoForReleasedTag(t *testing.T) {
 }
 
 func TestPrettyPrintExistingSignatureInfo(t *testing.T) {
-	fakeCli := test.NewFakeCli(&fakeClient{})
-
+	buf := bytes.NewBuffer(nil)
 	signers := []string{"Bob", "Alice", "Carol"}
 	existingSig := trustTagRow{trustTagKey{"tagName", "abc123"}, signers}
-	prettyPrintExistingSignatureInfo(fakeCli, existingSig)
+	prettyPrintExistingSignatureInfo(buf, existingSig)
 
-	assert.Contains(t, fakeCli.OutBuffer().String(), "Existing signatures for tag tagName digest abc123 from:\nAlice, Bob, Carol")
+	assert.Contains(t, buf.String(), "Existing signatures for tag tagName digest abc123 from:\nAlice, Bob, Carol")
 }
 
 func TestSignCommandChangeListIsCleanedOnError(t *testing.T) {

--- a/cli/command/trust/view.go
+++ b/cli/command/trust/view.go
@@ -11,9 +11,8 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
+	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
-	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/notary"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
@@ -61,15 +60,12 @@ func newViewCommand(dockerCli command.Cli) *cobra.Command {
 
 func lookupTrustInfo(cli command.Cli, remote string) error {
 	ctx := context.Background()
-	authResolver := func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
-		return command.ResolveAuthConfig(ctx, cli, index)
-	}
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver, remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
 	if err != nil {
 		return err
 	}
 	tag := imgRefAndAuth.Tag()
-	notaryRepo, err := cli.NotaryClient(*imgRefAndAuth, trust.ActionsPullOnly)
+	notaryRepo, err := cli.NotaryClient(imgRefAndAuth, trust.ActionsPullOnly)
 	if err != nil {
 		return trust.NotaryError(imgRefAndAuth.Reference().Name(), err)
 	}

--- a/cli/command/trust/view.go
+++ b/cli/command/trust/view.go
@@ -113,7 +113,9 @@ func lookupTrustInfo(cli command.Cli, remote string) error {
 	// If we do not have additional signers, do not display
 	if len(signerRoleToKeyIDs) > 0 {
 		fmt.Fprintf(cli.Out(), "\nList of signers and their keys for %s:\n\n", strings.Split(remote, ":")[0])
-		printSignerInfo(cli.Out(), signerRoleToKeyIDs)
+		if err := printSignerInfo(cli.Out(), signerRoleToKeyIDs); err != nil {
+			return err
+		}
 	}
 
 	// This will always have the root and targets information

--- a/cli/trust/trust_test.go
+++ b/cli/trust/trust_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/notary/trustpinning"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTag(t *testing.T) {
@@ -53,6 +54,7 @@ func TestGetSignableRolesError(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	require.NoError(t, err)
 	target := client.Target{}
 	_, err = GetSignableRoles(notaryRepo, &target)
 	assert.EqualError(t, err, "client is offline")

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -2,7 +2,7 @@ FROM    golang:1.8.3-alpine
 
 RUN     apk add -U git
 
-ARG     GOMETALINTER_SHA=4306381615a2ba2a207f8fcea02c08c6b2b0803f
+ARG     GOMETALINTER_SHA=8eca55135021737bbc65ed68b548b3336853274c
 RUN     go get -d github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \
         git checkout -q "$GOMETALINTER_SHA" && \

--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type cmdOption struct {
@@ -46,18 +46,17 @@ type cmdDoc struct {
 
 // GenYamlTree creates yaml structured ref files
 func GenYamlTree(cmd *cobra.Command, dir string) error {
-	identity := func(s string) string { return s }
 	emptyStr := func(s string) string { return "" }
-	return GenYamlTreeCustom(cmd, dir, emptyStr, identity)
+	return GenYamlTreeCustom(cmd, dir, emptyStr)
 }
 
 // GenYamlTreeCustom creates yaml structured ref files
-func GenYamlTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHandler func(string) string) error {
+func GenYamlTreeCustom(cmd *cobra.Command, dir string, filePrepender func(string) string) error {
 	for _, c := range cmd.Commands() {
 		if !c.IsAvailableCommand() || c.IsHelpCommand() {
 			continue
 		}
-		if err := GenYamlTreeCustom(c, dir, filePrepender, linkHandler); err != nil {
+		if err := GenYamlTreeCustom(c, dir, filePrepender); err != nil {
 			return err
 		}
 	}

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,8 +1,12 @@
 {
   "Vendor": true,
   "Deadline": "2m",
-  "Sort": ["linter", "severity", "path"],
-  "Exclude": ["cli/compose/schema/bindata.go"],
+  "Sort": ["linter", "severity", "path", "line"],
+  "Exclude": [
+      "cli/compose/schema/bindata.go",
+      "parameter .* always receives"
+  ],
+  "EnableGC": true,
 
   "DisableAll": true,
   "Enable": [

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -26,6 +26,6 @@
     "vet"
   ],
 
-  "Cyclo": 19,
+  "Cyclo": 16,
   "LineLength": 200
 }


### PR DESCRIPTION
Update gometalinter to pickup some bug fixes and updates to linters
Adjust the config to exclude a new category of errors added by unparam. Functions which always accept the same value for a parameter are just fine I think.
Refactor image pull and trust slightly to make use of the new struct added for the trust commands.

These new `// nolint: unparam` are for another new check added to unparam where it errors if no callers use the return value. I think this is ok in some cases, but a good check in others, so I just whitelisted a few.