### PR TITLE
Do not truncate ID on docker service ps --quiet

### DIFF
--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -14,6 +14,7 @@ type fakeClient struct {
 	serviceInspectWithRawFunc func(ctx context.Context, serviceID string, options types.ServiceInspectOptions) (swarm.Service, []byte, error)
 	serviceUpdateFunc         func(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error)
 	serviceListFunc           func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
+	taskListFunc              func(context.Context, types.TaskListOptions) ([]swarm.Task, error)
 	infoFunc                  func(ctx context.Context) (types.Info, error)
 }
 
@@ -22,6 +23,9 @@ func (f *fakeClient) NodeList(ctx context.Context, options types.NodeListOptions
 }
 
 func (f *fakeClient) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	if f.taskListFunc != nil {
+		return f.taskListFunc(ctx, options)
+	}
 	return nil, nil
 }
 

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -69,6 +69,9 @@ func runPS(dockerCli command.Cli, options psOptions) error {
 	if len(format) == 0 {
 		format = task.DefaultFormat(dockerCli.ConfigFile(), options.quiet)
 	}
+	if options.quiet {
+		options.noTrunc = true
+	}
 	if err := task.Print(ctx, dockerCli, tasks, idresolver.New(client, options.noResolve), !options.noTrunc, options.quiet, format); err != nil {
 		return err
 	}

--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -90,6 +90,22 @@ func TestRunPSWarnsOnNotFound(t *testing.T) {
 	assert.EqualError(t, err, "no such service: bar")
 }
 
+func TestRunPSQuiet(t *testing.T) {
+	client := &fakeClient{
+		serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+			return []swarm.Service{{ID: "foo"}}, nil
+		},
+		taskListFunc: func(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+			return []swarm.Task{{ID: "sxabyp0obqokwekpun4rjo0b3"}}, nil
+		},
+	}
+
+	cli := test.NewFakeCli(client)
+	err := runPS(cli, psOptions{services: []string{"foo"}, quiet: true, filter: opts.NewFilterOpt()})
+	require.NoError(t, err)
+	assert.Equal(t, "sxabyp0obqokwekpun4rjo0b3\n", cli.OutBuffer().String())
+}
+
 func TestUpdateNodeFilter(t *testing.T) {
 	selfNodeID := "foofoo"
 	filter := filters.NewArgs()


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/543

Running `docker service ps --quiet` should print the
full, non-truncated ID, even if the `--no-trunc` option
is not set.

This patch disables truncation if the `--quiet` flag
is set.

**- What I did**

Updated the code to override `options.noTrunc` if `options.quiet` is set

**- How to verify it**

Run `docker service ps <servicename>` and verify that the full, non-truncated ID is printed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
Print non-truncated task ID when using `docker service ps --quiet` [docker/cli#579](https://github.com/docker/cli/pull/579)
```

ping @stevvooe PTAL