### PR TITLE
Remove filewatcher

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -17,13 +17,6 @@ RUN     go get -d github.com/mjibson/esc && \
         go build -v -o /usr/bin/esc . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     FILEWATCHER_SHA=2e12ea42f6c8c089b19e992145bb94e8adaecedb
-RUN     go get -d github.com/dnephin/filewatcher && \
-        cd /go/src/github.com/dnephin/filewatcher && \
-        git checkout -q "$FILEWATCHER_SHA" && \
-        go build -v -o /usr/bin/filewatcher . && \
-        rm -rf /go/src/* /go/pkg/* /go/bin/*
-
 # FIXME(vdemeester) only used for e2e, could be in e2e special image in the future
 ARG     NOTARY_VERSION=v0.6.0
 RUN     export URL=https://github.com/theupdateframework/notary/releases/download; \

--- a/scripts/test/watch
+++ b/scripts/test/watch
@@ -1,3 +1,0 @@
-#!/bin/sh
-# shellcheck disable=SC2016
-exec filewatcher -L 6 -x build -x script go test -timeout 30s -v './${dir}'


### PR DESCRIPTION
I'm not sure if anyone else uses this thing. If someone else is using it I can change this PR to just update it to v0.2.1.

Something bad happened to the gopkg.in url for fsnotify (https://gopkg.in/fsnotify.v1) , which is imported by filewatcher before version 0.2.1. So this will cause builds to fail until it's either updated or removed.