### PR TITLE
move inspect test from moby to cli

### DIFF
--- a/e2e/system/inspect_test.go
+++ b/e2e/system/inspect_test.go
@@ -1,0 +1,16 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+// TestInspectInvalidReference migrated from moby/integration-cli
+func TestInspectInvalidReference(t *testing.T) {
+	// This test should work on both Windows and Linux
+	result := icmd.RunCmd(icmd.Command("docker", "inspect", "FooBar"))
+	result.Assert(t, icmd.Expected{
+		Out: "[]\nError: No such object: FooBar",
+	})
+}


### PR DESCRIPTION
Signed-off-by: Anda Xu <anda.xu@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
added test case for invalid reference name inspection, e.g. `docker inspect FooBar`
linking with https://github.com/docker/cli/pull/1071

original test: https://github.com/moby/moby/blob/9bd5d9912f0cb4fe22b994ac1e7e10038e3be65a/integration-cli/docker_cli_inspect_test.go#L462

**- How I did it**


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

