### PR TITLE
Fix leading characters being stripped from example sections in YAML

### DIFF
--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -220,10 +220,10 @@ func parseMDContent(mdString string) (description string, examples string) {
 	parsedContent := strings.Split(mdString, "\n## ")
 	for _, s := range parsedContent {
 		if strings.Index(s, "Description") == 0 {
-			description = strings.Trim(s, "Description\n")
+			description = strings.TrimSpace(strings.TrimPrefix(s, "Description"))
 		}
 		if strings.Index(s, "Examples") == 0 {
-			examples = strings.Trim(s, "Examples\n")
+			examples = strings.TrimSpace(strings.TrimPrefix(s, "Examples"))
 		}
 	}
 	return


### PR DESCRIPTION
`strings.Trim()` strips any character listed in the `cutset` argument,
so any example section having `E`, `x`, `a`, `m`, `p`, `l`, `e`, or `s`
in the first word, had these characters missing in the generated
YAML.

Also trim superfluent whitespace characters to consistently use `|-` ("strip")
as block chomping indicator (see http://www.yaml.org/spec/1.2/spec.html#id2794534)


Before:

<img width="361" alt="screen shot 2017-09-27 at 10 30 03" src="https://user-images.githubusercontent.com/1804568/30904743-1fe648c0-a373-11e7-9862-30093bc4b12f.png">

After:

<img width="387" alt="screen shot 2017-09-27 at 11 01 08" src="https://user-images.githubusercontent.com/1804568/30904767-34d7fc7e-a373-11e7-8cd4-b550b188e686.png">

