### PR TITLE
fixes id and name filter in service ls is the prefix not a part

### DIFF
--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -62,7 +62,9 @@ The currently supported filters are:
 
 #### id
 
-The `id` filter matches all or part of a service's ID.
+The `id` filter matches all or the prefix of a service's ID.
+
+The following filter matches services with an ID starting with `0bcjw`:
 
 ```console
 $ docker service ls -f "id=0bcjw"
@@ -110,9 +112,9 @@ w7y0v2yrn620        top                 global              1/1                 
 
 #### name
 
-The `name` filter matches on all or part of a service's name.
+The `name` filter matches on all or the prefix of a service's name.
 
-The following filter matches services with a name containing `redis`.
+The following filter matches services with a name starting with `redis`.
 
 ```console
 $ docker service ls --filter name=redis


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
In "https://docs.docker.com/engine/reference/commandline/service_ls/#filtering" said:
```
The name filter matches on all or part of a service’s name.
The following filter matches services with a name containing redis.
```
But:
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker service ls
ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
0blfshpz1hxh        1redis01            replicated          1/1                 redis:latest        
w15h18jz5yyp        redis               replicated          1/1                 redis:latest        
uzxrl0cgq7am        redis01             replicated          1/1                 redis:latest        
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker service ls --filter name=redis
ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
w15h18jz5yyp        redis               replicated          1/1                 redis:latest        
uzxrl0cgq7am        redis01             replicated          1/1                 redis:latest        
root@dockerdemo:~/gocode/src/github.com/docker/cli#
```
1redis01 containing redis, but not display.

**- How I did it**
For https://github.com/moby/moby/blob/master/daemon/cluster/services.go#L59
The name and id filter is the prefix.
So, I think we should update the doc.
