### PR TITLE
build: only show buildkit-specific flags if buildkit is enabled

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/docker/cli/cli"
@@ -131,6 +132,20 @@ func (cli *DockerCli) ClientInfo() ClientInfo {
 // environment variable.
 func (cli *DockerCli) ContentTrustEnabled() bool {
 	return cli.contentTrust
+}
+
+// BuildKitEnabled returns whether buildkit is enabled either through a daemon setting
+// or otherwise the client-side DOCKER_BUILDKIT environment variable
+func BuildKitEnabled(si ServerInfo) (bool, error) {
+	buildkitEnabled := si.BuildkitVersion == types.BuilderBuildKit
+	if buildkitEnv := os.Getenv("DOCKER_BUILDKIT"); buildkitEnv != "" {
+		var err error
+		buildkitEnabled, err = strconv.ParseBool(buildkitEnv)
+		if err != nil {
+			return false, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+		}
+	}
+	return buildkitEnabled, nil
 }
 
 // ManifestStore returns a store for local manifests


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>