### PR TITLE
[docs] Fix typo in manifest command docs: updated `MANFEST` to `MANIFEST`.

### DIFF
--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -21,7 +21,7 @@ func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
 	opts := createOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "create MANFEST_LIST MANIFEST [MANIFEST...]",
+		Use:   "create MANIFEST_LIST MANIFEST [MANIFEST...]",
 		Short: "Create a local manifest list for annotating and pushing to a registry",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -65,7 +65,7 @@ Options:
 ### manifest create 
 
 ```bash
-Usage:  docker manifest create MANFEST_LIST MANIFEST [MANIFEST...]
+Usage:  docker manifest create MANIFEST_LIST MANIFEST [MANIFEST...]
 
 Create a local manifest list for annotating and pushing to a registry
 


### PR DESCRIPTION

**- What I did**

Updated a typo in the `docker manifest` documentation, referring to the `MANIFEST_LIST`. The original text was `MANFEST_LIST`.

**- How I did it**

Updated `cli/docs/reference/commandline/manifest.md` and `cli/command/manifest/create_list.go`.

**- How to verify it**

When calling `docker manifest`, the description will be changed.

