### PR TITLE
Add an `Extras` field on the compose config types.

### DIFF
--- a/cli/compose/loader/full-example.yml
+++ b/cli/compose/loader/full-example.yml
@@ -278,6 +278,8 @@ services:
           size: 10000
 
     working_dir: /code
+    x-bar: baz
+    x-foo: bar
 
 networks:
   # Entries can be null, which specifies simply that a network
@@ -318,6 +320,8 @@ networks:
     # can be referred to within this file as "other-external-network"
     external:
       name: my-cool-network
+    x-bar: baz
+    x-foo: bar
 
 volumes:
   # Entries can be null, which specifies simply that a volume
@@ -361,6 +365,8 @@ volumes:
     # can be referred to within this file as "external-volume3"
     name: this-is-volume3
     external: true
+    x-bar: baz
+    x-foo: bar
 
 configs:
   config1:
@@ -374,6 +380,8 @@ configs:
     external: true
   config4:
     name: foo
+    x-bar: baz
+    x-foo: bar
 
 secrets:
   secret1:
@@ -387,3 +395,10 @@ secrets:
     external: true
   secret4:
     name: bar
+    x-bar: baz
+    x-foo: bar
+x-bar: baz
+x-foo: bar
+x-nested:
+  bar: baz
+  foo: bar

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -182,6 +182,23 @@ func TestLoad(t *testing.T) {
 	assert.Check(t, is.DeepEqual(sampleConfig.Volumes, actual.Volumes))
 }
 
+func TestLoadExtras(t *testing.T) {
+	actual, err := loadYAML(`
+version: "3.7"
+services:
+  foo:
+    image: busybox
+    x-foo: bar`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(actual.Services, 1))
+	service := actual.Services[0]
+	assert.Check(t, is.Equal("busybox", service.Image))
+	extras := map[string]interface{}{
+		"x-foo": "bar",
+	}
+	assert.Check(t, is.DeepEqual(extras, service.Extras))
+}
+
 func TestLoadV31(t *testing.T) {
 	actual, err := loadYAML(`
 version: "3.1"
@@ -825,6 +842,9 @@ func TestFullExample(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expectedConfig.Services, config.Services))
 	assert.Check(t, is.DeepEqual(expectedConfig.Networks, config.Networks))
 	assert.Check(t, is.DeepEqual(expectedConfig.Volumes, config.Volumes))
+	assert.Check(t, is.DeepEqual(expectedConfig.Secrets, config.Secrets))
+	assert.Check(t, is.DeepEqual(expectedConfig.Configs, config.Configs))
+	assert.Check(t, is.DeepEqual(expectedConfig.Extras, config.Extras))
 }
 
 func TestLoadTmpfsVolume(t *testing.T) {

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -77,6 +77,7 @@ type Config struct {
 	Volumes  map[string]VolumeConfig
 	Secrets  map[string]SecretConfig
 	Configs  map[string]ConfigObjConfig
+	Extras   map[string]interface{} `yaml:",inline"`
 }
 
 // Services is a list of ServiceConfig
@@ -142,6 +143,7 @@ type ServiceConfig struct {
 	Volumes         []ServiceVolumeConfig            `yaml:",omitempty"`
 	WorkingDir      string                           `mapstructure:"working_dir" yaml:"working_dir,omitempty"`
 	Isolation       string                           `mapstructure:"isolation" yaml:"isolation,omitempty"`
+	Extras          map[string]interface{}           `yaml:",inline"`
 }
 
 // BuildConfig is a type for build
@@ -354,14 +356,15 @@ func (u *UlimitsConfig) MarshalYAML() (interface{}, error) {
 
 // NetworkConfig for a network
 type NetworkConfig struct {
-	Name       string            `yaml:",omitempty"`
-	Driver     string            `yaml:",omitempty"`
-	DriverOpts map[string]string `mapstructure:"driver_opts" yaml:"driver_opts,omitempty"`
-	Ipam       IPAMConfig        `yaml:",omitempty"`
-	External   External          `yaml:",omitempty"`
-	Internal   bool              `yaml:",omitempty"`
-	Attachable bool              `yaml:",omitempty"`
-	Labels     Labels            `yaml:",omitempty"`
+	Name       string                 `yaml:",omitempty"`
+	Driver     string                 `yaml:",omitempty"`
+	DriverOpts map[string]string      `mapstructure:"driver_opts" yaml:"driver_opts,omitempty"`
+	Ipam       IPAMConfig             `yaml:",omitempty"`
+	External   External               `yaml:",omitempty"`
+	Internal   bool                   `yaml:",omitempty"`
+	Attachable bool                   `yaml:",omitempty"`
+	Labels     Labels                 `yaml:",omitempty"`
+	Extras     map[string]interface{} `yaml:",inline"`
 }
 
 // IPAMConfig for a network
@@ -377,11 +380,12 @@ type IPAMPool struct {
 
 // VolumeConfig for a volume
 type VolumeConfig struct {
-	Name       string            `yaml:",omitempty"`
-	Driver     string            `yaml:",omitempty"`
-	DriverOpts map[string]string `mapstructure:"driver_opts" yaml:"driver_opts,omitempty"`
-	External   External          `yaml:",omitempty"`
-	Labels     Labels            `yaml:",omitempty"`
+	Name       string                 `yaml:",omitempty"`
+	Driver     string                 `yaml:",omitempty"`
+	DriverOpts map[string]string      `mapstructure:"driver_opts" yaml:"driver_opts,omitempty"`
+	External   External               `yaml:",omitempty"`
+	Labels     Labels                 `yaml:",omitempty"`
+	Extras     map[string]interface{} `yaml:",inline"`
 }
 
 // External identifies a Volume or Network as a reference to a resource that is
@@ -408,10 +412,11 @@ type CredentialSpecConfig struct {
 
 // FileObjectConfig is a config type for a file used by a service
 type FileObjectConfig struct {
-	Name     string   `yaml:",omitempty"`
-	File     string   `yaml:",omitempty"`
-	External External `yaml:",omitempty"`
-	Labels   Labels   `yaml:",omitempty"`
+	Name     string                 `yaml:",omitempty"`
+	File     string                 `yaml:",omitempty"`
+	External External               `yaml:",omitempty"`
+	Labels   Labels                 `yaml:",omitempty"`
+	Extras   map[string]interface{} `yaml:",inline"`
 }
 
 // SecretConfig for a secret


### PR DESCRIPTION
That field is automaticaly populated with any `x-*` field in the yaml.
And marshalling the compose config struct put them back into place.

This make it possible to get those extra fields without re-inventing
the wheel (i.e. reimplementing 80% of the `cli/compose/*` packages.

Will be very useful for experiments in `docker/app` :angel: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
