### PR TITLE
Remove: add missing eol when --force is passed

### DIFF
--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -81,7 +81,7 @@ func runRemove(dockerCli command.Cli, opts removeOptions, images []string) error
 		if !opts.force || fatalErr {
 			return errors.New(msg)
 		}
-		fmt.Fprintf(dockerCli.Err(), msg)
+		fmt.Fprintln(dockerCli.Err(), msg)
 	}
 	return nil
 }

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -98,7 +98,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 				assert.Equal(t, true, options.Force)
 				return []types.ImageDeleteResponseItem{}, notFound{"image1"}
 			},
-			expectedStderr: "Error: No such image: image1",
+			expectedStderr: "Error: No such image: image1\n",
 		},
 
 		{


### PR DESCRIPTION
**- What I did**
I added a \n.

**- How I did it**
By s/f/ln/

**- How to verify it**
By `docker rmi -f alksdjklasjd`, unless you do have an image called this way.

**- A picture of a cute animal (not mandatory but encouraged)**
![porg](https://user-images.githubusercontent.com/232441/34979043-78ce6a74-faa0-11e7-983f-2c7cd53c6454.png)
