### PR TITLE
[18.09] Prefix engine repo with store

### DIFF
--- a/cli/command/engine/activate.go
+++ b/cli/command/engine/activate.go
@@ -56,7 +56,7 @@ https://hub.docker.com/ then specify the file with the '--license' flag.
 
 	flags.StringVar(&options.licenseFile, "license", "", "License File")
 	flags.StringVar(&options.version, "version", "", "Specify engine version (default is to use currently running version)")
-	flags.StringVar(&options.registryPrefix, "registry-prefix", "docker.io/docker", "Override the default location where engine images are pulled")
+	flags.StringVar(&options.registryPrefix, "registry-prefix", "docker.io/store/docker", "Override the default location where engine images are pulled")
 	flags.StringVar(&options.image, "engine-image", clitypes.EnterpriseEngineImage, "Specify engine image")
 	flags.StringVar(&options.format, "format", "", "Pretty-print licenses using a Go template")
 	flags.BoolVar(&options.displayOnly, "display-only", false, "only display the available licenses and exit")

--- a/cli/command/engine/auth.go
+++ b/cli/command/engine/auth.go
@@ -13,7 +13,7 @@ import (
 
 func getRegistryAuth(cli command.Cli, registryPrefix string) (*types.AuthConfig, error) {
 	if registryPrefix == "" {
-		registryPrefix = "docker.io/docker"
+		registryPrefix = "docker.io/store/docker"
 	}
 	distributionRef, err := reference.ParseNormalizedNamed(registryPrefix)
 	if err != nil {

--- a/cli/command/engine/init.go
+++ b/cli/command/engine/init.go
@@ -35,7 +35,7 @@ file on the host and may be pre-created before running the 'init' command.
 	flags := cmd.Flags()
 	flags.StringVar(&options.EngineVersion, "version", cli.Version, "Specify engine version")
 	flags.StringVar(&options.EngineImage, "engine-image", clitypes.CommunityEngineImage, "Specify engine image")
-	flags.StringVar(&options.RegistryPrefix, "registry-prefix", "docker.io/docker", "Override the default location where engine images are pulled")
+	flags.StringVar(&options.RegistryPrefix, "registry-prefix", "docker.io/store/docker", "Override the default location where engine images are pulled")
 	flags.StringVar(&options.ConfigFile, "config-file", "/etc/docker/daemon.json", "Specify the location of the daemon configuration file on the host")
 	flags.StringVar(&options.sockPath, "containerd", "", "override default location of containerd endpoint")
 

--- a/cli/command/engine/update_test.go
+++ b/cli/command/engine/update_test.go
@@ -28,7 +28,7 @@ func TestUpdateHappy(t *testing.T) {
 		},
 	)
 	cmd := newUpdateCommand(testCli)
-	cmd.Flags().Set("registry-prefix", "docker.io/docker")
+	cmd.Flags().Set("registry-prefix", "docker.io/store/docker")
 	cmd.Flags().Set("version", "someversion")
 	err := cmd.Execute()
 	assert.NilError(t, err)

--- a/internal/containerizedengine/update_test.go
+++ b/internal/containerizedengine/update_test.go
@@ -46,7 +46,7 @@ func TestGetCurrentEngineVersionEnterpriseHappy(t *testing.T) {
 	ctx := context.Background()
 	image := &fakeImage{
 		nameFunc: func() string {
-			return "docker.io/docker/" + clitypes.EnterpriseEngineImage + ":engineversion"
+			return "docker.io/store/docker/" + clitypes.EnterpriseEngineImage + ":engineversion"
 		},
 	}
 	container := &fakeContainer{
@@ -66,7 +66,7 @@ func TestGetCurrentEngineVersionEnterpriseHappy(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, opts.EngineImage, clitypes.EnterpriseEngineImage)
 	assert.Equal(t, opts.EngineVersion, "engineversion")
-	assert.Equal(t, opts.RegistryPrefix, "docker.io/docker")
+	assert.Equal(t, opts.RegistryPrefix, "docker.io/store/docker")
 }
 
 func TestGetCurrentEngineVersionNoEngine(t *testing.T) {


### PR DESCRIPTION
carry of https://github.com/docker/cli/pull/1360
closes https://github.com/docker/cli/pull/1360

The official access point for the Q3 engine images will be prefixed by store.
