### PR TITLE
added check for empty source in bind mount

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -337,7 +337,9 @@ func LoadService(name string, serviceDict map[string]interface{}, workingDir str
 		return nil, err
 	}
 
-	resolveVolumePaths(serviceConfig.Volumes, workingDir, lookupEnv)
+	if err := resolveVolumePaths(serviceConfig.Volumes, workingDir, lookupEnv); err != nil {
+		return nil, err
+	}
 	return serviceConfig, nil
 }
 
@@ -376,10 +378,14 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 	return nil
 }
 
-func resolveVolumePaths(volumes []types.ServiceVolumeConfig, workingDir string, lookupEnv template.Mapping) {
+func resolveVolumePaths(volumes []types.ServiceVolumeConfig, workingDir string, lookupEnv template.Mapping) error {
 	for i, volume := range volumes {
 		if volume.Type != "bind" {
 			continue
+		}
+
+		if volume.Source == "" {
+			return errors.New(`invalid mount config for type "bind": field Source must not be empty`)
 		}
 
 		filePath := expandUser(volume.Source, lookupEnv)
@@ -394,6 +400,7 @@ func resolveVolumePaths(volumes []types.ServiceVolumeConfig, workingDir string, 
 		volume.Source = filePath
 		volumes[i] = volume
 	}
+	return nil
 }
 
 // TODO: make this more robust


### PR DESCRIPTION
Provides a fix for #820 

**- What I did**
Fixed the bug that allowed a user to use a bind mount without a source in the compose file. Without providing a source the loader would add the path of the compose file.
**- How I did it**
Added error handing and explicit check for empty source in compose file. The loader now throws an error if it detects a bind mount without a source.
**- How to verify it**

1: make a docker-compose.yml file
```YAML
version: "3.4"
services:
  nginx:
    image: nginx:alpine
    volumes:
      - type: bind
        target: /app
```
2: run stack deploy commands
```
$: docker stack deploy -c docker-compose.yml nginx
```
The output should be the following error:
`invalid mount config for type "bind": field Source must not be empty`
