### PR TITLE
Added events filter scope for bash and zsh completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4658,6 +4658,10 @@ _docker_system_events() {
 			__docker_complete_networks --cur "${cur##*=}"
 			return
 			;;
+		scope)
+			COMPREPLY=( $( compgen -W "local swarm" -- "${cur##*=}" ) )
+			return
+			;;
 		type)
 			COMPREPLY=( $( compgen -W "config container daemon image network plugin secret service volume" -- "${cur##*=}" ) )
 			return
@@ -4670,7 +4674,7 @@ _docker_system_events() {
 
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "container daemon event image label network type volume" -- "$cur" ) )
+			COMPREPLY=( $( compgen -S = -W "container daemon event image label network scope type volume" -- "$cur" ) )
 			__docker_nospace
 			return
 			;;

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -431,7 +431,7 @@ __docker_complete_events_filter() {
     integer ret=1
     declare -a opts
 
-    opts=('container' 'daemon' 'event' 'image' 'label' 'network' 'type' 'volume')
+    opts=('container' 'daemon' 'event' 'image' 'label' 'network' 'scope' 'type' 'volume')
 
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
@@ -460,6 +460,11 @@ __docker_complete_events_filter() {
                 ;;
             (network)
                 __docker_complete_networks && ret=0
+                ;;
+            (scope)
+                local -a scope_opts
+                scope_opts=('local' 'swarm')
+                _describe -t scope-filter-opts "scope filter options" scope_opts && ret=0
                 ;;
             (type)
                 local -a type_opts


### PR DESCRIPTION
Signed-off-by: Paweł Szczekutowicz <pszczekutowicz@gmail.com>

**- What I did**

I added completion for bash and zsh for Docker events scope filter  

**- How to verify it**

1. Type `docker events --filter`
2. Start completion by pressing tab
3. Filter `scope=` should be present on list
4. Type `scope=`
5. Start completion by pressing tab
6. Values `local` and `swarm` should be present on list

**- Description for the changelog**

Added events filter scope for bash and zsh completion
