### PR TITLE
Don't prompt for github creds in unit test

### DIFF
--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -161,12 +161,16 @@ COPY data /data
 // TestRunBuildFromLocalGitHubDirNonExistingRepo tests that build contexts
 // starting with `github.com/` are special-cased, and the build command attempts
 // to clone the remote repo.
+// TODO: test "context selection" logic directly when runBuild is refactored
+// to support testing (ex: docker/cli#294)
 func TestRunBuildFromGitHubSpecialCase(t *testing.T) {
 	cmd := NewBuildCommand(test.NewFakeCli(nil))
-	cmd.SetArgs([]string{"github.com/docker/no-such-repository"})
+	// Clone a small repo that exists so git doesn't prompt for credentials
+	cmd.SetArgs([]string{"github.com/docker/for-win"})
 	cmd.SetOutput(ioutil.Discard)
 	err := cmd.Execute()
-	assert.ErrorContains(t, err, "unable to prepare context: unable to 'git clone'")
+	assert.ErrorContains(t, err, "unable to prepare context")
+	assert.ErrorContains(t, err, "docker-build-git")
 }
 
 // TestRunBuildFromLocalGitHubDirNonExistingRepo tests that a local directory


### PR DESCRIPTION
This test has been a thorn in my side for a long time. Every time I run unit tests for the `image` package it prompts for credentials and I have to hit enter a couple times for the test to run.

The ideal fix would be to refactor `runBuild` (#294) so that we can unit test the logic without actually performing a clone. Since that PR is stalled out this change will at least remedy the immediate problem.

Instead of using a non-existant repo, use a very small repo.