### PR TITLE
Update Notary vendor to 0.6.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -61,7 +61,6 @@ github.com/shurcooL/sanitized_anchor_name 10ef21a441db47d8b13ebcc5fd2310f636973c
 github.com/sirupsen/logrus v1.0.3
 github.com/spf13/cobra 34ceca591bcf34a17a8b7bad5b3ce5f9c165bee5
 github.com/spf13/pflag 97afa5e7ca8a08a383cb259e06636b5e2cc7897f
-github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 github.com/theupdateframework/notary v0.6.1
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 github.com/xeipuuv/gojsonpointer e0fe6f68307607d540ed8eac07a342c33fa1b54a

--- a/vendor.conf
+++ b/vendor.conf
@@ -62,7 +62,7 @@ github.com/sirupsen/logrus v1.0.3
 github.com/spf13/cobra 34ceca591bcf34a17a8b7bad5b3ce5f9c165bee5
 github.com/spf13/pflag 97afa5e7ca8a08a383cb259e06636b5e2cc7897f
 github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
-github.com/theupdateframework/notary v0.6.0
+github.com/theupdateframework/notary v0.6.1
 github.com/tonistiigi/fsutil dea3a0da73aee887fc02142d995be764106ac5e2
 github.com/xeipuuv/gojsonpointer e0fe6f68307607d540ed8eac07a342c33fa1b54a
 github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45

--- a/vendor/github.com/theupdateframework/notary/README.md
+++ b/vendor/github.com/theupdateframework/notary/README.md
@@ -29,16 +29,16 @@ secure. Once the publisher is ready to make the content available, they can
 push their signed trusted collection to a Notary Server.
 
 Consumers, having acquired the publisher's public key through a secure channel,
-can then communicate with any notary server or (insecure) mirror, relying
+can then communicate with any Notary server or (insecure) mirror, relying
 only on the publisher's key to determine the validity and integrity of the
 received content.
 
 ## Goals
 
