### PR TITLE
Add note about reported memory stats on linux

### DIFF
--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -34,6 +34,8 @@ The `docker stats` command returns a live data stream for running containers. To
 
 If you want more detailed information about a container's resource usage, use the `/containers/(id)/stats` API endpoint.
 
+> **Note**: On Linux, the Docker CLI reports memory usage by subtracting page cache usage from the total memory usage. The API does not perform such a calculation but rather provides the total memory usage and the amount from the page cache so that clients can use the data as needed.
+
 ## Examples
 
 Running `docker stats` on all running containers against a Linux daemon.


### PR DESCRIPTION
Since the API and the CLI both have a "Usage" field for memory, clarify
that the CLI does additional calculations to avoid confusion of API
consumers.

Closes moby/moby#35295