### PR TITLE
Clarify behaviour of restart policy in run ref doc

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -525,9 +525,9 @@ Docker supports the following restart policies:
     <tr>
       <td><strong>unless-stopped</strong></td>
       <td>
-        Always restart the container regardless of the exit status, but
-        do not start it on daemon startup if the container has been put
-        to a stopped state before.
+        Always restart the container regardless of the exit status,
+        including on daemon startup, except if the container was put
+        into a stopped state before the Docker daemon was stopped.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
**- What I did**

This clarifies that the behaviour of `unless-stopped` will restart the container on daemon start.  This was implied before, but now the restart-on-daemon-start behaviour is mentioned directly.

**- How I did it**

Edited the text file.

**- How to verify it**

Compare the two different phrasings.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Clarify behavior of `unless-stopped` restart policy in Docker run reference.


**- A picture of a cute animal (not mandatory but encouraged)**

![](https://httpstatusdogs.com/img/418.jpg)

