### PR TITLE
Removing titles from md files

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,6 +1,5 @@
 ---
 aliases: ["/engine/misc/deprecated/"]
-title: "Deprecated Engine Features"
 description: "Deprecated Features."
 keywords: "docker, documentation, about, technology, deprecate"
 ---

--- a/docs/extend/EBS_volume.md
+++ b/docs/extend/EBS_volume.md
@@ -1,7 +1,6 @@
 ---
 description: Volume plugin for Amazon EBS
 keywords: "API, Usage, plugins, documentation, developer, amazon, ebs, rexray, volume"
-title: Volume plugin for Amazon EBS
 ---
 
 <!-- This file is maintained within the docker/cli GitHub
@@ -13,7 +12,9 @@ title: Volume plugin for Amazon EBS
      will be rejected.
 -->
 
-# A proof-of-concept Rexray plugin
+# Volume plugin for Amazon EBS
+
+## A proof-of-concept Rexray plugin
 
 In this example, a simple Rexray plugin will be created for the purposes of using
 it on an Amazon EC2 instance with EBS. It is not meant to be a complete Rexray plugin.

--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -1,5 +1,4 @@
 ---
-title: "Plugin config"
 description: "How develop and use a plugin with the managed plugin system"
 keywords: "API, Usage, plugins, documentation, developer"
 ---

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -1,7 +1,6 @@
 ---
 description: Develop and use a plugin with the managed plugin system
 keywords: "API, Usage, plugins, documentation, developer"
-title: Managed plugin system
 ---
 
 <!-- This file is maintained within the docker/cli GitHub
@@ -62,7 +61,7 @@ enabled, and use it to create a volume.
     ```
 
     The plugin requests 2 privileges:
-    
+
     - It needs access to the `host` network.
     - It needs the `CAP_SYS_ADMIN` capability, which allows the plugin to run
     the `mount` command.
@@ -78,7 +77,7 @@ enabled, and use it to create a volume.
 
 3.  Create a volume using the plugin.
     This example mounts the `/remote` directory on host `1.2.3.4` into a
-    volume named `sshvolume`.   
+    volume named `sshvolume`.
 
     This volume can now be mounted into containers.
 

--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -1,7 +1,6 @@
 ---
 redirect_from:
 - "/engine/extend/plugins/"
-title: "Use Docker Engine plugins"
 description: "How to add additional functionality to Docker with plugins extensions"
 keywords: "Examples, Usage, plugins, docker, documentation, user guide"
 ---
@@ -14,6 +13,8 @@ keywords: "Examples, Usage, plugins, docker, documentation, user guide"
      requests which include edits to this file in other repositories
      will be rejected.
 -->
+
+# Use Docker Engine plugins
 
 This document describes the Docker Engine plugins generally available in Docker
 Engine. To view information on plugins managed by Docker,

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -1,5 +1,4 @@
 ---
-title: "Plugins API"
 description: "How to write Docker plugins extensions "
 keywords: "API, Usage, plugins, documentation, developer"
 ---

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -1,5 +1,4 @@
 ---
-title: "Access authorization plugin"
 description: "How to create authorization plugins to manage access control to your Docker daemon."
 keywords: "security, authorization, authentication, docker, documentation, plugin, extend"
 redirect_from:
@@ -15,7 +14,7 @@ redirect_from:
      will be rejected.
 -->
 
-# Create an authorization plugin
+# Access authorization plugin
 
 This document describes the Docker Engine plugins generally available in Docker
 Engine. To view information on plugins managed by Docker Engine,

--- a/docs/extend/plugins_graphdriver.md
+++ b/docs/extend/plugins_graphdriver.md
@@ -1,5 +1,4 @@
 ---
-title: "Graphdriver plugins"
 description: "How to manage image and container filesystems with external plugins"
 keywords: "Examples, Usage, storage, image, docker, data, graph, plugin, api"
 advisory: experimental
@@ -14,6 +13,7 @@ advisory: experimental
      will be rejected.
 -->
 
+# Graphdriver plugins
 
 ## Changelog
 

--- a/docs/extend/plugins_logging.md
+++ b/docs/extend/plugins_logging.md
@@ -1,5 +1,4 @@
 ---
-title: "Docker log driver plugins"
 description: "Log driver plugins."
 keywords: "Examples, Usage, plugins, docker, documentation, user guide, logging"
 ---
@@ -13,7 +12,7 @@ keywords: "Examples, Usage, plugins, docker, documentation, user guide, logging"
      will be rejected.
 -->
 
-# Logging driver plugins
+# Docker log driver plugins
 
 This document describes logging driver plugins for Docker.
 

--- a/docs/extend/plugins_metrics.md
+++ b/docs/extend/plugins_metrics.md
@@ -1,5 +1,4 @@
 ---
-title: "Docker metrics collector plugins"
 description: "Metrics plugins."
 keywords: "Examples, Usage, plugins, docker, documentation, user guide, metrics"
 ---
@@ -13,7 +12,7 @@ keywords: "Examples, Usage, plugins, docker, documentation, user guide, metrics"
      will be rejected.
 -->
 
-# Metrics Collector Plugins
+# Docker metrics collector plugins
 
 Docker exposes internal metrics based on the prometheus format. Metrics plugins
 enable accessing these metrics in a consistent way by providing a Unix

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -1,5 +1,4 @@
 ---
-title: "Docker network driver plugins"
 description: "Network driver plugins."
 keywords: "Examples, Usage, plugins, docker, documentation, user guide"
 ---
@@ -13,7 +12,7 @@ keywords: "Examples, Usage, plugins, docker, documentation, user guide"
      will be rejected.
 -->
 
-# Engine network driver plugins
+# Docker network driver plugins
 
 This document describes Docker Engine network driver plugins generally
 available in Docker Engine. To view information on plugins

--- a/docs/extend/plugins_services.md
+++ b/docs/extend/plugins_services.md
@@ -1,5 +1,4 @@
 ---
-description: Using services with plugins
 keywords: "API, Usage, plugins, documentation, developer"
 title: Plugins and Services
 ---
@@ -70,7 +69,7 @@ node1 is the manager and node2 is the worker.
 
     ```bash
     {% raw %}
