### PR TITLE
Return errors from client in stack deploy configs

### DIFF
--- a/cli/command/stack/deploy_composefile.go
+++ b/cli/command/stack/deploy_composefile.go
@@ -248,13 +248,13 @@ func createConfigs(
 		case err == nil:
 			// config already exists, then we update that
 			if err := client.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
-				errors.Wrapf(err, "failed to update config %s", configSpec.Name)
+				return errors.Wrapf(err, "failed to update config %s", configSpec.Name)
 			}
 		case apiclient.IsErrNotFound(err):
 			// config does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating config %s\n", configSpec.Name)
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {
-				errors.Wrapf(err, "failed to create config %s", configSpec.Name)
+				return errors.Wrapf(err, "failed to create config %s", configSpec.Name)
 			}
 		default:
 			return err


### PR DESCRIPTION
**- What I did**
Fixed https://github.com/docker/cli/issues/756

**- How I did it**
Added return statement.

**- How to verify it**
1. Create stack with service and config
2. Deploy stack
3. Update config file content
4. Deploy stack
5. Deploy should end with error 

**- Description for the changelog**
Return errors from daemon on stack deploy configs create/update