### PR TITLE
Small content trust enhancement

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -123,7 +123,7 @@ func (cli *DockerCli) ClientInfo() ClientInfo {
 	return cli.clientInfo
 }
 
-// ContentTrustEnabled returns if content trust has been enabled by an
+// ContentTrustEnabled returns whether content trust has been enabled by an
 // environment variable.
 func (cli *DockerCli) ContentTrustEnabled() bool {
 	return cli.contentTrust

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -156,7 +156,7 @@ func main() {
 	stdin, stdout, stderr := term.StdStreams()
 	logrus.SetOutput(stderr)
 
-	dockerCli := command.NewDockerCli(stdin, stdout, stderr, isContentTrustEnabled())
+	dockerCli := command.NewDockerCli(stdin, stdout, stderr, contentTrustEnabled())
 	cmd := newDockerCommand(dockerCli)
 
 	if err := cmd.Execute(); err != nil {
@@ -176,7 +176,7 @@ func main() {
 	}
 }
 
-func isContentTrustEnabled() bool {
+func contentTrustEnabled() bool {
 	if e := os.Getenv("DOCKER_CONTENT_TRUST"); e != "" {
 		if t, err := strconv.ParseBool(e); t || err != nil {
 			// treat any other value as true


### PR DESCRIPTION
- `replaceDockerfileForContentTrust` is only used when content trust is
  enabled, so remove the boolean.
- rename `isContentTrustEnabled` to `contentTrustEnabled`

follow-up from #929 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
