### PR TITLE
Update docs and completion-scripts for deprecated features

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2164,7 +2164,6 @@ _docker_create() {
 _docker_daemon() {
 	local boolean_options="
 		$global_boolean_options
-		--disable-legacy-registry
 		--experimental
 		--help
 		--icc=false

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2633,7 +2633,6 @@ __docker_subcommand() {
                 "($help)--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: " \
                 "($help)--default-shm-size=[Default shm size for containers]:size:" \
                 "($help)*--default-ulimit=[Default ulimits for containers]:ulimit: " \
-                "($help)--disable-legacy-registry[Disable contacting legacy registries (default true)]" \
                 "($help)*--dns=[DNS server to use]:DNS: " \
                 "($help)*--dns-opt=[DNS options to use]:DNS option: " \
                 "($help)*--dns-search=[DNS search domains to use]:DNS search: " \

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -88,10 +88,10 @@ The daemon is moved to a separate binary (`dockerd`), and should be used instead
 ### Duplicate keys with conflicting values in engine labels
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
-Duplicate keys with conflicting values have been deprecated. A warning is displayed
-in the output, and an error will be returned in the future.
+When setting duplicate keys with conflicting values, an error will be produced, and the daemon
+will fail to start.
 
 ### `MAINTAINER` in Dockerfile
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
@@ -110,11 +110,15 @@ future Engine versions. Instead of just requesting, for example, the URL
 ### Backing filesystem without `d_type` support for overlay/overlay2
 **Deprecated In Release: [v1.13.0](https://github.com/docker/docker/releases/tag/v1.13.0)**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
 The overlay and overlay2 storage driver does not work as expected if the backing
 filesystem does not support `d_type`. For example, XFS does not support `d_type`
 if it is formatted with the `ftype=0` option.
+
+Starting with Docker 17.12, new installations will not support running overlay2 on
+a backing filesystem without `d_type` support. For existing installations that upgrade
+to 17.12, a warning will be printed.
 
 Please also refer to [#27358](https://github.com/docker/docker/issues/27358) for
 further information.
@@ -292,7 +296,7 @@ of the `--changes` flag that allows to pass `Dockerfile` commands.
 
 **Disabled By Default In Release: v17.06**
 
-**Target For Removal In Release: v17.12**
+**Removed In Release: v17.12**
 
 Version 1.8.3 added a flag (`--disable-legacy-registry=false`) which prevents the
 docker daemon from `pull`, `push`, and `login` operations against v1
@@ -302,6 +306,21 @@ the v1 protocol.
 Support for the v1 protocol to the public registry was removed in 1.13. Any
 mirror configurations using v1 should be updated to use a
 [v2 registry mirror](https://docs.docker.com/registry/recipes/mirror/).
+
+Starting with Docker 17.12, support for V1 registries has been removed, and the
+`--disable-legacy-registry` flag can no longer be used, and `dockerd` will fail to
+start when set.
+
+### `--disable-legacy-registry` override daemon option
+
+**Disabled In Release: v17.12**
+
+**Target For Removal In Release: v18.03**
+
+The `--disable-legacy-registry` flag was disabled in Docker 17.12 and will print
+an error when used. For this error to be printed, the flag itself is still present,
+but hidden. The flag will be removed in Docker 18.03.
+
 
 ### Docker Content Trust ENV passphrase variables name change
 **Deprecated In Release: [v1.9.0](https://github.com/docker/docker/releases/tag/v1.9.0)**

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -42,7 +42,6 @@ Options:
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-runtime string                Default OCI runtime for containers (default "runc")
       --default-ulimit ulimit                 Default ulimits for containers (default [])
-      --disable-legacy-registry               Disable contacting legacy registries (default true)
       --dns list                              DNS server to use (default [])
       --dns-opt list                          DNS options to use (default [])
       --dns-search list                       DNS search domains to use (default [])
@@ -1054,18 +1053,14 @@ system's list of trusted CAs instead of enabling `--insecure-registry`.
 
 #### Legacy Registries
 
-Operations against registries supporting only the legacy v1 protocol are
-disabled by default. Specifically, the daemon will not attempt `push`,
-`pull` and `login` to v1 registries. The exception to this is `search`
-which can still be performed on v1 registries.
+Starting with Docker 17.12, operations against registries supporting only the 
+legacy v1 protocol are no longer supported. Specifically, the daemon will not
+attempt `push`, `pull` and `login` to v1 registries. The exception to this is
+`search` which can still be performed on v1 registries.
 
-Add `"disable-legacy-registry":false` to the [daemon configuration
-file](#daemon-configuration-file), or set the
-`--disable-legacy-registry=false` flag, if you need to interact with
-registries that have not yet migrated to the v2 protocol.
+The `disable-legacy-registry` configuration option has been removed and, when
+used, will produce an error on daemon startup.
 
-Interaction v1 registries will no longer be supported in Docker v17.12,
-and the `disable-legacy-registry` configuration option will be removed.
 
 ### Running a Docker daemon behind an HTTPS_PROXY
 
@@ -1339,7 +1334,6 @@ This is a full example of the allowed configuration options on Linux:
 	"registry-mirrors": [],
 	"seccomp-profile": "",
 	"insecure-registries": [],
-	"disable-legacy-registry": false,
 	"no-new-privileges": false,
 	"default-runtime": "runc",
 	"oom-score-adjust": -500,
@@ -1408,8 +1402,7 @@ This is a full example of the allowed configuration options on Windows:
     "raw-logs": false,
     "allow-nondistributable-artifacts": [],
     "registry-mirrors": [],
-    "insecure-registries": [],
-    "disable-legacy-registry": false
+    "insecure-registries": []
 }
 ```
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -26,7 +26,6 @@ dockerd - Enable daemon mode
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
 [**--default-ulimit**[=*[]*]]
-[**--disable-legacy-registry**]
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
@@ -196,9 +195,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--default-ulimit**=[]
   Default ulimits for containers.
-
-**--disable-legacy-registry**=*true*|*false*
-  Disable contacting legacy registries. Default is `true`.
 
 **--dns**=""
   Force Docker to use specific DNS servers


### PR DESCRIPTION
- the `--disable-legacy-registry` daemon flag was removed (https://github.com/moby/moby/pull/35751)
- duplicate keys with conflicting values for engine labels now produce an error instead of a warning (https://github.com/moby/moby/pull/35470).

