### PR TITLE
Add bash completion for `secret|config create --template-driver`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1220,14 +1220,18 @@ _docker_config_create() {
 		--label|-l)
 			return
 			;;
+		--template-driver)
+			COMPREPLY=( $( compgen -W "golang" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --label -l" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --label -l --template-driver" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--label|-l')
+			local counter=$(__docker_pos_first_nonflag '--label|-l|--template-driver')
 			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi
@@ -4238,14 +4242,18 @@ _docker_secret_create() {
 		--driver|-d|--label|-l)
 			return
 			;;
+		--template-driver)
+			COMPREPLY=( $( compgen -W "golang" -- "$cur" ) )
+			return
+			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--driver -d --help --label -l" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--driver -d --help --label -l --template-driver" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--driver|-d|--label|-l')
+			local counter=$(__docker_pos_first_nonflag '--driver|-d|--label|-l|--template-driver')
 			if [ "$cword" -eq "$((counter + 1))" ]; then
 				_filedir
 			fi


### PR DESCRIPTION
This adds bash completion for #896.
According to https://github.com/moby/moby/pull/33702, there is only one supported driver (_golang_), so I hard-coded support for it.