### PR TITLE
[18.09 backport] Fix `docker invalid-subcommand` regression

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -33,6 +33,9 @@ func newDockerCommand(dockerCli *command.DockerCli) *cobra.Command {
 		SilenceErrors:    true,
 		TraverseChildren: true,
 		Args:             noArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return command.ShowHelp(dockerCli.Err())(cmd, args)
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// flags must be the top-level command flags, not cmd.Flags()
 			opts.Common.SetDefaultOptions(flags)

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -30,4 +31,21 @@ func TestExitStatusForInvalidSubcommandWithHelpFlag(t *testing.T) {
 	cmd.SetArgs([]string{"help", "invalid"})
 	err := cmd.Execute()
 	assert.Error(t, err, "unknown help topic: invalid")
+}
+
+func TestExitStatusForInvalidSubcommand(t *testing.T) {
+	discard := ioutil.Discard
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard, false, nil))
+	cmd.SetArgs([]string{"invalid"})
+	err := cmd.Execute()
+	assert.Check(t, is.ErrorContains(err, "docker: 'invalid' is not a docker command."))
+}
+
+func TestVersion(t *testing.T) {
+	var b bytes.Buffer
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, &b, &b, false, nil))
+	cmd.SetArgs([]string{"--version"})
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(b.String(), "Docker version"))
 }


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1429 for 18.09


```
git checkout -b 18.09_backport_fix_docker_invalid_subcommand upstream/18.09
git cherry-pick -s -S -x d708cada43f31b79462e6d7325fbcfd75b47ae29
```

cherry-pick was clean; no conflicts


Starting with a3fe7d62b8274d69930286fb14653cccf37acadb,
`docker invalid-subcommand` did not exit with non-zero status.

Fix #1428

