### PR TITLE
build: add -buildmode=pie

### DIFF
--- a/scripts/build/dynbinary
+++ b/scripts/build/dynbinary
@@ -9,6 +9,6 @@ source ./scripts/build/.variables
 
 echo "Building dynamically linked $TARGET"
 export CGO_ENABLED=1
-go build -o "${TARGET}" -tags pkcs11 --ldflags "${LDFLAGS}" "${SOURCE}"
+go build -o "${TARGET}" -tags pkcs11 --ldflags "${LDFLAGS}" -buildmode=pie "${SOURCE}"
 
 ln -sf "$(basename "${TARGET}")" build/docker


### PR DESCRIPTION
Make all dynbinary builds be position-independent (this adds both
security benefits and can help with flaky builds on POWER
architectures).

Signed-off-by: Aleksa Sarai <asarai@suse.de>