### PR TITLE
Deprecate "devicemapper" storage driver.

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -34,6 +34,21 @@ on pre 4.x kernels. Now that all supported distributions are able to run `overla
 (as they are either on kernel 4.x, or have support for multiple lowerdirs
 backported), there is no reason to keep maintaining the `overlay` storage driver.
 
+### device mapper storage driver
+
+**Deprecated in Release: v18.09.0**
+
+The `devicemapper` storage driver is deprecated in favor of `overlay2`, and will
+be removed in a future release. Users of the `devicemapper` storage driver are
+recommended to migrate to a different storage driver, such as `overlay2`, which
+is now the default storage driver.
+
+The `devicemapper` storage driver facilitates running Docker on older (3.x) kernels
+that have no support for other storage drivers (such as overlay2, or AUFS).
+
+Now that support for `overlay2` is added to all supported distros (as they are
+either on kernel 4.x, or have support for multiple lowerdirs backported), there
+is no reason to continue maintenance of the `devicemapper` storage driver.
 
 ### Reserved namespaces in engine labels
 


### PR DESCRIPTION
The `devicemapper` storage driver is deprecated in favor of `overlay2`, and will
be removed in a future release. Users of the `devicemapper` storage driver are
recommended to migrate to a different storage driver, such as `overlay2`, which
is now the default storage driver.

The `devicemapper` storage driver facilitates running Docker on older (3.x) kernels
that have no support for other storage drivers (such as overlay2, or AUFS).

Now that support for `overlay2` is added to all supported distros (as they are
either on kernel 4.x, or have support for multiple lowerdirs backported), there
is no reason to continue maintenance of the `devicemapper` storage driver.

