### PR TITLE
builder: Implement `builder prune` to prune build cache

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -1,0 +1,22 @@
+package builder
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+)
+
+// NewBuilderCommand returns a cobra command for `builder` subcommands
+func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "builder",
+		Short: "Manage builds",
+		Args:  cli.NoArgs,
+		RunE:  command.ShowHelp(dockerCli.Err()),
+	}
+	cmd.AddCommand(
+		NewPruneCommand(dockerCli),
+	)
+	return cmd
+}

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -1,0 +1,31 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	units "github.com/docker/go-units"
+	"github.com/spf13/cobra"
+)
+
+// NewPruneCommand returns a new cobra prune command for images
+func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove build cache",
+		Args:  cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := dockerCli.Client().BuildCachePrune(context.Background())
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(report.SpaceReclaimed)))
+			return nil
+		},
+		Annotations: map[string]string{"version": "1.39"},
+	}
+
+	return cmd
+}

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/builder"
 	"github.com/docker/cli/cli/command/checkpoint"
 	"github.com/docker/cli/cli/command/config"
 	"github.com/docker/cli/cli/command/container"
@@ -39,6 +40,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// image
 		image.NewImageCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
+
+		// builder
+		builder.NewBuilderCommand(dockerCli),
 
 		// manifest
 		manifest.NewManifestCommand(dockerCli),


### PR DESCRIPTION
This is a version of #1292 without any API changes to make it easier. It would still be better than forcing users to run `docker system prune` which also removes stopped containers (undesirable side-effect).


This patch adds a new builder subcommand, allowing to add more builder-related commands in the future. Unfortunately `build` expects an argument so could not be used as a subcommand.

This also implements `docker builder prune`, which is needed to prune the builder cache manually without having to call `docker system prune`.

Today when relying on the legacy builder, users are able to prune dangling images (used as build cache) by running `docker image prune`. This patch allows the same usecase with buildkit.

Signed-off-by: Tibor Vass <tibor@docker.com>