### PR TITLE
[18.06] Improve version output alignment

### DIFF
--- a/cli/command/system/testdata/docker-client-version.golden
+++ b/cli/command/system/testdata/docker-client-version.golden
@@ -1,42 +1,42 @@
 Client:
- Version:      18.99.5-ce
- API version:  1.38
- Go version:   go1.10.2
- Git commit:   deadbeef
- Built:        Wed May 30 22:21:05 2018
- OS/Arch:      linux/amd64
- Experimental: true
+ Version:           18.99.5-ce
+ API version:       1.38
+ Go version:        go1.10.2
+ Git commit:        deadbeef
+ Built:             Wed May 30 22:21:05 2018
+ OS/Arch:           linux/amd64
+ Experimental:      true
 
 Server: Docker Enterprise Edition (EE) 2.0
  Engine:
-  Version:      17.06.2-ee-15
-  API version:  1.30 (minimum version 1.12)
-  Go version:   go1.8.7
-  Git commit:   64ddfa6
-  Built:        Mon Jul  9 23:38:38 2018
-  OS/Arch:      linux/amd64
-  Experimental: false
+  Version:          17.06.2-ee-15
+  API version:      1.30 (minimum version 1.12)
+  Go version:       go1.8.7
+  Git commit:       64ddfa6
+  Built:            Mon Jul  9 23:38:38 2018
+  OS/Arch:          linux/amd64
+  Experimental:     false
  Universal Control Plane:
-  Version:       17.06.2-ee-15
-  ApiVersion:    1.30
-  Arch:          amd64
-  BuildTime:     Mon Jul  2 21:24:07 UTC 2018
-  GitCommit:     4513922
-  GoVersion:     go1.9.4
-  MinApiVersion: 1.20
-  Os:            linux
-  Version:       3.0.3-tp2
+  Version:          17.06.2-ee-15
+  ApiVersion:       1.30
+  Arch:             amd64
+  BuildTime:        Mon Jul  2 21:24:07 UTC 2018
+  GitCommit:        4513922
+  GoVersion:        go1.9.4
+  MinApiVersion:    1.20
+  Os:               linux
+  Version:          3.0.3-tp2
  Kubernetes:
-  Version:      1.8+
-  buildDate:    2018-04-26T16:51:21Z
-  compiler:     gc
-  gitCommit:    8d637aedf46b9c21dde723e29c645b9f27106fa5
-  gitTreeState: clean
-  gitVersion:   v1.8.11-docker-8d637ae
-  goVersion:    go1.8.3
-  major:        1
-  minor:        8+
-  platform:     linux/amd64
+  Version:          1.8+
+  buildDate:        2018-04-26T16:51:21Z
+  compiler:         gc
+  gitCommit:        8d637aedf46b9c21dde723e29c645b9f27106fa5
+  gitTreeState:     clean
+  gitVersion:       v1.8.11-docker-8d637ae
+  goVersion:        go1.8.3
+  major:            1
+  minor:            8+
+  platform:         linux/amd64
  Calico:
   Version:          v3.0.8
   cni:              v2.0.6

--- a/cli/command/system/testdata/docker-client-version.golden
+++ b/cli/command/system/testdata/docker-client-version.golden
@@ -6,3 +6,39 @@ Client:
  Built:        Wed May 30 22:21:05 2018
  OS/Arch:      linux/amd64
  Experimental: true
+
+Server: Docker Enterprise Edition (EE) 2.0
+ Engine:
+  Version:      17.06.2-ee-15
+  API version:  1.30 (minimum version 1.12)
+  Go version:   go1.8.7
+  Git commit:   64ddfa6
+  Built:        Mon Jul  9 23:38:38 2018
+  OS/Arch:      linux/amd64
+  Experimental: false
+ Universal Control Plane:
+  Version:       17.06.2-ee-15
+  ApiVersion:    1.30
+  Arch:          amd64
+  BuildTime:     Mon Jul  2 21:24:07 UTC 2018
+  GitCommit:     4513922
+  GoVersion:     go1.9.4
+  MinApiVersion: 1.20
+  Os:            linux
+  Version:       3.0.3-tp2
+ Kubernetes:
+  Version:      1.8+
+  buildDate:    2018-04-26T16:51:21Z
+  compiler:     gc
+  gitCommit:    8d637aedf46b9c21dde723e29c645b9f27106fa5
+  gitTreeState: clean
+  gitVersion:   v1.8.11-docker-8d637ae
+  goVersion:    go1.8.3
+  major:        1
+  minor:        8+
+  platform:     linux/amd64
+ Calico:
+  Version:          v3.0.8
+  cni:              v2.0.6
+  kube-controllers: v2.0.5
+  node:             v3.0.8

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -204,7 +204,7 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 }
 
 func prettyPrintVersion(dockerCli command.Cli, vd versionInfo, tmpl *template.Template) error {
-	t := tabwriter.NewWriter(dockerCli.Out(), 15, 1, 1, ' ', 0)
+	t := tabwriter.NewWriter(dockerCli.Out(), 20, 1, 1, ' ', 0)
 	err := tmpl.Execute(t, vd)
 	t.Write([]byte("\n"))
 	t.Flush()

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -43,7 +43,66 @@ func TestVersionAlign(t *testing.T) {
 			BuildTime:         "Wed May 30 22:21:05 2018",
 			Experimental:      true,
 		},
+		Server: &types.Version{},
 	}
