### PR TITLE
Add dockerfile for building on non-amd64 platforms

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -5,6 +5,7 @@
 #
 
 DEV_DOCKER_IMAGE_NAME = docker-cli-dev$(IMAGE_TAG)
+BINARY_NATIVE_IMAGE_NAME = docker-cli-native$(IMAGE_TAG)
 LINTER_IMAGE_NAME = docker-cli-lint$(IMAGE_TAG)
 CROSS_IMAGE_NAME = docker-cli-cross$(IMAGE_TAG)
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate$(IMAGE_TAG)
@@ -30,11 +31,17 @@ build_cross_image:
 build_shell_validate_image:
 	docker build -t $(VALIDATE_IMAGE_NAME) -f ./dockerfiles/Dockerfile.shellcheck .
 
+.PHONY: build_binary_native_image
+build_binary_native_image:
+	docker build -t $(BINARY_NATIVE_IMAGE_NAME) -f ./dockerfiles/Dockerfile.binary-native .
+
+
 # build executable using a container
-binary: build_docker_image
-	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make binary
+binary: build_binary_native_image
+	docker run --rm $(ENVVARS) $(MOUNTS) $(BINARY_NATIVE_IMAGE_NAME)
 
 build: binary
+
 
 # clean build artifacts using a container
 .PHONY: clean

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,0 +1,8 @@
+FROM    golang:1.9.2-alpine3.6
+
+RUN     apk add -U git bash coreutils gcc musl-dev
+
+ENV     CGO_ENABLED=0 \
+        DISABLE_WARN_OUTSIDE_CONTAINER=1
+WORKDIR /go/src/github.com/docker/cli
+CMD     ./scripts/build/binary


### PR DESCRIPTION
Closes #767

Add a new `Dockerfile`, and `docker.Makefile` target for building on other platforms that require additional dependencies.

```
make -f docker.Makefile binary
```

cc @seemethere @arm64b