### PR TITLE
[18.06] build: use strconv.ParseBool to parse DOCKER_BUILDKIT to allow value "0"

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -176,8 +177,14 @@ func (out *lastProgressOutput) WriteProgress(prog progress.Progress) error {
 
 // nolint: gocyclo
 func runBuild(dockerCli command.Cli, options buildOptions) error {
-	if os.Getenv("DOCKER_BUILDKIT") != "" {
-		return runBuildBuildKit(dockerCli, options)
+	if buildkitEnv := os.Getenv("DOCKER_BUILDKIT"); buildkitEnv != "" {
+		enableBuildkit, err := strconv.ParseBool(buildkitEnv)
+		if err != nil {
+			return errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+		}
+		if enableBuildkit {
+			return runBuildBuildKit(dockerCli, options)
+		}
 	}
 
 	var (


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/1186 for 18.06

no conflicts, cherry-pick was clean



ping @tonistiigi @tiborvass 