### PR TITLE
Fix panics when --compress and --stream are used together

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -182,6 +182,10 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		remote        string
 	)
 
+	if options.compress && options.stream {
+		return errors.New("--compress conflicts with --stream options")
+	}
+
 	if options.dockerfileFromStdin() {
 		if options.contextFromStdin() {
 			return errors.New("invalid argument: can't use stdin for both build context and dockerfile")


### PR DESCRIPTION
Warns that `-compress` has no effect when used together with the
expremintal `--stream` flag.

Fixes #1044 

cc @dgageot

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
