### PR TITLE
Fix service rollback options being cross-wired

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -645,7 +645,7 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 		},
 		Mode:           serviceMode,
 		UpdateConfig:   options.update.updateConfig(flags),
-		RollbackConfig: options.update.rollbackConfig(flags),
+		RollbackConfig: options.rollback.rollbackConfig(flags),
 		EndpointSpec:   options.endpoint.ToEndpointSpec(),
 	}
 


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/37027

The "update" and "rollback" configurations were cross-wired, as a result, setting
`--rollback-*` options would override the service's update-options.

Creating a service with both update, and rollback configuration:

```bash
docker service create \
  --name=test \
  --update-failure-action=pause \
  --update-max-failure-ratio=0.6 \
  --update-monitor=3s \
  --update-order=stop-first \
  --update-parallelism=3 \
  --rollback-failure-action=continue \
  --rollback-max-failure-ratio=0.5 \
  --rollback-monitor=4s \
  --rollback-order=start-first \
  --rollback-parallelism=2 \
  --tty \
  busybox
```

Before this change:

```bash
docker service inspect --format '[{{json .Spec.UpdateConfig}},{{json .Spec.RollbackConfig}}]' test
```

Produces:

```json
[
  {"Parallelism":3,"FailureAction":"pause","Monitor":3000000000,"MaxFailureRatio":0.6,"Order":"stop-first"},
  {"Parallelism":3,"FailureAction":"pause","Monitor":3000000000,"MaxFailureRatio":0.6,"Order":"stop-first"}
]
```

After this change:

```json
[
  {"Parallelism":3,"FailureAction":"pause","Monitor":3000000000,"MaxFailureRatio":0.6,"Order":"stop-first"},
  {"Parallelism":2,"FailureAction":"continue","Monitor":4000000000,"MaxFailureRatio":0.5,"Order":"start-first"}
]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix `--rollback-*` options overwriting `--update-*` options [docker/cli#1052](https://github.com/docker/cli/pull/1052)
