### PR TITLE
Fix stack deploy re-deploying service after --force

### DIFF
--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -249,6 +249,12 @@ func deployServices(
 				// service update.
 				serviceSpec.TaskTemplate.ContainerSpec.Image = service.Spec.TaskTemplate.ContainerSpec.Image
 			}
+
+			// Stack deploy does not have a `--force` option. Preserve existing ForceUpdate
+			// value so that tasks are not re-deployed if not updated.
+			// TODO move this to API client?
+			serviceSpec.TaskTemplate.ForceUpdate = service.Spec.TaskTemplate.ForceUpdate
+
 			response, err := apiClient.ServiceUpdate(
 				ctx,
 				service.ID,


### PR DESCRIPTION
When updating a service with the `--force` option, the `ForceUpdate` property of the taskspec is incremented.

Stack deploy did not take this into account, and reset this field to its default value (0), causing the service to be re-deployed.

This patch copies the existing value before updating the service.

fixes https://github.com/moby/moby/issues/36028

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Fix docker stack deploy re-deploying services after the service was updated with `--force` []()
```

