### PR TITLE
Create '--build' option for docker run

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -24,6 +24,7 @@ type fakeClient struct {
 	logFunc               func(string, types.ContainerLogsOptions) (io.ReadCloser, error)
 	waitFunc              func(string) (<-chan container.ContainerWaitOKBody, <-chan error)
 	containerListFunc     func(types.ContainerListOptions) ([]types.Container, error)
+	imageBuildFunc        func(context.Context, io.Reader, types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	Version               string
 }
 
@@ -123,4 +124,11 @@ func (f *fakeClient) ContainerStart(_ context.Context, container string, options
 		return f.containerStartFunc(container, options)
 	}
 	return nil
+}
+
+func (f *fakeClient) ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
+	if f.imageBuildFunc != nil {
+		return f.imageBuildFunc(ctx, context, options)
+	}
+	return types.ImageBuildResponse{}, nil
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -179,6 +179,15 @@ func (out *lastProgressOutput) WriteProgress(prog progress.Progress) error {
 	return out.output.WriteProgress(prog)
 }
 
+// RunBuildWithTagName builds an image with specified tag name and context
+func RunBuildWithTagName(dockerCli command.Cli, tag, buildContext string) error {
+	buildOpts := newBuildOptions()
+	buildOpts.tags.Set(tag)
+	buildOpts.context = buildContext
+	buildOpts.untrusted = true
+	return runBuild(dockerCli, buildOpts)
+}
+
 // nolint: gocyclo
 func runBuild(dockerCli command.Cli, options buildOptions) error {
 	if buildkitEnv := os.Getenv("DOCKER_BUILDKIT"); buildkitEnv != "" {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added an option to docker run to allow building the Dockerfile without having to manually build and tag the image like:

    docker build . -t myTag && docker run -it myTag bash

Fixes https://github.com/moby/moby/issues/3763

**- How I did it**

I added a `--build` parameter to docker run which hooks in to the docker build flow before attempting to run the image. The image will then be run in a one-step command, as `docker run --build .`

**- How to verify it**

There is an E2E test to verify it. During development I ran `./build/docker run --build .` with my own minimal Dockerfile to test to output.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added '--build' option for docker run

**- A picture of a cute animal**

<img src="https://user-images.githubusercontent.com/9569897/44310155-d1506780-a3d1-11e8-9fc2-7ba447edffd4.jpg" width="400">