### PR TITLE
Add exec_die to the list of known container events

### DIFF
--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -48,6 +48,7 @@ Docker containers report the following events:
 - `die`
 - `exec_create`
 - `exec_detach`
+- `exec_die`
 - `exec_start`
 - `export`
 - `health_status`


### PR DESCRIPTION
Closes #1027 

**- What I did**
This PR should apply that intended patch of https://github.com/docker/docker.github.io/pull/6580 in the correct git repo.

All this does is add `exec_die` to the list of known container events. Since this event is introduced last december in https://github.com/moby/moby/pull/35744 . 

**- How I did it**


**- How to verify it**
After rebuilding the docs, you should see `exec_die` listed below exec_detach in the container events.

**- Description for the changelog**
Added exec_die to the list of known container events


**- A picture of a cute animal (not mandatory but encouraged)**
![unnamed](https://user-images.githubusercontent.com/3368018/39406980-84f27d20-4bbf-11e8-8cc8-7123423bc8d9.jpg)

