### PR TITLE
[18.06] Fix: Warning Message

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -96,12 +96,12 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 	file, err := os.Open(confFile)
 	if err != nil {
-		return configFile, errors.Wrap(err, confFile)
+		return configFile, errors.Wrap(err, filename)
 	}
 	defer file.Close()
 	err = configFile.LegacyLoadFromReader(file)
 	if err != nil {
-		return configFile, errors.Wrap(err, confFile)
+		return configFile, errors.Wrap(err, filename)
 	}
 	return configFile, nil
 }


### PR DESCRIPTION
Backport of https://github.com/docker/cli/pull/1140 for 18.06


```
git checkout -b 18.06-backport-1110-Fix-Warning-Message upstream/18.06
git cherry-pick -s -S -x ce3d0699362e3bf202b8b470af239562f063c12b
```

cherry-pick was clean; no conflicts
