### PR TITLE
specify specific permissions

### DIFF
--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -102,7 +102,7 @@ func getHTTPTransport(authConfig authtypes.AuthConfig, endpoint registry.APIEndp
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, passThruTokenHandler))
 	} else {
 		creds := registry.NewStaticCredentialStore(&authConfig)
-		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "*")
+		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "push", "pull")
 		basicHandler := auth.NewBasicHandler(creds)
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
 	}


### PR DESCRIPTION
When creating manifest lists, don't use "*" as the permission when
creating the token handler. This causes problems with gitlab's repos.

Fixes https://github.com/docker/cli/issues/1010

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

