### PR TITLE
Fix e2e build test

### DIFF
--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -34,8 +34,8 @@ func TestBuildFromContextDirectoryWithTag(t *testing.T) {
 		3:  equals("Step 2/4 : COPY\trun /usr/bin/run"),
 		5:  equals("Step 3/4 : RUN\t\trun"),
 		7:  equals("running"),
-		9:  equals("Step 4/4 : COPY\tdata /data"),
-		11: prefix("Removing intermediate container "),
+		8:  prefix("Removing intermediate container "),
+		10: equals("Step 4/4 : COPY\tdata /data"),
 		12: prefix("Successfully built "),
 		13: equals("Successfully tagged myimage:latest"),
 	})


### PR DESCRIPTION
The build output changed in 17.09 or 17.10 to move all the "Removing intermediate container" messages to the end. The test was written to match that output.

In 17.11 it looks like it's back to the old output, where the containers are removed immediately after the stage. The test has been updated to work work with 17.11.