### PR TITLE
Bump moby to 0ede01237c9ab871f1b8db0364427407f3e46541

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -300,12 +300,12 @@ func newHTTPClient(host string, tlsOptions *tlsconfig.Options) (*http.Client, er
 			Timeout:   30 * time.Second,
 		}).DialContext,
 	}
-	proto, addr, _, err := client.ParseHost(host)
+	hostURL, err := client.ParseHostURL(host)
 	if err != nil {
 		return nil, err
 	}
 
-	sockets.ConfigureTransport(tr, proto, addr)
+	sockets.ConfigureTransport(tr, hostURL.Scheme, hostURL.Host)
 
 	return &http.Client{
 		Transport:     tr,

--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/coreos/etcd v3.2.1
 github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker 079ed017b61eb819b8184b90013ce89465d3aaba
+github.com/docker/docker 0ede01237c9ab871f1b8db0364427407f3e46541
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.

--- a/vendor/github.com/docker/docker/api/common.go
+++ b/vendor/github.com/docker/docker/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion string = "1.36"
+	DefaultVersion string = "1.37"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/vendor/github.com/docker/docker/api/types/swarm/config.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/config.go
@@ -13,6 +13,10 @@ type Config struct {
 type ConfigSpec struct {
 	Annotations
 	Data []byte `json:",omitempty"`
+
+	// Templating controls whether and how to evaluate the config payload as
+	// a template. If it is not set, no templating is used.
+	Templating *Driver `json:",omitempty"`
 }
 
 // ConfigReferenceFileTarget is a file target in a config reference

--- a/vendor/github.com/docker/docker/api/types/swarm/secret.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/secret.go
@@ -14,6 +14,10 @@ type SecretSpec struct {
 	Annotations
 	Data   []byte  `json:",omitempty"`
 	Driver *Driver `json:",omitempty"` // name of the secrets driver used to fetch the secret's value from an external secret store
+
+	// Templating controls whether and how to evaluate the secret payload as
+	// a template. If it is not set, no templating is used.
+	Templating *Driver `json:",omitempty"`
 }
 
 // SecretReferenceFileTarget is a file target in a secret reference

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -37,6 +37,7 @@ type CommonAPIClient interface {
 	NegotiateAPIVersion(ctx context.Context)
 	NegotiateAPIVersionPing(types.Ping)
 	DialSession(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error)
+	Close() error
 }
 
 // ContainerAPIClient defines API client methods for the containers

--- a/vendor/github.com/docker/docker/client/request.go
+++ b/vendor/github.com/docker/docker/client/request.go
@@ -123,10 +123,7 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 	if err != nil {
 		return resp, err
 	}
-	if err := cli.checkResponseErr(resp); err != nil {
-		return resp, err
-	}
-	return resp, nil
+	return resp, cli.checkResponseErr(resp)
 }
 
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {


### PR DESCRIPTION
full diff: https://github.com/docker/docker/compare/079ed017b61eb819b8184b90013ce89465d3aaba...0ede01237c9ab871f1b8db0364427407f3e46541

Includes:

- https://github.com/moby/moby/pull/34899 [client] Remove duplicate NewClient functions
- https://github.com/moby/moby/pull/33702 Add API support for templated secrets and configs
- https://github.com/moby/moby/pull/36366 Adjust minimum API version for templated configs/secrets
