### PR TITLE
fixes when no equal sign in label file

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -965,6 +965,25 @@ func TestParseEnvfileVariables(t *testing.T) {
 	}
 }
 
+func TestParseEnvfileVariablesWithoutEqualSign(t *testing.T) {
+	// env without equal sign
+	config, _, _, err := parseRun([]string{"--env-file=testdata/noequalsign.env", "img", "cmd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Env) != 2 || config.Env[0] != "bar=" || config.Env[1] != "demo=true" {
+		t.Fatalf("Expected a config with [bar= demo=true], got %v", config.Env)
+	}
+	t.Setenv("foo", "bar")
+	config, _, _, err = parseRun([]string{"--env-file=testdata/noequalsign.env", "img", "cmd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Env) != 3 || config.Env[0] != "foo=bar" || config.Env[1] != "bar=" || config.Env[2] != "demo=true" {
+		t.Fatalf("Expected a config with [foo=bar bar= demo=true], got %v", config.Env)
+	}
+}
+
 func TestParseEnvfileVariablesWithBOMUnicode(t *testing.T) {
 	// UTF8 with BOM
 	config, _, _, err := parseRun([]string{"--env-file=testdata/utf8.env", "img", "cmd"})
@@ -1015,6 +1034,24 @@ func TestParseLabelfileVariables(t *testing.T) {
 	}
 	if len(config.Labels) != 2 || config.Labels["LABEL1"] != "value1" || config.Labels["LABEL2"] != "value2" {
 		t.Fatalf("Expected a config with [LABEL1:value1 LABEL2:value2], got %v", config.Labels)
+	}
+}
+
+func TestParseLabelfileVariablesWithoutEqualSign(t *testing.T) {
+	// label without equal sign
+	config, _, _, err := parseRun([]string{"--label-file=testdata/noequalsign.label", "img", "cmd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Labels) != 3 || config.Labels["demo"] != "true" || config.Labels["foo"] != "" || config.Labels["bar"] != "" {
+		t.Fatalf("Expected a config with [foo: bar: demo=true], got %v", config.Labels)
+	}
+	config, _, _, err = parseRun([]string{"--label-file=testdata/noequalsign.label", "--label=foo=bar", "img", "cmd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Labels) != 3 || config.Labels["demo"] != "true" || config.Labels["foo"] != "bar" || config.Labels["bar"] != "" {
+		t.Fatalf("Expected a config with [foo=bar bar: demo:true], got %v", config.Labels)
 	}
 }
 

--- a/cli/command/container/testdata/noequalsign.env
+++ b/cli/command/container/testdata/noequalsign.env
@@ -1,0 +1,3 @@
+foo
+bar=
+demo=true

--- a/cli/command/container/testdata/noequalsign.label
+++ b/cli/command/container/testdata/noequalsign.label
@@ -1,0 +1,3 @@
+foo
+bar=
+demo=true

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -13,7 +13,9 @@ import (
 // ReadKVStrings reads a file of line terminated key=value pairs, and overrides any keys
 // present in the file with additional pairs specified in the override parameter
 func ReadKVStrings(files []string, override []string) ([]string, error) {
-	return readKVStrings(files, override, nil)
+	return readKVStrings(files, override, func(string) (string, bool) {
+		return "", true
+	})
 }
 
 // ReadKVEnvStrings reads a file of line terminated key=value pairs, and overrides any keys


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When use --label:
`./build/docker run -d --name=redis5 --label foo redis`
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# ./build/docker inspect --format '{{.Config.Labels}}' redis5
map[foo:]
```
When use --label-file:
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# echo $foo
bar
root@dockerdemo:~/gocode/src/github.com/docker/cli# cat ~/labels.txt 
foo
bar=
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker run -d --name=redis7 --label-file ~/labels.txt redis
root@dockerdemo:~/gocode/src/github.com/docker/cli# ./build/docker inspect --format '{{.Config.Labels}}' redis7
map[bar:]
```

label foo is lost.

The behavior of --label and --label-file is different when there is no equal sign after label variable.
**- How I did it**
When there is no equal sign after label variable, and no emptyFn, add it to output.

**- How to verify it**
After fix:
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker run -d --name=redis8 --label-file ~/labels.txt redis
root@dockerdemo:~/gocode/src/github.com/docker/cli# ./build/docker inspect --format '{{.Config.Labels}}' redis8
map[bar: foo:]
```

**- Description for the changelog**
fixes when no equal sign in label file

**- A picture of a cute animal (not mandatory but encouraged)**
![508c439d40d41d0a9c2e3256ee1ca5a](https://user-images.githubusercontent.com/783424/46454818-c5cacb80-c7da-11e8-9660-dc79d2a4532f.png)
