### PR TITLE
Remove unused helath check func

### DIFF
--- a/cli/command/engine/activate.go
+++ b/cli/command/engine/activate.go
@@ -127,12 +127,7 @@ func runActivate(cli command.Cli, options activateOptions) error {
 		EngineVersion:  options.version,
 	}
 
-	if err := client.ActivateEngine(ctx, opts, cli.Out(), authConfig,
-		func(ctx context.Context) error {
-			client := cli.Client()
-			_, err := client.Ping(ctx)
-			return err
-		}); err != nil {
+	if err := client.ActivateEngine(ctx, opts, cli.Out(), authConfig); err != nil {
 		return err
 	}
 	fmt.Fprintln(cli.Out(), `Successfully activated engine.

--- a/cli/command/engine/client_test.go
+++ b/cli/command/engine/client_test.go
@@ -15,8 +15,7 @@ type (
 		activateEngineFunc func(ctx context.Context,
 			opts clitypes.EngineInitOptions,
 			out clitypes.OutStream,
-			authConfig *types.AuthConfig,
-			healthfn func(context.Context) error) error
+			authConfig *types.AuthConfig) error
 		initEngineFunc func(ctx context.Context,
 			opts clitypes.EngineInitOptions,
 			out clitypes.OutStream,
@@ -25,8 +24,7 @@ type (
 		doUpdateFunc func(ctx context.Context,
 			opts clitypes.EngineInitOptions,
 			out clitypes.OutStream,
-			authConfig *types.AuthConfig,
-			healthfn func(context.Context) error) error
+			authConfig *types.AuthConfig) error
 		getEngineVersionsFunc func(ctx context.Context,
 			registryClient registryclient.RegistryClient,
 			currentVersion,
@@ -48,10 +46,9 @@ func (w *fakeContainerizedEngineClient) Close() error {
 func (w *fakeContainerizedEngineClient) ActivateEngine(ctx context.Context,
 	opts clitypes.EngineInitOptions,
 	out clitypes.OutStream,
-	authConfig *types.AuthConfig,
-	healthfn func(context.Context) error) error {
+	authConfig *types.AuthConfig) error {
 	if w.activateEngineFunc != nil {
-		return w.activateEngineFunc(ctx, opts, out, authConfig, healthfn)
+		return w.activateEngineFunc(ctx, opts, out, authConfig)
 	}
 	return nil
 }
@@ -68,10 +65,9 @@ func (w *fakeContainerizedEngineClient) InitEngine(ctx context.Context,
 func (w *fakeContainerizedEngineClient) DoUpdate(ctx context.Context,
 	opts clitypes.EngineInitOptions,
 	out clitypes.OutStream,
-	authConfig *types.AuthConfig,
-	healthfn func(context.Context) error) error {
+	authConfig *types.AuthConfig) error {
 	if w.doUpdateFunc != nil {
-		return w.doUpdateFunc(ctx, opts, out, authConfig, healthfn)
+		return w.doUpdateFunc(ctx, opts, out, authConfig)
 	}
 	return nil
 }

--- a/cli/command/engine/update.go
+++ b/cli/command/engine/update.go
@@ -46,12 +46,7 @@ func runUpdate(dockerCli command.Cli, options extendedEngineInitOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := client.DoUpdate(ctx, options.EngineInitOptions, dockerCli.Out(), authConfig,
-		func(ctx context.Context) error {
-			client := dockerCli.Client()
-			_, err := client.Ping(ctx)
-			return err
-		}); err != nil {
+	if err := client.DoUpdate(ctx, options.EngineInitOptions, dockerCli.Out(), authConfig); err != nil {
 		return err
 	}
 	fmt.Fprintln(dockerCli.Out(), `Successfully updated engine.

--- a/internal/containerizedengine/update.go
+++ b/internal/containerizedengine/update.go
@@ -22,7 +22,7 @@ import (
 
 // ActivateEngine will switch the image from the CE to EE image
 func (c *baseClient) ActivateEngine(ctx context.Context, opts clitypes.EngineInitOptions, out clitypes.OutStream,
-	authConfig *types.AuthConfig, healthfn func(context.Context) error) error {
+	authConfig *types.AuthConfig) error {
 
 	// If the user didn't specify an image, determine the correct enterprise image to use
 	if opts.EngineImage == "" {
@@ -44,12 +44,12 @@ func (c *baseClient) ActivateEngine(ctx context.Context, opts clitypes.EngineIni
 	}
 
 	ctx = namespaces.WithNamespace(ctx, engineNamespace)
-	return c.DoUpdate(ctx, opts, out, authConfig, healthfn)
+	return c.DoUpdate(ctx, opts, out, authConfig)
 }
 
 // DoUpdate performs the underlying engine update
 func (c *baseClient) DoUpdate(ctx context.Context, opts clitypes.EngineInitOptions, out clitypes.OutStream,
-	authConfig *types.AuthConfig, healthfn func(context.Context) error) error {
+	authConfig *types.AuthConfig) error {
 
 	ctx = namespaces.WithNamespace(ctx, engineNamespace)
 	if opts.EngineVersion == "" {

--- a/internal/containerizedengine/update_test.go
+++ b/internal/containerizedengine/update_test.go
@@ -19,10 +19,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func healthfnHappy(ctx context.Context) error {
-	return nil
-}
-
 func TestActivateImagePermutations(t *testing.T) {
 	ctx := context.Background()
 	lookedup := "not called yet"
@@ -49,21 +45,21 @@ func TestActivateImagePermutations(t *testing.T) {
 		RuntimeMetadataDir: tmpdir,
 	}
 
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, expectedError.Error())
 	assert.Equal(t, lookedup, fmt.Sprintf("%s/%s:%s", opts.RegistryPrefix, clitypes.EnterpriseEngineImage, opts.EngineVersion))
 
 	metadata = clitypes.RuntimeMetadata{EngineImage: clitypes.CommunityEngineImage}
 	err = versions.WriteRuntimeMetadata(tmpdir, &metadata)
 	assert.NilError(t, err)
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, expectedError.Error())
 	assert.Equal(t, lookedup, fmt.Sprintf("%s/%s:%s", opts.RegistryPrefix, clitypes.EnterpriseEngineImage, opts.EngineVersion))
 
 	metadata = clitypes.RuntimeMetadata{EngineImage: clitypes.CommunityEngineImage + "-dm"}
 	err = versions.WriteRuntimeMetadata(tmpdir, &metadata)
 	assert.NilError(t, err)
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, expectedError.Error())
 	assert.Equal(t, lookedup, fmt.Sprintf("%s/%s:%s", opts.RegistryPrefix, clitypes.EnterpriseEngineImage+"-dm", opts.EngineVersion))
 }
@@ -114,7 +110,7 @@ func TestActivateConfigFailure(t *testing.T) {
 		RuntimeMetadataDir: tmpdir,
 	}
 
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "config lookup failure")
 }
 
@@ -156,7 +152,7 @@ func TestActivateDoUpdateFail(t *testing.T) {
 		RuntimeMetadataDir: tmpdir,
 	}
 
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "check for image")
 	assert.ErrorContains(t, err, "something went wrong")
 }
