### PR TITLE
[18.09] backport: remove containerizedengine package dependency from docker/cli/command…

### DIFF
--- a/cli/command/engine/activate.go
+++ b/cli/command/engine/activate.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/cli/internal/containerizedengine"
 	"github.com/docker/cli/internal/licenseutils"
+	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/licensing/model"
 	"github.com/pkg/errors"
@@ -57,7 +57,7 @@ https://hub.docker.com/ then specify the file with the '--license' flag.
 	flags.StringVar(&options.licenseFile, "license", "", "License File")
 	flags.StringVar(&options.version, "version", "", "Specify engine version (default is to use currently running version)")
 	flags.StringVar(&options.registryPrefix, "registry-prefix", "docker.io/docker", "Override the default location where engine images are pulled")
-	flags.StringVar(&options.image, "engine-image", containerizedengine.EnterpriseEngineImage, "Specify engine image")
+	flags.StringVar(&options.image, "engine-image", clitypes.EnterpriseEngineImage, "Specify engine image")
 	flags.StringVar(&options.format, "format", "", "Pretty-print licenses using a Go template")
 	flags.BoolVar(&options.displayOnly, "display-only", false, "only display the available licenses and exit")
 	flags.BoolVar(&options.quiet, "quiet", false, "Only display available licenses by ID")
@@ -98,7 +98,7 @@ func runActivate(cli command.Cli, options activateOptions) error {
 		return err
 	}
 
-	opts := containerizedengine.EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		RegistryPrefix: options.registryPrefix,
 		EngineImage:    options.image,
 		EngineVersion:  options.version,

--- a/cli/command/engine/activate_test.go
+++ b/cli/command/engine/activate_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/cli/internal/containerizedengine"
+	"github.com/docker/cli/types"
 	"gotest.tools/assert"
 )
 
 func TestActivateNoContainerd(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (types.ContainerizedClient, error) {
 			return nil, fmt.Errorf("some error")
 		},
 	)