+
+	vi.Server.Platform.Name = "Docker Enterprise Edition (EE) 2.0"
+
+	vi.Server.Components = append(vi.Server.Components, types.ComponentVersion{
+		Name:    "Engine",
+		Version: "17.06.2-ee-15",
+		Details: map[string]string{
+			"ApiVersion":    "1.30",
+			"MinAPIVersion": "1.12",
+			"GitCommit":     "64ddfa6",
+			"GoVersion":     "go1.8.7",
+			"Os":            "linux",
+			"Arch":          "amd64",
+			"BuildTime":     "Mon Jul  9 23:38:38 2018",
+			"Experimental":  "false",
+		},
+	})
+
+	vi.Server.Components = append(vi.Server.Components, types.ComponentVersion{
+		Name:    "Universal Control Plane",
+		Version: "17.06.2-ee-15",
+		Details: map[string]string{
+			"Version":       "3.0.3-tp2",
+			"ApiVersion":    "1.30",
+			"Arch":          "amd64",
+			"BuildTime":     "Mon Jul  2 21:24:07 UTC 2018",
+			"GitCommit":     "4513922",
+			"GoVersion":     "go1.9.4",
+			"MinApiVersion": "1.20",
+			"Os":            "linux",
+		},
+	})
+
+	vi.Server.Components = append(vi.Server.Components, types.ComponentVersion{
+		Name:    "Kubernetes",
+		Version: "1.8+",
+		Details: map[string]string{
+			"buildDate":    "2018-04-26T16:51:21Z",
+			"compiler":     "gc",
+			"gitCommit":    "8d637aedf46b9c21dde723e29c645b9f27106fa5",
+			"gitTreeState": "clean",
+			"gitVersion":   "v1.8.11-docker-8d637ae",
+			"goVersion":    "go1.8.3",
+			"major":        "1",
+			"minor":        "8+",
+			"platform":     "linux/amd64",
+		},
+	})
+
+	vi.Server.Components = append(vi.Server.Components, types.ComponentVersion{
+		Name:    "Calico",
+		Version: "v3.0.8",
+		Details: map[string]string{
+			"cni":              "v2.0.6",
+			"kube-controllers": "v2.0.5",
+			"node":             "v3.0.8",
+		},
+	})
 
 	cli := test.NewFakeCli(&fakeClient{})
 	tmpl, err := newVersionTemplate("")


### PR DESCRIPTION
### do not merge (yet):

rc3 was cut, and should be 18.06-GA; discuss with @andrewhsu first before merging


Cherry-pick of https://github.com/docker/cli/pull/1204 for 18.06

```
git checkout -b 18.06-backport-improve-version-align upstream/18.06
git cherry-pick -s -S -x 55ff66d967b9134f42aa5a9b28adde87fbfeca6e
git cherry-pick -s -S -x 0f7ae34ea9c9401a109640c2847756ff32e772bd
git push -u origin
```

cherry-pick was clean; no conflicts

Add some extra fixture information and test, and increase the column-width to account for wide names in component output;

### Before this change;

```
docker version

Client:
 Version:      18.99.5-ce
 API version:  1.38
 Go version:   go1.10.2
 Git commit:   deadbeef
 Built:        Wed May 30 22:21:05 2018
 OS/Arch:      linux/amd64
 Experimental: true

Server: Docker Enterprise Edition (EE) 2.0
 Engine:
  Version:      17.06.2-ee-15
  API version:  1.30 (minimum version 1.12)
  Go version:   go1.8.7
  Git commit:   64ddfa6
  Built:        Mon Jul  9 23:38:38 2018
  OS/Arch:      linux/amd64
  Experimental: false
 Universal Control Plane:
  Version:       17.06.2-ee-15
  ApiVersion:    1.30
  Arch:          amd64
  BuildTime:     Mon Jul  2 21:24:07 UTC 2018
  GitCommit:     4513922
  GoVersion:     go1.9.4
  MinApiVersion: 1.20
  Os:            linux
  Version:       3.0.3-tp2
 Kubernetes:
  Version:      1.8+
  buildDate:    2018-04-26T16:51:21Z
  compiler:     gc
  gitCommit:    8d637aedf46b9c21dde723e29c645b9f27106fa5
  gitTreeState: clean
  gitVersion:   v1.8.11-docker-8d637ae
  goVersion:    go1.8.3
  major:        1
  minor:        8+
  platform:     linux/amd64
 Calico:
  Version:          v3.0.8
  cni:              v2.0.6
  kube-controllers: v2.0.5
  node:             v3.0.8
```


### With this change applied:

```
docker version

Client:
 Version:           18.99.5-ce
 API version:       1.38
 Go version:        go1.10.2
 Git commit:        deadbeef
 Built:             Wed May 30 22:21:05 2018
 OS/Arch:           linux/amd64
 Experimental:      true

Server: Docker Enterprise Edition (EE) 2.0
 Engine:
  Version:          17.06.2-ee-15
  API version:      1.30 (minimum version 1.12)
  Go version:       go1.8.7
  Git commit:       64ddfa6
  Built:            Mon Jul  9 23:38:38 2018
  OS/Arch:          linux/amd64
  Experimental:     false
 Universal Control Plane:
  Version:          17.06.2-ee-15
  ApiVersion:       1.30
  Arch:             amd64
  BuildTime:        Mon Jul  2 21:24:07 UTC 2018
  GitCommit:        4513922
  GoVersion:        go1.9.4
  MinApiVersion:    1.20
  Os:               linux
  Version:          3.0.3-tp2
 Kubernetes:
  Version:          1.8+
  buildDate:        2018-04-26T16:51:21Z
  compiler:         gc
  gitCommit:        8d637aedf46b9c21dde723e29c645b9f27106fa5
  gitTreeState:     clean
  gitVersion:       v1.8.11-docker-8d637ae
  goVersion:        go1.8.3
  major:            1
  minor:            8+
  platform:         linux/amd64
 Calico:
  Version:          v3.0.8
  cni:              v2.0.6
  kube-controllers: v2.0.5
  node:             v3.0.8
```
