### PR TITLE
 Warn if DOCKER_ORCHESTRATOR is still used but not DOCKER_STACK_ORCHESTRATOR

### DIFF
--- a/cli/command/orchestrator.go
+++ b/cli/command/orchestrator.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -19,6 +20,7 @@ const (
 
 	defaultOrchestrator           = OrchestratorSwarm
 	envVarDockerStackOrchestrator = "DOCKER_STACK_ORCHESTRATOR"
+	envVarDockerOrchestrator      = "DOCKER_ORCHESTRATOR"
 )
 
 // HasKubernetes returns true if defined orchestrator has Kubernetes capabilities.
@@ -53,13 +55,16 @@ func normalize(value string) (Orchestrator, error) {
 
 // GetStackOrchestrator checks DOCKER_STACK_ORCHESTRATOR environment variable and configuration file
 // orchestrator value and returns user defined Orchestrator.
-func GetStackOrchestrator(flagValue, value string) (Orchestrator, error) {
+func GetStackOrchestrator(flagValue, value string, stderr io.Writer) (Orchestrator, error) {
 	// Check flag
 	if o, err := normalize(flagValue); o != orchestratorUnset {
 		return o, err
 	}
 	// Check environment variable
 	env := os.Getenv(envVarDockerStackOrchestrator)
+	if env == "" && os.Getenv(envVarDockerOrchestrator) != "" {
+		fmt.Fprintf(stderr, "WARNING: experimental environment variable %s is set. Please use %s instead\n", envVarDockerOrchestrator, envVarDockerStackOrchestrator)
+	}
 	if o, err := normalize(env); o != orchestratorUnset {
 		return o, err
 	}

--- a/cli/command/orchestrator_test.go
+++ b/cli/command/orchestrator_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -107,7 +108,7 @@ func TestOrchestratorSwitch(t *testing.T) {
 			err := cli.Initialize(options)
 			assert.NilError(t, err)
 
-			orchestrator, err := GetStackOrchestrator(testcase.flagOrchestrator, cli.ConfigFile().StackOrchestrator)
+			orchestrator, err := GetStackOrchestrator(testcase.flagOrchestrator, cli.ConfigFile().StackOrchestrator, ioutil.Discard)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(testcase.expectedKubernetes, orchestrator.HasKubernetes()))
 			assert.Check(t, is.Equal(testcase.expectedSwarm, orchestrator.HasSwarm()))

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -3,6 +3,7 @@ package stack
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -26,7 +27,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Manage Docker stacks",
 		Args:  cli.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			orchestrator, err := getOrchestrator(dockerCli.ConfigFile(), cmd)
+			orchestrator, err := getOrchestrator(dockerCli.ConfigFile(), cmd, dockerCli.Err())
 			if err != nil {
 				return err
 			}
@@ -71,12 +72,12 @@ func NewTopLevelDeployCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func getOrchestrator(config *configfile.ConfigFile, cmd *cobra.Command) (command.Orchestrator, error) {
+func getOrchestrator(config *configfile.ConfigFile, cmd *cobra.Command, stderr io.Writer) (command.Orchestrator, error) {
 	var orchestratorFlag string
 	if o, err := cmd.Flags().GetString("orchestrator"); err == nil {
 		orchestratorFlag = o
 	}
-	return command.GetStackOrchestrator(orchestratorFlag, config.StackOrchestrator)
+	return command.GetStackOrchestrator(orchestratorFlag, config.StackOrchestrator, stderr)
 }
 
 func hideOrchestrationFlags(cmd *cobra.Command, orchestrator command.Orchestrator) {

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -126,7 +126,7 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 		return cli.StatusError{StatusCode: 64, Status: err.Error()}
 	}
 
-	orchestrator, err := command.GetStackOrchestrator("", dockerCli.ConfigFile().StackOrchestrator)
+	orchestrator, err := command.GetStackOrchestrator("", dockerCli.ConfigFile().StackOrchestrator, dockerCli.Err())
 	if err != nil {
 		return cli.StatusError{StatusCode: 64, Status: err.Error()}
 	}


### PR DESCRIPTION
Follow up to https://github.com/docker/cli/pull/1137, and based on that branch; only the last commit is new