### PR TITLE
moby/moby#37961 : cp command can copy multiple files

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -95,7 +95,7 @@ func separateCopyCommands(dockerCli command.Cli, opts copyOptions, args []string
 		case acrossContainers:
 			return errors.New("copying between containers is not supported")
 		default:
-			return errors.New("Invalid use of cp command\n See 'docker cp --help'.")
+			return errors.New("invalid use of cp command\n see 'docker cp --help'")
 		}
 	}
 

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -22,7 +22,7 @@ func TestRunCopyWithInvalidArguments(t *testing.T) {
 		doc         string
 		options     copyOptions
 		expectedErr string
-		direction	copyDirection
+		direction   copyDirection
 	}{
 		{
 			doc: "copy between container",
@@ -31,7 +31,7 @@ func TestRunCopyWithInvalidArguments(t *testing.T) {
 				destination: splitCpArg("second:/path"),
 			},
 			expectedErr: "copying between containers is not supported",
-			direction: acrossContainers,
+			direction:   acrossContainers,
 		},
 		{
 			doc: "copy without a container",

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -26,16 +26,16 @@ func TestSeparateCopyCommands(t *testing.T) {
 		args        []string
 	}{
 		{
-			doc: "copy between container",
+			doc:         "copy between container",
 			expectedErr: "copying between containers is not supported",
 			direction:   acrossContainers,
-			args: []string {"first:/path", "first:/path"},
+			args:        []string{"first:/path", "first:/path"},
 		},
 		{
-			doc: "copy without container",
+			doc:         "copy without container",
 			expectedErr: "invalid use of cp command\n see 'docker cp --help'",
 			direction:   0,
-			args: []string {"/path", "/path"},
+			args:        []string{"/path", "/path"},
 		},
 	}
 	for _, testcase := range testcases {
@@ -54,28 +54,28 @@ func TestGetCpDirection(t *testing.T) {
 		expectedResult copyDirection
 	}{
 		{
-			doc: "container to container",
-			source:      splitCpArg("first:/path"),
-			destination: splitCpArg("second:/path"),
+			doc:            "container to container",
+			source:         splitCpArg("first:/path"),
+			destination:    splitCpArg("second:/path"),
 			expectedResult: acrossContainers,
 		},
 		{
-			doc: "source to container",
-			source:      splitCpArg("/path"),
-			destination: splitCpArg("second:/path"),
-			expectedResult: acrossContainers,
+			doc:            "source to container",
+			source:         splitCpArg("/path"),
+			destination:    splitCpArg("second:/path"),
+			expectedResult: toContainer,
 		},
 		{
-			doc: "container to source",
-			source:      splitCpArg("first:/path"),
-			destination: splitCpArg("/path"),
-			expectedResult: acrossContainers,
+			doc:            "container to source",
+			source:         splitCpArg("first:/path"),
+			destination:    splitCpArg("/path"),
+			expectedResult: fromContainer,
 		},
 		{
-			doc: "source to source",
-			source:      splitCpArg("/path"),
-			destination: splitCpArg("/path"),
-			expectedResult: acrossContainers,
+			doc:            "source to source",
+			source:         splitCpArg("/path"),
+			destination:    splitCpArg("/path"),
+			expectedResult: 0,
 		},
 	}
 	for _, testcase := range testcases {


### PR DESCRIPTION
Implemented multiple files copy functionality, described and requested under moby/moby issue no moby/moby#37961

Example: 
`docker cp container:file-a container:file-b local`
`docker cp local-file-a local-file-b container:folder`

**- What and How I did**
I've modified cp.go to handle more than 2 arguments, handled error cases as were defined before, where logic states for N number of sources and 1 destination only.

**- How to verify it**
Now it is possible to use docker cp as defined in example.

**- Description for the changelog**
docker cp support for multiple files in one command