-Notary is based on [The Update Framework](https://www.theupdateframework.com/), a secure general design for the problem of software distribution and updates. By using TUF, notary achieves a number of key advantages:
+Notary is based on [The Update Framework](https://www.theupdateframework.com/), a secure general design for the problem of software distribution and updates. By using TUF, Notary achieves a number of key advantages:
 
 * **Survivable Key Compromise**: Content publishers must manage keys in order to sign their content. Signing keys may be compromised or lost so systems must be designed in order to be flexible and recoverable in the case of key compromise. TUF's notion of key roles is utilized to separate responsibilities across a hierarchy of keys such that loss of any particular key (except the root role) by itself is not fatal to the security of the system.
-* **Freshness Guarantees**: Replay attacks are a common problem in designing secure systems, where previously valid payloads are replayed to trick another system. The same problem exists in the software update systems, where old signed can be presented as the most recent. notary makes use of timestamping on publishing so that consumers can know that they are receiving the most up to date content. This is particularly important when dealing with software update where old vulnerable versions could be used to attack users.
+* **Freshness Guarantees**: Replay attacks are a common problem in designing secure systems, where previously valid payloads are replayed to trick another system. The same problem exists in the software update systems, where old signed can be presented as the most recent. Notary makes use of timestamping on publishing so that consumers can know that they are receiving the most up to date content. This is particularly important when dealing with software update where old vulnerable versions could be used to attack users.
 * **Configurable Trust Thresholds**: Oftentimes there are a large number of publishers that are allowed to publish a particular piece of content. For example, open source projects where there are a number of core maintainers. Trust thresholds can be used so that content consumers require a configurable number of signatures on a piece of content in order to trust it. Using thresholds increases security so that loss of individual signing keys doesn't allow publishing of malicious content.
 * **Signing Delegation**: To allow for flexible publishing of trusted collections, a content publisher can delegate part of their collection to another signer. This delegation is represented as signed metadata so that a consumer of the content can verify both the content and the delegation.
 * **Use of Existing Distribution**: Notary's trust guarantees are not tied at all to particular distribution channels from which content is delivered. Therefore, trust can be added to any existing content delivery mechanism.
@@ -55,7 +55,7 @@ Any security vulnerabilities can be reported to security@docker.com.
 # Getting started with the Notary CLI
 
 Get the Notary Client CLI binary from [the official releases page](https://github.com/theupdateframework/notary/releases) or you can [build one yourself](#building-notary).
-The version of Notary server and signer should be greater than or equal to Notary CLI's version to ensure feature compatibility (ex: CLI version 0.2, server/signer version >= 0.2), and all official releases are associated with GitHub tags.
+The version of the Notary server and signer should be greater than or equal to Notary CLI's version to ensure feature compatibility (ex: CLI version 0.2, server/signer version >= 0.2), and all official releases are associated with GitHub tags.
 
 To use the Notary CLI with Docker hub images, have a look at Notary's
 [getting started docs](docs/getting_started.md).
@@ -68,7 +68,7 @@ To use the CLI against a local Notary server rather than against Docker Hub:
 1. Ensure that you have [docker and docker-compose](http://docs.docker.com/compose/install/) installed.
 1. `git clone https://github.com/theupdateframework/notary.git` and from the cloned repository path,
     start up a local Notary server and signer and copy the config file and testing certs to your
-    local notary config directory:
+    local Notary config directory:
 
     ```sh
     $ docker-compose build

--- a/vendor/github.com/theupdateframework/notary/client/changelist/change.go
+++ b/vendor/github.com/theupdateframework/notary/client/changelist/change.go
@@ -82,8 +82,8 @@ func (c TUFChange) Content() []byte {
 // unexpected race conditions between humans modifying the same delegation
 type TUFDelegation struct {
 	NewName       data.RoleName `json:"new_name,omitempty"`
-	NewThreshold  int           `json:"threshold, omitempty"`
-	AddKeys       data.KeyList  `json:"add_keys, omitempty"`
+	NewThreshold  int           `json:"threshold,omitempty"`
+	AddKeys       data.KeyList  `json:"add_keys,omitempty"`
 	RemoveKeys    []string      `json:"remove_keys,omitempty"`
 	AddPaths      []string      `json:"add_paths,omitempty"`
 	RemovePaths   []string      `json:"remove_paths,omitempty"`

--- a/vendor/github.com/theupdateframework/notary/fips.go
+++ b/vendor/github.com/theupdateframework/notary/fips.go
@@ -1,13 +1,14 @@
 package notary
 
-import "os"
+import (
+	"crypto"
+	// Need to import md5 so can test availability.
+	_ "crypto/md5"
+)
 
-// FIPSEnvVar is the name of the environment variable that is being used to switch
-// between FIPS and non-FIPS mode
-const FIPSEnvVar = "GOFIPS"
-
-// FIPSEnabled returns true if environment variable `GOFIPS` has been set to enable
-// FIPS mode
+// FIPSEnabled returns true if running in FIPS mode.
+// If compiled in FIPS mode the md5 hash function is never available
+// even when imported. This seems to be the best test we have for it.
 func FIPSEnabled() bool {
-	return os.Getenv(FIPSEnvVar) != ""
+	return !crypto.MD5.Available()
 }

--- a/vendor/github.com/theupdateframework/notary/vendor.conf
+++ b/vendor/github.com/theupdateframework/notary/vendor.conf
@@ -8,15 +8,14 @@ github.com/docker/distribution      edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 github.com/docker/go-connections    7395e3f8aa162843a74ed6d48e79627d9792ac55
 github.com/docker/go                d30aec9fd63c35133f8f79c3412ad91a3b08be06
-github.com/dvsekhvalnov/jose2go     6387d3c1f5abd8443b223577d5a7e0f4e0e5731f   # v1.2
+github.com/dvsekhvalnov/jose2go     f21a8cedbbae609f623613ec8f81125c243212e6   # v1.3
 github.com/go-sql-driver/mysql      a0583e0143b1624142adab07e0e97fe106d99561   # v1.3
-github.com/gorilla/mux              e444e69cbd2e2e3e0749a2f3c717cec491552bbf
+github.com/gorilla/mux              53c1911da2b537f792e7cafcb446b05ffe33b996   # v1.6.1
 github.com/jinzhu/gorm              5409931a1bb87e484d68d649af9367c207713ea2
 github.com/jinzhu/inflection        1c35d901db3da928c72a72d8458480cc9ade058f
 github.com/lib/pq                   0dad96c0b94f8dee039aa40467f767467392a0af
-github.com/mattn/go-sqlite3         b4142c444a8941d0d92b0b7103a24df9cd815e42   # v1.0.0
+github.com/mattn/go-sqlite3         6c771bb9887719704b210e87e934f08be014bdb1   # v1.6.0
 github.com/miekg/pkcs11             5f6e0d0dad6f472df908c8e968a98ef00c9224bb
-github.com/mitchellh/go-homedir     df55a15e5ce646808815381b3db47a8c66ea62f4
 github.com/prometheus/client_golang 449ccefff16c8e2b7229f6be1921ba22f62461fe
 github.com/prometheus/client_model  fa8ad6fec33561be4280a8f0514318c79d7f6cb6   # model-0.0.2-12-gfa8ad6f
 github.com/prometheus/procfs	    b1afdc266f54247f5dc725544f5d351a8661f502
@@ -32,9 +31,9 @@ github.com/pkg/errors 		    839d9e913e063e28dfd0e6c7b7512793e0a48be9
 
 github.com/spf13/pflag		    e57e3eeb33f795204c1ca35f56c44f83227c6e66  # v1.0.0
 github.com/spf13/cast		    4d07383ffe94b5e5a6fa3af9211374a4507a0184
-gopkg.in/yaml.v2 		    bef53efd0c76e49e6de55ead051f886bea7e9420
+gopkg.in/yaml.v2 		    5420a8b6744d3b0345ab293f6fcba19c978f1183  # v2.2.1
 gopkg.in/fatih/pool.v2		    cba550ebf9bce999a02e963296d4bc7a486cb715
-github.com/gorilla/context	    14f550f51af52180c2eefed15e5fd18d63c0a64a
+github.com/gorilla/context	    14f550f51af52180c2eefed15e5fd18d63c0a64a  # unused
 github.com/spf13/jwalterweatherman  3d60171a64319ef63c78bd45bd60e6eab1e75f8b
 github.com/mitchellh/mapstructure   2caf8efc93669b6c43e0441cdc6aed17546c96f3
 github.com/magiconair/properties    624009598839a9432bd97bb75552389422357723  # v1.5.3
@@ -55,5 +54,6 @@ github.com/cenk/backoff             32cd0c5b3aef12c76ed64aaf678f6c79736be7dc  # 
 
 # Testing requirements
 github.com/stretchr/testify                     089c7181b8c728499929ff09b62d3fdd8df8adff
-github.com/cloudflare/cfssl                     7fb22c8cba7ecaf98e4082d22d65800cf45e042a
-github.com/google/certificate-transparency      0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341
+github.com/cloudflare/cfssl                     4e2dcbde500472449917533851bf4bae9bdff562 # v1.3.1
+github.com/google/certificate-transparency-go   5ab67e519c93568ac3ee50fd6772a5bcf8aa460d
+github.com/gogo/protobuf                        1adfc126b41513cc696b209667c8656ea7aac67c # v1.0.0


### PR DESCRIPTION
Minor update. Also removed testify dependency which was unused.

![seal-2243104_960_720](https://user-images.githubusercontent.com/482364/38618953-f304f058-3d92-11e8-9652-267548663514.jpg)
