### PR TITLE
Use filepath.Base instead of path.Base

### DIFF
--- a/cli/command/stack/kubernetes/stack.go
+++ b/cli/command/stack/kubernetes/stack.go
@@ -2,7 +2,7 @@ package kubernetes
 
 import (
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"sort"
 
 	"github.com/docker/cli/kubernetes/compose/v1beta2"
@@ -36,7 +36,7 @@ func (s *stack) createFileBasedConfigMaps(configMaps corev1.ConfigMapInterface) 
 			continue
 		}
 
-		fileName := path.Base(config.File)
+		fileName := filepath.Base(config.File)
 		content, err := ioutil.ReadFile(config.File)
 		if err != nil {
 			return err
@@ -76,7 +76,7 @@ func (s *stack) createFileBasedSecrets(secrets corev1.SecretInterface) error {
 			continue
 		}
 
-		fileName := path.Base(secret.File)
+		fileName := filepath.Base(secret.File)
 		content, err := ioutil.ReadFile(secret.File)
 		if err != nil {
 			return err


### PR DESCRIPTION
**- What I did**

I fixed some path handling code in the Kubernetes ```docker stack``` integration.

This might be related to https://github.com/docker/cli/pull/966 in some way, however even with the changes contained in that PR the bug fixed here is still happening.

**- How I did it**

Changed a couple ```path.Abs``` to ```filepath.Abs```.

**- How to verify it**

With Docker on Windows with Kubernetes activated, apply the following change
```
diff --git a/e2e/stack/testdata/stack-with-named-resources.yml b/e2e/stack/testdata/stack-with-named-resources.yml
index f7a04b21..9835950a 100644
--- a/e2e/stack/testdata/stack-with-named-resources.yml
+++ b/e2e/stack/testdata/stack-with-named-resources.yml
@@ -4,7 +4,6 @@ services:
     image: registry:5000/alpine:3.6
     command: top
     networks: [network1, network2]
-    volumes: [volume1, volume2]
     secrets: [secret1, secret2]
     configs: [config1, config2]
```
as this won't work with Kubernetes (the test data come from the e2e tests running against Swarm).

Then without this PR
```
$ build/docker.exe stack deploy -c e2e/stack/testdata/stack-with-named-resources.yml test-stack-deploy-
with-names
ConfigMap "config1" is invalid: data[C:\dev\src\github.com\docker\cli\e2e\stack\testdata\data]: Invalid value: "C:\\dev\\src\\github.com\\docker\\cli\\e2e\\stack\\testdata\\data": a valid config key must consist of alphanumeric characters, '-', '_' or '.' (e.g. 'key.name',  or 'KEY_NAME',  or 'key-name', regex used for validation is '[-._a-zA-Z0-9]+')
```
whereas with this PR
```
$ build/docker.exe stack deploy -c e2e/stack/testdata/stack-with-named-resources.yml test-stack-deploy-
with-names
top-level network "network1" is ignored
top-level network "network2" is ignored
service "web": network "network2" is ignored
service "web": network "network1" is ignored
Waiting for the stack to be stable and running..
```

**- Description for the changelog**

Not sure if this is worth mentioning as this could be sneaked into https://github.com/docker/cli/pull/966…

* Fixed docker stack deploy on Kubernetes with compose file with relative paths in secrets and configs on Windows

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2386884/39705211-03309588-520e-11e8-918c-580352880cca.png)
