### PR TITLE
man: obey SOURCE_DATE_EPOCH when generating man pages

### DIFF
--- a/man/generate.go
+++ b/man/generate.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
@@ -22,6 +24,17 @@ func generateManPages(opts *options) error {
 		Title:   "DOCKER",
 		Section: "1",
 		Source:  "Docker Community",
+	}
+
+	// If SOURCE_DATE_EPOCH is set, in order to allow reproducible package
+	// builds, we explicitly set the build time to SOURCE_DATE_EPOCH.
+	if epoch := os.Getenv("SOURCE_DATE_EPOCH"); epoch != "" {
+		unixEpoch, err := strconv.ParseInt(epoch, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid SOURCE_DATE_EPOCH: %v", err)
+		}
+		now := time.Unix(unixEpoch, 0)
+		header.Date = &now
 	}
 
 	stdin, stdout, stderr := term.StdStreams()


### PR DESCRIPTION
Previously our man pages included the current time each time they were
generated. This causes an issue for reproducible builds, since each
re-build of a package that includes the man pages will have different
times listed in the man pages.

To fix this, add support for SOURCE_DATE_EPOCH ([which is a standardised
packaging environment variable, designed to be used specifically for
this purpose][1]). spf13/cobra doesn't support this natively yet (though
I will push a patch for that as well), but it's simpler to fix it
directly in docker/cli.
    
[1]: https://reproducible-builds.org/specs/source-date-epoch/
    
Signed-off-by: Aleksa Sarai <asarai@suse.de>