### PR TITLE
Adds flag modifying pull behavior for running and creating containers

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -25,7 +25,7 @@ import (
 // Pull constants
 const (
 	PullImageAlways  = "always"
-	PullImageMissing = "missing" // Default (matches previous bahevior)
+	PullImageMissing = "missing" // Default (matches previous behavior)
 	PullImageNever   = "never"
 )
 

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/fs"
@@ -76,154 +75,82 @@ func TestCIDFileCloseWithWrite(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func TestCreateContainerPullsImageIfMissing(t *testing.T) {
+func TestCreateContainerImagePullPolicy(t *testing.T) {
 	imageName := "does-not-exist-locally"
-	responseCounter := 0
 	containerID := "abcdef"
-
-	client := &fakeClient{
-		createContainerFunc: func(
-			config *container.Config,
-			hostConfig *container.HostConfig,
-			networkingConfig *network.NetworkingConfig,
-			containerName string,
-		) (container.ContainerCreateCreatedBody, error) {
-			defer func() { responseCounter++ }()
-			switch responseCounter {
-			case 0:
-				return container.ContainerCreateCreatedBody{}, fakeNotFound{}
-			case 1:
-				return container.ContainerCreateCreatedBody{ID: containerID}, nil
-			default:
-				return container.ContainerCreateCreatedBody{}, errors.New("unexpected")
-			}
-		},
-		imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("")), nil
-		},
-		infoFunc: func() (types.Info, error) {
-			return types.Info{IndexServerAddress: "http://indexserver"}, nil
-		},
-	}
-	cli := test.NewFakeCli(client)
 	config := &containerConfig{
 		Config: &container.Config{
 			Image: imageName,
 		},
 		HostConfig: &container.HostConfig{},
 	}
-	body, err := createContainer(context.Background(), cli, config, &createOptions{
-		name:      "name",
-		platform:  runtime.GOOS,
-		untrusted: true,
-		pull:      PullImageMissing,
-	})
-	assert.NilError(t, err)
-	expected := container.ContainerCreateCreatedBody{ID: containerID}
-	assert.Check(t, is.DeepEqual(expected, *body))
-	stderr := cli.ErrBuffer().String()
-	assert.Check(t, is.Contains(stderr, "Unable to find image 'does-not-exist-locally:latest' locally"))
-}
 
-func TestCreateContainerNeverPullsImage(t *testing.T) {
-	imageName := "does-not-exist-locally"
-	responseCounter := 0
-	pullCounter := 0
-
-	client := &fakeClient{
-		createContainerFunc: func(
-			config *container.Config,
-			hostConfig *container.HostConfig,
-			networkingConfig *network.NetworkingConfig,
-			containerName string,
-		) (container.ContainerCreateCreatedBody, error) {
-			defer func() { responseCounter++ }()
-			switch responseCounter {
-			case 0:
-				return container.ContainerCreateCreatedBody{}, fakeNotFound{}
-			default:
-				return container.ContainerCreateCreatedBody{}, errors.New("unexpected")
-			}
+	cases := []struct {
+		PullPolicy      string
+		ExpectedPulls   int
+		ExpectedBody    container.ContainerCreateCreatedBody
+		ExpectedErrMsg  string
+		ResponseCounter int
+	}{
+		{
+			PullPolicy:    PullImageMissing,
+			ExpectedPulls: 1,
+			ExpectedBody:  container.ContainerCreateCreatedBody{ID: containerID},
+		}, {
+			PullPolicy:      PullImageAlways,
+			ExpectedPulls:   1,
+			ExpectedBody:    container.ContainerCreateCreatedBody{ID: containerID},
+			ResponseCounter: 1, // This lets us return a container on the first pull
+		}, {
+			PullPolicy:     PullImageNever,
+			ExpectedPulls:  0,
+			ExpectedErrMsg: "error fake not found",
 		},
-		imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
-			defer func() { pullCounter++ }()
-			switch pullCounter {
-			case 0:
+	}
+	for _, c := range cases {
+		pullCounter := 0
+
+		client := &fakeClient{
+			createContainerFunc: func(
+				config *container.Config,
+				hostConfig *container.HostConfig,
+				networkingConfig *network.NetworkingConfig,
+				containerName string,
+			) (container.ContainerCreateCreatedBody, error) {
+				defer func() { c.ResponseCounter++ }()
+				switch c.ResponseCounter {
+				case 0:
+					return container.ContainerCreateCreatedBody{}, fakeNotFound{}
+				default:
+					return container.ContainerCreateCreatedBody{ID: containerID}, nil
+				}
+			},
+			imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
+				defer func() { pullCounter++ }()
 				return ioutil.NopCloser(strings.NewReader("")), nil
-			default:
-				return nil, errors.New("unexpected pull")
-			}
-		},
-		infoFunc: func() (types.Info, error) {
-			return types.Info{IndexServerAddress: "http://indexserver"}, nil
-		},
-	}
-	cli := test.NewFakeCli(client)
-	config := &containerConfig{
-		Config: &container.Config{
-			Image: imageName,
-		},
-		HostConfig: &container.HostConfig{},
-	}
-	_, err := createContainer(context.Background(), cli, config, &createOptions{
-		name:      "name",
-		platform:  runtime.GOOS,
-		untrusted: true,
-		pull:      PullImageNever,
-	})
-	assert.ErrorContains(t, err, "fake not found")
-}
-
-func TestCreateContainerAlwaysPullsImage(t *testing.T) {
-	imageName := "does-not-exist-locally"
-	pullTries := 7
-	responseCounter := 0
-	pullCounter := 0
-	containerID := "abcdef"
-
-	client := &fakeClient{
-		createContainerFunc: func(
-			config *container.Config,
-			hostConfig *container.HostConfig,
-			networkingConfig *network.NetworkingConfig,
-			containerName string,
-		) (container.ContainerCreateCreatedBody, error) {
-			defer func() { responseCounter++ }()
-			switch responseCounter {
-			default:
-				return container.ContainerCreateCreatedBody{ID: containerID}, nil
-			}
-		},
-		imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
-			defer func() { pullCounter++ }()
-			return ioutil.NopCloser(strings.NewReader("")), nil
-		},
-		infoFunc: func() (types.Info, error) {
-			return types.Info{IndexServerAddress: "http://indexserver"}, nil
-		},
-	}
-	cli := test.NewFakeCli(client)
-	config := &containerConfig{
-		Config: &container.Config{
-			Image: imageName,
-		},
-		HostConfig: &container.HostConfig{},
-	}
-	for i := 0; i < pullTries; i++ {
+			},
+			infoFunc: func() (types.Info, error) {
+				return types.Info{IndexServerAddress: "http://indexserver"}, nil
+			},
+		}
+		cli := test.NewFakeCli(client)
 		body, err := createContainer(context.Background(), cli, config, &createOptions{
 			name:      "name",
 			platform:  runtime.GOOS,
 			untrusted: true,
-			pull:      PullImageAlways,
+			pull:      c.PullPolicy,
 		})
-		assert.NilError(t, err)
-		expected := container.ContainerCreateCreatedBody{ID: containerID}
-		assert.Check(t, is.DeepEqual(expected, *body))
+
+		if c.ExpectedErrMsg != "" {
+			assert.ErrorContains(t, err, c.ExpectedErrMsg)
+		} else {
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(c.ExpectedBody, *body))
+		}
+
+		assert.Check(t, is.Equal(c.ExpectedPulls, pullCounter))
 	}
