### PR TITLE
Zsh completion fixes

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -848,7 +848,7 @@ __docker_container_subcommand() {
                 "($help -)*:containers:->values" && ret=0
             case $state in
                 (values)
-                    if [[ ${words[(r)-f]} == -f || ${words[(r)--force]} == --force ]]; then
+                    if [[ -n ${opt_args[(i)-f]} || -n ${opt_args[(i)--force]} ]]; then
                         __docker_complete_containers && ret=0
                     else
                         __docker_complete_stopped_containers && ret=0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I fixed two issues in the Zsh completion script:
1. Complete running containers correctly after `docker rm -vf`.
2. Fixed `docker container update` completion which was broken.

**- How I did it**
1. Checking for `-f` in `$opt_args` instead of in `$words`.
2. Adding a missing `$`.

**- How to verify it**
1. Enable `option-stacking` & try to complete after `docker rm -vf` when you have running containers:
```zsh
zstyle ':completion:*:*:docker:*' option-stacking yes
zstyle ':completion:*:*:docker-*:*' option-stacking yes
```
2. Try to complete after `docker container update`. It used to spew an error from `_arguments`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Complete running containers correctly after docker rm -vf in Zsh

* Fix docker container update completion in Zsh

P.S. Why is `option-stacking` (The `-s` argument to `_arguments`) even an option/zstyle, and not enabled by default? Whether option stacking is possible, or not, is a property of the docker command, which always accepts them. I think it really should be on by default, and I'm not sure having an option is even necessary.
  