### PR TITLE
Make it possible to override the volume mounts and shell for the dev container

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -4,17 +4,21 @@
 # Makefile for developing using Docker
 #
 
+# Overridable env vars
+DOCKER_CLI_MOUNTS ?= -v "$(CURDIR)":/go/src/github.com/docker/cli
+DOCKER_CLI_SHELL ?= ash
+DOCKER_CLI_CONTAINER_NAME ?=
+DOCKER_CLI_GO_BUILD_CACHE ?= y
+
 DEV_DOCKER_IMAGE_NAME = docker-cli-dev$(IMAGE_TAG)
 BINARY_NATIVE_IMAGE_NAME = docker-cli-native$(IMAGE_TAG)
 LINTER_IMAGE_NAME = docker-cli-lint$(IMAGE_TAG)
 CROSS_IMAGE_NAME = docker-cli-cross$(IMAGE_TAG)
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate$(IMAGE_TAG)
 E2E_IMAGE_NAME = docker-cli-e2e$(IMAGE_TAG)
-GO_BUILD_CACHE ?= y
-MOUNTS = -v "$(CURDIR)":/go/src/github.com/docker/cli
 CACHE_VOLUME_NAME := docker-cli-dev-cache
-ifeq ($(GO_BUILD_CACHE),y)
-MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
+ifeq ($(DOCKER_CLI_GO_BUILD_CACHE),y)
+DOCKER_CLI_MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
 endif
 VERSION = $(shell cat VERSION)
 ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM
@@ -50,74 +54,76 @@ build_binary_native_image:
 build_e2e_image:
 	docker build -t $(E2E_IMAGE_NAME) --build-arg VERSION=$(VERSION) --build-arg GITCOMMIT=$(GITCOMMIT) -f ./dockerfiles/Dockerfile.e2e .
 
+DOCKER_RUN_NAME_OPTION := $(if $(DOCKER_CLI_CONTAINER_NAME),--name $(DOCKER_CLI_CONTAINER_NAME),)
+DOCKER_RUN := docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(DOCKER_RUN_NAME_OPTION)
 
 binary: build_binary_native_image ## build the CLI
-	docker run --rm $(ENVVARS) $(MOUNTS) $(BINARY_NATIVE_IMAGE_NAME)
+	$(DOCKER_RUN) $(BINARY_NATIVE_IMAGE_NAME)
 
 build: binary ## alias for binary
 
 .PHONY: clean
 clean: build_docker_image ## clean build artifacts
-	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
+	$(DOCKER_RUN) $(DEV_DOCKER_IMAGE_NAME) make clean
 	docker volume rm -f $(CACHE_VOLUME_NAME)
 
 .PHONY: test-unit
 test-unit: build_docker_image ## run unit tests (using go test)
-	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make test-unit
+	$(DOCKER_RUN) $(DEV_DOCKER_IMAGE_NAME) make test-unit
 
 .PHONY: test ## run unit and e2e tests
 test: test-unit test-e2e
 
 .PHONY: cross
 cross: build_cross_image ## build the CLI for macOS and Windows
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make cross
+	$(DOCKER_RUN) $(CROSS_IMAGE_NAME) make cross
 
 .PHONY: binary-windows
 binary-windows: build_cross_image ## build the CLI for Windows
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	$(DOCKER_RUN) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: binary-osx
 binary-osx: build_cross_image ## build the CLI for macOS
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	$(DOCKER_RUN) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: dev
 dev: build_docker_image ## start a build container in interactive mode for in-container development
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) \
+	$(DOCKER_RUN) -it \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		$(DEV_DOCKER_IMAGE_NAME) ash
+		$(DEV_DOCKER_IMAGE_NAME) $(DOCKER_CLI_SHELL)
 
 shell: dev ## alias for dev
 
 .PHONY: lint
 lint: build_linter_image ## run linters
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(LINTER_IMAGE_NAME)
+	$(DOCKER_RUN) -it $(LINTER_IMAGE_NAME)
 
 .PHONY: fmt
 fmt: ## run gofmt
