### PR TITLE
[18.09] backport: update docs with the new features option in daemon.json

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1297,6 +1297,7 @@ This is a full example of the allowed configuration options on Linux:
 	"exec-opts": [],
 	"exec-root": "",
 	"experimental": false,
+	"features": {},
 	"storage-driver": "",
 	"storage-opts": [],
 	"labels": [],
@@ -1392,6 +1393,7 @@ This is a full example of the allowed configuration options on Windows:
     "dns-search": [],
     "exec-opts": [],
     "experimental": false,
+    "features":{},
     "storage-driver": "",
     "storage-opts": [],
     "labels": [],
@@ -1446,11 +1448,12 @@ The list of currently supported options that can be reconfigured is this:
   the runtime shipped with the official docker packages.
 - `runtimes`: it updates the list of available OCI runtimes that can
   be used to run containers.
-- `authorization-plugin`: specifies the authorization plugins to use.
+- `authorization-plugin`: it specifies the authorization plugins to use.
 - `allow-nondistributable-artifacts`: Replaces the set of registries to which the daemon will push nondistributable artifacts with a new set of registries.
 - `insecure-registries`: it replaces the daemon insecure registries with a new set of insecure registries. If some existing insecure registries in daemon's configuration are not in newly reloaded insecure resgitries, these existing ones will be removed from daemon's config.
 - `registry-mirrors`: it replaces the daemon registry mirrors with a new set of registry mirrors. If some existing registry mirrors in daemon's configuration are not in newly reloaded registry mirrors, these existing ones will be removed from daemon's config.
 - `shutdown-timeout`: it replaces the daemon's existing configuration timeout with a new timeout for shutting down all containers.
+- `features`: it explicitly enables or disables specific features.
 
 Updating and reloading the cluster configurations such as `--cluster-store`,
 `--cluster-advertise` and `--cluster-store-opts` will take effect only if


### PR DESCRIPTION
cherry-pick of https://github.com/docker/cli/pull/1307 for 18.09

```
git checkout -b 18.09-backport_update-docs upstream/18.09
git cherry-pick -s -S -x 3e0b0a6692e24df36bce5cbcee23150775054011
```

cherry-pick was clean; no conflicts