### PR TITLE
Fix compilation of defaultCredentialStore() on unsupported platforms

### DIFF
--- a/cli/config/credentials/default_store_unsupported.go
+++ b/cli/config/credentials/default_store_unsupported.go
@@ -2,4 +2,6 @@
 
 package credentials
 
-const defaultCredentialsStore = ""
+func defaultCredentialsStore() string {
+	return ""
+}


### PR DESCRIPTION

**- What I did**
Converted string constant into the function it should be.

**- How I did it**
Edited the file.

**- How to verify it**
```shell
GOOS=openbsd GOARCH=amd64 go build cli/config/credentials
```

**- Description for the changelog**

Fix compilation of defaultCredentialStore() on unsupported platforms.

