### PR TITLE
Add `help` and remove `watch` targets in docker.Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,6 @@ binary-osx: ## build executable for macOS
 dynbinary: ## build dynamically linked binary
 	./scripts/build/dynbinary
 
-.PHONY: watch
-watch: ## monitor file changes and run go test
-	./scripts/test/watch
-
 vendor: vendor.conf ## check that vendor matches vendor.conf
 	rm -rf vendor
 	bash -c 'vndr |& grep -v -i clone'


### PR DESCRIPTION
**- What I did**
* Add the `help` target to document make targets when building using a container
* Remove the `watch` target (filewatcher was removed with c0588a9c)

**- How I did it**
* I reused the smart way to generate an `help` already in place in the main Makefile;
* I moved most of the comments already available to have them printed with `help` and added new descriptions where needed;
* I removed the "using a container" from comments, as having `docker run` as target command is self documenting. Maybe we can add something like "All these targets are run inside a container" as header for `help`.

