### PR TITLE
Address issues with ADD/COPY on data deduplication drives

### DIFF
--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -19,6 +19,7 @@ import (
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/system"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
@@ -140,7 +141,7 @@ func tryNodeIdentifier() string {
 	out := cliconfig.Dir() // return config dir as default on permission error
 	if err := os.MkdirAll(cliconfig.Dir(), 0700); err == nil {
 		sessionFile := filepath.Join(cliconfig.Dir(), ".buildNodeID")
-		if _, err := os.Lstat(sessionFile); err != nil {
+		if _, err := system.GetFileInfo(sessionFile); err != nil {
 			if os.IsNotExist(err) { // create a new file with stored randomness
 				b := make([]byte, 32)
 				if _, err := rand.Read(b); err != nil {


### PR DESCRIPTION
This addresses the issue: https://github.com/moby/moby/issues/37026.

Signed-off-by: Salahuddin Khan <salah@docker.com>

**- What I did**

The os.Lstat() function treats all reparse points on Windows as name surrogates (essentially symbolic links), however, only certain types of reparse points fall into this category. As a result data deduplication reparse points (which are not symbolic links) result in failures because the cli and daemon are unable to interpret the link and fail the ADD/COPY.

**- How I did it**

The reparse point type contains a flag (0x20000000) if the reparse point is a name surrogate (symbolic link), however, if this flag is not present then the reparse point should not be interpreted as a symbolic link.

Since os.Lstat() returns an interface, there is no direct way to clear the symbolic link flag directly. Therefore, I added a new function called GetFileInfo() which invokes os.Lstat() and returns the same interface, but clears the symbolic link flag if the reparse point is not a symbolic link.

**- How to verify it**

On a Windows Server 2016 enable data deduplication on a non-system volume and copy files which contain duplicate information.

This can be done from powershell as follows (we assume a Volume-Path of "D:"):

Install-WindowsFeature -ComputerName <MyNanoServer> -Name FS-Data-Deduplication

Enable-DedupVolume -Volume <Volume-Path>

Set-DedupVolume -Volume <Volume-Path> -MinimumFileAgeDays 0

Then copy files to the target path and a set of the same files to another location under the same path.

Start the deduplication:

Start-DedupJob -Volume <Volume-Path> -Type Optimization

After this is complete, run the following which should work on the deduplication volume (by will fail without the fix).

PS C:\Test> Set-Content -Path Dockerfile -Value @"
>> FROM microsoft/windowsservercore
>> ADD D:\
>> "@
PS C:\Test> cd \temp
PS C:\Test> docker build .

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

This specific portion only makes the necessary changes to the CLI to invoke the new function and obtain a correct FileInfo structure (which does not include a symbolic link flag for non-symbolic link reparse points).
