### PR TITLE
Fix alignment issue in the version command output

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -24,7 +24,7 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  API version:	{{.APIVersion}}{{if ne .APIVersion .DefaultAPIVersion}} (downgraded from {{.DefaultAPIVersion}}){{end}}
  Go version:	{{.GoVersion}}
  Git commit:	{{.GitCommit}}
- Built:	{{.BuildTime}}
+ Built:		{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
  Experimental:	{{.Experimental}}
  Orchestrator:	{{.Orchestrator}}


### PR DESCRIPTION
**- What I did**
This tiny PR fixes an alignment issue in the version command output.

Before:
```
$ docker version
Client:
 Version:       18.03.0-ce
 API version:   1.37
 Go version:    go1.9.4
 Git commit:    0520e24
 Built: Wed Mar 21 23:06:22 2018
 OS/Arch:       darwin/amd64
 Experimental:  false
 Orchestrator:  swarm

Server:
 Engine:
  Version:      18.03.0-ce
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.4
  Git commit:   0520e24
  Built:        Wed Mar 21 23:14:32 2018
  OS/Arch:      linux/amd64
  Experimental: false
```

After:
```$ build/docker-darwin-amd64 version
Client:
 Version:       18.04.0-dev
 API version:   1.37
 Go version:    go1.9.4
 Git commit:    241c14d1
 Built:         Mon Mar 26 13:34:21 2018
 OS/Arch:       darwin/amd64
 Experimental:  false
 Orchestrator:  swarm

Server:
 Engine:
  Version:      18.03.0-ce
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.4
  Git commit:   0520e24
  Built:        Wed Mar 21 23:14:32 2018
  OS/Arch:      linux/amd64
  Experimental: false
```