### PR TITLE
Hide experimental checkpoint features on Windows

### DIFF
--- a/cli/command/checkpoint/cmd.go
+++ b/cli/command/checkpoint/cmd.go
@@ -9,11 +9,15 @@ import (
 // NewCheckpointCommand returns the `checkpoint` subcommand (only in experimental)
 func NewCheckpointCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:         "checkpoint",
-		Short:       "Manage checkpoints",
-		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
-		Annotations: map[string]string{"experimental": "", "version": "1.25"},
+		Use:   "checkpoint",
+		Short: "Manage checkpoints",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+		Annotations: map[string]string{
+			"experimental": "",
+			"ostype":       "linux",
+			"version":      "1.25",
+		},
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCli),

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -47,8 +47,10 @@ func NewStartCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags.StringVar(&opts.checkpoint, "checkpoint", "", "Restore from this checkpoint")
 	flags.SetAnnotation("checkpoint", "experimental", nil)
+	flags.SetAnnotation("checkpoint", "ostype", []string{"linux"})
 	flags.StringVar(&opts.checkpointDir, "checkpoint-dir", "", "Use a custom checkpoint storage directory")
 	flags.SetAnnotation("checkpoint-dir", "experimental", nil)
+	flags.SetAnnotation("checkpoint-dir", "ostype", []string{"linux"})
 	return cmd
 }
 

--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -25,6 +25,7 @@ type cmdOption struct {
 	ExperimentalCLI bool
 	Kubernetes      bool
 	Swarm           bool
+	OSType          string `yaml:"os_type,omitempty"`
 }
 
 type cmdDoc struct {
@@ -48,6 +49,7 @@ type cmdDoc struct {
 	ExperimentalCLI  bool
 	Kubernetes       bool
 	Swarm            bool
+	OSType           string `yaml:"os_type,omitempty"`
 }
 
 // GenYamlTree creates yaml structured ref files
@@ -120,6 +122,9 @@ func GenYamlCustom(cmd *cobra.Command, w io.Writer) error {
 		}
 		if _, ok := curr.Annotations["swarm"]; ok && !cliDoc.Swarm {
 			cliDoc.Swarm = true
+		}
+		if os, ok := curr.Annotations["ostype"]; ok && cliDoc.OSType == "" {
+			cliDoc.OSType = os
 		}
 	}
 
@@ -205,6 +210,15 @@ func genFlagResult(flags *pflag.FlagSet) []cmdOption {
 		}
 		if _, ok := flag.Annotations["swarm"]; ok {
 			opt.Swarm = true
+		}
+
+		// Note that the annotation can have multiple ostypes set, however, multiple
+		// values are currently not used (and unlikely will).
+		//
+		// To simplify usage of the os_type property in the YAML, and for consistency
+		// with the same property for commands, we're only using the first ostype that's set.
+		if ostypes, ok := flag.Annotations["ostype"]; ok && len(opt.OSType) == 0 && len(ostypes) > 0 {
+			opt.OSType = ostypes[0]
 		}
 
 		result = append(result, opt)


### PR DESCRIPTION
Relates to https://github.com/docker/docker.github.io/issues/6780

### Mark checkpoint feature as Linux-only

This patch adds annotations to mark the checkpoint commands as Linux only, which
hides them if the daemon is running a non-matching operating-system type;

Before:

    docker

    Usage:	docker COMMAND

    A self-sufficient runtime for containers

    ...

    Management Commands:
      config      Manage Docker configs
      container   Manage containers
      image       Manage images

After:

    docker

    Usage:	docker COMMAND

    A self-sufficient runtime for containers

    ...

    Management Commands:
      checkpoint  Manage checkpoints
      config      Manage Docker configs
      container   Manage containers
      image       Manage images


This change also prints errors when attempting to use checkpoint commands or
flags if the feature is not supported by the Daemon's operating system;

    $ docker checkpoint --help
    docker checkpoint is only supported on a Docker daemon running on linux, but the Docker daemon is running on windows

    $ docker checkpoint create --help
    docker checkpoint create is only supported on a Docker daemon running on linux, but the Docker daemon is running on windows

    $ docker checkpoint ls --help
    docker checkpoint ls is only supported on a Docker daemon running on linux, but the Docker daemon is running on windows

    $ docker checkpoint rm --help
    docker checkpoint rm is only supported on a Docker daemon running on linux, but the Docker daemon is running on windows

    $ docker container start --checkpoint=foo mycontainer
    "--checkpoint" requires the Docker daemon to run on linux, but the Docker daemon is running on windows

    $ docker container start --checkpoint-dir=/foo/bar mycontainer
    "--checkpoint-dir" requires the Docker daemon to run on linux, but the Docker daemon is running on windows


### YAML docs: add os_type property on flags and (sub)commands

This patch adds an `os_type` property in the generated YAML docs, both for
commands, and for flags;

```yaml
command: docker checkpoint create
short: Create a checkpoint from a running container
long: Create a checkpoint from a running container
usage: docker checkpoint create [OPTIONS] CONTAINER CHECKPOINT [flags]
pname: docker checkpoint
plink: docker_checkpoint.yaml
options:
- option: checkpoint-dir
  value_type: string
  description: Use a custom checkpoint storage directory
  deprecated: false
  experimental: false
  experimentalcli: false
  kubernetes: false
  swarm: false
- option: leave-running
  value_type: bool
  default_value: "false"
  description: Leave the container running after checkpoint
  deprecated: false
  experimental: false
  experimentalcli: false
  kubernetes: false
  swarm: false
deprecated: false
min_api_version: "1.25"
experimental: true
experimentalcli: false
kubernetes: false
swarm: false
os_type: windows
```

```yaml
command: docker container start
short: Start one or more stopped containers
long: Start one or more stopped containers
usage: docker container start [OPTIONS] CONTAINER [CONTAINER...] [flags]
pname: docker container
plink: docker_container.yaml
options:
- option: attach
  shorthand: a
  value_type: bool
  default_value: "false"
  description: Attach STDOUT/STDERR and forward signals
  deprecated: false
  experimental: false
  experimentalcli: false
  kubernetes: false
  swarm: false
- option: checkpoint
  value_type: string
  description: Restore from this checkpoint
  deprecated: false
  experimental: true
  experimentalcli: false
  kubernetes: false
  swarm: false
  os_type: linux
- option: checkpoint-dir
  value_type: string
  description: Use a custom checkpoint storage directory
  deprecated: false
  experimental: true
  experimentalcli: false
  kubernetes: false
  swarm: false
  os_type: linux
- option: detach-keys
  value_type: string
  description: Override the key sequence for detaching a container
  deprecated: false
  experimental: false
  experimentalcli: false
  kubernetes: false
  swarm: false
- option: interactive
  shorthand: i
  value_type: bool
  default_value: "false"
  description: Attach container's STDIN
  deprecated: false
  experimental: false
  experimentalcli: false
  kubernetes: false
  swarm: false
deprecated: false
experimental: false
experimentalcli: false
kubernetes: false
swarm: false
```