### PR TITLE
docs: Typofix in example "docker image ls"

### DIFF
--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -35,7 +35,7 @@ bzip2, or xz) from a file or STDIN. It restores both images and tags.
 ## Examples
 
 ```bash
-$ docker docker image ls
+$ docker image ls
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 


### PR DESCRIPTION
**- What I did**
Remove the double "docker docker" from example
