### PR TITLE
test rmi -f returns success

### DIFF
--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -24,6 +24,11 @@ func TestRunAttachedFromRemoteImageAndRemove(t *testing.T) {
 	golden.Assert(t, result.Stderr(), "run-attached-from-remote-and-remove.golden")
 }
 
+func TestForceRemoveImage(t *testing.T) {
+	result := icmd.RunCmd(shell(t, "docker rmi -f badb33f99donteatme"))
+	result.Assert(t, icmd.Success)
+}
+
 // TODO: create this with registry API instead of engine API
 func createRemoteImage(t *testing.T) string {
 	image := "registry:5000/alpine:test-run-pulls"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `e2e` test to verify `docker rmi -f` returns unix code success always because `-f`.

**- How I did it**

At my desk.

**- How to verify it**

```
$ make -f docker.Makefile test-e2e
...
=== RUN   TestForceRemoveImage
--- PASS: TestForceRemoveImage (0.16s)
PASS
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

N/A

**- A picture of a cute animal (not mandatory but encouraged)**

🐛 