### PR TITLE
Add bash completion for kubernetes orchestrator

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4435,8 +4435,9 @@ _docker_stack_deploy() {
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help --prune --resolve-image --with-registry-auth"
-			__docker_daemon_is_experimental && options+=" --bundle-file"
+			local options="--compose-file -c --help"
+			__docker_daemon_is_experimental && __docker_stack_orchestrator_is swarm && options+=" --bundle-file"
+			__docker_stack_orchestrator_is swarm && options+=" --prune --resolve-image --with-registry-auth"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -584,6 +584,31 @@ __docker_daemon_os_is() {
 	[ "$actual_os" = "$expected_os" ]
 }
 
+# __docker_stack_orchestrator_is tests whether the client is configured to use
+# the orchestrator that is passed in as the first argument.
+__docker_stack_orchestrator_is() {
+	case "$1" in
+		kubernetes)
+			if [ -z "$stack_orchestrator_is_kubernetes" ] ; then
+				__docker_q stack ls --help | grep -qe --namespace
+				stack_orchestrator_is_kubernetes=$?
+			fi
+			return $stack_orchestrator_is_kubernetes
+			;;
+		swarm)
+			if [ -z "$stack_orchestrator_is_swarm" ] ; then
+				__docker_q stack deploy --help | grep -qe "with-registry-auth"
+				stack_orchestrator_is_swarm=$?
+			fi
+			return $stack_orchestrator_is_swarm
+			;;
+		*)
+			return 1
+			;;
+
+	esac
+}
+
 # __docker_pos_first_nonflag finds the position of the first word that is neither
 # option nor an option's argument. If there are options that require arguments,
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
@@ -5037,6 +5062,9 @@ _docker() {
 	"
 
 	local host config daemon_os
+
+	# variables to cache client info, populated on demand for performance reasons
+	local stack_orchestrator_is_kubernetes stack_orchestrator_is_swarm
 
 	COMPREPLY=()
 	local cur prev words cword

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1075,6 +1075,23 @@ __docker_complete_signals() {
 	COMPREPLY=( $( compgen -W "${signals[*]} ${signals[*]#SIG}" -- "$( echo "$cur" | tr '[:lower:]' '[:upper:]')" ) )
 }
 
+__docker_complete_stack_orchestrator_options() {
+	case "$prev" in
+		--kubeconfig)
+			_filedir
+			return 0
+			;;
+		--namespace)
+			return 0
+			;;
+		--orchestrator)
+			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur") )
+			return 0
+			;;
+	esac
+	return 1
+}
+
 __docker_complete_user_group() {
 	if [[ $cur == *:* ]] ; then
 		COMPREPLY=( $(compgen -g -- "${cur#*:}") )
@@ -4403,11 +4420,15 @@ _docker_stack() {
 		remove
 		up
 	"
+
+	__docker_complete_stack_orchestrator_options && return
 	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			local options="--help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
@@ -4416,12 +4437,12 @@ _docker_stack() {
 }
 
 _docker_stack_deploy() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--bundle-file)
-			if __docker_daemon_is_experimental ; then
-				_filedir dab
-				return
-			fi
+			_filedir dab
+			return
 			;;
 		--compose-file|-c)
 			_filedir yml
@@ -4435,13 +4456,14 @@ _docker_stack_deploy() {
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help"
+			local options="--compose-file -c --help --orchestrator"
 			__docker_daemon_is_experimental && __docker_stack_orchestrator_is swarm && options+=" --bundle-file"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
 			__docker_stack_orchestrator_is swarm && options+=" --prune --resolve-image --with-registry-auth"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--resolve-image')
+			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--kubeconfig|--namespace|--orchestrator|--resolve-image')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4458,6 +4480,8 @@ _docker_stack_list() {
 }
 
 _docker_stack_ls() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--format)
 			return
@@ -4466,7 +4490,9 @@ _docker_stack_ls() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
+			local options="--format --help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 	esac
 }
@@ -4488,6 +4514,8 @@ _docker_stack_ps() {
 			;;
 	esac
 
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id name desired-state" -- "$cur" ) )
@@ -4501,10 +4529,12 @@ _docker_stack_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
+			local options="--filter -f --format --help --no-resolve --no-trunc --orchestrator --quiet -q"
+			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f')
+			local counter=$(__docker_pos_first_nonflag '--all-namespaces|--filter|-f|--format|--kubeconfig|--namespace')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4517,9 +4547,13 @@ _docker_stack_remove() {
 }
 
 _docker_stack_rm() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			local options="--help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_stacks
@@ -4543,6 +4577,8 @@ _docker_stack_services() {
 			;;
 	esac
 
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id label name" -- "$cur" ) )
@@ -4556,10 +4592,12 @@ _docker_stack_services() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --format --help --quiet -q" -- "$cur" ) )
+			local options="--filter -f --format --help --orchestrator --quiet -q"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format')
+			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format|--kubeconfig|--namespace|--orchestrator')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4826,6 +4864,8 @@ _docker_top() {
 }
 
 _docker_version() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--format|-f)
 			return
@@ -4834,7 +4874,9 @@ _docker_version() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			local options="--format -f --help"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
**Depends on #1251** edit: #1251 was merged.

This
- adds completions for kubernetes-specific options if kubernetes orchestrator is configured
- hides completions for swarm-specific options unless swarm orchestrator is configured

The configured orchestrator is determined from the output of `docker stack deploy|ls --help`.
~As the required help output is broken in 18.06.0 (see #1243) this work depends on #1251.~

~To test before #1251 is merged, just use a binary built at #1251.~
I recommend using `export DOCKER_STACK_ORCHESTRATOR=kubernetes|swarm|all`, then invoking the completions of `docker stack (deploy|ls|ps|rm|services)? --` and `docker version --`.

Thanks @silvin-lubecki for fixing the help output so fast.