### PR TITLE
Add support for building on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ binary: ## build executable for Linux
 	@echo "WARNING: binary creates a Linux executable. Use cross for macOS or Windows."
 	./scripts/build/binary
 
+.PHONY: binary-openbsd
+openbsd: ## build executable for openbsd
+	@echo "Building our OpenBSD hack..."
+	./scripts/build/openbsd
+
 .PHONY: cross
 cross: ## build executable for macOS and Windows
 	./scripts/build/cross

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ binary: ## build executable for Linux
 	./scripts/build/binary
 
 .PHONY: binary-openbsd
-openbsd: ## build executable for openbsd
-	@echo "Building our OpenBSD hack..."
+binary-openbsd: ## build executable for openbsd
 	./scripts/build/openbsd
 
 .PHONY: cross

--- a/cli/command/formatter/history.go
+++ b/cli/command/formatter/history.go
@@ -79,7 +79,7 @@ func (c *historyContext) ID() string {
 }
 
 func (c *historyContext) CreatedAt() string {
-	return time.Unix(c.h.Created, 0).Format(time.RFC3339)
+	return time.Unix(c.h.Created, 0).UTC().Format(time.RFC3339)
 }
 
 func (c *historyContext) CreatedSince() string {

--- a/cli/command/formatter/history_test.go
+++ b/cli/command/formatter/history_test.go
@@ -55,14 +55,14 @@ func TestHistoryContext_CreatedSince(t *testing.T) {
 	cases := []historyCase{
 		{
 			historyContext{
-				h:     image.HistoryResponseItem{Created: time.Now().AddDate(0, 0, -7).Unix()},
+				h:     image.HistoryResponseItem{Created: time.Now().UTC().AddDate(0, 0, -7).Unix()},
 				trunc: false,
 				human: true,
 			}, "7 days ago", ctx.CreatedSince,
 		},
 		{
 			historyContext{
-				h:     image.HistoryResponseItem{Created: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()},
+				h:     image.HistoryResponseItem{Created: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).UTC().Unix()},
 				trunc: false,
 				human: false,
 			}, "2009-11-10T23:00:00Z", ctx.CreatedSince,

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -24,6 +24,8 @@ import (
 
 func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
 	skip.IfCondition(t, runtime.GOOS == "windows", "uid and gid not relevant on windows")
+	skip.IfCondition(t, runtime.GOOS == "openbsd", "gotestyourself/fs not working right on openbsd")
+
 	dest := fs.NewDir(t, "test-build-context-dest")
 	defer dest.Remove()
 
@@ -58,6 +60,7 @@ func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
 	}
 }
 func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
+	skip.IfCondition(t, runtime.GOOS == "openbsd", "not working right on openbsd")
 	dest, err := ioutil.TempDir("", "test-build-compress-dest")
 	require.NoError(t, err)
 	defer os.RemoveAll(dest)

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
 	skip.IfCondition(t, runtime.GOOS == "windows", "uid and gid not relevant on windows")
-	skip.IfCondition(t, runtime.GOOS == "openbsd", "gotestyourself/fs not working right on openbsd")
+	skip.IfCondition(t, runtime.GOOS != "windows" && os.Getuid() != 0, "test requires elevated privileges")
 
 	dest := fs.NewDir(t, "test-build-context-dest")
 	defer dest.Remove()
@@ -60,7 +60,7 @@ func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
 	}
 }
 func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
-	skip.IfCondition(t, runtime.GOOS == "openbsd", "not working right on openbsd")
+	skip.IfCondition(t, runtime.GOOS != "windows" && os.Getuid() != 0, "test requires elevated privileges")
 	dest, err := ioutil.TempDir("", "test-build-compress-dest")
 	require.NoError(t, err)
 	defer os.RemoveAll(dest)

--- a/cli/config/credentials/default_store_unsupported.go
+++ b/cli/config/credentials/default_store_unsupported.go
@@ -3,5 +3,5 @@
 package credentials
 
 func defaultCredentialsStore() string {
-    return ""
+	return ""
 }

--- a/cli/config/credentials/default_store_unsupported.go
+++ b/cli/config/credentials/default_store_unsupported.go
@@ -2,4 +2,6 @@
 
 package credentials
 
-const defaultCredentialsStore = ""
+func defaultCredentialsStore() string {
+    return ""
+}

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -3,7 +3,11 @@ set -eu
 
 VERSION=${VERSION:-"unknown-version"}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
