### PR TITLE
[18.09 backport] fixes #1441 set default schema to tcp for docker host

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -43,6 +43,26 @@ func TestNewAPIClientFromFlags(t *testing.T) {
 	assert.Check(t, is.Equal(api.DefaultVersion, apiclient.ClientVersion()))
 }
 
+func TestNewAPIClientFromFlagsForDefaultSchema(t *testing.T) {
+	host := ":2375"
+	opts := &flags.CommonOptions{Hosts: []string{host}}
+	configFile := &configfile.ConfigFile{
+		HTTPHeaders: map[string]string{
+			"My-Header": "Custom-Value",
+		},
+	}
+	apiclient, err := NewAPIClientFromFlags(opts, configFile)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("tcp://localhost"+host, apiclient.DaemonHost()))
+
+	expectedHeaders := map[string]string{
+		"My-Header":  "Custom-Value",
+		"User-Agent": UserAgent(),
+	}
+	assert.Check(t, is.DeepEqual(expectedHeaders, apiclient.(*client.Client).CustomHTTPHeaders()))
+	assert.Check(t, is.Equal(api.DefaultVersion, apiclient.ClientVersion()))
+}
+
 func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 	customVersion := "v3.3.3"
 	defer env.Patch(t, "DOCKER_API_VERSION", customVersion)()

--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -77,6 +77,8 @@ func parseDockerDaemonHost(addr string) (string, error) {
 		return parseSimpleProtoAddr("npipe", addrParts[1], DefaultNamedPipe)
 	case "fd":
 		return addr, nil
+	case "ssh":
+		return addr, nil
 	default:
 		return "", fmt.Errorf("Invalid bind address format: %s", addr)
 	}


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1443 for 18.09
fixes https://github.com/docker/cli/issues/1441
fixes https://github.com/moby/moby/issues/38118

```
git checkout -b 18.09_backport_defaulttcpschema upstream/18.09 
git cherry-pick -s -S -x 2431dd144809812e8d3bb03d22af01703a5d36cd
git cherry-pick -s -S -x beed8748c0b7072db3cc1d8a2680a8b4856922a6
git push -u origin
```

cherry-pick was clean; no conflicts