### PR TITLE
[18.06] Updated the go-winio library to release 0.4.8 that has the fix for Windows containers

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -46,7 +46,7 @@ github.com/json-iterator/go 6240e1e7983a85228f7fd9c3e1b6932d46ec58e2
 github.com/mailru/easyjson d5b7844b561a7bc640052f1b935f7b800330d7e0
 github.com/mattn/go-shellwords v1.0.3
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-github.com/Microsoft/go-winio v0.4.6
+github.com/Microsoft/go-winio v0.4.8
 github.com/miekg/pkcs11 5f6e0d0dad6f472df908c8e968a98ef00c9224bb
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715
 github.com/moby/buildkit b062a2d8ddbaa477c25c63d68a9cffbb43f6e474

--- a/vendor/github.com/Microsoft/go-winio/file.go
+++ b/vendor/github.com/Microsoft/go-winio/file.go
@@ -16,7 +16,6 @@ import (
 //sys createIoCompletionPort(file syscall.Handle, port syscall.Handle, key uintptr, threadCount uint32) (newport syscall.Handle, err error) = CreateIoCompletionPort
 //sys getQueuedCompletionStatus(port syscall.Handle, bytes *uint32, key *uintptr, o **ioOperation, timeout uint32) (err error) = GetQueuedCompletionStatus
 //sys setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err error) = SetFileCompletionNotificationModes
-//sys timeBeginPeriod(period uint32) (n int32) = winmm.timeBeginPeriod
 
 type atomicBool int32
 
@@ -153,8 +152,6 @@ func (f *win32File) prepareIo() (*ioOperation, error) {
 
 // ioCompletionProcessor processes completed async IOs forever
 func ioCompletionProcessor(h syscall.Handle) {
-	// Set the timer resolution to 1. This fixes a performance regression in golang 1.6.
-	timeBeginPeriod(1)
 	for {
 		var bytes uint32
 		var key uintptr

--- a/vendor/github.com/Microsoft/go-winio/zsyscall_windows.go
+++ b/vendor/github.com/Microsoft/go-winio/zsyscall_windows.go
@@ -38,14 +38,12 @@ func errnoErr(e syscall.Errno) error {
 
 var (
 	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
-	modwinmm    = windows.NewLazySystemDLL("winmm.dll")
 	modadvapi32 = windows.NewLazySystemDLL("advapi32.dll")
 
 	procCancelIoEx                                           = modkernel32.NewProc("CancelIoEx")
 	procCreateIoCompletionPort                               = modkernel32.NewProc("CreateIoCompletionPort")
 	procGetQueuedCompletionStatus                            = modkernel32.NewProc("GetQueuedCompletionStatus")
 	procSetFileCompletionNotificationModes                   = modkernel32.NewProc("SetFileCompletionNotificationModes")
-	proctimeBeginPeriod                                      = modwinmm.NewProc("timeBeginPeriod")
 	procConnectNamedPipe                                     = modkernel32.NewProc("ConnectNamedPipe")
 	procCreateNamedPipeW                                     = modkernel32.NewProc("CreateNamedPipeW")
 	procCreateFileW                                          = modkernel32.NewProc("CreateFileW")
@@ -119,12 +117,6 @@ func setFileCompletionNotificationModes(h syscall.Handle, flags uint8) (err erro
 			err = syscall.EINVAL
 		}
 	}
-	return
-}
-
-func timeBeginPeriod(period uint32) (n int32) {
-	r0, _, _ := syscall.Syscall(proctimeBeginPeriod.Addr(), 1, uintptr(period), 0, 0)
-	n = int32(r0)
 	return
 }
 


### PR DESCRIPTION
cherry picked from commit c98c4080a323fb0e4fdf7429d8af4e2e946d09b5 (https://github.com/docker/cli/pull/1157) - no conflicts
