### PR TITLE
Clarify in docs that docker tag doesn't publish

### DIFF
--- a/man/src/image/tag.md
+++ b/man/src/image/tag.md
@@ -48,7 +48,7 @@ repository with "version1.0.test":
 
 ## Tagging an image for a private repository
 
-To push an image to a private registry and not the central Docker
+Before pushing an image to a private registry and not the central Docker
 registry you must tag it with the registry hostname and port (if needed).
 
     docker image tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0


### PR DESCRIPTION
First PR, just to clarify docs which confused me as a newcomer. Please let me know if I can do anything better.
-----
I am attempting to push a tag to a private repository. The documentation for `docker tag`  has an explicit example to for how ["To push an image to a private registry"](https://docs.docker.com/engine/reference/commandline/tag/#tag-an-image-referenced-by-name). My colleague clarified that this command does not in fact push anything, so I thought this PR might save some future novice the same confusion.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I changed the wording in the docker image tag docs which implied that the tag command would push an image.
**- How I did it**
I forked the repo and edited man/src/image/tag.md in GitHub.
**- How to verify it**
I don't know. 
**- Description for the changelog**
<!--
Clarify language in the image docs which implied that docker tag also pushes.
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![cute-baby-animals-2-2](https://user-images.githubusercontent.com/32850427/46498589-75a43700-c7e3-11e8-9fc2-c395a6eb6fa4.jpg)
