### PR TITLE
Allow running `make help` without out-of-container warning

### DIFF
--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -3,7 +3,7 @@ set -eu
 
 target="${1:-}"
 
-if [[ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]]; then
+if [[ "$target" != "help" && -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]]; then
     (
         echo
         echo


### PR DESCRIPTION
Allow running `make help` without specifying the  extra `-f Makefile` option. Reasons:
* Currently `make help` warns about begin out-of-container and prompts using `make -f docker.Makefile help`
* `help` is not a valid target in `docker.Makefile`
* `README.md` instructs to use `make help` as is

A picture of a cute animal (my cat):
![mycat](https://user-images.githubusercontent.com/424592/43450598-57fddc64-94b3-11e8-8da3-234c9c0d465c.jpg)


