### PR TITLE
Fix external networks in stacks

### DIFF
--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -62,7 +62,7 @@ func Networks(namespace Namespace, networks networkMap, servicesNetworks map[str
 	for internalName := range servicesNetworks {
 		network := networks[internalName]
 		if network.External.External {
-			externalNetworks = append(externalNetworks, network.External.Name)
+			externalNetworks = append(externalNetworks, network.Name)
 			continue
 		}
 

--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -55,10 +55,8 @@ func TestNetworks(t *testing.T) {
 			},
 		},
 		"outside": composetypes.NetworkConfig{
-			External: composetypes.External{
-				External: true,
-				Name:     "special",
-			},
+			External: composetypes.External{External: true},
+			Name:     "special",
 		},
 		"attachablenet": composetypes.NetworkConfig{
 			Driver:     "overlay",

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -230,7 +230,7 @@ func convertServiceNetworks(
 		}
 		target := namespace.Scope(networkName)
 		if networkConfig.External.External {
-			target = networkConfig.External.Name
+			target = networkConfig.Name
 		}
 		netAttachConfig := swarm.NetworkAttachmentConfig{
 			Target:  target,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -219,10 +219,8 @@ func TestConvertServiceNetworksOnlyDefault(t *testing.T) {
 func TestConvertServiceNetworks(t *testing.T) {
 	networkConfigs := networkMap{
 		"front": composetypes.NetworkConfig{
-			External: composetypes.External{
-				External: true,
-				Name:     "fronttier",
-			},
+			External: composetypes.External{External: true},
+			Name:     "fronttier",
 		},
 		"back": composetypes.NetworkConfig{},
 	}
@@ -259,10 +257,8 @@ func TestConvertServiceNetworks(t *testing.T) {
 func TestConvertServiceNetworksCustomDefault(t *testing.T) {
 	networkConfigs := networkMap{
 		"default": composetypes.NetworkConfig{
-			External: composetypes.External{
-				External: true,
-				Name:     "custom",
-			},
+			External: composetypes.External{External: true},
+			Name:     "custom",
 		},
 	}
 	networks := map[string]*composetypes.ServiceNetworkConfig{}


### PR DESCRIPTION
Fixes moby/moby#35755

Looks like I missed where the network name was used. I confirmed `External.Name` is no longer used anywhere after this patch.