### PR TITLE
Fix --format example for docker history

### DIFF
--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -77,17 +77,11 @@ output the data exactly as the template declares or, when using the
 `table` directive, will include column headers as well.
 
 The following example uses a template without headers and outputs the
-`ID` and `CreatedSince` entries separated by a colon for all images:
+`ID` and `CreatedSince` entries separated by a colon for the `busybox` image:
 
 ```bash
-$ docker images --format "{{.ID}}: {{.Created}} ago"
+$ docker history --format "{{.ID}}: {{.CreatedAt}}" busybox
 
-cc1b61406712: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 2 weeks ago
-<missing>: 3 weeks ago
-<missing>: 3 weeks ago
-<missing>: 3 weeks ago
+f6e427c148a7: 4 weeks ago
+<missing>: 4 weeks ago
 ```


### PR DESCRIPTION
Carrying the changes of https://github.com/docker/docker.github.io/pull/6236.

This was added in https://github.com/moby/moby/pull/30962, but the example didn't match the code-changes

ping @joaofnfernandes @gbarr01 PTAL