### PR TITLE
Documenting example default-ulimit in daemon.json

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1327,7 +1327,13 @@ This is a full example of the allowed configuration options on Linux:
 	"userns-remap": "",
 	"group": "",
 	"cgroup-parent": "",
-	"default-ulimits": {},
+	"default-ulimits": {
+		"nofile": {
+			"Name": "nofile",
+			"Hard": 64000,
+			"Soft": 64000
+		}
+	},
 	"init": false,
 	"init-path": "/usr/libexec/docker-init",
 	"ipv6": false,


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

**- What I did**

The documentation on setting a default-ulimit using the daemon.json file was missing an example. This includes an example syntax.

(Remaining PR sections removed since this is just a documentation change.)