### PR TITLE
Add support for experimental Cli configuration

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -1,17 +1,18 @@
 package command
 
 import (
+	"crypto/x509"
 	"os"
 	"testing"
 
-	"crypto/x509"
-
+	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/internal/test/testutil"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,9 +125,47 @@ func TestInitializeFromClient(t *testing.T) {
 
 			cli := &DockerCli{client: apiclient}
 			cli.initializeFromClient()
-			assert.Equal(t, defaultVersion, cli.defaultVersion)
-			assert.Equal(t, testcase.expectedServer, cli.server)
+			assert.Equal(t, testcase.expectedServer, cli.serverInfo)
 			assert.Equal(t, testcase.negotiated, apiclient.negotiated)
+		})
+	}
+}
+
+func TestExperimentalCLI(t *testing.T) {
+	defaultVersion := "v1.55"
+
+	var testcases = []struct {
+		doc                     string
+		configfile              string
+		expectedExperimentalCLI bool
+	}{
+		{
+			doc:                     "default",
+			configfile:              `{}`,
+			expectedExperimentalCLI: false,
+		},
+		{
+			doc: "experimental",
+			configfile: `{
+	"experimental": "enabled"
+}`,
+			expectedExperimentalCLI: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.doc, func(t *testing.T) {
+			dir := fs.NewDir(t, testcase.doc, fs.WithFile("config.json", testcase.configfile))
+			defer dir.Remove()
+			apiclient := &fakeClient{
+				version: defaultVersion,
+			}
+
+			cli := &DockerCli{client: apiclient, err: os.Stderr}
+			cliconfig.SetDir(dir.Path())
+			err := cli.Initialize(flags.NewClientOptions())
+			assert.NoError(t, err)
+			assert.Equal(t, testcase.expectedExperimentalCLI, cli.ClientInfo().HasExperimental)
 		})
 	}
 }

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -23,6 +23,7 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  Git commit:	{{.GitCommit}}
  Built:	{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
+ Experimental:	{{.Experimental}}
 {{- end}}
 
 {{- if .ServerOK}}{{with .Server}}
@@ -69,6 +70,7 @@ type clientVersion struct {
 	Os                string
 	Arch              string
 	BuildTime         string `json:",omitempty"`
+	Experimental      bool
 }
 
 // ServerOK returns true when the client could connect to the docker server
@@ -133,6 +135,7 @@ func runVersion(dockerCli *command.DockerCli, opts *versionOptions) error {
 			BuildTime:         cli.BuildTime,
 			Os:                runtime.GOOS,
 			Arch:              runtime.GOARCH,
+			Experimental:      dockerCli.ClientInfo().HasExperimental,
 		},
 	}
 	vd.Client.Platform.Name = cli.PlatformName

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -9,10 +9,11 @@ import (
 // NewTrustCommand returns a cobra command for `trust` subcommands
 func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "trust",
-		Short: "Manage trust on Docker images (experimental)",
-		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		Use:         "trust",
+		Short:       "Manage trust on Docker images (experimental)",
+		Args:        cli.NoArgs,
+		RunE:        command.ShowHelp(dockerCli.Err()),
+		Annotations: map[string]string{"experimentalCLI": ""},
 	}
 	cmd.AddCommand(
 		newViewCommand(dockerCli),

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -44,6 +44,7 @@ type ConfigFile struct {
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                    `json:"pruneFilters,omitempty"`
 	Proxies              map[string]ProxyConfig      `json:"proxies,omitempty"`
+	Experimental         string                      `json:"experimental,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -193,6 +193,7 @@ func dockerPreRun(opts *cliflags.ClientOptions) {
 
 type versionDetails interface {
 	Client() client.APIClient
+	ClientInfo() command.ClientInfo
 	ServerInfo() command.ServerInfo
 }
 
@@ -200,11 +201,17 @@ func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) {
 	clientVersion := details.Client().ClientVersion()
 	osType := details.ServerInfo().OSType
 	hasExperimental := details.ServerInfo().HasExperimental
+	hasExperimentalCLI := details.ClientInfo().HasExperimental
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		// hide experimental flags
 		if !hasExperimental {
 			if _, ok := f.Annotations["experimental"]; ok {
+				f.Hidden = true
+			}
+		}
+		if !hasExperimentalCLI {
+			if _, ok := f.Annotations["experimentalCLI"]; ok {
 				f.Hidden = true
 			}
 		}
@@ -222,6 +229,11 @@ func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) {
 				subcmd.Hidden = true
 			}
 		}
+		if !hasExperimentalCLI {
+			if _, ok := subcmd.Annotations["experimentalCLI"]; ok {
+				subcmd.Hidden = true
+			}
+		}
 
 		// hide subcommands not supported by the server
 		if subcmdVersion, ok := subcmd.Annotations["version"]; ok && versions.LessThan(clientVersion, subcmdVersion) {
@@ -234,6 +246,7 @@ func isSupported(cmd *cobra.Command, details versionDetails) error {
 	clientVersion := details.Client().ClientVersion()
 	osType := details.ServerInfo().OSType
 	hasExperimental := details.ServerInfo().HasExperimental
+	hasExperimentalCLI := details.ClientInfo().HasExperimental
 
 	// Check recursively so that, e.g., `docker stack ls` returns the same output as `docker stack`
 	for curr := cmd; curr != nil; curr = curr.Parent() {
@@ -242,6 +255,9 @@ func isSupported(cmd *cobra.Command, details versionDetails) error {
 		}
 		if _, ok := curr.Annotations["experimental"]; ok && !hasExperimental {
 			return fmt.Errorf("%s is only supported on a Docker daemon with experimental features enabled", cmd.CommandPath())
+		}
+		if _, ok := curr.Annotations["experimentalCLI"]; ok && !hasExperimentalCLI {
+			return fmt.Errorf("%s is only supported when experimental cli features are enabled", cmd.CommandPath())
 		}
 	}
 
@@ -259,6 +275,9 @@ func isSupported(cmd *cobra.Command, details versionDetails) error {
 			}
 			if _, ok := f.Annotations["experimental"]; ok && !hasExperimental {
 				errs = append(errs, fmt.Sprintf("\"--%s\" is only supported on a Docker daemon with experimental features enabled", f.Name))
+			}
+			if _, ok := f.Annotations["experimentalCLI"]; ok && !hasExperimentalCLI {
+				errs = append(errs, fmt.Sprintf("\"--%s\" is only supported when experimental cli features are enabled", f.Name))
 			}
 		}
 	})

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -32,7 +32,8 @@ func SetupConfigFile(t *testing.T) fs.Dir {
 			"https://notary-server:4443": {
 				"auth": "ZWlhaXM6cGFzc3dvcmQK"
 			}
-		}
+		},
+		"experimental": "enabled"
 	}
 	`))
 	return *dir


### PR DESCRIPTION
Allow to mark some commands and flags experimental on cli (i.e. not
depending to the state of the daemon). This will allow more flexibility
on experimentation with the cli.

Marking `docker trust` as cli experimental as it is documented so.

```bash
$ docker trust --help
docker trust is only supported on a Docker cli with experimental features enabled
# edit docker client configuration file
$ cat ~/.docker/config.json
{
        "experimentalCli": "enabled"
}
$ docker trust --help
Usage:  docker trust COMMAND

Manage trust on Docker images (experimental)

Options:


Management Commands:
  key         Manage keys for signing Docker images (experimental)
  signer      Manage entities who can sign Docker images (experimental)

Commands:
  revoke      Remove trust for an image
  sign        Sign an image
  view        Display detailed information about keys and signatures

Run 'docker trust COMMAND --help' for more information on a command.
```

This is required for https://github.com/docker/cli/pull/721/ (as we will put the k8s support under experimental at first)

![jpeg image 271 x 186 pixels](https://user-images.githubusercontent.com/6508/34210943-d67df6bc-e597-11e7-881f-96f80bb613c7.jpeg)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

