### PR TITLE
Import TestBuildIidFileSquash from moby to cli

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -119,5 +119,12 @@ shellcheck: build_shell_validate_image
 	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(VALIDATE_IMAGE_NAME) make shellcheck
 
 .PHONY: test-e2e
-test-e2e: build_e2e_image
+test-e2e: test-e2e-non-experimental test-e2e-experimental
+
+.PHONY: test-e2e-experimental
+test-e2e-experimental: build_e2e_image
+	docker run -e DOCKERD_EXPERIMENTAL=1 --rm -v /var/run/docker.sock:/var/run/docker.sock $(E2E_IMAGE_NAME)
+
+.PHONY: test-e2e-non-experimental
+test-e2e-non-experimental: build_e2e_image
 	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(E2E_IMAGE_NAME)

--- a/e2e/compose-env.experimental.yaml
+++ b/e2e/compose-env.experimental.yaml
@@ -1,0 +1,6 @@
+version: '2.1'
+
+services:
+  engine:
+      command: ["--insecure-registry=registry:5000", "--experimental"]
+

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -118,6 +118,7 @@ func TestBuildIidFileSquash(t *testing.T) {
 	FROM %s
 	ENV FOO FOO
 	ENV BAR BAR
+	RUN touch /fiip
 	RUN touch /foop`, fixtures.AlpineImage)),
 	)
 	defer buildDir.Remove()

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -15,7 +15,10 @@ function fetch_images {
 
 function setup {
     local project=$1
-    COMPOSE_PROJECT_NAME=$1 COMPOSE_FILE=$2 docker-compose up --build -d >&2
+    local file=$2
+
+    test "${DOCKERD_EXPERIMENTAL:-}" -eq "1" && file="${file}:./e2e/compose-env.experimental.yaml"
+    COMPOSE_PROJECT_NAME=$project COMPOSE_FILE=$file docker-compose up --build -d >&2
 
     local network="${project}_default"
     # TODO: only run if inside a container

--- a/scripts/test/e2e/wrapper
+++ b/scripts/test/e2e/wrapper
@@ -5,7 +5,6 @@ set -eu -o pipefail
 engine_host=$(./scripts/test/e2e/run setup)
 testexit=0
 
-
 test_cmd="test"
 if [[ -n "${TEST_DEBUG-}" ]]; then
     test_cmd="shell"


### PR DESCRIPTION
It's a cli only feature so the test belongs to the cli.

See https://github.com/moby/moby/pull/36746/files#diff-64d1c3a97fd8b1abf170680883e81aaaL6241

cc @dnephin 

It also make test-e2e run against experimental and non-experimental daemon.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