-
-	assert.Check(t, is.Equal(responseCounter, pullCounter))
 }
-
 func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -56,6 +56,8 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&opts.sigProxy, "sig-proxy", true, "Proxy received signals to the process")
 	flags.StringVar(&opts.name, "name", "", "Assign a name to the container")
 	flags.StringVar(&opts.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
+	flags.StringVar(&opts.createOptions.pull, "pull", PullImageMissing,
+		`Pull image before running ("`+PullImageAlways+`"|"`+PullImageMissing+`"|"`+PullImageNever+`")`)
 
 	// Add an explicit help that doesn't have a `-h` to prevent the conflict
 	// with hostname


### PR DESCRIPTION
Should close issue https://github.com/moby/moby/issues/34394

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
 - This PR adds a new `--pull` flag to `docker run` and `docker create`, following the proposal in (https://github.com/moby/moby/issues/34394)
- Per this proposal, the flag is tristate: 
  1. `--pull=missing` (this is the current behaviour and will be the default.)
  1. `--pull=never`
  1. `--pull=always`

**- How I did it**
 - Adds a new config field,  `createOptions.pull` which forks the execution of `container.createContainer` to either pull the image if it does not exist at all locally `--pull=missing`, always try and update the image `--pull=always`, or never try and update the image, only using images that already exist on the local machine `--pull=never`

Both `docker run` and  `docker create` can consume this flag.

**- How to verify it**
- Run `docker run` and `docker create` with the flag. Notice that pulls images or does not, depending on the behavior specified in the flag. Running those commands without the flag should maintain the current behavior.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adds flag modifying pull behavior for running and creating containers (Pull if Missing, Pull Always, Pull Never)

**- A picture of a cute animal (not mandatory but encouraged)**
![honey-badger](https://user-images.githubusercontent.com/5925347/48017647-cc5fa200-e0fc-11e8-8166-ba68ae9ea738.jpg)

