### PR TITLE
Make registry commands consistent

### DIFF
--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -18,7 +18,7 @@ keywords: "search, hub, images"
 ```markdown
 Usage:  docker search [OPTIONS] TERM
 
-Search the Docker Hub for images
+Search the Docker registry for images
 
 Options:
   -f, --filter value   Filter output based on conditions provided (default [])
@@ -33,7 +33,7 @@ Options:
 
 ## Description
 
-Search [Docker Hub](https://hub.docker.com) for images
+Use `docker search` to find images in the [Docker Hub](https://hub.docker.com) registry.
 
 See [*Find Public Images on Docker Hub*](https://docs.docker.com/engine/tutorials/dockerrepos/#searching-for-images) for
 more details on finding shared images from the command line.
@@ -50,7 +50,7 @@ This example displays images with a name containing 'busybox':
 $ docker search busybox
 
 NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
-busybox                          Busybox base image.                             316       [OK]       
+busybox                          Busybox base image.                             316       [OK]
 progrium/busybox                                                                 50                   [OK]
 radial/busyboxplus               Full-chain, Internet enabled, busybox made...   8                    [OK]
 odise/busybox-python                                                             2                    [OK]
@@ -85,7 +85,7 @@ at least 3 stars and the description isn't truncated in the output:
 ```bash
 $ docker search --stars=3 --no-trunc busybox
 NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
-busybox              Busybox base image.                                                                       325       [OK]       
+busybox              Busybox base image.                                                                       325       [OK]
 progrium/busybox                                                                                               50                   [OK]
 radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
 ```
@@ -115,7 +115,7 @@ least 3 stars:
 $ docker search --filter stars=3 busybox
 
 NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
-busybox              Busybox base image.                             325       [OK]       
+busybox              Busybox base image.                             325       [OK]
 progrium/busybox                                                     50                   [OK]
 radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
 ```
@@ -193,10 +193,10 @@ $ docker search --format "table {{.Name}}\t{{.IsAutomated}}\t{{.IsOfficial}}" ng
 
 NAME                                     AUTOMATED           OFFICIAL
 nginx                                                        [OK]
-jwilder/nginx-proxy                      [OK]                
-richarvey/nginx-php-fpm                  [OK]                
-jrcs/letsencrypt-nginx-proxy-companion   [OK]                
-million12/nginx-php                      [OK]                
-webdevops/php-nginx                      [OK]                
+jwilder/nginx-proxy                      [OK]
+richarvey/nginx-php-fpm                  [OK]
+jrcs/letsencrypt-nginx-proxy-companion   [OK]
+million12/nginx-php                      [OK]
+webdevops/php-nginx                      [OK]
 {% endraw %}
 ```


### PR DESCRIPTION
Signed-off-by: gbarr01 <gwendolynne.barr@docker.com>

**- What I did**
Changed the description for `search` from "Search the Docker Hub" to "Search the Docker registry" so that it matches the other registry commands: `login`, `logout`, `pull`, and `push`.

**- How to verify it**
Run `docker help | grep registry` ... which was the point. 

**- A picture of a cute animal (not mandatory but encouraged)**
![izzy_dockergirl](https://user-images.githubusercontent.com/31074572/40086071-b0b13dd6-5851-11e8-8b47-bb446734f283.jpg)

