### PR TITLE
Revert "Refactor image commands to make use of the new trust struct for trusted pull"

### DIFF
--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -32,6 +32,11 @@ func TestNewPullCommandErrors(t *testing.T) {
 			expectedError: "tag can't be used with --all-tags/-a",
 			args:          []string{"--all-tags", "image:tag"},
 		},
+		{
+			name:          "pull-error",
+			args:          []string{"--disable-content-trust=false", "image:tag"},
+			expectedError: "you are not authorized to perform this operation: server returned 401.",
+		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -11,12 +11,11 @@ import (
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -182,13 +181,57 @@ func imagePushPrivileged(ctx context.Context, cli command.Cli, authConfig types.
 }
 
 // trustedPull handles content trust pulling of an image
-func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth) error {
-	refs, err := getTrustedPullTargets(cli, imgRefAndAuth)
+func trustedPull(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo, ref reference.Named, authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error {
+	var refs []target
+
+	notaryRepo, err := trust.GetNotaryRepository(cli.In(), cli.Out(), command.UserAgent(), repoInfo, &authConfig, "pull")
 	if err != nil {
+		fmt.Fprintf(cli.Out(), "Error establishing connection to trust repository: %s\n", err)
 		return err
 	}
 
-	ref := imgRefAndAuth.Reference()
+	if tagged, isTagged := ref.(reference.NamedTagged); !isTagged {
+		// List all targets
+		targets, err := notaryRepo.ListTargets(trust.ReleasesRole, data.CanonicalTargetsRole)
+		if err != nil {
+			return trust.NotaryError(ref.Name(), err)
+		}
+		for _, tgt := range targets {
+			t, err := convertTarget(tgt.Target)
+			if err != nil {
+				fmt.Fprintf(cli.Out(), "Skipping target for %q\n", reference.FamiliarName(ref))
+				continue
+			}
+			// Only list tags in the top level targets role or the releases delegation role - ignore
+			// all other delegation roles
+			if tgt.Role != trust.ReleasesRole && tgt.Role != data.CanonicalTargetsRole {
+				continue
+			}
+			refs = append(refs, t)
+		}
+		if len(refs) == 0 {
+			return trust.NotaryError(ref.Name(), errors.Errorf("No trusted tags for %s", ref.Name()))
+		}
+	} else {
+		t, err := notaryRepo.GetTargetByName(tagged.Tag(), trust.ReleasesRole, data.CanonicalTargetsRole)
+		if err != nil {
+			return trust.NotaryError(ref.Name(), err)
+		}
+		// Only get the tag if it's in the top level targets role or the releases delegation role
+		// ignore it if it's in any other delegation roles
+		if t.Role != trust.ReleasesRole && t.Role != data.CanonicalTargetsRole {
+			return trust.NotaryError(ref.Name(), errors.Errorf("No trust data for %s", tagged.Tag()))
+		}
+
+		logrus.Debugf("retrieving target for %s role\n", t.Role)
+		r, err := convertTarget(t.Target)
+		if err != nil {
+			return err
+
+		}
+		refs = append(refs, r)
+	}
+
 	for i, r := range refs {
 		displayTag := r.name
 		if displayTag != "" {
@@ -200,7 +243,7 @@ func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.Image
 		if err != nil {
 			return err
 		}
-		if err := imagePullPrivileged(ctx, cli, imgRefAndAuth, false); err != nil {
+		if err := imagePullPrivileged(ctx, cli, authConfig, reference.FamiliarString(trustedRef), requestPrivilege, false); err != nil {
 			return err
 		}
 
@@ -216,65 +259,13 @@ func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.Image
 	return nil
 }
 
-func getTrustedPullTargets(cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth) ([]target, error) {
-	notaryRepo, err := cli.NotaryClient(imgRefAndAuth, trust.ActionsPullOnly)
-	if err != nil {
-		fmt.Fprintf(cli.Out(), "Error establishing connection to trust repository: %s\n", err)
-		return nil, err
-	}
-
-	ref := imgRefAndAuth.Reference()
-	tagged, isTagged := ref.(reference.NamedTagged)
-	if !isTagged {
-		// List all targets
-		targets, err := notaryRepo.ListTargets(trust.ReleasesRole, data.CanonicalTargetsRole)
-		if err != nil {
-			return nil, trust.NotaryError(ref.Name(), err)
-		}
-		var refs []target
-		for _, tgt := range targets {
-			t, err := convertTarget(tgt.Target)
-			if err != nil {
-				fmt.Fprintf(cli.Out(), "Skipping target for %q\n", reference.FamiliarName(ref))
-				continue
-			}
-			// Only list tags in the top level targets role or the releases delegation role - ignore
-			// all other delegation roles
-			if tgt.Role != trust.ReleasesRole && tgt.Role != data.CanonicalTargetsRole {
-				continue
-			}
-			refs = append(refs, t)
-		}
-		if len(refs) == 0 {
-			return nil, trust.NotaryError(ref.Name(), errors.Errorf("No trusted tags for %s", ref.Name()))
-		}
-		return refs, nil
-	}
-
-	t, err := notaryRepo.GetTargetByName(tagged.Tag(), trust.ReleasesRole, data.CanonicalTargetsRole)
-	if err != nil {
-		return nil, trust.NotaryError(ref.Name(), err)
-	}
-	// Only get the tag if it's in the top level targets role or the releases delegation role
-	// ignore it if it's in any other delegation roles
-	if t.Role != trust.ReleasesRole && t.Role != data.CanonicalTargetsRole {
-		return nil, trust.NotaryError(ref.Name(), errors.Errorf("No trust data for %s", tagged.Tag()))
-	}
-
-	logrus.Debugf("retrieving target for %s role\n", t.Role)
-	r, err := convertTarget(t.Target)
-	return []target{r}, err
-}
-
 // imagePullPrivileged pulls the image and displays it to the output
-func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, all bool) error {
-	ref := reference.FamiliarString(imgRefAndAuth.Reference())
+func imagePullPrivileged(ctx context.Context, cli command.Cli, authConfig types.AuthConfig, ref string, requestPrivilege types.RequestPrivilegeFunc, all bool) error {
 
-	encodedAuth, err := command.EncodeAuthToBase64(*imgRefAndAuth.AuthConfig())
+	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err
 	}
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(cli, imgRefAndAuth.RepoInfo().Index, "pull")
 	options := types.ImagePullOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,
@@ -354,11 +345,4 @@ func TagTrusted(ctx context.Context, cli command.Cli, trustedRef reference.Canon
 	fmt.Fprintf(cli.Out(), "Tagging %s as %s\n", trustedFamiliarRef, familiarRef)
 
 	return cli.Client().ImageTag(ctx, trustedFamiliarRef, familiarRef)
-}
-
-// AuthResolver returns an auth resolver function from a command.Cli
-func AuthResolver(cli command.Cli) func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
-	return func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
-		return command.ResolveAuthConfig(ctx, cli, index)
-	}
 }

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/docker/cli/cli"
-	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
-	"github.com/docker/cli/cli/trust"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
 	"github.com/pkg/errors"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/trust"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +38,10 @@ func newRevokeCommand(dockerCli command.Cli) *cobra.Command {
 
 func revokeTrust(cli command.Cli, remote string, options revokeOptions) error {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
+	authResolver := func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
+		return command.ResolveAuthConfig(ctx, cli, index)
+	}
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver, remote)
 	if err != nil {
 		return err
 	}
@@ -52,7 +57,7 @@ func revokeTrust(cli command.Cli, remote string, options revokeOptions) error {
 		}
 	}
 
-	notaryRepo, err := cli.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := cli.NotaryClient(*imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"bytes"
-
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/test"
@@ -266,12 +264,13 @@ func TestGetExistingSignatureInfoForReleasedTag(t *testing.T) {
 }
 
 func TestPrettyPrintExistingSignatureInfo(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
+	fakeCli := test.NewFakeCli(&fakeClient{})
+
 	signers := []string{"Bob", "Alice", "Carol"}
 	existingSig := trustTagRow{trustTagKey{"tagName", "abc123"}, signers}
-	prettyPrintExistingSignatureInfo(buf, existingSig)
+	prettyPrintExistingSignatureInfo(fakeCli, existingSig)
 
-	assert.Contains(t, buf.String(), "Existing signatures for tag tagName digest abc123 from:\nAlice, Bob, Carol")
+	assert.Contains(t, fakeCli.OutBuffer().String(), "Existing signatures for tag tagName digest abc123 from:\nAlice, Bob, Carol")
 }
 
 func TestSignCommandChangeListIsCleanedOnError(t *testing.T) {

--- a/cli/command/trust/view.go
+++ b/cli/command/trust/view.go
@@ -11,8 +11,9 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
+	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/notary"
 	"github.com/docker/notary/client"
 	"github.com/docker/notary/tuf/data"
@@ -60,12 +61,15 @@ func newViewCommand(dockerCli command.Cli) *cobra.Command {
 
 func lookupTrustInfo(cli command.Cli, remote string) error {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
+	authResolver := func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
+		return command.ResolveAuthConfig(ctx, cli, index)
+	}
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver, remote)
 	if err != nil {
 		return err
 	}
 	tag := imgRefAndAuth.Tag()
-	notaryRepo, err := cli.NotaryClient(imgRefAndAuth, trust.ActionsPullOnly)
+	notaryRepo, err := cli.NotaryClient(*imgRefAndAuth, trust.ActionsPullOnly)
 	if err != nil {
 		return trust.NotaryError(imgRefAndAuth.Reference().Name(), err)
 	}

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -31,7 +32,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (
@@ -288,7 +288,6 @@ func GetSignableRoles(repo client.Repository, target *client.Target) ([]data.Rol
 
 // ImageRefAndAuth contains all reference information and the auth config for an image request
 type ImageRefAndAuth struct {
-	original   string
 	authConfig *types.AuthConfig
 	reference  reference.Named
 	repoInfo   *registry.RepositoryInfo
@@ -296,29 +295,27 @@ type ImageRefAndAuth struct {
 	digest     digest.Digest
 }
 
+// NewImageRefAndAuth creates a new ImageRefAndAuth struct
+func NewImageRefAndAuth(authConfig *types.AuthConfig, reference reference.Named, repoInfo *registry.RepositoryInfo, tag string, digest digest.Digest) *ImageRefAndAuth {
+	return &ImageRefAndAuth{authConfig, reference, repoInfo, tag, digest}
+}
+
 // GetImageReferencesAndAuth retrieves the necessary reference and auth information for an image name
 // as a ImageRefAndAuth struct
-func GetImageReferencesAndAuth(ctx context.Context, authResolver func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig, imgName string) (ImageRefAndAuth, error) {
+func GetImageReferencesAndAuth(ctx context.Context, authResolver func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig, imgName string) (*ImageRefAndAuth, error) {
 	ref, err := reference.ParseNormalizedNamed(imgName)
 	if err != nil {
-		return ImageRefAndAuth{}, err
+		return nil, err
 	}
 
 	// Resolve the Repository name from fqn to RepositoryInfo
 	repoInfo, err := registry.ParseRepositoryInfo(ref)
 	if err != nil {
-		return ImageRefAndAuth{}, err
+		return nil, err
 	}
 
 	authConfig := authResolver(ctx, repoInfo.Index)
-	return ImageRefAndAuth{
-		original:   imgName,
-		authConfig: &authConfig,
-		reference:  ref,
-		repoInfo:   repoInfo,
-		tag:        getTag(ref),
-		digest:     getDigest(ref),
-	}, nil
+	return NewImageRefAndAuth(&authConfig, ref, repoInfo, getTag(ref), getDigest(ref)), nil
 }
 
 func getTag(ref reference.Named) string {
@@ -366,10 +363,4 @@ func (imgRefAuth *ImageRefAndAuth) Tag() string {
 // Digest returns the Image digest for a given ImageRefAndAuth
 func (imgRefAuth *ImageRefAndAuth) Digest() digest.Digest {
 	return imgRefAuth.digest
-}
-
-// Name returns the image name used to initialize the ImageRefAndAuth
-func (imgRefAuth *ImageRefAndAuth) Name() string {
-	return imgRefAuth.original
-
 }

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -26,6 +26,6 @@
     "vet"
   ],
 
-  "Cyclo": 16,
+  "Cyclo": 19,
   "LineLength": 200
 }


### PR DESCRIPTION
This reverts commit 4203b4943154ad09917702dbae2f2b414f70dc5d.

I've reverted because the immutable nature of `ImageRefAndAuth` doesn't fit as well for image pull as it did for the trust commands.

In particular: updating an `ImageRefAndAuth` for adding `latest` as a default tag, and the `trustedRef` in `trustedPull` is not used.

cc @dnephin @andrewhsu @RobbKistler 

I will followup with regression tests in the existing `DockerTrustSuite`