### PR TITLE
ssh options env var

### DIFF
--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -4,8 +4,15 @@ package ssh
 
 import (
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/pkg/errors"
+)
+
+// ssh options env variable
+var (
+	dockerSSHOptions = os.Getenv("DOCKER_HOST_SSH_OPTIONS")
 )
 
 // New returns cmd and its args
@@ -48,13 +55,15 @@ func parseSSHURL(daemonURL string) (*sshSpec, error) {
 	if u.Fragment != "" {
 		return nil, errors.Errorf("extra fragment: %s", u.Fragment)
 	}
+	sp.options = dockerSSHOptions
 	return &sp, err
 }
 
 type sshSpec struct {
-	user string
-	host string
-	port string
+	user    string
+	host    string
+	port    string
+	options string
 }
 
 func (sp *sshSpec) Args() []string {
@@ -64,6 +73,9 @@ func (sp *sshSpec) Args() []string {
 	}
 	if sp.port != "" {
 		args = append(args, "-p", sp.port)
+	}
+	if sp.options != "" {
+		args = append(args, strings.Split(sp.options, " ")...)
 	}
 	args = append(args, sp.host)
 	return args


### PR DESCRIPTION
Signed-off-by: Andre Fernandes <andre@vertigo.com.br>

Proposal: DOCKER_HOST_SSH_OPTIONS environment variable

- What I did
The new "ssh://" protocol for DOCKER_HOST is great, but sometimes we need to use different ssh options than the default. A common scenario if the need to point to a project-specific ssh config file instead of the default one at "~/.ssh/config".

- How I did it
An environment variable DOCKER_HOST_SSH_OPTIONS that can hold options for the ssh command docker uses when DOCKER_HOST contains the "ssh://" prefix.

- How to verify it
export DOCKER_HOST_SSH_OPTIONS="-F /my/own/ssh.cfg"
export DOCKER_HOST="ssh://somehost"
docker version

- Description for the changelog
DOCKER_HOST_SSH_OPTIONS to change ssh options when using "ssh://" protocol.