### PR TITLE
Fixing issue |No stack in docker help command"

### DIFF
--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -14,9 +14,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
-			"kubernetes": "",
-			"swarm":      "",
-			"version":    "1.25",
+			"version": "1.25",
 		},
 	}
 	cmd.AddCommand(


### PR DESCRIPTION
The issue on docker/for-linux: https://github.com/docker/for-linux/issues/278

**- What I did**
I just removed annotations on the command. These were always hiding the command, whatever was the enabled orchestrator, as these annotations are mutual exclusive.

Now the stack command is always showed, even if swarm is not enabled (as services, nodes, ...).

It's a partial revert of https://github.com/docker/cli/pull/804 .  

**- How to verify it**
```
$ DOCKER_ORCHESTRATOR=swarm docker --help

Usage:  docker COMMAND
...
Management Commands:
...
  stack       Manage Docker stacks
...

# Same with kubernetes
$ DOCKER_ORCHESTRATOR=kubernetes docker --help
...
  stack       Manage Docker stacks
...
```

**- Description for the changelog**
- Fix issue "No stack in docker help command"

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/38666708-dc8ce6e8-3e3f-11e8-8281-6f26f650a98b.png)
