### PR TITLE
fix insecure manifest inspect with restrictive certs perms

### DIFF
--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -200,7 +200,7 @@ func continueOnError(err error) bool {
 }
 
 func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named, each func(context.Context, distribution.Repository, reference.Named) (bool, error)) error {
-	endpoints, err := allEndpoints(namedRef)
+	endpoints, err := allEndpoints(namedRef, c.insecureRegistry)
 	if err != nil {
 		return err
 	}
@@ -262,12 +262,18 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 }
 
 // allEndpoints returns a list of endpoints ordered by priority (v2, https, v1).
-func allEndpoints(namedRef reference.Named) ([]registry.APIEndpoint, error) {
+func allEndpoints(namedRef reference.Named, insecure bool) ([]registry.APIEndpoint, error) {
 	repoInfo, err := registry.ParseRepositoryInfo(namedRef)
 	if err != nil {
 		return nil, err
 	}
-	registryService, err := registry.NewService(registry.ServiceOptions{})
+
+	var serviceOpts registry.ServiceOptions
+	if insecure {
+		logrus.Debugf("allowing insecure registry for: %s", reference.Domain(namedRef))
+		serviceOpts.InsecureRegistries = []string{reference.Domain(namedRef)}
+	}
+	registryService, err := registry.NewService(serviceOpts)
 	if err != nil {
 		return []registry.APIEndpoint{}, err
 	}


### PR DESCRIPTION
If, for some reason, the certs directory has permissions that are
inaccessible by docker, we should still be able to fetch manifests using
the `insecure` flag.

Since the cli doesn't access the engine's list of insecure registries,
the registry client should make a singleton list of the registry being queried with the
`insecure` flag.

Closes #1358

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>

