### PR TITLE
Docs touch-ups for "autoremove" and broken anchor

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -592,7 +592,7 @@ Docker supports the following restart policies:
 |:---------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `no`                       | Do not automatically restart the container when it exits. This is the default.                                                                                                                                                                                   |
 | `on-failure[:max-retries]` | Restart only if the container exits with a non-zero exit status. Optionally, limit the number of restart retries the Docker daemon attempts.                                                                                                                     |
-| `unless-stopped`           | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted. |
+| `unless-stopped`           | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted.                                                                                                                                                                  |
 | `always`                   | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
 
 ```bash
@@ -603,7 +603,7 @@ This will run the `redis` container with a restart policy of **always**
 so that if the container exits, Docker will restart it.
 
 More detailed information on restart policies can be found in the
-[Restart Policies (--restart)](../run.md#restart-policies-restart)
+[Restart Policies (--restart)](../run.md#restart-policies---restart)
 section of the Docker run reference page.
 
 ### Add entries to container hosts file (--add-host)

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -620,7 +620,7 @@ systems can really pile up. If instead you'd like Docker to
 **automatically clean up the container and remove the file system when
 the container exits**, you can add the `--rm` flag:
 
-    --rm=false: Automatically remove the container when it exits (incompatible with -d)
+    --rm=false: Automatically remove the container when it exits
 
 > **Note**: When you set the `--rm` flag, Docker also removes the anonymous volumes
 associated with the container when the container is removed. This is similar


### PR DESCRIPTION
`--rm` moved to the daemon, so is now also supported
when combined with `-d`.

ping @gbarr01 PTAL