### PR TITLE
use : instead of = in mounts service pretty inspect

### DIFF
--- a/cli/command/formatter/service.go
+++ b/cli/command/formatter/service.go
@@ -92,10 +92,10 @@ ContainerSpec:
 Mounts:
 {{- end }}
 {{- range $mount := .ContainerMounts }}
-  Target = {{ $mount.Target }}
-   Source = {{ $mount.Source }}
-   ReadOnly = {{ $mount.ReadOnly }}
-   Type = {{ $mount.Type }}
+ Target:	{{ $mount.Target }}
+  Source:	{{ $mount.Source }}
+  ReadOnly:	{{ $mount.ReadOnly }}
+  Type:		{{ $mount.Type }}
 {{- end -}}
 {{- if .Configs}}
 Configs:


### PR DESCRIPTION
Signed-off-by: Essam A. Hassan <es.hassan187@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Very trivial change for #1036 . I changed pretty print output from using equals to colons when printing mounts

**- How I did it**
Just modifying the pretty print template

**- How to verify it**
`docker inspect service [anyservicewithmounts] --pretty`

**- Description for the changelog**
use colons instead of equals in mounts service pretty inspect

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![husky](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSGlNtpGQ4xZvY5nJiXD9WfTtsPdgBWqMohacKRLtZlCcLx4Ziu)