### PR TITLE
Add new log driver options to bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -837,7 +837,7 @@ __docker_complete_log_options() {
 
 	local fluentd_options="$common_options1 $common_options2 fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries tag"
 	local gcplogs_options="$common_options1 $common_options2 gcp-log-cmd gcp-meta-id gcp-meta-name gcp-meta-zone gcp-project"
-	local gelf_options="$common_options1 $common_options2 gelf-address gelf-compression-level gelf-compression-type tag"
+	local gelf_options="$common_options1 $common_options2 gelf-address gelf-compression-level gelf-compression-type gelf-tcp-max-reconnect gelf-tcp-reconnect-delay tag"
 	local journald_options="$common_options1 $common_options2 tag"
 	local json_file_options="$common_options1 $common_options2 max-file max-size"
 	local logentries_options="$common_options1 $common_options2 logentries-token tag"
@@ -897,7 +897,7 @@ __docker_complete_log_driver_options() {
 			return
 			;;
 		gelf-address)
-			COMPREPLY=( $( compgen -W "udp" -S "://" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "tcp udp" -S "://" -- "${cur##*=}" ) )
 			__docker_nospace
 			return
 			;;

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -833,7 +833,7 @@ __docker_complete_log_options() {
 	local common_options2="env env-regex labels"
 
 	# awslogs does not implement the $common_options2.
-	local awslogs_options="$common_options1 awslogs-create-group awslogs-datetime-format awslogs-group awslogs-multiline-pattern awslogs-region awslogs-stream tag"
+	local awslogs_options="$common_options1 awslogs-create-group awslogs-credentials-endpoint awslogs-datetime-format awslogs-group awslogs-multiline-pattern awslogs-region awslogs-stream tag"
 
 	local fluentd_options="$common_options1 $common_options2 fluentd-address fluentd-async-connect fluentd-buffer-limit fluentd-retry-wait fluentd-max-retries tag"
 	local gcplogs_options="$common_options1 $common_options2 gcp-log-cmd gcp-meta-id gcp-meta-name gcp-meta-zone gcp-project"
@@ -890,6 +890,11 @@ __docker_complete_log_driver_options() {
 	case "$key" in
 		awslogs-create-group)
 			COMPREPLY=( $( compgen -W "false true" -- "${cur##*=}" ) )
+			return
+			;;
+		awslogs-credentials-endpoint)
+			COMPREPLY=( $( compgen -W "/" -- "${cur##*=}" ) )
+			__docker_nospace
 			return
 			;;
 		fluentd-async-connect)


### PR DESCRIPTION
The [Docker v17.11.0-ce-rc3 release notes](https://github.com/docker/docker-ce/releases/tag/v17.11.0-ce-rc3) mention new log driver options that are not yet supported in bash completion:

- `awslogs-credentials-endpoint` (https://github.com/moby/moby/pull/35055)
- `gelf-tcp-max-reconnect`, `gelf-tcp-reconnect-delay` (https://github.com/moby/moby/pull/34758/)

This PR adds support for these options.
This should go into 17.11.0 because the features are present in that release.