### PR TITLE
Fix alignment of client built time in version output

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -21,7 +21,7 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  API version:	{{.APIVersion}}{{if ne .APIVersion .DefaultAPIVersion}} (downgraded from {{.DefaultAPIVersion}}){{end}}
  Go version:	{{.GoVersion}}
  Git commit:	{{.GitCommit}}
- Built:	{{.BuildTime}}
+ Built:		{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
  Experimental:	{{.Experimental}}
 {{- end}}


### PR DESCRIPTION
**- What I did**
Add one more tab to the `Built` time to align the output of the docker client version.

**- How to verify it**

Before:

```
$ docker version
Client:
 Version:	18.01.0-dev
 API version:	1.35
 Go version:	go1.9.2
 Git commit:	c97c6d6
 Built:	Wed Dec 27 20:11:19 2017
 OS/Arch:	linux/amd64
 Experimental:	false
```

After:

```
$ docker version
Client:
 Version:	18.01.0-dev
 API version:	1.35
 Go version:	go1.9.2
 Git commit:	0dd05ac1
 Built:		Thu Dec 28 09:19:35 2017
 OS/Arch:	linux/amd64
 Experimental:	false
```

**- Description for the changelog**

Fix alignment of client built time in version output

Signed-off-by: Leander Janssen <leander@slaco.net>
