### PR TITLE
For docker/docker.github.io/issues/6987

### DIFF
--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -80,7 +80,7 @@ The following example uses a template without headers and outputs the
 `ID` and `CreatedSince` entries separated by a colon for the `busybox` image:
 
 ```bash
-$ docker history --format "{{.ID}}: {{.CreatedAt}}" busybox
+$ docker history --format "{{.ID}}: {{.CreatedSince}}" busybox
 
 f6e427c148a7: 4 weeks ago
 <missing>: 4 weeks ago


### PR DESCRIPTION
Fixes docker/docker.github.io/issues/6987. Fixing it here rather than at docker.github.io as per docker/docker.github.io's .NOT_EDITED_HERE.yaml.

Note that current https://docs.docker.com/engine/reference/commandline/history/#format-the-output reads ".Created." That is different to ".CreatedAt" in master before this pull req. That indicates the current https://docs.docker.com doesn't reflect master.