### PR TITLE
Allow the external CAs to be removed entirely using the CLI

### DIFF
--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"strings"
 	"time"
@@ -96,7 +97,9 @@ func (m *ExternalCAOption) Set(value string) error {
 		return err
 	}
 
-	m.values = append(m.values, parsed)
+	if parsed != nil {
+		m.values = append(m.values, parsed)
+	}
 	return nil
 }
 
@@ -109,8 +112,10 @@ func (m *ExternalCAOption) Type() string {
 func (m *ExternalCAOption) String() string {
 	externalCAs := []string{}
 	for _, externalCA := range m.values {
-		repr := fmt.Sprintf("%s: %s", externalCA.Protocol, externalCA.URL)
-		externalCAs = append(externalCAs, repr)
+		if externalCA != nil {
+			repr := fmt.Sprintf("%s: %s", externalCA.Protocol, externalCA.URL)
+			externalCAs = append(externalCAs, repr)
+		}
 	}
 	return strings.Join(externalCAs, ", ")
 }
@@ -158,6 +163,9 @@ func (p *PEMFile) Contents() string {
 func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 	csvReader := csv.NewReader(strings.NewReader(caSpec))
 	fields, err := csvReader.Read()
+	if err == io.EOF {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow setting --external-ca to an empty string, to allow for removing
all external CAs entirely.  This will help for instance if rotating
from a fully external CA to an internal CA (if the CA's cert and
key are already in the swarm for instance).

Signed-off-by: Ying Li <ying.li@docker.com>

cc @BillMills 