-	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make fmt
+	$(DOCKER_RUN) $(DEV_DOCKER_IMAGE_NAME) make fmt
 
 .PHONY: vendor
 vendor: build_docker_image vendor.conf ## download dependencies (vendor/) listed in vendor.conf
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make vendor
+	$(DOCKER_RUN) -it $(DEV_DOCKER_IMAGE_NAME) make vendor
 
 dynbinary: build_cross_image ## build the CLI dynamically linked
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make dynbinary
+	$(DOCKER_RUN) -it $(CROSS_IMAGE_NAME) make dynbinary
 
 .PHONY: authors
 authors: ## generate AUTHORS file from git history
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make authors
+	$(DOCKER_RUN) -it $(DEV_DOCKER_IMAGE_NAME) make authors
 
 .PHONY: manpages
 manpages: build_docker_image ## generate man pages from go source and markdown
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make manpages
+	$(DOCKER_RUN) -it $(DEV_DOCKER_IMAGE_NAME) make manpages
 
 .PHONY: yamldocs
 yamldocs: build_docker_image ## generate documentation YAML files consumed by docs repo
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make yamldocs
+	$(DOCKER_RUN) -it $(DEV_DOCKER_IMAGE_NAME) make yamldocs
 
 .PHONY: shellcheck
 shellcheck: build_shell_validate_image ## run shellcheck validation
-	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(VALIDATE_IMAGE_NAME) make shellcheck
+	$(DOCKER_RUN) -it $(VALIDATE_IMAGE_NAME) make shellcheck
 
 .PHONY: test-e2e
 test-e2e: test-e2e-non-experimental test-e2e-experimental test-e2e-connhelper-ssh ## run all e2e tests


### PR DESCRIPTION
**- What I did**

This patch provides some way for non-Linux devs to work on this repo without
suffering too much from the notorious terrible I/O perf of mounted volumes (eg
on OS X).

**- How I did it**

We now allow to override the volume mounts and shell for the dev container
through the `DOCKER_CLI_MOUNTS` and `DOCKER_CLI_SHELL` env variables.
We also allow setting the dev container name through the
`DOCKER_CLI_CONTAINER_NAME` env var.

The motivation for allowing overriding the volume mounts is the same as for
https://github.com/moby/moby/pull/37845, namely that I/O perf on native mounted
disks on non-Linux (notably Mac OS) is just terrible, thus making it a real
pain to develop: one has to choose between re-building the image after every
single change (eg to run a test) or just work directly inside the same
container (eg with vim, but even then one would have to re-configure their dev
container every time it gets destroyed - containers, after all, are not
supposed to be long-lived).

Allowing to override DOCKER_CLI_MOUNTS makes it easy for everyone
to decide what their volume/syncing strategy is; for example
one can choose to use [docker-sync](https://github.com/EugenMayer/docker-sync).

As for the shell, it's nice to be able to use bash instead of the more
bare-bones `ash` if preferred.

Finally, being able to name the container can come in handy for easier
scripting on the host.

This patch won't change anything for anyone who doesn't set these env variables
in their environment.

**- How to verify it**

The output of:
```
make -f docker.Makefile -n shell
```
should be unchanged compared to what it was before this patch; but:
```
DOCKER_CLI_MOUNTS='-v test:/test' make -f docker.Makefile -n shell
```
should replace the `-v` flag from the command above with just
`-v test:/test`, and finally:
```
DOCKER_CLI_MOUNTS=' ' make -f docker.Makefile -n shell
```
should be devoid of any `-v` flags (besides the socket one).

All the make targets should be unchanged when not setting any of the
new env vars.

**- A picture of a cute animal (not mandatory but encouraged)**

![bunny](https://wallpapercave.com/wp/CAAIAu8.jpg)
