### PR TITLE
For system prune, -f is not an alias for --filter

### DIFF
--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -115,7 +115,7 @@ Total reclaimed space: 13.5 MB
 
 ### Filtering
 
-The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:


### PR DESCRIPTION
Fixes https://github.com/docker/docker.github.io/issues/5059

It's also weird that for `system events`, `-f` does mean `--filter`. It seems like maybe someone needs to do a consistency pass on these, as a follow-up.