### PR TITLE
Update deploy.go

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -81,7 +81,7 @@ func RunDeploy(dockerCli command.Cli, flags *pflag.FlagSet, config *composetypes
 	case commonOrchestrator.HasKubernetes():
 		kli, err := kubernetes.WrapCli(dockerCli, kubernetes.NewOptions(flags, commonOrchestrator))
 		if err != nil {
-			return err
+			return errors.Wrap(err, "unable to deploy to Kubernetes")
 		}
 		return kubernetes.RunDeploy(kli, opts, config)
 	default:


### PR DESCRIPTION
Added proper error handling for no Kubernetes config file when it is used as the orchestrator.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added proper error handling for stack/deploy in the event Kubernetes is used as orchestrator, but no config file is present.

Fix for https://github.com/docker/cli/issues/985

**- How I did it**
Wrapped the err object with clearer error message.

**- How to verify it**
Run `docker stack deploy -c docker-compose.yml foo` with no `$HOME/.kube/config`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added proper error handling for no Kubernetes config file when used as orchestrator.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute pic](https://img.thedailybeast.com/image/upload/c_crop,d_placeholder_euli9k,h_675,w_1200,x_0,y_0/dpr_2.0/c_limit,w_740/fl_lossy,q_auto/v1492809850/galleries/2012/03/29/beyonce-worlds-tiniest-puppy-and-more-cute-tiny-animals-photos/130402-tiny-animals-tease-update_uku8tv)