### PR TITLE
Add test for version output aligning

### DIFF
--- a/cli/command/system/testdata/docker-client-version.golden
+++ b/cli/command/system/testdata/docker-client-version.golden
@@ -1,0 +1,9 @@
+Client:
+ Version:      18.99.5-ce
+ API version:  1.38
+ Go version:   go1.10.2
+ Git commit:   deadbeef
+ Built:        Wed May 30 22:21:05 2018
+ OS/Arch:      linux/amd64
+ Experimental: true
+ Orchestrator: swarm

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gotestyourself/gotestyourself/assert"
 	is "github.com/gotestyourself/gotestyourself/assert/cmp"
+	"github.com/gotestyourself/gotestyourself/golden"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api"
@@ -42,6 +43,30 @@ func TestVersionWithOrchestrator(t *testing.T) {
 	cmd := NewVersionCommand(cli)
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Contains(cleanTabs(cli.OutBuffer().String()), "Orchestrator: swarm"))
+}
+
+func TestVersionAlign(t *testing.T) {
+	vi := versionInfo{
+		Client: clientVersion{
+			Version:           "18.99.5-ce",
+			APIVersion:        "1.38",
+			DefaultAPIVersion: "1.38",
+			GitCommit:         "deadbeef",
+			GoVersion:         "go1.10.2",
+			Os:                "linux",
+			Arch:              "amd64",
+			BuildTime:         "Wed May 30 22:21:05 2018",
+			Experimental:      true,
+			Orchestrator:      "swarm",
+		},
+	}
+
+	cli := test.NewFakeCli(&fakeClient{})
+	tmpl, err := newVersionTemplate("")
+	assert.NilError(t, err)
+	assert.NilError(t, prettyPrintVersion(cli, vi, tmpl))
+	assert.Check(t, golden.String(cli.OutBuffer().String(), "docker-client-version.golden"))
+	assert.Check(t, is.Equal("", cli.ErrBuffer().String()))
 }
 
 func cleanTabs(line string) string {


### PR DESCRIPTION
Includes some refactoring to allow testing the output in isolation.

Relates to https://github.com/docker/cli/pull/965

**- A picture of a cute animal (not mandatory but encouraged)**

![cute-baby-beavers-54-570620dce058f__605](https://user-images.githubusercontent.com/1804568/40770838-23bf3046-64bc-11e8-8a74-222981a43ce9.jpg)


Image: [Viktorija G](https://www.boredpanda.com/meet-3-adorable-baby-beavers/)