### PR TITLE
Correct table html with close tag for </thead>

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -764,6 +764,7 @@ The options you can specify are:
   <th>Long syntax</th>
   <th>Description</th>
 </tr>
+</thead>
 <tr>
   <td>published and target port </td>
   <td><tt></tt></td>


### PR DESCRIPTION
Currently shows as:

```
"The options you can specify are:
</table> "
```

on the docker website - missing a close tag for thead (to be honest https://docs.docker.com/engine/reference/commandline/service_create/#publish-service-ports-externally-to-the-swarm--p-publish is a bit of a mess at the moment)

**- A picture of a cute animal (not mandatory but encouraged)**
(my user pic is one of my bunnies if that helps?)


  