### PR TITLE
Allow npipe volume type on stack file

### DIFF
--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -122,6 +122,26 @@ func handleTmpfsToMount(volume composetypes.ServiceVolumeConfig) (mount.Mount, e
 	return result, nil
 }
 
+func handleNpipeToMount(volume composetypes.ServiceVolumeConfig) (mount.Mount, error) {
+	result := createMountFromVolume(volume)
+
+	if volume.Source == "" {
+		return mount.Mount{}, errors.New("invalid npipe source, source cannot be empty")
+	}
+	if volume.Volume != nil {
+		return mount.Mount{}, errors.New("volume options are incompatible with type npipe")
+	}
+	if volume.Tmpfs != nil {
+		return mount.Mount{}, errors.New("tmpfs options are incompatible with type npipe")
+	}
+	if volume.Bind != nil {
+		result.BindOptions = &mount.BindOptions{
+			Propagation: mount.Propagation(volume.Bind.Propagation),
+		}
+	}
+	return result, nil
+}
+
 func convertVolumeToMount(
 	volume composetypes.ServiceVolumeConfig,
 	stackVolumes volumes,
@@ -135,6 +155,8 @@ func convertVolumeToMount(
 		return handleBindToMount(volume)
 	case "tmpfs":
 		return handleTmpfsToMount(volume)
+	case "npipe":
+		return handleNpipeToMount(volume)
 	}
-	return mount.Mount{}, errors.New("volume type must be volume, bind, or tmpfs")
+	return mount.Mount{}, errors.New("volume type must be volume, bind, tmpfs or npipe")
 }

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -41,7 +41,7 @@ func TestConvertVolumeToMountUnapprovedType(t *testing.T) {
 		Target: "/foo/bar",
 	}
 	_, err := convertVolumeToMount(config, volumes{}, NewNamespace("foo"))
-	assert.Error(t, err, "volume type must be volume, bind, or tmpfs")
+	assert.Error(t, err, "volume type must be volume, bind, tmpfs or npipe")
 }
 
 func TestConvertVolumeToMountConflictingOptionsBindInVolume(t *testing.T) {
@@ -342,4 +342,20 @@ func TestConvertTmpfsToMountVolumeWithSource(t *testing.T) {
 
 	_, err := convertVolumeToMount(config, volumes{}, NewNamespace("foo"))
 	assert.Error(t, err, "invalid tmpfs source, source must be empty")
+}
+
+func TestConvertVolumeToMountAnonymousNpipe(t *testing.T) {
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Source: `\\.\pipe\foo`,
+		Target: `\\.\pipe\foo`,
+	}
+	expected := mount.Mount{
+		Type:   mount.TypeNamedPipe,
+		Source: `\\.\pipe\foo`,
+		Target: `\\.\pipe\foo`,
+	}
+	mount, err := convertVolumeToMount(config, volumes{}, NewNamespace("foo"))
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, mount))
 }

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -271,7 +271,7 @@ metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).
 Docker supports three different kinds of mounts, which allow containers to read
 from or write to files or directories, either on the host operating system, or
 on memory filesystems. These types are _data volumes_ (often referred to simply
-as volumes), _bind mounts_, and _tmpfs_.
+as volumes), _bind mounts_, _tmpfs_, and _named pipes_.
 
 A **bind mount** makes a file or directory on the host available to the
 container it is mounted within. A bind mount may be either read-only or
@@ -290,6 +290,8 @@ containers. Docker uses a _volume driver_ to create, manage, and mount volumes.
 You can back up or restore volumes using Docker commands.
 
 A **tmpfs** mounts a tmpfs inside a container for volatile data.
+
+A **npipe** mounts a named pipe from the host into the container.
 
 Consider a situation where your image starts a lightweight web server. You could
 use that image as a base image, copy in your website's HTML files, and package
@@ -312,21 +314,22 @@ volumes in a service:
     <th>Description</th>
   </tr>
   <tr>
-    <td><b>types</b></td>
+    <td><b>type</b></td>
     <td></td>
     <td>
-      <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, or <tt>tmpfs</tt>. Defaults to <tt>volume</tt> if no type is specified.
+      <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.
       <ul>
         <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
         into the container.</li> <li><tt>bind</tt>:
         bind-mounts a directory or file from the host into the container.</li>
         <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>
+        <li><tt>npipe</tt>: mounts named pipe from the host into the container (Windows containers only).</li>
       </ul></p>
     </td>
   </tr>
   <tr>
     <td><b>src</b> or <b>source</b></td>
-    <td>for <tt>type=bind</tt> only></td>
+    <td>for <tt>type=bind</tt> and <tt>type=npipe</tt></td>
     <td>
       <ul>
         <li>


### PR DESCRIPTION
**- What I did**
Added volume type **npipe** to compose file handing.

**- How to verify it**
Can be tested together with docked from https://github.com/moby/moby/pull/37400

Pre-requirement for https://github.com/moby/moby/pull/37400 to be able to fix https://github.com/moby/moby/issues/34795

