### PR TITLE
Use HasAvailableFlags instead of HasFlags for Options in help

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -128,7 +128,7 @@ Examples:
 {{ .Example }}
 
 {{- end}}
-{{- if .HasFlags}}
+{{- if .HasAvailableFlags}}
 
 Options:
 {{ wrappedFlagUsages . | trimRightSpace}}


### PR DESCRIPTION
> HasAvailableFlags checks if the command contains any flags (local
> plus persistent from the entire structure) which are not hidden or
> deprecated.

This fix the `--help` display when the `Options` is empty (but
showing), like on `docker trust key`

Before this change, it looks like that :

```bash
$ docker trust key --help
Usage:  docker trust key COMMAND

Manage keys for signing Docker images (experimental)

Options:


Commands:
  generate    Generate and load a signing key-pair
  load        Load a private key file for signing

Run 'docker trust key COMMAND --help' for more information on a command.
```

After 

```bash
$ docker trust key --help

Usage:  docker trust key COMMAND

Manage keys for signing Docker images

Commands:
  generate    Generate and load a signing key-pair
  load        Load a private key file for signing

Run 'docker trust key COMMAND --help' for more information on a command.
```

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>