### PR TITLE
Enhancement: don't need to type ssh password twice when docker logs with ssh

### DIFF
--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -50,6 +50,11 @@ func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
 func runLogs(dockerCli command.Cli, opts *logsOptions) error {
 	ctx := context.Background()
 
+	c, err := dockerCli.Client().ContainerInspect(ctx, opts.container)
+	if err != nil {
+		return err
+	}
+
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
@@ -60,16 +65,11 @@ func runLogs(dockerCli command.Cli, opts *logsOptions) error {
 		Tail:       opts.tail,
 		Details:    opts.details,
 	}
-	responseBody, err := dockerCli.Client().ContainerLogs(ctx, opts.container, options)
+	responseBody, err := dockerCli.Client().ContainerLogs(ctx, c.ID, options)
 	if err != nil {
 		return err
 	}
 	defer responseBody.Close()
-
-	c, err := dockerCli.Client().ContainerInspect(ctx, opts.container)
-	if err != nil {
-		return err
-	}
 
 	if c.Config.Tty {
 		_, err = io.Copy(dockerCli.Out(), responseBody)


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
When use ssh host, docker logs need user to type password twice.
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# docker -H ssh://localhost logs test1
root@localhost's password: (First time)
root@localhost's password: (Second time)
1:C 11 Oct 03:41:51.863 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 11 Oct 03:41:51.863 # Redis version=4.0.11, bits=64, commit=00000000, modified=0, pid=1, just started
```

**- How I did it**
Because ContainerInspect is behind ContainerLogs, but ContainerLogs don't close the response, so ContainerInspect can't reuse the connection.
So, move ContainerInspect to the ahead of ContainerLogs.

**- How to verify it**
```
root@dockerdemo:~/gocode/src/github.com/docker/cli# build/docker -H ssh://localhost logs test1
root@localhost's password: (Just once)
1:C 11 Oct 03:41:51.863 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 11 Oct 03:41:51.863 # Redis version=4.0.11, bits=64, commit=00000000, modified=0, pid=1, just started
```

**- Description for the changelog**
Move ContainerInspect to the ahead of ContainerLogs, so we can reuse docker host connection.

**- A picture of a cute animal (not mandatory but encouraged)**
![n o wn5glp4xjfbgq evcv](https://user-images.githubusercontent.com/783424/47289298-961a2100-d62c-11e8-93fe-c93b54cf1f6e.png)
