### PR TITLE
Fix bash completion for "docker swarm"

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4945,6 +4945,7 @@ _docker() {
 		secret
 		service
 		stack
+		swarm
 		system
 		volume
 	)
@@ -4988,7 +4989,6 @@ _docker() {
 		start
 		stats
 		stop
-		swarm
 		tag
 		top
 		unpause


### PR DESCRIPTION
"docker swarm" auto-completion is invalid.