### PR TITLE
Docs: Add Spaces Around Parenthesis Where Needed

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -167,7 +167,7 @@ The docker login command is removing the ability to automatically register for a
 
 **Target For Removal In Release: v17.06**
 
-The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consistency with other similar flags, like `--storage-opt`.
+The flag `--security-opt` doesn't use the colon separator (`:`) anymore to divide keys and values, it uses the equal symbol (`=`) for consistency with other similar flags, like `--storage-opt`.
 
 ### `/containers/(id or name)/copy` endpoint
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1379,7 +1379,7 @@ Keep the following things in mind about volumes in the `Dockerfile`.
   data within the volume after it has been declared, those changes will be discarded.
 
 - **JSON formatting**: The list is parsed as a JSON array.
-  You must enclose words with double quotes (`"`)rather than single quotes (`'`).
+  You must enclose words with double quotes (`"`) rather than single quotes (`'`).
 
 - **The host directory is declared at container run-time**: The host directory
   (the mountpoint) is, by its nature, host-dependent. This is to preserve image

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -418,7 +418,7 @@ $ docker run -l my-label --label com.example.foo=bar ubuntu bash
 ```
 
 The `my-label` key doesn't specify a value so the label defaults to an empty
-string(`""`). To add multiple labels, repeat the label flag (`-l` or `--label`).
+string (`""`). To add multiple labels, repeat the label flag (`-l` or `--label`).
 
 The `key=value` must be unique to avoid overwriting the label value. If you
 specify labels with identical keys but different values, each subsequent value

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1085,7 +1085,7 @@ per second from `/dev/sda`:
 
     $ docker run -it --device-read-bps /dev/sda:1mb ubuntu
 
-The `--device-write-bps` flag limits the write rate (bytes per second)to a device.
+The `--device-write-bps` flag limits the write rate (bytes per second) to a device.
 For example, this command creates a container and limits the write rate to `1mb`
 per second for `/dev/sda`:
 


### PR DESCRIPTION
Signed-off-by: Alex Mayer <amayer5125@gmail.com>

**- What I did**
Add spaces to docs around parenthesis to allow for easier reading.

**- Description for the changelog**
Add spaces to docs around parenthesis to allow for easier reading.
