### PR TITLE
fixes #1441 set default schema to tcp for docker host

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -43,6 +43,26 @@ func TestNewAPIClientFromFlags(t *testing.T) {
 	assert.Check(t, is.Equal(api.DefaultVersion, apiclient.ClientVersion()))
 }
 
+func TestNewAPIClientFromFlagsForDefaultSchema(t *testing.T) {
+	host := ":2375"
+	opts := &flags.CommonOptions{Hosts: []string{host}}
+	configFile := &configfile.ConfigFile{
+		HTTPHeaders: map[string]string{
+			"My-Header": "Custom-Value",
+		},
+	}
+	apiclient, err := NewAPIClientFromFlags(opts, configFile)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("tcp://localhost"+host, apiclient.DaemonHost()))
+
+	expectedHeaders := map[string]string{
+		"My-Header":  "Custom-Value",
+		"User-Agent": UserAgent(),
+	}
+	assert.Check(t, is.DeepEqual(expectedHeaders, apiclient.(*client.Client).CustomHTTPHeaders()))
+	assert.Check(t, is.Equal(api.DefaultVersion, apiclient.ClientVersion()))
+}
+
 func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 	customVersion := "v3.3.3"
 	defer env.Patch(t, "DOCKER_API_VERSION", customVersion)()

--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -77,6 +77,8 @@ func parseDockerDaemonHost(addr string) (string, error) {
 		return parseSimpleProtoAddr("npipe", addrParts[1], DefaultNamedPipe)
 	case "fd":
 		return addr, nil
+	case "ssh":
+		return addr, nil
 	default:
 		return "", fmt.Errorf("Invalid bind address format: %s", addr)
 	}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>
**- What I did**
Please see #1441 
There is a traditional command "docker -H :2375 ps" in docker cli, but in master, it can't work now.
Is this feature removed in plan or just an error?

**- How I did it**
I think this may be a bug after merge #1014 
add case ssh to dopts.ParseHost, together with all other schema.

**- How to verify it**
see #1441

**- Description for the changelog**
set default schema to tcp for docker host param when there is no schema

**- A picture of a cute animal (not mandatory but encouraged)**
![p08ehdk zh d s d426fzw](https://user-images.githubusercontent.com/783424/46844518-0f826a00-ce0a-11e8-9a6e-b787d2dd3c08.png)
