### PR TITLE
Fix --network-add adding duplicate networks

### DIFF
--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -16,6 +16,7 @@ type fakeClient struct {
 	serviceListFunc           func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
 	taskListFunc              func(context.Context, types.TaskListOptions) ([]swarm.Task, error)
 	infoFunc                  func(ctx context.Context) (types.Info, error)
+	networkInspectFunc        func(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
 }
 
 func (f *fakeClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
@@ -58,6 +59,13 @@ func (f *fakeClient) Info(ctx context.Context) (types.Info, error) {
 		return types.Info{}, nil
 	}
 	return f.infoFunc(ctx)
+}
+
+func (f *fakeClient) NetworkInspect(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error) {
+	if f.networkInspectFunc != nil {
+		return f.networkInspectFunc(ctx, networkID, options)
+	}
+	return types.NetworkResource{}, nil
 }
 
 func newService(id string, name string) swarm.Service {

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -353,22 +353,21 @@ func (c *credentialSpecOpt) Value() *swarm.CredentialSpec {
 	return c.value
 }
 
-func convertNetworks(ctx context.Context, apiClient client.NetworkAPIClient, networks opts.NetworkOpt) ([]swarm.NetworkAttachmentConfig, error) {
+func resolveNetworkID(ctx context.Context, apiClient client.NetworkAPIClient, networkIDOrName string) (string, error) {
+	nw, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
+	return nw.ID, err
+}
+
+func convertNetworks(networks opts.NetworkOpt) []swarm.NetworkAttachmentConfig {
 	var netAttach []swarm.NetworkAttachmentConfig
 	for _, net := range networks.Value() {
-		networkIDOrName := net.Target
-		_, err := apiClient.NetworkInspect(ctx, networkIDOrName, types.NetworkInspectOptions{Scope: "swarm"})
-		if err != nil {
-			return nil, err
-		}
 		netAttach = append(netAttach, swarm.NetworkAttachmentConfig{
 			Target:     net.Target,
 			Aliases:    net.Aliases,
 			DriverOpts: net.DriverOpts,
 		})
 	}
-	sort.Sort(byNetworkTarget(netAttach))
-	return netAttach, nil
+	return netAttach
 }
 
 type endpointOptions struct {
@@ -590,10 +589,15 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 		return service, err
 	}
 
-	networks, err := convertNetworks(ctx, apiClient, options.networks)
-	if err != nil {
-		return service, err
+	networks := convertNetworks(options.networks)
+	for i, net := range networks {
+		nwID, err := resolveNetworkID(ctx, apiClient, net.Target)
+		if err != nil {
+			return service, err
+		}
+		networks[i].Target = nwID
 	}
+	sort.Sort(byNetworkTarget(networks))
 
 	resources, err := options.resources.ToResourceRequirements()
 	if err != nil {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1119,14 +1119,16 @@ func updateNetworks(ctx context.Context, apiClient client.NetworkAPIClient, flag
 
 	if flags.Changed(flagNetworkAdd) {
 		values := flags.Lookup(flagNetworkAdd).Value.(*opts.NetworkOpt)
-		networks, err := convertNetworks(ctx, apiClient, *values)
-		if err != nil {
-			return err
-		}
+		networks := convertNetworks(*values)
 		for _, network := range networks {
-			if _, exists := existingNetworks[network.Target]; exists {
+			nwID, err := resolveNetworkID(ctx, apiClient, network.Target)
+			if err != nil {
+				return err
+			}
+			if _, exists := existingNetworks[nwID]; exists {
 				return errors.Errorf("service is already attached to network %s", network.Target)
 			}
+			network.Target = nwID
 			newNetworks = append(newNetworks, network)
 			existingNetworks[network.Target] = struct{}{}
 		}


### PR DESCRIPTION
When adding a network using `docker service update --network-add`,
the new network was added by _name_.

Existing entries in a service spec are listed by network ID, which
resulted in the CLI not detecting duplicate entries for the same
network.

This patch changes the behavior to always use the network-ID,
so that duplicate entries are correctly caught.

Before this change;

```bash
$ docker network create -d overlay foo
$ docker service create --name=test --network=foo nginx:alpine
$ docker service update --network-add foo test
$ docker service inspect --format '{{ json .Spec.TaskTemplate.Networks}}' test
[
  {
    "Target": "9ot0ieagg5xv1gxd85m7y33eq"
  },
  {
    "Target": "9ot0ieagg5xv1gxd85m7y33eq"
  }
]
```

After this change:

```bash
$ docker network create -d overlay foo
$ docker service create --name=test --network=foo nginx:alpine
$ docker service update --network-add foo test
service is already attached to network 9ot0ieagg5xv1gxd85m7y33eq
```

**- Description for the changelog**

```Markdown
* Fix duplicate networks being added with `docker service update --network-add` [docker/cli#780](https://github.com/docker/cli/pull/780)
```

  