### PR TITLE
Support for relative path in bind mounts

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -348,6 +348,12 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, err
 				}
 				// use the resolved file path
 				bind = resolved + ":" + parsed.Target
+				if parsed.ReadOnly {
+					bind += ":ro"
+				}
+				if parsed.Consistency != "" {
+					bind += ":" + parsed.Consistency
+				}
 			}
 
 			// after creating the bind mount we want to delete it from the copts.volumes values because


### PR DESCRIPTION
Signed-off-by: Matthew Wo <9029537@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add support for resolving relative paths in bind mounts as discussed in #1203.

For example:
```sh
docker run -v ./data:/data-dump my-image
```
will mount the folder `data` in the current working directory.

**- How I did it**
Made changes in the parser (`opts.go`) to resolve the relative path but only if the volume is a bind mount.

**- How to verify it**
```sh
docker run -v ./hello:/hello-folder alpine sh -c "touch /hello-folder/test"
```
the folder `hello` in the current working directory of the host machine should have the file `test`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Resolves relative path in `docker run` bind mounts.

**- A picture of a cute animal (not mandatory but encouraged)**
![baby-anteater](https://user-images.githubusercontent.com/2998111/43680864-ed3eaa22-97f8-11e8-946c-f33cac58fe04.jpg)

Zot Zot Zot (as an UCI alumni).