### PR TITLE
add a unit test to cover container export command output file option

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -24,6 +24,7 @@ type fakeClient struct {
 	logFunc               func(string, types.ContainerLogsOptions) (io.ReadCloser, error)
 	waitFunc              func(string) (<-chan container.ContainerWaitOKBody, <-chan error)
 	containerListFunc     func(types.ContainerListOptions) ([]types.Container, error)
+	containerExportFunc   func(string) (io.ReadCloser, error)
 	Version               string
 }
 
@@ -123,4 +124,11 @@ func (f *fakeClient) ContainerStart(_ context.Context, container string, options
 		return f.containerStartFunc(container, options)
 	}
 	return nil
+}
+
+func (f *fakeClient) ContainerExport(_ context.Context, container string) (io.ReadCloser, error) {
+	if f.containerExportFunc != nil {
+		return f.containerExportFunc(container)
+	}
+	return nil, nil
 }

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -1,0 +1,33 @@
+package container
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/assert"
+	"gotest.tools/fs"
+)
+
+func TestContainerExportOutputToFile(t *testing.T) {
+	dir := fs.NewDir(t, "export-test")
+	defer dir.Remove()
+
+	cli := test.NewFakeCli(&fakeClient{
+		containerExportFunc: func(container string) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader("bar")), nil
+		},
+	})
+	cmd := NewExportCommand(cli)
+	cmd.SetOutput(ioutil.Discard)
+	cmd.SetArgs([]string{"-o", dir.Join("foo"), "container"})
+	assert.NilError(t, cmd.Execute())
+
+	expected := fs.Expected(t,
+		fs.WithFile("foo", "bar", fs.MatchAnyFileMode),
+	)
+
+	assert.Assert(t, fs.Equal(dir.Path(), expected))
+}


### PR DESCRIPTION
Adding a unit test to cover the output file option of the `export` command. If merged, this allows the removal of the redundant integration test `TestExportContainerWithOutputAndImportImage` from `moby`, which is the same as `TestExportContainerAndImportImage`, except for the output file option:

https://github.com/moby/moby/blob/d6a7c22f7b9aa028623ef8c7cb31d1bb04dd9d84/integration-cli/docker_cli_export_import_test.go#L12-L17


Signed-off-by: Arash Deshmeh <adeshmeh@ca.ibm.com>


**- What I did**
Added a unit test to cover the output file option of the `export` command

**- How I did it**
Added new test file `cli/command/container/export_test.go`

**- How to verify it**

**- Description for the changelog**
Added unit test for output to file option of the export command.

**- A picture of a cute animal (not mandatory but encouraged)**

