### PR TITLE
Fix markdown link in service-create reference docs

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -294,8 +294,9 @@ volumes in a service:
     <td>
       <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, or <tt>tmpfs</tt>. Defaults to <tt>volume</tt> if no type is specified.
       <ul>
-        <li><tt>volume</tt>: mounts a [managed volume](volume_create.md) into the container.</li>
-        <li><tt>bind</tt>: bind-mounts a directory or file from the host into the container.</li>
+        <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
+        into the container.</li> <li><tt>bind</tt>:
+        bind-mounts a directory or file from the host into the container.</li>
         <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
       </ul></p>
     </td>


### PR DESCRIPTION
Markdown nested in a HTML table doesn't work, so changing the link to a plain HTML link.

fixes https://github.com/docker/cli/issues/602


ping @johndmulhausen @mstanleyjones 