### PR TITLE
[18.09] backport fix substitution with non-empty env-var

### DIFF
--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -176,15 +176,21 @@ func extractVariable(value interface{}, pattern *regexp.Regexp) ([]extractedValu
 
 // Soft default (fall back if unset or empty)
 func softDefault(substitution string, mapping Mapping) (string, bool, error) {
-	return withDefault(substitution, mapping, "-:")
+	sep := ":-"
+	if !strings.Contains(substitution, sep) {
+		return "", false, nil
+	}
+	name, defaultValue := partition(substitution, sep)
+	value, ok := mapping(name)
+	if !ok || value == "" {
+		return defaultValue, true, nil
+	}
+	return value, true, nil
 }
 
 // Hard default (fall back if-and-only-if empty)
 func hardDefault(substitution string, mapping Mapping) (string, bool, error) {
-	return withDefault(substitution, mapping, "-")
-}
-
-func withDefault(substitution string, mapping Mapping, sep string) (string, bool, error) {
+	sep := "-"
 	if !strings.Contains(substitution, sep) {
 		return "", false, nil
 	}

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -78,6 +78,12 @@ func TestEmptyValueWithSoftDefault(t *testing.T) {
 	assert.Check(t, is.Equal("ok def", result))
 }
 
+func TestValueWithSoftDefault(t *testing.T) {
+	result, err := Substitute("ok ${FOO:-def}", defaultMapping)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("ok first", result))
+}
+
 func TestEmptyValueWithHardDefault(t *testing.T) {
 	result, err := Substitute("ok ${BAR-def}", defaultMapping)
 	assert.NilError(t, err)


### PR DESCRIPTION
 backport of https://github.com/docker/cli/pull/1392/commits/ec3daea0214b9600062e13413ce3062c9d3690cb for 18.09
 
 fixes https://github.com/docker/cli/issues/1391 for 18.09
 
```
git checkout -b 18.09_backport_ upstream/18.09
git cherry-pick -s -S -x  ec3daea0214b9600062e13413ce3062c9d3690cb
git push -u origin
```

cherry-pick was clean; no conflicts


Due to a typo, substitution would not work if the given
environment-variable was set.

Given the following docker compose file;

```yaml
version: "3.7"

services:
  app:
    image: nginx:${version:-latest}
```

Deploying a stack with `$version` set would ignore the `$version`
environment variable, and use the default value instead;

```bash
version=alpine docker stack deploy -c docker-compose.yml foobar

Creating network foobar_default
Creating service foobar_app

docker service ls

ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
rskkjxe6sm0w        foobar_app          replicated          1/1                 nginx:latest
```

This patch also fixes "soft default" not detecting empty environment variables,
only non-set environment variables.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit ec3daea0214b9600062e13413ce3062c9d3690cb)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

