### PR TITLE
Remove Kubernetes commands from experimental

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -166,7 +166,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "Experimental field")
 	}
-	orchestrator, err := GetOrchestrator(hasExperimental, opts.Common.Orchestrator, cli.configFile.Orchestrator)
+	orchestrator, err := GetOrchestrator(opts.Common.Orchestrator, cli.configFile.Orchestrator)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ type ClientInfo struct {
 
 // HasKubernetes checks if kubernetes orchestrator is enabled
 func (c ClientInfo) HasKubernetes() bool {
-	return c.HasExperimental && (c.Orchestrator == OrchestratorKubernetes || c.Orchestrator == OrchestratorAll)
+	return c.Orchestrator == OrchestratorKubernetes || c.Orchestrator == OrchestratorAll
 }
 
 // HasSwarm checks if swarm orchestrator is enabled

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -176,20 +176,7 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "default",
 			configfile: `{
-				"experimental": "enabled"
 			}`,
-			expectedOrchestrator: "swarm",
-			expectedKubernetes:   false,
-			expectedSwarm:        true,
-		},
-		{
-			doc: "kubernetesIsExperimental",
-			configfile: `{
-				"experimental": "disabled",
-				"orchestrator": "kubernetes"
-			}`,
-			envOrchestrator:      "kubernetes",
-			flagOrchestrator:     "kubernetes",
 			expectedOrchestrator: "swarm",
 			expectedKubernetes:   false,
 			expectedSwarm:        true,
@@ -197,7 +184,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "kubernetesConfigFile",
 			configfile: `{
-				"experimental": "enabled",
 				"orchestrator": "kubernetes"
 			}`,
 			expectedOrchestrator: "kubernetes",
@@ -207,7 +193,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "kubernetesEnv",
 			configfile: `{
-				"experimental": "enabled"
 			}`,
 			envOrchestrator:      "kubernetes",
 			expectedOrchestrator: "kubernetes",
@@ -217,7 +202,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "kubernetesFlag",
 			configfile: `{
-				"experimental": "enabled"
 			}`,
 			flagOrchestrator:     "kubernetes",
 			expectedOrchestrator: "kubernetes",
@@ -227,7 +211,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "allOrchestratorFlag",
 			configfile: `{
-				"experimental": "enabled"
 			}`,
 			flagOrchestrator:     "all",
 			expectedOrchestrator: "all",
@@ -237,7 +220,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "envOverridesConfigFile",
 			configfile: `{
-				"experimental": "enabled",
 				"orchestrator": "kubernetes"
 			}`,
 			envOrchestrator:      "swarm",
@@ -248,7 +230,6 @@ func TestOrchestratorSwitch(t *testing.T) {
 		{
 			doc: "flagOverridesEnv",
 			configfile: `{
-				"experimental": "enabled"
 			}`,
 			envOrchestrator:      "kubernetes",
 			flagOrchestrator:     "swarm",

--- a/cli/command/orchestrator.go
+++ b/cli/command/orchestrator.go
@@ -38,11 +38,7 @@ func normalize(value string) (Orchestrator, error) {
 
 // GetOrchestrator checks DOCKER_ORCHESTRATOR environment variable and configuration file
 // orchestrator value and returns user defined Orchestrator.
-func GetOrchestrator(isExperimental bool, flagValue, value string) (Orchestrator, error) {
-	// Non experimental CLI has kubernetes disabled
-	if !isExperimental {
-		return defaultOrchestrator, nil
-	}
+func GetOrchestrator(flagValue, value string) (Orchestrator, error) {
 	// Check flag
 	if o, err := normalize(flagValue); o != orchestratorUnset {
 		return o, err

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -33,7 +33,6 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.PersistentFlags()
 	flags.String("kubeconfig", "", "Kubernetes config file")
 	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
-	flags.SetAnnotation("kubeconfig", "experimentalCLI", nil)
 	return cmd
 }
 

--- a/cli/command/stack/kubernetes/cli.go
+++ b/cli/command/stack/kubernetes/cli.go
@@ -42,7 +42,6 @@ func NewOptions(flags *flag.FlagSet) Options {
 func AddNamespaceFlag(flags *flag.FlagSet) {
 	flags.String("namespace", "", "Kubernetes namespace to use")
 	flags.SetAnnotation("namespace", "kubernetes", nil)
-	flags.SetAnnotation("namespace", "experimentalCLI", nil)
 }
 
 // WrapCli wraps command.Cli with kubernetes specifics

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -30,10 +30,8 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.Format, "format", "", "Pretty-print stacks using a Go template")
 	flags.StringSliceVar(&opts.Namespaces, "namespace", []string{}, "Kubernetes namespaces to use")
 	flags.SetAnnotation("namespace", "kubernetes", nil)
-	flags.SetAnnotation("namespace", "experimentalCLI", nil)
 	flags.BoolVarP(&opts.AllNamespaces, "all-namespaces", "", false, "List stacks from all Kubernetes namespaces")
 	flags.SetAnnotation("all-namespaces", "kubernetes", nil)
-	flags.SetAnnotation("all-namespaces", "experimentalCLI", nil)
 	return cmd
 }
 

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -108,7 +108,6 @@ func NewVersionCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&opts.format, "format", "f", "", "Format the output using the given Go template")
 	flags.StringVarP(&opts.kubeConfig, "kubeconfig", "k", "", "Kubernetes config file")
 	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
-	flags.SetAnnotation("kubeconfig", "experimentalCLI", nil)
 
 	return cmd
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -53,8 +53,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 
 	// Install persistent flags
 	persistentFlags := cmd.PersistentFlags()
-	persistentFlags.StringVar(&opts.Common.Orchestrator, "orchestrator", "", "Orchestrator to use (swarm|kubernetes|all) (experimental)")
-	persistentFlags.SetAnnotation("orchestrator", "experimentalCLI", nil)
+	persistentFlags.StringVar(&opts.Common.Orchestrator, "orchestrator", "", "Orchestrator to use (swarm|kubernetes|all)")
 
 	setFlagErrorFunc(dockerCli, cmd, flags, opts)
 


### PR DESCRIPTION
**- What I did**
I removed the experimentalCli annotations and all the experimental code linked to the Kubernetes features.

**- How to verify it**
```
# Make sure the CLI is not experimental
$ docker version
Client:
...
 Experimental: false

# Check the help of stack commands with kubernetes orchestrator, it should list some kubernetes flags 
$ docker --orchestrator=kubernetes stack --help
...
      --kubeconfig string     Kubernetes config file
```

**- Description for the changelog**
* Remove Kubernetes commands from experimental

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/40246132-ea9a7cf6-5ac7-11e8-89da-1f0d87c84cd0.png)

⚠️ Needs #1023 #1035 #1059 to be merged before that.
