### PR TITLE
Update gometalinter to v2.0.6, remove nakedret

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -42,7 +42,6 @@ func TestValidateAttach(t *testing.T) {
 	}
 }
 
-// nolint: unparam
 func parseRun(args []string) (*container.Config, *container.HostConfig, *networktypes.NetworkingConfig, error) {
 	flags, copts := setupRunFlags()
 	if err := flags.Parse(args); err != nil {

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -28,7 +28,6 @@ type fakeClient struct {
 	client.Client
 }
 
-// nolint: unparam
 func (c fakeClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registrytypes.AuthenticateOKBody, error) {
 	if auth.Password == expiredPassword {
 		return registrytypes.AuthenticateOKBody{}, fmt.Errorf("Invalid Username or Password")

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -78,6 +78,7 @@ func isLastSignerForReleases(roleWithSig data.Role, allRoles []client.RoleWithSi
 
 // removeSingleSigner attempts to remove a single signer and returns whether signer removal happened.
 // The signer not being removed doesn't necessarily raise an error e.g. user choosing "No" when prompted for confirmation.
+// nolint: unparam
 func removeSingleSigner(cli command.Cli, repoName, signerName string, forceYes bool) (bool, error) {
 	ctx := context.Background()
 	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), repoName)

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -2,19 +2,12 @@ FROM    golang:1.10.3-alpine
 
 RUN     apk add -U git
 
-ARG     GOMETALINTER_SHA=7f9672e7ea538b8682e83395d50b12f09bb17b91
+ARG     GOMETALINTER_SHA=v2.0.6
 RUN     go get -d github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \
         git checkout -q "$GOMETALINTER_SHA" && \
         go build -v -o /usr/local/bin/gometalinter . && \ 
         gometalinter --install && \
-        rm -rf /go/src/* /go/pkg/*
-
-ARG     NAKEDRET_SHA=3ddb495a6d63bc9041ba843e7d651cf92639d8cb
-RUN     go get -d github.com/alexkohler/nakedret && \
-        cd /go/src/github.com/alexkohler/nakedret && \
-        git checkout -q "$NAKEDRET_SHA" && \
-        go build -v -o /usr/local/bin/nakedret . && \
         rm -rf /go/src/* /go/pkg/*
 
 WORKDIR /go/src/github.com/docker/cli


### PR DESCRIPTION
similar change in engine; https://github.com/moby/moby/pull/37436

full diff: https://github.com/alecthomas/gometalinter/compare/7f9672e7ea538b8682e83395d50b12f09bb17b91...v2.0.6

Manual installation of nakedret was removed, because it's now installed by default with gometalinter