### PR TITLE
Added support for docker push --quiet

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -14,6 +15,7 @@ import (
 type pushOptions struct {
 	remote    string
 	untrusted bool
+	quiet     bool
 }
 
 // NewPushCommand creates a new `docker push` command
@@ -31,7 +33,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
+	command.AddQuietFlag(flags, &opts.quiet)
 	command.AddTrustSigningFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
 
 	return cmd
@@ -66,5 +68,9 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	}
 
 	defer responseBody.Close()
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	if !opts.quiet {
+		return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	}
+	fmt.Fprintln(dockerCli.Out(), repoInfo.Name)
+	return nil
 }

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -69,3 +69,26 @@ func TestNewPushCommandSuccess(t *testing.T) {
 		assert.NilError(t, cmd.Execute())
 	}
 }
+
+func TestNewQuietPushCommandSuccess(t *testing.T) {
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "simple",
+			args: []string{"--quiet", "image:tag"},
+		},
+	}
+	for _, tc := range testCases {
+		cli := test.NewFakeCli(&fakeClient{
+			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
+				return ioutil.NopCloser(strings.NewReader("")), nil
+			},
+		})
+		cmd := NewPushCommand(cli)
+		cmd.SetOutput(ioutil.Discard)
+		cmd.SetArgs(tc.args)
+		assert.NilError(t, cmd.Execute())
+	}
+}

--- a/cli/command/quiet.go
+++ b/cli/command/quiet.go
@@ -1,0 +1,10 @@
+package command
+
+import (
+	"github.com/spf13/pflag"
+)
+
+//AddQuietFlag Hides Output
+func AddQuietFlag(fs *pflag.FlagSet, v *bool) {
+	fs.BoolVar(v, "quiet", *v, "Suppress Output")
+}


### PR DESCRIPTION
Signed-off-by: Justyn Temme <justyntemme@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added --quiet flag for docker push
Fix for https://github.com/docker/cli/issues/958

**- How I did it**

Passing a flag to either write out the content body of the response, or simply output nothing

**- How to verify it**
docker push --quiet tagged/image
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added a --quiet flag for docker push

**- A picture of a cute animal (not mandatory but encouraged)**

![cute bunny](https://i.ytimg.com/vi/cWnu4HGu3RA/hqdefault.jpg)