### PR TITLE
Bump Go to 1.8.5

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross@sha256:8a347b3692ba925dcef753f2de289e11774410c1bc752b9d525cb05477a7697b
+FROM    dockercore/golang-cross@sha256:25ff84377e9d7f40639c33cc374166a3b0f1829b8462cf7001d742a846de2687
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.4-alpine3.6
+FROM    golang:1.8.5-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.8.4-alpine3.6
+FROM    golang:1.8.5-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION
ping @seemethere @dnephin - also opened https://github.com/docker/golang-cross/pull/1, so I can update if that's merged and built