### PR TITLE
Try to fix `--config` and shell expansion issues

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
@@ -66,6 +67,9 @@ func LoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
 func Load(configDir string) (*configfile.ConfigFile, error) {
 	if configDir == "" {
 		configDir = Dir()
+	}
+	if strings.HasPrefix(configDir, homedir.GetShortcutString()) {
+		configDir = filepath.Join(homedir.Get(), strings.TrimPrefix(configDir, homedir.GetShortcutString()))
 	}
 
 	filename := filepath.Join(configDir, ConfigFileName)


### PR DESCRIPTION
It makes `--config ~/.docker` and `--config=~/.docker` act the same.
If the specified `configDir` starts with `~`, then we use `homedir`
package (already used for default `configDir`) to get home.

Fixes https://github.com/moby/moby/issues/22526

cc @runcom 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
