### PR TITLE
Migrate to non-deprecated functions of `api/types/filters`

### DIFF
--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -140,7 +140,7 @@ loop:
 }
 
 func updateNodeFilter(ctx context.Context, client client.APIClient, filter filters.Args) error {
-	if filter.Include("node") {
+	if filter.Contains("node") {
 		nodeFilters := filter.Get("node")
 		for _, nodeFilter := range nodeFilters {
 			nodeReference, err := node.Reference(ctx, client, nodeFilter)

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -68,7 +68,7 @@ func runBuildCachePrune(dockerCli command.Cli, _ opts.FilterOpt) (uint64, string
 
 func runPrune(dockerCli command.Cli, options pruneOptions) error {
 	// TODO version this once "until" filter is supported for volumes
-	if options.pruneVolumes && options.filter.Value().Include("until") {
+	if options.pruneVolumes && options.filter.Value().Contains("until") {
 		return fmt.Errorf(`ERROR: The "until" filter is not supported with "--volumes"`)
 	}
 	if versions.LessThan(dockerCli.Client().ClientVersion(), "1.31") {

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -102,14 +102,14 @@ func PruneFilters(dockerCli Cli, pruneFilters filters.Args) filters.Args {
 			// CLI label filter supersede config.json.
 			// If CLI label filter conflict with config.json,
 			// skip adding label! filter in config.json.
-			if pruneFilters.Include("label!") && pruneFilters.ExactMatch("label!", parts[1]) {
+			if pruneFilters.Contains("label!") && pruneFilters.ExactMatch("label!", parts[1]) {
 				continue
 			}
 		} else if parts[0] == "label!" {
 			// CLI label! filter supersede config.json.
 			// If CLI label! filter conflict with config.json,
 			// skip adding label filter in config.json.
-			if pruneFilters.Include("label") && pruneFilters.ExactMatch("label", parts[1]) {
+			if pruneFilters.Contains("label") && pruneFilters.ExactMatch("label", parts[1]) {
 				continue
 			}
 		}


### PR DESCRIPTION
- Use `Contains` instead of `Include`
- Use `ToJSON` instead of `ToParam`
- Remove usage of `ParseFlag` as it is deprecated too

See https://godoc.org/github.com/docker/docker/api/types/filters for `Deprecated` methods.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
