### PR TITLE
[18.09] Fix panic in display only case for license

### DIFF
--- a/cli/command/engine/activate.go
+++ b/cli/command/engine/activate.go
@@ -60,7 +60,7 @@ https://hub.docker.com/ then specify the file with the '--license' flag.
 	flags.StringVar(&options.registryPrefix, "registry-prefix", clitypes.RegistryPrefix, "Override the default location where engine images are pulled")
 	flags.StringVar(&options.image, "engine-image", "", "Specify engine image")
 	flags.StringVar(&options.format, "format", "", "Pretty-print licenses using a Go template")
-	flags.BoolVar(&options.displayOnly, "display-only", false, "only display the available licenses and exit")
+	flags.BoolVar(&options.displayOnly, "display-only", false, "only display license information and exit")
 	flags.BoolVar(&options.quiet, "quiet", false, "Only display available licenses by ID")
 	flags.StringVar(&options.sockPath, "containerd", "", "override default location of containerd endpoint")
 
@@ -89,6 +89,9 @@ func runActivate(cli command.Cli, options activateOptions) error {
 	if options.licenseFile == "" {
 		if license, err = getLicenses(ctx, authConfig, cli, options); err != nil {
 			return err
+		}
+		if options.displayOnly {
+			return nil
 		}
 	} else {
 		if license, err = licenseutils.LoadLocalIssuedLicense(ctx, options.licenseFile); err != nil {

--- a/cli/command/engine/activate.go
+++ b/cli/command/engine/activate.go
@@ -16,19 +16,21 @@ import (
 )
 
 type activateOptions struct {
-	licenseFile    string
-	version        string
-	registryPrefix string
-	format         string
-	image          string
-	quiet          bool
-	displayOnly    bool
-	sockPath       string
+	licenseFile      string
+	version          string
+	registryPrefix   string
+	format           string
+	image            string
+	quiet            bool
+	displayOnly      bool
+	sockPath         string
+	licenseLoginFunc func(ctx context.Context, authConfig *types.AuthConfig) (licenseutils.HubUser, error)
 }
 
 // newActivateCommand creates a new `docker engine activate` command
 func newActivateCommand(dockerCli command.Cli) *cobra.Command {
 	var options activateOptions
+	options.licenseLoginFunc = licenseutils.Login
 
 	cmd := &cobra.Command{
 		Use:   "activate [OPTIONS]",
@@ -139,7 +141,7 @@ Restart docker with 'systemctl restart docker' to complete the activation.`)
 }
 
 func getLicenses(ctx context.Context, authConfig *types.AuthConfig, cli command.Cli, options activateOptions) (*model.IssuedLicense, error) {
-	user, err := licenseutils.Login(ctx, authConfig)
+	user, err := options.licenseLoginFunc(ctx, authConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/engine/testdata/expired-hub-license-display-only.golden
+++ b/cli/command/engine/testdata/expired-hub-license-display-only.golden
@@ -1,0 +1,3 @@
+Looking for existing licenses for ...
+NUM                 OWNER               PRODUCT ID          EXPIRES                         PRICING COMPONENTS
+0                                                           2010-01-01 00:00:00 +0000 UTC   

--- a/internal/licenseutils/utils.go
+++ b/internal/licenseutils/utils.go
@@ -20,7 +20,7 @@ import (
 // HubUser wraps a licensing client and holds key information
 // for a user to avoid multiple lookups
 type HubUser struct {
-	client licensing.Client
+	Client licensing.Client
 	token  string
 	User   model.User
 	Orgs   []model.Org
@@ -73,7 +73,7 @@ func Login(ctx context.Context, authConfig *types.AuthConfig) (HubUser, error) {
 		return HubUser{}, err
 	}
 	return HubUser{
-		client: lclient,
+		Client: lclient,
 		token:  token,
 		User:   *user,
 		Orgs:   orgs,
@@ -83,12 +83,12 @@ func Login(ctx context.Context, authConfig *types.AuthConfig) (HubUser, error) {
 
 // GetAvailableLicenses finds all available licenses for a given account and their orgs
 func (u HubUser) GetAvailableLicenses(ctx context.Context) ([]LicenseDisplay, error) {
-	subs, err := u.client.ListSubscriptions(ctx, u.token, u.User.ID)
+	subs, err := u.Client.ListSubscriptions(ctx, u.token, u.User.ID)
 	if err != nil {
 		return nil, err
 	}
 	for _, org := range u.Orgs {
-		orgSub, err := u.client.ListSubscriptions(ctx, u.token, org.ID)
+		orgSub, err := u.Client.ListSubscriptions(ctx, u.token, org.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -134,16 +134,16 @@ func (u HubUser) GetAvailableLicenses(ctx context.Context) ([]LicenseDisplay, er
 
 // GenerateTrialLicense will generate a new trial license for the specified user or org
 func (u HubUser) GenerateTrialLicense(ctx context.Context, targetID string) (*model.IssuedLicense, error) {
-	subID, err := u.client.GenerateNewTrialSubscription(ctx, u.token, targetID, u.User.Email)
+	subID, err := u.Client.GenerateNewTrialSubscription(ctx, u.token, targetID, u.User.Email)
 	if err != nil {
 		return nil, err
 	}
-	return u.client.DownloadLicenseFromHub(ctx, u.token, subID)
+	return u.Client.DownloadLicenseFromHub(ctx, u.token, subID)
 }
 
 // GetIssuedLicense will download a license by ID
 func (u HubUser) GetIssuedLicense(ctx context.Context, ID string) (*model.IssuedLicense, error) {
-	return u.client.DownloadLicenseFromHub(ctx, u.token, ID)
+	return u.Client.DownloadLicenseFromHub(ctx, u.token, ID)
 }
 
 // LoadLocalIssuedLicense will load a local license file

--- a/internal/licenseutils/utils_test.go
+++ b/internal/licenseutils/utils_test.go
@@ -43,7 +43,7 @@ func TestGetOrgByID(t *testing.T) {
 func TestGetAvailableLicensesListFail(t *testing.T) {
 	ctx := context.Background()
 	user := HubUser{
-		client: &fakeLicensingClient{
+		Client: &fakeLicensingClient{
 			listSubscriptionsFunc: func(ctx context.Context, authToken, dockerID string) (response []*model.Subscription, err error) {
 				return nil, fmt.Errorf("list subscriptions error")
 			},
@@ -59,7 +59,7 @@ func TestGetAvailableLicensesOrgFail(t *testing.T) {
 		Orgs: []model.Org{
 			{ID: "orgid"},
 		},
-		client: &fakeLicensingClient{
+		Client: &fakeLicensingClient{
 			listSubscriptionsFunc: func(ctx context.Context, authToken, dockerID string) (response []*model.Subscription, err error) {
 				if dockerID == "orgid" {
 					return nil, fmt.Errorf("list subscriptions org error")
@@ -86,7 +86,7 @@ func TestGetAvailableLicensesHappy(t *testing.T) {
 				Orgname: "orgname",
 			},
 		},
-		client: &fakeLicensingClient{
+		Client: &fakeLicensingClient{
 			listSubscriptionsFunc: func(ctx context.Context, authToken, dockerID string) (response []*model.Subscription, err error) {
 				if dockerID == "orgid" {
 					return []*model.Subscription{
@@ -146,7 +146,7 @@ func TestGetAvailableLicensesHappy(t *testing.T) {
 func TestGenerateTrialFail(t *testing.T) {
 	ctx := context.Background()
 	user := HubUser{
-		client: &fakeLicensingClient{
+		Client: &fakeLicensingClient{
 			generateNewTrialSubscriptionFunc: func(ctx context.Context, authToken, dockerID, email string) (subscriptionID string, err error) {
 				return "", fmt.Errorf("generate trial failure")
 			},
@@ -160,7 +160,7 @@ func TestGenerateTrialFail(t *testing.T) {
 func TestGenerateTrialHappy(t *testing.T) {
 	ctx := context.Background()
 	user := HubUser{
-		client: &fakeLicensingClient{
+		Client: &fakeLicensingClient{
 			generateNewTrialSubscriptionFunc: func(ctx context.Context, authToken, dockerID, email string) (subscriptionID string, err error) {
 				return "subid", nil
 			},
@@ -174,7 +174,7 @@ func TestGenerateTrialHappy(t *testing.T) {
 func TestGetIssuedLicense(t *testing.T) {
 	ctx := context.Background()
 	user := HubUser{
-		client: &fakeLicensingClient{},
+		Client: &fakeLicensingClient{},
 	}
 	id := "idgoeshere"
 	_, err := user.GetIssuedLicense(ctx, id)


### PR DESCRIPTION
Prior refactoring passes missed a corner case.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>
