### PR TITLE
[18.06] backport: bump Go to 1.10.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.10.3
+  GOVERSION: 1.10.4
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.10.3-alpine
+FROM    golang:1.10.4-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.10.3@sha256:7671b4ed357fda50124e5679d36c4c3206ded4d43f1d2e0ff3d120a1e2bf94d7
+FROM    dockercore/golang-cross:1.10.4@sha256:55c7b933ac944f4922b673b4d4340d1a0404f3c324bd0b3f13a4326c427b1f2a
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.10.3-alpine
+FROM    golang:1.10.4-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.10.3
+ARG GO_VERSION=1.10.4
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.10.3-alpine
+FROM    golang:1.10.4-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1315 for 18.06. Minor conflict in dockerfiles/Dockerfile.e2e;

```patch
diff --cc dockerfiles/Dockerfile.e2e
index 167bbf0e,581f505e..00000000
--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@@ -1,4 -1,7 +1,11 @@@
++<<<<<<< HEAD
 +ARG GO_VERSION=1.10.3
++=======
+ ARG GO_VERSION=1.10.4
+ 
+ FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
+ 
++>>>>>>> 44ca0901... Bump Go to 1.10.4
  # Use Debian based image as docker-compose requires glibc.
  FROM golang:${GO_VERSION}
```



Includes fixes to the go command, linker, and the net/http, mime/multipart,
ld/macho, bytes, and strings packages. See the Go 1.10.4 milestone on the
issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.10.4

(cherry picked from commit 44ca0901d17b36510aa6d71c7dfa895ae568d04a)
