### PR TITLE
[18.06] Add bash completion for `service create|update --init`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3402,6 +3402,7 @@ _docker_service_update_and_create() {
 	local boolean_options="
 		--detach -d
 		--help
+		--init
 		--no-healthcheck
 		--read-only
 		--tty -t


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/1210 for 18.06

cherry-pick was clean; no conflicts


This adds bash completion for #479.