### PR TITLE
Fix `docker stack deploy` reference flag

### DIFF
--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -81,7 +81,7 @@ configuration and environment-specific overrides, you can provide multiple
 `--compose-file` flags.
 
 ```bash
-$ docker stack deploy --compose-file docker-compose.yml -f docker-compose.prod.yml vossibility
+$ docker stack deploy --compose-file docker-compose.yml -c docker-compose.prod.yml vossibility
 
 Ignoring unsupported options: links
 


### PR DESCRIPTION
Fix #976

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
