### PR TITLE
Allow vendoring on compose file JSON schemas

### DIFF
--- a/cli/compose/schema/data/doc.go
+++ b/cli/compose/schema/data/doc.go
@@ -1,0 +1,4 @@
+//
+// +domain=docker.com
+
+package data


### PR DESCRIPTION
**- What I did**
Compose JSON schemas are stored in directory, without any go code in it, so it cannot be vendored if the pruning is enabled.

**- How I did it**
I simply added a doc.go file...

**- How to verify it**

1. Vendor docker/cli in another project
2. Add somewhere in your project: 
```go
import _ github.com/docker/cli/cli/compose/schema/data
```
3. Prune the vendoring
=> Schemas are still there!

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/42100196-d6e5c17a-7bbf-11e8-9f4e-3ca6cf79ec13.png)

