### PR TITLE
Fix `--label` behavior on run

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -16,6 +16,7 @@ type fakeClient struct {
 	execInspectFunc       func(execID string) (types.ContainerExecInspect, error)
 	execCreateFunc        func(container string, config types.ExecConfig) (types.IDResponse, error)
 	createContainerFunc   func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
+	containerStartFunc    func(container string, options types.ContainerStartOptions) error
 	imageCreateFunc       func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	infoFunc              func() (types.Info, error)
 	containerStatPathFunc func(container, path string) (types.ContainerPathStat, error)
@@ -115,4 +116,11 @@ func (f *fakeClient) ContainerWait(_ context.Context, container string, _ contai
 		return f.waitFunc(container)
 	}
 	return nil, nil
+}
+
+func (f *fakeClient) ContainerStart(_ context.Context, container string, options types.ContainerStartOptions) error {
+	if f.containerStartFunc != nil {
+		return f.containerStartFunc(container, options)
+	}
+	return nil
 }

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -145,7 +145,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 		expose:            opts.NewListOpts(nil),
 		extraHosts:        opts.NewListOpts(opts.ValidateExtraHost),
 		groupAdd:          opts.NewListOpts(nil),
-		labels:            opts.NewListOpts(opts.ValidateLabel),
+		labels:            opts.NewListOpts(nil),
 		labelsFile:        opts.NewListOpts(nil),
 		linkLocalIPs:      opts.NewListOpts(nil),
 		links:             opts.NewListOpts(opts.ValidateLink),

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -1,0 +1,25 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunLabel(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		createContainerFunc: func(_ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ string) (container.ContainerCreateCreatedBody, error) {
+			return container.ContainerCreateCreatedBody{
+				ID: "id",
+			}, nil
+		},
+		Version: "1.36",
+	})
+	cmd := NewRunCommand(cli)
+	cmd.Flags().Set("detach", "true")
+	cmd.SetArgs([]string{"--label", "foo", "busybox"})
+	assert.NoError(t, cmd.Execute())
+}


### PR DESCRIPTION
Commit 2b17f4c8a8caad552025edb05a73db683fb8a5c6 fixed the way empty labels
are taken into account (i.e. not interpolated from environment variable),
but it created a regression.

`ValidateLabel` functions doesn't allow empty label value, but it has
always been possible to pass an empty label via the cli (`docker run --label foo`).

This fixes that by not validating the label flag.

This needs to be backported to 18.03 👼 and this will fix one `docker-ce` CI failure.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
