### PR TITLE
k8s: watch stack status in addition to pods scheduling

### DIFF
--- a/cli/command/stack/kubernetes/deploy.go
+++ b/cli/command/stack/kubernetes/deploy.go
@@ -31,10 +31,6 @@ func RunDeploy(dockerCli *KubeCli, opts options.Deploy) error {
 	configMaps := composeClient.ConfigMaps()
 	secrets := composeClient.Secrets()
 	services := composeClient.Services()
-	pods := composeClient.Pods()
-	watcher := DeployWatcher{
-		Pods: pods,
-	}
 
 	// Parse the compose file
 	stack, cfg, err := LoadStack(opts.Namespace, opts.Composefiles)
@@ -73,10 +69,17 @@ func RunDeploy(dockerCli *KubeCli, opts options.Deploy) error {
 
 	fmt.Fprintln(cmdOut, "Waiting for the stack to be stable and running...")
 
-	<-watcher.Watch(stack, serviceNames(cfg))
+	pods := composeClient.Pods()
+	watcher := &deployWatcher{
+		out:    dockerCli.Out(),
+		stacks: stacks,
+		pods:   pods,
+	}
+	if err := watcher.Watch(stack, serviceNames(cfg)); err != nil {
+		return err
+	}
 
 	fmt.Fprintf(cmdOut, "Stack %s is stable and running\n\n", stack.Name)
-	// TODO: fmt.Fprintf(cmdOut, "Read the logs with:\n  $ %s stack logs %s\n", filepath.Base(os.Args[0]), stack.Name)
 
 	return nil
 }


### PR DESCRIPTION
If the controller updates the stack status to failure, we can stop
watching pods scheduling as it won't happen any time.

I'm not a huge fan of the `watcher` file but hopefully it will be easier to handle that with the next version 👼 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
