### PR TITLE
LCOW: --platform on import (already in API)

### DIFF
--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -19,6 +19,7 @@ type importOptions struct {
 	reference string
 	changes   dockeropts.ListOpts
 	message   string
+	platform  string
 }
 
 // NewImportCommand creates a new `docker import` command
@@ -43,6 +44,7 @@ func NewImportCommand(dockerCli command.Cli) *cobra.Command {
 	options.changes = dockeropts.NewListOpts(nil)
 	flags.VarP(&options.changes, "change", "c", "Apply Dockerfile instruction to the created image")
 	flags.StringVarP(&options.message, "message", "m", "", "Set commit message for imported image")
+	command.AddPlatformFlag(flags, &options.platform)
 
 	return cmd
 }
@@ -71,8 +73,9 @@ func runImport(dockerCli command.Cli, options importOptions) error {
 	}
 
 	importOptions := types.ImageImportOptions{
-		Message: options.message,
-		Changes: options.changes.GetAll(),
+		Message:  options.message,
+		Changes:  options.changes.GetAll(),
+		Platform: options.platform,
 	}
 
 	clnt := dockerCli.Client()

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -24,6 +24,7 @@ Options:
   -c, --change value     Apply Dockerfile instruction to the created image (default [])
       --help             Print usage
   -m, --message string   Set commit message for imported image
+      --platform string  Set platform if server is multi-platform capable
 ```
 
 ## Description
@@ -87,3 +88,11 @@ Note the `sudo` in this example – you must preserve
 the ownership of the files (especially root ownership) during the
 archiving with tar. If you are not root (or the sudo command) when you
 tar, then the ownerships might not get preserved.
+
+## When the daemon supports multiple operating systems
+If the daemon supports multiple operating systems, and the image being imported
+does not match the default operating system, it may be necessary to add
+`--platform`. This would be necessary when importing a Linux image into a Windows
+daemon.
+
+    # docker import --platform=linux .\linuximage.tar

--- a/man/src/image/import.md
+++ b/man/src/image/import.md
@@ -38,5 +38,13 @@ This example sets the docker image ENV variable DEBUG to true by default.
 
     # tar -c . | docker image import -c="ENV DEBUG true" - exampleimagedir
 
+## When the daemon supports multiple operating systems
+If the daemon supports multiple operating systems, and the image being imported
+does not match the default operating system, it may be necessary to add
+`--platform`. This would be necessary when importing a Linux image into a Windows
+daemon.
+
+    # docker image import --platform=linux .\linuximage.tar
+
 # See also
 **docker-export(1)** to export the contents of a filesystem as a tar archive to STDOUT.


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

A tester here found import doesn't work for LCOW. No idea how I missed this - it's in the API, just not in the CLI. As the tar generated in export doesn't have any indication of platform, it needs to be explicit. See how in the before-fix case, it's going down the WCOW route (windowsfilter),

Before:
```
PS E:\> docker import test.tar
Error response from daemon: re-exec error: exit status 1: output: ProcessBaseLayer \\?\C:\control\windowsfilter\db15e89fc696ce2b7e8a9c7ee328553690cec3558fd01cb843c837b230e2e1f2: The system cannot find the path specified.
```

After:
```
PS E:\> docker import --platform=linux test.tar
sha256:f68c6c11dcd5f4b4bbdc71d07fb5712325b00ffaa546ec868a0775bd8d62d20a
```

