### PR TITLE
[18.09 backport] various docs fixes

### DIFF
--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -148,7 +148,7 @@ func TestAddStageSigners(t *testing.T) {
 	assert.NilError(t, err)
 	changeList := cl.List()
 	assert.Check(t, is.Len(changeList, 4))
-	// ordering is determinstic:
+	// ordering is deterministic:
 
 	// first change is for targets/user key creation
 	newSignerKeyChange := changeList[0]

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -198,7 +198,7 @@ The docker login command is removing the ability to automatically register for a
 
 **Target For Removal In Release: v17.06**
 
-The flag `--security-opt` doesn't use the colon separator(`:`) anymore to divide keys and values, it uses the equal symbol(`=`) for consistency with other similar flags, like `--storage-opt`.
+The flag `--security-opt` doesn't use the colon separator (`:`) anymore to divide keys and values, it uses the equal symbol (`=`) for consistency with other similar flags, like `--storage-opt`.
 
 ### `/containers/(id or name)/copy` endpoint
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1379,7 +1379,7 @@ Keep the following things in mind about volumes in the `Dockerfile`.
   data within the volume after it has been declared, those changes will be discarded.
 
 - **JSON formatting**: The list is parsed as a JSON array.
-  You must enclose words with double quotes (`"`)rather than single quotes (`'`).
+  You must enclose words with double quotes (`"`) rather than single quotes (`'`).
 
 - **The host directory is declared at container run-time**: The host directory
   (the mountpoint) is, by its nature, host-dependent. This is to preserve image

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -85,7 +85,7 @@ Options:
       --memory-reservation string     Memory soft limit
       --memory-swap string            Swap limit equal to memory plus swap: '-1' to enable unlimited swap
       --memory-swappiness int         Tune container memory swappiness (0 to 100) (default -1)
-      --mount value                   Attach a filesytem mount to the container (default [])
+      --mount value                   Attach a filesystem mount to the container (default [])
       --name string                   Assign a name to the container
       --network-alias value           Add network-scoped alias for the container (default [])
       --network string                Connect a container to a network (default "default")

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -256,5 +256,5 @@ docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
 Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
 the required device when it is added.
 
-NOTE: initially present devices still need to be explicitely added to
+NOTE: initially present devices still need to be explicitly added to
 the create/run command

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1327,7 +1327,13 @@ This is a full example of the allowed configuration options on Linux:
 	"userns-remap": "",
 	"group": "",
 	"cgroup-parent": "",
-	"default-ulimits": {},
+	"default-ulimits": {
+		"nofile": {
+			"Name": "nofile",
+			"Hard": 64000,
+			"Soft": 64000
+		}
+	},
 	"init": false,
 	"init-path": "/usr/libexec/docker-init",
 	"ipv6": false,

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -191,7 +191,10 @@ $ docker -H ssh://example.com ps
 ```
 
 To use SSH connection, you need to set up `ssh` so that it can reach the
-remote host with public key authentication.
+remote host with public key authentication. Password authentication is not
+supported. If your key is protected with passphrase, you need to set up
+`ssh-agent`.
+
 Also, you need to have `docker` binary 18.09 or later on the daemon host.
 
 #### Bind Docker to another host/port or a Unix socket

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1424,6 +1424,16 @@ This is a full example of the allowed configuration options on Windows:
 }
 ```
 
+#### Feature options
+The optional field `features` in `daemon.json` allows users to enable or disable specific 
+daemon features. For example, `{"features":{"buildkit": true}}` enables `buildkit` as the 
+default docker image builder.
+
+The list of currently supported feature options:
+- `buildkit`: It enables `buildkit` as default builder when set to `true` or disables it by
+`false`. Note that if this option is not explicitly set in the daemon config file, then it
+is up to the cli to determine which builder to invoke.
+
 #### Configuration reload behavior
 
 Some options can be reconfigured when the daemon is running without requiring

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -85,6 +85,8 @@ you can download them from:
 - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
 - [pass](https://www.passwordstore.org/): https://github.com/docker/docker-credential-helpers/releases
 
+#### Configure the credentials store
+
 You need to specify the credentials store in `$HOME/.docker/config.json`
 to tell the docker engine to use it. The value of the config property should be
 the suffix of the program to use (i.e. everything after `docker-credential-`).
@@ -99,7 +101,7 @@ For example, to use `docker-credential-osxkeychain`:
 If you are currently logged in, run `docker logout` to remove
 the credentials from the file and run `docker login` again.
 
-### Default behavior
+#### Default behavior
 
 By default, Docker looks for the native binary on each of the platforms, i.e.
 "osxkeychain" on macOS, "wincred" on windows, and "pass" on Linux. A special
@@ -108,7 +110,7 @@ it cannot find the "pass" binary. If none of these binaries are present, it
 stores the credentials (i.e. password) in base64 encoding in the config files
 described above.
 
-### Credential helper protocol
+#### Credential helper protocol
 
 Credential helpers can be any program or script that follows a very simple protocol.
 This protocol is heavily inspired by Git, but it differs in the information shared.
@@ -162,7 +164,7 @@ designated programs to handle credentials for *specific registries*. The default
 credential store (`credsStore` or the config file itself) will not be used for
 operations concerning credentials of the specified registries.
 
-### Logging out
+#### Configure credential helpers
 
 If you are currently logged in, run `docker logout` to remove
 the credentials from the default store.
@@ -182,3 +184,7 @@ For example:
   }
 }
 ```
+
+## Related commands
+
+* [logout](logout.md)

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -30,3 +30,7 @@ Options:
 ```bash
 $ docker logout localhost:8080
 ```
+
+## Related commands
+
+* [login](login.md)

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -46,11 +46,11 @@ $ docker rmi fd484f19954f
 Error: Conflict, cannot delete image fd484f19954f because it is tagged in multiple repositories, use -f to force
 2013/12/11 05:47:16 Error: failed to remove one or more images
 
-$ docker rmi test1
+$ docker rmi test1:latest
 
 Untagged: test1:latest
 
-$ docker rmi test2
+$ docker rmi test2:latest
 
 Untagged: test2:latest
 
@@ -60,7 +60,7 @@ $ docker images
 REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
 test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
 
-$ docker rmi test
+$ docker rmi test:latest
 
 Untagged: test:latest
 Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -418,7 +418,7 @@ $ docker run -l my-label --label com.example.foo=bar ubuntu bash
 ```
 
 The `my-label` key doesn't specify a value so the label defaults to an empty
