### PR TITLE
Docs - Typo in volume plugin doc

### DIFF
--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -199,7 +199,7 @@ Request the path to the volume with the given `volume_name`.
 
   ```json
   {
-      "Mountpoin": "/path/to/directory/on/host",
+      "Mountpoint": "/path/to/directory/on/host",
       "Err": ""
   }
   ```


### PR DESCRIPTION
There is a typo in the `plugins_volume.md#volumedriverpath` section.
The `/VolumeDriver.Path` response (v1) should be `Mountpoint`and not `Mountpoin`.
