### PR TITLE
 build: update session support detection

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -350,7 +350,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		buildCtx = dockerfileCtx
 	}
 
-	s, err := trySession(dockerCli, contextDir)
+	s, err := trySession(dockerCli, contextDir, true)
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -43,7 +43,7 @@ var errDockerfileConflict = errors.New("ambiguous Dockerfile source: both stdin 
 func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 	ctx := appcontext.Context()
 
-	s, err := trySession(dockerCli, options.context)
+	s, err := trySession(dockerCli, options.context, false)
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -27,16 +27,16 @@ import (
 
 const clientSessionRemote = "client-session"
 
-func isSessionSupported(dockerCli command.Cli) bool {
-	if versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.39") {
+func isSessionSupported(dockerCli command.Cli, forStream bool) bool {
+	if !forStream && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.39") {
 		return true
 	}
 	return dockerCli.ServerInfo().HasExperimental && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.31")
 }
 
-func trySession(dockerCli command.Cli, contextDir string) (*session.Session, error) {
+func trySession(dockerCli command.Cli, contextDir string, forStream bool) (*session.Session, error) {
 	var s *session.Session
-	if isSessionSupported(dockerCli) {
+	if isSessionSupported(dockerCli, forStream) {
 		sharedKey, err := getBuildSharedKey(contextDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get build shared key")


### PR DESCRIPTION
Avoid testing for session support in non-buildkit builder to support
servers that falsely report as `1.39` compatible