### PR TITLE
[WIP] Do not call `pass` all the time…

### DIFF
--- a/cli/config/credentials/default_store_linux.go
+++ b/cli/config/credentials/default_store_linux.go
@@ -5,7 +5,7 @@ import (
 )
 
 func defaultCredentialsStore() string {
-	if pass.PassInitialized {
+	if pass.IsPresent() {
 		return "pass"
 	}
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -7,7 +7,7 @@ github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
 github.com/docker/docker c752b0991e31ba9869ab6a0661af57e9423874fb
-github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b
+github.com/docker/docker-credential-helpers 19b711cc92fbaa47533646fa8adb457d199c99e1
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go d30aec9fd63c35133f8f79c3412ad91a3b08be06

--- a/vendor/github.com/docker/docker-credential-helpers/README.md
+++ b/vendor/github.com/docker/docker-credential-helpers/README.md
@@ -55,6 +55,12 @@ You can see examples of each function in the [client](https://godoc.org/github.c
 1. osxkeychain: Provides a helper to use the OS X keychain as credentials store.
 2. secretservice: Provides a helper to use the D-Bus secret service as credentials store.
 3. wincred: Provides a helper to use Windows credentials manager as store.
+4. pass: Provides a helper to use `pass` as credentials store.
+
+#### Note
+
+`pass` needs to be configured for `docker-credential-pass` to work properly.
+It must be initialized with a `gpg2` key ID. Make sure your GPG key exists is in `gpg2` keyring as `pass` uses `gpg2` instead of the regular `gpg`.
 
 ## Development
 

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
@@ -1,4 +1,4 @@
 package credentials
 
 // Version holds a string describing the current version
-const Version = "0.5.2"
+const Version = "0.6.0"


### PR DESCRIPTION
… even when it's not the active credential store.
The check (and calls) will only be when a command require some
credentials (like `login`, `logout`, `pull`, …)

Depends on https://github.com/docker/docker-credential-helpers/pull/106
Should fix https://github.com/docker/cli/issues/699

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
