### PR TITLE
Allow `docker push` to push multiple tags

### DIFF
--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -22,7 +22,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 		{
 			name:          "wrong-args",
 			args:          []string{},
-			expectedError: "requires exactly 1 argument.",
+			expectedError: "requires at least 1 argument.",
 		},
 		{
 			name:          "invalid-name",


### PR DESCRIPTION
**- What I did**

Changed `docker push` to push multiple image tags in parallel. Feature request for #267 , partially implemented and abandoned in #458. More discussion about this in moby/moby#7336, moby/moby#11682, moby/moby#16106, and related, moby/moby#23383. 

There seem to be further improvements that can be made here, especially with regard to caching. These are mostly performance improvements I think though... so IMO it is worth getting this or similar into the mainline, since it seems like it would get good use. We should decide what exact cli interface we want here. 
 
**- How I did it**

Changed docker push to allow more than one argument. 

**- How to verify it**

`docker push name_a:tag_1 name_b:tag_2`

**- Description for the changelog**

`ability to push multiple docker images with docker push`

**- A picture of a cute animal (not mandatory but encouraged)**
![red_panda](https://user-images.githubusercontent.com/6983492/39170004-bd261136-474e-11e8-989a-70243d910e41.jpg)