-string(`""`). To add multiple labels, repeat the label flag (`-l` or `--label`).
+string (`""`). To add multiple labels, repeat the label flag (`-l` or `--label`).
 
 The `key=value` must be unique to avoid overwriting the label value. If you
 specify labels with identical keys but different values, each subsequent value

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1085,7 +1085,7 @@ per second from `/dev/sda`:
 
     $ docker run -it --device-read-bps /dev/sda:1mb ubuntu
 
-The `--device-write-bps` flag limits the write rate (bytes per second)to a device.
+The `--device-write-bps` flag limits the write rate (bytes per second) to a device.
 For example, this command creates a container and limits the write rate to `1mb`
 per second for `/dev/sda`:
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1555,7 +1555,7 @@ The example below mounts an empty tmpfs into the container with the `rw`,
     If neither 'rw' or 'ro' is specified then the volume is mounted in
     read-write mode.
 
-    The `nocopy` modes is used to disable automatic copying requested volume
+    The `nocopy` mode is used to disable automatically copying the requested volume
     path in the container to the volume storage location.
     For named volumes, `copy` is the default mode. Copy modes are not supported
     for bind-mounted volumes.

--- a/man/src/image/tag.md
+++ b/man/src/image/tag.md
@@ -48,7 +48,7 @@ repository with "version1.0.test":
 
 ## Tagging an image for a private repository
 
-To push an image to a private registry and not the central Docker
+Before pushing an image to a private registry and not the central Docker
 registry you must tag it with the registry hostname and port (if needed).
 
     docker image tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0


### PR DESCRIPTION

Cherry-pick of the following documentation fixes for 18.09:

- https://github.com/docker/cli/pull/1307 update docs with the new features option in daemon.json
- https://github.com/docker/cli/pull/1314 update docs with currently supported features options
- https://github.com/docker/cli/pull/1351 Typo fix: filesytem -> filesystem
- https://github.com/docker/cli/pull/1352 Typo fix
- https://github.com/docker/cli/pull/1399 Docs: Add Spaces Around Parenthesis Where Needed
- https://github.com/docker/cli/pull/1414 Fix login documentation layout
- https://github.com/docker/cli/pull/1418 Clarify in docs that docker tag doesn't publish
- https://github.com/docker/cli/pull/1434 Minor typo fix in run documentation
- https://github.com/docker/cli/pull/1445 Updating rmi doc example to specify latest tag
- https://github.com/docker/cli/pull/1446 Documenting example default-ulimit in daemon.json
- https://github.com/docker/cli/pull/1482 docs, ssh: unsupport password auth explicitly



```
git checkout -b 18.09_backport_docs_fixes upstream/18.09
git cherry-pick -s -S -x 3e0b0a6692e24df36bce5cbcee23150775054011
git cherry-pick -s -S -x d6567066782c1003f6b7b444dcbb6cbbea0461d7
git cherry-pick -s -S -x 2eb95909ee6f9529e25be00ac798ca0b5d5ecc9c
git cherry-pick -s -S -x ca5e4531800bd08f88c5b4b1c382094edcdd5d5e
git cherry-pick -s -S -x 2b0fdd0f17dba1ae16fbb19c061c4b81d3eb92d5
git cherry-pick -s -S -x a0e3ec87909320e1d8214ded8f8b42cea3f3a829
git cherry-pick -s -S -x 4ed484bac42c7b9bf862490a4cb0fa5b5255228c
git cherry-pick -s -S -x 50143cff1213cb5d9db57bfabf22615e15baaeea
git cherry-pick -s -S -x f913b73c81dfa8270a2d645f82b19764cb23017a
git cherry-pick -s -S -x 3f4f450941acf57b1a71e53bfcd78afcc079fce6
git cherry-pick -s -S -x 16b014e062c3a95fc718140063e77af83d81af87
```

cherry-picks were clean; no conflicts