### PR TITLE
[18.09] backport getEngineConfigFilePath is only used during test so moving it in test files for now.

### DIFF
--- a/internal/containerizedengine/engine.go
+++ b/internal/containerizedengine/engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"syscall"
 	"time"
 
@@ -90,35 +89,6 @@ func (c *baseClient) getEngineImage(engine containerd.Container) (string, error)
 		return "", err
 	}
 	return image.Name(), nil
-}
-
-// getEngineConfigFilePath will extract the config file location from the engine flags
-func (c baseClient) getEngineConfigFilePath(ctx context.Context, engine containerd.Container) (string, error) {
-	spec, err := engine.Spec(ctx)
-	configFile := ""
-	if err != nil {
-		return configFile, err
-	}
-	for i := 0; i < len(spec.Process.Args); i++ {
-		arg := spec.Process.Args[i]
-		if strings.HasPrefix(arg, "--config-file") {
-			if strings.Contains(arg, "=") {
-				split := strings.SplitN(arg, "=", 2)
-				configFile = split[1]
-			} else {
-				if i+1 >= len(spec.Process.Args) {
-					return configFile, ErrMalformedConfigFileParam
-				}
-				configFile = spec.Process.Args[i+1]
-			}
-		}
-	}
-
-	if configFile == "" {
-		// TODO - any more diagnostics to offer?
-		return configFile, ErrEngineConfigLookupFailure
-	}
-	return configFile, nil
 }
 
 var (

--- a/internal/containerizedengine/engine_test.go
+++ b/internal/containerizedengine/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -537,4 +538,33 @@ func TestGetEngineConfigFilePathMalformed1(t *testing.T) {
 	}
 	_, err := client.getEngineConfigFilePath(ctx, container)
 	assert.Assert(t, err == ErrMalformedConfigFileParam)
+}
+
+// getEngineConfigFilePath will extract the config file location from the engine flags
+func (c baseClient) getEngineConfigFilePath(ctx context.Context, engine containerd.Container) (string, error) {
+	spec, err := engine.Spec(ctx)
+	configFile := ""
+	if err != nil {
+		return configFile, err
+	}
+	for i := 0; i < len(spec.Process.Args); i++ {
+		arg := spec.Process.Args[i]
+		if strings.HasPrefix(arg, "--config-file") {
+			if strings.Contains(arg, "=") {
+				split := strings.SplitN(arg, "=", 2)
+				configFile = split[1]
+			} else {
+				if i+1 >= len(spec.Process.Args) {
+					return configFile, ErrMalformedConfigFileParam
+				}
+				configFile = spec.Process.Args[i+1]
+			}
+		}
+	}
+
+	if configFile == "" {
+		// TODO - any more diagnostics to offer?
+		return configFile, ErrEngineConfigLookupFailure
+	}
+	return configFile, nil
 }


### PR DESCRIPTION
Backport of https://github.com/docker/cli/pull/1304 for 18.09

```
git checkout -b 18.09_backport_move_test_function_in_there upstream/18.09
git cherry-pick -s -S -x 37ca5d681372c5af4a2442de512643ad827b13e9 
```

cherry-pick was clean; no conflicts
