### PR TITLE
Fix component information alignment

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -48,7 +48,7 @@ Server:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
   Version:	{{$component.Version}}
   {{- $detailsOrder := getDetailsOrder $component}}
   {{- range $key := $detailsOrder}}
-  {{$key}}:		{{index $component.Details $key}}
+  {{$key}}:	{{index $component.Details $key}}
    {{- end}}
   {{- end}}
  {{- end}}


### PR DESCRIPTION
The `docker version` output now uses a tabwriter, so use single
tabs to print the output.

Before this change:

    Server:
     Engine:
      Version:      18.05.0-ce
      API version:  1.37 (minimum version 1.12)
      Go version:   go1.10.1
      Git commit:   f150324
      Built:        Wed May  9 22:20:16 2018
      OS/Arch:      linux/amd64
      Experimental: true
     Kubernetes:
      Version:     v1.9.6
      StackAPI:                   v1beta2

After this change:

    Server:
     Engine:
      Version:      18.05.0-ce
      API version:  1.37 (minimum version 1.12)
      Go version:   go1.10.1
      Git commit:   f150324
      Built:        Wed May  9 22:20:16 2018
      OS/Arch:      linux/amd64
      Experimental: true
     Kubernetes:
      Version:     v1.9.6
      StackAPI:    v1beta2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
* Fix component information alignment in `docker version`
```

