### PR TITLE
Orchestrator column

### DIFF
--- a/cli/command/formatter/stack.go
+++ b/cli/command/formatter/stack.go
@@ -5,9 +5,10 @@ import (
 )
 
 const (
-	defaultStackTableFormat = "table {{.Name}}\t{{.Services}}"
+	defaultStackTableFormat = "table {{.Name}}\t{{.Services}}\t{{.Orchestrator}}"
 
-	stackServicesHeader = "SERVICES"
+	stackServicesHeader      = "SERVICES"
+	stackOrchestrastorHeader = "ORCHESTRATOR"
 )
 
 // Stack contains deployed stack information.
@@ -16,6 +17,8 @@ type Stack struct {
 	Name string
 	// Services is the number of the services
 	Services int
+	// Orchestratort is the platform on which the stack is deployed
+	Orchestrator string
 }
 
 // NewStackFormat returns a format for use with a stack Context
@@ -48,8 +51,9 @@ type stackContext struct {
 func newStackContext() *stackContext {
 	stackCtx := stackContext{}
 	stackCtx.header = map[string]string{
-		"Name":     nameHeader,
-		"Services": stackServicesHeader,
+		"Name":         nameHeader,
+		"Services":     stackServicesHeader,
+		"Orchestrator": stackOrchestrastorHeader,
 	}
 	return &stackCtx
 }
@@ -64,4 +68,8 @@ func (s *stackContext) Name() string {
 
 func (s *stackContext) Services() string {
 	return strconv.Itoa(s.s.Services)
+}
+
+func (s *stackContext) Orchestrator() string {
+	return s.s.Orchestrator
 }

--- a/cli/command/formatter/stack_test.go
+++ b/cli/command/formatter/stack_test.go
@@ -27,9 +27,9 @@ func TestStackContextWrite(t *testing.T) {
 		// Table format
 		{
 			Context{Format: NewStackFormat("table")},
-			`NAME                SERVICES
-baz                 2
-bar                 1
+			`NAME                SERVICES            ORCHESTRATOR
+baz                 2                   orchestrator1
+bar                 1                   orchestrator2
 `,
 		},
 		{
@@ -49,8 +49,8 @@ bar
 	}
 
 	stacks := []*Stack{
-		{Name: "baz", Services: 2},
-		{Name: "bar", Services: 1},
+		{Name: "baz", Services: 2, Orchestrator: "orchestrator1"},
+		{Name: "bar", Services: 1, Orchestrator: "orchestrator2"},
 	}
 	for _, testcase := range cases {
 		out := bytes.NewBufferString("")

--- a/cli/command/stack/kubernetes/list.go
+++ b/cli/command/stack/kubernetes/list.go
@@ -46,8 +46,9 @@ func getStacks(kubeCli *KubeCli) ([]*formatter.Stack, error) {
 	var formattedStacks []*formatter.Stack
 	for _, stack := range stacks {
 		formattedStacks = append(formattedStacks, &formatter.Stack{
-			Name:     stack.name,
-			Services: len(stack.getServices()),
+			Name:         stack.name,
+			Services:     len(stack.getServices()),
+			Orchestrator: "Kubernetes",
 		})
 	}
 	return formattedStacks, nil

--- a/cli/command/stack/swarm/list.go
+++ b/cli/command/stack/swarm/list.go
@@ -59,8 +59,9 @@ func getStacks(ctx context.Context, apiclient client.APIClient) ([]*formatter.St
 		ztack, ok := m[name]
 		if !ok {
 			m[name] = &formatter.Stack{
-				Name:     name,
-				Services: 1,
+				Name:         name,
+				Services:     1,
+				Orchestrator: "Swarm",
 			}
 		} else {
 			ztack.Services++

--- a/cli/command/stack/testdata/stack-list-sort-natural.golden
+++ b/cli/command/stack/testdata/stack-list-sort-natural.golden
@@ -1,4 +1,4 @@
-NAME                  SERVICES
-service-name-1-foo    1
-service-name-2-foo    1
-service-name-10-foo   1
+NAME                  SERVICES            ORCHESTRATOR
+service-name-1-foo    1                   Swarm
+service-name-2-foo    1                   Swarm
+service-name-10-foo   1                   Swarm

--- a/cli/command/stack/testdata/stack-list-sort.golden
+++ b/cli/command/stack/testdata/stack-list-sort.golden
@@ -1,3 +1,3 @@
-NAME                SERVICES
-service-name-bar    1
-service-name-foo    1
+NAME                SERVICES            ORCHESTRATOR
+service-name-bar    1                   Swarm
+service-name-foo    1                   Swarm

--- a/cli/command/stack/testdata/stack-list-without-format.golden
+++ b/cli/command/stack/testdata/stack-list-without-format.golden
@@ -1,2 +1,2 @@
-NAME                SERVICES
-service-name-foo    1
+NAME                SERVICES            ORCHESTRATOR
+service-name-foo    1                   Swarm

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -39,9 +39,9 @@ The following command shows all stacks and some additional information:
 ```bash
 $ docker stack ls
 
-ID                 SERVICES
-vossibility-stack  6
-myapp              2
+ID                 SERVICES            ORCHESTRATOR
+myapp              2                   Kubernetes
+vossibility-stack  6                   Swarm
 ```
 
 ### Formatting
@@ -50,10 +50,11 @@ The formatting option (`--format`) pretty-prints stacks using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder | Description        |
-| ----------- | ------------------ |
-| `.Name`     | Stack name         |
-| `.Services` | Number of services |
+| Placeholder     | Description        |
+| --------------- | ------------------ |
+| `.Name`         | Stack name         |
+| `.Services`     | Number of services |
+| `.Orchestrator` | Orchestrator name  |
 
 When using the `--format` option, the `stack ls` command either outputs
 the data exactly as the template declares or, when using the


### PR DESCRIPTION
**- What I did**
To perform administration tasks more easily, I added an ORCHESTRATOR column in the `docker stack ls` command.

⚠️ Depends on #903  ⚠️ 

**- How I did it**
I added a column in the Stack formatter, and hardcoded the orchestrator in each list command implementation.

**- How to verify it**
```
$ DOCKER_ORCHESTRATOR=kubernetes docker stack ls
NAME                SERVICES            ORCHESTRATOR
mystack             3                   Kubernetes

$ DOCKER_ORCHESTRATOR=swarm docker stack ls
NAME                SERVICES            ORCHESTRATOR
mystack             4                   Swarm
```

**- Description for the changelog**
Added ORCHESTRATOR column to docker stack ls command 

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/37974887-4d6dc058-31de-11e8-8ed7-7c3a8cc7e45a.png)
