### PR TITLE
Bump Go to 1.9.2

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross@sha256:25ff84377e9d7f40639c33cc374166a3b0f1829b8462cf7001d742a846de2687
+FROM    dockercore/golang-cross@sha256:2e843a0e4d82b6bab34d2cb7abe26d1a6cda23226ecc3869100c8db553603f9b
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.8.5-alpine3.6
+FROM    golang:1.9.2-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.8.5-alpine3.6
+FROM    golang:1.9.2-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Now that https://github.com/moby/moby/pull/33892 is merged, we can update `docker/cli` to go 1.9.2 too :angel: 

🐯 🐻 🦁

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
