### PR TITLE
fix error message from docker inspect

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -170,10 +170,6 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		return info.Swarm.ControlAvailable
 	}
 
-	isErrNotSupported := func(err error) bool {
-		return strings.Contains(err.Error(), "not supported")
-	}
-
 	return func(ref string) (interface{}, []byte, error) {
 		const (
 			swarmSupportUnknown = iota
@@ -201,7 +197,7 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 			}
 			v, raw, err := inspectData.objectInspector(ref)
 			if err != nil {
-				if typeConstraint == "" && (apiclient.IsErrNotFound(err) || isErrNotSupported(err)) {
+				if typeConstraint == "" && isErrSkippable(err) {
 					continue
 				}
 				return v, raw, err
@@ -213,4 +209,10 @@ func inspectAll(ctx context.Context, dockerCli *command.DockerCli, getSize bool,
 		}
 		return nil, nil, errors.Errorf("Error: No such object: %s", ref)
 	}
+}
+
+func isErrSkippable(err error) bool {
+	return apiclient.IsErrNotFound(err) ||
+		strings.Contains(err.Error(), "not supported") ||
+		strings.Contains(err.Error(), "invalid reference format")
 }


### PR DESCRIPTION
Signed-off-by: Anda Xu <anda.xu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix docker inspect error message on invalid reference format to return generic message `Error: No such object:`

**- How I did it**
add error message checking

**- How to verify it**

**- Description for the changelog**
When `docker inspect FooBar`, it is supposed to return the error message `Error: No such object: FooBar`. However it returns `Error response from daemon: no such image: FooBar: invalid reference format: repository name must be lowercase` instead. After the fix, it should return the former message.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @thaJeztah @tiborvass 
