### PR TITLE
[18.06] Added events filter scope for bash and zsh completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4658,6 +4658,10 @@ _docker_system_events() {
 			__docker_complete_networks --cur "${cur##*=}"
 			return
 			;;
+		scope)
+			COMPREPLY=( $( compgen -W "local swarm" -- "${cur##*=}" ) )
+			return
+			;;
 		type)
 			COMPREPLY=( $( compgen -W "config container daemon image network plugin secret service volume" -- "${cur##*=}" ) )
 			return
@@ -4670,7 +4674,7 @@ _docker_system_events() {
 
 	case "$prev" in
 		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "container daemon event image label network type volume" -- "$cur" ) )
+			COMPREPLY=( $( compgen -S = -W "container daemon event image label network scope type volume" -- "$cur" ) )
 			__docker_nospace
 			return
 			;;

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -431,7 +431,7 @@ __docker_complete_events_filter() {
     integer ret=1
     declare -a opts
 
-    opts=('container' 'daemon' 'event' 'image' 'label' 'network' 'type' 'volume')
+    opts=('container' 'daemon' 'event' 'image' 'label' 'network' 'scope' 'type' 'volume')
 
     if compset -P '*='; then
         case "${${words[-1]%=*}#*=}" in
@@ -460,6 +460,11 @@ __docker_complete_events_filter() {
                 ;;
             (network)
                 __docker_complete_networks && ret=0
+                ;;
+            (scope)
+                local -a scope_opts
+                scope_opts=('local' 'swarm')
+                _describe -t scope-filter-opts "scope filter options" scope_opts && ret=0
                 ;;
             (type)
                 local -a type_opts


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/1227 for 18.06

```
git checkout -b 18.06-backport-completion upstream/18.06
git cherry-pick -s -S -x c922ea2f453d2c2b1f4f1f805e0288cfd72aee8d
git cherry-pick -s -S -x 13db1bc95fc7815b918f34f14b5105110d25881a
git push -u origin
```

cherry-pick was clean, no conflicts
