### PR TITLE
use 'config' over 'configuration file'

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -28,7 +28,7 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create [OPTIONS] CONFIG file|-",
-		Short: "Create a configuration file from a file or STDIN as content",
+		Short: "Create a config from a file or STDIN",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			createOpts.name = args[0]

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -21,7 +21,7 @@ func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
 	opts := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] CONFIG [CONFIG...]",
-		Short: "Display detailed information on one or more configuration files",
+		Short: "Display detailed information on one or more configs",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.names = args

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -19,7 +19,7 @@ func newConfigRemoveCommand(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm CONFIG [CONFIG...]",
 		Aliases: []string{"remove"},
-		Short:   "Remove one or more configuration files",
+		Short:   "Remove one or more configs",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := removeOptions{


### PR DESCRIPTION
**- What I did**

The help text for `config` commands is not consistent about whether the object being modified is called a "config" or a "configuration file". I changed it to be "config" for all commands since that's shorter.

Previously:

```
Commands:
  create      Create a configuration file from a file or STDIN as content
  inspect     Display detailed information on one or more configuration files
  ls          List configs
  rm          Remove one or more configuration files
```

**- How to verify it**

`docker config --help`

**- Description for the changelog**

Descriptions for config commands now use the same name when describing configs.