### PR TITLE
Switch from x/net/context to context

### DIFF
--- a/cli/command/checkpoint/client_test.go
+++ b/cli/command/checkpoint/client_test.go
@@ -1,9 +1,10 @@
 package checkpoint
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/checkpoint/create.go
+++ b/cli/command/checkpoint/create.go
@@ -1,9 +1,8 @@
 package checkpoint
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/checkpoint/list.go
+++ b/cli/command/checkpoint/list.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/checkpoint/remove.go
+++ b/cli/command/checkpoint/remove.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -28,7 +29,6 @@ import (
 	"github.com/theupdateframework/notary"
 	notaryclient "github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/passphrase"
-	"golang.org/x/net/context"
 )
 
 // Streams is an interface which exposes the standard input and output streams

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"context"
 	"crypto/x509"
 	"os"
 	"runtime"
@@ -17,7 +18,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/env"
 	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNewAPIClientFromFlags(t *testing.T) {

--- a/cli/command/config/client_test.go
+++ b/cli/command/config/client_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/config/ls.go
+++ b/cli/command/config/ls.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"vbom.ml/util/sortorder"
 )
 

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type removeOptions struct {

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http/httputil"
@@ -14,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type attachOptions struct {

--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -1,13 +1,13 @@
 package container
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type commitOptions struct {

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type copyOptions struct {

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -1,12 +1,13 @@
 package container
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type diffOptions struct {

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type execOptions struct {

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func withDefaultOpts(options execOptions) execOptions {

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -1,13 +1,13 @@
 package container
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type exportOptions struct {

--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"runtime"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // The default escape key sequence: ctrl-p, ctrl-q

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -1,11 +1,12 @@
 package container
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type killOptions struct {

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"io/ioutil"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type psOptions struct {

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type logsOptions struct {

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pauseOptions struct {

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type portOptions struct {

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type renameOptions struct {

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type restartOptions struct {

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type rmOptions struct {

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http/httputil"
@@ -21,7 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 type runOptions struct {

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -157,6 +157,7 @@ func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptio
 	}
 
 	ctx, cancelFun := context.WithCancel(context.Background())
+	defer cancelFun()
 
 	createResponse, err := createContainer(ctx, dockerCli, containerConfig, &opts.createOptions)
 	if err != nil {

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -55,6 +55,7 @@ func NewStartCommand(dockerCli command.Cli) *cobra.Command {
 // nolint: gocyclo
 func runStart(dockerCli command.Cli, opts *startOptions) error {
 	ctx, cancelFun := context.WithCancel(context.Background())
+	defer cancelFun()
 
 	if opts.attach || opts.openStdin {
 		// We're going to attach to a container.

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http/httputil"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type startOptions struct {

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type statsOptions struct {

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type stats struct {

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type stopOptions struct {

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"text/tabwriter"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type topOptions struct {

--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"os"
 	gosignal "os/signal"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // resizeTtyTo resizes tty to specific height and width

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type unpauseOptions struct {

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type updateOptions struct {

--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/docker/cli/cli/command"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 func waitExitOrRemoved(ctx context.Context, dockerCli command.Cli, containerID string, waitRemove bool) <-chan int {

--- a/cli/command/container/utils_test.go
+++ b/cli/command/container/utils_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func waitFn(cid string) (<-chan container.ContainerWaitOKBody, <-chan error) {

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type waitOptions struct {

--- a/cli/command/idresolver/client_test.go
+++ b/cli/command/idresolver/client_test.go
@@ -1,10 +1,11 @@
 package idresolver
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/idresolver/idresolver.go
+++ b/cli/command/idresolver/idresolver.go
@@ -1,7 +1,7 @@
 package idresolver
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"

--- a/cli/command/idresolver/idresolver_test.go
+++ b/cli/command/idresolver/idresolver_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	// Import builders to get the builder function as package function
+	"context"
+
 	. "github.com/docker/cli/internal/test/builders"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestResolveError(t *testing.T) {

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type buildOptions struct {

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,7 +20,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/fs"
 	"github.com/gotestyourself/gotestyourself/skip"
-	"golang.org/x/net/context"
 )
 
 func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {

--- a/cli/command/image/client_test.go
+++ b/cli/command/image/client_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type importOptions struct {

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -1,13 +1,14 @@
 package image
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type imagesOptions struct {

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -1,9 +1,8 @@
 package image
 
 import (
+	"context"
 	"io"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -1,9 +1,8 @@
 package image
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // PullOptions defines what and how to pull

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -1,10 +1,9 @@
 package image
 
 import (
+	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type saveOptions struct {

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -19,7 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
-	"golang.org/x/net/context"
 )
 
 type target struct {

--- a/cli/command/manifest/client_test.go
+++ b/cli/command/manifest/client_test.go
@@ -1,12 +1,13 @@
 package manifest
 
 import (
+	"context"
+
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/cli/cli/registry/client"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
-	"golang.org/x/net/context"
 )
 
 type fakeRegistryClient struct {

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type createOpts struct {

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestManifestCreateErrors(t *testing.T) {

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -17,7 +18,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/golden"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func newTempManifestStore(t *testing.T) (store.Store, func()) {

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pushOpts struct {

--- a/cli/command/manifest/push_test.go
+++ b/cli/command/manifest/push_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func newFakeRegistryClient() *fakeRegistryClient {

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -1,11 +1,12 @@
 package manifest
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/reference"
-	"golang.org/x/net/context"
 )
 
 type osArch struct {

--- a/cli/command/network/client_test.go
+++ b/cli/command/network/client_test.go
@@ -1,10 +1,11 @@
 package network
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -1,12 +1,13 @@
 package network
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/network"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type connectOptions struct {

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkConnectErrors(t *testing.T) {

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkCreateErrors(t *testing.T) {

--- a/cli/command/network/disconnect.go
+++ b/cli/command/network/disconnect.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -1,13 +1,13 @@
 package network
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkDisconnectErrors(t *testing.T) {

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -1,7 +1,7 @@
 package network
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type byNetworkName []types.NetworkResource

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/golden"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestNetworkListErrors(t *testing.T) {

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -1,13 +1,13 @@
 package network
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -1,9 +1,8 @@
 package network
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/node/client_test.go
+++ b/cli/command/node/client_test.go
@@ -1,10 +1,11 @@
 package node
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	apiclient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // NewNodeCommand returns a cobra command for `node` subcommands

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"vbom.ml/util/sortorder"
 )
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type psOptions struct {

--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -1,10 +1,9 @@
 package node
 
 import (
+	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/cli/command/plugin/client_test.go
+++ b/cli/command/plugin/client_test.go
@@ -1,11 +1,11 @@
 package plugin
 
 import (
+	"context"
 	"io"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // validateTag checks if the given repoName can be resolved.

--- a/cli/command/plugin/disable.go
+++ b/cli/command/plugin/disable.go
@@ -1,13 +1,13 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 func newDisableCommand(dockerCli command.Cli) *cobra.Command {

--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type enableOpts struct {

--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -1,11 +1,12 @@
 package plugin
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 type pluginOptions struct {

--- a/cli/command/plugin/list.go
+++ b/cli/command/plugin/list.go
@@ -1,12 +1,13 @@
 package plugin
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type listOptions struct {

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/plugin/remove.go
+++ b/cli/command/plugin/remove.go
@@ -1,13 +1,13 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type rmOptions struct {

--- a/cli/command/plugin/set.go
+++ b/cli/command/plugin/set.go
@@ -1,7 +1,7 @@
 package plugin
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ElectAuthServer returns the default registry to use (by asking the daemon)

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -1,11 +1,10 @@
 package registry
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/gotestyourself/gotestyourself/fs"
-	"golang.org/x/net/context"
 )
 
 const userErr = "userunknownError"

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -1,9 +1,8 @@
 package registry
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -11,7 +12,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type searchOptions struct {

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -2,13 +2,13 @@ package command_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
 	// Prevents a circular import with "github.com/docker/cli/internal/test"
 

--- a/cli/command/secret/client_test.go
+++ b/cli/command/secret/client_test.go
@@ -1,10 +1,11 @@
 package secret
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	"vbom.ml/util/sortorder"
 )
 

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type removeOptions struct {

--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -1,10 +1,11 @@
 package service
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 	// Import builders to get the builder function as package function
 	. "github.com/docker/cli/internal/test/builders"
 )

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 func newCreateCommand(dockerCli command.Cli) *cobra.Command {

--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -1,13 +1,13 @@
 package service
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service/progress"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"golang.org/x/net/context"
 )
 
 // waitOnService waits for the service to converge. It outputs a progress bar,

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -1,9 +1,8 @@
 package service
 
 import (
+	"context"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type listOptions struct {

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/gotestyourself/gotestyourself/golden"
-	"golang.org/x/net/context"
 )
 
 func TestServiceListOrder(t *testing.T) {

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -2,13 +2,12 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"sort"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -18,7 +19,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 type int64Value interface {

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -1,12 +1,13 @@
 package service
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // ParseSecrets retrieves the secrets with the requested names and fills

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -1,6 +1,7 @@
 package progress
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type psOptions struct {

--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestCreateFilter(t *testing.T) {

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 func newRemoveCommand(dockerCli command.Cli) *cobra.Command {

--- a/cli/command/service/rollback_test.go
+++ b/cli/command/service/rollback_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestRollback(t *testing.T) {

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -1,11 +1,10 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/service/trust.go
+++ b/cli/command/service/trust.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/hex"
 
 	"github.com/docker/cli/cli/command"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary/tuf/data"
-	"golang.org/x/net/context"
 )
 
 func resolveServiceImageDigestContentTrust(dockerCli command.Cli, service *swarm.ServiceSpec) error {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 func newUpdateCommand(dockerCli command.Cli) *cobra.Command {

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestUpdateServiceArgs(t *testing.T) {

--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/cli/cli/compose/convert"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/stack/swarm/client_test.go
+++ b/cli/command/stack/swarm/client_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"strings"
 
 	"github.com/docker/cli/cli/compose/convert"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/stack/swarm/common.go
+++ b/cli/command/stack/swarm/common.go
@@ -1,13 +1,14 @@
 package swarm
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 func getStackFilter(namespace string) filters.Args {

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // Resolve image constants

--- a/cli/command/stack/swarm/deploy_bundlefile.go
+++ b/cli/command/stack/swarm/deploy_bundlefile.go
@@ -1,11 +1,10 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/bundlefile"

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
@@ -14,7 +15,6 @@ import (
 	apiclient "github.com/docker/docker/client"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func deployCompose(ctx context.Context, dockerCli command.Cli, opts options.Deploy) error {

--- a/cli/command/stack/swarm/deploy_composefile_test.go
+++ b/cli/command/stack/swarm/deploy_composefile_test.go
@@ -1,13 +1,13 @@
 package swarm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/cli/internal/test/network"
 	"github.com/docker/docker/api/types"
 	"github.com/gotestyourself/gotestyourself/assert"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type notFound struct {

--- a/cli/command/stack/swarm/deploy_test.go
+++ b/cli/command/stack/swarm/deploy_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/cli/cli/compose/convert"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
-	"golang.org/x/net/context"
 )
 
 func TestPruneServices(t *testing.T) {

--- a/cli/command/stack/swarm/list.go
+++ b/cli/command/stack/swarm/list.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli/command"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"vbom.ml/util/sortorder"
 )
 

--- a/cli/command/stack/swarm/ps.go
+++ b/cli/command/stack/swarm/ps.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/task"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 // RunPS is the swarm implementation of docker stack ps

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // RunRemove is the swarm implementation of docker stack remove

--- a/cli/command/stack/swarm/services.go
+++ b/cli/command/stack/swarm/services.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"golang.org/x/net/context"
 )
 
 // RunServices is the swarm implementation of docker stack services

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 )
 
 type caOptions struct {

--- a/cli/command/swarm/client_test.go
+++ b/cli/command/swarm/client_test.go
@@ -1,10 +1,11 @@
 package swarm
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -1,10 +1,9 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -1,10 +1,9 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type joinTokenOptions struct {

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -1,9 +1,8 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/swarm/progress/root_rotation.go
+++ b/cli/command/swarm/progress/root_rotation.go
@@ -2,12 +2,11 @@ package progress
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"os/signal"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/context"
 )
 
 func newUnlockCommand(dockerCli command.Cli) *cobra.Command {

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type unlockKeyOptions struct {

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -1,9 +1,8 @@
 package swarm
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"

--- a/cli/command/system/client_test.go
+++ b/cli/command/system/client_test.go
@@ -1,9 +1,10 @@
 package system
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -1,13 +1,13 @@
 package system
 
 import (
+	"context"
 	"errors"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type diskUsageOptions struct {

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/docker/api/types"
 	eventtypes "github.com/docker/docker/api/types/events"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type eventsOptions struct {

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type infoOptions struct {

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -11,7 +12,6 @@ import (
 	apiclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"text/template"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sort"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 	kubernetesClient "k8s.io/client-go/kubernetes"
 )
 

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"golang.org/x/net/context"
 )
 
 func TestVersionWithoutServer(t *testing.T) {

--- a/cli/command/task/client_test.go
+++ b/cli/command/task/client_test.go
@@ -1,10 +1,11 @@
 package task
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/task/print.go
+++ b/cli/command/task/print.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/api/types/swarm"
-	"golang.org/x/net/context"
 )
 
 type tasksBySlot []swarm.Task

--- a/cli/command/task/print_test.go
+++ b/cli/command/task/print_test.go
@@ -1,13 +1,13 @@
 package task
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/internal/test"
-	"golang.org/x/net/context"
 	// Import builders to get the builder function as package function
 	. "github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"

--- a/cli/command/volume/client_test.go
+++ b/cli/command/volume/client_test.go
@@ -1,11 +1,12 @@
 package volume
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
 )
 
 type fakeClient struct {

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -9,7 +10,6 @@ import (
 	volumetypes "github.com/docker/docker/api/types/volume"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type createOptions struct {

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -1,11 +1,12 @@
 package volume
 
 import (
+	"context"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type byVolumeName []*types.Volume

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type pruneOptions struct {

--- a/cli/command/volume/remove.go
+++ b/cli/command/volume/remove.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 type removeOptions struct {

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"context"
 	"os"
 	"sort"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 func TestConvertRestartPolicyFromNone(t *testing.T) {

--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // RegistryClient is a client used to communicate with a Docker distribution

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli/manifest/types"
@@ -15,7 +16,6 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // fetchManifest pulls a manifest from a registry and returns it. An error

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -31,7 +32,6 @@ import (
 	"github.com/theupdateframework/notary/trustpinning"
 	"github.com/theupdateframework/notary/tuf/data"
 	"github.com/theupdateframework/notary/tuf/signed"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/internal/test/network/client.go
+++ b/internal/test/network/client.go
@@ -1,10 +1,11 @@
 package network
 
 import (
+	"context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
-	"golang.org/x/net/context"
 )
 
 // FakeClient is a fake NetworkAPIClient


### PR DESCRIPTION
Since go 1.7, "context" is a standard package. Since go 1.9, x/net/context merely provides some types aliased to those in the standard context package, so there is no functional change.

The changes were performed by the following script:
```sh
for f in $(git ls-files \*.go | grep -v ^vendor/); do
	sed -i 's|golang.org/x/net/context|context|' $f
       	goimports -w $f
	awk '/^$/ {e=1; next;}
		/\t"context"$/ {e=0;}
		{if (e) {print ""; e=0}; print;}' < $f > $f.new && \
			mv $f.new $f
	goimports -w $f
done
```

Similar PRs:
* https://github.com/docker/libnetwork/pull/2140
* https://github.com/containerd/containerd/pull/2305
* https://github.com/moby/moby/pull/36904