### PR TITLE
Fix cpu/memory limits and reservations being reset on service update

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -314,12 +314,12 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 	}
 
 	if flags.Changed(flagLimitCPU) || flags.Changed(flagLimitMemory) {
-		taskResources().Limits = &swarm.Resources{}
+		taskResources().Limits = spec.TaskTemplate.Resources.Limits
 		updateInt64Value(flagLimitCPU, &task.Resources.Limits.NanoCPUs)
 		updateInt64Value(flagLimitMemory, &task.Resources.Limits.MemoryBytes)
 	}
 	if flags.Changed(flagReserveCPU) || flags.Changed(flagReserveMemory) {
-		taskResources().Reservations = &swarm.Resources{}
+		taskResources().Reservations = spec.TaskTemplate.Resources.Reservations
 		updateInt64Value(flagReserveCPU, &task.Resources.Reservations.NanoCPUs)
 		updateInt64Value(flagReserveMemory, &task.Resources.Reservations.MemoryBytes)
 	}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -313,12 +313,13 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 		return err
 	}
 
-	if flags.Changed(flagLimitCPU) || flags.Changed(flagLimitMemory) {
+	if anyChanged(flags, flagLimitCPU, flagLimitMemory) {
 		taskResources().Limits = spec.TaskTemplate.Resources.Limits
 		updateInt64Value(flagLimitCPU, &task.Resources.Limits.NanoCPUs)
 		updateInt64Value(flagLimitMemory, &task.Resources.Limits.MemoryBytes)
 	}
-	if flags.Changed(flagReserveCPU) || flags.Changed(flagReserveMemory) {
+
+	if anyChanged(flags, flagReserveCPU, flagReserveMemory) {
 		taskResources().Reservations = spec.TaskTemplate.Resources.Reservations
 		updateInt64Value(flagReserveCPU, &task.Resources.Reservations.NanoCPUs)
 		updateInt64Value(flagReserveMemory, &task.Resources.Reservations.MemoryBytes)


### PR DESCRIPTION
Fix cpu/memory limits and reservations being reset on service update

fixes https://github.com/moby/moby/issues/37036
fixes https://github.com/moby/moby/issues/37037

## Before this change:


Create a service with reservations and limits for memory and cpu:

```bash
docker service create \
  --limit-memory=100M \
  --limit-cpu=1 \
  --reserve-memory=100M \
  --reserve-cpu=1 \
  --name test \
  nginx:alpine
```

Verify the configuration

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq . 
```
 
```json
{
  "Limits": {
    "NanoCPUs": 1000000000,
    "MemoryBytes": 104857600
  },
  "Reservations": {
    "NanoCPUs": 1000000000,
    "MemoryBytes": 104857600
  }
}
``` 

Update just CPU limit and reservation:

```bash
docker service update --limit-cpu=2 --reserve-cpu=2 test
```

Notice that the memory limit and reservation is not preserved:

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq .
```

```json
{
  "Limits": {
    "NanoCPUs": 2000000000
  },
  "Reservations": {
    "NanoCPUs": 2000000000
  }
}
```

Update just Memory limit and reservation:

```bash
docker service update --limit-memory=200M --reserve-memory=200M test
```

Notice that the CPU limit and reservation is not preserved:

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq .
```

```json
{
  "Limits": {
    "MemoryBytes": 209715200
  },
  "Reservations": {
    "MemoryBytes": 209715200
  }
}
```


## After this change:


Create a service with reservations and limits for memory and cpu:

```bash
docker service create \
  --limit-memory=100M \
  --limit-cpu=1 \
  --reserve-memory=100M \
  --reserve-cpu=1 \
  --name test \
  nginx:alpine
```

Verify the configuration

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq . 
```
 
```json
{
  "Limits": {
    "NanoCPUs": 1000000000,
    "MemoryBytes": 104857600
  },
  "Reservations": {
    "NanoCPUs": 1000000000,
    "MemoryBytes": 104857600
  }
}
``` 

Update just CPU limit and reservation:

```bash
docker service update --limit-cpu=2 --reserve-cpu=2 test
```

Confirm that the CPU limits/reservations are updated, but memory limit and reservation are preserved:

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq .
```

```json
{
  "Limits": {
    "NanoCPUs": 2000000000,
    "MemoryBytes": 104857600
  },
  "Reservations": {
    "NanoCPUs": 2000000000,
    "MemoryBytes": 104857600
  }
}
```

Update just Memory limit and reservation:

```bash
docker service update --limit-memory=200M --reserve-memory=200M test
```

Confirm that the Mempry limits/reservations are updated, but CPU limit and reservation are preserved:

```bash
docker service inspect --format '{{json .Spec.TaskTemplate.Resources}}' test | jq .
```

```json
{
  "Limits": {
    "NanoCPUs": 2000000000,
    "MemoryBytes": 209715200
  },
  "Reservations": {
    "NanoCPUs": 2000000000,
    "MemoryBytes": 209715200
  }
}
```