### PR TITLE
[18.06] Fix manifest lists to always use correct size

### DIFF
--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/store"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -64,20 +65,23 @@ func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
 	}
 
 	// Update the mf
+	if imageManifest.Descriptor.Platform == nil {
+		imageManifest.Descriptor.Platform = new(ocispec.Platform)
+	}
 	if opts.os != "" {
-		imageManifest.Platform.OS = opts.os
+		imageManifest.Descriptor.Platform.OS = opts.os
 	}
 	if opts.arch != "" {
-		imageManifest.Platform.Architecture = opts.arch
+		imageManifest.Descriptor.Platform.Architecture = opts.arch
 	}
 	for _, osFeature := range opts.osFeatures {
-		imageManifest.Platform.OSFeatures = appendIfUnique(imageManifest.Platform.OSFeatures, osFeature)
+		imageManifest.Descriptor.Platform.OSFeatures = appendIfUnique(imageManifest.Descriptor.Platform.OSFeatures, osFeature)
 	}
 	if opts.variant != "" {
-		imageManifest.Platform.Variant = opts.variant
+		imageManifest.Descriptor.Platform.Variant = opts.variant
 	}
 
-	if !isValidOSArch(imageManifest.Platform.OS, imageManifest.Platform.Architecture) {
+	if !isValidOSArch(imageManifest.Descriptor.Platform.OS, imageManifest.Descriptor.Platform.Architecture) {
 		return errors.Errorf("manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
 	}
 	return manifestStore.Save(targetRef, imgRef, imageManifest)

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -123,7 +124,7 @@ func printManifestList(dockerCli command.Cli, namedRef reference.Named, list []t
 		for _, img := range list {
 			mfd, err := buildManifestDescriptor(targetRepo, img)
 			if err != nil {
-				return fmt.Errorf("error assembling ManifestDescriptor")
+				return errors.Wrap(err, "failed to assemble ManifestDescriptor")
 			}
 			manifests = append(manifests, mfd)
 		}

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -50,8 +51,22 @@ func fullImageManifest(t *testing.T, ref reference.Named) types.ImageManifest {
 		},
 	})
 	assert.NilError(t, err)
+
 	// TODO: include image data for verbose inspect
-	return types.NewImageManifest(ref, digest.Digest("sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d62abcd"), types.Image{OS: "linux", Architecture: "amd64"}, man)
+	mt, raw, err := man.Payload()
+	assert.NilError(t, err)
+
+	desc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(raw),
+		Size:      int64(len(raw)),
+		MediaType: mt,
+		Platform: &ocispec.Platform{
+			Architecture: "amd64",
+			OS:           "linux",
+		},
+	}
+
+	return types.NewImageManifest(ref, desc, man)
 }
 
 func TestInspectCommandLocalManifestNotFound(t *testing.T) {

--- a/cli/command/manifest/testdata/inspect-annotate.golden
+++ b/cli/command/manifest/testdata/inspect-annotate.golden
@@ -1,6 +1,18 @@
 {
 	"Ref": "example.com/alpine:3.0",
-	"Digest": "sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d62abcd",
+	"Descriptor": {
+		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+		"digest": "sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe",
+		"size": 528,
+		"platform": {
+			"architecture": "arm",
+			"os": "freebsd",
+			"os.features": [
+				"feature1"
+			],
+			"variant": "v7"
+		}
+	},
 	"SchemaV2Manifest": {
 		"schemaVersion": 2,
 		"mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -16,13 +28,5 @@
 				"digest": "sha256:88286f41530e93dffd4b964e1db22ce4939fffa4a4c665dab8591fbab03d4926"
 			}
 		]
-	},
-	"Platform": {
-		"architecture": "arm",
-		"os": "freebsd",
-		"os.features": [
-			"feature1"
-		],
-		"variant": "v7"
 	}
 }

--- a/cli/command/manifest/testdata/inspect-manifest-list.golden
+++ b/cli/command/manifest/testdata/inspect-manifest-list.golden
@@ -4,8 +4,8 @@
    "manifests": [
       {
          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "size": 428,
-         "digest": "sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d62abcd",
+         "size": 528,
+         "digest": "sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe",
          "platform": {
             "architecture": "amd64",
             "os": "linux"
@@ -13,8 +13,8 @@
       },
       {
          "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
-         "size": 428,
-         "digest": "sha256:7328f6f8b41890597575cbaadc884e7386ae0acc53b747401ebce5cf0d62abcd",
+         "size": 528,
+         "digest": "sha256:1072e499f3f655a032e88542330cf75b02e7bdf673278f701d7ba61629ee3ebe",
          "platform": {
             "architecture": "amd64",
             "os": "linux"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

backport:
* #1156 Fix manifest lists to always use correct size

**- How I did it**

```
$ git cherry-pick -s -x 1fd2d66df89890ca7d830a862d66e1275337ef65
[manifest 15695813a] Fix manifest lists to always use correct size
 Author: Derek McGowan <derek@mcgstyle.net>
 Date: Thu Jun 28 17:41:47 2018 -0700
 9 files changed, 161 insertions(+), 82 deletions(-)
```

no conflicts

**- How to verify it**

```
$ make -f docker.Makefile test-unit
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Fix manifest lists to always use correct size.

**- A picture of a cute animal (not mandatory but encouraged)**
🐦 
