### PR TITLE
Kubernetes orchestrator all namespaces

### DIFF
--- a/cli/command/stack/kubernetes/list.go
+++ b/cli/command/stack/kubernetes/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/stack/options"
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/pkg/errors"
 	core_v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -19,9 +20,16 @@ import (
 // GetStacks lists the kubernetes stacks
 func GetStacks(kubeCli *KubeCli, opts options.List) ([]*formatter.Stack, error) {
 	if opts.AllNamespaces || len(opts.Namespaces) == 0 {
+		if isAllNamespacesDisabled(kubeCli.ConfigFile().Kubernetes) {
+			opts.AllNamespaces = true
+		}
 		return getStacksWithAllNamespaces(kubeCli, opts)
 	}
 	return getStacksWithNamespaces(kubeCli, opts, removeDuplicates(opts.Namespaces))
+}
+
+func isAllNamespacesDisabled(kubeCliConfig *configfile.KubernetesConfig) bool {
+	return kubeCliConfig == nil || kubeCliConfig != nil && kubeCliConfig.AllNamespaces != "disabled"
 }
 
 func getStacks(kubeCli *KubeCli, opts options.List) ([]*formatter.Stack, error) {

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -46,6 +46,7 @@ type ConfigFile struct {
 	Proxies              map[string]ProxyConfig      `json:"proxies,omitempty"`
 	Experimental         string                      `json:"experimental,omitempty"`
 	Orchestrator         string                      `json:"orchestrator,omitempty"`
+	Kubernetes           *KubernetesConfig           `json:"kubernetes,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings
@@ -54,6 +55,11 @@ type ProxyConfig struct {
 	HTTPSProxy string `json:"httpsProxy,omitempty"`
 	NoProxy    string `json:"noProxy,omitempty"`
 	FTPProxy   string `json:"ftpProxy,omitempty"`
+}
+
+// KubernetesConfig contains Kubernetes orchestrator settings
+type KubernetesConfig struct {
+	AllNamespaces string `json:"allNamespaces,omitempty"`
 }
 
 // New initializes an empty configuration file for the given filename 'fn'

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -55,8 +55,6 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&commonOpts.LogLevel, "log-level", "l", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
 	flags.BoolVar(&commonOpts.TLS, "tls", dockerTLS, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&commonOpts.TLSVerify, FlagTLSVerify, dockerTLSVerify, "Use TLS and verify the remote")
-	flags.StringVar(&commonOpts.Orchestrator, "orchestrator", "", "Orchestrator to use (swarm|kubernetes|all) (experimental)")
-	flags.SetAnnotation("orchestrator", "experimentalCLI", nil)
 
 	// TODO use flag flags.String("identity"}, "i", "", "Path to libtrust key file")
 

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -51,6 +51,11 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 	flags.StringVar(&opts.ConfigDir, "config", cliconfig.Dir(), "Location of client config files")
 	opts.Common.InstallFlags(flags)
 
+	// Install persistent flags
+	persistentFlags := cmd.PersistentFlags()
+	persistentFlags.StringVar(&opts.Common.Orchestrator, "orchestrator", "", "Orchestrator to use (swarm|kubernetes|all) (experimental)")
+	persistentFlags.SetAnnotation("orchestrator", "experimentalCLI", nil)
+
 	setFlagErrorFunc(dockerCli, cmd, flags, opts)
 
 	setHelpFunc(dockerCli, cmd, flags, opts)


### PR DESCRIPTION
**- What I did**

I made ```--orchestrator=all``` behave as if also ```--all-namespaces``` unless specific namespaces have been queried with ```--namespace```

**- How I did it**

Opts.AllNamespaces gets set to true if requesting for all orchestrators without `specifying` a namespace

**- Description for the changelog**

Setting `--orchestrator=all` also sets `--all-namespaces` unless specific `--namespace` are set.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2386884/39428791-f9988088-4c88-11e8-89ee-5d31dfba0c32.png)
