### PR TITLE
Fix `docker invalid-subcommand` regression

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -33,6 +33,9 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 		SilenceErrors:    true,
 		TraverseChildren: true,
 		Args:             noArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return command.ShowHelp(dockerCli.Err())(cmd, args)
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// flags must be the top-level command flags, not cmd.Flags()
 			opts.Common.SetDefaultOptions(flags)

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -30,4 +31,21 @@ func TestExitStatusForInvalidSubcommandWithHelpFlag(t *testing.T) {
 	cmd.SetArgs([]string{"help", "invalid"})
 	err := cmd.Execute()
 	assert.Error(t, err, "unknown help topic: invalid")
+}
+
+func TestExitStatusForInvalidSubcommand(t *testing.T) {
+	discard := ioutil.Discard
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard, false, nil))
+	cmd.SetArgs([]string{"invalid"})
+	err := cmd.Execute()
+	assert.Check(t, is.ErrorContains(err, "docker: 'invalid' is not a docker command."))
+}
+
+func TestVersion(t *testing.T) {
+	var b bytes.Buffer
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, &b, &b, false, nil))
+	cmd.SetArgs([]string{"--version"})
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(b.String(), "Docker version"))
 }


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Starting with a3fe7d62b8274d69930286fb14653cccf37acadb,
`docker invalid-subcommand` did not exit with non-zero status.

Fix #1428

**- How I did it**

Restored `RunE`

**- How to verify it**

```console
$ docker invalid-subcommand
docker: 'invalid-subcommand' is not a docker command.
See 'docker --help'
$ echo $?
1
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix `docker invalid-subcommand` regression

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
