### PR TITLE
Clarify description of volume prune command

### DIFF
--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -22,7 +22,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
-		Short: "Remove all unused volumes",
+		Short: "Remove all unused local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spaceReclaimed, output, err := runPrune(dockerCli, options)
@@ -45,7 +45,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-const warning = `WARNING! This will remove all volumes not used by at least one container.
+const warning = `WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue?`
 
 func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint64, output string, err error) {

--- a/cli/command/volume/testdata/volume-prune-no.golden
+++ b/cli/command/volume/testdata/volume-prune-no.golden
@@ -1,2 +1,2 @@
-WARNING! This will remove all volumes not used by at least one container.
+WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] Total reclaimed space: 0B

--- a/cli/command/volume/testdata/volume-prune-yes.golden
+++ b/cli/command/volume/testdata/volume-prune-yes.golden
@@ -1,4 +1,4 @@
-WARNING! This will remove all volumes not used by at least one container.
+WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] Deleted Volumes:
 foo
 bar

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -110,7 +110,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [volume create](volume_create.md) | Creates a new volume where containers can consume and store data |
 | [volume inspect](volume_inspect.md) | Display information about a volume     |
 | [volume ls](volume_ls.md) | Lists all the volumes Docker knows about         |
-| [volume prune](volume_prune.md) | Remove all unused volumes                  |
+| [volume prune](volume_prune.md) | Remove all unused local volumes            |
 | [volume rm](volume_rm.md) | Remove one or more volumes                       |
 
 ### Swarm node commands

--- a/docs/reference/commandline/volume.md
+++ b/docs/reference/commandline/volume.md
@@ -27,7 +27,7 @@ Commands:
   create      Create a volume
   inspect     Display detailed information on one or more volumes
   ls          List volumes
-  prune       Remove all unused volumes
+  prune       Remove all unused local volumes
   rm          Remove one or more volumes
 
 Run 'docker volume COMMAND --help' for more information on a command.

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -1,6 +1,6 @@
 ---
 title: "volume prune"
-description: "Remove unused volumes"
+description: "Remove unused local volumes"
 keywords: "volume, prune, delete"
 ---
 
@@ -18,7 +18,7 @@ keywords: "volume, prune, delete"
 ```markdown
 Usage:	docker volume prune [OPTIONS]
 
-Remove all unused volumes
+Remove all unused local volumes
 
 Options:
       --filter filter   Provide filter values (e.g. 'label=<label>')
@@ -28,14 +28,14 @@ Options:
 
 ## Description
 
-Remove all unused volumes. Unused volumes are those which are not referenced by any containers
+Remove all unused local volumes. Unused local volumes are those which are not referenced by any containers
 
 ## Examples
 
 ```bash
 $ docker volume prune
 
-WARNING! This will remove all volumes not used by at least one container.
+WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] y
 Deleted Volumes:
 07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Clarify description of volume prune command

**- How I did it**
I have specified that only local volumes are removed by the volume prune command.

**- How to verify it**

https://github.com/moby/moby/blob/master/daemon/prune.go#L104
As shown in the above link, docker volume prune command removes only local volumes. 
It does not remove volumes created by other volume plugins.

Signed-off-by: Sungwon Han <sungwon.han@navercorp.com>