### PR TITLE
Fix daemon.json runtime example

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1326,8 +1326,8 @@ This is a full example of the allowed configuration options on Linux:
 	"default-runtime": "runc",
 	"oom-score-adjust": -500,
 	"runtimes": {
-		"runc": {
-			"path": "runc"
+		"cc-runtime": {
+			"path": "/usr/bin/cc-runtime"
 		},
 		"custom": {
 			"path": "/usr/local/bin/my-runc-replacement",


### PR DESCRIPTION
The example in the documentation used "runc", which is a
reserved runtime name (as it's the default).

This patch updates the example, and uses a different name.

fixes https://github.com/docker/for-linux/issues/144

thanks @mcastelino for reporting!