### PR TITLE
908 - Adding configs/secrets to service inspect pretty

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -97,6 +97,18 @@ Mounts:
    ReadOnly = {{ $mount.ReadOnly }}
    Type = {{ $mount.Type }}
 {{- end -}}
+{{- if .Configs}}
+Configs:
+{{- range $config := .Configs }}
+ Target:	{{$config.File.Name}}
+  Source:	{{$config.ConfigName}}
+{{- end }}{{ end }}
+{{- if .Secrets }}
+Secrets:
+{{- range $secret := .Secrets }}
+ Target:	{{$secret.File.Name}}
+  Source:	{{$secret.SecretName}}
+{{- end }}{{ end }}
 {{- if .HasResources }}
 Resources:
 {{- if .HasResourceReservations }}
@@ -198,6 +210,14 @@ func (ctx *serviceInspectContext) Name() string {
 
 func (ctx *serviceInspectContext) Labels() map[string]string {
 	return ctx.Service.Spec.Labels
+}
+
+func (ctx *serviceInspectContext) Configs() []*swarm.ConfigReference {
+	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Configs
+}
+
+func (ctx *serviceInspectContext) Secrets() []*swarm.SecretReference {
+	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Secrets
 }
 
 func (ctx *serviceInspectContext) IsModeGlobal() bool {

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -44,6 +44,18 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 			TaskTemplate: swarm.TaskSpec{
 				ContainerSpec: &swarm.ContainerSpec{
 					Image: "foo/bar@sha256:this_is_a_test",
+					Configs: []*swarm.ConfigReference{
+						{
+							ConfigID:   "mtc3i44r1awdoziy2iceg73z8",
+							ConfigName: "configtest.conf",
+						},
+					},
+					Secrets: []*swarm.SecretReference{
+						{
+							SecretID:   "3hv39ehbbb4hdozo7spod9ftn",
+							SecretName: "secrettest.conf",
+						},
+					},
 				},
 				Networks: []swarm.NetworkAttachmentConfig{
 					{

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -48,12 +48,18 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 						{
 							ConfigID:   "mtc3i44r1awdoziy2iceg73z8",
 							ConfigName: "configtest.conf",
+							File: &swarm.ConfigReferenceFileTarget{
+								Name: "/configtest.conf",
+							},
 						},
 					},
 					Secrets: []*swarm.SecretReference{
 						{
 							SecretID:   "3hv39ehbbb4hdozo7spod9ftn",
 							SecretName: "secrettest.conf",
+							File: &swarm.SecretReferenceFileTarget{
+								Name: "/secrettest.conf",
+							},
 						},
 					},
 				},
@@ -144,4 +150,11 @@ func TestJSONFormatWithNoUpdateConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Check(t, is.DeepEqual(m1, m2))
+}
+
+func TestPrettyPrintWithConfigsAndSecrets(t *testing.T) {
+	s := formatServiceInspect(t, formatter.NewServiceFormat("pretty"), time.Now())
+
+	assert.Check(t, is.Contains(s, "Configs:"), "Pretty print missing configs")
+	assert.Check(t, is.Contains(s, "Secrets:"), "Pretty print missing secrets")
 }


### PR DESCRIPTION
Signed-off-by: Essam A. Hassan <es.hassan187@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Resolving #908 showing info about configs/secrets in docker service inspect --pretty version


**- How I did it**
1- methods to get configs and secrets
2- adding configs/secrets to the template if they exists

**- How to verify it**

 `docker config create configtest.conf`

`docker secret create secrettest.conf`

```bash
    docker service create -d \
    --config source=foo.conf,target=/foo.conf,uid=123,gid=456 \
    --secret source=secret.conf,target=/secret.conf,uid=234,gid=567 \
    --replicas 1 \
    --name myservice \
    nginx:alpine
```
Output should be
```bash
ID:		v6hlue5d5g0yhethbsxwsuvgp #other id
Name:		myservice
Configs:
 Target:	/foo.conf
  Source:	foo.conf
Secrets:
 Target:	/secret.conf
  Source:	secret.conf
Service Mode:	Replicated
 Replicas:	1
Placement:
UpdateConfig:
 Parallelism:	1
 On failure:	pause
 Monitoring Period: 5s
 Max failure ratio: 0
 Update order:      stop-first
RollbackConfig:
 Parallelism:	1
 On failure:	pause
 Monitoring Period: 5s
 Max failure ratio: 0
 Rollback order:    stop-first
ContainerSpec:
 Image:		nginx:alpine@sha256:89f15d9cbad18d54fe49acc79b24199a05b4b1c48294ce4516393bdd2bc714b2
Resources:
Endpoint Mode:	vip

```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

adding configs/secrets to service inspect pretty
**- A picture of a cute animal (not mandatory but encouraged)**

Very important cat!
![A smart cat](https://i.pinimg.com/originals/38/ac/10/38ac10c472eeb2cae7ff2b22b61a762a.jpg)
