### PR TITLE
err message improve when ssh fail

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -181,7 +181,7 @@ func (c *commandConn) onEOF(eof error) error {
 	c.stderrMu.Lock()
 	stderr := c.stderr.String()
 	c.stderrMu.Unlock()
-	return errors.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%q", c.cmd.Args, werr, stderr)
+	return errors.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%s", c.cmd.Args, werr, stderr)
 }
 
 func ignorableCloseError(err error) bool {


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# ../cli.bak/build/docker -H ssh://localhost run -itd --name=test12 -p 32770:6379 redis
root@localhost's password: 
root@localhost's password: 
../cli.bak/build/docker: error during connect: Post http://docker/v1.39/containers/create?name=test12: command [ssh localhost -- docker system dial-stdio] has exited with exit status 1, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr="\nUsage:\tdocker system COMMAND\n\nManage Docker\n\nOptions:\n\n\nCommands:\n  df          Show docker disk usage\n  events      Get real time events from the server\n  info        Display system-wide information\n  prune       Remove unused data\n\nRun 'docker system COMMAND --help' for more information on a command.\n".
See '../cli.bak/build/docker run --help'.
root@dockerdemo:~/gocode/src/github.com/docker/cli#
```
`\n` can't display

**- How I did it**
A very small change:
use %s replace %q in error message

**- How to verify it**
After fix:
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker -H ssh://localhost run -itd --name=test12 -p 32770:6379 redis
root@localhost's password: 
root@localhost's password: 
build/docker: error during connect: Post http://docker/v1.39/containers/create?name=test12: command [ssh localhost -- docker system dial-stdio] has exited with exit status 1, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
Usage:	docker system COMMAND

Manage Docker

Options:


Commands:
  df          Show docker disk usage
  events      Get real time events from the server
  info        Display system-wide information
  prune       Remove unused data

Run 'docker system COMMAND --help' for more information on a command.

See 'build/docker run --help'.
root@dockerdemo:~/gocode/src/github.com/docker/cli#
```