### PR TITLE
Fix grammar typo in comment

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -1,7 +1,7 @@
 package cli
 
 // Default build-time variable.
-// These values are overriding via ldflags
+// These values are overridden via ldflags
 var (
 	PlatformName = ""
 	Version      = "unknown-version"


### PR DESCRIPTION
Overriding is the incorrect part of speech for this sentence. It is more common to state that the values are overridden instead.

Other options would include:

```golang
// ldflags is overriding these values
```

```golang
// These values will be overridden by ldflags
```

etc.

**- What I did**
Fixed a grammatical issue

**- How I did it**
By reviewing the phrasing in place and updating it accordingly

**- How to verify it**
Reading examples of the term's usage on websites such as http://www.dictionary.com/browse/overridden


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix grammatical error in default ldflags build variable comment

**- A picture of a cute animal (not mandatory but encouraged)**
![cute puppy](http://www.zarias.com/wp-content/uploads/2015/12/61-cute-puppies.jpg)
