### PR TITLE
Improve presentation of published port ranges

### DIFF
--- a/cli/command/formatter/service_test.go
+++ b/cli/command/formatter/service_test.go
@@ -224,3 +224,124 @@ func TestServiceContextWriteJSONField(t *testing.T) {
 		assert.Equal(t, services[i].Spec.Name, s, msg)
 	}
 }
+
+func TestServiceContext_Ports(t *testing.T) {
+	c := serviceContext{
+		service: swarm.Service{
+			Endpoint: swarm.Endpoint{
+				Ports: []swarm.PortConfig{
+					{
+						Protocol:      "tcp",
+						TargetPort:    80,
+						PublishedPort: 81,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    80,
+						PublishedPort: 80,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    95,
+						PublishedPort: 95,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    90,
+						PublishedPort: 90,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    91,
+						PublishedPort: 91,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    92,
+						PublishedPort: 92,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    93,
+						PublishedPort: 93,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    94,
+						PublishedPort: 94,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    95,
+						PublishedPort: 95,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    90,
+						PublishedPort: 90,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    96,
+						PublishedPort: 96,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    91,
+						PublishedPort: 91,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    92,
+						PublishedPort: 92,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    93,
+						PublishedPort: 93,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "udp",
+						TargetPort:    94,
+						PublishedPort: 94,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    60,
+						PublishedPort: 60,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    61,
+						PublishedPort: 61,
+						PublishMode:   "ingress",
+					},
+					{
+						Protocol:      "tcp",
+						TargetPort:    61,
+						PublishedPort: 62,
+						PublishMode:   "ingress",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "*:60-61->60-61/tcp, *:62->61/tcp, *:80-81->80/tcp, *:90-95->90-95/tcp, *:90-96->90-96/udp", c.Ports())
+}


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/178

Port mappings in `docker service ls` are quite verbose, and occupy a lot of
space when ranges of ports are published.

This patch improves the output by reconstructing ranges of ports.

Given the following service;

    $ docker service create \
      -p 60-61:60-61 \
      -p 62:61 \
      -p 80:80 \
      -p 81:80 \
      -p 90-95:90-95 \
      -p 90-92:90-92/udp \
      -p 93-96:93-96/udp \
      --name foo \
      nginx:alpine

Before this patch is applied:

    $ docker service ls
    ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
    u1kwguv841qg        foo                 replicated          1/1                 nginx:alpine        *:60->60/tcp,*:61->61/tcp,*:62->61/tcp,*:80->80/tcp,*:81->80/tcp,*:90->90/tcp,*:91->91/tcp,*:92->92/tcp,*:93->93/tcp,*:94->94/tcp,*:95->95/tcp,*:90->90/udp,*:91->91/udp,*:92->92/udp,*:93->93/udp,*:94->94/udp,*:95->95/udp,*:96->96/udp

After this patch is applied:

    $ docker service ls
    ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
    u1kwguv841qg        foo                 replicated          1/1                 nginx:alpine        *:60-62->60-61/tcp,*:80-81->80/tcp,*:90-95->90-95/tcp,*:90-96->90-96/udp

Additional enhancements can still be made, and marked as TODO in this change;

- combine non-consecutive ports mapped to a single port (`80->80`, `81->80`,
  `84->80`, `86->80`, `87->80`); to be printed as `*:80-81,84,86-87->80`.
- combine `tcp` and `udp` mappings if their port-mapping is the same;
  print `*:80-81->80-81/tcp+udp` instead of `*:80-81->80-81/tcp, *:80-81->80-81/udp`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* Improve presentation of published ports by combining port-ranges [docker/cli#581](https://github.com/docker/cli/pull/581)
```