### PR TITLE
[18.09] backport add `docker engine` commands only on Linux…

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/builder"
@@ -85,9 +86,6 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// volume
 		volume.NewVolumeCommand(dockerCli),
 
-		// engine
-		engine.NewEngineCommand(dockerCli),
-
 		// legacy commands may be hidden
 		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInfoCommand(dockerCli)),
@@ -124,7 +122,10 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		hide(image.NewSaveCommand(dockerCli)),
 		hide(image.NewTagCommand(dockerCli)),
 	)
-
+	if runtime.GOOS == "linux" {
+		// engine
+		cmd.AddCommand(engine.NewEngineCommand(dockerCli))
+	}
 }
 
 func hide(cmd *cobra.Command) *cobra.Command {


### PR DESCRIPTION
Backport of https://github.com/docker/cli/pull/1362 for 18.09

```
git checkout -b 18.09-backport_engine-only-linux upstream/18.09 
git cherry-pick -s -S -x a3a955f20453c5013f47e89132c794e8aee6ec0d
git push -u origin
```

cherry-pick was clean; no conflicts

this is, for now, the only platform that is supported


