### PR TITLE
[18.09] backport LCOW: --platform on import (already in API)

### DIFF
--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -19,6 +19,7 @@ type importOptions struct {
 	reference string
 	changes   dockeropts.ListOpts
 	message   string
+	platform  string
 }
 
 // NewImportCommand creates a new `docker import` command
@@ -43,6 +44,7 @@ func NewImportCommand(dockerCli command.Cli) *cobra.Command {
 	options.changes = dockeropts.NewListOpts(nil)
 	flags.VarP(&options.changes, "change", "c", "Apply Dockerfile instruction to the created image")
 	flags.StringVarP(&options.message, "message", "m", "", "Set commit message for imported image")
+	command.AddPlatformFlag(flags, &options.platform)
 
 	return cmd
 }
@@ -71,8 +73,9 @@ func runImport(dockerCli command.Cli, options importOptions) error {
 	}
 
 	importOptions := types.ImageImportOptions{
-		Message: options.message,
-		Changes: options.changes.GetAll(),
+		Message:  options.message,
+		Changes:  options.changes.GetAll(),
+		Platform: options.platform,
 	}
 
 	clnt := dockerCli.Client()

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -24,6 +24,7 @@ Options:
   -c, --change value     Apply Dockerfile instruction to the created image (default [])
       --help             Print usage
   -m, --message string   Set commit message for imported image
+      --platform string  Set platform if server is multi-platform capable
 ```
 
 ## Description
@@ -87,3 +88,11 @@ Note the `sudo` in this example – you must preserve
 the ownership of the files (especially root ownership) during the
 archiving with tar. If you are not root (or the sudo command) when you
 tar, then the ownerships might not get preserved.
+
+## When the daemon supports multiple operating systems
+If the daemon supports multiple operating systems, and the image being imported
+does not match the default operating system, it may be necessary to add
+`--platform`. This would be necessary when importing a Linux image into a Windows
+daemon.
+
+    # docker import --platform=linux .\linuximage.tar

--- a/man/src/image/import.md
+++ b/man/src/image/import.md
@@ -38,5 +38,13 @@ This example sets the docker image ENV variable DEBUG to true by default.
 
     # tar -c . | docker image import -c="ENV DEBUG true" - exampleimagedir
 
+## When the daemon supports multiple operating systems
+If the daemon supports multiple operating systems, and the image being imported
+does not match the default operating system, it may be necessary to add
+`--platform`. This would be necessary when importing a Linux image into a Windows
+daemon.
+
+    # docker image import --platform=linux .\linuximage.tar
+
 # See also
 **docker-export(1)** to export the contents of a filesystem as a tar archive to STDOUT.


### PR DESCRIPTION
Although LCOW is still experimental, this patch was fairly trivial, so I think it'd be ok to backport (but open to input)

This backports https://github.com/docker/cli/pull/1371 to the 18.09 branch

```
git checkout -b 18.09_backport_importlcow upstream/18.09   
git cherry-pick -s -S -x b55a0b681fb9592da0de4b770b682d1493c73038 
```

cherry-pick was clean; no conflicts