### PR TITLE
Bump moby to ae7016427f8cba4e4d8fcb979d6ba313ee2c0702

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -5,7 +5,7 @@ github.com/coreos/etcd v3.2.1
 github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
-github.com/docker/docker 0ede01237c9ab871f1b8db0364427407f3e46541
+github.com/docker/docker ae7016427f8cba4e4d8fcb979d6ba313ee2c0702
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.
@@ -13,7 +13,7 @@ github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06
 github.com/docker/go-connections 7beb39f0b969b075d1325fecb092faf27fd357b6
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
-github.com/docker/swarmkit f74983e7c015a38a81c8642803a78b8322cf7eac
+github.com/docker/swarmkit 49a9d7f6ba3c1925262641e694c18eb43575f74b
 github.com/emicklei/go-restful ff4f55a206334ef123e4f79bbf348980da81ca46
 github.com/emicklei/go-restful-swagger12 dcef7f55730566d41eae5db10e7d6981829720f6
 github.com/flynn-archive/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
@@ -50,7 +50,7 @@ github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 6c55f98695e902427906eed2c799e566e3d3dfb5
+github.com/opencontainers/runc 4fc53a81fb7c994640722ac585fa9ca548971871
 github.com/peterbourgon/diskv 5f041e8faa004a95c88a202771f4cc3e991971e6
 github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
 github.com/pmezard/go-difflib v1.0.0
@@ -69,7 +69,7 @@ github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45
 github.com/xeipuuv/gojsonschema 93e72a773fade158921402d6a24c819b48aba29d
 golang.org/x/crypto 558b6879de74bc843225cde5686419267ff707ca
 golang.org/x/net a8b9294777976932365dabb6640cf1468d95c70f
-golang.org/x/sync f52d1811a62927559de87708c
+golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 golang.org/x/sys 37707fdb30a5b38865cfb95e5aab41707daec7fd
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb

