### PR TITLE
cli: add a separate --domainname flag

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -74,6 +74,7 @@ type containerOptions struct {
 	containerIDFile    string
 	entrypoint         string
 	hostname           string
+	domainname         string
 	memory             opts.MemBytes
 	memoryReservation  opts.MemBytes
 	memorySwap         opts.MemSwapBytes
@@ -169,6 +170,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.StringVar(&copts.entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	flags.Var(&copts.groupAdd, "group-add", "Add additional groups to join")
 	flags.StringVarP(&copts.hostname, "hostname", "h", "", "Container host name")
+	flags.StringVar(&copts.domainname, "domainname", "", "Container NIS domain name")
 	flags.BoolVarP(&copts.stdin, "interactive", "i", false, "Keep STDIN open even if not attached")
 	flags.VarP(&copts.labels, "label", "l", "Set meta data on a container")
 	flags.Var(&copts.labelsFile, "label-file", "Read in a line delimited file of labels")
@@ -546,6 +548,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, err
 
 	config := &container.Config{
 		Hostname:     copts.hostname,
+		Domainname:   copts.domainname,
 		ExposedPorts: ports,
 		User:         copts.user,
 		Tty:          copts.tty,

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -265,14 +265,35 @@ func TestParseHostname(t *testing.T) {
 	hostnameWithDomainTld := "--hostname=hostname.domainname.tld"
 	for hostname, expectedHostname := range validHostnames {
 		if config, _ := mustParse(t, fmt.Sprintf("--hostname=%s", hostname)); config.Hostname != expectedHostname {
-			t.Fatalf("Expected the config to have 'hostname' as hostname, got '%v'", config.Hostname)
+			t.Fatalf("Expected the config to have 'hostname' as %q, got %q", expectedHostname, config.Hostname)
 		}
 	}
-	if config, _ := mustParse(t, hostnameWithDomain); config.Hostname != "hostname.domainname" && config.Domainname != "" {
-		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname, got '%v'", config.Hostname)
+	if config, _ := mustParse(t, hostnameWithDomain); config.Hostname != "hostname.domainname" || config.Domainname != "" {
+		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname, got %q", config.Hostname)
 	}
-	if config, _ := mustParse(t, hostnameWithDomainTld); config.Hostname != "hostname.domainname.tld" && config.Domainname != "" {
-		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname.tld, got '%v'", config.Hostname)
+	if config, _ := mustParse(t, hostnameWithDomainTld); config.Hostname != "hostname.domainname.tld" || config.Domainname != "" {
+		t.Fatalf("Expected the config to have 'hostname' as hostname.domainname.tld, got %q", config.Hostname)
+	}
+}
+
+func TestParseHostnameDomainname(t *testing.T) {
+	validDomainnames := map[string]string{
+		"domainname":    "domainname",
+		"domain-name":   "domain-name",
+		"domainname123": "domainname123",
+		"123domainname": "123domainname",
+		"domainname-63-bytes-long-should-be-valid-and-without-any-errors": "domainname-63-bytes-long-should-be-valid-and-without-any-errors",
+	}
+	for domainname, expectedDomainname := range validDomainnames {
+		if config, _ := mustParse(t, "--domainname="+domainname); config.Domainname != expectedDomainname {
+			t.Fatalf("Expected the config to have 'domainname' as %q, got %q", expectedDomainname, config.Domainname)
+		}
+	}
+	if config, _ := mustParse(t, "--hostname=some.prefix --domainname=domainname"); config.Hostname != "some.prefix" || config.Domainname != "domainname" {
+		t.Fatalf("Expected the config to have 'hostname' as 'some.prefix' and 'domainname' as 'domainname', got %q and %q", config.Hostname, config.Domainname)
+	}
+	if config, _ := mustParse(t, "--hostname=another-prefix --domainname=domainname.tld"); config.Hostname != "another-prefix" || config.Domainname != "domainname.tld" {
+		t.Fatalf("Expected the config to have 'hostname' as 'another-prefix' and 'domainname' as 'domainname.tld', got %q and %q", config.Hostname, config.Domainname)
 	}
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5,8 +5,8 @@
 #  - SC2016: Expressions don't expand in single quotes, use double quotes for that.
 #  - SC2119: Use foo "$@" if function's $1 should mean script's $1.
 #  - SC2155: Declare and assign separately to avoid masking return values.
-# 
-# You can find more details for each warning at the following page: 
+#
+# You can find more details for each warning at the following page:
 #    https://github.com/koalaman/shellcheck/wiki/<SCXXXX>
 #
 # bash completion file for core docker commands
@@ -1802,6 +1802,7 @@ _docker_container_run_and_create() {
 		--dns
 		--dns-option
 		--dns-search
+		--domainname
 		--entrypoint
 		--env -e
 		--env-file

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -617,6 +617,7 @@ __docker_container_subcommand() {
         "($help)*--dns=[Custom DNS servers]:DNS server: "
         "($help)*--dns-option=[Custom DNS options]:DNS option: "
         "($help)*--dns-search=[Custom DNS search domains]:DNS domains: "
+        "($help)*--domainname=[Container NIS domain name]:domainname:_hosts"
         "($help)*"{-e=,--env=}"[Environment variables]:environment variable: "
         "($help)--entrypoint=[Overwrite the default entrypoint of the image]:entry point: "
         "($help)*--env-file=[Read environment variables from a file]:environment file:_files"

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -53,6 +53,7 @@ Options:
       --dns value                     Set custom DNS servers (default [])
       --dns-option value              Set DNS options (default [])
       --dns-search value              Set custom DNS search domains (default [])
+      --domainname string             Container NIS domain name
       --entrypoint string             Overwrite the default ENTRYPOINT of the image
   -e, --env value                     Set environment variables (default [])
       --env-file value                Read in a file of environment variables (default [])

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -57,6 +57,7 @@ Options:
       --dns value                     Set custom DNS servers (default [])
       --dns-option value              Set DNS options (default [])
       --dns-search value              Set custom DNS search domains (default [])
+      --domainname string             Container NIS domain name
       --entrypoint string             Overwrite the default ENTRYPOINT of the image
   -e, --env value                     Set environment variables (default [])
       --env-file value                Read in a file of environment variables (default [])

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -256,7 +256,7 @@ The UTS namespace is for setting the hostname and the domain that is visible
 to running processes in that namespace.  By default, all containers, including
 those with `--network=host`, have their own UTS namespace.  The `host` setting will
 result in the container using the same UTS namespace as the host.  Note that
-`--hostname` is invalid in `host` UTS mode.
+`--hostname` and `--domainname` are invalid in `host` UTS mode.
 
 You may wish to share the UTS namespace with the host if you would like the
 hostname of the container to change as the hostname of the host changes.  A
@@ -396,8 +396,8 @@ network stack and all interfaces from the host will be available to the
 container.  The container's hostname will match the hostname on the host
 system. Note that `--mac-address` is invalid in `host` netmode. Even in `host`
 network mode a container has its own UTS namespace by default. As such
-`--hostname` is allowed in `host` network mode and will only change the
-hostname inside the container.
+`--hostname` and `--domainname` are allowed in `host` network mode and will
+only change the hostname and domain name inside the container.
 Similar to `--hostname`, the `--add-host`, `--dns`, `--dns-search`, and
 `--dns-option` options can be used in `host` network mode. These options update
 `/etc/hosts` or `/etc/resolv.conf` inside the container. No change are made to

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -35,6 +35,7 @@ docker-run - Run a command in a new container
 [**--dns**[=*[]*]]
 [**--dns-option**[=*[]*]]
 [**--dns-search**[=*[]*]]
+[**--domainname**[=*DOMAINNAME*]]
 [**-e**|**--env**[=*[]*]]
 [**--entrypoint**[=*ENTRYPOINT*]]
 [**--env-file**[=*[]*]]
@@ -284,6 +285,12 @@ permissions for the host device **/dev/sdc**, seen as **/dev/xvdc** inside the c
 configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
 is the case the **--dns** flags is necessary for every run.
+
+**--domainname**=""
+   Container NIS domain name
+
+   Sets the container's NIS domain name (see also **setdomainname(2)**) that is
+   available inside the container.
 
 **-e**, **--env**=[]
    Set environment variables


### PR DESCRIPTION
A while ago, Docker split the "Domainname" field out from the "Hostname"
field for the container configuration. There was no real user-visible
change associated with this (and under the hood "Domainname" was mostly
left unused from the command-line point of view). We now add this flag
in order to match other proposed changes to allow for setting the NIS
domainname of a container.

[![Cute cat by .:I&#x27;m-a-kitty-cat!:.](https://farm4.staticflickr.com/3483/3274624318_95433914e3_b.jpg)](https://flic.kr/p/5ZniHY)

###### [Cute cat](https://flic.kr/p/5ZniHY) by [.:I&#x27;m-a-kitty-cat!:.](https://www.flickr.com/photos/tiina93/)

Signed-off-by: Aleksa Sarai <asarai@suse.de>