### PR TITLE
Add info for events backlog and scope

### DIFF
--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -31,7 +31,12 @@ Options:
 ## Description
 
 Use `docker events` to get real-time events from the server. These events differ
-per Docker object type.
+per Docker object type. Different event types have different scopes. The local 
+scoped events are only seen on the node they take place on, and swarm scoped 
+events are seen on all managers.
+
+Note that there is a limited backlog of events you can filter. `docker events` is 
+a rolling log, and has at most 1000 events at a time.
 
 ### Object types
 
@@ -158,6 +163,9 @@ timestamps enter seconds[.nanoseconds], where seconds is the number of seconds
 that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
 seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
 fraction of a second no more than nine digits long.
+
+Note that there is a limited backlog of events you can filter. `docker events` is 
+a rolling log, and has at most 1000 events at a time.
 
 #### Filtering
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -31,12 +31,12 @@ Options:
 ## Description
 
 Use `docker events` to get real-time events from the server. These events differ
-per Docker object type. Different event types have different scopes. The local 
+per Docker object type. Different event types have different scopes. Local 
 scoped events are only seen on the node they take place on, and swarm scoped 
 events are seen on all managers.
 
-Note that there is a limited backlog of events you can filter. `docker events` is 
-a rolling log, and has at most 1000 events at a time.
+Only the last 1000 log events are returned. You can use filters to further limit 
+the number of events returned.
 
 ### Object types
 
@@ -164,8 +164,8 @@ that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
 seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
 fraction of a second no more than nine digits long.
 
-Note that there is a limited backlog of events you can filter. `docker events` is 
-a rolling log, and has at most 1000 events at a time.
+Only the last 1000 log events are returned. You can use filters to further limit 
+the number of events returned.
 
 #### Filtering
 


### PR DESCRIPTION
Fixes #727 

**- What I did**

1. Add `docker events` description info on the two scope types of events.
2. Add `docker events` note in two places about backlog limit of event log.

**- How I did it**
After testing and using the events feature and discovering these undocumented things, I edited some markdown lines with my bare hands :)

**- How to verify it**
Like @joaofnfernandes mentioned in https://github.com/docker/docker.github.io/issues/5432#issuecomment-349084294 we may need @cpuguy83 and/or @thaJeztah to validate the 1000 message buffer limit.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added documentation on docker events scope and buffer limits.

**- A picture of a cute animal (not mandatory but encouraged)**

![giphy](https://user-images.githubusercontent.com/792287/34920704-9efdb2f2-f944-11e7-8812-d573973b2021.gif)

Signed-off-by: Bret Fisher <bret@bretfisher.com>