### PR TITLE
Remove aliases for orchestrator

### DIFF
--- a/cli/command/orchestrator.go
+++ b/cli/command/orchestrator.go
@@ -21,9 +21,9 @@ const (
 
 func normalize(flag string) Orchestrator {
 	switch flag {
-	case "kubernetes", "k8s":
+	case "kubernetes":
 		return OrchestratorKubernetes
-	case "swarm", "swarmkit":
+	case "swarm":
 		return OrchestratorSwarm
 	default:
 		return orchestratorUnset


### PR DESCRIPTION
Prefer "strict" values for orchestrator, as it's easier to add aliases (if we think it's needed) than to remove them later.

I commented on this in my review on https://github.com/docker/cli/pull/721#discussion_r158812964, but looks like we forgot to actually make that change.


ping @vdemeester @silvin-lubecki PTAL

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
