### PR TITLE
Fix bash completion for `service update --force`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3395,7 +3395,6 @@ _docker_service_update_and_create() {
 	local options_with_args="
 		--endpoint-mode
 		--entrypoint
-		--force
 		--health-cmd
 		--health-interval
 		--health-retries
@@ -3519,6 +3518,10 @@ _docker_service_update_and_create() {
 			--rollback
 			--secret-add
 			--secret-rm
+		"
+
+		boolean_options="$boolean_options
+			--force
 		"
 
 		case "$prev" in


### PR DESCRIPTION
**- What I did**
There are two issues with bash completion for `docker service create|update --force` (introduced in https://github.com/moby/moby/pull/27596)

- `--force` is not available in `service create`
- `--force` is a boolean option

This PR fixes these issues.

**- How to verify it**

* Verify that `docker service create --fo<tab>` does not complete to `--force`
* Verify that `docker service update --force --<tab>` completes options
