### PR TITLE
Ability to overwrite an existing manifest

### DIFF
--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -92,6 +92,26 @@ func TestManifestCreateRefuseAmend(t *testing.T) {
 	assert.Error(t, err, "refusing to amend an existing manifest list with no --amend flag")
 }
 
+// Successfully overwrite a saved manifest
+func TestManifestCreateOverwrite(t *testing.T) {
+	store, cleanup := newTempManifestStore(t)
+	defer cleanup()
+
+	cli := test.NewFakeCli(nil)
+	cli.SetManifestStore(store)
+	namedRef := ref(t, "alpine:3.0")
+	imageManifest := fullImageManifest(t, namedRef)
+	err := store.Save(ref(t, "list:v1"), namedRef, imageManifest)
+	assert.NilError(t, err)
+
+	cmd := newCreateListCommand(cli)
+	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
+	cmd.Flags().Set("overwrite", "true")
+	cmd.SetOutput(ioutil.Discard)
+	err = cmd.Execute()
+	assert.NilError(t, err)
+}
+
 // attempt to make a manifest list without valid images
 func TestManifestCreateNoManifest(t *testing.T) {
 	store, cleanup := newTempManifestStore(t)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Sometimes amend is not enough, especially when `--purge` was
not used during `manifest push` command. And since we don't have a
`manifest delete` either to clean up. So just adding an `--overwrite`
seems like a good thought.

**- How I did it**

Added a `--overwrite` in command/manifest/create_list.go

**- How to verify it**

create and push a manifest, then try to create the same manifest with --overwrite. It used to fail before, with this new option, it should succeed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Ability to overwrite an existing manifest in `docker manifest create`

**- A picture of a cute animal (not mandatory but encouraged)**

