### PR TITLE
attach: Use ContainerWait instead of Inspect

### DIFF
--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -8,9 +9,9 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/testutil"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestNewAttachCommandErrors(t *testing.T) {
@@ -78,40 +79,50 @@ func TestNewAttachCommandErrors(t *testing.T) {
 }
 
 func TestGetExitStatus(t *testing.T) {
-	containerID := "the exec id"
-	expecatedErr := errors.New("unexpected error")
+	var (
+		expectedErr = fmt.Errorf("unexpected error")
+		errC        = make(chan error, 1)
+		resultC     = make(chan container.ContainerWaitOKBody, 1)
+	)
 
 	testcases := []struct {
-		inspectError  error
-		exitCode      int
+		result        *container.ContainerWaitOKBody
+		err           error
 		expectedError error
 	}{
 		{
-			inspectError: nil,
-			exitCode:     0,
+			result: &container.ContainerWaitOKBody{
+				StatusCode: 0,
+			},
 		},
 		{
-			inspectError:  expecatedErr,
-			expectedError: expecatedErr,
+			err:           expectedErr,
+			expectedError: expectedErr,
 		},
 		{
-			exitCode:      15,
+			result: &container.ContainerWaitOKBody{
+				Error: &container.ContainerWaitOKBodyError{
+					expectedErr.Error(),
+				},
+			},
+			expectedError: expectedErr,
+		},
+		{
+			result: &container.ContainerWaitOKBody{
+				StatusCode: 15,
+			},
 			expectedError: cli.StatusError{StatusCode: 15},
 		},
 	}
 
 	for _, testcase := range testcases {
-		client := &fakeClient{
-			inspectFunc: func(id string) (types.ContainerJSON, error) {
-				assert.Equal(t, containerID, id)
-				return types.ContainerJSON{
-					ContainerJSONBase: &types.ContainerJSONBase{
-						State: &types.ContainerState{ExitCode: testcase.exitCode},
-					},
-				}, testcase.inspectError
-			},
+		if testcase.err != nil {
+			errC <- testcase.err
 		}
-		err := getExitStatus(context.Background(), client, containerID)
+		if testcase.result != nil {
+			resultC <- *testcase.result
+		}
+		err := getExitStatus(errC, resultC)
 		assert.Equal(t, testcase.expectedError, err)
 	}
 }

--- a/e2e/container/attach_test.go
+++ b/e2e/container/attach_test.go
@@ -1,0 +1,17 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+func TestAttachExitCode(t *testing.T) {
+	cName := "test-attach-exit-code"
+	icmd.RunCommand("docker", "run", "-d", "--rm", "--name", cName,
+		alpineImage, "sh", "-c", "sleep 5 ; exit 21").Assert(t, icmd.Success)
+	cmd := icmd.Command("docker", "wait", cName)
+	res := icmd.StartCmd(cmd)
+	icmd.RunCommand("docker", "attach", cName).Assert(t, icmd.Expected{ExitCode: 21})
+	icmd.WaitOnCmd(8, res).Assert(t, icmd.Expected{ExitCode: 0, Out: "21"})
+}

--- a/e2e/container/attach_test.go
+++ b/e2e/container/attach_test.go
@@ -1,17 +1,29 @@
 package container
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
 func TestAttachExitCode(t *testing.T) {
-	cName := "test-attach-exit-code"
-	icmd.RunCommand("docker", "run", "-d", "--rm", "--name", cName,
-		alpineImage, "sh", "-c", "sleep 5 ; exit 21").Assert(t, icmd.Success)
-	cmd := icmd.Command("docker", "wait", cName)
-	res := icmd.StartCmd(cmd)
-	icmd.RunCommand("docker", "attach", cName).Assert(t, icmd.Expected{ExitCode: 21})
-	icmd.WaitOnCmd(8, res).Assert(t, icmd.Expected{ExitCode: 0, Out: "21"})
+	containerID := runBackgroundContainsWithExitCode(t, 21)
+
+	result := icmd.RunCmd(
+		icmd.Command("docker", "attach", containerID),
+		withStdinNewline)
+
+	result.Assert(t, icmd.Expected{ExitCode: 21})
+}
+
+func runBackgroundContainsWithExitCode(t *testing.T, exitcode int) string {
+	result := icmd.RunCmd(shell(t,
+		"docker run -d -i --rm %s sh -c 'read; exit %d'", alpineImage, exitcode))
+	result.Assert(t, icmd.Success)
+	return strings.TrimSpace(result.Stdout())
+}
+
+func withStdinNewline(cmd *icmd.Cmd) {
+	cmd.Stdin = strings.NewReader("\n")
 }


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

Addresses https://github.com/moby/moby/issues/35497

**- What I did**

Use `ContainerWait()` instead of `Inspect` to retrieve the final exit code in atach

**- How I did it**

Changed the code ;-)

**- How to verify it**
```
$ docker run -f --name exit alpine sh -c 'sleep 10; exit 21'
$ docker attach exit
$ echo $?
21
```

**- Description for the changelog**

Ensure attach exit code matches container's

**- A picture of a cute animal (not mandatory but encouraged)**
:dog: 