### PR TITLE
[18.09 backport] builder/prune: rename max-age filter to unused-for in help output

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -45,7 +45,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
-	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'max-age=24h')")
+	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'unused-for=24h')")
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 
 	return cmd


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>
(cherry picked from commit c9ce6dc65643d86f4f661d214d04666503698f99) (https://github.com/docker/cli/pull/1451)
Signed-off-by: Tibor Vass <tibor@docker.com>