### PR TITLE
Container: let rm -f exit with success

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -67,7 +67,11 @@ func runRm(dockerCli command.Cli, opts *rmOptions) error {
 		fmt.Fprintln(dockerCli.Out(), name)
 	}
 	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
+		msg := strings.Join(errs, "\n")
+		if !opts.force {
+			return errors.New(msg)
+		}
+		fmt.Fprintln(dockerCli.Err(), msg)
 	}
 	return nil
 }


### PR DESCRIPTION
`rm -f non-existing` exits with success, and so does `docker rmi -f non-existing`.  But not `docker rm -f`.

Arguably we should actually check whether these errors are really doesNotExist (rm -f exits with failure for lack of permissions for instance), but at least we should be consistent.

FWIW, in the code, we have Rm in cli/command/container/rm.go and Remove in cli/command/image/remove.go.  The latter has a test suite, not the former.

**- A picture of a cute animal (not mandatory but encouraged)**

![lamasticot](https://user-images.githubusercontent.com/232441/35158167-918e3894-fd36-11e7-8c37-de76a37d0ddb.png)