### PR TITLE
Remove use of deprecated IsErr...NotFound checks

### DIFF
--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -54,7 +54,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 	getRef := func(ref string) (interface{}, []byte, error) {
 		// Service inspect shows defaults values in empty fields.
 		service, _, err := client.ServiceInspectWithRaw(ctx, ref, types.ServiceInspectOptions{InsertDefaults: true})
-		if err == nil || !apiclient.IsErrServiceNotFound(err) {
+		if err == nil || !apiclient.IsErrNotFound(err) {
 			return service, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such service: %s", ref)
@@ -62,7 +62,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 
 	getNetwork := func(ref string) (interface{}, []byte, error) {
 		network, _, err := client.NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{Scope: "swarm"})
-		if err == nil || !apiclient.IsErrNetworkNotFound(err) {
+		if err == nil || !apiclient.IsErrNotFound(err) {
 			return network, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such network: %s", ref)

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -102,7 +102,7 @@ func runLogs(dockerCli *command.DockerCli, opts *logsOptions) error {
 		}
 		task, _, err := cli.TaskInspectWithRaw(ctx, opts.target)
 		if err != nil {
-			if client.IsErrTaskNotFound(err) {
+			if client.IsErrNotFound(err) {
 				// if the task isn't found, rewrite the error to be clear
 				// that we looked for services AND tasks and found none
 				err = fmt.Errorf("no such task or service: %v", opts.target)

--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -222,7 +222,7 @@ func createSecrets(
 			if err := client.SecretUpdate(ctx, secret.ID, secret.Meta.Version, secretSpec); err != nil {
 				return errors.Wrapf(err, "failed to update secret %s", secretSpec.Name)
 			}
-		case apiclient.IsErrSecretNotFound(err):
+		case apiclient.IsErrNotFound(err):
 			// secret does not exist, then we create a new one.
 			if _, err := client.SecretCreate(ctx, secretSpec); err != nil {
 				return errors.Wrapf(err, "failed to create secret %s", secretSpec.Name)
@@ -249,7 +249,7 @@ func createConfigs(
 			if err := client.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
 				errors.Wrapf(err, "failed to update config %s", configSpec.Name)
 			}
-		case apiclient.IsErrConfigNotFound(err):
+		case apiclient.IsErrNotFound(err):
 			// config does not exist, then we create a new one.
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {
 				errors.Wrapf(err, "failed to create config %s", configSpec.Name)


### PR DESCRIPTION
These were deprecated in favour of `apiclient.IsErrNotFound()`