### PR TITLE
cli/config/configfile: Atomically rewrite the config file when saving.

### DIFF
--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -2,6 +2,8 @@ package configfile
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/docker/cli/cli/config/credentials"
@@ -412,4 +414,14 @@ func TestCheckKubernetesConfigurationRaiseAnErrorOnInvalidValue(t *testing.T) {
 			assert.NilError(t, err, test.name)
 		}
 	}
+}
+
+func TestSave(t *testing.T) {
+	configFile := New("test-save")
+	defer os.Remove("test-save")
+	err := configFile.Save()
+	assert.NilError(t, err)
+	cfg, err := ioutil.ReadFile("test-save")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
 }


### PR DESCRIPTION
The config file was being truncated first, which created a window during
which it was empty, causing concurrent uses of the `docker` command to
potentially fail with:
```
WARNING: Error loading config file: /var/lib/jenkins/.docker/config.json: EOF
Error response from daemon: Get https://registry/v2/foo/manifests/latest: no basic auth credentials
```

Signed-off-by: Benoit Sigoure <tsunanet@gmail.com>

**- Description for the changelog**

The use of commands that change the Docker CLI config (e.g. `docker login`) concurrently with other commands could lead to the other commands not being able to read the configuration.

**- A picture of a cute animal (not mandatory but encouraged)**

🐹