### PR TITLE
Preserve sort-order of extra hosts, and allow duplicate entries

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -868,6 +868,10 @@ func updateReplicas(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error 
 	return nil
 }
 
+// updateHosts performs a diff between existing host entries, entries to be
+// removed, and entries to be added. Host entries preserve the order in which they
+// were added, as the specification mentions that in case multiple entries for a
+// host exist, the first entry should be used (by default).
 func updateHosts(flags *pflag.FlagSet, hosts *[]string) error {
 	// Combine existing Hosts (in swarmkit format) with the host to add (convert to swarmkit format)
 	if flags.Changed(flagHostAdd) {
@@ -901,9 +905,6 @@ func updateHosts(flags *pflag.FlagSet, hosts *[]string) error {
 			newHosts = append(newHosts, entry)
 		}
 	}
-
-	// Sort so that result is predictable.
-	sort.Strings(newHosts)
 
 	*hosts = newHosts
 	return nil

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -57,6 +57,15 @@ func TestConvertEnvironment(t *testing.T) {
 	assert.Equal(t, []string{"foo=bar", "key=value"}, env)
 }
 
+func TestConvertExtraHosts(t *testing.T) {
+	source := composetypes.HostsList{
+		"zulu:127.0.0.2",
+		"alpha:127.0.0.1",
+		"zulu:ff02::1",
+	}
+	assert.Equal(t, []string{"127.0.0.2 zulu", "127.0.0.1 alpha", "ff02::1 zulu"}, convertExtraHosts(source))
+}
+
 func TestConvertResourcesFull(t *testing.T) {
 	source := composetypes.Resources{
 		Limits: &composetypes.Resource{

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -97,8 +97,8 @@ type ServiceConfig struct {
 	Environment     MappingWithEquals
 	EnvFile         StringList `mapstructure:"env_file"`
 	Expose          StringOrNumberList
-	ExternalLinks   []string         `mapstructure:"external_links"`
-	ExtraHosts      MappingWithColon `mapstructure:"extra_hosts"`
+	ExternalLinks   []string  `mapstructure:"external_links"`
+	ExtraHosts      HostsList `mapstructure:"extra_hosts"`
 	Hostname        string
 	HealthCheck     *HealthCheckConfig
 	Image           string
@@ -161,6 +161,9 @@ type Labels map[string]string
 // MappingWithColon is a mapping type that can be converted from a list of
 // 'key: value' strings
 type MappingWithColon map[string]string
+
+// HostsList is a list of colon-separated host-ip mappings
+type HostsList []string
 
 // LoggingConfig the logging configuration for a service
 type LoggingConfig struct {


### PR DESCRIPTION
Extra hosts (`extra_hosts` in compose-file, or `--hosts` in services) adds custom host/ip mappings to the container's `/etc/hosts`.

The current implementation used a `map[string]string{}` as intermediate storage, and sorted the results alphabetically when converting to a service-spec. As a result, duplicate hosts were removed, and order of host/ip mappings was not preserved (in case the compose-file used a list instead of a map).

According to the [**host.conf(5)**](http://man7.org/linux/man-pages/man5/host.conf.5.html) man page:

    multi  Valid values are on and off.  If set to on, the resolver
      library will return all valid addresses for a host that
      appears in the /etc/hosts file, instead of only the first.
      This is off by default, as it may cause a substantial
      performance loss at sites with large hosts files.

Multiple entries for a host are allowed, and even required for some situations, for example, to add mappings for IPv4 and IPv6 addreses for a host, as illustrated by the example hosts file in the [**hosts(5)**](http://man7.org/linux/man-pages/man5/hosts.5.html) man page:

    # The following lines are desirable for IPv4 capable hosts
    127.0.0.1       localhost

    # 127.0.1.1 is often used for the FQDN of the machine
    127.0.1.1       thishost.mydomain.org  thishost
    192.168.1.10    foo.mydomain.org       foo
    192.168.1.13    bar.mydomain.org       bar
    146.82.138.7    master.debian.org      master
    209.237.226.90  www.opensource.org

    # The following lines are desirable for IPv6 capable hosts
    ::1             localhost ip6-localhost ip6-loopback
    ff02::1         ip6-allnodes
    ff02::2         ip6-allrouters

This patch changes the intermediate storage format to use a `[]string`, and only sorts entries if the input format in the compose file is a mapping. If the input format is a list, the original sort-order is preserved.

**- Description for the changelog**

```Markdown
* Preserve order and duplicate hosts for extra-hosts in services [docker/cli#651](https://github.com/docker/cli/pull/651)
```