### PR TITLE
system/df: allow -v with --format

### DIFF
--- a/cli/command/formatter/buildcache.go
+++ b/cli/command/formatter/buildcache.go
@@ -15,6 +15,7 @@ const (
 	defaultBuildCacheTableFormat = "table {{.ID}}\t{{.Type}}\t{{.Size}}\t{{.CreatedSince}}\t{{.LastUsedSince}}\t{{.UsageCount}}\t{{.Shared}}\t{{.Description}}"
 
 	cacheIDHeader       = "CACHE ID"
+	cacheTypeHeader     = "CACHE TYPE"
 	parentHeader        = "PARENT"
 	lastUsedSinceHeader = "LAST USED"
 	usageCountHeader    = "USAGE"
@@ -36,10 +37,12 @@ func NewBuildCacheFormat(source string, quiet bool) Format {
 		}
 		format := `build_cache_id: {{.ID}}
 parent_id: {{.Parent}}
-type: {{.Type}}
+build_cache_type: {{.CacheType}}
 description: {{.Description}}
-created_at: {{.CreatedSince}}
-last_used_at: {{.LastUsedSince}}
+created_at: {{.CreatedAt}}
+created_since: {{.CreatedSince}}
+last_used_at: {{.LastUsedAt}}
+last_used_since: {{.LastUsedSince}}
 usage_count: {{.UsageCount}}
 in_use: {{.InUse}}
 shared: {{.Shared}}
@@ -95,7 +98,7 @@ func newBuildCacheContext() *buildCacheContext {
 	buildCacheCtx.header = buildCacheHeaderContext{
 		"ID":            cacheIDHeader,
 		"Parent":        parentHeader,
-		"Type":          typeHeader,
+		"CacheType":     cacheTypeHeader,
 		"Size":          sizeHeader,
 		"CreatedSince":  createdSinceHeader,
 		"LastUsedSince": lastUsedSinceHeader,
@@ -129,7 +132,7 @@ func (c *buildCacheContext) Parent() string {
 	return c.v.Parent
 }
 
-func (c *buildCacheContext) Type() string {
+func (c *buildCacheContext) CacheType() string {
 	return c.v.Type
 }
 
@@ -141,8 +144,19 @@ func (c *buildCacheContext) Size() string {
 	return units.HumanSizeWithPrecision(float64(c.v.Size), 3)
 }
 
+func (c *buildCacheContext) CreatedAt() string {
+	return c.v.CreatedAt.String()
+}
+
 func (c *buildCacheContext) CreatedSince() string {
 	return units.HumanDuration(time.Now().UTC().Sub(c.v.CreatedAt)) + " ago"
+}
+
+func (c *buildCacheContext) LastUsedAt() string {
+	if c.v.LastUsedAt == nil {
+		return ""
+	}
+	return c.v.LastUsedAt.String()
 }
 
 func (c *buildCacheContext) LastUsedSince() string {

--- a/cli/command/formatter/disk_usage_test.go
+++ b/cli/command/formatter/disk_usage_test.go
@@ -18,7 +18,7 @@ func TestDiskUsageContextFormatWrite(t *testing.T) {
 		{
 			DiskUsageContext{
 				Context: Context{
-					Format: NewDiskUsageFormat("table"),
+					Format: NewDiskUsageFormat("table", false),
 				},
 				Verbose: false},
 			`TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
@@ -29,7 +29,7 @@ Build Cache         0                   0                   0B                  
 `,
 		},
 		{
-			DiskUsageContext{Verbose: true},
+			DiskUsageContext{Verbose: true, Context: Context{Format: NewDiskUsageFormat("table", true)}},
 			`Images space usage:
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE                SHARED SIZE         UNIQUE SIZE         CONTAINERS
@@ -44,8 +44,16 @@ VOLUME NAME         LINKS               SIZE
 
 Build cache usage: 0B
 
-CACHE ID            TYPE                SIZE                CREATED             LAST USED           USAGE               SHARED
+CACHE ID            CACHE TYPE          SIZE                CREATED             LAST USED           USAGE               SHARED
 `,
+		},
+		{
+			DiskUsageContext{Verbose: true, Context: Context{Format: NewDiskUsageFormat("raw", true)}},
+			``,
+		},
+		{
+			DiskUsageContext{Verbose: true, Context: Context{Format: NewDiskUsageFormat("{{json .}}", true)}},
+			`{"Images":[],"Containers":[],"Volumes":[],"BuildCache":[]}`,
 		},
 		// Errors
 		{
@@ -70,7 +78,7 @@ CACHE ID            TYPE                SIZE                CREATED             
 		{
 			DiskUsageContext{
 				Context: Context{
-					Format: NewDiskUsageFormat("table"),
+					Format: NewDiskUsageFormat("table", false),
 				},
 			},
 			`TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
@@ -83,7 +91,7 @@ Build Cache         0                   0                   0B                  
 		{
 			DiskUsageContext{
 				Context: Context{
-					Format: NewDiskUsageFormat("table {{.Type}}\t{{.Active}}"),
+					Format: NewDiskUsageFormat("table {{.Type}}\t{{.Active}}", false),
 				},
 			},
 			string(golden.Get(t, "disk-usage-context-write-custom.golden")),
@@ -92,7 +100,7 @@ Build Cache         0                   0                   0B                  
 		{
 			DiskUsageContext{
 				Context: Context{
-					Format: NewDiskUsageFormat("raw"),
+					Format: NewDiskUsageFormat("raw", false),
 				},
 			},
 			string(golden.Get(t, "disk-usage-raw-format.golden")),

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"context"
-	"errors"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -38,10 +37,6 @@ func newDiskUsageCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runDiskUsage(dockerCli command.Cli, opts diskUsageOptions) error {
-	if opts.verbose && len(opts.format) != 0 {
-		return errors.New("the verbose and the format options conflict")
-	}
-
 	du, err := dockerCli.Client().DiskUsage(context.Background())
 	if err != nil {
 		return err
@@ -62,7 +57,7 @@ func runDiskUsage(dockerCli command.Cli, opts diskUsageOptions) error {
 	duCtx := formatter.DiskUsageContext{
 		Context: formatter.Context{
 			Output: dockerCli.Out(),
-			Format: formatter.NewDiskUsageFormat(format),
+			Format: formatter.NewDiskUsageFormat(format, opts.verbose),
 		},
 		LayersSize:  du.LayersSize,
 		BuilderSize: bsz,


### PR DESCRIPTION
This allows to provide more information for build cache disk usage.

Signed-off-by: Tibor Vass <tibor@docker.com>
