### PR TITLE
Fix moby/moby #37229 allowing to create networks even there are no services attached to it when deploying stacks

### DIFF
--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -112,61 +112,11 @@ func TestNetworksCreatedWithoutServices(t *testing.T) {
 	namespace := Namespace{name: "foo"}
 	serviceNetworks := map[string]struct{}{}
 	source := networkMap{
-		"normal": composetypes.NetworkConfig{
-			Driver: "overlay",
-			DriverOpts: map[string]string{
-				"opt": "value",
-			},
-			Ipam: composetypes.IPAMConfig{
-				Driver: "driver",
-				Config: []*composetypes.IPAMPool{
-					{
-						Subnet: "10.0.0.0",
-					},
-				},
-			},
-			Labels: map[string]string{
-				"something": "labeled",
-			},
-		},
-		"outside": composetypes.NetworkConfig{
-			External: composetypes.External{External: true},
-			Name:     "special",
-		},
-		"attachablenet": composetypes.NetworkConfig{
-			Driver:     "overlay",
-			Attachable: true,
-		},
 		"named": composetypes.NetworkConfig{
 			Name: "othername",
 		},
 	}
 	expected := map[string]types.NetworkCreate{
-		"normal": {
-			Driver: "overlay",
-			IPAM: &network.IPAM{
-				Driver: "driver",
-				Config: []network.IPAMConfig{
-					{
-						Subnet: "10.0.0.0",
-					},
-				},
-			},
-			Options: map[string]string{
-				"opt": "value",
-			},
-			Labels: map[string]string{
-				"something":    "labeled",
-				LabelNamespace: "foo",
-			},
-		},
-		"attachablenet": {
-			Driver:     "overlay",
-			Attachable: true,
-			Labels: map[string]string{
-				LabelNamespace: "foo",
-			},
-		},
 		"named": {
 			Labels: map[string]string{
 				LabelNamespace: "foo",
@@ -176,7 +126,7 @@ func TestNetworksCreatedWithoutServices(t *testing.T) {
 
 	networks, externals := Networks(namespace, source, serviceNetworks)
 	assert.DeepEqual(t, expected, networks)
-	assert.DeepEqual(t, []string{"special"}, externals)
+	assert.DeepEqual(t, []string{}, externals)
 }
 
 func TestSecrets(t *testing.T) {


### PR DESCRIPTION
**- What I did**
Make `docker stack deploy` create networks even if there are no services attached to it, so you can create stack files for networks only
**- How I did it**
Change `cli/compose/convert/compose.go` to consider the `networks` map when `servicesNetworks` lenght is equals 0
**- How to verify it**
The issue [#37229](https://github.com/moby/moby/issues/37229) in moby repo has more information about how to reproduce the error
**- Description for the changelog**
Support deploy network only stacks


![pug](https://vignette.wikia.nocookie.net/animal-jam-clans-1/images/d/d4/Cute-animal-wallpapers-hd-wild-life-photos-pet-images-lovely-animals-hairy-claws-amazing-eyes-cool-884x627.jpg/revision/latest?cb=20160123042737)

