### PR TITLE
[18.09] Update release note link to final location

### DIFF
--- a/cli/command/engine/check.go
+++ b/cli/command/engine/check.go
@@ -117,7 +117,7 @@ func processVersions(currentVersion, verType string,
 			availUpdates = append(availUpdates, clitypes.Update{
 				Type:    verType,
 				Version: ver.Tag,
-				Notes:   fmt.Sprintf("%s/%s", clitypes.ReleaseNotePrefix, ver.Tag),
+				Notes:   fmt.Sprintf("%s?%s", clitypes.ReleaseNotePrefix, ver.Tag),
 			})
 		}
 	}

--- a/cli/command/engine/testdata/check-all.golden
+++ b/cli/command/engine/testdata/check-all.golden
@@ -1,11 +1,11 @@
 TYPE                VERSION             NOTES
 current             1.1.0               
-patch               1.1.1               https://docs.docker.com/releasenotes/1.1.1
-patch               1.1.2               https://docs.docker.com/releasenotes/1.1.2
-patch               1.1.3-beta1         https://docs.docker.com/releasenotes/1.1.3-beta1
-upgrade             1.2.0               https://docs.docker.com/releasenotes/1.2.0
-upgrade             2.0.0               https://docs.docker.com/releasenotes/2.0.0
-upgrade             2.1.0-beta1         https://docs.docker.com/releasenotes/2.1.0-beta1
-downgrade           1.0.1               https://docs.docker.com/releasenotes/1.0.1
-downgrade           1.0.2               https://docs.docker.com/releasenotes/1.0.2
-downgrade           1.0.3-beta1         https://docs.docker.com/releasenotes/1.0.3-beta1
+patch               1.1.1               https://docker.com/engine/releasenotes?1.1.1
+patch               1.1.2               https://docker.com/engine/releasenotes?1.1.2
+patch               1.1.3-beta1         https://docker.com/engine/releasenotes?1.1.3-beta1
+upgrade             1.2.0               https://docker.com/engine/releasenotes?1.2.0
+upgrade             2.0.0               https://docker.com/engine/releasenotes?2.0.0
+upgrade             2.1.0-beta1         https://docker.com/engine/releasenotes?2.1.0-beta1
+downgrade           1.0.1               https://docker.com/engine/releasenotes?1.0.1
+downgrade           1.0.2               https://docker.com/engine/releasenotes?1.0.2
+downgrade           1.0.3-beta1         https://docker.com/engine/releasenotes?1.0.3-beta1

--- a/cli/command/engine/testdata/check-no-downgrades.golden
+++ b/cli/command/engine/testdata/check-no-downgrades.golden
@@ -1,6 +1,6 @@
 TYPE                VERSION             NOTES
 current             1.1.0               
-patch               1.1.1               https://docs.docker.com/releasenotes/1.1.1
-patch               1.1.2               https://docs.docker.com/releasenotes/1.1.2
-upgrade             1.2.0               https://docs.docker.com/releasenotes/1.2.0
-upgrade             2.0.0               https://docs.docker.com/releasenotes/2.0.0
+patch               1.1.1               https://docker.com/engine/releasenotes?1.1.1
+patch               1.1.2               https://docker.com/engine/releasenotes?1.1.2
+upgrade             1.2.0               https://docker.com/engine/releasenotes?1.2.0
+upgrade             2.0.0               https://docker.com/engine/releasenotes?2.0.0

--- a/cli/command/engine/testdata/check-no-prerelease.golden
+++ b/cli/command/engine/testdata/check-no-prerelease.golden
@@ -1,8 +1,8 @@
 TYPE                VERSION             NOTES
 current             1.1.0               
-patch               1.1.1               https://docs.docker.com/releasenotes/1.1.1
-patch               1.1.2               https://docs.docker.com/releasenotes/1.1.2
-upgrade             1.2.0               https://docs.docker.com/releasenotes/1.2.0
-upgrade             2.0.0               https://docs.docker.com/releasenotes/2.0.0
-downgrade           1.0.1               https://docs.docker.com/releasenotes/1.0.1
-downgrade           1.0.2               https://docs.docker.com/releasenotes/1.0.2
+patch               1.1.1               https://docker.com/engine/releasenotes?1.1.1
+patch               1.1.2               https://docker.com/engine/releasenotes?1.1.2
+upgrade             1.2.0               https://docker.com/engine/releasenotes?1.2.0
+upgrade             2.0.0               https://docker.com/engine/releasenotes?2.0.0
+downgrade           1.0.1               https://docker.com/engine/releasenotes?1.0.1
+downgrade           1.0.2               https://docker.com/engine/releasenotes?1.0.2

--- a/cli/command/engine/testdata/check-patches-only.golden
+++ b/cli/command/engine/testdata/check-patches-only.golden
@@ -1,4 +1,4 @@
 TYPE                VERSION             NOTES
 current             1.1.0               
-patch               1.1.1               https://docs.docker.com/releasenotes/1.1.1
-patch               1.1.2               https://docs.docker.com/releasenotes/1.1.2
+patch               1.1.1               https://docker.com/engine/releasenotes?1.1.1
+patch               1.1.2               https://docker.com/engine/releasenotes?1.1.2

--- a/internal/containerizedengine/update.go
+++ b/internal/containerizedengine/update.go
@@ -179,5 +179,5 @@ func getReleaseNotesURL(imageName string) string {
 			versionTag = taggedRef.Tag()
 		}
 	}
-	return fmt.Sprintf("%s/%s", clitypes.ReleaseNotePrefix, versionTag)
+	return fmt.Sprintf("%s?%s", clitypes.ReleaseNotePrefix, versionTag)
 }

--- a/internal/containerizedengine/update_test.go
+++ b/internal/containerizedengine/update_test.go
@@ -290,11 +290,11 @@ func TestActivateDoUpdateVerifyImageName(t *testing.T) {
 func TestGetReleaseNotesURL(t *testing.T) {
 	imageName := "bogus image name #$%&@!"
 	url := getReleaseNotesURL(imageName)
-	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"/")
+	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"?")
 	imageName = "foo.bar/valid/repowithouttag"
 	url = getReleaseNotesURL(imageName)
-	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"/")
+	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"?")
 	imageName = "foo.bar/valid/repowithouttag:tag123"
 	url = getReleaseNotesURL(imageName)
-	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"/tag123")
+	assert.Equal(t, url, clitypes.ReleaseNotePrefix+"?tag123")
 }

--- a/types/types.go
+++ b/types/types.go
@@ -19,7 +19,7 @@ const (
 	RegistryPrefix = "docker.io/store/docker"
 
 	// ReleaseNotePrefix is where to point users to for release notes
-	ReleaseNotePrefix = "https://docs.docker.com/releasenotes"
+	ReleaseNotePrefix = "https://docker.com/engine/releasenotes"
 
 	// RuntimeMetadataName is the name of the runtime metadata file
 	// When stored as a label on the container it is prefixed by "com.docker."


### PR DESCRIPTION
We'll be using a redirect from this URL to the back-end docs system for
hosting release notes. Final location confirmed with Docs team and PM.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>