### PR TITLE
Add bash completion for `stack deploy --resolve-image`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4346,16 +4346,20 @@ _docker_stack_deploy() {
 			_filedir yml
 			return
 			;;
+		--resolve-image)
+			COMPREPLY=( $( compgen -W "always changed never" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help --prune --with-registry-auth"
+			local options="--compose-file -c --help --prune --resolve-image --with-registry-auth"
 			__docker_daemon_is_experimental && options+=" --bundle-file"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--compose-file|-c|--bundle-file')
+			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--resolve-image')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -28,6 +28,8 @@ Options:
   -c, --compose-file string   Path to a Compose file
       --help                  Print usage
       --prune                 Prune services that are no longer referenced
+      --resolve-image string  Query the registry to resolve image digest and supported platforms
+                              ("always"|"changed"|"never") (default "always")
       --with-registry-auth    Send registry authentication details to Swarm agents
 ```
 


### PR DESCRIPTION
Bash completion for #121.
The flag did not get added to the docs yet.
I do not know enough about this feature to add an example, so I just added it to the help output section.