### PR TITLE
Docs - Adding note about creating Windows users

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1325,6 +1325,17 @@ group (or GID) to use when running the image and for any `RUN`, `CMD` and
 > When the user does doesn't have a primary group then the image (or the next
 > instructions) will be run with the `root` group.
 
+> On Windows, the user must be created first if it's not a built-in account.
+> This can be done with the `net user` command called as part of a Dockerfile.
+
+```Dockerfile
+    FROM microsoft/windowsservercore
+    # Create Windows user in the container
+    RUN net user /add patrick
+    # Set it for subsequent commands
+    USER patrick
+```
+
 
 ## WORKDIR
 


### PR DESCRIPTION

**- What I did**

Added a clarification on how to use `USER` in Dockerfiles for building Windows containers. You must manually create the user first as part of building the container

**- How to verify it**
Doc change only

Building the sample included in the doc

```
PS C:\Users\plang\Source\usertest> docker build -t usertest .
Sending build context to Docker daemon  23.55kB
Step 1/3 : FROM microsoft/windowsservercore:1709
 ---> 9458f3e79488
Step 2/3 : RUN net user /add patrick
 ---> Running in 08aa8dedb726
The command completed successfully.

 ---> 4c1b85a8791a
Removing intermediate container 08aa8dedb726
Step 3/3 : USER patrick
 ---> Running in 9abdc28359f9
 ---> f34890f7eb0e
Removing intermediate container 9abdc28359f9
Successfully built f34890f7eb0e
Successfully tagged usertest:latest
```

Running it

```
PS C:\Users\plang\Source\usertest> docker run usertest whoami
dae0380f0a76\Patrick
```

**- Description for the changelog**
Adding note about creating Windows users


**- A picture of a cute animal (not mandatory but encouraged)**

![stevie](https://imgur.com/k93qdwo.gif)

Signed-off-by: Patrick Lang <plang@microsoft.com>