### PR TITLE
Fix file path comparison on Windows in tests

### DIFF
--- a/cli/command/image/build/context_test.go
+++ b/cli/command/image/build/context_test.go
@@ -243,6 +243,8 @@ func TestValidateContextDirectoryWithOneFileExcludes(t *testing.T) {
 func createTestTempDir(t *testing.T, dir, prefix string) (string, func()) {
 	path, err := ioutil.TempDir(dir, prefix)
 	assert.NilError(t, err)
+	path, err = filepath.EvalSymlinks(path)
+	assert.NilError(t, err)
 	return path, func() { assert.NilError(t, os.RemoveAll(path)) }
 }
 


### PR DESCRIPTION
**- What I did**

Fixed the following tests failing on Windows :
```
PS C:\dev\src\github.com\docker\cli> .\scripts\make.ps1 -TestUnit
INFO: make.ps1 starting at 04/30/2018 16:48:51
INFO: Building...
INFO: Running unit tests...
(…)
--- FAIL: TestGetContextFromLocalDirWithNoDirectory (0.02s)
        context_test.go:83: assertion failed: C:\Users\MATHIE~1\AppData\Local\Temp\builder-context-test506175288 (contextDir string) != C:\Users\Mathieu Champlon\AppData\Local\Temp\builder-context-test506175288 (absContextDir string)
--- FAIL: TestGetContextFromLocalDirWithDockerfile (0.02s)
        context_test.go:96: assertion failed: C:\Users\MATHIE~1\AppData\Local\Temp\builder-context-test204207927 (contextDir string) != C:\Users\Mathieu Champlon\AppData\Local\Temp\builder-context-test204207927 (absContextDir string)
--- FAIL: TestGetContextFromLocalDirWithCustomDockerfile (0.03s)
        context_test.go:134: assertion failed: C:\Users\MATHIE~1\AppData\Local\Temp\builder-context-test377694849 (contextDir string) != C:\Users\Mathieu Champlon\AppData\Local\Temp\builder-context-test377694849 (absContextDir string)
(…)
FAIL    github.com/docker/cli/cli/command/image/build   0.765s
```

**- How I did it**

Calling filepath.EvalSymlinks on ```C:\Users\MATHIE~1``` resolves it to ```C:\Users\Mathieu Champlon```.

**- How to verify it**
```
PS C:\dev\src\github.com\docker\cli> .\scripts\make.ps1 -TestUnit
(…)
ok      github.com/docker/cli/cli/command/image/build   0.499s  coverage: 43.8% of statements
(…)
```
**- Description for the changelog**

n/a

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2386884/39435941-f29b1296-4c9c-11e8-9d33-d2016bcfd1ea.png)
