### PR TITLE
Fix issue #850, Warn user of filter when pruning

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -128,6 +128,10 @@ func confirmationMessage(options pruneOptions) string {
 	if options.pruneBuildCache {
 		warnings = append(warnings, "all build cache")
 	}
+	if len(options.filter.String()) > 0 {
+		warnings = append(warnings, "Elements to be pruned will be filtered with:")
+		warnings = append(warnings, "label="+options.filter.String())
+	}
 
 	var buffer bytes.Buffer
 	t.Execute(&buffer, &warnings)


### PR DESCRIPTION
Append a warning with which filter the elements will be pruned with if filter is set.
This is a fix for issue https://github.com/docker/cli/issues/850

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a message in prune warning if filter is applied.

**- How I did it**

I have checked the length of the string of the options.prune argument, and appended the warning along with the string value of that arguments supplied.

**- How to verify it**
docker system prune --filter=label=foo
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added warning to prune command when filter is applied.

**- A picture of a cute animal (not mandatory but encouraged)**
My icon :)
