### PR TITLE
Bump moby/moby vendoring and fix tests

### DIFF
--- a/cli/command/node/client_test.go
+++ b/cli/command/node/client_test.go
@@ -10,13 +10,14 @@ import (
 
 type fakeClient struct {
 	client.Client
-	infoFunc        func() (types.Info, error)
-	nodeInspectFunc func() (swarm.Node, []byte, error)
-	nodeListFunc    func() ([]swarm.Node, error)
-	nodeRemoveFunc  func() error
-	nodeUpdateFunc  func(nodeID string, version swarm.Version, node swarm.NodeSpec) error
-	taskInspectFunc func(taskID string) (swarm.Task, []byte, error)
-	taskListFunc    func(options types.TaskListOptions) ([]swarm.Task, error)
+	infoFunc           func() (types.Info, error)
+	nodeInspectFunc    func() (swarm.Node, []byte, error)
+	nodeListFunc       func() ([]swarm.Node, error)
+	nodeRemoveFunc     func() error
+	nodeUpdateFunc     func(nodeID string, version swarm.Version, node swarm.NodeSpec) error
+	taskInspectFunc    func(taskID string) (swarm.Task, []byte, error)
+	taskListFunc       func(options types.TaskListOptions) ([]swarm.Task, error)
+	serviceInspectFunc func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
 }
 
 func (cli *fakeClient) NodeInspectWithRaw(ctx context.Context, ref string) (swarm.Node, []byte, error) {
@@ -66,4 +67,11 @@ func (cli *fakeClient) TaskList(ctx context.Context, options types.TaskListOptio
 		return cli.taskListFunc(options)
 	}
 	return []swarm.Task{}, nil
+}
+
+func (cli *fakeClient) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+	if cli.serviceInspectFunc != nil {
+		return cli.serviceInspectFunc(ctx, serviceID, opts)
+	}
+	return swarm.Service{}, []byte{}, nil
 }

--- a/cli/command/plugin/client_test.go
+++ b/cli/command/plugin/client_test.go
@@ -70,3 +70,7 @@ func (c *fakeClient) PluginInspectWithRaw(ctx context.Context, name string) (*ty
 
 	return nil, nil, nil
 }
+
+func (c *fakeClient) Info(ctx context.Context) (types.Info, error) {
+	return types.Info{}, nil
+}

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -28,6 +28,10 @@ type fakeClient struct {
 	client.Client
 }
 
