### PR TITLE
refactored commands to use sort.Slice

### DIFF
--- a/cli/command/formatter/trust.go
+++ b/cli/command/formatter/trust.go
@@ -133,18 +133,3 @@ func (c *signerInfoContext) Keys() string {
 func (c *signerInfoContext) Signer() string {
 	return c.s.Name
 }
-
-// SignerInfoList helps sort []SignerInfo by signer names
-type SignerInfoList []SignerInfo
-
-func (signerInfoComp SignerInfoList) Len() int {
-	return len(signerInfoComp)
-}
-
-func (signerInfoComp SignerInfoList) Less(i, j int) bool {
-	return signerInfoComp[i].Name < signerInfoComp[j].Name
-}
-
-func (signerInfoComp SignerInfoList) Swap(i, j int) {
-	signerInfoComp[i], signerInfoComp[j] = signerInfoComp[j], signerInfoComp[i]
-}

--- a/cli/command/formatter/trust_test.go
+++ b/cli/command/formatter/trust_test.go
@@ -222,7 +222,7 @@ eve                 foobarbazquxquux, key31, key32
 	}
 
 	for _, testcase := range cases {
-		signerInfo := SignerInfoList{
+		signerInfo := []SignerInfo{
 			{Name: "alice", Keys: []string{"key11", "key12"}},
 			{Name: "bob", Keys: []string{"key21"}},
 			{Name: "eve", Keys: []string{"key31", "key32", "foobarbazquxquux"}},

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
 )
@@ -81,13 +80,14 @@ func runSearch(dockerCli command.Cli, options searchOptions) error {
 
 	clnt := dockerCli.Client()
 
-	unorderedResults, err := clnt.ImageSearch(ctx, options.term, searchOptions)
+	results, err := clnt.ImageSearch(ctx, options.term, searchOptions)
 	if err != nil {
 		return err
 	}
 
-	results := searchResultsByStars(unorderedResults)
-	sort.Sort(results)
+	sort.Slice(results, func(i, j int) bool {
+		return results[j].StarCount < results[i].StarCount
+	})
 	searchCtx := formatter.Context{
 		Output: dockerCli.Out(),
 		Format: formatter.NewSearchFormat(options.format),
@@ -95,10 +95,3 @@ func runSearch(dockerCli command.Cli, options searchOptions) error {
 	}
 	return formatter.SearchWrite(searchCtx, results, options.automated, int(options.stars))
 }
-
-// searchResultsByStars sorts search results in descending order by number of stars.
-type searchResultsByStars []registrytypes.SearchResult
-
-func (r searchResultsByStars) Len() int           { return len(r) }
-func (r searchResultsByStars) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
-func (r searchResultsByStars) Less(i, j int) bool { return r[j].StarCount < r[i].StarCount }

--- a/cli/command/trust/inspect_pretty.go
+++ b/cli/command/trust/inspect_pretty.go
@@ -51,7 +51,7 @@ func printSortedAdminKeys(out io.Writer, adminRoles []client.RoleWithSignatures)
 }
 
 // pretty print with ordered rows
-func printSignatures(out io.Writer, signatureRows trustTagRowList) error {
+func printSignatures(out io.Writer, signatureRows []trustTagRow) error {
 	trustTagCtx := formatter.Context{
 		Output: out,
 		Format: formatter.NewTrustTagFormat(),
@@ -78,13 +78,15 @@ func printSignerInfo(out io.Writer, roleToKeyIDs map[string][]string) error {
 		Format: formatter.NewSignerInfoFormat(),
 		Trunc:  true,
 	}
-	formattedSignerInfo := formatter.SignerInfoList{}
+	formattedSignerInfo := []formatter.SignerInfo{}
 	for name, keyIDs := range roleToKeyIDs {
 		formattedSignerInfo = append(formattedSignerInfo, formatter.SignerInfo{
 			Name: name,
 			Keys: keyIDs,
 		})
 	}
-	sort.Sort(formattedSignerInfo)
+	sort.Slice(formattedSignerInfo, func(i, j int) bool {
+		return formattedSignerInfo[i].Name < formattedSignerInfo[j].Name
+	})
 	return formatter.SignerInfoWrite(signerInfoCtx, formattedSignerInfo)
 }

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -202,12 +202,6 @@ func sortStrings(strs []string) []string {
 	return strs
 }
 
-type byNetworkTarget []swarm.NetworkAttachmentConfig
-
-func (a byNetworkTarget) Len() int           { return len(a) }
-func (a byNetworkTarget) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byNetworkTarget) Less(i, j int) bool { return a[i].Target < a[j].Target }
-
 func convertServiceNetworks(
 	networks map[string]*composetypes.ServiceNetworkConfig,
 	networkConfigs networkMap,
@@ -246,7 +240,9 @@ func convertServiceNetworks(
 		nets = append(nets, netAttachConfig)
 	}
 
-	sort.Sort(byNetworkTarget(nets))
+	sort.Slice(nets, func(i, j int) bool {
+		return nets[i].Target < nets[j].Target
+	})
 	return nets, nil
 }
 
@@ -536,12 +532,6 @@ func convertResources(source composetypes.Resources) (*swarm.ResourceRequirement
 	return resources, nil
 }
 
-type byPublishedPort []swarm.PortConfig
-
-func (a byPublishedPort) Len() int           { return len(a) }
-func (a byPublishedPort) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byPublishedPort) Less(i, j int) bool { return a[i].PublishedPort < a[j].PublishedPort }
-
 func convertEndpointSpec(endpointMode string, source []composetypes.ServicePortConfig) (*swarm.EndpointSpec, error) {
 	portConfigs := []swarm.PortConfig{}
 	for _, port := range source {
@@ -554,7 +544,10 @@ func convertEndpointSpec(endpointMode string, source []composetypes.ServicePortC
 		portConfigs = append(portConfigs, portConfig)
 	}
 
-	sort.Sort(byPublishedPort(portConfigs))
+	sort.Slice(portConfigs, func(i, j int) bool {
+		return portConfigs[i].PublishedPort < portConfigs[j].PublishedPort
+	})
+
 	return &swarm.EndpointSpec{
 		Mode:  swarm.ResolutionMode(strings.ToLower(endpointMode)),
 		Ports: portConfigs,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -247,11 +247,8 @@ func TestConvertServiceNetworks(t *testing.T) {
 		},
 	}
 
-	sortedConfigs := byTargetSort(configs)
-	sort.Sort(&sortedConfigs)
-
 	assert.NilError(t, err)
-	assert.Check(t, is.DeepEqual(expected, []swarm.NetworkAttachmentConfig(sortedConfigs)))
+	assert.Check(t, is.DeepEqual(expected, configs))
 }
 
 func TestConvertServiceNetworksCustomDefault(t *testing.T) {
@@ -275,20 +272,6 @@ func TestConvertServiceNetworksCustomDefault(t *testing.T) {
 
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(expected, []swarm.NetworkAttachmentConfig(configs)))
-}
-
-type byTargetSort []swarm.NetworkAttachmentConfig
-
-func (s byTargetSort) Len() int {
-	return len(s)
-}
-
-func (s byTargetSort) Less(i, j int) bool {
-	return strings.Compare(s[i].Target, s[j].Target) < 0
-}
-
-func (s byTargetSort) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
 }
 
 func TestConvertDNSConfigEmpty(t *testing.T) {

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -985,15 +985,11 @@ services:
 }
 
 func serviceSort(services []types.ServiceConfig) []types.ServiceConfig {
-	sort.Sort(servicesByName(services))
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].Name < services[j].Name
+	})
 	return services
 }
-
-type servicesByName []types.ServiceConfig
-
-func (sbn servicesByName) Len() int           { return len(sbn) }
-func (sbn servicesByName) Swap(i, j int)      { sbn[i], sbn[j] = sbn[j], sbn[i] }
-func (sbn servicesByName) Less(i, j int) bool { return sbn[i].Name < sbn[j].Name }
 
 func TestLoadAttachableNetwork(t *testing.T) {
 	config, err := loadYAML(`


### PR DESCRIPTION
**- What I did**
refactored remaining uses of `sort.Slice`, mostly in `cli/compose` and `cli/command/trust` to remove custom types used for sorting and use `sort.Slice`

**- How I did it**
refactored `cli/compose` and `cli/command/trust` to use `sort.Slice`

**- How to verify it**

**- Description for the changelog**
commands use sort.Slice for sorting and custom types used for sorting have been removed

**- A picture of a cute animal (not mandatory but encouraged)**

