### PR TITLE
Adds unpause output to docs

### DIFF
--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -37,6 +37,7 @@ for further details.
 
 ```bash
 $ docker unpause my_container
+my_container
 ```
 
 ## Related commands


### PR DESCRIPTION
Signed-off-by: Jesse Adametz <jesseadametz@gmail.com>

fixes #589 

**- What I did**

Added output to the documentation for `docker unpause`

**- How I did it**

Updated the ~codez~ markdown

**- How to verify it**

The documentation's codeblock now shows `my_container` as the output of the command.

**- Description for the changelog**

N/A


**- A picture of a cute animal (not mandatory but encouraged)**

I'm biased but I tend to think my dog Zoey, is pretty damn cute.

![img_2191](https://user-images.githubusercontent.com/5579640/32091581-ab630a30-baa9-11e7-99dc-42ec9c241bff.jpg)


