### PR TITLE
GetAll -> Get to retrieve credentials from credential helpers

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -19,7 +19,7 @@ const (
 	// This constant is only used for really old config files when the
 	// URL wasn't saved as part of the config file and it was just
 	// assumed to be this value.
-	defaultIndexserver = "https://index.docker.io/v1/"
+	defaultIndexServer = "https://index.docker.io/v1/"
 )
 
 // ConfigFile ~/.docker/config.json file info
@@ -87,8 +87,8 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 		if err != nil {
 			return err
 		}
-		authConfig.ServerAddress = defaultIndexserver
-		configFile.AuthConfigs[defaultIndexserver] = authConfig
+		authConfig.ServerAddress = defaultIndexServer
+		configFile.AuthConfigs[defaultIndexServer] = authConfig
 	} else {
 		for k, authConfig := range configFile.AuthConfigs {
 			authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,7 +143,37 @@ func TestConfigFile(t *testing.T) {
 	assert.Equal(t, configFilename, configFile.Filename)
 }
 
-func TestGetAllCredentials(t *testing.T) {
+type mockNativeStore struct {
+	GetAllCallCount int
+	authConfigs     map[string]types.AuthConfig
+}
+
+func (c *mockNativeStore) Erase(registryHostname string) error {
+	delete(c.authConfigs, registryHostname)
+	return nil
+}
+
+func (c *mockNativeStore) Get(registryHostname string) (types.AuthConfig, error) {
+	return c.authConfigs[registryHostname], nil
+}
+
+func (c *mockNativeStore) GetAll() (map[string]types.AuthConfig, error) {
+	c.GetAllCallCount = c.GetAllCallCount + 1
+	return c.authConfigs, nil
+}
+
+func (c *mockNativeStore) Store(authConfig types.AuthConfig) error {
+	return nil
+}
+
+// make sure it satisfies the interface
+var _ credentials.Store = (*mockNativeStore)(nil)
+
+func NewMockNativeStore(authConfigs map[string]types.AuthConfig) credentials.Store {
+	return &mockNativeStore{authConfigs: authConfigs}
+}
+
+func TestGetAllCredentialsFileStoreOnly(t *testing.T) {
 	configFile := New("filename")
 	exampleAuth := types.AuthConfig{
 		Username: "user",
@@ -156,4 +187,187 @@ func TestGetAllCredentials(t *testing.T) {
 	expected := make(map[string]types.AuthConfig)
 	expected["example.com/foo"] = exampleAuth
 	assert.Equal(t, expected, authConfigs)
+}
+
+func TestGetAllCredentialsCredsStore(t *testing.T) {
+	configFile := New("filename")
+	configFile.CredentialsStore = "test_creds_store"
+	testRegistryHostname := "example.com"
+	expectedAuth := types.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	}
+
+	testCredsStore := NewMockNativeStore(map[string]types.AuthConfig{testRegistryHostname: expectedAuth})
+
+	tmpNewNativeStore := newNativeStore
+	defer func() { newNativeStore = tmpNewNativeStore }()
+	newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+		return testCredsStore
+	}
+
+	authConfigs, err := configFile.GetAllCredentials()
+	require.NoError(t, err)
+
+	expected := make(map[string]types.AuthConfig)
+	expected[testRegistryHostname] = expectedAuth
+	assert.Equal(t, expected, authConfigs)
+	assert.Equal(t, 1, testCredsStore.(*mockNativeStore).GetAllCallCount)
+}
+
+func TestGetAllCredentialsCredHelper(t *testing.T) {
+	testCredHelperSuffix := "test_cred_helper"
+	testCredHelperRegistryHostname := "credhelper.com"
+	testExtraCredHelperRegistryHostname := "somethingweird.com"
+
+	unexpectedCredHelperAuth := types.AuthConfig{
+		Username: "file_store_user",
+		Password: "file_store_pass",
+	}
+	expectedCredHelperAuth := types.AuthConfig{
+		Username: "cred_helper_user",
+		Password: "cred_helper_pass",
+	}
+
+	configFile := New("filename")
+	configFile.CredentialHelpers = map[string]string{testCredHelperRegistryHostname: testCredHelperSuffix}
+
+	testCredHelper := NewMockNativeStore(map[string]types.AuthConfig{
+		testCredHelperRegistryHostname: expectedCredHelperAuth,
+		// Add in an extra auth entry which doesn't appear in CredentialHelpers section of the configFile.
+		// This verifies that only explicitly configured registries are being requested from the cred helpers.
+		testExtraCredHelperRegistryHostname: unexpectedCredHelperAuth,
+	})
+
+	tmpNewNativeStore := newNativeStore
+	defer func() { newNativeStore = tmpNewNativeStore }()
+	newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+		return testCredHelper
+	}
+
+	authConfigs, err := configFile.GetAllCredentials()
+	require.NoError(t, err)
+
+	expected := make(map[string]types.AuthConfig)
+	expected[testCredHelperRegistryHostname] = expectedCredHelperAuth
+	assert.Equal(t, expected, authConfigs)
+	assert.Equal(t, 0, testCredHelper.(*mockNativeStore).GetAllCallCount)
+}
+
+func TestGetAllCredentialsFileStoreAndCredHelper(t *testing.T) {
+	testFileStoreRegistryHostname := "example.com"
+	testCredHelperSuffix := "test_cred_helper"
+	testCredHelperRegistryHostname := "credhelper.com"
+
+	expectedFileStoreAuth := types.AuthConfig{
+		Username: "file_store_user",
+		Password: "file_store_pass",
+	}
+	expectedCredHelperAuth := types.AuthConfig{
+		Username: "cred_helper_user",
+		Password: "cred_helper_pass",
+	}
+
+	configFile := New("filename")
+	configFile.CredentialHelpers = map[string]string{testCredHelperRegistryHostname: testCredHelperSuffix}
+	configFile.AuthConfigs[testFileStoreRegistryHostname] = expectedFileStoreAuth
+
+	testCredHelper := NewMockNativeStore(map[string]types.AuthConfig{testCredHelperRegistryHostname: expectedCredHelperAuth})
+
+	newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+		return testCredHelper
+	}
+
+	tmpNewNativeStore := newNativeStore
+	defer func() { newNativeStore = tmpNewNativeStore }()
+	authConfigs, err := configFile.GetAllCredentials()
+	require.NoError(t, err)
+
+	expected := make(map[string]types.AuthConfig)
+	expected[testFileStoreRegistryHostname] = expectedFileStoreAuth
+	expected[testCredHelperRegistryHostname] = expectedCredHelperAuth
+	assert.Equal(t, expected, authConfigs)
+	assert.Equal(t, 0, testCredHelper.(*mockNativeStore).GetAllCallCount)
+}
+
+func TestGetAllCredentialsCredStoreAndCredHelper(t *testing.T) {
+	testCredStoreSuffix := "test_creds_store"
+	testCredStoreRegistryHostname := "credstore.com"
+	testCredHelperSuffix := "test_cred_helper"
+	testCredHelperRegistryHostname := "credhelper.com"
+
+	configFile := New("filename")
+	configFile.CredentialsStore = testCredStoreSuffix
+	configFile.CredentialHelpers = map[string]string{testCredHelperRegistryHostname: testCredHelperSuffix}
+
+	expectedCredStoreAuth := types.AuthConfig{
+		Username: "cred_store_user",
+		Password: "cred_store_pass",
+	}
+	expectedCredHelperAuth := types.AuthConfig{
+		Username: "cred_helper_user",
+		Password: "cred_helper_pass",
+	}
+
+	testCredHelper := NewMockNativeStore(map[string]types.AuthConfig{testCredHelperRegistryHostname: expectedCredHelperAuth})
+	testCredsStore := NewMockNativeStore(map[string]types.AuthConfig{testCredStoreRegistryHostname: expectedCredStoreAuth})
+
+	tmpNewNativeStore := newNativeStore
+	defer func() { newNativeStore = tmpNewNativeStore }()
+	newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+		if helperSuffix == testCredHelperSuffix {
+			return testCredHelper
+		}
+		return testCredsStore
+	}
+
+	authConfigs, err := configFile.GetAllCredentials()
+	require.NoError(t, err)
+
+	expected := make(map[string]types.AuthConfig)
+	expected[testCredStoreRegistryHostname] = expectedCredStoreAuth
+	expected[testCredHelperRegistryHostname] = expectedCredHelperAuth
+	assert.Equal(t, expected, authConfigs)
+	assert.Equal(t, 1, testCredsStore.(*mockNativeStore).GetAllCallCount)
+	assert.Equal(t, 0, testCredHelper.(*mockNativeStore).GetAllCallCount)
+}
+
+func TestGetAllCredentialsCredHelperOverridesDefaultStore(t *testing.T) {
+	testCredStoreSuffix := "test_creds_store"
+	testCredHelperSuffix := "test_cred_helper"
+	testRegistryHostname := "example.com"
+
+	configFile := New("filename")
+	configFile.CredentialsStore = testCredStoreSuffix
+	configFile.CredentialHelpers = map[string]string{testRegistryHostname: testCredHelperSuffix}
+
+	unexpectedCredStoreAuth := types.AuthConfig{
+		Username: "cred_store_user",
+		Password: "cred_store_pass",
+	}
+	expectedCredHelperAuth := types.AuthConfig{
+		Username: "cred_helper_user",
+		Password: "cred_helper_pass",
+	}
+
+	testCredHelper := NewMockNativeStore(map[string]types.AuthConfig{testRegistryHostname: expectedCredHelperAuth})
+	testCredsStore := NewMockNativeStore(map[string]types.AuthConfig{testRegistryHostname: unexpectedCredStoreAuth})
+
+	tmpNewNativeStore := newNativeStore
+	defer func() { newNativeStore = tmpNewNativeStore }()
+	newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentials.Store {
+		if helperSuffix == testCredHelperSuffix {
+			return testCredHelper
+		}
+		return testCredsStore
+	}
+
+	authConfigs, err := configFile.GetAllCredentials()
+	require.NoError(t, err)
+
+	expected := make(map[string]types.AuthConfig)
+	expected[testRegistryHostname] = expectedCredHelperAuth
+	assert.Equal(t, expected, authConfigs)
+	assert.Equal(t, 1, testCredsStore.(*mockNativeStore).GetAllCallCount)
+	assert.Equal(t, 0, testCredHelper.(*mockNativeStore).GetAllCallCount)
 }


