### PR TITLE
Fix flag description for --host-add

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -92,7 +92,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagDNSOptionAdd, "version", []string{"1.25"})
 	flags.Var(&options.dnsSearch, flagDNSSearchAdd, "Add or update a custom DNS search domain")
 	flags.SetAnnotation(flagDNSSearchAdd, "version", []string{"1.25"})
-	flags.Var(&options.hosts, flagHostAdd, "Add or update a custom host-to-IP mapping (host:ip)")
+	flags.Var(&options.hosts, flagHostAdd, "Add a custom host-to-IP mapping (host:ip)")
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.25"})
 
 	return cmd

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -49,7 +49,7 @@ Options:
       --health-start-period duration       Start period for the container to initialize before counting retries towards unstable (ms|s|m|h)
       --health-timeout duration            Maximum time to allow one check to run (ms|s|m|h)
       --help                               Print usage
-      --host-add list                      Add or update a custom host-to-IP mapping (host:ip)
+      --host-add list                      Add a custom host-to-IP mapping (host:ip)
       --host-rm list                       Remove a custom host-to-IP mapping (host:ip)
       --hostname string                    Container hostname
       --image string                       Service image tag


### PR DESCRIPTION
The `--host-add` flag adds a new `host:ip` mapping. Even though adding an entry is idempotent (adding the same mapping multiple times does not update the service's definition), it does not _update_  an existing mapping with a new IP-address (multiple IP-addresses can be defined for a host).

This patch removes the "or update" part from the flag's description.

relates to https://github.com/moby/moby/issues/35325

There's possibly some other flags that fall in the same category, but I kept those out for now (can do a follow up)

ping @vdemeester @dnephin PTAL
