### PR TITLE
Add example get API version

### DIFF
--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -69,6 +69,14 @@ $ docker version --format '{{.Server.Version}}'
 19.03.8
 ```
 
+### Get the client API version
+
+```console
+$ docker version --format '{{.Client.APIVersion}}'
+
+1.41
+```
+
 ### Dump raw JSON data
 
 ```console


### PR DESCRIPTION
Getting the client API version is non-intuitive. 
Other keys follow the json example or the version output, however `'{{.Client.ApiVersion}}'` does not work, nor does `'{{.Client.APIversion}}'`

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added an example to the `docker version` docs

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added an example for getting Client API version

**- A picture of a cute animal (not mandatory but encouraged)**

