### PR TITLE
add support for mandatory variables to stack deploy

### DIFF
--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -37,75 +37,72 @@ func Substitute(template string, mapping Mapping) (string, error) {
 	var err error
 	result := pattern.ReplaceAllStringFunc(template, func(substring string) string {
 		matches := pattern.FindStringSubmatch(substring)
-		groups := make(map[string]string)
-		for i, name := range pattern.SubexpNames() {
-			if i != 0 {
-				groups[name] = matches[i]
-			}
+		groups := matchGroups(matches)
+		if escaped := groups["escaped"]; escaped != "" {
+			return escaped
 		}
 
 		substitution := groups["named"]
 		if substitution == "" {
 			substitution = groups["braced"]
 		}
-		if substitution != "" {
-			// Soft default (fall back if unset or empty)
-			if strings.Contains(substitution, ":-") {
-				name, defaultValue := partition(substitution, ":-")
-				value, ok := mapping(name)
-				if !ok || value == "" {
-					return defaultValue
-				}
-				return value
-			}
 
-			// Hard default (fall back if-and-only-if empty)
-			if strings.Contains(substitution, "-") {
-				name, defaultValue := partition(substitution, "-")
-				value, ok := mapping(name)
-				if !ok {
-					return defaultValue
-				}
-				return value
-			}
+		switch {
 
-			if strings.Contains(substitution, ":?") {
-				name, errorMessage := partition(substitution, ":?")
-				value, ok := mapping(name)
-				if !ok || value == "" {
-					err = &InvalidTemplateError{Template: errorMessage}
-					return ""
-				}
-				return value
-			}
+		case substitution == "":
+			err = &InvalidTemplateError{Template: template}
+			return ""
 
-			if strings.Contains(substitution, "?") {
-				name, errorMessage := partition(substitution, "?")
-				value, ok := mapping(name)
-				if !ok {
-					err = &InvalidTemplateError{Template: errorMessage}
-					return ""
-				}
-				return value
+		// Soft default (fall back if unset or empty)
+		case strings.Contains(substitution, ":-"):
+			name, defaultValue := partition(substitution, ":-")
+			value, ok := mapping(name)
+			if !ok || value == "" {
+				return defaultValue
 			}
+			return value
 
-			// No default (fall back to empty string)
-			value, ok := mapping(substitution)
+		// Hard default (fall back if-and-only-if empty)
+		case strings.Contains(substitution, "-"):
+			name, defaultValue := partition(substitution, "-")
+			value, ok := mapping(name)
 			if !ok {
+				return defaultValue
+			}
+			return value
+
+		case strings.Contains(substitution, ":?"):
+			name, errorMessage := partition(substitution, ":?")
+			value, ok := mapping(name)
+			if !ok || value == "" {
+				err = &InvalidTemplateError{Template: errorMessage}
+				return ""
+			}
+			return value
+
+		case strings.Contains(substitution, "?"):
+			name, errorMessage := partition(substitution, "?")
+			value, ok := mapping(name)
+			if !ok {
+				err = &InvalidTemplateError{Template: errorMessage}
 				return ""
 			}
 			return value
 		}
 
-		if escaped := groups["escaped"]; escaped != "" {
-			return escaped
-		}
-
-		err = &InvalidTemplateError{Template: template}
-		return ""
+		value, _ := mapping(substitution)
+		return value
 	})
 
 	return result, err
+}
+
+func matchGroups(matches []string) map[string]string {
+	groups := make(map[string]string)
+	for i, name := range pattern.SubexpNames()[1:] {
+		groups[name] = matches[i+1]
+	}
+	return groups
 }
 
 // Split the string at the first occurrence of sep, and return the part before the separator,

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -7,7 +7,7 @@ import (
 )
 
 var delimiter = "\\$"
-var substitution = "[_a-z][_a-z0-9]*(?::?-[^}]+)?"
+var substitution = "[_a-z][_a-z0-9]*(?::?[-?][^}]+)?"
 
 var patternString = fmt.Sprintf(
 	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
@@ -65,6 +65,26 @@ func Substitute(template string, mapping Mapping) (string, error) {
 				value, ok := mapping(name)
 				if !ok {
 					return defaultValue
+				}
+				return value
+			}
+
+			if strings.Contains(substitution, ":?") {
+				name, errorMessage := partition(substitution, ":?")
+				value, ok := mapping(name)
+				if !ok || value == "" {
+					err = &InvalidTemplateError{Template: errorMessage}
+					return ""
+				}
+				return value
+			}
+
+			if strings.Contains(substitution, "?") {
+				name, errorMessage := partition(substitution, "?")
+				value, ok := mapping(name)
+				if !ok {
+					err = &InvalidTemplateError{Template: errorMessage}
+					return ""
 				}
 				return value
 			}

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -7,7 +7,7 @@ import (
 )
 
 var delimiter = "\\$"
-var substitution = "[_a-z][_a-z0-9]*(?::?[-?][^}]+)?"
+var substitution = "[_a-z][_a-z0-9]*(?::?[-?][^}]*)?"
 
 var patternString = fmt.Sprintf(
 	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
@@ -75,7 +75,9 @@ func Substitute(template string, mapping Mapping) (string, error) {
 			name, errorMessage := partition(substitution, ":?")
 			value, ok := mapping(name)
 			if !ok || value == "" {
-				err = &InvalidTemplateError{Template: errorMessage}
+				err = &InvalidTemplateError{
+					Template: fmt.Sprintf("required variable %s is missing a value: %s", name, errorMessage),
+				}
 				return ""
 			}
 			return value
@@ -84,7 +86,9 @@ func Substitute(template string, mapping Mapping) (string, error) {
 			name, errorMessage := partition(substitution, "?")
 			value, ok := mapping(name)
 			if !ok {
-				err = &InvalidTemplateError{Template: errorMessage}
+				err = &InvalidTemplateError{
+					Template: fmt.Sprintf("required variable %s is missing a value: %s", name, errorMessage),
+				}
 				return ""
 			}
 			return value

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"testing"
 
+	"github.com/docker/cli/internal/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -119,7 +120,8 @@ func TestMandatoryVariableErrors(t *testing.T) {
 	for _, tc := range testCases {
 		_, err := Substitute(tc.template, defaultMapping)
 		assert.Error(t, err)
-		assert.IsType(t, &InvalidTemplateError{tc.expectedError}, err)
+		assert.IsType(t, &InvalidTemplateError{}, err)
+		testutil.ErrorContains(t, err, tc.expectedError)
 	}
 }
 

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var defaults = map[string]string{
@@ -20,6 +21,12 @@ func TestEscaped(t *testing.T) {
 	result, err := Substitute("$${foo}", defaultMapping)
 	assert.Nil(t, err)
 	assert.Equal(t, "${foo}", result)
+}
+
+func TestSubstituteNoMatch(t *testing.T) {
+	result, err := Substitute("foo", defaultMapping)
+	require.NoError(t, err)
+	require.Equal(t, "foo", result)
 }
 
 func TestInvalid(t *testing.T) {

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -97,23 +97,23 @@ func TestMandatoryVariableErrors(t *testing.T) {
 	}{
 		{
 			template:      "not ok ${UNSET_VAR:?Mandatory Variable Unset}",
-			expectedError: "Mandatory Variable Unset",
+			expectedError: "required variable UNSET_VAR is missing a value: Mandatory Variable Unset",
 		},
 		{
 			template:      "not ok ${BAR:?Mandatory Variable Empty}",
-			expectedError: "Mandatory Variable Empty",
+			expectedError: "required variable BAR is missing a value: Mandatory Variable Empty",
 		},
 		{
 			template:      "not ok ${UNSET_VAR:?}",
-			expectedError: "",
+			expectedError: "required variable UNSET_VAR is missing a value",
 		},
 		{
-			template:      "not ok ${UNSET_VAR?Mandatory Variable Unset",
-			expectedError: "Mandatory Variable Unset",
+			template:      "not ok ${UNSET_VAR?Mandatory Variable Unset}",
+			expectedError: "required variable UNSET_VAR is missing a value: Mandatory Variable Unset",
 		},
 		{
 			template:      "not ok ${UNSET_VAR?}",
-			expectedError: "",
+			expectedError: "required variable UNSET_VAR is missing a value",
 		},
 	}
 


### PR DESCRIPTION
This PR adds support for mandatory variables syntax to stack deploy. Fixes #805 

Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>

**- What I did**
Added support for mandatory variables syntax, i.e. ${VAR?error message} and ${VAR:?error message}, to stack deploy command.

**- How I did it**
Added the code required to handle the syntax in cli/compose/template/template.go, and the corresponding tests in cli/compose/template/template_test.go

**- How to verify it**
Run stack deploy command on a compose file that contains mandatory variable(s).

**- Description for the changelog**
Added support for mandatory variables to stack deploy command.

**- A picture of a cute animal (not mandatory but encouraged)**

