### PR TITLE
Add API-version anotation for --data-path-addr

### DIFF
--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -41,6 +41,7 @@ func newInitCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.advertiseAddr, flagAdvertiseAddr, "", "Advertised address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.dataPathAddr, flagDataPathAddr, "", "Address or interface to use for data path traffic (format: <ip|interface>)")
+	flags.SetAnnotation(flagDataPathAddr, "version", []string{"1.31"})
 	flags.BoolVar(&opts.forceNewCluster, "force-new-cluster", false, "Force create a new cluster from current state")
 	flags.BoolVar(&opts.autolock, flagAutolock, false, "Enable manager autolocking (requiring an unlock key to start a stopped manager)")
 	flags.StringVar(&opts.availability, flagAvailability, "active", `Availability of the node ("active"|"pause"|"drain")`)

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -42,6 +42,7 @@ func newJoinCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Var(&opts.listenAddr, flagListenAddr, "Listen address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.advertiseAddr, flagAdvertiseAddr, "", "Advertised address (format: <ip|interface>[:port])")
 	flags.StringVar(&opts.dataPathAddr, flagDataPathAddr, "", "Address or interface to use for data path traffic (format: <ip|interface>)")
+	flags.SetAnnotation(flagDataPathAddr, "version", []string{"1.31"})
 	flags.StringVar(&opts.token, flagToken, "", "Token for entry into the swarm")
 	flags.StringVar(&opts.availability, flagAvailability, "active", `Availability of the node ("active"|"pause"|"drain")`)
 	return cmd


### PR DESCRIPTION
This flag was added in Docker 17.06, API version 1.31 through https://github.com/moby/moby/pull/32717/commits/8dc8cd4719f165c01c98e7d3ce1d6cea6a8f60b 8(https://github.com/moby/moby/pull/32717), but didn't add API-version annotations.

This patch adds the missing annotations to hide this flag if the CLI is connected to an older version of the daemon that doesn't support that API.

Before this patch:

    DOCKER_API_VERSION=1.30 docker swarm init --help | grep data-path-addr
          --data-path-addr string           Address or interface to use for data path traffic (format: <ip|interface>)

    DOCKER_API_VERSION=1.31 docker swarm init --help | grep data-path-addr
          --data-path-addr string           Address or interface to use for data path traffic (format: <ip|interface>)

With this patch applied:

    DOCKER_API_VERSION=1.30 docker swarm init --help | grep data-path-addr
    # (no result)

    DOCKER_API_VERSION=1.31 docker swarm init --help | grep data-path-addr
          --data-path-addr string           Address or interface to use for data path traffic (format: <ip|interface>)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- How to verify it**

See above

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
+ Hide `--data-path-addr` flags when connected to a daemon that doesn't support this option [docker/cli#1240](https://github.com/docker/cli/pull/1240)
```