### PR TITLE
Add bash completion for `cp --archive`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1437,7 +1437,7 @@ _docker_container_commit() {
 _docker_container_cp() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--follow-link -L --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--archive -a --follow-link -L --help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)


### PR DESCRIPTION
Bash completion for `docker cp --archive|-a` was missing.