### PR TITLE
[18.06] backport "Fix help message flags on docker stack commands and sub-commands"

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -58,7 +58,7 @@ func newDeployCommand(dockerCli command.Cli, common *commonOptions) *cobra.Comma
 	flags.StringVar(&opts.Bundlefile, "bundle-file", "", "Path to a Distributed Application Bundle file")
 	flags.SetAnnotation("bundle-file", "experimental", nil)
 	flags.SetAnnotation("bundle-file", "swarm", nil)
-	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, "Path to a Compose file")
+	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, `Path to a Compose file, or "-" to read from stdin`)
 	flags.SetAnnotation("compose-file", "version", []string{"1.25"})
 	flags.BoolVar(&opts.SendRegistryAuth, "with-registry-auth", false, "Send registry authentication details to Swarm agents")
 	flags.SetAnnotation("with-registry-auth", "swarm", nil)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2209,7 +2209,7 @@ __docker_stack_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)--bundle-file=[Path to a Distributed Application Bundle file]:dab:_files -g \"*.dab\"" \
-                "($help -c --compose-file)"{-c=,--compose-file=}"[Path to a Compose file]:compose file:_files -g \"*.(yml|yaml)\"" \
+                "($help -c --compose-file)"{-c=,--compose-file=}"[Path to a Compose file, or '-' to read from stdin]:compose file:_files -g \"*.(yml|yaml)\"" \
                 "($help)--with-registry-auth[Send registry authentication details to Swarm agents]" \
                 "($help -):stack:__docker_complete_stacks" && ret=0
             ;;

--- a/docs/reference/commandline/deploy.md
+++ b/docs/reference/commandline/deploy.md
@@ -28,7 +28,7 @@ Aliases:
 
 Options:
       --bundle-file string    Path to a Distributed Application Bundle file
-      --compose-file string   Path to a Compose file
+      --compose-file string   Path to a Compose file, or "-" to read from stdin
       --help                  Print usage
       --prune                 Prune services that are no longer referenced
       --with-registry-auth    Send registry authentication details to Swarm agents

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -25,7 +25,7 @@ Aliases:
 
 Options:
       --bundle-file string    Path to a Distributed Application Bundle file
-  -c, --compose-file strings  Path to a Compose file
+  -c, --compose-file strings  Path to a Compose file, or "-" to read from stdin
       --help                  Print usage
       --kubeconfig string     Kubernetes config file
       --namespace string      Kubernetes namespace to use

--- a/e2e/stack/help_test.go
+++ b/e2e/stack/help_test.go
@@ -1,0 +1,24 @@
+package stack
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/golden"
+	"gotest.tools/icmd"
+)
+
+func TestStackDeployHelp(t *testing.T) {
+	t.Run("Swarm", func(t *testing.T) {
+		testStackDeployHelp(t, "swarm")
+	})
+	t.Run("Kubernetes", func(t *testing.T) {
+		testStackDeployHelp(t, "kubernetes")
+	})
+}
+
+func testStackDeployHelp(t *testing.T, orchestrator string) {
+	result := icmd.RunCommand("docker", "stack", "deploy", "--orchestrator", orchestrator, "--help")
+	result.Assert(t, icmd.Success)
+	golden.Assert(t, result.Stdout(), fmt.Sprintf("stack-deploy-help-%s.golden", orchestrator))
+}

--- a/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
+++ b/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
@@ -1,0 +1,14 @@
+
+Usage:	docker stack deploy [OPTIONS] STACK
+
+Deploy a new stack or update an existing stack
+
+Aliases:
+  deploy, up
+
+Options:
+  -c, --compose-file strings   Path to a Compose file, or "-" to read
+                               from stdin
+      --kubeconfig string      Kubernetes config file
+      --namespace string       Kubernetes namespace to use
+      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)

--- a/e2e/stack/testdata/stack-deploy-help-swarm.golden
+++ b/e2e/stack/testdata/stack-deploy-help-swarm.golden
@@ -1,0 +1,19 @@
+
+Usage:	docker stack deploy [OPTIONS] STACK
+
+Deploy a new stack or update an existing stack
+
+Aliases:
+  deploy, up
+
+Options:
+      --bundle-file string     Path to a Distributed Application Bundle file
+  -c, --compose-file strings   Path to a Compose file, or "-" to read
+                               from stdin
+      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
+      --prune                  Prune services that are no longer referenced
+      --resolve-image string   Query the registry to resolve image digest
+                               and supported platforms
+                               ("always"|"changed"|"never") (default "always")
+      --with-registry-auth     Send registry authentication details to
+                               Swarm agents


### PR DESCRIPTION
Backport https://github.com/docker/cli/pull/1251 and https://github.com/docker/cli/pull/1222 for 18.06

fixes https://github.com/docker/cli/issues/1243 for 18.06


```
git checkout -b 18.06-backport-fix-stack-help-command upstream/18.06
git cherry-pick -s -S -x 2c7822b0361dd3e78bb0745a5c03f741bc21821e
git cherry-pick -s -S -x 21cce52b3060414aa76b89d4d401ada74b178789
git push -u origin
```

cherry-pick was clean; no conflicts


PersistentPreRunE needs to be called within the help function to initialize all the flags (notably the orchestrator flag) Add an e2e test as regression test
