### PR TITLE
Corrected descriptions for MAC_ADMIN and MAC_OVERRIDE

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1198,8 +1198,8 @@ The next table shows the capabilities which are not granted by default and may b
 | SYS_TIME        | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock.                      |
 | SYS_TTY_CONFIG  | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals.                             |
 | AUDIT_CONTROL   | Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules. |
-| MAC_OVERRIDE    | Allow MAC configuration or state changes. Implemented for the Smack LSM.                                        |
-| MAC_ADMIN       | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM).                 |
+| MAC_ADMIN       | Allow MAC configuration or state changes. Implemented for the Smack LSM.                                        |
+| MAC_OVERRIDE    | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM).                 |
 | NET_ADMIN       | Perform various network-related operations.                                                                     |
 | SYSLOG          | Perform privileged syslog(2) operations.                                                                        |
 | DAC_READ_SEARCH | Bypass file read permission checks and directory read and execute permission checks.                            |


### PR DESCRIPTION
The description for capabilities are mismatched for MAC_ADMIN and MAC_OVERRIDE.
You can find the correct information [here](http://man7.org/linux/man-pages/man7/capabilities.7.html) on the linux man page.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

