### PR TITLE
use sortorder library for sorting network list output

### DIFF
--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
+	"vbom.ml/util/sortorder"
 )
 
 type listOptions struct {
@@ -59,7 +60,7 @@ func runList(dockerCli command.Cli, options listOptions) error {
 	}
 
 	sort.Slice(networkResources, func(i, j int) bool {
-		return networkResources[i].Name < networkResources[j].Name
+		return sortorder.NaturalLess(networkResources[i].Name, networkResources[j].Name)
 	})
 
 	networksCtx := formatter.Context{

--- a/cli/command/network/testdata/network-list-sort.golden
+++ b/cli/command/network/testdata/network-list-sort.golden
@@ -1,3 +1,3 @@
 network-1-foo
-network-10-foo
 network-2-foo
+network-10-foo

--- a/cli/command/trust/common.go
+++ b/cli/command/trust/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
+	"vbom.ml/util/sortorder"
 )
 
 // trustTagKey represents a unique signed tag and hex-encoded hash pair
@@ -149,7 +150,7 @@ func matchReleasedSignatures(allTargets []client.TargetSignedStruct) []trustTagR
 		signatureRows = append(signatureRows, trustTagRow{targetKey, signers})
 	}
 	sort.Slice(signatureRows, func(i, j int) bool {
-		return signatureRows[i].SignedTag < signatureRows[j].SignedTag
+		return sortorder.NaturalLess(signatureRows[i].SignedTag, signatureRows[j].SignedTag)
 	})
 	return signatureRows
 }

--- a/cli/command/trust/common_test.go
+++ b/cli/command/trust/common_test.go
@@ -1,0 +1,33 @@
+package trust
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/trust"
+	"github.com/theupdateframework/notary/client"
+	"github.com/theupdateframework/notary/tuf/data"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestMatchReleasedSignaturesSortOrder(t *testing.T) {
+	var releasesRole = data.DelegationRole{BaseRole: data.BaseRole{Name: trust.ReleasesRole}}
+	targets := []client.TargetSignedStruct{
+		{Target: client.Target{Name: "target10-foo"}, Role: releasesRole},
+		{Target: client.Target{Name: "target1-foo"}, Role: releasesRole},
+		{Target: client.Target{Name: "target2-foo"}, Role: releasesRole},
+	}
+
+	rows := matchReleasedSignatures(targets)
+
+	var targetNames []string
+	for _, r := range rows {
+		targetNames = append(targetNames, r.SignedTag)
+	}
+	expected := []string{
+		"target1-foo",
+		"target2-foo",
+		"target10-foo",
+	}
+	assert.Check(t, is.DeepEqual(expected, targetNames))
+}

--- a/cli/command/trust/inspect_pretty.go
+++ b/cli/command/trust/inspect_pretty.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/theupdateframework/notary/client"
+	"vbom.ml/util/sortorder"
 )
 
 func prettyPrintTrustInfo(cli command.Cli, remote string) error {
@@ -86,7 +87,7 @@ func printSignerInfo(out io.Writer, roleToKeyIDs map[string][]string) error {
 		})
 	}
 	sort.Slice(formattedSignerInfo, func(i, j int) bool {
-		return formattedSignerInfo[i].Name < formattedSignerInfo[j].Name
+		return sortorder.NaturalLess(formattedSignerInfo[i].Name, formattedSignerInfo[j].Name)
 	})
 	return formatter.SignerInfoWrite(signerInfoCtx, formattedSignerInfo)
 }

--- a/cli/command/trust/inspect_pretty_test.go
+++ b/cli/command/trust/inspect_pretty_test.go
@@ -1,6 +1,7 @@
 package trust
 
 import (
+	"bytes"
 	"encoding/hex"
 	"io/ioutil"
 	"testing"
@@ -439,4 +440,21 @@ func TestFormatAdminRole(t *testing.T) {
 	}
 	targetsRoleWithSigs := client.RoleWithSignatures{Role: targetsRole, Signatures: nil}
 	assert.Check(t, is.Equal("Repository Key:\tabc, key11, key99\n", formatAdminRole(targetsRoleWithSigs)))
+}
+
+func TestPrintSignerInfoSortOrder(t *testing.T) {
+	roleToKeyIDs := map[string][]string{
+		"signer2-foo":  {"B"},
+		"signer10-foo": {"C"},
+		"signer1-foo":  {"A"},
+	}
+
+	expected := `SIGNER              KEYS
+signer1-foo         A
+signer2-foo         B
+signer10-foo        C
+`
+	buf := new(bytes.Buffer)
+	assert.NilError(t, printSignerInfo(buf, roleToKeyIDs))
+	assert.Check(t, is.Equal(expected, buf.String()))
 }

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
+	"vbom.ml/util/sortorder"
 )
 
 type listOptions struct {
@@ -55,7 +56,7 @@ func runList(dockerCli command.Cli, options listOptions) error {
 	}
 
 	sort.Slice(volumes.Volumes, func(i, j int) bool {
-		return volumes.Volumes[i].Name < volumes.Volumes[j].Name
+		return sortorder.NaturalLess(volumes.Volumes[i].Name, volumes.Volumes[j].Name)
 	})
 
 	volumeCtx := formatter.Context{

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -109,3 +109,21 @@ func TestVolumeListWithFormat(t *testing.T) {
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-with-format.golden")
 }
+
+func TestVolumeListSortOrder(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		volumeListFunc: func(filter filters.Args) (volumetypes.VolumeListOKBody, error) {
+			return volumetypes.VolumeListOKBody{
+				Volumes: []*types.Volume{
+					Volume(VolumeName("volume-2-foo")),
+					Volume(VolumeName("volume-10-foo")),
+					Volume(VolumeName("volume-1-foo")),
+				},
+			}, nil
+		},
+	})
+	cmd := newListCommand(cli)
+	cmd.Flags().Set("format", "{{ .Name }}")
+	assert.NilError(t, cmd.Execute())
+	golden.Assert(t, cli.OutBuffer().String(), "volume-list-sort.golden")
+}

--- a/cli/command/volume/testdata/volume-list-sort.golden
+++ b/cli/command/volume/testdata/volume-list-sort.golden
@@ -1,0 +1,3 @@
+volume-1-foo
+volume-2-foo
+volume-10-foo


### PR DESCRIPTION
**- What I did**
Use sortorder lib for sorting the output of `network list` command

**- How I did it**
Used `NaturalLess` for ordering the output, consistent with other commands

**- How to verify it**
- create 3 networks: net-1, net-2, net-10
- run `docker network list --format '{{ .Name }}'`
- output:
```
...
net-1
net-10
net-2
...
```

- output after the changes made by this PR:
```
...
net-1
net-2
net-10
...
```

**- Description for the changelog**
network list command uses sortorder lib to sort the output

**- A picture of a cute animal (not mandatory but encouraged)**

