### PR TITLE
Fix docker version output alignment

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime"
 	"sort"
+	"text/tabwriter"
 	"text/template"
 	"time"
 
@@ -195,11 +196,12 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 			})
 		}
 	}
-
-	if err2 := tmpl.Execute(dockerCli.Out(), vd); err2 != nil && err == nil {
+	t := tabwriter.NewWriter(dockerCli.Out(), 15, 1, 1, ' ', 0)
+	if err2 := tmpl.Execute(t, vd); err2 != nil && err == nil {
 		err = err2
 	}
-	dockerCli.Out().Write([]byte{'\n'})
+	t.Write([]byte("\n"))
+	t.Flush()
 	return err
 }
 


### PR DESCRIPTION
closes https://github.com/docker/cli/pull/964
closes https://github.com/docker/cli/pull/769
closes https://github.com/docker/cli/pull/913

Use tabwriter to print the version output


@tiborvass I tried using a tab writer, and this seems to work correctly; do you know what bug you ran into?

Output with this change:

```
Client:
 Version:      18.04.0-dev
 API version:  1.37
 Go version:   go1.9.4
 Git commit:   76439457
 Built:        Mon Mar 26 14:10:50 2018
 OS/Arch:      linux/amd64
 Experimental: false
 Orchestrator: swarm

Server:
 Engine:
  Version:      18.03.0-ce-rc4
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.4
  Git commit:   fbedb97
  Built:        Thu Mar 15 07:42:29 2018
  OS/Arch:      linux/amd64
  Experimental: true
```