### PR TITLE
Update bash completion and deprecation for synchronous service updates

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3224,7 +3224,7 @@ _docker_service_rm() {
 _docker_service_rollback() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach=false -d --help --quit -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --quit -q" -- "$cur" ) )
 			;;
 		*)
 			local counter=$( __docker_pos_first_nonflag )
@@ -3238,7 +3238,7 @@ _docker_service_rollback() {
 _docker_service_scale() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach=false -d=false --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_services
@@ -3339,7 +3339,7 @@ _docker_service_update_and_create() {
 	"
 
 	local boolean_options="
-		--detach=false -d=false
+		--detach -d
 		--help
 		--no-healthcheck
 		--read-only

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -24,12 +24,15 @@ see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-depreca
 
 **Deprecated In Release: v17.05.0**
 
-**Disabled by default in release: [v17.09](https://github.com/docker/docker-ce/releases/tag/v17.09.0-ce)**
+**Disabled by default in release: [v17.10](https://github.com/docker/docker-ce/releases/tag/v17.10.0-ce)**
 
 Docker 17.05.0 added an optional `--detach=false` option to make the
 `docker service create` and `docker service update` work synchronously. This
-option will be enable by default in Docker 17.09, at which point the `--detach`
+option will be enabled by default in Docker 17.10, at which point the `--detach`
 flag can be used to use the previous (asynchronous) behavior.
+
+The default for this option will also be changed accordingly for `docker service rollback`
+and `docker service scale` in Docker 17.10.
 
 ### `-g` and `--graph` flags on `dockerd`
 


### PR DESCRIPTION
The default value for `docker service create|update|scale|rollback --detach|-d` changed from `true` to `false`.
This updates bash completion to complete just `--detach|-d`.

This should go into 17.10.0 because the behavior changes in this release.

Also updates the deprecation of asynchronous service updates:
- The default was not changed in 17.09 but will be in 17.10
- `service scale` and `service rollback` are also affected.