### PR TITLE
Allow `.` in variables used for interpolation

### DIFF
--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -6,15 +6,17 @@ import (
 	"strings"
 )
 
-var delimiter = "\\$"
-var substitution = "[_a-z.][_a-z0-9.]*(?::?[-?][^}]*)?"
+var (
+	delimiter    = "\\$"
+	substitution = "[_a-z.][_a-z0-9.]*(?::?[-?][^}]*)?"
 
-var patternString = fmt.Sprintf(
-	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
-	delimiter, delimiter, substitution, substitution,
+	patternString = fmt.Sprintf(
+		"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",
+		delimiter, delimiter, substitution, substitution,
+	)
+
+	pattern = regexp.MustCompile(patternString)
 )
-
-var pattern = regexp.MustCompile(patternString)
 
 // InvalidTemplateError is returned when a variable template is not in a valid
 // format

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -7,7 +7,7 @@ import (
 )
 
 var delimiter = "\\$"
-var substitution = "[_a-z][_a-z0-9]*(?::?[-?][^}]*)?"
+var substitution = "[_a-z.][_a-z0-9.]*(?::?[-?][^}]*)?"
 
 var patternString = fmt.Sprintf(
 	"%s(?i:(?P<escaped>%s)|(?P<named>%s)|{(?P<braced>%s)}|(?P<invalid>))",


### PR DESCRIPTION
> Environment variable names used by the utilities in the Shell and
> Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase
> letters, digits, and the '_' (underscore) from the characters
> defined in Portable Character Set and do not begin with a
> digit. **Other characters may be permitted by an implementation;
> applications shall tolerate the presence of such names**. Uppercase
> and lowercase letters shall retain their unique identities and shall
> not be folded together. The name space of environment variable names
> containing lowercase letters is reserved for applications.

As it is possible to use them in environment variable, we should also
allow them during interpolation.

It's also required if we want to allow smarter interpolation in the
future (and for `docker/app` too 👼)

:lion: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