-    $ docker ps --format '{{.ID}}\t {{.Status}} {{.Names}} {{.Command}}' 
+    $ docker ps --format '{{.ID}}\t {{.Status}} {{.Names}} {{.Command}}'
     83fc1e842599     Up 2 days my-service.1.9jn59qzn7nbc3m0zt1hij12xs "top"
     {% endraw %}
     ```

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -1,5 +1,4 @@
 ---
-title: "Volume plugins"
 description: "How to manage data with external volume plugins"
 keywords: "Examples, Usage, volume, docker, data, volumes, plugin, api"
 ---
@@ -13,7 +12,7 @@ keywords: "Examples, Usage, volume, docker, data, volumes, plugin, api"
      will be rejected.
 -->
 
-# Write a volume plugin
+# Docker volume plugins
 
 Docker Engine volume plugins enable Engine deployments to be integrated with
 external storage systems such as Amazon EBS, and enable data volumes to persist

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1,5 +1,4 @@
 ---
-title: "Dockerfile reference"
 description: "Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image."
 keywords: "builder, docker, Dockerfile, automation, image creation"
 redirect_from:

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,5 +1,4 @@
 ---
-title: "Docker Glossary"
 description: "Glossary of terms used around Docker"
 keywords: "glossary, docker, terms, definitions"
 ---

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,4 @@
 ---
-title: "Engine reference"
 description: "Docker Engine reference"
 keywords: "Engine"
 ---

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,5 +1,4 @@
 ---
-title: "Docker run reference"
 description: "Configure containers at runtime"
 keywords: "docker, run, configure, runtime"
 ---


### PR DESCRIPTION
Fixes docs bug https://github.com/docker/docker.github.io/issues/4589

Having `title` in the front-matter of the md files we import from docker/cli is not necessary because we use the GitHub Pages gem at build time which includes the jekyll-titles-from-headings gem, which derives `page.title` from the first `H1` in the page.

cc @mstanleyjones 

See: https://pages.github.com/versions/