### PR TITLE
Show long help message when defined

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -104,7 +104,7 @@ var usageTemplate = `Usage:
 {{- if not .HasSubCommands}}	{{.UseLine}}{{end}}
 {{- if .HasSubCommands}}	{{ .CommandPath}} COMMAND{{end}}
 
-{{ .Short | trim }}
+{{if ne .Long ""}}{{ .Long | trim }}{{ else }}{{ .Short | trim }}{{end}}
 
 {{- if gt .Aliases 0}}
 


### PR DESCRIPTION
This fixes the help template so that if a command
includes a Long form help message that is displayed instead
of ignoring it and always showing the Short message.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>


For example:
https://github.com/docker/cli/blob/master/cli/command/container/cp.go#L49-L56

Before this fix:
```
% docker container cp --help

Usage:	docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
	docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Copy files/folders between a container and the local filesystem

Options:
  -a, --archive       Archive mode (copy all uid/gid information)
  -L, --follow-link   Always follow symbol link in SRC_PATH
```

After this fix
```
% docker container cp --help

Usage:	docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
	docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Copy files/folders between a container and the local filesystem

Use '-' as the source to read a tar archive from stdin
and extract it to a directory destination in a container.
Use '-' as the destination to stream a tar archive of a
container source to stdout.

Options:
  -a, --archive               Archive mode (copy all uid/gid information)
  -L, --follow-link           Always follow symbol link in SRC_PATH
      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
```
(The orchestrator flag is a bug recently introduced - unrelated to this PR)