### PR TITLE
Bump Golang to 1.9.5

### DIFF
--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.9.4@sha256:b8d43ef11ccaa15bec63a1f1fd0c28a0e729074aa62fcfa51f0a5888f3571315
+FROM    dockercore/golang-cross:1.9.5@sha256:4d090b8c2e6d369a48254c882a4e653ba90caaa0b758105da772d9110394d958
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9.4-alpine3.6
+FROM    golang:1.9.5-alpine3.6
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.9.5 (released 2018/03/28) includes fixes to the compiler, go command, and net/http/pprof package. See the Go 1.9.5 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.9.5


