### PR TITLE
Minor refactor in stack helper functions

### DIFF
--- a/cli/command/stack/swarm/common.go
+++ b/cli/command/stack/swarm/common.go
@@ -17,7 +17,7 @@ func getStackFilter(namespace string) filters.Args {
 	return filter
 }
 
-func getServiceFilter(namespace string) filters.Args {
+func getStackServiceFilter(namespace string) filters.Args {
 	return getStackFilter(namespace)
 }
 
@@ -33,42 +33,18 @@ func getAllStacksFilter() filters.Args {
 	return filter
 }
 
-func getServices(
-	ctx context.Context,
-	apiclient client.APIClient,
-	namespace string,
-) ([]swarm.Service, error) {
-	return apiclient.ServiceList(
-		ctx,
-		types.ServiceListOptions{Filters: getServiceFilter(namespace)})
+func getStackServices(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Service, error) {
+	return apiclient.ServiceList(ctx, types.ServiceListOptions{Filters: getStackServiceFilter(namespace)})
 }
 
-func getStackNetworks(
-	ctx context.Context,
-	apiclient client.APIClient,
-	namespace string,
-) ([]types.NetworkResource, error) {
-	return apiclient.NetworkList(
-		ctx,
-		types.NetworkListOptions{Filters: getStackFilter(namespace)})
+func getStackNetworks(ctx context.Context, apiclient client.APIClient, namespace string) ([]types.NetworkResource, error) {
+	return apiclient.NetworkList(ctx, types.NetworkListOptions{Filters: getStackFilter(namespace)})
 }
 
-func getStackSecrets(
-	ctx context.Context,
-	apiclient client.APIClient,
-	namespace string,
-) ([]swarm.Secret, error) {
-	return apiclient.SecretList(
-		ctx,
-		types.SecretListOptions{Filters: getStackFilter(namespace)})
+func getStackSecrets(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Secret, error) {
+	return apiclient.SecretList(ctx, types.SecretListOptions{Filters: getStackFilter(namespace)})
 }
 
-func getStackConfigs(
-	ctx context.Context,
-	apiclient client.APIClient,
-	namespace string,
-) ([]swarm.Config, error) {
-	return apiclient.ConfigList(
-		ctx,
-		types.ConfigListOptions{Filters: getStackFilter(namespace)})
+func getStackConfigs(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Config, error) {
+	return apiclient.ConfigList(ctx, types.ConfigListOptions{Filters: getStackFilter(namespace)})
 }

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -73,7 +73,7 @@ func checkDaemonIsSwarmManager(ctx context.Context, dockerCli command.Cli) error
 func pruneServices(ctx context.Context, dockerCli command.Cli, namespace convert.Namespace, services map[string]struct{}) {
 	client := dockerCli.Client()
 
-	oldServices, err := getServices(ctx, client, namespace.Name())
+	oldServices, err := getStackServices(ctx, client, namespace.Name())
 	if err != nil {
 		fmt.Fprintf(dockerCli.Err(), "Failed to list services: %s\n", err)
 	}

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -209,7 +209,7 @@ func deployServices(
 	apiClient := dockerCli.Client()
 	out := dockerCli.Out()
 
-	existingServices, err := getServices(ctx, apiClient, namespace.Name())
+	existingServices, err := getStackServices(ctx, apiClient, namespace.Name())
 	if err != nil {
 		return err
 	}

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -22,7 +22,7 @@ func RunRemove(dockerCli command.Cli, opts options.Remove) error {
 
 	var errs []string
 	for _, namespace := range namespaces {
-		services, err := getServices(ctx, client, namespace)
+		services, err := getStackServices(ctx, client, namespace)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Don't wrap the code to be slightly more readable
- Rename `getServiceFilter()` to `getStackServiceFilter()` to be
  consistent with other helper functions.

