### PR TITLE
[WIP] Add new `builder` subcommand and implement `builder prune` to prune build cache

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -1,0 +1,22 @@
+package builder
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+)
+
+// NewBuilderCommand returns a cobra command for `builder` subcommands
+func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "builder",
+		Short: "Manage builds",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		NewPruneCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -1,0 +1,39 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
+	units "github.com/docker/go-units"
+	"github.com/spf13/cobra"
+)
+
+// NewPruneCommand returns a new cobra prune command for images
+func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+	options := types.BuildCachePruneOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "prune [OPTIONS]",
+		Short: "Remove build cache",
+		Args:  cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := dockerCli.Client().BuildCachePrune(context.Background(), options)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(report.SpaceReclaimed)))
+			return nil
+		},
+		Annotations: map[string]string{"version": "1.39"},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&options.All, "all", "a", false, "Remove all build cache, including internal/frontend references")
+	flags.DurationVar(&options.KeepDuration, "keep-duration", 0, "Keep build cache data newer than <duration> ago (default: 0)")
+	flags.Float64Var(&options.KeepStorage, "keep-storage", 0, "Keep total build cache size below this limit (in MB) (default: 0)")
+
+	return cmd
+}

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/builder"
 	"github.com/docker/cli/cli/command/checkpoint"
 	"github.com/docker/cli/cli/command/config"
 	"github.com/docker/cli/cli/command/container"
@@ -39,6 +40,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// image
 		image.NewImageCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
+
+		// builder
+		builder.NewBuilderCommand(dockerCli),
 
 		// manifest
 		manifest.NewManifestCommand(dockerCli),

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -600,3 +600,10 @@ type BuildCache struct {
 	Parent      string
 	Description string
 }
+
+// BuildCachePruneOptions hold parameters to prune the build cache
+type BuildCachePruneOptions struct {
+	All          bool
+	KeepDuration time.Duration
+	KeepStorage  float64
+}

--- a/vendor/github.com/docker/docker/client/build_prune.go
+++ b/vendor/github.com/docker/docker/client/build_prune.go
@@ -4,19 +4,27 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/docker/docker/api/types"
 )
 
 // BuildCachePrune requests the daemon to delete unused cache data
-func (cli *Client) BuildCachePrune(ctx context.Context) (*types.BuildCachePruneReport, error) {
+func (cli *Client) BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error) {
 	if err := cli.NewVersionError("1.31", "build prune"); err != nil {
 		return nil, err
 	}
 
 	report := types.BuildCachePruneReport{}
 
-	serverResp, err := cli.post(ctx, "/build/prune", nil, nil, nil)
+	query := url.Values{}
+	if opts.All {
+		query.Set("all", "1")
+	}
+	query.Set("keep-duration", fmt.Sprintf("%d", opts.KeepDuration))
+	query.Set("keep-storage", fmt.Sprintf("%f", opts.KeepStorage))
+
+	serverResp, err := cli.post(ctx, "/build/prune", query, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -86,7 +86,7 @@ type DistributionAPIClient interface {
 // ImageAPIClient defines API client methods for the images
 type ImageAPIClient interface {
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
-	BuildCachePrune(ctx context.Context) (*types.BuildCachePruneReport, error)
+	BuildCachePrune(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 	BuildCancel(ctx context.Context, id string) error
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)


### PR DESCRIPTION
*WIP*: this modifies vendor
- [ ] Waiting on https://github.com/moby/moby/pull/37651

This patch adds a new builder subcommand to manage builds, allowing to add more
builder-related commands in the future. Unfortunately `build` expects an argument
so could not be used as a subcommand.

This also implements `docker builder prune`, which is needed to prune the builder
cache manually without having to call `docker system prune`.

Today when relying on the legacy builder, users are able to list a set of images
(used as build cache) based on time filters and delete them. This patch allows the
same usecase and more (specifying storage size) when relying on the new builder.

The behavior of the `--all` option on `system prune` is slightly modified with
respect to build cache: without `--all`, all but internal/frontend cache is removed
whereas with `--all`, it removes the entirety of buildkit's cache. This is similar
to keeping non-dangling images by default and removing them if `--all` is specified.

Signed-off-by: Tibor Vass <tibor@docker.com>