### PR TITLE
Add bash completion for experimental `build --stream`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2467,7 +2467,10 @@ _docker_image_build() {
 		--quiet -q
 		--rm
 	"
-	__docker_daemon_is_experimental && boolean_options+="--squash"
+	__docker_daemon_is_experimental && boolean_options+="
+		--squash
+		--stream
+	"
 
 	local all_options="$options_with_args $boolean_options"
 


### PR DESCRIPTION
This adds bash completion for #231.
The new flag is only considered when the deamon runs in experimental mode.