### PR TITLE
Bash: update trust completions

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4713,9 +4713,9 @@ _docker_tag() {
 
 _docker_trust() {
 	local subcommands="
+		inspect
 		revoke
 		sign
-		view
 	"
 	__docker_subcommands "$subcommands" && return
 
@@ -4725,6 +4725,20 @@ _docker_trust() {
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_trust_inspect() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help --pretty" -- "$cur" ) )
+			;;
+		*)
+			local counter=$(__docker_pos_first_nonflag)
+			if [ "$cword" -eq "$counter" ]; then
+				__docker_complete_images --repo --tag
+			fi
 			;;
 	esac
 }
@@ -4752,20 +4766,6 @@ _docker_trust_sign() {
 			local counter=$(__docker_pos_first_nonflag)
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_images --force-tag --id
-			fi
-			;;
-	esac
-}
-
-_docker_trust_view() {
-	case "$cur" in
-		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
-			;;
-		*)
-			local counter=$(__docker_pos_first_nonflag)
-			if [ "$cword" -eq "$counter" ]; then
-				__docker_complete_images --repo --tag
 			fi
 			;;
 	esac
@@ -4947,6 +4947,7 @@ _docker() {
 		stack
 		swarm
 		system
+		trust
 		volume
 	)
 
@@ -4999,7 +5000,6 @@ _docker() {
 	local experimental_commands=(
 		checkpoint
 		deploy
-		trust
 	)
 
 	local commands=(${management_commands[*]} ${top_level_commands[*]})


### PR DESCRIPTION
The `docker trust` commands were moved out of experimental, and the `docker trust view` command was changed to `docker trust inspect --pretty`.

**- How to verify it**

Build, and start a dev-container

```bash
make -f docker.Makefile binary shell
```

Start bash, install bash-completion, and load the completion script:

```bash
bash
apk add --no-cache bash-completion
. /usr/share/bash-completion/bash_completion
. /go/src/github.com/docker/cli/contrib/completion/bash/docker
```

Then try completions;

```bash
docker tr<tab> i<tab> --p<tab>
```

which should complete to `docker trust inspect --pretty`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
