### PR TITLE
docs, ssh: unsupport password auth explicitly

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -191,7 +191,10 @@ $ docker -H ssh://example.com ps
 ```
 
 To use SSH connection, you need to set up `ssh` so that it can reach the
-remote host with public key authentication.
+remote host with public key authentication. Password authentication is not
+supported. If your key is protected with passphrase, you need to set up
+`ssh-agent`.
+
 Also, you need to have `docker` binary 18.09 or later on the daemon host.
 
 #### Bind Docker to another host/port or a Unix socket


### PR DESCRIPTION
The issue with password auth is tracked in #1476 and #1477 .

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

@thaJeztah @lifubang 