### PR TITLE
Fixing zsh column finding in nodes and stacks.

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1393,7 +1393,7 @@ __docker_nodes() {
     # Names
     if [[ $type = (names|all) ]]; then
         for line in $lines; do
-            s="${line[${begin[NAME]},${end[NAME]}]%% ##}"
+            s="${line[${begin[HOSTNAME]},${end[HOSTNAME]}]%% ##}"
             nodes=($nodes $s)
         done
     fi
@@ -2169,9 +2169,9 @@ __docker_stacks() {
     end[${header[$i,$((j-1))]}]=-1
     lines=(${lines[2,-1]})
 
-    # Service ID
+    # Service NAME
     for line in $lines; do
-        s="${line[${begin[ID]},${end[ID]}]%% ##}"
+        s="${line[${begin[NAME]},${end[NAME]}]%% ##}"
         stacks=($stacks $s)
     done
 


### PR DESCRIPTION
fixes #729 

**- What I did**
Changed Zsh completion script to find the proper column titles for `docker node` and `docker stack` commands.

**Note** the Zsh selector for node names still has an issue selecting a node with an asterisk next to it (denoting the manager you're currently talking to). I wasn't savvy enough in Zsh functions nor regex to filter out the ` *` when tabbing to select node name, but I'm happy to update this PR if someone can point me to a solution.  This fix still works if you choose the ID, and it's better then before where you wouldn't get a list.

This is what that bug looks like:
![screen capture on 2017-12-05 at 01-20-44](https://user-images.githubusercontent.com/792287/33592810-a4be2276-d95a-11e7-88a4-43ab1b09702a.gif)

**- How I did it**
Edited three lines with my bare hands :)

**- How to verify it**
Update your Zsh docker completion file with this one, run `compinit` to update completions, and type `docker node rm` and `docker stack rm` (assuming you have one of each in their lists) and hit tab. You should get back a list or an auto-filled CLI rather than error about "empty string"

**- Description for the changelog**
Fixed Zsh completion for node and stack commands.

**- A picture of a cute animal (not mandatory but encouraged)**
My dog Leelu
![leeludocker - 1](https://user-images.githubusercontent.com/792287/33592505-597a6ae6-d959-11e7-9c7e-3d6dc0d6da00.jpg)



Signed-off-by: Bret Fisher <bret@bretfisher.com>