### PR TITLE
display message improve in run

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -316,7 +316,10 @@ func attachContainer(
 // reportError is a utility method that prints a user-friendly message
 // containing the error that occurred during parsing and a suggestion to get help
 func reportError(stderr io.Writer, name string, str string, withHelp bool) {
-	str = strings.TrimSuffix(str, ".") + "."
+	puncRegexp := regexp.MustCompile(`[\n\r\!\.\?]$`)
+	if !puncRegexp.MatchString(str) {
+		str += "."
+	}
 	if withHelp {
 		str += "\nSee '" + os.Args[0] + " " + name + " --help'."
 	}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker --debug -H tcp://localhost:113 run -itd --name=test12 -p 32770:6379 redis
build/docker: Cannot connect to the Docker daemon at tcp://localhost:113. Is the docker daemon running?.
See 'build/docker run --help'.
root@dockerdemo:~/gocode/src/github.com/docker/cli#
```
There is "." after "?"
I think it looks ugly.

**- How I did it**
When `[\n\r\!\.\?]$`.MatchString(str), no need add "."
