### PR TITLE
build: Remove API requirement for --progress as it is CLI only

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -156,7 +156,6 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags.StringVar(&options.progress, "progress", "auto", "Set type of progress output (only if BuildKit enabled) (auto, plain, tty). Use plain to show container output")
 	flags.SetAnnotation("progress", "experimental", nil)
-	flags.SetAnnotation("progress", "version", []string{"1.38"})
 
 	flags.StringArrayVar(&options.secrets, "secret", []string{}, "Secret file to expose to the build (only if BuildKit enabled): id=mysecret,src=/local/secret")
 	flags.SetAnnotation("secret", "experimental", nil)


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>
