### PR TITLE
Don't set a default filename for ConfigFile

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -75,18 +75,18 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	if _, err := os.Stat(filename); err == nil {
 		file, err := os.Open(filename)
 		if err != nil {
-			return configFile, errors.Errorf("%s - %v", filename, err)
+			return configFile, errors.Wrap(err, filename)
 		}
 		defer file.Close()
 		err = configFile.LoadFromReader(file)
 		if err != nil {
-			err = errors.Errorf("%s - %v", filename, err)
+			err = errors.Wrap(err, filename)
 		}
 		return configFile, err
 	} else if !os.IsNotExist(err) {
 		// if file is there but we can't stat it for any reason other
 		// than it doesn't exist then stop
-		return configFile, errors.Errorf("%s - %v", filename, err)
+		return configFile, errors.Wrap(err, filename)
 	}
 
 	// Can't find latest config file so check for the old one
@@ -96,12 +96,12 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 	file, err := os.Open(confFile)
 	if err != nil {
-		return configFile, errors.Errorf("%s - %v", confFile, err)
+		return configFile, errors.Wrap(err, confFile)
 	}
 	defer file.Close()
 	err = configFile.LegacyLoadFromReader(file)
 	if err != nil {
-		return configFile, errors.Errorf("%s - %v", confFile, err)
+		return configFile, errors.Wrap(err, confFile)
 	}
 	return configFile, nil
 }

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/pkg/errors"
 )
 
 func setupConfigDir(t *testing.T) (string, func()) {
@@ -77,7 +79,8 @@ func TestEmptyFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = Load(tmpHome)
-	assert.ErrorContains(t, err, "EOF")
+	assert.Equal(t, errors.Cause(err), io.EOF)
+	assert.ErrorContains(t, err, ConfigFileName)
 }
 
 func TestEmptyJSON(t *testing.T) {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/cli/internal/test/testutil"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
@@ -78,7 +77,7 @@ func TestEmptyFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = Load(tmpHome)
-	testutil.ErrorContains(t, err, "EOF")
+	assert.ErrorContains(t, err, "EOF")
 }
 
 func TestEmptyJSON(t *testing.T) {
@@ -122,7 +121,7 @@ email`: "Invalid auth configuration file",
 		assert.NilError(t, err)
 
 		_, err = Load(tmpHome)
-		testutil.ErrorContains(t, err, expectedError)
+		assert.ErrorContains(t, err, expectedError)
 	}
 }
 
@@ -469,7 +468,7 @@ func TestJSONSaveWithNoFile(t *testing.T) {
 	config, err := LoadFromReader(strings.NewReader(js))
 	assert.NilError(t, err)
 	err = config.Save()
-	testutil.ErrorContains(t, err, "with empty filename")
+	assert.ErrorContains(t, err, "with empty filename")
 
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
@@ -500,7 +499,7 @@ func TestLegacyJSONSaveWithNoFile(t *testing.T) {
 	config, err := LegacyLoadFromReader(strings.NewReader(js))
 	assert.NilError(t, err)
 	err = config.Save()
-	testutil.ErrorContains(t, err, "with empty filename")
+	assert.ErrorContains(t, err, "with empty filename")
 
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -40,12 +40,14 @@ func NewFakeCli(client client.APIClient) *FakeCli {
 	outBuffer := new(bytes.Buffer)
 	errBuffer := new(bytes.Buffer)
 	return &FakeCli{
-		client:     client,
-		out:        command.NewOutStream(outBuffer),
-		outBuffer:  outBuffer,
-		err:        errBuffer,
-		in:         command.NewInStream(ioutil.NopCloser(strings.NewReader(""))),
-		configfile: configfile.New("configfile"),
+		client:    client,
+		out:       command.NewOutStream(outBuffer),
+		outBuffer: outBuffer,
+		err:       errBuffer,
+		in:        command.NewInStream(ioutil.NopCloser(strings.NewReader(""))),
+		// Use an empty string for filename so that tests don't create configfiles
+		// Set cli.ConfigFile().Filename to a tempfile to support Save.
+		configfile: configfile.New(""),
 	}
 }
 


### PR DESCRIPTION
With a default filename tests will leave a file in the working directory
that is never cleaned up.

Also cleanup error handling in config load.