### PR TITLE
Add env variable option for experimental

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -162,7 +162,12 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions) error {
 	if err != nil {
 		return err
 	}
-	hasExperimental, err := isEnabled(cli.configFile.Experimental)
+	var experimentalValue string
+	// Environment variable always overrides configuration
+	if experimentalValue = os.Getenv("DOCKER_CLI_EXPERIMENTAL"); experimentalValue == "" {
+		experimentalValue = cli.configFile.Experimental
+	}
+	hasExperimental, err := isEnabled(experimentalValue)
 	if err != nil {
 		return errors.Wrap(err, "Experimental field")
 	}

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -61,6 +61,7 @@ by the `docker` command line:
 * `DOCKER_API_VERSION` The API version to use (e.g. `1.19`)
 * `DOCKER_CONFIG` The location of your client configuration files.
 * `DOCKER_CERT_PATH` The location of your authentication keys.
+* `DOCKER_CLI_EXPERIMENTAL` Enable experimental features for the cli (e.g. `enabled` or `disabled`)
 * `DOCKER_DRIVER` The graph driver to use.
 * `DOCKER_HOST` Daemon socket to connect to.
 * `DOCKER_NOWARN_KERNEL_VERSION` Prevent warnings that your Linux kernel is


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added an option to enable the experimental cli options with an environment variable

**- How to verify it**

<details>
<summary>Proof of work</summary>

```
~/go/src/github.com/docker/cli env_experimental eli@castlerock
❯ DOCKER_CLI_EXPERIMENTAL=enabled ./build/docker manifest

Usage:  docker manifest COMMAND

Manage Docker image manifests and manifest lists

Options:
      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)

Commands:
  annotate    Add additional information to a local image manifest
  create      Create a local manifest list for annotating and pushing to a registry
  inspect     Display an image manifest, or manifest list
  push        Push a manifest list to a repository

Run 'docker manifest COMMAND --help' for more information on a command.

~/go/src/github.com/docker/cli env_experimental eli@castlerock
❯ DOCKER_CLI_EXPERIMENTAL=disabled ./build/docker manifest
docker manifest is only supported on a Docker cli with experimental cli features enabled

~/go/src/github.com/docker/cli env_experimental eli@castlerock
❯ ./build/docker manifest
docker manifest is only supported on a Docker cli with experimental cli features enabled
```

</details>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Added the option to enable experimental cli features through the `DOCKER_CLI_EXPERIMENTAL environment variable
```


**- A picture of a cute animal (not mandatory but encouraged)**
![pirate](http://www.funny-potato.com/images/animals/birds/bird-arms/pirate-bird.jpg)
