### PR TITLE
Add options to the compose loader

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -14,6 +14,8 @@ type Options struct {
 	LookupValue LookupValue
 	// TypeCastMapping maps key paths to functions to cast to a type
 	TypeCastMapping map[Path]Cast
+	// Substitution function to use
+	Substitute func(string, template.Mapping) (string, error)
 }
 
 // LookupValue is a function which maps from variable names to values.
@@ -33,6 +35,9 @@ func Interpolate(config map[string]interface{}, opts Options) (map[string]interf
 	if opts.TypeCastMapping == nil {
 		opts.TypeCastMapping = make(map[Path]Cast)
 	}
+	if opts.Substitute == nil {
+		opts.Substitute = template.Substitute
+	}
 
 	out := map[string]interface{}{}
 
@@ -51,7 +56,7 @@ func recursiveInterpolate(value interface{}, path Path, opts Options) (interface
 	switch value := value.(type) {
 
 	case string:
-		newValue, err := template.Substitute(value, template.Mapping(opts.LookupValue))
+		newValue, err := opts.Substitute(value, template.Mapping(opts.LookupValue))
 		if err != nil || newValue == value {
 			return value, newPathError(path, err)
 		}

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -64,11 +64,6 @@ func toBoolean(value string) (interface{}, error) {
 	}
 }
 
-func interpolateConfig(configDict map[string]interface{}, lookupEnv interp.LookupValue) (map[string]interface{}, error) {
-	return interp.Interpolate(
-		configDict,
-		interp.Options{
-			LookupValue:     lookupEnv,
-			TypeCastMapping: interpolateTypeCastMapping,
-		})
+func interpolateConfig(configDict map[string]interface{}, opts interp.Options) (map[string]interface{}, error) {
+	return interp.Interpolate(configDict, opts)
 }


### PR DESCRIPTION
- Add the possibility to skip interpolation
- Add the possibility to skip schema validation
- Allow customizing the substitution function, to add special cases.

Example of use.

```go
loader.Load(composetypes.ConfigDetails{
	WorkingDir:  ".",
	ConfigFiles: files,
	Environment: env,
}, func(opts *loader.Options) {
	opts.Interpolate.Substitute = composetemplate.SubstituteWith(template, mapping, errorIfMissing)
})

// […]

func errorIfMissing(substitution string, mapping composetemplate.Mapping) (string, bool, error) {
	value, found := mapping(substitution)
	if !found {
		return "", true, &composetemplate.InvalidTemplateError{
			Template: fmt.Sprintf("required variable %s is missing a value", substitution),
		}
	}
	return value, true, nil
}
```

Again, this is gonna be *very useful* for `docker/app` :angel: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
