### PR TITLE
Add bash completion for `service --no-resolve-image`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3440,6 +3440,7 @@ _docker_service_update_and_create() {
 		--help
 		--init
 		--no-healthcheck
+		--no-resolve-image
 		--read-only
 		--tty -t
 		--with-registry-auth


### PR DESCRIPTION
**- What I did**
add bash completion for `service {create,update} --no-resolve-image`

**- How I did it**
update `contrib/completion/bash/docker:_docker_service_update_and_create()`

**- How to verify it**
```
bash
source contrib/completion/bash/docker
docker service update <TAB><TAB>
docker service create <TAB><TAB>
```

**- Description for the changelog**
NA