### PR TITLE
Add missing fields in compose/types

### DIFF
--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -135,13 +135,16 @@ type ServiceConfig struct {
 	Restart         string                           `yaml:",omitempty"`
 	Secrets         []ServiceSecretConfig            `yaml:",omitempty"`
 	SecurityOpt     []string                         `mapstructure:"security_opt" yaml:"security_opt,omitempty"`
+	ShmSize         string                           `mapstructure:"shm_size" yaml:"shm_size,omitempty"`
 	StdinOpen       bool                             `mapstructure:"stdin_open" yaml:"stdin_open,omitempty"`
 	StopGracePeriod *time.Duration                   `mapstructure:"stop_grace_period" yaml:"stop_grace_period,omitempty"`
 	StopSignal      string                           `mapstructure:"stop_signal" yaml:"stop_signal,omitempty"`
+	Sysctls         StringList                       `yaml:",omitempty"`
 	Tmpfs           StringList                       `yaml:",omitempty"`
 	Tty             bool                             `mapstructure:"tty" yaml:"tty,omitempty"`
 	Ulimits         map[string]*UlimitsConfig        `yaml:",omitempty"`
 	User            string                           `yaml:",omitempty"`
+	UserNSMode      string                           `mapstructure:"userns_mode" yaml:"userns_mode,omitempty"`
 	Volumes         []ServiceVolumeConfig            `yaml:",omitempty"`
 	WorkingDir      string                           `mapstructure:"working_dir" yaml:"working_dir,omitempty"`
 


### PR DESCRIPTION
Even though those fields are not supported by `docker stack deploy`
they are defined in versions `3.x` of compose schema, so the `compose`
package should be able to marshal/unmarshal them.

Related to https://github.com/docker/app/issues/304 (but useful for any user of this package)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