### PR DESCRIPTION
**- What I did**
Improved `docker build` times.

**- How I did it**
Only request credentials for the configured registry from the corresponding credential helper, rather than doing a GetAll for each one.

**- How to verify it**
Build some toy image with several credential helpers configured...

```
jsand@jsand:~/go/src/github.com/docker/cli$ time docker build ~/gcloud-cred-helper-test
Sending build context to Docker daemon   5.12kB
Step 1/7 : FROM node:8
 ---> b87c2ad8344d
Step 2/7 : WORKDIR /usr/src/app
 ---> Using cache
 ---> b27c87b196eb
Step 3/7 : COPY package*.json ./
COPY failed: no source files were specified

real	1m28.929s
user	0m54.868s
sys	0m10.988s
jsand@jsand:~/go/src/github.com/docker/cli$ time ./build/docker build ~/gcloud-cred-helper-test
Sending build context to Docker daemon   5.12kB
Step 1/7 : FROM node:8
 ---> b87c2ad8344d
Step 2/7 : WORKDIR /usr/src/app
 ---> Using cache
 ---> b27c87b196eb
Step 3/7 : COPY package*.json ./
COPY failed: no source files were specified

real	0m7.137s
user	0m4.408s
sys	0m0.884s
```

**- Description for the changelog**
`docker build` now runs faster when registry-specific credential helper(s) are configured.

![10/10 good doggo](https://i.redd.it/r17hl9m3kgc01.jpg)
