### PR TITLE
Make an error for an invalid orchestrator

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -166,7 +166,10 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "Experimental field")
 	}
-	orchestrator := GetOrchestrator(hasExperimental, opts.Common.Orchestrator, cli.configFile.Orchestrator)
+	orchestrator, err := GetOrchestrator(hasExperimental, opts.Common.Orchestrator, cli.configFile.Orchestrator)
+	if err != nil {
+		return err
+	}
 	cli.clientInfo = ClientInfo{
 		DefaultVersion:  cli.client.ClientVersion(),
 		HasExperimental: hasExperimental,


### PR DESCRIPTION
**- What I did**

I made an invalid specified orchestrator yield an error instead of being silently ignored.

**- How I did it**

I added checks and error handling.

**- How to verify it**

Before if
```
$ cat ~/.docker/config.json | grep orchestrator
  "orchestrator": "kubernetes",
```
then (notice the missing r in swarm)
```
$ docker --orchestrator=swam stack ls
NAME                SERVICES            ORCHESTRATOR        NAMESPACE
dtcccccc            5                   Kubernetes          default
```
the orchestrator flag value being invalid it falls back to the one defined in `~/.docker/config.json`.

Now it correctly fails with
```
$ docker --orchestrator=swam stack ls
specified orchestrator "swam" is invalid, please use either kubernetes or swarm
```

**- Description for the changelog**

An invalid orchestrator now generates an error instead of being silently ignored.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2386884/39932493-950838aa-5540-11e8-88ca-3bb72e5b4029.png)
