### PR TITLE
Document long form of --network and --network-add

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -716,7 +716,7 @@ etjpu59cykrptrgw0z0hk5snf
 After you create an overlay network in swarm mode, all manager nodes have
 access to the network.
 
-When you create a service and pass the --network flag to attach the service to
+When you create a service and pass the `--network` flag to attach the service to
 the overlay network:
 
 ```bash
@@ -733,6 +733,9 @@ The swarm extends my-network to each node running the service.
 
 Containers on the same network can access each other using
 [service discovery](https://docs.docker.com/engine/swarm/networking/#use-swarm-mode-service-discovery).
+
+Long form syntax of `--network` allows to specify list of aliases and driver options:  
+`--network name=my-network,alias=web1,driver-opt=field1=value1`
 
 ### Publish service ports externally to the swarm (-p, --publish)
 

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -181,7 +181,7 @@ myservice
 
 Use the `--publish-add` or `--publish-rm` flags to add or remove a published
 port for a service. You can use the short or long syntax discussed in the
-[docker service create](service_create/#attach-a-service-to-an-existing-network-network)
+[docker service create](service_create/#publish-service-ports-externally-to-the-swarm)
 reference.
 
 The following example adds a published service port to an existing service.
@@ -189,6 +189,22 @@ The following example adds a published service port to an existing service.
 ```bash
 $ docker service update \
   --publish-add published=8080,target=80 \
+  myservice
+```
+
+### Add or remove network
+
+Use the `--network-add` or `--network-rm` flags to add or remove a network for
+a service. You can use the short or long syntax discussed in the
+[docker service create](service_create/#attach-a-service-to-an-existing-network-network)
+reference.
+
+The following example adds a new alias name to an existing service already connected to network my-network:
+
+```bash
+$ docker service update \
+  --network-rm my-network \
+  --network-add name=my-network,alias=web1 \
   myservice
 ```
 


### PR DESCRIPTION
Signed-off-by: Alexander Ryabov <i@sepa.spb.ru>

**- What I did**
Added missing documentation for long form of --network/--network-add
**- How I did it**
Read PR: moby/moby/pull/33130
**- How to verify it**

**- Description for the changelog**
Document long form of --network and --network-add

**- A picture of a cute animal (not mandatory but encouraged)**

