### PR TITLE
Added confirmation when removing volumes #1437

### DIFF
--- a/cli/command/volume/remove.go
+++ b/cli/command/volume/remove.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/prompt"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
 )
@@ -46,14 +48,23 @@ func runRemove(ctx context.Context, dockerCLI command.Cli, opts *removeOptions) 
 
 	var errs []error
 	for _, name := range opts.volumes {
-		_, err := apiClient.VolumeRemove(ctx, name, client.VolumeRemoveOptions{
+		deleteRemote, err := prompt.Confirm(ctx, os.Stdin, dockerCLI.Out(), fmt.Sprintf("\nPlease confirm you would like to remove volume %s ?", name))
+		if err != nil {
+			return err
+		}
+		if !deleteRemote {
+			fmt.Fprintf(dockerCLI.Out(), "Volume %s wasn't deleted.\n", name)
+			continue
+		}
+
+		_, err = apiClient.VolumeRemove(ctx, name, client.VolumeRemoveOptions{
 			Force: opts.force,
 		})
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		_, _ = fmt.Fprintln(dockerCLI.Out(), name)
+		_, _ = fmt.Fprintf(dockerCLI.Out(), "Successfully deleted volume %s\n", name)
 	}
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
**- What I did**
Confirmation is now required for deleting a volume with `docker volume rm`. (#1437)
It will ask a confirmation for each volumes.

**- How I did it**
Simply added a condition in `/cli/command/volume/remove.go`.

**- How to verify it**
Create some volumes with `docker volume create [name]` (eg. `docker volume create dog-volume`, `docker volume create cat-volume`, `docker volume create rabbit-volume`)  then delete them with `docker volume rm` (`docker volume rm cat-volume dog-volume`).


**- A picture of a cute animal**
![image](https://user-images.githubusercontent.com/14354161/47267306-26c80280-d542-11e8-893c-1d4c8c38406d.png)


