### PR TITLE
[18.09] fix subscription filter

### DIFF
--- a/internal/licenseutils/utils.go
+++ b/internal/licenseutils/utils.go
@@ -97,7 +97,7 @@ func (u HubUser) GetAvailableLicenses(ctx context.Context) ([]LicenseDisplay, er
 	// Filter out expired licenses
 	i := 0
 	for _, s := range subs {
-		if s.State != "expired" && s.Expires != nil {
+		if s.State == "active" && s.Expires != nil {
 			owner := ""
 			if s.DockerID == u.User.ID {
 				owner = u.User.Username


### PR DESCRIPTION
Fixes the subscription filter to only include "active" subscriptions. As is, we are letting cancelled subscriptions through which misleads the user.
