### PR TITLE
Fix lint on master

### DIFF
--- a/e2e/container/attach_test.go
+++ b/e2e/container/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/cli/e2e/internal/fixtures"
 	"github.com/gotestyourself/gotestyourself/icmd"
 )
 
@@ -19,7 +20,7 @@ func TestAttachExitCode(t *testing.T) {
 
 func runBackgroundContainsWithExitCode(t *testing.T, exitcode int) string {
 	result := icmd.RunCmd(shell(t,
-		"docker run -d -i --rm %s sh -c 'read; exit %d'", alpineImage, exitcode))
+		"docker run -d -i --rm %s sh -c 'read; exit %d'", fixtures.AlpineImage, exitcode))
 	result.Assert(t, icmd.Success)
 	return strings.TrimSpace(result.Stdout())
 }


### PR DESCRIPTION
An older PR had changes which didn't work with master. This var was moved to `fixtures`