-BUILDTIME=${BUILDTIME:-$(date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')}
+if [ "$(uname)" == "OpenBSD" ]; then
+    BUILDTIME=${BUILDTIME:-$(date -u +%Y-%m-%dT%H:%M.%S 2> /dev/null)}
+else
+    BUILDTIME=${BUILDTIME:-$(date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')}
+fi
 
 export LDFLAGS="\
     -w \

--- a/scripts/build/openbsd
+++ b/scripts/build/openbsd
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Build a static binary for the host OS/ARCH
+#
+
+set -eu -o pipefail
+
+source ./scripts/build/.variables
+
+TARGET="build/docker-$GOOS-$GOARCH"
+
+echo "Building statically linked $TARGET"
+export CGO_ENABLED=1
+go build -o "${TARGET}" --ldflags "${LDFLAGS}" "${SOURCE}"
+
+ln -sf "$(basename "${TARGET}")" build/docker

--- a/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_openbsd.go
@@ -1,0 +1,12 @@
+package sysx
+
+import (
+	"errors"
+)
+
+// Initial stub version for OpenBSD. OpenBSD has a different
+// syscall API from Darwin and Linux for extended attributes;
+// it is also not widely used. It is not exposed at all by the
+// Go syscall package, so we need to implement directly eventually.
+
+var unsupported = errors.New("extended attributes unsupported on OpenBSD")

--- a/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
+++ b/vendor/github.com/containerd/continuity/sysx/xattr_unsupported.go
@@ -1,4 +1,4 @@
-// +build freebsd solaris
+// +build openbsd freebsd solaris
 
 package sysx
 

--- a/vendor/github.com/docker/docker/pkg/term/winsize.go
+++ b/vendor/github.com/docker/docker/pkg/term/winsize.go
@@ -1,4 +1,4 @@
-// +build !solaris,!windows
+// +build !solaris,!windows,!openbsd
 
 package term
 

--- a/vendor/github.com/docker/docker/pkg/term/winsize_solaris_cgo.go
+++ b/vendor/github.com/docker/docker/pkg/term/winsize_solaris_cgo.go
@@ -1,4 +1,4 @@
-// +build solaris,cgo,openbsd
+// +build solaris,cgo
 
 package term
 

--- a/vendor/github.com/tonistiigi/fsutil/diskwriter_openbsd.go
+++ b/vendor/github.com/tonistiigi/fsutil/diskwriter_openbsd.go
@@ -1,0 +1,7 @@
+// +build openbsd
+
+package fsutil
+
+func chtimes(path string, un int64) error {
+	return nil
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've made a first attempt at porting docker/cli to OpenBSD. See also a [PR](https://github.com/docker/machine/pull/4287) I submitted for docker/machine.

With these changes, and the similar `docker-machine` changes, a developer on OpenBSD can user docker from the command line successfully like a user on Linux or other platforms. (The assumption being they've used `docker-machine` to configure their target docker service.)

**- How I did it**
- Extended the `Makefile` to add a new target: `binary-openbsd`
- Updated `scripts/build/.variables` to handle differences in OpenBSD's `date` output
- Added a new build script that turns on `CGO`
- Tweaked some vendor packages to add OpenBSD support or disable certain unsupported features (e.g. credentials store)

**Note:** I'm not positive about the change I made in `cli/command/formatter/history.go`. The tests were failing due to the current logic on OpenBSD printing the Time adjusted for the local timezone. I needed to add `.UTC()` to force the time to stay UTC. 

**- How to verify it**

For OpenBSD, it should work on both `6.2` and `-current` using the following packages:
- `go` (go 1.9.1)
- `gmake` (GNU Make)

Running `gmake binary-openbsd` will build the binary.

Note that running `gmake test` will potentially appear to hang at the `github.com/docker/cli/cli/command/idresolver` test the username prompt might not visibly render (it doesn't in XTerm running tmux at least), so type your username and hit enter. You should then see the password prompt and can enter that as well. Tests will continue at that point.

Currently I haven't tested cross-compiling the OpenBSD binary as it will probably require a bit more work on the tweaks to the supporting vendor code (i.e. rewriting the inline C `ioctl()` calls to using Go's `syscall`).

I've tested building using `Makefile.docker` on macOS and it appears to build and behave as normal with these changes. `make test` also passes.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Adds support for building binary on OpenBSD.

**- A picture of a cute animal (not mandatory but encouraged)**

Maple:
![My dog](https://user-images.githubusercontent.com/9891346/31784753-de3f7ae4-b4d0-11e7-8150-f6aac1a6f35e.jpg)