### PR TITLE
Bump Go to 1.8.4

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross@sha256:d24e7affa3a85d460d2303c2549f03fc866f2b97d771ccf07b0e6e2b411dd207
+FROM    dockercore/golang-cross@sha256:8a347b3692ba925dcef753f2de289e11774410c1bc752b9d525cb05477a7697b
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.3-alpine
+FROM    golang:1.8.4-alpine
 
 RUN     apk add -U git make bash coreutils
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.8.3-alpine
+FROM    golang:1.8.4-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Bumps the Go version used to 1.8.4, which contains security fixes;
https://groups.google.com/forum/#!topic/golang-announce/1hZYiemnkdE

This will currently fail, as the images are not live yet on Docker Hub, but they're currently building, so should be available shortly(r)(tm)

https://hub.docker.com/r/library/golang/tags/