### PR TITLE
fixes docker -H :2375 can't work

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/docker/cli/cli"
@@ -265,7 +266,7 @@ func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.
 	}
 	var clientOpts []func(*client.Client) error
 	helper, err := connhelper.GetConnectionHelper(unparsedHost)
-	if err != nil {
+	if err != nil && !strings.HasPrefix(err.Error(), "parse ") {
 		return &client.Client{}, err
 	}
 	if helper == nil {


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
```
docker -H :2375 checkpoint create --checkpoint-dir ~/checkpoints/ --leave-running sad_cori swarm-03
parse :2375: missing protocol scheme
```
A small error fix. A Classical option "-H :2375" can't work now. 