### PR TITLE
fixed output leak from TestRunCommandWithContentTrustErrors

### DIFF
--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -66,6 +67,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewRunCommand(cli)
 		cmd.SetArgs(tc.args)
+		cmd.SetOutput(ioutil.Discard)
 		err := cmd.Execute()
 		assert.Assert(t, err != nil)
 		assert.Assert(t, is.Contains(cli.ErrBuffer().String(), tc.expectedError))


### PR DESCRIPTION
**- What I did**
Fixed output leaked to stdout from unit tests in `TestRunCommandWithContentTrustErrors`

**- How I did it**
Redirected output to `ioutil.Discard`

**- How to verify it**
Current output:
```
=== RUN   TestRunCommandWithContentTrustErrors
Error: Status: , Code: 125
Usage:
  run [OPTIONS] IMAGE [COMMAND] [ARG...] [flags]

Flags:
      --add-host list                  Add a custom host-to-IP mapping (host:ip)
  -a, --attach list                    Attach to STDIN, STDOUT or STDERR
      --blkio-weight uint16            Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
      --blkio-weight-device list       Block IO weight (relative device weight) (default [])
      --cap-add list                   Add Linux capabilities
      --cap-drop list                  Drop Linux capabilities
      --cgroup-parent string           Optional parent cgroup for t
```
...
```
      --volumes-from list              Mount volumes from the specified container(s)
  -w, --workdir string                 Working directory inside the container

--- PASS: TestRunCommandWithContentTrustErrors (0.00s)
```

With the changes made by this PR:
```
=== RUN   TestRunCommandWithContentTrustErrors
--- PASS: TestRunCommandWithContentTrustErrors (0.00s)
```
**- Description for the changelog**
Fixed output leak from unit tests in TestRunCommandWithContentTrustErrors

**- A picture of a cute animal (not mandatory but encouraged)**

