### PR TITLE
Enable notary trust pinning with docker content trust

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -225,7 +225,7 @@ func getClientWithPassword(passRetriever notary.PassRetriever, newClient func(pa
 
 // NotaryClient provides a Notary Repository to interact with signed metadata for an image
 func (cli *DockerCli) NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error) {
-	return trust.GetNotaryRepository(cli.In(), cli.Out(), UserAgent(), imgRefAndAuth.RepoInfo(), imgRefAndAuth.AuthConfig(), actions...)
+	return trust.GetNotaryRepository(cli.In(), cli.Out(), UserAgent(), imgRefAndAuth.RepoInfo(), imgRefAndAuth.AuthConfig(), cli.configFile.ParseTrustPinning(), actions...)
 }
 
 // ServerInfo stores details about the supported features and platform of the

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -102,7 +102,8 @@ func PushTrustedReference(streams command.Streams, repoInfo *registry.Repository
 
 	fmt.Fprintln(streams.Out(), "Signing and pushing trust metadata")
 
-	repo, err := trust.GetNotaryRepository(streams.In(), streams.Out(), command.UserAgent(), repoInfo, &authConfig, "push", "pull")
+	trustPinningConfig := streams.(command.Cli).ConfigFile().ParseTrustPinning()
+	repo, err := trust.GetNotaryRepository(streams.In(), streams.Out(), command.UserAgent(), repoInfo, &authConfig, trustPinningConfig, "push", "pull")
 	if err != nil {
 		return errors.Wrap(err, "error establishing connection to trust repository")
 	}

--- a/cli/command/service/trust.go
+++ b/cli/command/service/trust.go
@@ -59,7 +59,7 @@ func trustedResolveDigest(ctx context.Context, cli command.Cli, ref reference.Na
 
 	authConfig := command.ResolveAuthConfig(ctx, cli, repoInfo.Index)
 
-	notaryRepo, err := trust.GetNotaryRepository(cli.In(), cli.Out(), command.UserAgent(), repoInfo, &authConfig, "pull")
+	notaryRepo, err := trust.GetNotaryRepository(cli.In(), cli.Out(), command.UserAgent(), repoInfo, &authConfig, cli.ConfigFile().ParseTrustPinning(), "pull")
 	if err != nil {
 		return nil, errors.Wrap(err, "error establishing connection to trust repository")
 	}

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
+	"github.com/theupdateframework/notary/trustpinning"
 )
 
 const (
@@ -48,6 +49,14 @@ type ConfigFile struct {
 	Experimental         string                      `json:"experimental,omitempty"`
 	StackOrchestrator    string                      `json:"stackOrchestrator,omitempty"`
 	Kubernetes           *KubernetesConfig           `json:"kubernetes,omitempty"`
+	TrustPinning         *TrustPinningConfig         `json:"trustPinning,omitempty"`
+}
+
+// TrustPinningConfig contains notary trust pinning settings
+type TrustPinningConfig struct {
+	Certs       map[string][]string `json:certs,omitempty`
+	CA          map[string]string   `json:ca,omitempty`
+	DisableTOFU bool                `json:disableTofu,omitempty`
 }
 
 // ProxyConfig contains proxy configuration settings
@@ -184,6 +193,27 @@ func (configFile *ConfigFile) Save() error {
 	}
 	defer f.Close()
 	return configFile.SaveToWriter(f)
+}
+
+// ParseTrustPinning parses Notary trust pinning structure from configuration, and prepends CA certificate files with
+// the absolute path of the configuration directory
+func (configFile *ConfigFile) ParseTrustPinning() trustpinning.TrustPinConfig {
+	if configFile.TrustPinning == nil {
+		return trustpinning.TrustPinConfig{}
+	}
+	// Prepend CA file path with config directory path
+	configPath := filepath.Dir(configFile.GetFilename())
+	caMap := configFile.TrustPinning.CA
+	resultCaMap := make(map[string]string)
+	for gun, caFileName := range caMap {
+		resultCaMap[gun] = filepath.Join(configPath, caFileName)
+	}
+
+	return trustpinning.TrustPinConfig{
+		DisableTOFU: configFile.TrustPinning.DisableTOFU,
+		Certs:       configFile.TrustPinning.Certs,
+		CA:          resultCaMap,
+	}
 }
 
 // ParseProxyConfig computes proxy configuration by retrieving the config for the provided host and

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/docker/api/types"
+	"github.com/theupdateframework/notary/trustpinning"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -19,6 +20,34 @@ func TestEncodeAuth(t *testing.T) {
 	expected.Username, expected.Password, err = decodeAuth(authStr)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(expected, newAuthConfig))
+}
+
+func TestTrustPinningConfig(t *testing.T) {
+	certs := map[string][]string{
+		"docker.io/test/*":   {"id1", "id2"},
+		"docker.io/test/abc": {"id3", "id4"},
+	}
+	ca := map[string]string{
+		"docker.io/test/*": "filename.cert",
+	}
+
+	trustConfig := TrustPinningConfig{
+		Certs:       certs,
+		CA:          ca,
+		DisableTOFU: false,
+	}
+
+	cfg := ConfigFile{
+		TrustPinning: &trustConfig,
+	}
+
+	trustPinningConfig := cfg.ParseTrustPinning()
+	expected := trustpinning.TrustPinConfig{
+		DisableTOFU: trustConfig.DisableTOFU,
+		CA:          trustConfig.CA,
+		Certs:       trustConfig.Certs,
+	}
+	assert.Check(t, is.DeepEqual(expected, trustPinningConfig))
 }
 
 func TestProxyConfig(t *testing.T) {

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -96,7 +96,9 @@ func (scs simpleCredentialStore) SetRefreshToken(*url.URL, string, string) {
 // GetNotaryRepository returns a NotaryRepository which stores all the
 // information needed to operate on a notary repository.
 // It creates an HTTP transport providing authentication support.
-func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo *registry.RepositoryInfo, authConfig *types.AuthConfig, actions ...string) (client.Repository, error) {
+func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo *registry.RepositoryInfo,
+	authConfig *types.AuthConfig, trustPinningConfig trustpinning.TrustPinConfig, actions ...string,
+) (client.Repository, error) {
 	server, err := Server(repoInfo.Index)
 	if err != nil {
 		return nil, err
@@ -180,7 +182,7 @@ func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo
 		server,
 		tr,
 		GetPassphraseRetriever(in, out),
-		trustpinning.TrustPinConfig{})
+		trustPinningConfig)
 }
 
 // GetPassphraseRetriever returns a passphrase retriever that utilizes Content Trust env vars


### PR DESCRIPTION
This adds an optional trust_pinning configuration section that specifies how to bootstrap the root of docker's content trust.

As defined in https://github.com/theupdateframework/notary/blob/master/docs/reference/client-config.md, one can provide specific certificates to pin to, or a CA to pin to as a root of trust for a GUN.
Multiple sections can be specified, but the pinned certificates will take highest priority for validation, followed by the pinned CA, followed by TOFUS (TOFU over HTTPS).

Replaces empty trust pinning in `GetNotaryRepository` with  structure parsed from configuration.

Addresses #84 
