### PR TITLE
Drop experimental tag for manifest commands

### DIFF
--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -20,7 +20,6 @@ func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
 		},
-		Annotations: map[string]string{"experimentalCLI": ""},
 	}
 	cmd.AddCommand(
 		newCreateListCommand(dockerCli),


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas davanum@gmail.com

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Some of us working on Kubernetes have been using the docker manifest
experimental commands to build images for some time now. The last
problem we had was fixed by one of the commits a few months ago:
https://github.com/docker/cli/commit/69e1743e3d05e487ad8fc6d665b75f5b5d28b76c

Could we please promote these commands from experimental to GA

**- How I did it**

Delete the annotation for the command that sets it to experimental

**- How to verify it**

Just run `docker manifest` commands without the config.json or environment flag for experimental mode

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
docker manifest commands are now no longer considered experimental and available for general use

**- A picture of a cute animal (not mandatory but encouraged)**

![2282173](https://user-images.githubusercontent.com/23304/45248973-47b3fb80-b2e6-11e8-8fe0-f68dbdf842fd.jpg)


