### PR TITLE
Validate stack-names for empty values

### DIFF
--- a/cli/command/stack/swarm/common.go
+++ b/cli/command/stack/swarm/common.go
@@ -2,6 +2,9 @@ package swarm
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/docker/cli/opts"
@@ -47,4 +50,29 @@ func getStackSecrets(ctx context.Context, apiclient client.APIClient, namespace 
 
 func getStackConfigs(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Config, error) {
 	return apiclient.ConfigList(ctx, types.ConfigListOptions{Filters: getStackFilter(namespace)})
+}
+
+// validateStackName checks if the provided string is a valid stack name (namespace).
+//
+// It currently only does a rudimentary check if the string is empty, or consists
+// of only whitespace and quoting characters.
+func validateStackName(namespace string) error {
+	v := strings.TrimFunc(namespace, quotesOrWhitespace)
+	if len(v) == 0 {
+		return fmt.Errorf("invalid stack name: %q", namespace)
+	}
+	return nil
+}
+
+func validateStackNames(namespaces []string) error {
+	for _, ns := range namespaces {
+		if err := validateStackName(ns); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func quotesOrWhitespace(r rune) bool {
+	return unicode.IsSpace(r) || r == '"' || r == '\''
 }

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -24,6 +24,9 @@ const (
 func RunDeploy(dockerCli command.Cli, opts options.Deploy) error {
 	ctx := context.Background()
 
+	if err := validateStackName(opts.Namespace); err != nil {
+		return err
+	}
 	if err := validateResolveImageFlag(dockerCli, &opts); err != nil {
 		return err
 	}

--- a/cli/command/stack/swarm/deploy_bundlefile.go
+++ b/cli/command/stack/swarm/deploy_bundlefile.go
@@ -16,6 +16,9 @@ import (
 )
 
 func deployBundle(ctx context.Context, dockerCli command.Cli, opts options.Deploy) error {
+	if err := validateStackName(opts.Namespace); err != nil {
+		return err
+	}
 	bundle, err := loadBundlefile(dockerCli.Err(), opts.Namespace, opts.Bundlefile)
 	if err != nil {
 		return err

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -18,6 +18,9 @@ import (
 )
 
 func deployCompose(ctx context.Context, dockerCli command.Cli, opts options.Deploy) error {
+	if err := validateStackName(opts.Namespace); err != nil {
+		return err
+	}
 	config, err := loader.LoadComposefile(dockerCli, opts)
 	if err != nil {
 		return err

--- a/cli/command/stack/swarm/deploy_test.go
+++ b/cli/command/stack/swarm/deploy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
@@ -24,6 +25,15 @@ func TestPruneServices(t *testing.T) {
 
 	pruneServices(ctx, dockerCli, namespace, services)
 	assert.Check(t, is.DeepEqual(buildObjectIDs([]string{objectName("foo", "remove")}), client.removedServices))
+}
+
+func TestDeployWithEmptyName(t *testing.T) {
+	ctx := context.Background()
+	client := &fakeClient{}
+	dockerCli := test.NewFakeCli(client)
+
+	err := deployCompose(ctx, dockerCli, options.Deploy{Namespace: "'   '", Prune: true})
+	assert.Check(t, is.Error(err, `invalid stack name: "'   '"`))
 }
 
 // TestServiceUpdateResolveImageChanged tests that the service's

--- a/cli/command/stack/swarm/ps.go
+++ b/cli/command/stack/swarm/ps.go
@@ -13,19 +13,21 @@ import (
 
 // RunPS is the swarm implementation of docker stack ps
 func RunPS(dockerCli command.Cli, opts options.PS) error {
-	namespace := opts.Namespace
-	client := dockerCli.Client()
-	ctx := context.Background()
+	if err := validateStackName(opts.Namespace); err != nil {
+		return err
+	}
 
 	filter := getStackFilterFromOpt(opts.Namespace, opts.Filter)
 
+	ctx := context.Background()
+	client := dockerCli.Client()
 	tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 	if err != nil {
 		return err
 	}
 
 	if len(tasks) == 0 {
-		return fmt.Errorf("nothing found in stack: %s", namespace)
+		return fmt.Errorf("nothing found in stack: %s", opts.Namespace)
 	}
 
 	format := opts.Format

--- a/cli/command/stack/swarm/ps_test.go
+++ b/cli/command/stack/swarm/ps_test.go
@@ -1,0 +1,18 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/command/stack/options"
+	"github.com/docker/cli/internal/test"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestRunPSWithEmptyName(t *testing.T) {
+	client := &fakeClient{}
+	dockerCli := test.NewFakeCli(client)
+
+	err := RunPS(dockerCli, options.PS{Namespace: "'   '"})
+	assert.Check(t, is.Error(err, `invalid stack name: "'   '"`))
+}

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -16,12 +16,15 @@ import (
 
 // RunRemove is the swarm implementation of docker stack remove
 func RunRemove(dockerCli command.Cli, opts options.Remove) error {
-	namespaces := opts.Namespaces
+	if err := validateStackNames(opts.Namespaces); err != nil {
+		return err
+	}
+
 	client := dockerCli.Client()
 	ctx := context.Background()
 
 	var errs []string
-	for _, namespace := range namespaces {
+	for _, namespace := range opts.Namespaces {
 		services, err := getStackServices(ctx, client, namespace)
 		if err != nil {
 			return err

--- a/cli/command/stack/swarm/remove_test.go
+++ b/cli/command/stack/swarm/remove_test.go
@@ -1,0 +1,18 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/command/stack/options"
+	"github.com/docker/cli/internal/test"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestRunRemoveWithEmptyName(t *testing.T) {
+	client := &fakeClient{}
+	dockerCli := test.NewFakeCli(client)
+
+	err := RunRemove(dockerCli, options.Remove{Namespaces: []string{"good", "'   '", "alsogood"}})
+	assert.Check(t, is.Error(err, `invalid stack name: "'   '"`))
+}

--- a/cli/command/stack/swarm/services.go
+++ b/cli/command/stack/swarm/services.go
@@ -14,6 +14,9 @@ import (
 
 // RunServices is the swarm implementation of docker stack services
 func RunServices(dockerCli command.Cli, opts options.Services) error {
+	if err := validateStackName(opts.Namespace); err != nil {
+		return err
+	}
 	ctx := context.Background()
 	client := dockerCli.Client()
 

--- a/cli/command/stack/swarm/services_test.go
+++ b/cli/command/stack/swarm/services_test.go
@@ -1,0 +1,18 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/command/stack/options"
+	"github.com/docker/cli/internal/test"
+	"github.com/gotestyourself/gotestyourself/assert"
+	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+)
+
+func TestRunServicesWithEmptyName(t *testing.T) {
+	client := &fakeClient{}
+	dockerCli := test.NewFakeCli(client)
+
+	err := RunServices(dockerCli, options.Services{Namespace: "'   '"})
+	assert.Check(t, is.Error(err, `invalid stack name: "'   '"`))
+}


### PR DESCRIPTION
Fixes https://github.com/moby/moby/issues/36776

Add validation for stack names to prevent an empty name resulting in _all_
stacks to be returned after filtering, which can result in removal of services
for all stacks if `--prune`, or `docker stack rm` is used.

Before this change;

    docker stack deploy -c docker-compose.yml one
    docker stack deploy -c docker-compose.yml two
    docker stack deploy -c docker-compose.yml three

    docker stack deploy -c docker-compose.yml --prune ''
    Removing service one_web
    Removing service two_web
    Removing service three_web

After this change:

    docker stack deploy -c docker-compose.yml one
    docker stack deploy -c docker-compose.yml two
    docker stack deploy -c docker-compose.yml three

    docker stack deploy -c docker-compose.yml --prune ''
    invalid stack name: ""

Other stack commands were updated as well:

Before this change;

    docker stack deploy -c docker-compose.yml ''
    Creating network _default
    failed to create network _default: Error response from daemon: rpc error: code = InvalidArgument desc = name must be valid as a DNS name component

    docker stack ps ''
    nothing found in stack:

    docker stack rm ''
    Removing service one_web
    Removing service three_web
    Removing service two_web

After this change:

    docker stack deploy -c docker-compose.yml ''
    invalid stack name: ""

    docker stack ps ''
    invalid stack name: ""

    docker stack rm ''
    invalid stack name: ""

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
* Fix `docker stack deploy --prune` with empty name removing all services [docker/cli#1088](https://github.com/docker/cli/pull/1088)
```
