### PR TITLE
Fix broken Kubernetes stack flags

### DIFF
--- a/cli/command/stack/kubernetes/cli.go
+++ b/cli/command/stack/kubernetes/cli.go
@@ -27,15 +27,15 @@ func WrapCli(dockerCli command.Cli, cmd *cobra.Command) (*KubeCli, error) {
 		Cli:           dockerCli,
 		kubeNamespace: "default",
 	}
-	if cmd.PersistentFlags().Changed("namespace") {
-		cli.kubeNamespace, err = cmd.PersistentFlags().GetString("namespace")
+	if cmd.Flags().Changed("namespace") {
+		cli.kubeNamespace, err = cmd.Flags().GetString("namespace")
 		if err != nil {
 			return nil, err
 		}
 	}
 	kubeConfig := ""
-	if cmd.PersistentFlags().Changed("kubeconfig") {
-		kubeConfig, err = cmd.PersistentFlags().GetString("kubeconfig")
+	if cmd.Flags().Changed("kubeconfig") {
+		kubeConfig, err = cmd.Flags().GetString("kubeconfig")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**- What I did**
I fixed the broken kubernetes stack flags `namespace` and `kubeconfig`.

**- How I did it**
I switched PersistentFlags to Flags while reading flags during the command `run` phase.

**- How to verify it**

1. Deploy a kubernetes stack using default namespace
2. `docker stack ls --namespace myemptynamespace` should print nothing

**- Description for the changelog**
Fix broken Kubernetes stack flags

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/35346851-42a43b7e-00e8-11e8-8440-9ec5765d5916.png)

