### PR TITLE
Prevent overwriting irregular files (cp, save, export commands)

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -128,6 +128,10 @@ func copyFromContainer(ctx context.Context, dockerCli command.Cli, copyConfig cp
 		}
 	}
 
+	if err := command.ValidateOutputPath(dstPath); err != nil {
+		return err
+	}
+
 	client := dockerCli.Client()
 	// if client requests to follow symbol link, then must decide target file to be copied
 	var rebaseName string
@@ -207,6 +211,11 @@ func copyToContainer(ctx context.Context, dockerCli command.Cli, copyConfig cpCo
 
 		dstInfo.Path = linkTarget
 		dstStat, err = client.ContainerStatPath(ctx, copyConfig.container, linkTarget)
+	}
+
+	// Validate the destination path
+	if err := command.ValidateOutputPathFileMode(dstStat.Mode); err != nil {
+		return errors.Wrapf(err, `destination "%s:%s" must be a directory or a regular file`, copyConfig.container, dstPath)
 	}
 
 	// Ignore any error and assume that the parent directory of the destination

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -190,3 +190,12 @@ func TestSplitCpArg(t *testing.T) {
 		})
 	}
 }
+
+func TestRunCopyFromContainerToFilesystemIrregularDestination(t *testing.T) {
+	options := copyOptions{source: "container:/dev/null", destination: "/dev/random"}
+	cli := test.NewFakeCli(nil)
+	err := runCopy(cli, options)
+	assert.Assert(t, err != nil)
+	expected := `"/dev/random" must be a directory or a regular file`
+	assert.ErrorContains(t, err, expected)
+}

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -41,6 +41,10 @@ func runExport(dockerCli command.Cli, opts exportOptions) error {
 		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}
 
+	if err := command.ValidateOutputPath(opts.output); err != nil {
+		return errors.Wrap(err, "failed to export container")
+	}
+
 	clnt := dockerCli.Client()
 
 	responseBody, err := clnt.ContainerExport(context.Background(), opts.container)

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -31,3 +31,19 @@ func TestContainerExportOutputToFile(t *testing.T) {
 
 	assert.Assert(t, fs.Equal(dir.Path(), expected))
 }
+
+func TestContainerExportOutputToIrregularFile(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		containerExportFunc: func(container string) (io.ReadCloser, error) {
+			return ioutil.NopCloser(strings.NewReader("foo")), nil
+		},
+	})
+	cmd := NewExportCommand(cli)
+	cmd.SetOutput(ioutil.Discard)
+	cmd.SetArgs([]string{"-o", "/dev/random", "container"})
+
+	err := cmd.Execute()
+	assert.Assert(t, err != nil)
+	expected := `"/dev/random" must be a directory or a regular file`
+	assert.ErrorContains(t, err, expected)
+}

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -3,8 +3,6 @@ package image
 import (
 	"context"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -44,7 +42,7 @@ func RunSave(dockerCli command.Cli, opts saveOptions) error {
 		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}
 
-	if err := validateOutputPath(opts.output); err != nil {
+	if err := command.ValidateOutputPath(opts.output); err != nil {
 		return errors.Wrap(err, "failed to save image")
 	}
 
@@ -60,14 +58,4 @@ func RunSave(dockerCli command.Cli, opts saveOptions) error {
 	}
 
 	return command.CopyToFile(opts.output, responseBody)
-}
-
-func validateOutputPath(path string) error {
-	dir := filepath.Dir(path)
-	if dir != "" && dir != "." {
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			return errors.Errorf("unable to validate output path: directory %q does not exist", dir)
-		}
-	}
-	return nil
 }

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -44,7 +44,12 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		{
 			name:          "output directory does not exist",
 			args:          []string{"-o", "fakedir/out.tar", "arg1"},
-			expectedError: "failed to save image: unable to validate output path: directory \"fakedir\" does not exist",
+			expectedError: "failed to save image: invalid output path: directory \"fakedir\" does not exist",
+		},
+		{
+			name:          "output file is irregular",
+			args:          []string{"-o", "/dev/null", "arg1"},
+			expectedError: "failed to save image: invalid output path: \"/dev/null\" must be a directory or a regular file",
 		},
 	}
 	for _, tc := range testCases {

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/system"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -124,4 +125,38 @@ func AddPlatformFlag(flags *pflag.FlagSet, target *string) {
 	flags.StringVar(target, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"), "Set platform if server is multi-platform capable")
 	flags.SetAnnotation("platform", "version", []string{"1.32"})
 	flags.SetAnnotation("platform", "experimental", nil)
+}
+
+// ValidateOutputPath validates the output paths of the `export` and `save` commands.
+func ValidateOutputPath(path string) error {
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			return errors.Errorf("invalid output path: directory %q does not exist", dir)
+		}
+	}
+	// check whether `path` points to a regular file
+	// (if the path exists and doesn't point to a directory)
+	if fileInfo, err := os.Stat(path); !os.IsNotExist(err) {
+		if fileInfo.Mode().IsDir() || fileInfo.Mode().IsRegular() {
+			return nil
+		}
+
+		if err := ValidateOutputPathFileMode(fileInfo.Mode()); err != nil {
+			return errors.Wrapf(err, fmt.Sprintf("invalid output path: %q must be a directory or a regular file", path))
+		}
+	}
+	return nil
+}
+
+// ValidateOutputPathFileMode validates the output paths of the `cp` command and serves as a
+// helper to `ValidateOutputPath`
+func ValidateOutputPathFileMode(fileMode os.FileMode) error {
+	switch {
+	case fileMode&os.ModeDevice != 0:
+		return errors.New("got a device")
+	case fileMode&os.ModeIrregular != 0:
+		return errors.New("got an irregular file")
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Philipp Schmied <pschmied@schutzwerk.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This fixes #1514.

**- How I did it**

The function `command.ValidateOutputPath` was already present in `cli/command/image/save.go`. I've moved this to `cli/command/utils.go` in order to use this function to fix the issue for all three commands.

After that, I've added code to this existing function to use a new helper method called `ValidateOutputPathFileMode` which also resides in `cli/command/utils.go`. This is being used to check for irregular files/devices and returns an error in case an invalid target is being passed. This is now being called at the start of the functions implementing the `cp`, `export` and `save` commands. For `cp` operations *to* a container, the fix only uses the helper method mentioned above, so it's possible to unify this check for all three operations. The helper method also determines whether the target path points to a device or any other invalid/irregular file to display an error message accordingly.

Also, I've added test cases for all commands.

**- How to verify it**

- Clone the `cli` master branch and compile a static `docker` binary
- Pull an arbitrary docker image: `docker pull ubuntu:latest`
- Invoke `docker save ubuntu:latest -o /dev/random`
- Check the output of `stat /dev/random` indicating `/dev/random` is now a regular file
- Perform the steps above using my PR and see that this operation is prevented, yielding `failed to save image: invalid output path: "/dev/random" must be a directory or a regular file: Got a device`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

cp, save, export: Prevent overwriting irregular files

**- A picture of a cute animal (not mandatory but encouraged)**

![20foup2](https://user-images.githubusercontent.com/15813113/48415851-e3cb0a80-e74e-11e8-8e26-d07ecf3afa75.jpg)
