### PR TITLE
Update stack_deploy.md

### DIFF
--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -82,7 +82,7 @@ you can combine these by passing them to `docker-compose config` with the `-f` o
 and redirecting the merged output into a new file.
 
 ```bash
-$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml config > docker-stack.yml
+$ docker-compose config -f docker-compose.yml -f docker-compose.prod.yml config > docker-stack.yml
 $ docker stack deploy --compose-file docker-stack.yml vossibility
 
 Ignoring unsupported options: links


### PR DESCRIPTION
The word `config` was missing in the code example to illustrate the `docker-compose config` command to merge multiple docker-compose YAML files.
This little PR (one has to start somewhere  ^^) just fixes it.

Picture of a cute animal :-)
![23c53a013d8f3f86b56d472395065241](https://user-images.githubusercontent.com/9500406/32144856-6cc1b96c-bcbf-11e7-9148-d5338a82e8eb.jpg)



