### PR TITLE
[K8s] Do env-variable expansion on the uninterpreted Config files

### DIFF
--- a/cli/command/stack/kubernetes/stackclient_test.go
+++ b/cli/command/stack/kubernetes/stackclient_test.go
@@ -26,7 +26,7 @@ func TestFromCompose(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, "foo", s.name)
-	assert.Equal(t, string(`version: "3.1"
+	assert.Equal(t, string(`version: "3.5"
 services:
   bar:
     image: bar
@@ -37,4 +37,28 @@ volumes: {}
 secrets: {}
 configs: {}
 `), s.composeFile)
+}
+
+func TestFromComposeUnsupportedVersion(t *testing.T) {
+	stackClient := &stackV1Beta1{}
+	_, err := stackClient.FromCompose(ioutil.Discard, "foo", &composetypes.Config{
+		Version:  "3.6",
+		Filename: "banana",
+		Services: []composetypes.ServiceConfig{
+			{
+				Name:  "foo",
+				Image: "foo",
+				Volumes: []composetypes.ServiceVolumeConfig{
+					{
+						Type:   "tmpfs",
+						Target: "/app",
+						Tmpfs: &composetypes.ServiceVolumeTmpfs{
+							Size: 10000,
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.ErrorContains(t, err, "the compose yaml file is invalid with v3.5: services.foo.volumes.0 Additional property tmpfs is not allowed")
 }

--- a/kubernetes/compose/v1beta1/parsing.go
+++ b/kubernetes/compose/v1beta1/parsing.go
@@ -1,0 +1,4 @@
+package v1beta1
+
+// MaxComposeVersion is the most recent version of compose file Schema supported in v1beta1
+const MaxComposeVersion = "3.5"


### PR DESCRIPTION
This fix an issue where composefiles like
```
version: '3'
services:
  front:
    image: nginx:1.12.1-alpine
      ports:
      - 80
```
get translated into
```
version: "3.0"
services:
  front:
    image: nginx:1.12.1-alpine
      ports:
      - mode: ingress
        target: 80
        protocol: tcp
```

The problem here is that the long format for describing ports has been
introduced in 3.2 and so, the generated compose file is invalid.

I thought first about just always use latest version information to
override the output composefile version, but that would just make the
problem worse once we introduce a new compose file schema in the CLI
that is not supported on the server side.

This PR makes it possible to interpolate the compose files without
converting them into composetypes.Config (but only work on the loaded
config file format: `map[string]interface{}`. This way, we don't expand
short representations into long ones, and don't risk breaking original
compose files.

