### PR TITLE
fixes clean utf8bom in combined env file

### DIFF
--- a/opts/file.go
+++ b/opts/file.go
@@ -38,9 +38,9 @@ func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]
 			return []string{}, fmt.Errorf("env file %s contains invalid utf8 bytes at line %d: %v", filename, currentLine+1, scannedBytes)
 		}
 		// We trim UTF8 BOM
-		if currentLine == 0 {
-			scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
-		}
+		// For combined file, each line may contain utf8bom,
+		// not just the first line
+		scannedBytes = bytes.TrimPrefix(scannedBytes, utf8bom)
 		// trim the line from all leading whitespace first
 		line := strings.TrimLeftFunc(string(scannedBytes), unicode.IsSpace)
 		currentLine++


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When combined two utf8(with bom) env files, one env variable will be lost.

**- How I did it**
Clean utf8bom for each line

**- How to verify it**
```
root@dockerdemo:~/deploytest# cat test2.env
﻿def=456
foo
bar
root@dockerdemo:~/deploytest#
```
```
root@dockerdemo:~/deploytest# cat test1.env 
﻿abc=123

root@dockerdemo:~/deploytest# 
```
```
root@dockerdemo:~/deploytest# cat test2.env > test3.env
root@dockerdemo:~/deploytest# cat test1.env >> test3.env
root@dockerdemo:~/deploytest# cat test3.env
﻿def=456
foo
bar
﻿abc=123

root@dockerdemo:~/deploytest#
```
```
root@dockerdemo:~/deploytest# cat docker-compose.yml 
version: "3.7"
services:
  app:
    environment:
      foo: "bar"
    env_file:
      - ./test3.env
    image: docker.acmcoder.com/public/ubuntu:ssh
    entrypoint: /bin/bash
    tty: true
root@dockerdemo:~/deploytest#
```
```
root@dockerdemo:~/deploytest# ~/gocode/src/github.com/docker/cli/build/docker stack deploy -c docker-compose.yml foobar
Creating network foobar_default
Creating service foobar_app
root@dockerdemo:~/deploytest# docker exec -it foobar_app.1.lv4pvvw5siuypvin53dkgbzl5 /bin/bash
root@ccd9a92c49f1:/# echo $def
456
root@ccd9a92c49f1:/# echo $foo
bar
root@ccd9a92c49f1:/# echo $abc

root@ccd9a92c49f1:/#
```
abc is lost.

**- Description for the changelog**
Each line may contain utf8bom, so we need to clean them not just for the first line.


**- A picture of a cute animal**
![eo394r 4eip3y ecjns2cc](https://user-images.githubusercontent.com/783424/46241713-604c9880-c3f0-11e8-8bba-3b9e193fb9c3.png)
