### PR TITLE
Switch to golang:1.8.4-alpine3.6

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.4-alpine
+FROM    golang:1.8.4-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.8.4-alpine
+FROM    golang:1.8.4-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
golang:1.8.4-alpine does not have multi-arch images available in the
manifest. (s390x, ppc64le, etc.)

This makes it so that if you are trying to compile on different
arches you aren't forced to have to write your own Dockerfile and can
instead use the one bundled with the CLI repo.

**- How I did it**
Switch the images to `golang:1.8.4-alpine3.6` and switch the package management commands to
`apt-get`

**- How to verify it**
`make -f docker.Makefile binary`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
> Switched build image to allow for multi-arch compilation

**- A picture of a cute animal (not mandatory but encouraged)**
![kayak](https://i.redd.it/nldd8smbsesz.jpg)
