### PR TITLE
Fix docs YAML generation setting "kubernetes" for "swarm"

### DIFF
--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -123,7 +123,7 @@ func GenYamlCustom(cmd *cobra.Command, w io.Writer) error {
 			cliDoc.Kubernetes = true
 		}
 		if _, ok := curr.Annotations["swarm"]; ok && !cliDoc.Swarm {
-			cliDoc.Kubernetes = true
+			cliDoc.Swarm = true
 		}
 	}
 
@@ -208,7 +208,7 @@ func genFlagResult(flags *pflag.FlagSet) []cmdOption {
 			opt.Kubernetes = true
 		}
 		if _, ok := flag.Annotations["swarm"]; ok {
-			opt.Kubernetes = true
+			opt.Swarm = true
 		}
 
 		result = append(result, opt)


### PR DESCRIPTION
Due to a copy/paste error, commands annotated with "swarm" were incorrectly setting the "kubernetes" property.

This was introduced in https://github.com/docker/cli/pull/721/commits/f1b116179f2a95d0ea45780dfb8be51c2825b9c0 (https://github.com/docker/cli/pull/721)

**- Description for the changelog**

```Markdown
* Fix wrong orchestrator attribute being set in docs YAML [docker/cli#802](https://github.com/docker/cli/pull/802)
```


ping @silvin-lubecki @mistyhacks @dnephin PTAL