+func (c fakeClient) Info(ctx context.Context) (types.Info, error) {
+	return types.Info{}, nil
+}
+
 func (c fakeClient) RegistryLogin(ctx context.Context, auth types.AuthConfig) (registrytypes.AuthenticateOKBody, error) {
 	if auth.Password == expiredPassword {
 		return registrytypes.AuthenticateOKBody{}, fmt.Errorf("Invalid Username or Password")

--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -179,6 +179,17 @@ func (cli *fakeClient) ConfigRemove(ctx context.Context, configID string) error 
 	return nil
 }
 
+func (cli *fakeClient) ServiceInspectWithRaw(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+	return swarm.Service{
+		ID: serviceID,
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name: serviceID,
+			},
+		},
+	}, []byte{}, nil
+}
+
 func serviceFromName(name string) swarm.Service {
 	return swarm.Service{
 		ID: "ID-" + name,

--- a/cli/command/trust/inspect_pretty_test.go
+++ b/cli/command/trust/inspect_pretty_test.go
@@ -2,17 +2,21 @@ package trust
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
+	"io"
 	"io/ioutil"
 	"testing"
 
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/test"
 	notaryfake "github.com/docker/cli/internal/test/notary"
+	"github.com/docker/docker/api/types"
 	dockerClient "github.com/docker/docker/client"
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
+	"github.com/theupdateframework/notary/tuf/utils"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"gotest.tools/golden"
@@ -22,6 +26,18 @@ import (
 
 type fakeClient struct {
 	dockerClient.Client
+}
+
+func (c *fakeClient) Info(ctx context.Context) (types.Info, error) {
+	return types.Info{}, nil
+}
+
+func (c *fakeClient) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	return types.ImageInspect{}, []byte{}, nil
+}
+
+func (c *fakeClient) ImagePush(ctx context.Context, image string, options types.ImagePushOptions) (io.ReadCloser, error) {
+	return &utils.NoopCloser{Reader: bytes.NewBuffer([]byte{})}, nil
 }
 
 func TestTrustInspectPrettyCommandErrors(t *testing.T) {

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -304,6 +304,6 @@ func TestSignCommandLocalFlag(t *testing.T) {
 	cmd := newSignCommand(cli)
 	cmd.SetArgs([]string{"--local", "reg-name.io/image:red"})
 	cmd.SetOutput(ioutil.Discard)
-	assert.ErrorContains(t, cmd.Execute(), "error during connect: Get /images/reg-name.io/image:red/json: unsupported protocol scheme")
+	assert.ErrorContains(t, cmd.Execute(), "error contacting notary server: dial tcp: lookup reg-name.io")
 
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76 # v1.1.0
 github.com/dgrijalva/jwt-go a2c85815a77d0f951e33ba4db5ae93629a1530af
 github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
-github.com/docker/docker 9f296d1e6fccd9f73bae345e4aad4f3f6e92fdeb
+github.com/docker/docker bd224b5fe564f343e22fa76ae8569ec949f35802
 github.com/docker/docker-credential-helpers 5241b46610f2491efdf9d1c85f1ddf5b02f6d962
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.

--- a/vendor/github.com/docker/docker/api/common.go
+++ b/vendor/github.com/docker/docker/api/common.go
@@ -3,7 +3,7 @@ package api // import "github.com/docker/docker/api"
 // Common constants for daemon and client.
 const (
 	// DefaultVersion of Current REST API
-	DefaultVersion = "1.39"
+	DefaultVersion = "1.40"
 
 	// NoBaseImageSpecifier is the symbol used by the FROM
 	// command to specify that no base image is to be used.

--- a/vendor/github.com/docker/docker/api/types/mount/mount.go
+++ b/vendor/github.com/docker/docker/api/types/mount/mount.go
@@ -79,7 +79,8 @@ const (
 
 // BindOptions defines options specific to mounts of type "bind".
 type BindOptions struct {
-	Propagation Propagation `json:",omitempty"`
+	Propagation  Propagation `json:",omitempty"`
+	NonRecursive bool        `json:",omitempty"`
 }
 
 // VolumeOptions represents the options for a mount of type volume.

--- a/vendor/github.com/docker/docker/client/request.go
+++ b/vendor/github.com/docker/docker/client/request.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 // serverResponse is a wrapper for http API responses.
@@ -129,7 +128,8 @@ func (cli *Client) sendRequest(ctx context.Context, method, path string, query u
 func (cli *Client) doRequest(ctx context.Context, req *http.Request) (serverResponse, error) {
 	serverResp := serverResponse{statusCode: -1, reqURL: req.URL}
 
-	resp, err := ctxhttp.Do(ctx, cli.client, req)
+	req = req.WithContext(ctx)
+	resp, err := cli.client.Do(req)
 	if err != nil {
 		if cli.scheme != "https" && strings.Contains(err.Error(), "malformed HTTP response") {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
@@ -195,9 +195,17 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(serverResp.body)
+	bodyMax := 1 * 1024 * 1024 // 1 MiB
+	bodyR := &io.LimitedReader{
+		R: serverResp.body,
+		N: int64(bodyMax),
+	}
+	body, err := ioutil.ReadAll(bodyR)
 	if err != nil {
 		return err
+	}
+	if bodyR.N == 0 {
+		return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), bodyMax, serverResp.reqURL)
 	}
 	if len(body) == 0 {
 		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), serverResp.reqURL)

--- a/vendor/github.com/docker/docker/client/service_update.go
+++ b/vendor/github.com/docker/docker/client/service_update.go
@@ -10,7 +10,9 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 )
 
-// ServiceUpdate updates a Service.
+// ServiceUpdate updates a Service. The version number is required to avoid conflicting writes.
+// It should be the value as set *before* the update. You can find this value in the Meta field
+// of swarm.Service, which can be found using ServiceInspectWithRaw.
 func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
 	var (
 		query   = url.Values{}

--- a/vendor/github.com/docker/docker/pkg/archive/archive.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive.go
@@ -660,11 +660,13 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 	var errors []string
 	for key, value := range hdr.Xattrs {
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
-			if err == syscall.ENOTSUP {
+			if err == syscall.ENOTSUP || err == syscall.EPERM {
 				// We ignore errors here because not all graphdrivers support
 				// xattrs *cough* old versions of AUFS *cough*. However only
 				// ENOTSUP should be emitted in that case, otherwise we still
 				// bail.
+				// EPERM occurs if modifying xattrs is not allowed. This can
+				// happen when running in userns with restrictions (ChromeOS).
 				errors = append(errors, err.Error())
 				continue
 			}

--- a/vendor/github.com/docker/docker/pkg/fileutils/fileutils.go
+++ b/vendor/github.com/docker/docker/pkg/fileutils/fileutils.go
@@ -106,7 +106,7 @@ func (pm *PatternMatcher) Patterns() []*Pattern {
 	return pm.patterns
 }
 
-// Pattern defines a single regexp used used to filter file paths.
+// Pattern defines a single regexp used to filter file paths.
 type Pattern struct {
 	cleanedPattern string
 	dirs           []string

--- a/vendor/github.com/docker/docker/pkg/mount/sharedsubtree_linux.go
+++ b/vendor/github.com/docker/docker/pkg/mount/sharedsubtree_linux.go
@@ -48,18 +48,22 @@ func MakeRUnbindable(mountPoint string) error {
 	return ensureMountedAs(mountPoint, "runbindable")
 }
 
-func ensureMountedAs(mountPoint, options string) error {
-	mounted, err := Mounted(mountPoint)
+// MakeMount ensures that the file or directory given is a mount point,
+// bind mounting it to itself it case it is not.
+func MakeMount(mnt string) error {
+	mounted, err := Mounted(mnt)
 	if err != nil {
 		return err
 	}
-
-	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
-			return err
-		}
+	if mounted {
+		return nil
 	}
-	if _, err = Mounted(mountPoint); err != nil {
+
+	return Mount(mnt, mnt, "none", "bind")
+}
+
+func ensureMountedAs(mountPoint, options string) error {
+	if err := MakeMount(mountPoint); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/docker/docker/pkg/signal/signal_linux_mipsx.go
+++ b/vendor/github.com/docker/docker/pkg/signal/signal_linux_mipsx.go
@@ -1,4 +1,5 @@
-// +build !mips,!mipsle,!mips64,!mips64le
+// +build linux
+// +build mips mipsle mips64 mips64le
 
 package signal // import "github.com/docker/docker/pkg/signal"
 
@@ -10,7 +11,7 @@ import (
 
 const (
 	sigrtmin = 34
-	sigrtmax = 64
+	sigrtmax = 127
 )
 
 // SignalMap is a map of Linux signals.
@@ -34,7 +35,7 @@ var SignalMap = map[string]syscall.Signal{
 	"PWR":      unix.SIGPWR,
 	"QUIT":     unix.SIGQUIT,
 	"SEGV":     unix.SIGSEGV,
-	"STKFLT":   unix.SIGSTKFLT,
+	"SIGEMT":   unix.SIGEMT,
 	"STOP":     unix.SIGSTOP,
 	"SYS":      unix.SIGSYS,
 	"TERM":     unix.SIGTERM,

--- a/vendor/github.com/docker/docker/pkg/streamformatter/streamformatter.go
+++ b/vendor/github.com/docker/docker/pkg/streamformatter/streamformatter.go
@@ -94,7 +94,7 @@ func NewProgressOutput(out io.Writer) progress.Output {
 	return &progressOutput{sf: &rawProgressFormatter{}, out: out, newLines: true}
 }
 
-// NewJSONProgressOutput returns a progress.Output that that formats output
+// NewJSONProgressOutput returns a progress.Output that formats output
 // using JSON objects
 func NewJSONProgressOutput(out io.Writer, newLines bool) progress.Output {
 	return &progressOutput{sf: &jsonProgressFormatter{}, out: out, newLines: newLines}

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,13 +1,13 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim v0.7.3
+github.com/Microsoft/hcsshim v0.7.12
 github.com/Microsoft/go-winio v0.4.11
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
 github.com/gorilla/context v1.1
 github.com/gorilla/mux v1.1
-github.com/Microsoft/opengcs v0.3.8
+github.com/Microsoft/opengcs v0.3.9
 github.com/kr/pty 5cf931ef8f
 github.com/mattn/go-shellwords v1.0.3
 github.com/sirupsen/logrus v1.0.6
@@ -26,8 +26,8 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit 39404586a50d1b9d0fb1c578cf0f4de7bdb7afe5
-github.com/tonistiigi/fsutil b19464cd1b6a00773b4f2eb7acf9c30426f9df42
+github.com/moby/buildkit c7bb575343df0cbfeab8b5b28149630b8153fcc6
+github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
@@ -36,8 +36,8 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 
 #get libnetwork packages
 
-# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork 36d3bed0e9f4b3c8c66df9bd45278bb90b33e911
+# When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
+github.com/docker/libnetwork 49627167f0585504fd78ed8827529aec57a9618d
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -75,8 +75,8 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.12.0
 
 # This does not need to match RUNC_COMMIT as it is used for helper packages but should be newer or equal
-github.com/opencontainers/runc 20aff4f0488c6d4b8df4d85b4f63f1f704c11abd
-github.com/opencontainers/runtime-spec d810dbc60d8c5aeeb3d054bd1132fab2121968ce # v1.0.1-43-gd810dbc
+github.com/opencontainers/runc 58592df56734acf62e574865fe40b9e53e967910
+github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 
@@ -114,23 +114,24 @@ github.com/googleapis/gax-go v2.0.0
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd d97a907f7f781c0ab8340877d8e6b53cc7f1c2f6
+github.com/containerd/containerd c4446665cb9c30056f4998ed953e6d4ff22c7c39 # v1.2.0
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/continuity f44b615e492bdfb371aae2f76ec694d9da1db537
+github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
+github.com/containerd/cri f913714917d2456d7e65a0be84962b1ce8acb487 # release/1.2 branch
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/ttrpc 94dde388801693c54f88a6596f713b51a8b30b2d
+github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit 9f271c2963d18a7c60d2c4001fb418ca4037df19
+github.com/docker/swarmkit a84c01f49091167dd086c26b45dc18b38d52e4d9
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
 github.com/google/certificate-transparency-go v1.0.20
-golang.org/x/crypto a2144134853fc9a27a7b1e3eb4f19f1a76df13c9
+golang.org/x/crypto 0709b304e793a5edb4a2c0145f281ecdc20838a4
 golang.org/x/time fbb02b2291d28baffd63558aa44b4b56f178d650
 github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
@@ -143,7 +144,7 @@ github.com/prometheus/client_model 6f3806018612930941127f2a7c6c453ba2c527d2
 github.com/prometheus/common 7600349dcfe1abd18d72d3a1770870d9800a7801
 github.com/prometheus/procfs 7d6f385de8bea29190f15ba9931442a0eaef9af7
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
+github.com/pkg/errors 645ef00459ed84a119197bfb8d8205042c6df63d # v0.8.0
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 
 # cli
@@ -155,4 +156,4 @@ github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.
 # metrics
 github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
-github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
+github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a


### PR DESCRIPTION
A recent change in moby/moby (https://github.com/moby/moby/commit/3e5b9cb46688ee5d6886ad3be4cb591f1ba49ed1#diff-ac3eb5494dc3178ea5947441c086942b) made tests with missing client function mocks fail with a panic (underlying http client is nil within unit tests). This PR bumps Moby/moby and fix the impacted tests by adding missing mock functions. 

**- What I did**
- Bumped moby/moby
- Fixed panicking tests

**- How I did it**
- Added missing mocks

**- How to verify it**
Run unit tests

