### PR TITLE
add cli integration for masked and readonly paths

### DIFF
--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -50,6 +50,19 @@ func TestRunWithContentTrust(t *testing.T) {
 	})
 }
 
+func TestRunMaskedPaths(t *testing.T) {
+	result := icmd.RunCmd(
+		icmd.Command("docker", "run", image),
+		fixtures.WithConfig(dir.Path()),
+		fixtures.WithTrust,
+		fixtures.WithNotary,
+	)
+	result.Assert(t, icmd.Expected{
+		Err: fmt.Sprintf("Tagging %s@sha", image[:len(image)-7]),
+	})
+
+}
+
 // TODO: create this with registry API instead of engine API
 func createRemoteImage(t *testing.T) string {
 	image := "registry:5000/alpine:test-run-pulls"


### PR DESCRIPTION
I wanted to make sure this design was okay before going any further.

This adds flags --masked-paths and --readonly-paths to the cli as a follow up from https://github.com/moby/moby/pull/36644 cc @AkihiroSuda 

Happy to change the design in any way you want then will add docs and tests.