### PR TITLE
Add a "top-level" annotation to hide persistent flags

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -54,6 +54,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 	// Install persistent flags
 	persistentFlags := cmd.PersistentFlags()
 	persistentFlags.StringVar(&opts.Common.Orchestrator, "orchestrator", "", "Orchestrator to use (swarm|kubernetes|all)")
+	persistentFlags.SetAnnotation("orchestrator", "top-level", []string{"version", "stack"})
 
 	setFlagErrorFunc(dockerCli, cmd, flags, opts)
 
@@ -245,6 +246,12 @@ func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) {
 		if !isOSTypeSupported(f, osType) || !isVersionSupported(f, clientVersion) {
 			f.Hidden = true
 		}
+		// root command shows all top-level flags
+		if cmd.Parent() != nil {
+			if commands, ok := f.Annotations["top-level"]; ok {
+				f.Hidden = !findCommand(cmd, commands)
+			}
+		}
 	})
 
 	for _, subcmd := range cmd.Commands() {
@@ -257,6 +264,19 @@ func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) {
 			subcmd.Hidden = true
 		}
 	}
+}
+
+// Checks if a command or one of its ancestors is in the list
+func findCommand(cmd *cobra.Command, commands []string) bool {
+	if cmd == nil {
+		return false
+	}
+	for _, c := range commands {
+		if c == cmd.Name() {
+			return true
+		}
+	}
+	return findCommand(cmd.Parent(), commands)
 }
 
 func isSupported(cmd *cobra.Command, details versionDetails) error {


### PR DESCRIPTION
**- What I did**
I added a "top-level" annotation to hide persistent flags in all sub-commands, excepting some specific commands, while printing help.
Fixes issue #1099.

**- How to verify it**

```sh
# All commands excepting stack and version hides orchestrator flag
$ docker container cp --help

Usage:  docker container cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
        docker cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH

Copy files/folders between a container and the local filesystem

Options:
  -a, --archive       Archive mode (copy all uid/gid information)
  -L, --follow-link   Always follow symbol link in SRC_PATH

$ docker version --help
...
      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
...

$ docker stack --help
...
      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
...

# Works also with stack sub-commands
$ docker stack ls --help
...
      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
...
```

**- Description for the changelog**
* Only show orchestrator flag in root, stack and version commands in help (fixes #1099) 

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/40842138-234d3e0e-65ad-11e8-9d9d-7a1cb66f8e01.png)

