### PR TITLE
Set a non-zero timeout for HTTP client communication with plugin backend.

### DIFF
--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -30,7 +30,7 @@ func newEnableCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.IntVar(&opts.timeout, "timeout", 0, "HTTP client timeout (in seconds)")
+	flags.IntVar(&opts.timeout, "timeout", 30, "HTTP client timeout (in seconds)")
 	return cmd
 }
 


### PR DESCRIPTION
Currently, the timeout is set to 0, which means no timeout. Set it to a
sane default timeout of 30 seconds.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>