### PR TITLE
Add platform and its components to docker version output

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -3,7 +3,8 @@ package cli
 // Default build-time variable.
 // These values are overriding via ldflags
 var (
-	Version   = "unknown-version"
-	GitCommit = "unknown-commit"
-	BuildTime = "unknown-buildtime"
+	PlatformName = ""
+	Version      = "unknown-version"
+	GitCommit    = "unknown-commit"
+	BuildTime    = "unknown-buildtime"
 )

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,7 +10,7 @@ CROSS_IMAGE_NAME = docker-cli-cross$(IMAGE_TAG)
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate$(IMAGE_TAG)
 MOUNTS = -v "$(CURDIR)":/go/src/github.com/docker/cli
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 set -eu
 
+PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-"unknown-version"}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 BUILDTIME=${BUILDTIME:-$(date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')}
 
+PLATFORM_LDFLAGS=
+if test -n "${PLATFORM}"; then
+	PLATFORM_LDFLAGS="-X \"github.com/docker/cli/cli.PlatformName=${PLATFORM}\""
+fi
+
 export LDFLAGS="\
     -w \
-    -X github.com/docker/cli/cli.GitCommit=${GITCOMMIT} \
-    -X github.com/docker/cli/cli.BuildTime=${BUILDTIME} \
-    -X github.com/docker/cli/cli.Version=${VERSION} \
+    ${PLATFORM_LDFLAGS} \
+    -X \"github.com/docker/cli/cli.GitCommit=${GITCOMMIT}\" \
+    -X \"github.com/docker/cli/cli.BuildTime=${BUILDTIME}\" \
+    -X \"github.com/docker/cli/cli.Version=${VERSION}\" \
     ${LDFLAGS:-} \
 "
 

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -55,10 +55,16 @@ func Parse(format string) (*template.Template, error) {
 	return NewParse("", format)
 }
 
+// New creates a new empty template with the provided tag and built-in
+// template functions.
+func New(tag string) *template.Template {
+	return template.New(tag).Funcs(basicFunctions)
+}
+
 // NewParse creates a new tagged template with the basic functions
 // and parses the given format.
 func NewParse(tag, format string) (*template.Template, error) {
-	return template.New(tag).Funcs(basicFunctions).Parse(format)
+	return New(tag).Parse(format)
 }
 
 // padWithSpace adds whitespace to the input if the input is non-empty

--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/coreos/etcd v3.2.1
 github.com/cpuguy83/go-md2man a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker 5e5fadb3c0201553929d4a6ea8dc8f9d8a1e56fe
+github.com/docker/docker a1be987ea9e03e5ebdb1b415a7acdd8d6f0aaa08
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b
 
 # the docker/go package contains a customized version of canonical/json

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -107,9 +107,21 @@ type Ping struct {
 	Experimental bool
 }
 
+// ComponentVersion describes the version information for a specific component.
+type ComponentVersion struct {
+	Name    string
+	Version string
+	Details map[string]string `json:",omitempty"`
+}
+
 // Version contains response of Engine API:
 // GET "/version"
 type Version struct {
+	Platform   struct{ Name string } `json:",omitempty"`
+	Components []ComponentVersion    `json:",omitempty"`
+
+	// The following fields are deprecated, they relate to the Engine component and are kept for backwards compatibility
+
 	Version       string
 	APIVersion    string `json:"ApiVersion"`
 	MinAPIVersion string `json:"MinAPIVersion,omitempty"`

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -30,7 +30,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
-github.com/docker/libnetwork 64ae58878fc8f95e4a167499d654e13fa36abdc7
+github.com/docker/libnetwork 9bca9a4a220b158cc94402e0f8c2c7714eb6f503
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -42,7 +42,7 @@ github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
 github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
-github.com/vishvananda/netlink bd6d5de5ccef2d66b0a26177928d0d8895d7f969
+github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
 github.com/BurntSushi/toml f706d00e3de6abe700c994cdd545a1a4915af060
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d


### PR DESCRIPTION
The Server section of version output is now composed of an Engine
component and potentially more, based on what the /version endpoint
returns.

Signed-off-by: Tibor Vass <tibor@docker.com>

Related to https://github.com/moby/moby/pull/35705

Against old CE:
```
Client: Docker CE
 Version:    17.12.0-dev
 API version:    1.34 (downgraded from 1.35)
 Go version:    go1.9.2
 Git commit:    259ec810
 Built:    Wed Dec  6 20:07:54 2017
 OS/Arch:    linux/amd64

Server:
 Engine:
  Version:    17.11.0-ce
  API version:    1.34 (minimum version 1.12)
  Go version:    go1.8.5
  Git commit:    1caf76c
  Built:    Mon Nov 20 18:39:28 2017
  OS/Arch:    linux/amd64
  Experimental:    true
```

Against new CE:
```
Client: Docker CE
 Version:    17.12.0-dev
 API version:    1.35
 Go version:    go1.9.2
 Git commit:    259ec810
 Built:    Wed Dec  6 20:07:54 2017
 OS/Arch:    linux/amd64

Server: Docker CE
 Engine:
  Version:    dev
  API version:    1.35 (minimum version 1.12)
  Go version:    go1.9.2
  Git commit:    dc0058ef6f
  Built:    Wed Dec  6 20:49:58 2017
  OS/Arch:    linux/amd64
  Experimental:    false
```

`Engine` is now one component, and there can be multiple ones added that require to have a Version field, and can add an optional Details key-value hashmap for extra fields.

For backwards compatibility, the Engine output is special-cased in terms of output.

- [x] Vendor API