### PR TITLE
Add stack orchestrator to info command

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -182,6 +182,10 @@ func prettyPrintInfo(dockerCli command.Cli, info types.Info) error {
 	fprintlnNonEmpty(dockerCli.Out(), "Cluster Store:", info.ClusterStore)
 	fprintlnNonEmpty(dockerCli.Out(), "Cluster Advertise:", info.ClusterAdvertise)
 
+	if err := printOrchestratorInfos(dockerCli); err != nil {
+		return err
+	}
+
 	if info.RegistryConfig != nil && (len(info.RegistryConfig.InsecureRegistryCIDRs) > 0 || len(info.RegistryConfig.IndexConfigs) > 0) {
 		fmt.Fprintln(dockerCli.Out(), "Insecure Registries:")
 		for _, registry := range info.RegistryConfig.IndexConfigs {
@@ -327,6 +331,16 @@ func printStorageDriverWarnings(dockerCli command.Cli, info types.Info) {
 			fmt.Fprintln(dockerCli.Err(), msg)
 		}
 	}
+}
+
+func printOrchestratorInfos(dockerCli command.Cli) error {
+	orchestrator, err := command.GetStackOrchestrator("", dockerCli.ConfigFile().StackOrchestrator, dockerCli.Err())
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(dockerCli.Out(), "Orchestrator:")
+	fmt.Fprintln(dockerCli.Out(), " Stack:", orchestrator)
+	return nil
 }
 
 func getBackingFs(info types.Info) string {

--- a/cli/command/system/testdata/docker-info-no-swarm.golden
+++ b/cli/command/system/testdata/docker-info-no-swarm.golden
@@ -45,6 +45,8 @@ Registry: https://index.docker.io/v1/
 Labels:
  provider=digitalocean
 Experimental: false
+Orchestrator:
+ Stack: swarm
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false

--- a/cli/command/system/testdata/docker-info-with-swarm.golden
+++ b/cli/command/system/testdata/docker-info-with-swarm.golden
@@ -67,6 +67,8 @@ Registry: https://index.docker.io/v1/
 Labels:
  provider=digitalocean
 Experimental: false
+Orchestrator:
+ Stack: swarm
 Insecure Registries:
  127.0.0.0/8
 Live Restore Enabled: false


### PR DESCRIPTION
**- What I did**
Added which stack orchestrator is resolved in `docker info` command, using environment variable DOCKER_STACK_ORCHESTRATOR and/or the docker configuration file.
The information was previously removed from `docker version`.

**- How to verify it**
```sh
$ docker info
...
Orchestrator:
 Stack: swarm

$ DOCKER_STACK_ORCHESTRATOR=kubernetes docker info
...
Orchestrator:
 Stack: kubernetes

```

**- Description for the changelog**
* Add stack orchestrator to info command

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/43522596-1e196756-959a-11e8-9611-ec55f11c4960.png)
