### PR TITLE
Allow Dockerfile from outside build-context

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -167,6 +167,10 @@ func GetContextFromGitURL(gitURL, dockerfileName string) (string, string, error)
 		return "", "", err
 	}
 	relDockerfile, err := getDockerfileRelPath(absContextDir, dockerfileName)
+	if err == nil && strings.HasPrefix(relDockerfile, ".."+string(filepath.Separator)) {
+		return "", "", errors.Errorf("the Dockerfile (%s) must be within the build context", dockerfileName)
+	}
+
 	return absContextDir, relDockerfile, err
 }
 
@@ -316,10 +320,6 @@ func getDockerfileRelPath(absContextDir, givenDockerfile string) (string, error)
 	relDockerfile, err := filepath.Rel(absContextDir, absDockerfile)
 	if err != nil {
 		return "", errors.Errorf("unable to get relative Dockerfile path: %v", err)
-	}
-
-	if strings.HasPrefix(relDockerfile, ".."+string(filepath.Separator)) {
-		return "", errors.Errorf("the Dockerfile (%s) must be within the build context", givenDockerfile)
 	}
 
 	return relDockerfile, nil


### PR DESCRIPTION
Historically, the Dockerfile had to be insde the build-context, because it was sent as part of the build-context.

https://github.com/moby/moby/pull/31236/commits/3f6dc81e10b8b813fffaa9b4167a60c5a507fa38 added support for passing the Dockerfile through stdin, in which case the contents of the Dockerfile is injected into the build-context.

This patch uses the same mechanism for situations where the location of the Dockerfile is passed, and its path is outside of the build-context.

Before this change:

```bash
$ mkdir -p myproject/context myproject/dockerfiles && cd myproject
$ echo "hello" > context/hello
$ echo -e "FROM busybox\nCOPY /hello /\nRUN cat /hello" > dockerfiles/Dockerfile
$ docker build --no-cache -f $PWD/dockerfiles/Dockerfile $PWD/context

unable to prepare context: the Dockerfile (/Users/sebastiaan/projects/test/dockerfile-outside/myproject/dockerfiles/Dockerfile) must be within the build context
```

After this change:

```bash
$ mkdir -p myproject/context myproject/dockerfiles && cd myproject
$ echo "hello" > context/hello
$ echo -e "FROM busybox\nCOPY /hello /\nRUN cat /hello" > dockerfiles/Dockerfile
$ docker build --no-cache -f $PWD/dockerfiles/Dockerfile $PWD/context

Sending build context to Docker daemon  2.607kB
Step 1/3 : FROM busybox
 ---> 6ad733544a63
Step 2/3 : COPY /hello /
 ---> 9a5ae1c7be9e
Step 3/3 : RUN cat /hello
 ---> Running in 20dfef2d180f
hello
Removing intermediate container 20dfef2d180f
 ---> ce1748f91bb2
Successfully built ce1748f91bb2
```

**- What I did**

Added support for building from a Dockerfile that's outside the build-context

**- How I did it**

See above

**- How to verify it**

See above

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
+ Allow Dockerfile to be outside of build-context [docker/cli#886](https://github.com/docker/cli/pull/886)
```

**- A picture of a cute animal (not mandatory but encouraged)**

![mestkever](https://user-images.githubusercontent.com/1804568/36347055-617077a2-1402-11e8-9934-28c10bd699d4.jpg)
