### PR TITLE
[18.06] backport various Bash completion script updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # GitHub code owners
 # See https://github.com/blog/2392-introducing-code-owners
 
-cli/command/stack/**        @vdemeester
+cli/command/stack/**        @vdemeester @silvin-lubecki
 cli/compose/**              @vdemeester
 contrib/completion/bash/**  @albers
 contrib/completion/zsh/**   @sdurrheimer
-docs/**                     @mistyhacks @vdemeester @thaJeztah
+docs/**                     @vdemeester @thaJeztah

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -41,7 +41,6 @@
 	# TODO Describe the docs maintainers role.
 
 		people = [
-			"misty",
 			"thajeztah"
 		]
 
@@ -94,11 +93,6 @@
 	Name = "Justin Cormack"
 	Email = "justin.cormack@docker.com"
 	GitHub = "justincormack"
-
-	[people.misty]
-	Name = "Misty Stanley-Jones"
-	Email = "misty@docker.com"
-	GitHub = "mistyhacks"
 
 	[people.programmerq]
 	Name = "Jeff Anderson"

--- a/contrib/completion/REVIEWERS
+++ b/contrib/completion/REVIEWERS
@@ -1,2 +1,0 @@
-Tianon Gravi <admwiggin@gmail.com> (@tianon)
-Jessie Frazelle <jess@docker.com> (@jfrazelle)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4435,8 +4435,9 @@ _docker_stack_deploy() {
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help --prune --resolve-image --with-registry-auth"
-			__docker_daemon_is_experimental && options+=" --bundle-file"
+			local options="--compose-file -c --help"
+			__docker_daemon_is_experimental && __docker_stack_orchestrator_is swarm && options+=" --bundle-file"
+			__docker_stack_orchestrator_is swarm && options+=" --prune --resolve-image --with-registry-auth"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -584,6 +584,31 @@ __docker_daemon_os_is() {
 	[ "$actual_os" = "$expected_os" ]
 }
 
+# __docker_stack_orchestrator_is tests whether the client is configured to use
+# the orchestrator that is passed in as the first argument.
+__docker_stack_orchestrator_is() {
+	case "$1" in
+		kubernetes)
+			if [ -z "$stack_orchestrator_is_kubernetes" ] ; then
+				__docker_q stack ls --help | grep -qe --namespace
+				stack_orchestrator_is_kubernetes=$?
+			fi
+			return $stack_orchestrator_is_kubernetes
+			;;
+		swarm)
+			if [ -z "$stack_orchestrator_is_swarm" ] ; then
+				__docker_q stack deploy --help | grep -qe "with-registry-auth"
+				stack_orchestrator_is_swarm=$?
+			fi
+			return $stack_orchestrator_is_swarm
+			;;
+		*)
+			return 1
+			;;
+
+	esac
+}
+
 # __docker_pos_first_nonflag finds the position of the first word that is neither
 # option nor an option's argument. If there are options that require arguments,
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
@@ -5037,6 +5062,9 @@ _docker() {
 	"
 
 	local host config daemon_os
+
+	# variables to cache client info, populated on demand for performance reasons
+	local stack_orchestrator_is_kubernetes stack_orchestrator_is_swarm
 
 	COMPREPLY=()
 	local cur prev words cword

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -288,10 +288,9 @@ __docker_complete_networks() {
 	COMPREPLY=( $(compgen -W "$(__docker_networks "$@")" -- "$current") )
 }
 
-# shellcheck disable=SC2128,SC2178
 __docker_complete_containers_in_network() {
-	local containers=$(__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1")
-	COMPREPLY=( $(compgen -W "$containers" -- "$cur") )
+	local containers=($(__docker_q network inspect -f '{{range $i, $c := .Containers}}{{$i}} {{$c.Name}} {{end}}' "$1"))
+	COMPREPLY=( $(compgen -W "${containers[*]}" -- "$cur") )
 }
 
 # __docker_volumes returns a list of all volumes. Additional options to
@@ -347,8 +346,7 @@ __docker_plugins_bundled() {
 	for del in "${remove[@]}" ; do
 		plugins=(${plugins[@]/$del/})
 	done
-	# shellcheck disable=SC2145
-	echo "${plugins[@]} ${add[@]}"
+	echo "${plugins[@]}" "${add[@]}"
 }
 
 # __docker_complete_plugins_bundled applies completion of plugins based on the current
@@ -1456,8 +1454,7 @@ _docker_container_cp() {
 						local containers=( ${COMPREPLY[@]} )
 
 						COMPREPLY=( $( compgen -W "${files[*]} ${containers[*]}" -- "$cur" ) )
-						# shellcheck disable=SC2128
-						if [[ "$COMPREPLY" == *: ]]; then
+						if [[ "${COMPREPLY[*]}" = *: ]]; then
 							__docker_nospace
 						fi
 						return
@@ -1955,8 +1952,7 @@ _docker_container_run_and_create() {
 					;;
 				*)
 					COMPREPLY=( $( compgen -W 'none host private shareable container:' -- "$cur" ) )
-					# shellcheck disable=SC2128
-					if [ "$COMPREPLY" = "container:" ]; then
+					if [ "${COMPREPLY[*]}" = "container:" ]; then
 						__docker_nospace
 					fi
 					;;
@@ -2010,8 +2006,7 @@ _docker_container_run_and_create() {
 					;;
 				*)
 					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
-					# shellcheck disable=SC2128
-					if [ "$COMPREPLY" = "container:" ]; then
+					if [ "${COMPREPLY[*]}" = "container:" ]; then
 						__docker_nospace
 					fi
 					;;
@@ -2074,15 +2069,14 @@ _docker_container_run_and_create() {
 
 _docker_container_start() {
 	__docker_complete_detach_keys && return
-	# shellcheck disable=SC2078
 	case "$prev" in
 		--checkpoint)
-			if [ __docker_daemon_is_experimental ] ; then
+			if __docker_daemon_is_experimental ; then
 				return
 			fi
 			;;
 		--checkpoint-dir)
-			if [ __docker_daemon_is_experimental ] ; then
+			if __docker_daemon_is_experimental ; then
 				_filedir -d
 				return
 			fi

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1437,7 +1437,7 @@ _docker_container_commit() {
 _docker_container_cp() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--follow-link -L --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--archive -a --follow-link -L --help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1075,6 +1075,23 @@ __docker_complete_signals() {
 	COMPREPLY=( $( compgen -W "${signals[*]} ${signals[*]#SIG}" -- "$( echo "$cur" | tr '[:lower:]' '[:upper:]')" ) )
 }
 
+__docker_complete_stack_orchestrator_options() {
+	case "$prev" in
+		--kubeconfig)
+			_filedir
+			return 0
+			;;
+		--namespace)
+			return 0
+			;;
+		--orchestrator)
+			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur") )
+			return 0
+			;;
+	esac
+	return 1
+}
+
 __docker_complete_user_group() {
 	if [[ $cur == *:* ]] ; then
 		COMPREPLY=( $(compgen -g -- "${cur#*:}") )
@@ -4403,11 +4420,15 @@ _docker_stack() {
 		remove
 		up
 	"
+
+	__docker_complete_stack_orchestrator_options && return
 	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			local options="--help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
@@ -4416,12 +4437,12 @@ _docker_stack() {
 }
 
 _docker_stack_deploy() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--bundle-file)
-			if __docker_daemon_is_experimental ; then
-				_filedir dab
-				return
-			fi
+			_filedir dab
+			return
 			;;
 		--compose-file|-c)
 			_filedir yml
@@ -4435,13 +4456,14 @@ _docker_stack_deploy() {
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help"
+			local options="--compose-file -c --help --orchestrator"
 			__docker_daemon_is_experimental && __docker_stack_orchestrator_is swarm && options+=" --bundle-file"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
 			__docker_stack_orchestrator_is swarm && options+=" --prune --resolve-image --with-registry-auth"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--resolve-image')
+			local counter=$(__docker_pos_first_nonflag '--bundle-file|--compose-file|-c|--kubeconfig|--namespace|--orchestrator|--resolve-image')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4458,6 +4480,8 @@ _docker_stack_list() {
 }
 
 _docker_stack_ls() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--format)
 			return
@@ -4466,7 +4490,9 @@ _docker_stack_ls() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
+			local options="--format --help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 	esac
 }
@@ -4488,6 +4514,8 @@ _docker_stack_ps() {
 			;;
 	esac
 
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id name desired-state" -- "$cur" ) )
@@ -4501,10 +4529,12 @@ _docker_stack_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
+			local options="--filter -f --format --help --no-resolve --no-trunc --orchestrator --quiet -q"
+			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f')
+			local counter=$(__docker_pos_first_nonflag '--all-namespaces|--filter|-f|--format|--kubeconfig|--namespace')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4517,9 +4547,13 @@ _docker_stack_remove() {
 }
 
 _docker_stack_rm() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			local options="--help --orchestrator"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_stacks
@@ -4543,6 +4577,8 @@ _docker_stack_services() {
 			;;
 	esac
 
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id label name" -- "$cur" ) )
@@ -4556,10 +4592,12 @@ _docker_stack_services() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--filter -f --format --help --quiet -q" -- "$cur" ) )
+			local options="--filter -f --format --help --orchestrator --quiet -q"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format')
+			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format|--kubeconfig|--namespace|--orchestrator')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4826,6 +4864,8 @@ _docker_top() {
 }
 
 _docker_version() {
+	__docker_complete_stack_orchestrator_options && return
+
 	case "$prev" in
 		--format|-f)
 			return
@@ -4834,7 +4874,9 @@ _docker_version() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			local options="--format -f --help"
+			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3220,7 +3220,7 @@ _docker_service_logs() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--follow -f --help --no-resolve --no-task-ids --no-trunc --since --tail --timestamps -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--details --follow -f --help --no-resolve --no-task-ids --no-trunc --raw --since --tail --timestamps -t" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--since|--tail')


### PR DESCRIPTION
Cherry-picks of the following PR's for 18.06

- https://github.com/docker/cli/pull/1215 Add bash completion for `service logs --details|--raw`
- https://github.com/docker/cli/pull/1254 Add bash completion for kubernetes orchestrator
- https://github.com/docker/cli/pull/1256 Remove outdated completion reviewers file
- https://github.com/docker/cli/pull/1269 Add bash completion for `cp --archive`
  - since 17.06
- https://github.com/docker/cli/pull/1271 Fix shellcheck warnings

```
git checkout -b 18.06-completion-updates upstream/18.06

# https://github.com/docker/cli/pull/1215
git cherry-pick -s -S -x 4912846de22fe3efd4b9fe8e3059615948f9112a

# https://github.com/docker/cli/pull/1254
git cherry-pick -s -S -x ff953751d342f7815060593d14763030af77621c
git cherry-pick -s -S -x 8ef01e869ea55aa3eb860ee4e7e60a44a5d0ff81
git cherry-pick -s -S -x 08f8ee13200d0a69b1e4fbd72ffe9c7d55a152b4

# https://github.com/docker/cli/pull/1256
git cherry-pick -s -S -x 9022a00fbe2aa47da5a17652144b028dc32292d9

# https://github.com/docker/cli/pull/1269
git cherry-pick -s -S -x b9b3754ad3fc795942bc7388b8d143701bf19515

# https://github.com/docker/cli/pull/1271
git cherry-pick -s -S -x e587ec293bf154281215189487d7504cc1d70666
```

cherry-pick was clean; no conflicts
