### PR TITLE
Change default stats format and add --no-trunc flag

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -21,6 +21,7 @@ import (
 type statsOptions struct {
 	all        bool
 	noStream   bool
+	noTrunc    bool
 	format     string
 	containers []string
 }
@@ -42,6 +43,7 @@ func NewStatsCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.all, "all", "a", false, "Show all containers (default shows just running)")
 	flags.BoolVar(&opts.noStream, "no-stream", false, "Disable streaming stats and only pull the first result")
+	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 	return cmd
 }
@@ -214,7 +216,7 @@ func runStats(dockerCli *command.DockerCli, opts *statsOptions) error {
 			ccstats = append(ccstats, c.GetStatistics())
 		}
 		cStats.mu.Unlock()
-		if err = formatter.ContainerStatsWrite(statsCtx, ccstats, daemonOSType); err != nil {
+		if err = formatter.ContainerStatsWrite(statsCtx, ccstats, daemonOSType, !opts.noTrunc); err != nil {
 			break
 		}
 		if len(cStats.cs) == 0 && !showAll {

--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	winOSType                  = "windows"
-	defaultStatsTableFormat    = "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
-	winDefaultStatsTableFormat = "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
+	defaultStatsTableFormat    = "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
+	winDefaultStatsTableFormat = "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
 
 	containerHeader = "CONTAINER"
 	cpuPercHeader   = "CPU %"

--- a/cli/command/formatter/stats.go
+++ b/cli/command/formatter/stats.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/docker/docker/pkg/stringid"
 	units "github.com/docker/go-units"
 )
 
@@ -114,12 +115,13 @@ func NewContainerStats(container string) *ContainerStats {
 }
 
 // ContainerStatsWrite renders the context for a list of containers statistics
-func ContainerStatsWrite(ctx Context, containerStats []StatsEntry, osType string) error {
+func ContainerStatsWrite(ctx Context, containerStats []StatsEntry, osType string, trunc bool) error {
 	render := func(format func(subContext subContext) error) error {
 		for _, cstats := range containerStats {
 			containerStatsCtx := &containerStatsContext{
-				s:  cstats,
-				os: osType,
+				s:     cstats,
+				os:    osType,
+				trunc: trunc,
 			}
 			if err := format(containerStatsCtx); err != nil {
 				return err
@@ -149,8 +151,9 @@ func ContainerStatsWrite(ctx Context, containerStats []StatsEntry, osType string
 
 type containerStatsContext struct {
 	HeaderContext
-	s  StatsEntry
-	os string
+	s     StatsEntry
+	os    string
+	trunc bool
 }
 
 func (c *containerStatsContext) MarshalJSON() ([]byte, error) {
@@ -169,6 +172,9 @@ func (c *containerStatsContext) Name() string {
 }
 
 func (c *containerStatsContext) ID() string {
+	if c.trunc {
+		return stringid.TruncateID(c.s.ID)
+	}
 	return c.s.ID
 }
 

--- a/cli/command/formatter/stats_test.go
+++ b/cli/command/formatter/stats_test.go
@@ -114,7 +114,7 @@ container2  --
 		}
 		var out bytes.Buffer
 		te.context.Output = &out
-		err := ContainerStatsWrite(te.context, stats, "linux")
+		err := ContainerStatsWrite(te.context, stats, "linux", false)
 		if err != nil {
 			assert.EqualError(t, err, te.expected)
 		} else {
@@ -180,7 +180,7 @@ container2  --  --
 		}
 		var out bytes.Buffer
 		te.context.Output = &out
-		err := ContainerStatsWrite(te.context, stats, "windows")
+		err := ContainerStatsWrite(te.context, stats, "windows", false)
 		if err != nil {
 			assert.EqualError(t, err, te.expected)
 		} else {
@@ -220,7 +220,7 @@ func TestContainerStatsContextWriteWithNoStats(t *testing.T) {
 	}
 
 	for _, context := range contexts {
-		ContainerStatsWrite(context.context, []StatsEntry{}, "linux")
+		ContainerStatsWrite(context.context, []StatsEntry{}, "linux", false)
 		assert.Equal(t, context.expected, out.String())
 		// Clean buffer
 		out.Reset()
@@ -258,7 +258,41 @@ func TestContainerStatsContextWriteWithNoStatsWindows(t *testing.T) {
 	}
 
 	for _, context := range contexts {
-		ContainerStatsWrite(context.context, []StatsEntry{}, "windows")
+		ContainerStatsWrite(context.context, []StatsEntry{}, "windows", false)
+		assert.Equal(t, context.expected, out.String())
+		// Clean buffer
+		out.Reset()
+	}
+}
+
+func TestContainerStatsContextWriteTrunc(t *testing.T) {
+	var out bytes.Buffer
+
+	contexts := []struct {
+		context  Context
+		trunc    bool
+		expected string
+	}{
+		{
+			Context{
+				Format: "{{.ID}}",
+				Output: &out,
+			},
+			false,
+			"b95a83497c9161c9b444e3d70e1a9dfba0c1840d41720e146a95a08ebf938afc\n",
+		},
+		{
+			Context{
+				Format: "{{.ID}}",
+				Output: &out,
+			},
+			true,
+			"b95a83497c91\n",
+		},
+	}
+
+	for _, context := range contexts {
+		ContainerStatsWrite(context.context, []StatsEntry{{ID: "b95a83497c9161c9b444e3d70e1a9dfba0c1840d41720e146a95a08ebf938afc"}}, "linux", context.trunc)
 		assert.Equal(t, context.expected, out.String())
 		// Clean buffer
 		out.Reset()

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2023,7 +2023,7 @@ _docker_container_stats() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --format --help --no-stream" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --format --help --no-stream --no-trunc" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_containers_running

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -897,6 +897,7 @@ __docker_container_subcommand() {
                 "($help -a --all)"{-a,--all}"[Show all containers (default shows just running)]" \
                 "($help)--format=[Pretty-print images using a Go template]:template: " \
                 "($help)--no-stream[Disable streaming stats and only pull the first result]" \
+                "($help)--no-trunc[Do not truncate output]" \
                 "($help -)*:containers:__docker_complete_running_containers" && ret=0
             ;;
         (stop)

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -25,6 +25,7 @@ Options:
       --format string   Pretty-print images using a Go template
       --help            Print usage
       --no-stream       Disable streaming stats and only pull the first result
+      --no-trunc        Don't truncate output
 ```
 
 ## Description
@@ -39,30 +40,34 @@ Running `docker stats` on all running containers against a Linux daemon.
 
 ```bash
 $ docker stats
-CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
-1285939c1fd3        0.07%               796 KiB / 64 MiB        1.21%               788 B / 648 B       3.568 MB / 512 KB
-9c76f7834ae2        0.07%               2.746 MiB / 64 MiB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
-d1ea048f04e4        0.03%               4.583 MiB / 64 MiB      6.30%               2.854 KB / 648 B    27.7 MB / 0 B
+
+CONTAINER ID        NAME                                    CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
+b95a83497c91        awesome_brattain                        0.28%               5.629MiB / 1.952GiB   0.28%               916B / 0B           147kB / 0B          9
+67b2525d8ad1        foobar                                  0.00%               1.727MiB / 1.952GiB   0.09%               2.48kB / 0B         4.11MB / 0B         2
+e5c383697914        test-1951.1.kay7x1lh1twk9c0oig50sd5tr   0.00%               196KiB / 1.952GiB     0.01%               71.2kB / 0B         770kB / 0B          1
+4bda148efbc0        random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
 ```
 
 Running `docker stats` on multiple containers by name and id against a Linux daemon.
 
 ```bash
-$ docker stats fervent_panini 5acfcb1b4fd1
-CONTAINER           CPU %               MEM USAGE/LIMIT       MEM %               NET I/O
-5acfcb1b4fd1        0.00%               115.2 MiB/1.045 GiB   11.03%              1.422 kB/648 B
-fervent_panini      0.02%               11.08 MiB/1.045 GiB   1.06%               648 B/648 B
+$ docker stats awesome_brattain 67b2525d8ad1
+
+CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
+b95a83497c91        awesome_brattain    0.28%               5.629MiB / 1.952GiB   0.28%               916B / 0B           147kB / 0B          9
+67b2525d8ad1        foobar              0.00%               1.727MiB / 1.952GiB   0.09%               2.48kB / 0B         4.11MB / 0B         2
 ```
 
 Running `docker stats` with customized format on all (Running and Stopped) containers.
 
 ```bash
-$ docker stats --all --format "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}"
-CONTAINER ID                                                       NAME                     CPU %               MEM USAGE / LIMIT
-c9dfa83f0317f87637d5b7e67aa4223337d947215c5a9947e697e4f7d3e0f834   ecstatic_noether         0.00%               56KiB / 15.57GiB
-8f92d01cf3b29b4f5fca4cd33d907e05def7af5a3684711b20a2369d211ec67f   stoic_goodall            0.07%               32.86MiB / 15.57GiB
-38dd23dba00f307d53d040c1d18a91361bbdcccbf592315927d56cf13d8b7343   drunk_visvesvaraya       0.00%               0B / 0B
-5a8b07ec4cc52823f3cbfdb964018623c1ba307bce2c057ccdbde5f4f6990833   big_heisenberg           0.00%               0B / 0B
+$ docker stats --all --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" fervent_panini 5acfcb1b4fd1 drunk_visvesvaraya big_heisenberg
+
+CONTAINER                CPU %               MEM USAGE / LIMIT
+fervent_panini           0.00%               56KiB / 15.57GiB
+5acfcb1b4fd1             0.07%               32.86MiB / 15.57GiB
+drunk_visvesvaraya       0.00%               0B / 0B
+big_heisenberg           0.00%               0B / 0B
 ```
 
 `drunk_visvesvaraya` and `big_heisenberg` are stopped containers in the above example.
@@ -71,7 +76,7 @@ Running `docker stats` on all running containers against a Windows daemon.
 
 ```powershell
 PS E:\> docker stats
-CONTAINER           CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
+CONTAINER ID        CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
 09d3bb5b1604        6.61%               38.21 MiB           17.1 kB / 7.73 kB   10.7 MB / 3.57 MB
 9db7aa4d986d        9.19%               38.26 MiB           15.2 kB / 7.65 kB   10.6 MB / 3.3 MB
 3f214c61ad1d        0.00%               28.64 MiB           64 kB / 6.84 kB     4.42 MB / 6.93 MB
@@ -81,15 +86,15 @@ Running `docker stats` on multiple containers by name and id against a Windows d
 
 ```powershell
 PS E:\> docker ps -a
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-3f214c61ad1d        nanoserver          "cmd"               2 minutes ago       Up 2 minutes                            big_minsky
-9db7aa4d986d        windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            mad_wilson
-09d3bb5b1604        windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            affectionate_easley
+CONTAINER ID        NAME                IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+3f214c61ad1d        awesome_brattain    nanoserver          "cmd"               2 minutes ago       Up 2 minutes                            big_minsky
+9db7aa4d986d        mad_wilson          windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            mad_wilson
+09d3bb5b1604        fervent_panini      windowsservercore   "cmd"               2 minutes ago       Up 2 minutes                            affectionate_easley
 
 PS E:\> docker stats 3f214c61ad1d mad_wilson
-CONTAINER           CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
-3f214c61ad1d        0.00%               46.25 MiB           76.3 kB / 7.92 kB   10.3 MB / 14.7 MB
-mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
+CONTAINER ID        NAME                CPU %               PRIV WORKING SET    NET I/O             BLOCK I/O
+3f214c61ad1d        awesome_brattain    0.00%               46.25 MiB           76.3 kB / 7.92 kB   10.3 MB / 14.7 MB
+9db7aa4d986d        mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
 ```
 
 ### Formatting
@@ -138,3 +143,17 @@ CONTAINER           CPU %               PRIV WORKING SET
 9c76f7834ae2        0.07%               2.746 MiB / 64 MiB
 d1ea048f04e4        0.03%               4.583 MiB / 64 MiB
 ```
+
+The default format is as follows:
+
+On Linux:
+
+    "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
+
+On Windows:
+
+    "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
+
+
+> **Note**: On Docker 17.09 and older, the `{{.Container}}` column was used, in
+> stead of `{{.ID}}\t{{.Name}}`.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes https://github.com/moby/moby/issues/20973

**- What I did**

### Update default output format for stats to include ID and Name

The `docker container stats` output has a column (`CONTAINER`), that shows either
the container _id_ or container _name_, depending on the arguments given.

For example, running `docker container stats foobar` shows:

    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    foobar              0.00%               1.938MiB / 1.952GiB   0.10%               782B / 0B           4.11MB / 0B         2

Whereas `docker container stats 67b2525d8ad1` (`67b2525d8ad1` being the ID for
container `foobar`) shows:

    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    67b2525d8ad1        0.00%               1.938MiB / 1.952GiB   0.10%               916B / 0B           4.11MB / 0B         2

This behavior is confusing.

This patch updates the default output format for `docker stats` to use separate
columns for container ID and container Name (similar to `docker container ls`).

With this patch applied, both commands show the same output:

    $ docker container stats foobar
    CONTAINER ID                                                       NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    67b2525d8ad10bb236a49960e93c09993b0baabeef12c2d46cd5f4fbb6f4808c   foobar              0.00%               1.938MiB / 1.952GiB   0.10%               1.25kB / 0B         4.11MB / 0B         2

    $ docker container stats 67b2525d8ad1
    CONTAINER ID                                                       NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    67b2525d8ad10bb236a49960e93c09993b0baabeef12c2d46cd5f4fbb6f4808c   foobar              0.00%               1.938MiB / 1.952GiB   0.10%               1.31kB / 0B         4.11MB / 0B         2

Users that want to use the old format can configure a custom format in the
cli configuration file (`~/.docker/config.json`);

on Linux:

    {
      "statsFormat" : "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}"
    }

on Windows:

    {
      "statsFormat" : "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
    }

### Add `--no-trunc` flag to docker container stats

This patch adds a `--no-trunc` option to `docker container stats`;

With this patch applied, the default output is:

    CONTAINER ID        NAME                                    CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    b95a83497c91        awesome_brattain                        0.28%               5.629MiB / 1.952GiB   0.28%               916B / 0B           147kB / 0B          9
    67b2525d8ad1        foobar                                  0.00%               1.727MiB / 1.952GiB   0.09%               2.48kB / 0B         4.11MB / 0B         2
    e5c383697914        test-1951.1.kay7x1lh1twk9c0oig50sd5tr   0.00%               196KiB / 1.952GiB     0.01%               71.2kB / 0B         770kB / 0B          1
    4bda148efbc0        random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
    84e3deaa45b2        registry                                0.01%               3.402MiB / 1.952GiB   0.17%               127kB / 378B        233kB / 0B          10
    2ed915778ceb        foo.1.lsmxrefn5yp9c9ijz1hzgdq4u         0.00%               1.727MiB / 1.952GiB   0.09%               166kB / 7.76kB      614kB / 0B          2

Addin the `--no-trunc` option, changes the output to:

    CONTAINER ID                                                       NAME                                    CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
    b95a83497c9161c9b444e3d70e1a9dfba0c1840d41720e146a95a08ebf938afc   awesome_brattain                        0.25%               5.75MiB / 1.952GiB    0.29%               648B / 0B           147kB / 0B          10
    67b2525d8ad10bb236a49960e93c09993b0baabeef12c2d46cd5f4fbb6f4808c   foobar                                  0.00%               1.727MiB / 1.952GiB   0.09%               2.35kB / 0B         4.11MB / 0B         2
    e5c383697914b98b10cbbc9d0bd324b7b927099ac584f031057b8208d2fba9b1   test-1951.1.kay7x1lh1twk9c0oig50sd5tr   0.00%               196KiB / 1.952GiB     0.01%               71.1kB / 0B         770kB / 0B          1
    4bda148efbc006b0063373c3678083159af89f8cc83a6a28def14cb0dd171f70   random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
    84e3deaa45b2fc363e06167df9b90ab59f88d4f101e3f9b8df03a62a8f6783e1   registry                                0.00%               3.387MiB / 1.952GiB   0.17%               127kB / 378B        233kB / 0B          10
    2ed915778cebddf9ec69263a75cfdcf00962a5198d94d42cda75d5cd45bb82f2   foo.1.lsmxrefn5yp9c9ijz1hzgdq4u         0.00%               1.727MiB / 1.952GiB   0.09%               166kB / 7.76kB      614kB / 0B          2

Which is the same as the default before this patch was applied.


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
Change the default output format for `docker container stats` to show `CONTAINER ID` and `NAME` [docker/cli#565](https://github.com/docker/cli/pull/565)
```

```Markdown
Add `--no-trunc` flag to `docker container stats` [docker/cli#565](https://github.com/docker/cli/pull/565)
```
**- A picture of a cute animal (not mandatory but encouraged)**