### PR TITLE
Fixed typo breaking zsh docker update autocomplete (closes #1231)

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -928,7 +928,7 @@ __docker_container_subcommand() {
             local state
             _arguments $(__docker_arguments) \
                 $opts_help \
-                opts_create_run_update \
+                $opts_create_run_update \
                 "($help -)*: :->values" && ret=0
             case $state in
                 (values)


### PR DESCRIPTION
Signed-off-by: Tom Milligan <tommilligan@users.noreply.github.com>

Closes #1231 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed typo in zsh autocompletion (missing `$`)

**- How I did it**

**- How to verify it**

After pulling this update, reload a zshell terminal. Typing `docker update ` + `Tab` will display correct autocomplete options, rather than the error described in the issue.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- Fixed zsh cli autocompletion for the docker update subcommand

**- A picture of a cute animal (not mandatory but encouraged)**

[adopt a derp](https://www.battersea.org.uk/dogs/ted/?filters=true&returnID=15325181065138450214&id=423596)
[![derp](https://dscsu8d79j5ty.cloudfront.net/sites/default/files/animal_images/00P0X00001OaWHCUA3.jpeg)](https://www.battersea.org.uk/dogs/ted/?filters=true&returnID=15325181065138450214&id=423596)
