### PR TITLE
Fix typo in versionTemplate: missing a tab in front of {{.BuildTime}}

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -25,7 +25,7 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  API version:	{{.APIVersion}}{{if ne .APIVersion .DefaultAPIVersion}} (downgraded from {{.DefaultAPIVersion}}){{end}}
  Go version:	{{.GoVersion}}
  Git commit:	{{.GitCommit}}
- Built:	{{.BuildTime}}
+ Built:		{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
  Experimental:	{{.Experimental}}
  Orchestrator:	{{.Orchestrator}}


### PR DESCRIPTION
**- What I did**
Align BuiltTime text correctly from the output of `docker version`

**- How I did it**
It missed a tab in front of {{.BuildTime}} since v17.12.0-ce.
So I add it.

**- How to verify it**
Type `docker version` command in the terminal and you will see a perfect alignment displayed on the screen.


