### PR TITLE
Fix 'trust inspect' typo: "AdminstrativeKeys"

### DIFF
--- a/cli/command/trust/common.go
+++ b/cli/command/trust/common.go
@@ -31,10 +31,10 @@ type trustTagRow struct {
 
 // trustRepo represents consumable information about a trusted repository
 type trustRepo struct {
-	Name              string
-	SignedTags        []trustTagRow
-	Signers           []trustSigner
-	AdminstrativeKeys []trustSigner
+	Name               string
+	SignedTags         []trustTagRow
+	Signers            []trustSigner
+	AdministrativeKeys []trustSigner
 }
 
 // trustSigner represents a trusted signer in a trusted repository

--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -107,9 +107,9 @@ func getRepoTrustInfo(cli command.Cli, remote string) ([]byte, error) {
 	sort.Slice(adminList, func(i, j int) bool { return adminList[i].Name > adminList[j].Name })
 
 	return json.Marshal(trustRepo{
-		Name:              remote,
-		SignedTags:        signatureRows,
-		Signers:           signerList,
-		AdminstrativeKeys: adminList,
+		Name:               remote,
+		SignedTags:         signatureRows,
+		Signers:            signerList,
+		AdministrativeKeys: adminList,
 	})
 }

--- a/cli/command/trust/testdata/trust-inspect-empty-repo.golden
+++ b/cli/command/trust/testdata/trust-inspect-empty-repo.golden
@@ -3,7 +3,7 @@
         "Name": "reg/img:unsigned-tag",
         "SignedTags": [],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/cli/command/trust/testdata/trust-inspect-full-repo-no-signers.golden
+++ b/cli/command/trust/testdata/trust-inspect-full-repo-no-signers.golden
@@ -11,7 +11,7 @@
             }
         ],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/cli/command/trust/testdata/trust-inspect-full-repo-with-signers.golden
+++ b/cli/command/trust/testdata/trust-inspect-full-repo-with-signers.golden
@@ -43,7 +43,7 @@
                 ]
             }
         ],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/cli/command/trust/testdata/trust-inspect-multiple-repos-with-signers.golden
+++ b/cli/command/trust/testdata/trust-inspect-multiple-repos-with-signers.golden
@@ -43,7 +43,7 @@
                 ]
             }
         ],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [
@@ -106,7 +106,7 @@
                 ]
             }
         ],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/cli/command/trust/testdata/trust-inspect-one-tag-no-signers.golden
+++ b/cli/command/trust/testdata/trust-inspect-one-tag-no-signers.golden
@@ -11,7 +11,7 @@
             }
         ],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/cli/command/trust/testdata/trust-inspect-unsigned-tag-with-signers.golden
+++ b/cli/command/trust/testdata/trust-inspect-unsigned-tag-with-signers.golden
@@ -20,7 +20,7 @@
                 ]
             }
         ],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [

--- a/docs/reference/commandline/trust_inspect.md
+++ b/docs/reference/commandline/trust_inspect.md
@@ -53,7 +53,7 @@ $ docker trust inspect alpine:latest
       }
     ],
     "Signers": [],
-    "AdminstrativeKeys": [
+    "AdministrativeKeys": [
       {
         "Name": "Repository",
         "Keys": [
@@ -131,7 +131,7 @@ $ docker trust inspect my-image:purple
         ]
       }
     ],
-    "AdminstrativeKeys": [
+    "AdministrativeKeys": [
       {
         "Name": "Repository",
         "Keys": [
@@ -170,7 +170,7 @@ $ docker trust inspect alpine:unsigned
   {
     "Name": "alpine:unsigned",
     "Signers": [],
-    "AdminstrativeKeys": [
+    "AdministrativeKeys": [
       {
         "Name": "Repository",
         "Keys": [
@@ -233,7 +233,7 @@ $ docker trust inspect alpine
             }
         ],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Repository",
                 "Keys": [
@@ -304,7 +304,7 @@ $ docker trust inspect alpine notary
             }
         ],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Repository",
                 "Keys": [
@@ -342,7 +342,7 @@ $ docker trust inspect alpine notary
             }
         ],
         "Signers": [],
-        "AdminstrativeKeys": [
+        "AdministrativeKeys": [
             {
                 "Name": "Root",
                 "Keys": [


### PR DESCRIPTION
Signed-off-by: Marsh Macy <marsma@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #1299 typo: "AdminstrativeKeys" in 'trust inspect' command

Replaced all instances of "AdminstrativeKeys" with "AdministrativeKeys"

**- How I did it**

`find . -type f -exec sed -i 's/AdminstrativeKeys/AdministrativeKeys/g' {} +`

**- How to verify it**

1. Pull the branch down
1. Run `make -f docker.Makefile shell`
1. Run `docker login` with your creds
1. Run `docker trust inspect alpine:latest`
1. View JSON output

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes typo "AdminstrativeKeys" with "AdministrativeKeys" in `trust inspect` command.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/13394541/44315642-23e25180-a3db-11e8-81d0-3f56edd7ed97.png)