### PR TITLE
Align `Built` in docker version output Client section

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -24,7 +24,7 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  API version:	{{.APIVersion}}{{if ne .APIVersion .DefaultAPIVersion}} (downgraded from {{.DefaultAPIVersion}}){{end}}
  Go version:	{{.GoVersion}}
  Git commit:	{{.GitCommit}}
- Built:	{{.BuildTime}}
+ Built:		{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
  Experimental:	{{.Experimental}}
  Orchestrator:	{{.Orchestrator}}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Somewhat amazed this hadn't been noticed/fixed before.....

Before
![image](https://user-images.githubusercontent.com/10522484/36820036-d0d1c9b0-1ca0-11e8-8868-515fe92b9d4c.png)

![image](https://user-images.githubusercontent.com/10522484/36820055-e88e46fa-1ca0-11e8-8a98-0408de6a788e.png)

After
![image](https://user-images.githubusercontent.com/10522484/36820091-10781952-1ca1-11e8-9f8e-1f21f7e172b2.png)



