### PR TITLE
[18.06] backport using strings.Builder instead of string appending

### DIFF
--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -73,14 +74,20 @@ func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint6
 	}
 
 	if len(report.ImagesDeleted) > 0 {
-		output = "Deleted Images:\n"
+		var sb strings.Builder
+		sb.WriteString("Deleted Images:\n")
 		for _, st := range report.ImagesDeleted {
 			if st.Untagged != "" {
-				output += fmt.Sprintln("untagged:", st.Untagged)
+				sb.WriteString("untagged: ")
+				sb.WriteString(st.Untagged)
+				sb.WriteByte('\n')
 			} else {
-				output += fmt.Sprintln("deleted:", st.Deleted)
+				sb.WriteString("deleted: ")
+				sb.WriteString(st.Deleted)
+				sb.WriteByte('\n')
 			}
 		}
+		output = sb.String()
 		spaceReclaimed = report.SpaceReclaimed
 	}
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1423 for 18.06
fixes https://github.com/docker/cli/issues/1422 for 18.06

```
git checkout -b 18.06_backport_use_string_builder upstream/18.06
git cherry-pick -s -S -x 814ced4b30d0d2164c74d2f2007603ce81d0d17b
```

cherry-pick was clean; no conflicts