### PR TITLE
Default path added to the docker build command

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -112,7 +112,11 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
 	flags.Var(&options.buildArgs, "build-arg", "Set build-time variables")
 	flags.Var(options.ulimits, "ulimit", "Ulimit options")
-	flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
+
+	if &options.dockerfileName == " " {
+		&options.dockerfileName = '.'
+	}
+
 	flags.VarP(&options.memory, "memory", "m", "Memory limit")
 	flags.Var(&options.memorySwap, "memory-swap", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
 	flags.Var(&options.shmSize, "shm-size", "Size of /dev/shm")

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -109,14 +109,15 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	
-
-	if &options.dockerfileName == string.TrimSpace(flags.Args()) {
-		&options.dockerfileName = '.'
-		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
-	}else {
+	if string.TrimSpace(flags.Args()) == "" {
+		&options.dockerfileName = "."
 		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	}
-	
+	else {
+		
+		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
+	}
+
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
 	flags.Var(&options.buildArgs, "build-arg", "Set build-time variables")

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -108,16 +108,14 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	
+
 	if string.TrimSpace(flags.Args()) == "" {
 		&options.dockerfileName = "."
 		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
-	}
-	else {
-		
+	} else {
+
 		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	}
-
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
 	flags.Var(&options.buildArgs, "build-arg", "Set build-time variables")

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -115,6 +115,8 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 
 	if &options.dockerfileName == " " {
 		&options.dockerfileName = '.'
+	}else{
+		flags.StringVarP(&options.dockerfileName, "file", "f", "", "Name of the Dockerfile (Default is 'PATH/Dockerfile')")
 	}
 
 	flags.VarP(&options.memory, "memory", "m", "Memory limit")


### PR DESCRIPTION
I added the default path parameter to docker build command if client wants the build Dockerfile at the current directory .  @hasanemrebeyy 

I change 115.line of code, added only one if statement.

Link at below.
 https://github.com/WoodProgrammer/cli/blob/master/cli/command/image/build.go 
