### PR TITLE
Bump Golang to 1.10.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.10
+  GOVERSION: 1.10.3
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.10.2-alpine
+FROM    golang:1.10.3-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.10.2@sha256:297fa4bc113facd7a528699919f86009420a6b5bedbdc89da35c14f7fee047e1
+FROM    dockercore/golang-cross:1.10.3@sha256:7671b4ed357fda50124e5679d36c4c3206ded4d43f1d2e0ff3d120a1e2bf94d7
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.10.2-alpine
+FROM    golang:1.10.3-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.10.2
+ARG GO_VERSION=1.10.3
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.10.2-alpine
+FROM    golang:1.10.3-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.10.3 (released 2018/06/05) includes fixes to the go command, and the
crypto/tls, crypto/x509, and strings packages. In particular, it adds minimal
support to the go command for the vgo transition. See the Go 1.10.3 milestone
on our issue tracker for details;
https://github.com/golang/go/issues?q=milestone%3AGo1.10.3
