### PR TITLE
bump docker/go-connections to 98e7d807e5d804e4e42a98d74d1dd695321224ef

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@ github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
-github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
+github.com/docker/go-connections 98e7d807e5d804e4e42a98d74d1dd695321224ef
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/swarmkit 713d79dc8799b33465c58ed120b870c52eb5eb4f

--- a/vendor/github.com/docker/go-connections/tlsconfig/config.go
+++ b/vendor/github.com/docker/go-connections/tlsconfig/config.go
@@ -65,22 +65,34 @@ var allTLSVersions = map[uint16]struct{}{
 }
 
 // ServerDefault returns a secure-enough TLS configuration for the server TLS configuration.
-func ServerDefault() *tls.Config {
-	return &tls.Config{
-		// Avoid fallback to SSL protocols < TLS1.0
+func ServerDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
+		// Avoid fallback by default to SSL protocols < TLS1.0
 		MinVersion:               tls.VersionTLS10,
 		PreferServerCipherSuites: true,
 		CipherSuites:             DefaultServerAcceptedCiphers,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // ClientDefault returns a secure-enough TLS configuration for the client TLS configuration.
-func ClientDefault() *tls.Config {
-	return &tls.Config{
+func ClientDefault(ops ...func(*tls.Config)) *tls.Config {
+	tlsconfig := &tls.Config{
 		// Prefer TLS1.2 as the client minimum
 		MinVersion:   tls.VersionTLS12,
 		CipherSuites: clientCipherSuites,
 	}
+
+	for _, op := range ops {
+		op(tlsconfig)
+	}
+
+	return tlsconfig
 }
 
 // certPool returns an X.509 certificate pool from `caFile`, the certificate file.


### PR DESCRIPTION
full diff: https://github.com/docker/go-connections/compare/3ede32e2033de7505e6500d6c868c2b9ed9f169d...98e7d807e5d804e4e42a98d74d1dd695321224ef
