### PR TITLE
run.md: add IDs for headers with dashes

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -83,6 +83,7 @@ default foreground mode:
 
     -d=false: Detached mode: Run container in the background, print new container id
 
+<a id="detached--d"></a>
 ### Detached (-d)
 
 To start a container in detached mode, you use `-d=true` or just `-d` option. By
@@ -145,6 +146,7 @@ is receiving its standard input from a pipe, as in:
 
 ## Container identification
 
+<a id="name---name"></a>
 ### Name (--name)
 
 The operator can identify a container in three ways:
@@ -248,6 +250,7 @@ $ docker run -it --pid=container:my-redis my_strace_docker_image bash
 $ strace -p 1
 ```
 
+<a id="uts-settings---uts"></a>
 ## UTS settings (--uts)
 
     --uts=""  : Set the UTS namespace mode for the container,
@@ -263,6 +266,7 @@ You may wish to share the UTS namespace with the host if you would like the
 hostname of the container to change as the hostname of the host changes.  A
 more advanced use case would be changing the host's hostname from a container.
 
+<a id="ipc-settings---ipc"></a>
 ## IPC settings (--ipc)
 
     --ipc="MODE"  : Set the IPC mode for the container
@@ -475,6 +479,7 @@ may be situations when processes inside the container can end up reading an
 empty or incomplete `/etc/hosts` file. In most cases, retrying the read again
 should fix the problem.
 
+<a id="restart-policies---restart"></a>
 ## Restart policies (--restart)
 
 Using the `--restart` flag on Docker run you can specify a restart policy for
@@ -611,6 +616,7 @@ the exit codes follow the `chroot` standard, see below:
     $ docker run busybox /bin/sh -c 'exit 3'; echo $?
     # 3
 
+<a id="clean-up---rm"></a>
 ## Clean up (--rm)
 
 By default a container's file system persists even after the container


### PR DESCRIPTION
TL;DR: this is an attempt to fix https://github.com/docker/docker.github.io/issues/4877

So, these docs are used both on github and on docs.docker.com. The problem is,
different markdown to html converters are used for github and docs.docker.com.
In particular, auto-generation of IDs for headers differs between those two, in case
dashes are used inside header text. With github, dashes are not stripped, and so
if we have a header like:
```
## Some --option
```
then github will generate `id="some---option"`, while Jekyll (kramdown), used for docs.docker.com,
will generate `id="some-option"`. With this difference, there is no way to refer to a section of a document
and make it work on both github and docs.docker.com.

A solution would be to patch kramdown to not strip dashes from the header text. Unfortunately,
this does not look realistic.

So, here's a workaround: provide "github-compatible" id for every header that contains dashes.
This is what this commit does.