### PR TITLE
Improve `docker image rm` documentation

### DIFF
--- a/man/src/image/rm.md
+++ b/man/src/image/rm.md
@@ -1,6 +1,11 @@
-Removes one or more images from the host node. This does not remove images from
-a registry. You cannot remove an image of a running container unless you use the
-**-f** option. To see all images on a host use the **docker image ls** command.
+Removes (and un-tags) one or more images from the host node. If an image has
+multiple tags, using this command with the tag as a parameter only removes the
+tag. If the tag is the only one for the image, both the image and the tag are
+removed.
+
+This does not remove images from a registry. You cannot remove an image of a
+running container unless you use the **-f** option. To see all images on a host
+use the **docker image ls** command.
 
 # EXAMPLES
 


### PR DESCRIPTION
The `docker image rm` command can be used not only
to remove images but also remove tags.

This update improves the documentation to make
this clear.

Signed-off-by: Filip Jareš <filipjares@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Update `docker image rm` docs to make it clear it can be used to remove tags.

