### PR TITLE
Check allNamespace config value while loading configuration file

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -3,6 +3,7 @@ package configfile
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -125,7 +126,7 @@ func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
 		ac.ServerAddress = addr
 		configFile.AuthConfigs[addr] = ac
 	}
-	return nil
+	return checkKubernetesConfiguration(configFile.Kubernetes)
 }
 
 // ContainsAuth returns whether there is authentication configured
@@ -317,4 +318,18 @@ func (configFile *ConfigFile) GetAllCredentials() (map[string]types.AuthConfig, 
 // GetFilename returns the file name that this config file is based on.
 func (configFile *ConfigFile) GetFilename() string {
 	return configFile.Filename
+}
+
+func checkKubernetesConfiguration(kubeConfig *KubernetesConfig) error {
+	if kubeConfig == nil {
+		return nil
+	}
+	switch kubeConfig.AllNamespaces {
+	case "":
+	case "enabled":
+	case "disabled":
+	default:
+		return fmt.Errorf("invalid 'kubernetes.allNamespaces' value, should be 'enabled' or 'disabled': %s", kubeConfig.AllNamespaces)
+	}
+	return nil
 }

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -371,3 +371,45 @@ func TestGetAllCredentialsCredHelperOverridesDefaultStore(t *testing.T) {
 	assert.Check(t, is.Equal(1, testCredsStore.(*mockNativeStore).GetAllCallCount))
 	assert.Check(t, is.Equal(0, testCredHelper.(*mockNativeStore).GetAllCallCount))
 }
+
+func TestCheckKubernetesConfigurationRaiseAnErrorOnInvalidValue(t *testing.T) {
+	testCases := []struct {
+		name        string
+		config      *KubernetesConfig
+		expectError bool
+	}{
+		{
+			"no kubernetes config is valid",
+			nil,
+			false,
+		},
+		{
+			"enabled is valid",
+			&KubernetesConfig{AllNamespaces: "enabled"},
+			false,
+		},
+		{
+			"disabled is valid",
+			&KubernetesConfig{AllNamespaces: "disabled"},
+			false,
+		},
+		{
+			"empty string is valid",
+			&KubernetesConfig{AllNamespaces: ""},
+			false,
+		},
+		{
+			"other value is invalid",
+			&KubernetesConfig{AllNamespaces: "unknown"},
+			true,
+		},
+	}
+	for _, test := range testCases {
+		err := checkKubernetesConfiguration(test.config)
+		if test.expectError {
+			assert.Assert(t, err != nil, test.name)
+		} else {
+			assert.NilError(t, err, test.name)
+		}
+	}
+}


### PR DESCRIPTION
**- How to verify it**
```
# Add allNamespaces to your config file
$ cat ~/.docker/config.json
{
    "kubernetes": {
        "allNamespaces": "disabled"
    }
}
# Try some command
$ docker version
...
# Amend your config file with unknown value
$ cat ~/.docker/config.json
{
    "kubernetes": {
        "allNamespaces": "unknown"
    }
}
# Now a warning is displayed
$ docker version
WARNING: Error loading config file: /Users/silvin/.docker/config.json: invalid 'kubernetes.allNamespaces' value, should be 'enabled' or 'disabled': unknown
...
```

**- Description for the changelog**
* Restrict kubernetes.allNamespaces value to 'enabled' or 'disabled' in configuration file

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/40615363-b4f3d478-6286-11e8-8c7d-5df32a04a238.png)
