### PR TITLE
Fix vendor validation (and vendor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ watch: ## monitor file changes and run go test
 	./scripts/test/watch
 
 vendor: vendor.conf ## check that vendor matches vendor.conf
-	vndr 2> /dev/null
+	rm -rf vendor
+	bash -c 'vndr |& grep -v -i clone'
 	scripts/validate/check-git-diff vendor
 
 .PHONY: authors

--- a/vendor.conf
+++ b/vendor.conf
@@ -68,6 +68,7 @@ github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45
 github.com/xeipuuv/gojsonschema 93e72a773fade158921402d6a24c819b48aba29d
 golang.org/x/crypto 558b6879de74bc843225cde5686419267ff707ca
 golang.org/x/net a8b9294777976932365dabb6640cf1468d95c70f
+golang.org/x/sync f52d1811a62927559de87708c
 golang.org/x/sys 95c6576299259db960f6c5b9b69ea52422860fce
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb


### PR DESCRIPTION
vendor/ must be removed first, otherwise files added to vendor/ but not vendor.conf
will not cause the validation to fail

It turns out we were missing a version for `x/sync` as well.