### PR TITLE
Fix description of filter flag in prune commands

### DIFF
--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -48,7 +48,7 @@ Total reclaimed space: 212 B
 
 ### Filtering
 
-The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -70,7 +70,7 @@ Total reclaimed space: 16.43 MB
 
 ### Filtering
 
-The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -36,7 +36,7 @@ n2
 
 ### Filtering
 
-The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -46,7 +46,7 @@ Total reclaimed space: 36 B
 
 ## Filtering
 
-The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
+The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:


### PR DESCRIPTION
**- What I did**
Fix description of filter flag in prune commands.

**- How to verify it**
None of the following work demonstrating the issue:
```bash
user@ubuntu:~$ docker image prune -f "until=24h"
"docker image prune" accepts no arguments.
See 'docker image prune --help'.

Usage:  docker image prune [OPTIONS] [flags]

Remove unused images
user@ubuntu:~$ docker volume prune -f "until=24h"
"docker volume prune" accepts no arguments.
See 'docker volume prune --help'.

Usage:  docker volume prune [OPTIONS] [flags]

Remove all unused volumes
user@ubuntu:~$ docker network prune -f "until=24h"
"docker network prune" accepts no arguments.
See 'docker network prune --help'.

Usage:  docker network prune [OPTIONS] [flags]

Remove all unused networks
user@ubuntu:~$ docker container prune -f "until=24h"
"docker container prune" accepts no arguments.
See 'docker container prune --help'.

Usage:  docker container prune [OPTIONS] [flags]

Remove all stopped containers
user@ubuntu:~$ docker system prune -f "until=24h"
"docker system prune" accepts no arguments.
See 'docker system prune --help'.

Usage:  docker system prune [OPTIONS] [flags]

Remove unused data
```
Correct output when the proper flag is used:
```
user@ubuntu:~$ docker image prune --filter "until=24h"
WARNING! This will remove all dangling images.
Are you sure you want to continue? [y/N] n
Total reclaimed space: 0B
```

**- Description for the changelog**
Fix description of filter flag in prune commands. The "-f" flag is an alias for --force, not --filter (as correctly stated at the top of each documents). The system_prune.md didn't have this error.

**- A picture of a cute animal (not mandatory but encouraged)**

![Meerkats](https://cdn.discordapp.com/attachments/371737320564457472/397413165861961738/180336-049-42EE0398.png)
