### PR TITLE
Return error status when ps brings no containers

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"io/ioutil"
+	"errors"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -120,6 +121,9 @@ func runPs(dockerCli command.Cli, options *psOptions) error {
 	containers, err := dockerCli.Client().ContainerList(ctx, *listOptions)
 	if err != nil {
 		return err
+	}
+	if len(containers) == 0 {
+		return errors.New("no containers")
 	}
 
 	format := options.format


### PR DESCRIPTION
Signed-off-by: Juan Eugenio Abadie <juaneabadie@gmail.com>

**- What I did**

I added a new validation to `ps` to know if the command matched some container. It can be very useful for scripting (avoiding greping the output).

**- How I did it**

I checked if `ps` is returning any container in the `containers` array.

**- How to verify it**

```
$ docker ps && echo "Some container found"
$ docker ps -f filter=value && echo "Some container found"
```

**- Description for the changelog**

Return an error status when `ps [-f filter=value]` brings no containers.
