### PR TITLE
Update reference docs for docker stack deploy

### DIFF
--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -25,7 +25,7 @@ Aliases:
 
 Options:
       --bundle-file string    Path to a Distributed Application Bundle file
-  -c, --compose-file string   Path to a Compose file
+  -c, --compose-file strings  Path to a Compose file
       --help                  Print usage
       --prune                 Prune services that are no longer referenced
       --resolve-image string  Query the registry to resolve image digest and supported platforms
@@ -76,14 +76,12 @@ Creating service vossibility_ghollector
 Creating service vossibility_lookupd
 ```
 
-Only a single Compose file is accepted. If your configuration is split between
-multiple Compose files, e.g. a base configuration and environment-specific overrides,
-you can combine these by passing them to `docker-compose config` with the `-f` option
-and redirecting the merged output into a new file.
+If your configuration is split between multiple Compose files, e.g. a base
+configuration and environment-specific overrides, you can provide multiple
+`--compose-file` flags.
 
 ```bash
-$ docker-compose -f docker-compose.yml -f docker-compose.prod.yml config > docker-stack.yml
-$ docker stack deploy --compose-file docker-stack.yml vossibility
+$ docker stack deploy --compose-file docker-compose.yml -f docker-compose.prod.yml vossibility
 
 Ignoring unsupported options: links
 


### PR DESCRIPTION
`docker stack deploy` now support multiple composefil. This updates the
reference doc to take that fact into account.

Follow-up of 569 👼 🦁 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>