### PR TITLE
Only warn on volume.external.name for version 3.4

### DIFF
--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -68,14 +68,13 @@ func convertVolumeToMount(
 		result.VolumeOptions.NoCopy = volume.Volume.NoCopy
 	}
 
-	// External named volumes
-	if stackVolume.External.External {
-		result.Source = stackVolume.External.Name
-		return result, nil
-	}
-
 	if stackVolume.Name != "" {
 		result.Source = stackVolume.Name
+	}
+
+	// External named volumes
+	if stackVolume.External.External {
+		return result, nil
 	}
 
 	result.VolumeOptions.Labels = AddStackLabel(namespace, stackVolume.Labels)

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -148,20 +148,16 @@ func TestConvertVolumeToMountNamedVolumeWithNameCustomizd(t *testing.T) {
 func TestConvertVolumeToMountNamedVolumeExternal(t *testing.T) {
 	stackVolumes := volumes{
 		"outside": composetypes.VolumeConfig{
-			External: composetypes.External{
-				External: true,
-				Name:     "special",
-			},
+			Name:     "special",
+			External: composetypes.External{External: true},
 		},
 	}
 	namespace := NewNamespace("foo")
 	expected := mount.Mount{
-		Type:   mount.TypeVolume,
-		Source: "special",
-		Target: "/foo",
-		VolumeOptions: &mount.VolumeOptions{
-			NoCopy: false,
-		},
+		Type:          mount.TypeVolume,
+		Source:        "special",
+		Target:        "/foo",
+		VolumeOptions: &mount.VolumeOptions{NoCopy: false},
 	}
 	config := composetypes.ServiceVolumeConfig{
 		Type:   "volume",
@@ -176,10 +172,8 @@ func TestConvertVolumeToMountNamedVolumeExternal(t *testing.T) {
 func TestConvertVolumeToMountNamedVolumeExternalNoCopy(t *testing.T) {
 	stackVolumes := volumes{
 		"outside": composetypes.VolumeConfig{
-			External: composetypes.External{
-				External: true,
-				Name:     "special",
-			},
+			Name:     "special",
+			External: composetypes.External{External: true},
 		},
 	}
 	namespace := NewNamespace("foo")

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -55,6 +55,7 @@ type ConfigFile struct {
 
 // ConfigDetails are the details about a group of ConfigFiles
 type ConfigDetails struct {
+	Version     string
 	WorkingDir  string
 	ConfigFiles []ConfigFile
 	Environment map[string]string


### PR DESCRIPTION
Fixes #608

Also remove use of `volume.external.name` so we don't have duplicate fields.