### PR TITLE
Export Push and Save

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -26,7 +26,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runPush(dockerCli, opts)
+			return RunPush(dockerCli, opts)
 		},
 	}
 
@@ -37,7 +37,8 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runPush(dockerCli command.Cli, opts pushOptions) error {
+// RunPush performs a push against the engine based on the specified options
+func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	ref, err := reference.ParseNormalizedNamed(opts.remote)
 	if err != nil {
 		return err

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -27,7 +27,7 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.images = args
-			return runSave(dockerCli, opts)
+			return RunSave(dockerCli, opts)
 		},
 	}
 
@@ -38,7 +38,8 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runSave(dockerCli command.Cli, opts saveOptions) error {
+// RunSave performs a save against the engine based on the specified options
+func RunSave(dockerCli command.Cli, opts saveOptions) error {
 	if opts.output == "" && dockerCli.Out().IsTerminal() {
 		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}


### PR DESCRIPTION
As we did for `Pull`, it will be helpful to expose the push and save
implementation.

This will be required for `docker/app` in the near future :angel: :pray: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
