### PR TITLE
Add String method so quieted output displays properly

### DIFF
--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -122,6 +122,10 @@ func (bw *bufferedWriter) flushBuffer() {
 	bw.mu.Unlock()
 }
 
+func (bw *bufferedWriter) String() string {
+	return fmt.Sprintf("%s", bw.Writer)
+}
+
 func getBuildSharedKey(dir string) (string, error) {
 	// build session is hash of build dir with node based randomness
 	s := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", tryNodeIdentifier(), dir)))


### PR DESCRIPTION
Fixes #1089 as well as addresses https://github.com/moby/moby/issues/36812

**- What I did**
It turns out that the when the --stream flag is provided, a struct with a few different fields is used and when trying to print it in the quiet case, it uses a default string representation of the struct. I added a custom String method to only display the relevant data.

**- Description for the changelog**
Fixed bug displaying garbage output for build command when --stream and --quiet flags combined