### PR TITLE
Fix #512 Bash autocompletion works incorrect with inspect

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2838,6 +2838,7 @@ _docker_inspect() {
 						$(__docker_services)
 						$(__docker_volumes)
 					" -- "$cur" ) )
+					__ltrim_colon_completions "$cur"
 					;;
 				container)
 					__docker_complete_containers_all


### PR DESCRIPTION
Fixes #512

completion or `docker inspect` fails for all image names that contain a `:`, e.g. `hello-world:` or `localhost:5000/hello-world/`. The substring before the first `:` is duplicated, resulting in invalid image names.

Note: completion for `docker inspect --type image` or `docker image inspect` was not affected by this issue.