### PR TITLE
fix 1476 let ssh use stdin to type password when docker run with -it

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -182,37 +182,42 @@ func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptio
 		}()
 	}
 	attach := config.AttachStdin || config.AttachStdout || config.AttachStderr
+	statusChan := waitExitOrRemoved(ctx, dockerCli, createResponse.ID, copts.autoRemove)
+	startc := func() error {
+		if err := client.ContainerStart(ctx, createResponse.ID, types.ContainerStartOptions{}); err != nil {
+			// If we have hijackedIOStreamer, we should notify
+			// hijackedIOStreamer we are going to exit and wait
+			// to avoid the terminal are not restored.
+			if attach {
+				cancelFun()
+				<-errCh
+			}
+
+			reportError(stderr, "run", err.Error(), false)
+			if copts.autoRemove {
+				// wait container to be removed
+				<-statusChan
+			}
+			return runStartContainerErr(err)
+		}
+		return nil
+	}
 	if attach {
 		if opts.detachKeys != "" {
 			dockerCli.ConfigFile().DetachKeys = opts.detachKeys
 		}
 
-		close, err := attachContainer(ctx, dockerCli, &errCh, config, createResponse.ID)
+		// attach and start the container
+		// use callback to let user type ssh password when needed
+		close, err := attachContainer(ctx, dockerCli, &errCh, config, createResponse.ID, startc)
 
 		if err != nil {
 			return err
 		}
 		defer close()
-	}
-
-	statusChan := waitExitOrRemoved(ctx, dockerCli, createResponse.ID, copts.autoRemove)
-
-	//start the container
-	if err := client.ContainerStart(ctx, createResponse.ID, types.ContainerStartOptions{}); err != nil {
-		// If we have hijackedIOStreamer, we should notify
-		// hijackedIOStreamer we are going to exit and wait
-		// to avoid the terminal are not restored.
-		if attach {
-			cancelFun()
-			<-errCh
-		}
-
-		reportError(stderr, "run", err.Error(), false)
-		if copts.autoRemove {
-			// wait container to be removed
-			<-statusChan
-		}
-		return runStartContainerErr(err)
+	} else {
+		// start the container
+		startc()
 	}
 
 	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && dockerCli.Out().IsTerminal() {
@@ -253,7 +258,7 @@ func attachContainer(
 	errCh *chan error,
 	config *container.Config,
 	containerID string,
-) (func(), error) {
+	beforeHijack func() error) (func(), error) {
 	stdout, stderr := dockerCli.Out(), dockerCli.Err()
 	var (
 		out, cerr io.Writer
@@ -287,6 +292,14 @@ func attachContainer(
 		// means server met an error and put it in Hijacked connection
 		// keep the error and read detailed error message from hijacked connection later
 		return nil, errAttach
+	}
+
+	if beforeHijack != nil {
+		err := beforeHijack()
+		if err != nil {
+			resp.Close()
+			return nil, err
+		}
 	}
 
 	ch := make(chan error, 1)


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

**- What I did**
As the issue #1476, when use ssh with password, docker run -it will fail.

**- How I did it**
Because after attachContainer, ssh can't use stdin to type password.
So, in func attachContainer, use a call back func beforeHijack to run ContainerStart before hijackedIOStreamer.

**- How to verify it**
After fix:
```
docker -H ssh://localhost  run --name=testssh -it --entrypoint=/bin/bash docker.acmcoder.com/public/ubuntu:ssh
root@localhost's password: 
root@localhost's password: 
root@localhost's password: 
root@25eaf3b846dc:/# ls -lh
total 64K
drwxr-xr-x   2 root root 4.0K Oct  1  2015 bin
drwxr-xr-x   2 root root 4.0K Apr 10  2014 boot
```

**- Description for the changelog**
modify attachContainer add a param "beforeHijack func() error"

**- A picture of a cute animal (not mandatory but encouraged)**
![h _zaman0 0 al 3 _luj](https://user-images.githubusercontent.com/783424/47334692-59950680-d6ba-11e8-8841-43d5133dc72e.png)
