### PR TITLE
Adjust formatting on daemon.json documentation

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1364,8 +1364,10 @@ This is a full example of the allowed configuration options on Linux:
 			]
 		}
 	},
-	"default-address-pools":[{"base":"172.80.0.0/16","size":24},
-	{"base":"172.90.0.0/16","size":24}]
+	"default-address-pools":[
+		{"base":"172.80.0.0/16","size":24},
+		{"base":"172.90.0.0/16","size":24}
+	]
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

**- What I did**

Cleaned up the formatting of the daemon.json documentation on default-address-pools option to improve readability.

(Rest of the PR fields removed since there are no code changes.)