### PR TITLE
[18.06] documentation and man-page fixes

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1432,11 +1432,12 @@ The list of currently supported options that can be reconfigured is this:
   specified at container creation. It defaults to "default" which is
   the runtime shipped with the official docker packages.
 - `runtimes`: it updates the list of available OCI runtimes that can
-  be used to run containers
+  be used to run containers.
 - `authorization-plugin`: specifies the authorization plugins to use.
 - `allow-nondistributable-artifacts`: Replaces the set of registries to which the daemon will push nondistributable artifacts with a new set of registries.
 - `insecure-registries`: it replaces the daemon insecure registries with a new set of insecure registries. If some existing insecure registries in daemon's configuration are not in newly reloaded insecure resgitries, these existing ones will be removed from daemon's config.
 - `registry-mirrors`: it replaces the daemon registry mirrors with a new set of registry mirrors. If some existing registry mirrors in daemon's configuration are not in newly reloaded registry mirrors, these existing ones will be removed from daemon's config.
+- `shutdown-timeout`: it replaces the daemon's existing configuration timeout with a new timeout for shutting down all containers.
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -80,7 +80,7 @@ The following example uses a template without headers and outputs the
 `ID` and `CreatedSince` entries separated by a colon for the `busybox` image:
 
 ```bash
-$ docker history --format "{{.ID}}: {{.CreatedAt}}" busybox
+$ docker history --format "{{.ID}}: {{.CreatedSince}}" busybox
 
 f6e427c148a7: 4 weeks ago
 <missing>: 4 weeks ago

--- a/man/src/image/history.md
+++ b/man/src/image/history.md
@@ -41,7 +41,7 @@ The following example uses a template without headers and outputs the
 `ID` and `CreatedSince` entries separated by a colon for all images:
 
 ```bash
-$ docker images --format "{{.ID}}: {{.Created}} ago"
+$ docker images --format "{{.ID}}: {{.CreatedSince}} ago"
 
 cc1b61406712: 2 weeks ago
 <missing>: 2 weeks ago


### PR DESCRIPTION
cherry-picks of https://github.com/docker/cli/pull/1145, https://github.com/docker/cli/pull/1171, https://github.com/docker/cli/pull/1192 for 18.06

```
git checkout -b 18.06-docs-fixes upstream/18.06
git cherry-pick -s -S -x a205aecb807ab9c0edc859a2371e2887dfdba67c
git cherry-pick -s -S -x d0ddf91539c4d9b0618e15087c395452dd97a58a
git cherry-pick -s -S -x 249c8652a272d2031651f026e8c698094de5ecc9
```

cherry-picks were clean; no conflicts