### PR TITLE
Bump Go to 1.9.3

### DIFF
--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross@sha256:2e843a0e4d82b6bab34d2cb7abe26d1a6cda23226ecc3869100c8db553603f9b
+FROM    dockercore/golang-cross:1.9.3@sha256:2ac6046dd738cf83a7557a9fc2be52accb97c103c5e9d2c2a50daa797c8eb79f
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.9.2-alpine3.6
+FROM    golang:1.9.3-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9.2-alpine3.6
+FROM    golang:1.9.3-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION
still needs https://github.com/docker/golang-cross/pull/3 to be merged, and a new version built on Docker Hub so that we can update the Dockerfile.cross

release notes: https://golang.org/doc/devel/release.html#go1.9.minor

full diff: https://github.com/golang/go/compare/go1.9.2...go1.9.3



ping @vdemeester @dnephin 