### PR TITLE
[Compose] Cast values to expected type after interpolating values

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -1,75 +1,88 @@
 package interpolation
 
 import (
+	"os"
+
 	"github.com/docker/cli/cli/compose/template"
 	"github.com/pkg/errors"
 )
 
+// Options supported by Interpolate
+type Options struct {
+	// SectionName of the configuration section
+	SectionName string
+	// LookupValue from a key
+	LookupValue LookupValue
+}
+
+// LookupValue is a function which maps from variable names to values.
+// Returns the value as a string and a bool indicating whether
+// the value is present, to distinguish between an empty string
+// and the absence of a value.
+type LookupValue func(key string) (string, bool)
+
 // Interpolate replaces variables in a string with the values from a mapping
-func Interpolate(config map[string]interface{}, section string, mapping template.Mapping) (map[string]interface{}, error) {
+func Interpolate(config map[string]interface{}, opts Options) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 
-	for name, item := range config {
+	if opts.LookupValue == nil {
+		opts.LookupValue = os.LookupEnv
+	}
+
+	for key, item := range config {
 		if item == nil {
-			out[name] = nil
+			out[key] = nil
 			continue
 		}
 		mapItem, ok := item.(map[string]interface{})
 		if !ok {
-			return nil, errors.Errorf("Invalid type for %s : %T instead of %T", name, item, out)
+			return nil, errors.Errorf("Invalid type for %s : %T instead of %T", key, item, out)
 		}
-		interpolatedItem, err := interpolateSectionItem(name, mapItem, section, mapping)
+		interpolatedItem, err := interpolateSectionItem(key, mapItem, opts)
 		if err != nil {
 			return nil, err
 		}
-		out[name] = interpolatedItem
+		out[key] = interpolatedItem
 	}
 
 	return out, nil
 }
 
 func interpolateSectionItem(
-	name string,
+	sectionkey string,
 	item map[string]interface{},
-	section string,
-	mapping template.Mapping,
+	opts Options,
 ) (map[string]interface{}, error) {
-
 	out := map[string]interface{}{}
 
 	for key, value := range item {
-		interpolatedValue, err := recursiveInterpolate(value, mapping)
+		interpolatedValue, err := recursiveInterpolate(value, opts)
 		switch err := err.(type) {
 		case nil:
 		case *template.InvalidTemplateError:
 			return nil, errors.Errorf(
 				"Invalid interpolation format for %#v option in %s %#v: %#v. You may need to escape any $ with another $.",
-				key, section, name, err.Template,
+				key, opts.SectionName, sectionkey, err.Template,
 			)
 		default:
-			return nil, errors.Wrapf(err, "error while interpolating %s in %s %s", key, section, name)
+			return nil, errors.Wrapf(err, "error while interpolating %s in %s %s", key, opts.SectionName, sectionkey)
 		}
 		out[key] = interpolatedValue
 	}
 
 	return out, nil
-
 }
 
-func recursiveInterpolate(
-	value interface{},
-	mapping template.Mapping,
-) (interface{}, error) {
-
+func recursiveInterpolate(value interface{}, opts Options) (interface{}, error) {
 	switch value := value.(type) {
 
 	case string:
-		return template.Substitute(value, mapping)
+		return template.Substitute(value, template.Mapping(opts.LookupValue))
 
 	case map[string]interface{}:
 		out := map[string]interface{}{}
 		for key, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, mapping)
+			interpolatedElem, err := recursiveInterpolate(elem, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -80,7 +93,7 @@ func recursiveInterpolate(
 	case []interface{}:
 		out := make([]interface{}, len(value))
 		for i, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, mapping)
+			interpolatedElem, err := recursiveInterpolate(elem, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -92,5 +105,4 @@ func recursiveInterpolate(
 		return value, nil
 
 	}
-
 }

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -3,6 +3,8 @@ package interpolation
 import (
 	"os"
 
+	"strings"
+
 	"github.com/docker/cli/cli/compose/template"
 	"github.com/pkg/errors"
 )
@@ -13,6 +15,8 @@ type Options struct {
 	SectionName string
 	// LookupValue from a key
 	LookupValue LookupValue
+	// TypeCastMapping maps key paths to functions to cast to a type
+	TypeCastMapping map[Path]Cast
 }
 
 // LookupValue is a function which maps from variable names to values.
@@ -21,12 +25,18 @@ type Options struct {
 // and the absence of a value.
 type LookupValue func(key string) (string, bool)
 
+// Cast a value to a new type, or return an error if the value can't be cast
+type Cast func(value string) (interface{}, error)
+
 // Interpolate replaces variables in a string with the values from a mapping
 func Interpolate(config map[string]interface{}, opts Options) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 
 	if opts.LookupValue == nil {
 		opts.LookupValue = os.LookupEnv
+	}
+	if opts.TypeCastMapping == nil {
+		opts.TypeCastMapping = make(map[Path]Cast)
 	}
 
 	for key, item := range config {
@@ -38,7 +48,7 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 		if !ok {
 			return nil, errors.Errorf("Invalid type for %s : %T instead of %T", key, item, out)
 		}
-		interpolatedItem, err := interpolateSectionItem(key, mapItem, opts)
+		interpolatedItem, err := interpolateSectionItem(NewPath(key), mapItem, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -49,23 +59,23 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 }
 
 func interpolateSectionItem(
-	sectionkey string,
+	path Path,
 	item map[string]interface{},
 	opts Options,
 ) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 
 	for key, value := range item {
-		interpolatedValue, err := recursiveInterpolate(value, opts)
+		interpolatedValue, err := recursiveInterpolate(value, path.Next(key), opts)
 		switch err := err.(type) {
 		case nil:
 		case *template.InvalidTemplateError:
 			return nil, errors.Errorf(
 				"Invalid interpolation format for %#v option in %s %#v: %#v. You may need to escape any $ with another $.",
-				key, opts.SectionName, sectionkey, err.Template,
+				key, opts.SectionName, path.root(), err.Template,
 			)
 		default:
-			return nil, errors.Wrapf(err, "error while interpolating %s in %s %s", key, opts.SectionName, sectionkey)
+			return nil, errors.Wrapf(err, "error while interpolating %s in %s %s", key, opts.SectionName, path.root())
 		}
 		out[key] = interpolatedValue
 	}
@@ -73,16 +83,24 @@ func interpolateSectionItem(
 	return out, nil
 }
 
-func recursiveInterpolate(value interface{}, opts Options) (interface{}, error) {
+func recursiveInterpolate(value interface{}, path Path, opts Options) (interface{}, error) {
 	switch value := value.(type) {
 
 	case string:
-		return template.Substitute(value, template.Mapping(opts.LookupValue))
+		newValue, err := template.Substitute(value, template.Mapping(opts.LookupValue))
+		if err != nil || newValue == value {
+			return value, err
+		}
+		caster, ok := opts.getCasterForPath(path)
+		if !ok {
+			return newValue, nil
+		}
+		return caster(newValue)
 
 	case map[string]interface{}:
 		out := map[string]interface{}{}
 		for key, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, opts)
+			interpolatedElem, err := recursiveInterpolate(elem, path.Next(key), opts)
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +111,7 @@ func recursiveInterpolate(value interface{}, opts Options) (interface{}, error) 
 	case []interface{}:
 		out := make([]interface{}, len(value))
 		for i, elem := range value {
-			interpolatedElem, err := recursiveInterpolate(elem, opts)
+			interpolatedElem, err := recursiveInterpolate(elem, path, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -105,4 +123,63 @@ func recursiveInterpolate(value interface{}, opts Options) (interface{}, error) 
 		return value, nil
 
 	}
+}
+
+const pathSeparator = "."
+
+// PathMatchAll is a token used as part of a Path to match any key at that level
+// in the nested structure
+const PathMatchAll = "*"
+
+// Path is a dotted path of keys to a value in a nested mapping structure. A *
+// section in a path will match any key in the mapping structure.
+type Path string
+
+// NewPath returns a new Path
+func NewPath(items ...string) Path {
+	return Path(strings.Join(items, pathSeparator))
+}
+
+// Next returns a new path by append part to the current path
+func (p Path) Next(part string) Path {
+	return Path(string(p) + pathSeparator + part)
+}
+
+func (p Path) root() string {
+	parts := p.parts()
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+func (p Path) parts() []string {
+	return strings.Split(string(p), pathSeparator)
+}
+
+func (p Path) matches(pattern Path) bool {
+	patternParts := pattern.parts()
+	parts := p.parts()
+
+	if len(patternParts) != len(parts) {
+		return false
+	}
+	for index, part := range parts {
+		switch patternParts[index] {
+		case PathMatchAll, part:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (o Options) getCasterForPath(path Path) (Cast, bool) {
+	for pattern, caster := range o.TypeCastMapping {
+		if path.matches(pattern) {
+			return caster, true
+		}
+	}
+	return nil, false
 }

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -45,10 +45,7 @@ func TestInterpolate(t *testing.T) {
 			},
 		},
 	}
-	result, err := Interpolate(services, Options{
-		SectionName: "service",
-		LookupValue: defaultMapping,
-	})
+	result, err := Interpolate(services, Options{LookupValue: defaultMapping})
 	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
@@ -59,11 +56,8 @@ func TestInvalidInterpolation(t *testing.T) {
 			"image": "${",
 		},
 	}
-	_, err := Interpolate(services, Options{
-		SectionName: "service",
-		LookupValue: defaultMapping,
-	})
-	assert.EqualError(t, err, `Invalid interpolation format for "image" option in service "servicea": "${". You may need to escape any $ with another $.`)
+	_, err := Interpolate(services, Options{LookupValue: defaultMapping})
+	assert.EqualError(t, err, `invalid interpolation format for servicea.image: "${". You may need to escape any $ with another $.`)
 }
 
 func TestInterpolateWithDefaults(t *testing.T) {
@@ -95,7 +89,7 @@ func TestInterpolateWithCast(t *testing.T) {
 	}
 	result, err := Interpolate(config, Options{
 		LookupValue:     defaultMapping,
-		TypeCastMapping: map[Path]Cast{NewPath("*", "replicas"): toInt},
+		TypeCastMapping: map[Path]Cast{NewPath(PathMatchAll, "replicas"): toInt},
 	})
 	assert.NoError(t, err)
 	expected := map[string]interface{}{

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -1,0 +1,95 @@
+package loader
+
+import (
+	"strconv"
+	"strings"
+
+	interp "github.com/docker/cli/cli/compose/interpolation"
+	"github.com/pkg/errors"
+)
+
+var interpolateTypeCastMapping = map[string]map[interp.Path]interp.Cast{
+	"services": {
+		iPath("configs", "mode"):                              toInt,
+		iPath("secrets", "mode"):                              toInt,
+		iPath("healthcheck", "retries"):                       toInt,
+		iPath("healthcheck", "disable"):                       toBoolean,
+		iPath("deploy", "replicas"):                           toInt,
+		iPath("deploy", "update_config", "parallelism:"):      toInt,
+		iPath("deploy", "update_config", "max_failure_ratio"): toFloat,
+		iPath("deploy", "restart_policy", "max_attempts"):     toInt,
+		iPath("ports", "target"):                              toInt,
+		iPath("ports", "published"):                           toInt,
+		iPath("ulimits", interp.PathMatchAll):                 toInt,
+		iPath("ulimits", interp.PathMatchAll, "hard"):         toInt,
+		iPath("ulimits", interp.PathMatchAll, "soft"):         toInt,
+		iPath("privileged"):                                   toBoolean,
+		iPath("read_only"):                                    toBoolean,
+		iPath("stdin_open"):                                   toBoolean,
+		iPath("tty"):                                          toBoolean,
+		iPath("volumes", "read_only"):                         toBoolean,
+		iPath("volumes", "volume", "nocopy"):                  toBoolean,
+	},
+	"networks": {
+		iPath("external"):   toBoolean,
+		iPath("internal"):   toBoolean,
+		iPath("attachable"): toBoolean,
+	},
+	"volumes": {
+		iPath("external"): toBoolean,
+	},
+	"secrets": {
+		iPath("external"): toBoolean,
+	},
+	"configs": {
+		iPath("external"): toBoolean,
+	},
+}
+
+func iPath(parts ...string) interp.Path {
+	return interp.NewPath(append([]string{interp.PathMatchAll}, parts...)...)
+}
+
+func toInt(value string) (interface{}, error) {
+	return strconv.Atoi(value)
+}
+
+func toFloat(value string) (interface{}, error) {
+	return strconv.ParseFloat(value, 64)
+}
+
+// should match http://yaml.org/type/bool.html
+func toBoolean(value string) (interface{}, error) {
+	switch strings.ToLower(value) {
+	case "y", "yes", "true", "on":
+		return true, nil
+	case "n", "no", "false", "off":
+		return false, nil
+	default:
+		return nil, errors.Errorf("invalid boolean: %s", value)
+	}
+}
+
+func interpolateConfig(configDict map[string]interface{}, lookupEnv interp.LookupValue) (map[string]map[string]interface{}, error) {
+	config := make(map[string]map[string]interface{})
+
+	for _, key := range []string{"services", "networks", "volumes", "secrets", "configs"} {
+		section, ok := configDict[key]
+		if !ok {
+			config[key] = make(map[string]interface{})
+			continue
+		}
+		var err error
+		config[key], err = interp.Interpolate(
+			section.(map[string]interface{}),
+			interp.Options{
+				SectionName:     key,
+				LookupValue:     lookupEnv,
+				TypeCastMapping: interpolateTypeCastMapping[key],
+			})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return config, nil
+}

--- a/vendor/github.com/gotestyourself/gotestyourself/env/env.go
+++ b/vendor/github.com/gotestyourself/gotestyourself/env/env.go
@@ -1,0 +1,58 @@
+/*Package env provides functions to test code that read environment variables
+ */
+package env
+
+import (
+	"os"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Patch changes the value of an environment variable, and returns a
+// function which will reset the the value of that variable back to the
+// previous state.
+func Patch(t require.TestingT, key, value string) func() {
+	oldValue, ok := os.LookupEnv(key)
+	require.NoError(t, os.Setenv(key, value))
+	return func() {
+		if !ok {
+			require.NoError(t, os.Unsetenv(key))
+			return
+		}
+		require.NoError(t, os.Setenv(key, oldValue))
+	}
+}
+
+// PatchAll sets the environment to env, and returns a function which will
+// reset the environment back to the previous state.
+func PatchAll(t require.TestingT, env map[string]string) func() {
+	oldEnv := os.Environ()
+	os.Clearenv()
+
+	for key, value := range env {
+		require.NoError(t, os.Setenv(key, value))
+	}
+	return func() {
+		os.Clearenv()
+		for key, oldVal := range ToMap(oldEnv) {
+			require.NoError(t, os.Setenv(key, oldVal))
+		}
+	}
+}
+
+// ToMap takes a list of strings in the format returned by os.Environ() and
+// returns a mapping of keys to values.
+func ToMap(env []string) map[string]string {
+	result := map[string]string{}
+	for _, raw := range env {
+		parts := strings.SplitN(raw, "=", 2)
+		switch len(parts) {
+		case 1:
+			result[raw] = ""
+		case 2:
+			result[parts[0]] = parts[1]
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Fixes #229

Required a change to the order of operations to handle interpolation before schema validation. This should be safe because interpolation should not require any specific structure.

cc @shin- 
@vdemeester sorry in advance for conflicts with #569 if this merges first