### PR TITLE
Add output for "secrets" and "configs" on stack deploy

### DIFF
--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -224,6 +224,7 @@ func createSecrets(
 			}
 		case apiclient.IsErrSecretNotFound(err):
 			// secret does not exist, then we create a new one.
+			fmt.Fprintf(dockerCli.Out(), "Creating secret %s\n", secretSpec.Name)
 			if _, err := client.SecretCreate(ctx, secretSpec); err != nil {
 				return errors.Wrapf(err, "failed to create secret %s", secretSpec.Name)
 			}
@@ -251,6 +252,7 @@ func createConfigs(
 			}
 		case apiclient.IsErrConfigNotFound(err):
 			// config does not exist, then we create a new one.
+			fmt.Fprintf(dockerCli.Out(), "Creating config %s\n", configSpec.Name)
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {
 				errors.Wrapf(err, "failed to create config %s", configSpec.Name)
 			}


### PR DESCRIPTION
When deploying a stack from a compose file, the output did not show
that a secret or config was created. This patch adds messages for these.

Create a configuration file and compose file:

```bash
$ cat > config.yml <<EOF
hello: world
EOF

$ cat > secret.txt <<EOF
p@ssw0rd
EOF


$ cat > docker-compose.yml <<EOF
version: "3.3"
services:
   test:
     image: nginx:alpine
     configs:
     - source: myconfig
       target: /my-config.yml
     secrets:
     - source: mysecret
       target: /my-secret.txt
configs:
  myconfig:
    file: ./config.yml
secrets:
  mysecret:
    file: ./secret.txt
EOF
```

Before this patch is applied:

```bash
$ docker stack deploy -c docker-compose.yml example

Creating network example_default
Creating service example_test
```

After this patch is applied:

```bash
$ docker stack deploy -c docker-compose.yml example
Creating network example_default
Creating secret example_mysecret
Creating config example_myconfig
Creating service example_test
```

**- What I did**

Added additional messages during `docker stack deploy`

**- How to verify it**

See steps above

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Add informational messages about creating `secrets` and `configs` during `docker stack deploy` [docker/cli#593](https://github.com/docker/cli/pull/593)
```

**- A picture of a cute animal (not mandatory but encouraged)**