### PR TITLE
Add "pid" to unsupported options list

### DIFF
--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -657,6 +657,7 @@ services:
      context: ./web
     links:
       - bar
+    pid: host
   db:
     image: db
     build:
@@ -670,7 +671,7 @@ services:
 	require.NoError(t, err)
 
 	unsupported := GetUnsupportedProperties(configDetails)
-	assert.Equal(t, []string{"build", "links"}, unsupported)
+	assert.Equal(t, []string{"build", "links", "pid"}, unsupported)
 }
 
 func TestBuildProperties(t *testing.T) {

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -17,6 +17,7 @@ var UnsupportedProperties = []string{
 	"links",
 	"mac_address",
 	"network_mode",
+	"pid",
 	"privileged",
 	"restart",
 	"security_opt",


### PR DESCRIPTION
Services do not support custom "pid"-modes (e.g. `--pid=host`, see https://github.com/docker/swarmkit/issues/1605), but this option was ignored silently when deploying a stack.

This patch adds `pid` to the list of unsupported options so that a warning is printed;

With this patch applied:

    $ docker stack deploy -c docker-compose.yml foobar
    Ignoring unsupported options: pid

    Creating network foobar_default
    Creating service foobar_test


**- How to verify it**

Deploy this docker-compose file, and verify that a warning is printed;

```yaml
version: '3.4'
services:
    test:
        image: nginx:alpine
        pid: host
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
