### PR TITLE
[18.06] backport bash completion enhancements

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4619,6 +4619,7 @@ _docker_system_events() {
 				enable
 				exec_create
 				exec_detach
+				exec_die
 				exec_start
 				export
 				health_status

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2222,6 +2222,7 @@ _docker_daemon() {
 		--cpu-rt-period
 		--cpu-rt-runtime
 		--data-root
+		--default-address-pool
 		--default-gateway
 		--default-gateway-v6
 		--default-runtime


### PR DESCRIPTION
Backport of;

- https://github.com/docker/cli/pull/1158 Add bash completion for `dockerd --default-address-pool`
- https://github.com/docker/cli/pull/1159 Add bash completion for `exec_die` event


/cc @vdemeester @albers