### PR TITLE
[18.06] backport "fixed typo breaking zsh docker update autocomplete"

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -923,7 +923,7 @@ __docker_container_subcommand() {
             local state
             _arguments $(__docker_arguments) \
                 $opts_help \
-                opts_create_run_update \
+                $opts_create_run_update \
                 "($help -)*: :->values" && ret=0
             case $state in
                 (values)


### PR DESCRIPTION
Backport https://github.com/docker/cli/pull/1232 for 18.06

fixes https://github.com/docker/cli/issues/1231 for 18.06

```
git checkout -b 18.06-backport-1231-zsh-autocomplete-update-invalid upstream/18.06
git cherry-pick -s -S -x da00d1c49f8366240f33b82952e582bf563026c8
git push -u origin
```

cherry-pick was clean; no conflicts
