### PR TITLE
Add support for generic resources to bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2221,6 +2221,7 @@ _docker_daemon() {
 		--metrics-addr
 		--mtu
 		--network-control-plane-mtu
+		--node-generic-resource
 		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror
@@ -3396,6 +3397,7 @@ _docker_service_update_and_create() {
 			--dns-option
 			--dns-search
 			--env-file
+			--generic-resource
 			--group
 			--host
 			--mode
@@ -3457,6 +3459,8 @@ _docker_service_update_and_create() {
 			--dns-rm
 			--dns-search-add
 			--dns-search-rm
+			--generic-resource-add
+			--generic-resource-rm
 			--group-add
 			--group-rm
 			--host-add


### PR DESCRIPTION
Adds bash completion for #429:
- `service create --generic-resource`
- `service update --generic-resource-(add|rm)`
- `dockerd --node-generic-resource`