### PR TITLE
Bump mergo to v0.3.6

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -34,7 +34,7 @@ github.com/gregjones/httpcache 9cad4c3443a7200dd6400aef47183728de563a38
 github.com/grpc-ecosystem/grpc-gateway 1a03ca3bad1e1ebadaedd3abb76bc58d4ac8143b
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/hashicorp/golang-lru 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
-github.com/imdario/mergo v0.3.5
+github.com/imdario/mergo v0.3.6
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0
 github.com/json-iterator/go ab8a2e0c74be9d3be70b3184d9acc634935ded82 # 1.1.4
 github.com/mattn/go-shellwords v1.0.3

--- a/vendor/github.com/imdario/mergo/README.md
+++ b/vendor/github.com/imdario/mergo/README.md
@@ -27,7 +27,7 @@ It is ready for production use. [It is used in several projects by Docker, Googl
 
 ### Latest release
 
-[Release v0.3.4](https://github.com/imdario/mergo/releases/tag/v0.3.4).
+[Release v0.3.6](https://github.com/imdario/mergo/releases/tag/v0.3.6).
 
 ### Important note
 

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -9,6 +9,7 @@
 package mergo
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -127,6 +128,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 					if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 						dstSlice = srcSlice
 					} else if config.AppendSlice {
+						if srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
 					}
 					dst.SetMapIndex(key, dstSlice)
@@ -150,6 +154,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 			dst.Set(src)
 		} else if config.AppendSlice {
+			if src.Type() != dst.Type() {
+				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+			}
 			dst.Set(reflect.AppendSlice(dst, src))
 		}
 	case reflect.Ptr:


### PR DESCRIPTION
Diff is https://github.com/imdario/mergo/compare/v0.3.5...v0.3.6

```diff
diff --git a/merge.go b/merge.go
index 706b220..44f70a8 100644
--- a/merge.go
+++ b/merge.go
@@ -9,6 +9,7 @@
 package mergo
 import (
+       "fmt"
        "reflect"
 )
@@ -127,6 +128,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
                                        if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
                                                dstSlice = srcSlice
                                        } else if config.AppendSlice {
+                                               if srcSlice.Type() != dstSlice.Type() {
+                                                       return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+                                               }
                                                dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
                                        }
                                        dst.SetMapIndex(key, dstSlice)
@@ -150,6 +154,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
                if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
                        dst.Set(src)
                } else if config.AppendSlice {
+                       if src.Type() != dst.Type() {
+                               return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+                       }
                        dst.Set(reflect.AppendSlice(dst, src))
                }
        case reflect.Ptr:
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
