### PR TITLE
Allow custom pattern when extracting variable…

### DIFF
--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -161,15 +161,15 @@ func TestSubstituteWithCustomFunc(t *testing.T) {
 		return value, true, nil
 	}
 
-	result, err := SubstituteWith("ok ${FOO}", defaultMapping, pattern, errIsMissing)
+	result, err := SubstituteWith("ok ${FOO}", defaultMapping, defaultPattern, errIsMissing)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("ok first", result))
 
-	result, err = SubstituteWith("ok ${BAR}", defaultMapping, pattern, errIsMissing)
+	result, err = SubstituteWith("ok ${BAR}", defaultMapping, defaultPattern, errIsMissing)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("ok ", result))
 
-	_, err = SubstituteWith("ok ${NOTHERE}", defaultMapping, pattern, errIsMissing)
+	_, err = SubstituteWith("ok ${NOTHERE}", defaultMapping, defaultPattern, errIsMissing)
 	assert.Check(t, is.ErrorContains(err, "required variable"))
 }
 
@@ -245,18 +245,21 @@ func TestExtractVariables(t *testing.T) {
 				},
 				"baz": []interface{}{
 					"foo",
+					"$docker:${project:-cli}",
 					"$toto",
 				},
 			},
 			expected: map[string]string{
-				"bar":   "foo",
-				"fruit": "banana",
-				"toto":  "",
+				"bar":     "foo",
+				"fruit":   "banana",
+				"toto":    "",
+				"docker":  "",
+				"project": "cli",
 			},
 		},
 	}
 	for _, tc := range testCases {
-		actual := ExtractVariables(tc.dict)
+		actual := ExtractVariables(tc.dict, defaultPattern)
 		assert.Check(t, is.DeepEqual(actual, tc.expected))
 	}
 }


### PR DESCRIPTION
… as it is possible to do it when interpolating. It also fixes when
there is 2 variables on the same *value* (in the composefile, on the
same line)

Finaly, renaming the default, used in cli, pattern to `defaultPattern`
to not be shadowed unintentionally.

Useful for `docker/app` (and required to fix `docker/app` :sweat_smile:)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
