### PR TITLE
Remove "experimental" annotations for buildkit

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -155,10 +155,8 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("stream", "version", []string{"1.31"})
 
 	flags.StringVar(&options.progress, "progress", "auto", "Set type of progress output (only if BuildKit enabled) (auto, plain, tty). Use plain to show container output")
-	flags.SetAnnotation("progress", "experimental", nil)
 
 	flags.StringArrayVar(&options.secrets, "secret", []string{}, "Secret file to expose to the build (only if BuildKit enabled): id=mysecret,src=/local/secret")
-	flags.SetAnnotation("secret", "experimental", nil)
 	flags.SetAnnotation("secret", "version", []string{"1.39"})
 	return cmd
 }

--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -28,6 +28,9 @@ import (
 const clientSessionRemote = "client-session"
 
 func isSessionSupported(dockerCli command.Cli) bool {
+	if versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.39") {
+		return true
+	}
 	return dockerCli.ServerInfo().HasExperimental && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.31")
 }
 


### PR DESCRIPTION
BuildKit can now be enabled without the daemon having experimental features enabled.


related engine PR; https://github.com/moby/moby/pull/37686