--- a/vendor/github.com/docker/docker/errdefs/defs.go
+++ b/vendor/github.com/docker/docker/errdefs/defs.go
@@ -35,7 +35,7 @@ type ErrForbidden interface {
 // ErrSystem signals that some internal error occurred.
 // An example of this would be a failed mount request.
 type ErrSystem interface {
-	ErrSystem()
+	System()
 }
 
 // ErrNotModified signals that an action can't be performed because it's already in the desired state

--- a/vendor/github.com/docker/docker/errdefs/is.go
+++ b/vendor/github.com/docker/docker/errdefs/is.go
@@ -21,7 +21,7 @@ func getImplementer(err error) error {
 		ErrDeadline,
 		ErrDataLoss,
 		ErrUnknown:
-		return e
+		return err
 	case causer:
 		return getImplementer(e.Cause())
 	default:

--- a/vendor/github.com/docker/docker/pkg/mount/mount.go
+++ b/vendor/github.com/docker/docker/pkg/mount/mount.go
@@ -72,7 +72,9 @@ func RecursiveUnmount(target string) error {
 	}
 
 	// Make the deepest mount be first
-	sort.Sort(sort.Reverse(byMountpoint(mounts)))
+	sort.Slice(mounts, func(i, j int) bool {
+		return len(mounts[i].Mountpoint) > len(mounts[j].Mountpoint)
+	})
 
 	for i, m := range mounts {
 		if !strings.HasPrefix(m.Mountpoint, target) {

--- a/vendor/github.com/docker/docker/pkg/mount/mountinfo.go
+++ b/vendor/github.com/docker/docker/pkg/mount/mountinfo.go
@@ -38,17 +38,3 @@ type Info struct {
 	// VfsOpts represents per super block options.
 	VfsOpts string
 }
-
-type byMountpoint []*Info
-
-func (by byMountpoint) Len() int {
-	return len(by)
-}
-
-func (by byMountpoint) Less(i, j int) bool {
-	return by[i].Mountpoint < by[j].Mountpoint
-}
-
-func (by byMountpoint) Swap(i, j int) {
-	by[i], by[j] = by[j], by[i]
-}

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -1,6 +1,7 @@
 package system // import "github.com/docker/docker/pkg/system"
 
 import (
+	"fmt"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
@@ -51,6 +52,10 @@ func GetOSVersion() OSVersion {
 	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
 	osv.Build = uint16(osv.Version >> 16)
 	return osv
+}
+
+func (osv OSVersion) ToString() string {
+	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
 }
 
 // IsWindowsClient returns true if the SKU is client

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -5,6 +5,7 @@ github.com/Microsoft/go-winio v0.4.6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
+github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
 github.com/Microsoft/opengcs v0.3.6
@@ -25,15 +26,15 @@ github.com/google/go-cmp v0.1.0
 
 github.com/RackSec/srslog 456df3a81436d29ba874f3590eeeee25d666f8a5
 github.com/imdario/mergo 0.2.1
-golang.org/x/sync de49d9dcd27d4f764488181bea099dfe6179bcf0
+golang.org/x/sync fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 
 github.com/moby/buildkit aaff9d591ef128560018433fe61beb802e149de8
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 
 #get libnetwork packages
 
-# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/binaries-commits accordingly
-github.com/docker/libnetwork ed2130d117c11c542327b4d5216a5db36770bc65
+# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
+github.com/docker/libnetwork 8892d7537c67232591f1f3af60587e3e77e61d41
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -47,7 +48,7 @@ github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
 
-# When updating, consider updating TOMLV_COMMIT in hack/dockerfile/binaries-commits accordingly
+# When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv accordingly
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/samuel/go-zookeeper d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set ef32fa3046d9f249d399f98ebaf9be944430fd1d
@@ -70,8 +71,8 @@ github.com/pborman/uuid v1.0
 
 google.golang.org/grpc v1.3.0
 
-# When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
-github.com/opencontainers/runc 6c55f98695e902427906eed2c799e566e3d3dfb5
+# When updating, also update RUNC_COMMIT in hack/dockerfile/install/runc accordingly
+github.com/opencontainers/runc 4fc53a81fb7c994640722ac585fa9ca548971871
 github.com/opencontainers/runtime-spec v1.0.1
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
@@ -113,14 +114,14 @@ github.com/containerd/containerd 3fa104f843ec92328912e042b767d26825f202aa
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity d8fb8589b0e8e85b8c8bbaa8840226d0dfeb7371
 github.com/containerd/cgroups c0710c92e8b3a44681d1321dcfd1360fc5c6c089
-github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
+github.com/containerd/console 2748ece16665b45a47f884001d5831ec79703880
 github.com/containerd/go-runc 4f6e87ae043f859a38255247b49c9abc262d002f
 github.com/containerd/typeurl f6943554a7e7e88b3c14aad190bf05932da84788
 github.com/dmcgowan/go-tar go1.10
 github.com/stevvooe/ttrpc d4528379866b0ce7e9d71f3eb96f0582fc374577
 
 # cluster
-github.com/docker/swarmkit f74983e7c015a38a81c8642803a78b8322cf7eac
+github.com/docker/swarmkit 49a9d7f6ba3c1925262641e694c18eb43575f74b
 github.com/gogo/protobuf v0.4
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/google/certificate-transparency d90e65c3a07988180c5b1ece71791c0b6506826e

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -41,7 +41,17 @@ make
 sudo make install
 ```
 
+You can also use `go get` to install to your `GOPATH`, assuming that you have a `github.com` parent folder already created under `src`:
+
+```bash
+go get github.com/opencontainers/runc
+cd $GOPATH/src/github.com/opencontainers/runc
+make
+sudo make install
+```
+
 `runc` will be installed to `/usr/local/sbin/runc` on your system.
+
 
 #### Build Tags
 

--- a/vendor/github.com/opencontainers/runc/vendor.conf
+++ b/vendor/github.com/opencontainers/runc/vendor.conf
@@ -21,5 +21,5 @@ github.com/urfave/cli d53eb991652b1d438abdd34ce4bfa3ef1539108e
 golang.org/x/sys 7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce https://github.com/golang/sys
 
 # console dependencies
-github.com/containerd/console 84eeaae905fa414d03e07bcd6c8d3f19e7cf180e
+github.com/containerd/console 2748ece16665b45a47f884001d5831ec79703880
 github.com/pkg/errors v0.8.0

--- a/vendor/golang.org/x/sync/README
+++ b/vendor/golang.org/x/sync/README
@@ -1,2 +1,0 @@
-This repository provides Go concurrency primitives in addition to the
-ones provided by the language and "sync" and "sync/atomic" packages.

--- a/vendor/golang.org/x/sync/README.md
+++ b/vendor/golang.org/x/sync/README.md
@@ -1,0 +1,18 @@
+# Go Sync
+
+This repository provides Go concurrency primitives in addition to the
+ones provided by the language and "sync" and "sync/atomic" packages.
+
+## Download/Install
+
+The easiest way to install is to run `go get -u golang.org/x/sync`. You can
+also manually git clone the repository to `$GOPATH/src/golang.org/x/sync`.
+
+## Report Issues / Send Patches
+
+This repository uses Gerrit for code changes. To learn how to submit changes to
+this repository, see https://golang.org/doc/contribute.html.
+
+The main issue tracker for the sync repository is located at
+https://github.com/golang/go/issues. Prefix your issue with "x/sync:" in the
+subject line, so it is easy to find.


### PR DESCRIPTION
Mainly to not get too far behind:

Brings in:

- https://github.com/moby/moby/pull/36517 ensure hijackedConn implements CloseWrite function
- https://github.com/moby/moby/pull/36489 (fixes `errdefs.ErrSystem` interface)
- https://github.com/moby/moby/pull/36506 pkg/mount: use sort.Slice
- https://github.com/moby/moby/pull/36451 Windows: Report Version and UBR

(full diff: https://github.com/moby/moby/compare/0ede01237c9ab871f1b8db0364427407f3e46541...ae7016427f8cba4e4d8fcb979d6ba313ee2c0702)

Also update moby dependencies to keep them in sync

- golang.org/x/sync (no code changes)
- Bump runc to 4fc53a81fb7c994640722ac585fa9ca548971871
- Bump swarmkit to 49a9d7f6ba3c1925262641e694c18eb43575f74b

no local code changes
