### PR TITLE
Bump Golang to 1.10.2

### DIFF
--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.9.5-alpine3.6
+FROM    golang:1.10.2-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.9.5@sha256:4d090b8c2e6d369a48254c882a4e653ba90caaa0b758105da772d9110394d958
+FROM    dockercore/golang-cross:1.10.2@sha256:297fa4bc113facd7a528699919f86009420a6b5bedbdc89da35c14f7fee047e1
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.9.5-alpine3.6
+FROM    golang:1.10.2-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.9.5-alpine3.6
+FROM    golang:1.10.2-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Go 1.10 release notes: https://golang.org/doc/go1.10

Go 1.10: https://github.com/golang/go/issues?q=milestone%3AGo1.10
Go 1.10.1: https://github.com/golang/go/issues?q=milestone%3AGo1.10.1
Go 1.10.2: https://github.com/golang/go/issues?q=milestone%3AGo1.10.2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
* Update Go to 1.10.2 [docker/cli#1048](https://github.com/docker/cli/pull/1048)
```

**- A picture of a cute animal (not mandatory but encouraged)**

![wallpapers-computer-cute-butterfly](https://user-images.githubusercontent.com/1804568/39803676-fe33e1e2-5371-11e8-97d5-f9bb0df752f3.jpg)

source: [Wallpapers Computer Cute Butterfly](https://livewallpaperhd.com/wallpapers-computer-cute-butterfly-12388/)