### PR TITLE
Updating rmi doc example to specify latest tag

### DIFF
--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -46,11 +46,11 @@ $ docker rmi fd484f19954f
 Error: Conflict, cannot delete image fd484f19954f because it is tagged in multiple repositories, use -f to force
 2013/12/11 05:47:16 Error: failed to remove one or more images
 
-$ docker rmi test1
+$ docker rmi test1:latest
 
 Untagged: test1:latest
 
-$ docker rmi test2
+$ docker rmi test2:latest
 
 Untagged: test2:latest
 
@@ -60,7 +60,7 @@ $ docker images
 REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
 test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
 
-$ docker rmi test
+$ docker rmi test:latest
 
 Untagged: test:latest
 Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

**- What I did**

Updated documentation of `docker rmi` examples to specify the latest tag. This fixes https://github.com/docker/docker.github.io/issues/7390.

(Remaining sections of the PR message removed since this is not a code change.)
