### PR TITLE
Fix stack marshaling for Kubernetes

### DIFF
--- a/cli/command/stack/kubernetes/deploy.go
+++ b/cli/command/stack/kubernetes/deploy.go
@@ -26,7 +26,7 @@ func RunDeploy(dockerCli *KubeCli, opts options.Deploy) error {
 	if err != nil {
 		return err
 	}
-	stack, err := LoadStack(opts.Namespace, version, cfg)
+	stack, err := LoadStack(opts.Namespace, version, *cfg)
 	if err != nil {
 		return err
 	}

--- a/cli/command/stack/kubernetes/loader.go
+++ b/cli/command/stack/kubernetes/loader.go
@@ -8,15 +8,16 @@ import (
 )
 
 type versionedConfig struct {
-	composetypes.Config
-	Version string
+	*composetypes.Config `yaml:",inline"`
+	Version              string
 }
 
 // LoadStack loads a stack from a Compose config, with a given name.
-func LoadStack(name, version string, cfg *composetypes.Config) (*apiv1beta1.Stack, error) {
+func LoadStack(name, version string, cfg composetypes.Config) (*apiv1beta1.Stack, error) {
+	cfg.Filename = ""
 	res, err := yaml.Marshal(versionedConfig{
 		Version: version,
-		Config:  *cfg,
+		Config:  &cfg,
 	})
 	if err != nil {
 		return nil, err

--- a/cli/command/stack/kubernetes/loader_test.go
+++ b/cli/command/stack/kubernetes/loader_test.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"testing"
+
+	composetypes "github.com/docker/cli/cli/compose/types"
+	apiv1beta1 "github.com/docker/cli/kubernetes/compose/v1beta1"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestLoadStack(t *testing.T) {
+	s, err := LoadStack("foo", "3.1", composetypes.Config{
+		Filename: "banana",
+		Services: []composetypes.ServiceConfig{
+			{
+				Name:  "foo",
+				Image: "foo",
+			},
+			{
+				Name:  "bar",
+				Image: "bar",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, &apiv1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: apiv1beta1.StackSpec{
+			ComposeFile: string(`configs: {}
+networks: {}
+secrets: {}
+services:
+  bar:
+    image: bar
+  foo:
+    image: foo
+volumes: {}
+`),
+		},
+	}, s)
+}


### PR DESCRIPTION
**- What I did**
Fix stack marshaling for Kubernetes.

**- How I did it**
Add missing `inline` flag to the compose config struct.

**- How to verify it**
Try to deploy a stack against Kubernetes on Docker For Mac, it was broken.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/36433046-e9854a7c-165b-11e8-9603-fb35a265a769.png)
