### PR TITLE
[18.09 backport] deprecate devicemapper and legacy overlay storage drivers

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -19,6 +19,22 @@ The following list of features are deprecated in Engine.
 To learn more about Docker Engine's deprecation policy,
 see [Feature Deprecation Policy](https://docs.docker.com/engine/#feature-deprecation-policy).
 
+### Legacy "overlay" storage driver
+
+**Deprecated in Release: v18.09.0**
+
+The `overlay` storage driver is deprecated in favor of the `overlay2` storage
+driver, which has all the benefits of `overlay`, without its limitations (excessive
+inode consumption). The legacy `overlay` storage driver will be removed in a future
+release. Users of the `overlay` storage driver should migrate to the `overlay2`
+storage driver.
+
+The legacy `overlay` storage driver allowed using overlayFS-backed filesystems
+on pre 4.x kernels. Now that all supported distributions are able to run `overlay2`
+(as they are either on kernel 4.x, or have support for multiple lowerdirs
+backported), there is no reason to keep maintaining the `overlay` storage driver.
+
+
 ### Reserved namespaces in engine labels
 
 **Deprecated in Release: v18.06.0**

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -34,6 +34,21 @@ on pre 4.x kernels. Now that all supported distributions are able to run `overla
 (as they are either on kernel 4.x, or have support for multiple lowerdirs
 backported), there is no reason to keep maintaining the `overlay` storage driver.
 
+### device mapper storage driver
+
+**Deprecated in Release: v18.09.0**
+
+The `devicemapper` storage driver is deprecated in favor of `overlay2`, and will
+be removed in a future release. Users of the `devicemapper` storage driver are
+recommended to migrate to a different storage driver, such as `overlay2`, which
+is now the default storage driver.
+
+The `devicemapper` storage driver facilitates running Docker on older (3.x) kernels
+that have no support for other storage drivers (such as overlay2, or AUFS).
+
+Now that support for `overlay2` is added to all supported distros (as they are
+either on kernel 4.x, or have support for multiple lowerdirs backported), there
+is no reason to continue maintenance of the `devicemapper` storage driver.
 
 ### Reserved namespaces in engine labels
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1424 and https://github.com/docker/cli/pull/1425 for 18.09

```
git checkout -b 18.09_backport_legacy_drivers upstream/18.09
git cherry-pick -s -S -x 8bc2aa45a64226db86469ee2d91248937755dcca
git cherry-pick -s -S -x 662441ba311b98ac8eaf5b54475fa878278c0552
```

cherry-pick was clean; no conflicts