### PR TITLE
Fix e2e/system tests

### DIFF
--- a/e2e/system/inspect_test.go
+++ b/e2e/system/inspect_test.go
@@ -11,6 +11,8 @@ func TestInspectInvalidReference(t *testing.T) {
 	// This test should work on both Windows and Linux
 	result := icmd.RunCmd(icmd.Command("docker", "inspect", "FooBar"))
 	result.Assert(t, icmd.Expected{
-		Out: "[]\nError: No such object: FooBar",
+		Out:      "[]",
+		Err:      "Error: No such object: FooBar",
+		ExitCode: 1,
 	})
 }

--- a/e2e/system/main_test.go
+++ b/e2e/system/main_test.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/internal/test/environment"
+)
+
+func TestMain(m *testing.M) {
+	if err := environment.Setup(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(3)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
a setup step is required and the test fails.

The e2e tests didn't run on https://github.com/docker/cli/pull/1072 (jenkins doesn't appear in the list of checks)

:frog: 

cc @AntaresS @tiborvass 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
