### PR TITLE
Fix and simplify bash completion for service env, mounts and labels

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3408,37 +3408,12 @@ _docker_service_update_and_create() {
 		"
 
 		case "$prev" in
-			--config)
-				__docker_complete_configs
-				return
-				;;
 			--env-file)
 				_filedir
 				return
 				;;
-			--group)
-				COMPREPLY=( $(compgen -g -- "$cur") )
-				return
-				;;
-			--host)
-				case "$cur" in
-					*:)
-						__docker_complete_resolved_hostname
-						return
-						;;
-				esac
-				;;
 			--mode)
 				COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
-				return
-				;;
-			--placement-pref)
-				COMPREPLY=( $( compgen -W "spread" -S = -- "$cur" ) )
-				__docker_nospace
-				return
-				;;
-			--secret)
-				__docker_complete_secrets
 				return
 				;;
 		esac
@@ -3483,41 +3458,12 @@ _docker_service_update_and_create() {
 		"
 
 		case "$prev" in
-			--config-add|--config-rm)
-				__docker_complete_configs
-				return
-				;;
 			--env-rm)
 				COMPREPLY=( $( compgen -e -- "$cur" ) )
 				return
 				;;
-			--group-add|--group-rm)
-				COMPREPLY=( $(compgen -g -- "$cur") )
-				return
-				;;
-			--host-add|--host-rm)
-				case "$cur" in
-					*:)
-						__docker_complete_resolved_hostname
-						return
-						;;
-				esac
-				;;
 			--image)
 				__docker_complete_image_repos_and_tags
-				return
-				;;
-			--network-add|--network-rm)
-				__docker_complete_networks
-				return
-				;;
-			--placement-pref-add|--placement-pref-rm)
-				COMPREPLY=( $( compgen -W "spread" -S = -- "$cur" ) )
-				__docker_nospace
-				return
-				;;
-			--secret-add|--secret-rm)
-				__docker_complete_secrets
 				return
 				;;
 		esac
@@ -3533,6 +3479,10 @@ _docker_service_update_and_create() {
 	esac
 
 	case "$prev" in
+		--config|--config-add|--config-rm)
+			__docker_complete_configs
+			return
+			;;
 		--endpoint-mode)
 			COMPREPLY=( $( compgen -W "dnsrr vip" -- "$cur" ) )
 			return
@@ -3542,6 +3492,18 @@ _docker_service_update_and_create() {
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			__docker_nospace
 			return
+			;;
+		--group|--group-add|--group-rm)
+			COMPREPLY=( $(compgen -g -- "$cur") )
+			return
+			;;
+		--host|--host-add|--host-rm)
+			case "$cur" in
+				*:)
+					__docker_complete_resolved_hostname
+					return
+					;;
+			esac
 			;;
 		--isolation)
 			__docker_complete_isolation
@@ -3555,8 +3517,13 @@ _docker_service_update_and_create() {
 			__docker_complete_log_options
 			return
 			;;
-		--network)
+		--network|--network-add|--network-rm)
 			__docker_complete_networks
+			return
+			;;
+		--placement-pref|--placement-pref-add|--placement-pref-rm)
+			COMPREPLY=( $( compgen -W "spread" -S = -- "$cur" ) )
+			__docker_nospace
 			return
 			;;
 		--restart-condition)
@@ -3565,6 +3532,10 @@ _docker_service_update_and_create() {
 			;;
 		--rollback-failure-action)
 			COMPREPLY=( $( compgen -W "continue pause" -- "$cur" ) )
+			return
+			;;
+		--secret|--secret-add|--secret-rm)
+			__docker_complete_secrets
 			return
 			;;
 		--stop-signal)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3333,7 +3333,6 @@ _docker_service_update_and_create() {
 	local options_with_args="
 		--endpoint-mode
 		--entrypoint
-		--env -e
 		--force
 		--health-cmd
 		--health-interval
@@ -3342,12 +3341,10 @@ _docker_service_update_and_create() {
 		--health-timeout
 		--hostname
 		--isolation
-		--label -l
 		--limit-cpu
 		--limit-memory
 		--log-driver
 		--log-opt
-		--mount
 		--replicas
 		--reserve-cpu
 		--reserve-memory
@@ -3395,11 +3392,14 @@ _docker_service_update_and_create() {
 			--dns
 			--dns-option
 			--dns-search
+			--env -e
 			--env-file
 			--generic-resource
 			--group
 			--host
+			--label -l
 			--mode
+			--mount
 			--name
 			--network
 			--placement-pref
@@ -3458,6 +3458,8 @@ _docker_service_update_and_create() {
 			--dns-rm
 			--dns-search-add
 			--dns-search-rm
+			--env-add
+			--env-rm
 			--generic-resource-add
 			--generic-resource-rm
 			--group-add
@@ -3465,6 +3467,10 @@ _docker_service_update_and_create() {
 			--host-add
 			--host-rm
 			--image
+			--label-add
+			--label-rm
+			--mount-add
+			--mount-rm
 			--network-add
 			--network-rm
 			--placement-pref-add
@@ -3479,6 +3485,10 @@ _docker_service_update_and_create() {
 		case "$prev" in
 			--config-add|--config-rm)
 				__docker_complete_configs
+				return
+				;;
+			--env-rm)
+				COMPREPLY=( $( compgen -e -- "$cur" ) )
 				return
 				;;
 			--group-add|--group-rm)
@@ -3527,7 +3537,7 @@ _docker_service_update_and_create() {
 			COMPREPLY=( $( compgen -W "dnsrr vip" -- "$cur" ) )
 			return
 			;;
-		--env|-e)
+		--env|-e|--env-add)
 			# we do not append a "=" here because "-e VARNAME" is legal systax, too
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			__docker_nospace


### PR DESCRIPTION
`service create` and `service update` both used to have `--env`, `--label` and `--mount` options.
These options now are only valid for `service create`.
`service update` got corresponding `--xxx-add|rm` options instead.

Also removes some duplication between the completions for `--xxx` and the corresponding
`-xxx-add` and `-xxx-rm` options.