### PR TITLE
Remove reference to non-existing "stack config" command

### DIFF
--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -104,7 +104,6 @@ axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/
 
 ## Related commands
 
-* [stack config](stack_config.md)
 * [stack deploy](stack_deploy.md)
 * [stack ls](stack_ls.md)
 * [stack ps](stack_ps.md)


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/35872

ping @vdemeester @ajeetraina