### PR TITLE
ssh options env var

### DIFF
--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -9,8 +9,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ssh options env variable
 var (
-	dockerSSHOptions = os.Getenv("DOCKER_SSH_OPTIONS")
+	dockerSSHOptions = os.Getenv("DOCKER_HOST_SSH_OPTIONS")
 )
 
 // New returns cmd and its args
@@ -73,7 +74,7 @@ func (sp *sshSpec) Args() []string {
 		args = append(args, "-p", sp.port)
 	}
 	if sp.options != "" {
-		args = append(args, sp.options)
+		args = append(args, strings.Split(sp.options," ")...)
 	}
 	args = append(args, sp.host)
 	return args

--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -4,8 +4,13 @@ package ssh
 
 import (
 	"net/url"
+	"os"
 
 	"github.com/pkg/errors"
+)
+
+var (
+	dockerSSHOptions = os.Getenv("DOCKER_SSH_OPTIONS")
 )
 
 // New returns cmd and its args
@@ -48,6 +53,7 @@ func parseSSHURL(daemonURL string) (*sshSpec, error) {
 	if u.Fragment != "" {
 		return nil, errors.Errorf("extra fragment: %s", u.Fragment)
 	}
+	sp.options = dockerSSHOptions
 	return &sp, err
 }
 
@@ -55,6 +61,7 @@ type sshSpec struct {
 	user string
 	host string
 	port string
+	options string
 }
 
 func (sp *sshSpec) Args() []string {
@@ -64,6 +71,9 @@ func (sp *sshSpec) Args() []string {
 	}
 	if sp.port != "" {
 		args = append(args, "-p", sp.port)
+	}
+	if sp.options != "" {
+		args = append(args, sp.options)
 	}
 	args = append(args, sp.host)
 	return args

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1370,8 +1370,10 @@ This is a full example of the allowed configuration options on Linux:
 			]
 		}
 	},
-	"default-address-pools":[{"base":"172.80.0.0/16","size":24},
-	{"base":"172.90.0.0/16","size":24}]
+	"default-address-pools":[
+		{"base":"172.80.0.0/16","size":24},
+		{"base":"172.90.0.0/16","size":24}
+	]
 }
 ```
 


### PR DESCRIPTION
Proposal: DOCKER_HOST_SSH_OPTIONS environment variable

**- What I did**
The new "ssh://" protocol for DOCKER_HOST is great, but sometimes we need to use different ssh options than the default. A common scenario if the need to point to a project-specific ssh config file instead of the default one at "~/.ssh/config".

**- How I did it**
An environment variable DOCKER_HOST_SSH_OPTIONS that can hold options for the ssh command docker uses when DOCKER_HOST contains the "ssh://" prefix.

**- How to verify it**
export DOCKER_HOST_SSH_OPTIONS="-F /my/own/ssh.cfg"
export DOCKER_HOST="ssh://somehost"
docker version

**- Description for the changelog**
Just a couple lines at ssh.go, no big deal.

**- A picture of a cute animal (not mandatory but encouraged)**

                    ##        .            
              ## ## ##       ==            
           ## ## ## ##      ===            
       /""""""""""""""""\___/ ===        
  ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~   
       \______ o          __/            
         \    \        __/             
          \____\______/                
 