@@ -24,7 +24,7 @@ func TestActivateNoContainerd(t *testing.T) {
 
 func TestActivateBadLicense(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (types.ContainerizedClient, error) {
 			return &fakeContainerizedEngineClient{}, nil
 		},
 	)

--- a/cli/command/engine/check.go
+++ b/cli/command/engine/check.go
@@ -7,7 +7,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +72,7 @@ func runCheck(dockerCli command.Cli, options checkOptions) error {
 		return err
 	}
 
-	availUpdates := []containerizedengine.Update{
+	availUpdates := []clitypes.Update{
 		{Type: "current", Version: currentVersion},
 	}
 	if len(versions.Patches) > 0 {
@@ -115,14 +115,14 @@ func runCheck(dockerCli command.Cli, options checkOptions) error {
 
 func processVersions(currentVersion, verType string,
 	includePrerelease bool,
-	versions []containerizedengine.DockerVersion) []containerizedengine.Update {
-	availUpdates := []containerizedengine.Update{}
+	versions []clitypes.DockerVersion) []clitypes.Update {
+	availUpdates := []clitypes.Update{}
 	for _, ver := range versions {
 		if !includePrerelease && ver.Prerelease() != "" {
 			continue
 		}
 		if ver.Tag != currentVersion {
-			availUpdates = append(availUpdates, containerizedengine.Update{
+			availUpdates = append(availUpdates, clitypes.Update{
 				Type:    verType,
 				Version: ver.Tag,
 				Notes:   fmt.Sprintf("%s/%s", releaseNotePrefix, ver.Tag),

--- a/cli/command/engine/client_test.go
+++ b/cli/command/engine/client_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containerd/containerd"
 	registryclient "github.com/docker/cli/cli/registry/client"
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/api/types"
 )
 
@@ -13,28 +13,28 @@ type (
 	fakeContainerizedEngineClient struct {
 		closeFunc          func() error
 		activateEngineFunc func(ctx context.Context,
-			opts containerizedengine.EngineInitOptions,
-			out containerizedengine.OutStream,
+			opts clitypes.EngineInitOptions,
+			out clitypes.OutStream,
 			authConfig *types.AuthConfig,
 			healthfn func(context.Context) error) error
 		initEngineFunc func(ctx context.Context,
-			opts containerizedengine.EngineInitOptions,
-			out containerizedengine.OutStream,
+			opts clitypes.EngineInitOptions,
+			out clitypes.OutStream,
 			authConfig *types.AuthConfig,
 			healthfn func(context.Context) error) error
 		doUpdateFunc func(ctx context.Context,
-			opts containerizedengine.EngineInitOptions,
-			out containerizedengine.OutStream,
+			opts clitypes.EngineInitOptions,
+			out clitypes.OutStream,
 			authConfig *types.AuthConfig,
 			healthfn func(context.Context) error) error
 		getEngineVersionsFunc func(ctx context.Context,
 			registryClient registryclient.RegistryClient,
 			currentVersion,
-			imageName string) (containerizedengine.AvailableVersions, error)
+			imageName string) (clitypes.AvailableVersions, error)
 
 		getEngineFunc               func(ctx context.Context) (containerd.Container, error)
-		removeEngineFunc            func(ctx context.Context, engine containerd.Container) error
-		getCurrentEngineVersionFunc func(ctx context.Context) (containerizedengine.EngineInitOptions, error)
+		removeEngineFunc            func(ctx context.Context) error
+		getCurrentEngineVersionFunc func(ctx context.Context) (clitypes.EngineInitOptions, error)
 	}
 )
 
@@ -46,8 +46,8 @@ func (w *fakeContainerizedEngineClient) Close() error {
 }
 
 func (w *fakeContainerizedEngineClient) ActivateEngine(ctx context.Context,
-	opts containerizedengine.EngineInitOptions,
-	out containerizedengine.OutStream,
+	opts clitypes.EngineInitOptions,
+	out clitypes.OutStream,
 	authConfig *types.AuthConfig,
 	healthfn func(context.Context) error) error {
 	if w.activateEngineFunc != nil {
@@ -56,8 +56,8 @@ func (w *fakeContainerizedEngineClient) ActivateEngine(ctx context.Context,
 	return nil
 }
 func (w *fakeContainerizedEngineClient) InitEngine(ctx context.Context,
-	opts containerizedengine.EngineInitOptions,
-	out containerizedengine.OutStream,
+	opts clitypes.EngineInitOptions,
+	out clitypes.OutStream,
 	authConfig *types.AuthConfig,
 	healthfn func(context.Context) error) error {
 	if w.initEngineFunc != nil {
@@ -66,8 +66,8 @@ func (w *fakeContainerizedEngineClient) InitEngine(ctx context.Context,
 	return nil
 }
 func (w *fakeContainerizedEngineClient) DoUpdate(ctx context.Context,
-	opts containerizedengine.EngineInitOptions,
-	out containerizedengine.OutStream,
+	opts clitypes.EngineInitOptions,
+	out clitypes.OutStream,
 	authConfig *types.AuthConfig,
 	healthfn func(context.Context) error) error {
 	if w.doUpdateFunc != nil {
@@ -77,12 +77,12 @@ func (w *fakeContainerizedEngineClient) DoUpdate(ctx context.Context,
 }
 func (w *fakeContainerizedEngineClient) GetEngineVersions(ctx context.Context,
 	registryClient registryclient.RegistryClient,
-	currentVersion, imageName string) (containerizedengine.AvailableVersions, error) {
+	currentVersion, imageName string) (clitypes.AvailableVersions, error) {
 
 	if w.getEngineVersionsFunc != nil {
 		return w.getEngineVersionsFunc(ctx, registryClient, currentVersion, imageName)
 	}
-	return containerizedengine.AvailableVersions{}, nil
+	return clitypes.AvailableVersions{}, nil
 }
 
 func (w *fakeContainerizedEngineClient) GetEngine(ctx context.Context) (containerd.Container, error) {
@@ -91,15 +91,15 @@ func (w *fakeContainerizedEngineClient) GetEngine(ctx context.Context) (containe
 	}
 	return nil, nil
 }
-func (w *fakeContainerizedEngineClient) RemoveEngine(ctx context.Context, engine containerd.Container) error {
+func (w *fakeContainerizedEngineClient) RemoveEngine(ctx context.Context) error {
 	if w.removeEngineFunc != nil {
-		return w.removeEngineFunc(ctx, engine)
+		return w.removeEngineFunc(ctx)
 	}
 	return nil
 }
-func (w *fakeContainerizedEngineClient) GetCurrentEngineVersion(ctx context.Context) (containerizedengine.EngineInitOptions, error) {
+func (w *fakeContainerizedEngineClient) GetCurrentEngineVersion(ctx context.Context) (clitypes.EngineInitOptions, error) {
 	if w.getCurrentEngineVersionFunc != nil {
 		return w.getCurrentEngineVersionFunc(ctx)
 	}
-	return containerizedengine.EngineInitOptions{}, nil
+	return clitypes.EngineInitOptions{}, nil
 }

--- a/cli/command/engine/init.go
+++ b/cli/command/engine/init.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 type extendedEngineInitOptions struct {
-	containerizedengine.EngineInitOptions
+	clitypes.EngineInitOptions
 	sockPath string
 }
 
@@ -34,7 +34,7 @@ file on the host and may be pre-created before running the 'init' command.
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&options.EngineVersion, "version", cli.Version, "Specify engine version")
-	flags.StringVar(&options.EngineImage, "engine-image", containerizedengine.CommunityEngineImage, "Specify engine image")
+	flags.StringVar(&options.EngineImage, "engine-image", clitypes.CommunityEngineImage, "Specify engine image")
 	flags.StringVar(&options.RegistryPrefix, "registry-prefix", "docker.io/docker", "Override the default location where engine images are pulled")
 	flags.StringVar(&options.ConfigFile, "config-file", "/etc/docker/daemon.json", "Specify the location of the daemon configuration file on the host")
 	flags.StringVar(&options.sockPath, "containerd", "", "override default location of containerd endpoint")

--- a/cli/command/engine/init_test.go
+++ b/cli/command/engine/init_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"gotest.tools/assert"
 )
 
 func TestInitNoContainerd(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return nil, fmt.Errorf("some error")
 		},
 	)
@@ -23,7 +23,7 @@ func TestInitNoContainerd(t *testing.T) {
 
 func TestInitHappy(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return &fakeContainerizedEngineClient{}, nil
 		},
 	)

--- a/cli/command/engine/rm.go
+++ b/cli/command/engine/rm.go
@@ -45,10 +45,5 @@ func runRm(dockerCli command.Cli, options rmOptions) error {
 	}
 	defer client.Close()
 
-	engine, err := client.GetEngine(ctx)
-	if err != nil {
-		return err
-	}
-
-	return client.RemoveEngine(ctx, engine)
+	return client.RemoveEngine(ctx)
 }

--- a/cli/command/engine/rm_test.go
+++ b/cli/command/engine/rm_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"gotest.tools/assert"
 )
 
 func TestRmNoContainerd(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return nil, fmt.Errorf("some error")
 		},
 	)
@@ -23,7 +23,7 @@ func TestRmNoContainerd(t *testing.T) {
 
 func TestRmHappy(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return &fakeContainerizedEngineClient{}, nil
 		},
 	)

--- a/cli/command/engine/update_test.go
+++ b/cli/command/engine/update_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"gotest.tools/assert"
 )
 
 func TestUpdateNoContainerd(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return nil, fmt.Errorf("some error")
 		},
 	)
@@ -23,7 +23,7 @@ func TestUpdateNoContainerd(t *testing.T) {
 
 func TestUpdateHappy(t *testing.T) {
 	testCli.SetContainerizedEngineClient(
-		func(string) (containerizedengine.Client, error) {
+		func(string) (clitypes.ContainerizedClient, error) {
 			return &fakeContainerizedEngineClient{}, nil
 		},
 	)

--- a/cli/command/formatter/updates.go
+++ b/cli/command/formatter/updates.go
@@ -1,7 +1,7 @@
 package formatter
 
 import (
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 )
 
 const (
@@ -31,7 +31,7 @@ func NewUpdatesFormat(source string, quiet bool) Format {
 }
 
 // UpdatesWrite writes the context
-func UpdatesWrite(ctx Context, availableUpdates []containerizedengine.Update) error {
+func UpdatesWrite(ctx Context, availableUpdates []clitypes.Update) error {
 	render := func(format func(subContext subContext) error) error {
 		for _, update := range availableUpdates {
 			updatesCtx := &updateContext{trunc: ctx.Trunc, u: update}
@@ -53,7 +53,7 @@ func UpdatesWrite(ctx Context, availableUpdates []containerizedengine.Update) er
 type updateContext struct {
 	HeaderContext
 	trunc bool
-	u     containerizedengine.Update
+	u     clitypes.Update
 }
 
 func (c *updateContext) MarshalJSON() ([]byte, error) {

--- a/cli/command/formatter/updates_test.go
+++ b/cli/command/formatter/updates_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -84,7 +84,7 @@ version2
 	}
 
 	for _, testcase := range cases {
-		updates := []containerizedengine.Update{
+		updates := []clitypes.Update{
 			{Type: "updateType1", Version: "version1", Notes: "description 1"},
 			{Type: "updateType2", Version: "version2", Notes: "description 2"},
 		}
@@ -100,7 +100,7 @@ version2
 }
 
 func TestUpdateContextWriteJSON(t *testing.T) {
-	updates := []containerizedengine.Update{
+	updates := []clitypes.Update{
 		{Type: "updateType1", Version: "version1", Notes: "note1"},
 		{Type: "updateType2", Version: "version2", Notes: "note2"},
 	}
@@ -124,7 +124,7 @@ func TestUpdateContextWriteJSON(t *testing.T) {
 }
 
 func TestUpdateContextWriteJSONField(t *testing.T) {
-	updates := []containerizedengine.Update{
+	updates := []clitypes.Update{
 		{Type: "updateType1", Version: "version1"},
 		{Type: "updateType2", Version: "version2"},
 	}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal/containerizedengine"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/term"
@@ -168,7 +169,7 @@ func main() {
 	stdin, stdout, stderr := term.StdStreams()
 	logrus.SetOutput(stderr)
 
-	dockerCli := command.NewDockerCli(stdin, stdout, stderr, contentTrustEnabled())
+	dockerCli := command.NewDockerCli(stdin, stdout, stderr, contentTrustEnabled(), containerizedengine.NewClient)
 	cmd := newDockerCommand(dockerCli)
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -26,7 +26,7 @@ func TestClientDebugEnabled(t *testing.T) {
 
 func TestExitStatusForInvalidSubcommandWithHelpFlag(t *testing.T) {
 	discard := ioutil.Discard
-	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard, false))
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard, false, nil))
 	cmd.SetArgs([]string{"help", "invalid"})
 	err := cmd.Execute()
 	assert.Error(t, err, "unknown help topic: invalid")

--- a/docs/yaml/generate.go
+++ b/docs/yaml/generate.go
@@ -19,7 +19,7 @@ const descriptionSourcePath = "docs/reference/commandline/"
 
 func generateCliYaml(opts *options) error {
 	stdin, stdout, stderr := term.StdStreams()
-	dockerCli := command.NewDockerCli(stdin, stdout, stderr, false)
+	dockerCli := command.NewDockerCli(stdin, stdout, stderr, false, nil)
 	cmd := &cobra.Command{Use: "docker"}
 	commands.AddCommands(cmd, dockerCli)
 	source := filepath.Join(opts.source, descriptionSourcePath)

--- a/e2eengine/utils.go
+++ b/e2eengine/utils.go
@@ -5,8 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/containerd"
 	"github.com/docker/cli/internal/containerizedengine"
+	"github.com/docker/cli/types"
 )
+
+type containerizedclient interface {
+	types.ContainerizedClient
+	GetEngine(context.Context) (containerd.Container, error)
+}
 
 // CleanupEngine ensures the local engine has been removed between testcases
 func CleanupEngine(t *testing.T) error {
@@ -19,7 +26,7 @@ func CleanupEngine(t *testing.T) error {
 	}
 
 	// See if the engine exists first
-	engine, err := client.GetEngine(ctx)
+	_, err = client.(containerizedclient).GetEngine(ctx)
 	if err != nil {
 		if strings.Contains(err.Error(), "not present") {
 			t.Log("engine was not detected, no cleanup to perform")
@@ -31,7 +38,7 @@ func CleanupEngine(t *testing.T) error {
 		return err
 	}
 	// TODO Consider nuking the docker dir too so there's no cached content between test cases
-	err = client.RemoveEngine(ctx, engine)
+	err = client.RemoveEngine(ctx)
 	if err != nil {
 		t.Logf("Failed to remove engine: %s", err)
 	}

--- a/internal/containerizedengine/client_test.go
+++ b/internal/containerizedengine/client_test.go
@@ -1,7 +1,6 @@
 package containerizedengine
 
 import (
-	"bytes"
 	"context"
 	"syscall"
 
@@ -68,10 +67,6 @@ type (
 		updateFunc      func(context.Context, ...containerd.UpdateTaskOpts) error
 		loadProcessFunc func(context.Context, string, cio.Attach) (containerd.Process, error)
 		metricsFunc     func(context.Context) (*containerdtypes.Metric, error)
-	}
-
-	testOutStream struct {
-		bytes.Buffer
 	}
 )
 
@@ -338,11 +333,4 @@ func (t *fakeTask) Metrics(ctx context.Context) (*containerdtypes.Metric, error)
 		return t.metricsFunc(ctx)
 	}
 	return nil, nil
-}
-
-func (o *testOutStream) FD() uintptr {
-	return 0
-}
-func (o *testOutStream) IsTerminal() bool {
-	return false
 }

--- a/internal/containerizedengine/containerd.go
+++ b/internal/containerizedengine/containerd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/remotes/docker"
+	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,7 +16,7 @@ import (
 // NewClient returns a new containerizedengine client
 // This client can be used to manage the lifecycle of
 // dockerd running as a container on containerd.
-func NewClient(sockPath string) (Client, error) {
+func NewClient(sockPath string) (clitypes.ContainerizedClient, error) {
 	if sockPath == "" {
 		sockPath = containerdSockPath
 	}
@@ -23,17 +24,17 @@ func NewClient(sockPath string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return baseClient{
+	return &baseClient{
 		cclient: cclient,
 	}, nil
 }
 
 // Close will close the underlying clients
-func (c baseClient) Close() error {
+func (c *baseClient) Close() error {
 	return c.cclient.Close()
 }
 
-func (c baseClient) pullWithAuth(ctx context.Context, imageName string, out OutStream,
+func (c *baseClient) pullWithAuth(ctx context.Context, imageName string, out clitypes.OutStream,
 	authConfig *types.AuthConfig) (containerd.Image, error) {
 
 	resolver := docker.NewResolver(docker.ResolverOptions{

--- a/internal/containerizedengine/containerd_test.go
+++ b/internal/containerizedengine/containerd_test.go
@@ -1,11 +1,13 @@
 package containerizedengine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
 
 	"github.com/containerd/containerd"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	"gotest.tools/assert"
 )
@@ -22,7 +24,7 @@ func TestPullWithAuthPullFail(t *testing.T) {
 	}
 	imageName := "testnamegoeshere"
 
-	_, err := client.pullWithAuth(ctx, imageName, &testOutStream{}, &types.AuthConfig{})
+	_, err := client.pullWithAuth(ctx, imageName, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "pull failure")
 }
 
@@ -38,6 +40,6 @@ func TestPullWithAuthPullPass(t *testing.T) {
 	}
 	imageName := "testnamegoeshere"
 
-	_, err := client.pullWithAuth(ctx, imageName, &testOutStream{}, &types.AuthConfig{})
+	_, err := client.pullWithAuth(ctx, imageName, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.NilError(t, err)
 }

--- a/internal/containerizedengine/update_test.go
+++ b/internal/containerizedengine/update_test.go
@@ -1,6 +1,7 @@
 package containerizedengine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -8,6 +9,8 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/docker/cli/cli/command"
+	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/api/types"
 	"gotest.tools/assert"
 )
@@ -16,7 +19,7 @@ func TestGetCurrentEngineVersionHappy(t *testing.T) {
 	ctx := context.Background()
 	image := &fakeImage{
 		nameFunc: func() string {
-			return "acme.com/dockermirror/" + CommunityEngineImage + ":engineversion"
+			return "acme.com/dockermirror/" + clitypes.CommunityEngineImage + ":engineversion"
 		},
 	}
 	container := &fakeContainer{
@@ -34,7 +37,7 @@ func TestGetCurrentEngineVersionHappy(t *testing.T) {
 
 	opts, err := client.GetCurrentEngineVersion(ctx)
 	assert.NilError(t, err)
-	assert.Equal(t, opts.EngineImage, CommunityEngineImage)
+	assert.Equal(t, opts.EngineImage, clitypes.CommunityEngineImage)
 	assert.Equal(t, opts.RegistryPrefix, "acme.com/dockermirror")
 	assert.Equal(t, opts.EngineVersion, "engineversion")
 }
@@ -43,7 +46,7 @@ func TestGetCurrentEngineVersionEnterpriseHappy(t *testing.T) {
 	ctx := context.Background()
 	image := &fakeImage{
 		nameFunc: func() string {
-			return "docker.io/docker/" + EnterpriseEngineImage + ":engineversion"
+			return "docker.io/docker/" + clitypes.EnterpriseEngineImage + ":engineversion"
 		},
 	}
 	container := &fakeContainer{
@@ -61,7 +64,7 @@ func TestGetCurrentEngineVersionEnterpriseHappy(t *testing.T) {
 
 	opts, err := client.GetCurrentEngineVersion(ctx)
 	assert.NilError(t, err)
-	assert.Equal(t, opts.EngineImage, EnterpriseEngineImage)
+	assert.Equal(t, opts.EngineImage, clitypes.EnterpriseEngineImage)
 	assert.Equal(t, opts.EngineVersion, "engineversion")
 	assert.Equal(t, opts.RegistryPrefix, "docker.io/docker")
 }
@@ -147,14 +150,14 @@ func TestActivateNoEngine(t *testing.T) {
 			},
 		},
 	}
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
-		EngineImage:    EnterpriseEngineImage,
+		EngineImage:    clitypes.EnterpriseEngineImage,
 	}
 
-	err := client.ActivateEngine(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "unable to find")
 }
 
@@ -163,7 +166,7 @@ func TestActivateNoChange(t *testing.T) {
 	registryPrefix := "registryprefixgoeshere"
 	image := &fakeImage{
 		nameFunc: func() string {
-			return registryPrefix + "/" + EnterpriseEngineImage + ":engineversion"
+			return registryPrefix + "/" + clitypes.EnterpriseEngineImage + ":engineversion"
 		},
 	}
 	container := &fakeContainer{
@@ -184,14 +187,14 @@ func TestActivateNoChange(t *testing.T) {
 			},
 		},
 	}
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
-		EngineImage:    EnterpriseEngineImage,
+		EngineImage:    clitypes.EnterpriseEngineImage,
 	}
 
-	err := client.ActivateEngine(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.NilError(t, err)
 }
 
@@ -219,34 +222,34 @@ func TestActivateDoUpdateFail(t *testing.T) {
 			},
 		},
 	}
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
-		EngineImage:    EnterpriseEngineImage,
+		EngineImage:    clitypes.EnterpriseEngineImage,
 	}
 
-	err := client.ActivateEngine(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "check for image")
 	assert.ErrorContains(t, err, "something went wrong")
 }
 
 func TestDoUpdateNoVersion(t *testing.T) {
 	ctx := context.Background()
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
-		EngineImage:    EnterpriseEngineImage,
+		EngineImage:    clitypes.EnterpriseEngineImage,
 	}
 	client := baseClient{}
-	err := client.DoUpdate(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "please pick the version you")
 }
 
 func TestDoUpdateImageMiscError(t *testing.T) {
 	ctx := context.Background()
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
@@ -260,14 +263,14 @@ func TestDoUpdateImageMiscError(t *testing.T) {
 			},
 		},
 	}
-	err := client.DoUpdate(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "check for image")
 	assert.ErrorContains(t, err, "something went wrong")
 }
 
 func TestDoUpdatePullFail(t *testing.T) {
 	ctx := context.Background()
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
@@ -284,14 +287,14 @@ func TestDoUpdatePullFail(t *testing.T) {
 			},
 		},
 	}
-	err := client.DoUpdate(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "unable to pull")
 	assert.ErrorContains(t, err, "pull failure")
 }
 
 func TestDoUpdateEngineMissing(t *testing.T) {
 	ctx := context.Background()
-	opts := EngineInitOptions{
+	opts := clitypes.EngineInitOptions{
 		EngineVersion:  "engineversiongoeshere",
 		RegistryPrefix: "registryprefixgoeshere",
 		ConfigFile:     "/tmp/configfilegoeshere",
@@ -313,6 +316,6 @@ func TestDoUpdateEngineMissing(t *testing.T) {
 			},
 		},
 	}
-	err := client.DoUpdate(ctx, opts, &testOutStream{}, &types.AuthConfig{}, healthfnHappy)
+	err := client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
 	assert.ErrorContains(t, err, "unable to find existing engine")
 }

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -12,7 +12,7 @@ import (
 	manifeststore "github.com/docker/cli/cli/manifest/store"
 	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/trust"
-	"github.com/docker/cli/internal/containerizedengine"
+	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/client"
 	notaryclient "github.com/theupdateframework/notary/client"
 )
@@ -20,7 +20,7 @@ import (
 // NotaryClientFuncType defines a function that returns a fake notary client
 type NotaryClientFuncType func(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
 type clientInfoFuncType func() command.ClientInfo
-type containerizedEngineFuncType func(string) (containerizedengine.Client, error)
+type containerizedEngineFuncType func(string) (clitypes.ContainerizedClient, error)
 
 // FakeCli emulates the default DockerCli
 type FakeCli struct {
@@ -172,7 +172,7 @@ func EnableContentTrust(c *FakeCli) {
 }
 
 // NewContainerizedEngineClient returns a containerized engine client
-func (c *FakeCli) NewContainerizedEngineClient(sockPath string) (containerizedengine.Client, error) {
+func (c *FakeCli) NewContainerizedEngineClient(sockPath string) (clitypes.ContainerizedClient, error) {
 	if c.containerizedEngineClientFunc != nil {
 		return c.containerizedEngineClientFunc(sockPath)
 	}

--- a/man/generate.go
+++ b/man/generate.go
@@ -25,7 +25,7 @@ func generateManPages(opts *options) error {
 	}
 
 	stdin, stdout, stderr := term.StdStreams()
-	dockerCli := command.NewDockerCli(stdin, stdout, stderr, false)
+	dockerCli := command.NewDockerCli(stdin, stdout, stderr, false, nil)
 	cmd := &cobra.Command{Use: "docker"}
 	commands.AddCommands(cmd, dockerCli)
 	source := filepath.Join(opts.source, descriptionSourcePath)

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,81 @@
+package types
+
+import (
+	"context"
+	"io"
+
+	registryclient "github.com/docker/cli/cli/registry/client"
+	"github.com/docker/docker/api/types"
+	ver "github.com/hashicorp/go-version"
+)
+
+const (
+	// CommunityEngineImage is the repo name for the community engine
+	CommunityEngineImage = "engine-community"
+
+	// EnterpriseEngineImage is the repo name for the enterprise engine
+	EnterpriseEngineImage = "engine-enterprise"
+)
+
+// ContainerizedClient can be used to manage the lifecycle of
+// dockerd running as a container on containerd.
+type ContainerizedClient interface {
+	Close() error
+	ActivateEngine(ctx context.Context,
+		opts EngineInitOptions,
+		out OutStream,
+		authConfig *types.AuthConfig,
+		healthfn func(context.Context) error) error
+	InitEngine(ctx context.Context,
+		opts EngineInitOptions,
+		out OutStream,
+		authConfig *types.AuthConfig,
+		healthfn func(context.Context) error) error
+	DoUpdate(ctx context.Context,
+		opts EngineInitOptions,
+		out OutStream,
+		authConfig *types.AuthConfig,
+		healthfn func(context.Context) error) error
+	GetEngineVersions(ctx context.Context, registryClient registryclient.RegistryClient, currentVersion, imageName string) (AvailableVersions, error)
+	GetCurrentEngineVersion(ctx context.Context) (EngineInitOptions, error)
+	RemoveEngine(ctx context.Context) error
+}
+
+// EngineInitOptions contains the configuration settings
+// use during initialization of a containerized docker engine
+type EngineInitOptions struct {
+	RegistryPrefix string
+	EngineImage    string
+	EngineVersion  string
+	ConfigFile     string
+	Scope          string
+}
+
+// AvailableVersions groups the available versions which were discovered
+type AvailableVersions struct {
+	Downgrades []DockerVersion
+	Patches    []DockerVersion
+	Upgrades   []DockerVersion
+}
+
+// DockerVersion wraps a semantic version to retain the original tag
+// since the docker date based versions don't strictly follow semantic
+// versioning (leading zeros, etc.)
+type DockerVersion struct {
+	ver.Version
+	Tag string
+}
+
+// Update stores available updates for rendering in a table
+type Update struct {
+	Type    string
+	Version string
+	Notes   string
+}
+
+// OutStream is an output stream used to write normal program output.
+type OutStream interface {
+	io.Writer
+	FD() uintptr
+	IsTerminal() bool
+}


### PR DESCRIPTION
Backport of https://github.com/docker/cli/pull/1361 for 18.09


```
git checkout -b 18.09-backport_contains-containerized upstream/18.09
git cherry-pick -s -S -x 2d344b2f6129c83601e039aa31c8477aab927d94
git push -u origin
```

cherry-pick was clean; no conflicts

this removes a whole lot of dependencies from people depending on docker/cli…

