### PR TITLE
fixes #1452 set path separator to slash in interpolation and add a test case

### DIFF
--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -108,7 +108,7 @@ func newPathError(path Path, err error) error {
 	}
 }
 
-const pathSeparator = "."
+const pathSeparator = "/"
 
 // PathMatchAll is a token used as part of a Path to match any key at that level
 // in the nested structure

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -58,7 +58,7 @@ func TestInvalidInterpolation(t *testing.T) {
 		},
 	}
 	_, err := Interpolate(services, Options{LookupValue: defaultMapping})
-	assert.Error(t, err, `invalid interpolation format for servicea.image: "${". You may need to escape any $ with another $.`)
+	assert.Error(t, err, `invalid interpolation format for servicea/image: "${". You may need to escape any $ with another $.`)
 }
 
 func TestInterpolateWithDefaults(t *testing.T) {

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -566,6 +566,26 @@ volumes:
 	assert.Check(t, is.Equal(home, config.Volumes["test"].Driver))
 }
 
+func TestLoadWithDotInServiceName(t *testing.T) {
+	dict, err := ParseYAML([]byte(`
+version: "3.4"
+services:
+  app.0:
+    ulimits:
+      nofile:
+        soft: ${APP_NOFILE}
+        hard: ${APP_NOFILE}`))
+	assert.NilError(t, err)
+	env := map[string]string{
+		"APP_NOFILE": "555",
+	}
+	config, err := Load(buildConfigDetails(dict, env))
+	assert.NilError(t, err)
+	assert.Check(t, is.Len(config.Services, 1))
+	assert.Check(t, is.Equal(config.Services[0].Ulimits["nofile"].Hard, 555))
+	assert.Check(t, is.Equal(config.Services[0].Ulimits["nofile"].Soft, 555))
+}
+
 func TestLoadWithInterpolationCastFull(t *testing.T) {
 	dict, err := ParseYAML([]byte(`
 version: "3.4"


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
Please see issue #1452 , Variable type conversion in Compose file breaks if service name contains dot.

**- How I did it**
set path separator from dot to slash in interpolation and add a test case

**- How to verify it**
After this patch:
```
root@dockerdemo:~/testd# cat file2.yaml 
version: "3.0"
services:
  app.test_1:
    image: redis
    ulimits:
      nofile:
        soft: ${APP_NOFILE}
        hard: ${APP_NOFILE}
root@dockerdemo:~/testd#
```
```
root@dockerdemo:~/testd# APP_NOFILE=1 ~/gocode/src/github.com/docker/cli/build/docker stack deploy -c file2.yaml stk2
Creating service stk2_app.test_1
```

**- Description for the changelog**
set path separator from dot to slash in interpolation

**- Addition info**
But, but, the daemon said:
failed to create service stk2_app.test_1: Error response from daemon: rpc error: code = InvalidArgument desc = name must be valid as a DNS name component
The daemon's check regexp is `^[a-zA-Z0-9](?:[-_]*[A-Za-z0-9]+)*$`, don't contain dot.
But I think this is another issue( see #1470 ).
At least, by this patch, we can get the right response.