### PR TITLE
Sort plugin names in a natural order

### DIFF
--- a/cli/command/plugin/list.go
+++ b/cli/command/plugin/list.go
@@ -2,12 +2,14 @@ package plugin
 
 import (
 	"context"
+	"sort"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
+	"vbom.ml/util/sortorder"
 )
 
 type listOptions struct {
@@ -45,6 +47,10 @@ func runList(dockerCli command.Cli, options listOptions) error {
 	if err != nil {
 		return err
 	}
+
+	sort.Slice(plugins, func(i, j int) bool {
+		return sortorder.NaturalLess(plugins[i].Name, plugins[j].Name)
+	})
 
 	format := options.format
 	if len(format) == 0 {

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -135,6 +135,30 @@ func TestList(t *testing.T) {
 			golden:   "plugin-list-with-format.golden",
 			listFunc: singlePluginListFunc,
 		},
+		{
+			description: "list output is sorted based on plugin name",
+			args:        []string{},
+			flags: map[string]string{
+				"format": "{{ .Name }}",
+			},
+			golden: "plugin-list-sort.golden",
+			listFunc: func(filter filters.Args) (types.PluginsListResponse, error) {
+				return types.PluginsListResponse{
+					{
+						ID:   "id-1",
+						Name: "plugin-1-foo",
+					},
+					{
+						ID:   "id-2",
+						Name: "plugin-10-foo",
+					},
+					{
+						ID:   "id-3",
+						Name: "plugin-2-foo",
+					},
+				}, nil
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/command/plugin/testdata/plugin-list-sort.golden
+++ b/cli/command/plugin/testdata/plugin-list-sort.golden
@@ -1,0 +1,3 @@
+plugin-1-foo
+plugin-2-foo
+plugin-10-foo


### PR DESCRIPTION
**- What I did**
Sorted the output of `plugin list` command by plugin name. fixes #1164

**- How I did it**
Added sort functionality to `cli/command/plugin/list.go` and unit tests to `cli/command/plugin/list_test.go`

**- How to verify it**
1. Create multiple plugins
2. Run `docker plugin ls`
3. Output is sorted based on plugins' names

**- Description for the changelog**
docker plugin ls output is sorted based on plugin name

**- A picture of a cute animal (not mandatory but encouraged)**

