### PR TITLE
trust: remove extraneous OPTIONS from commands that do not use it

### DIFF
--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -21,7 +21,7 @@ import (
 
 func newSignCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "sign [OPTIONS] IMAGE:TAG",
+		Use:   "sign IMAGE:TAG",
 		Short: "Sign an image",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/trust/view.go
+++ b/cli/command/trust/view.go
@@ -49,7 +49,7 @@ func (tagComparator trustTagRowList) Swap(i, j int) {
 
 func newViewCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "view [OPTIONS] IMAGE[:TAG]",
+		Use:   "view IMAGE[:TAG]",
 		Short: "Display detailed information about keys and signatures",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/trust_sign.md
+++ b/docs/reference/commandline/trust_sign.md
@@ -16,7 +16,7 @@ keywords: "sign, notary, trust"
 # trust sign
 
 ```markdown
-Usage:  docker trust sign [OPTIONS] IMAGE:TAG
+Usage:  docker trust sign IMAGE:TAG
 
 Sign an image
 

--- a/docs/reference/commandline/trust_view.md
+++ b/docs/reference/commandline/trust_view.md
@@ -16,7 +16,7 @@ keywords: "view, notary, trust"
 # trust view
 
 ```markdown
-Usage:  docker trust view [OPTIONS] IMAGE[:TAG]
+Usage:  docker trust view IMAGE[:TAG]
 
 Display detailed information about keys and signatures
 


### PR DESCRIPTION
Currently, both `docker trust view` and `docker trust sign` do not take any options - so remove `[OPTIONS]` from usage.  Also updates docs.

![](http://newmediarockstars.com/wp-content/uploads/2013/01/CatHacker-300x214.jpg)

cc @eiais @ashfall 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>