@@ -178,7 +174,7 @@ func TestDoUpdateNoVersion(t *testing.T) {
 	}
 
 	client := baseClient{}
-	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "pick the version you")
 }
 
@@ -206,7 +202,7 @@ func TestDoUpdateImageMiscError(t *testing.T) {
 		},
 	}
 
-	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "check for image")
 	assert.ErrorContains(t, err, "something went wrong")
 }
@@ -238,7 +234,7 @@ func TestDoUpdatePullFail(t *testing.T) {
 		},
 	}
 
-	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.DoUpdate(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "unable to pull")
 	assert.ErrorContains(t, err, "pull failure")
 }
@@ -284,7 +280,7 @@ func TestActivateDoUpdateVerifyImageName(t *testing.T) {
 		RuntimeMetadataDir: tmpdir,
 	}
 
-	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{}, healthfnHappy)
+	err = client.ActivateEngine(ctx, opts, command.NewOutStream(&bytes.Buffer{}), &types.AuthConfig{})
 	assert.ErrorContains(t, err, "check for image")
 	assert.ErrorContains(t, err, "something went wrong")
 	expectedImage := fmt.Sprintf("%s/%s:%s", opts.RegistryPrefix, opts.EngineImage, opts.EngineVersion)

--- a/types/types.go
+++ b/types/types.go
@@ -33,13 +33,11 @@ type ContainerizedClient interface {
 	ActivateEngine(ctx context.Context,
 		opts EngineInitOptions,
 		out OutStream,
-		authConfig *types.AuthConfig,
-		healthfn func(context.Context) error) error
+		authConfig *types.AuthConfig) error
 	DoUpdate(ctx context.Context,
 		opts EngineInitOptions,
 		out OutStream,
-		authConfig *types.AuthConfig,
-		healthfn func(context.Context) error) error
+		authConfig *types.AuthConfig) error
 }
 
 // EngineInitOptions contains the configuration settings


### PR DESCRIPTION
Follow up from #1388 

During the refactoring for 18.09 the activate/update flows no longer
restart the engine explicitly but let the user do that when they're ready,
so the health check logic is no longer required.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>