### PR TITLE
Fix help message flags on docker stack commands and sub-commands

### DIFF
--- a/e2e/stack/help_test.go
+++ b/e2e/stack/help_test.go
@@ -1,0 +1,24 @@
+package stack
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/golden"
+	"gotest.tools/icmd"
+)
+
+func TestStackDeployHelp(t *testing.T) {
+	t.Run("Swarm", func(t *testing.T) {
+		testStackDeployHelp(t, "swarm")
+	})
+	t.Run("Kubernetes", func(t *testing.T) {
+		testStackDeployHelp(t, "kubernetes")
+	})
+}
+
+func testStackDeployHelp(t *testing.T, orchestrator string) {
+	result := icmd.RunCommand("docker", "stack", "deploy", "--orchestrator", orchestrator, "--help")
+	result.Assert(t, icmd.Success)
+	golden.Assert(t, result.Stdout(), fmt.Sprintf("stack-deploy-help-%s.golden", orchestrator))
+}

--- a/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
+++ b/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
@@ -1,0 +1,14 @@
+
+Usage:	docker stack deploy [OPTIONS] STACK
+
+Deploy a new stack or update an existing stack
+
+Aliases:
+  deploy, up
+
+Options:
+  -c, --compose-file strings   Path to a Compose file, or "-" to read
+                               from stdin
+      --kubeconfig string      Kubernetes config file
+      --namespace string       Kubernetes namespace to use
+      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)

--- a/e2e/stack/testdata/stack-deploy-help-swarm.golden
+++ b/e2e/stack/testdata/stack-deploy-help-swarm.golden
@@ -1,0 +1,19 @@
+
+Usage:	docker stack deploy [OPTIONS] STACK
+
+Deploy a new stack or update an existing stack
+
+Aliases:
+  deploy, up
+
+Options:
+      --bundle-file string     Path to a Distributed Application Bundle file
+  -c, --compose-file strings   Path to a Compose file, or "-" to read
+                               from stdin
+      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
+      --prune                  Prune services that are no longer referenced
+      --resolve-image string   Query the registry to resolve image digest
+                               and supported platforms
+                               ("always"|"changed"|"never") (default "always")
+      --with-registry-auth     Send registry authentication details to
+                               Swarm agents


### PR DESCRIPTION
**- What I did**
Fix issue #1243 
Add an e2e test as regression test

**- How I did it**
PersistentPreRunE needs to be called within the help function to initialize all the flags (notably the orchestrator flag)

**- How to verify it**
```sh
$ docker stack deploy --help --orchestrator=kubernetes

Usage:	docker stack deploy [OPTIONS] STACK

Deploy a new stack or update an existing stack

Aliases:
  deploy, up

Options:
  -c, --compose-file strings   Path to a Compose file, or "-" to read from stdin
      --kubeconfig string      Kubernetes config file
      --namespace string       Kubernetes namespace to use
      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)

$ docker stack deploy --help --orchestrator=swarm

Usage:	docker stack deploy [OPTIONS] STACK

Deploy a new stack or update an existing stack

Aliases:
  deploy, up

Options:
      --bundle-file string     Path to a Distributed Application Bundle file
  -c, --compose-file strings   Path to a Compose file, or "-" to read from stdin
      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
      --prune                  Prune services that are no longer referenced
      --resolve-image string   Query the registry to resolve image digest and supported platforms ("always"|"changed"|"never") (default "always")
      --with-registry-auth     Send registry authentication details to Swarm agents
```

**- Description for the changelog**
* Fix #1243 help message flags on docker stack commands and sub-commands

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/43493328-bbfb6dd8-952d-11e8-9f9c-b46bb8291fe8.png)

Lots of kudos for @albers !!