### PR TITLE
[18.06] Propagate the provided external CA certificate to the external CA object in swarm

### DIFF
--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -230,7 +230,7 @@ func addSwarmFlags(flags *pflag.FlagSet, opts *swarmOptions) {
 	addSwarmCAFlags(flags, &opts.swarmCAOptions)
 }
 
-func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet) {
+func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet, caCert string) {
 	if flags.Changed(flagTaskHistoryLimit) {
 		spec.Orchestration.TaskHistoryRetentionLimit = &opts.taskHistoryLimit
 	}
@@ -246,7 +246,7 @@ func (opts *swarmOptions) mergeSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet)
 	if flags.Changed(flagAutolock) {
 		spec.EncryptionConfig.AutoLockManagers = opts.autolock
 	}
-	opts.mergeSwarmSpecCAFlags(spec, flags)
+	opts.mergeSwarmSpecCAFlags(spec, flags, caCert)
 }
 
 type swarmCAOptions struct {
@@ -254,17 +254,20 @@ type swarmCAOptions struct {
 	externalCA     ExternalCAOption
 }
 
-func (opts *swarmCAOptions) mergeSwarmSpecCAFlags(spec *swarm.Spec, flags *pflag.FlagSet) {
+func (opts *swarmCAOptions) mergeSwarmSpecCAFlags(spec *swarm.Spec, flags *pflag.FlagSet, caCert string) {
 	if flags.Changed(flagCertExpiry) {
 		spec.CAConfig.NodeCertExpiry = opts.nodeCertExpiry
 	}
 	if flags.Changed(flagExternalCA) {
 		spec.CAConfig.ExternalCAs = opts.externalCA.Value()
+		for _, ca := range spec.CAConfig.ExternalCAs {
+			ca.CACert = caCert
+		}
 	}
 }
 
 func (opts *swarmOptions) ToSpec(flags *pflag.FlagSet) swarm.Spec {
 	var spec swarm.Spec
-	opts.mergeSwarmSpec(&spec, flags)
+	opts.mergeSwarmSpec(&spec, flags, "")
 	return spec
 }

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -48,7 +48,7 @@ func runUpdate(dockerCli command.Cli, flags *pflag.FlagSet, opts swarmOptions) e
 
 	prevAutoLock := swarmInspect.Spec.EncryptionConfig.AutoLockManagers
 
-	opts.mergeSwarmSpec(&swarmInspect.Spec, flags)
+	opts.mergeSwarmSpec(&swarmInspect.Spec, flags, swarmInspect.ClusterInfo.TLSInfo.TrustRoot)
 
 	curAutoLock := swarmInspect.Spec.EncryptionConfig.AutoLockManagers
 


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/1178 for 18.06

cherry-pick was clean; no conflicts


Also, fix some CLI command confusions:
1. If the --external-ca flag is provided, require a --ca-cert flag as well, otherwise
   the external CA is set but the CA certificate is actually rotated to an internal
   cert
2. If a --ca-cert flag is provided, require a --ca-key or --external-ca flag be
   provided as well, otherwise either the server will say that the request is
   invalid, or if there was previously an external CA corresponding to the cert, it
   will succeed.  While that works, it's better to require the user to explicitly
   set all the parameters of the new desired root CA.

This also changes the `swarm update` function to set the external CA's CACert field,
which while not strictly necessary, makes the CA list more explicit.

Signed-off-by: Ying Li <ying.li@docker.com>
(cherry picked from commit 4243440e1fad0f65a525dba86ced608dcea6918f)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

