### PR TITLE
Use printf, not echo when creating secrets

### DIFF
--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -27,7 +27,7 @@ Options:
 
 ## Description
 
-Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node. 
+Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
@@ -36,7 +36,7 @@ For detailed information about using secrets, refer to [manage sensitive data wi
 ### Create a secret
 
 ```bash
-$ echo <secret> | docker secret create my_secret -
+$ printf <secret> | docker secret create my_secret -
 
 onakdyv307se2tl7nl20anokv
 


### PR DESCRIPTION
Update the docs so that users don't use `echo` when creating
secrets from STDIN. `echo` adds a trailing new line, so users
will probably be confused when their passwords don't work.

Relates to docker/docker.github.io#6294

Signed-off-by: Joao Fernandes <joao.fernandes@docker.com>