### PR TITLE
[wip] Map "until" to "unused-for" for build-cache pruning on "docker system prune"

### DIFF
--- a/vendor/github.com/docker/docker/api/types/filters/parse.go
+++ b/vendor/github.com/docker/docker/api/types/filters/parse.go
@@ -159,6 +159,15 @@ func (args Args) Get(key string) []string {
 	return slice
 }
 
+// All returns the list of values associated with each key
+func (args Args) All() map[string][]string {
+	values := make(map[string][]string, len(args.fields))
+	for key, _ := range args.fields {
+		values[key] = args.Get(key)
+	}
+	return values
+}
+
 // Add a new value to the set of values
 func (args Args) Add(key, value string) {
 	if _, ok := args.fields[key]; ok {


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/38208

The `docker system prune` command has an `until` filter; filters on the
`system prune` command should be common to all object-types, however,
build-cache pruning does not support the `until` filter.

As a result, attempting to use the `until` filter on `docker system prune`
caused an error message to be printed, and further pruning to be aborted;

docker system prune --filter "until=24h" --force
Error response from daemon: failed to prune build cache: Invalid filter 'until'

To resolve this, we should either;

1. ignore the `until` filter for "build cache" and print a warning.
2. similar to "volumes" not supporting this option; produce an error if
pruning build cache is enabled.
3. map the `until` filter to another filter for the build cache that
matches the behavior.

Looking at those options; option 2. is not possible, because enabling/disablign
pruning of the build cache is done automatically, based on which build is selected.

Option 1. would be a good solution, with the downside that if the `--force` flag
is used, the user cannot be informed about the filter being ignored until the
pruning is already started.

Looking at option 3.; the build-cache has a `unused-for` filter, which seems
to be a close match to `until`, and purges the cache if it hasn't been used
for the specified duration.

This patch implements option 3., and maps the `until` filter to `unused-for`.

Before this patch;

```
DOCKER_BUILDKIT=1 docker system prune --filter until=24h --force
Error response from daemon: failed to prune build cache: Invalid filter 'until'
```

With this patch applied;

```
DOCKER_BUILDKIT=1 docker system prune --filter until=24h --force
....
deleted: sha256:a4d4a0273aaeab2067405bcf17e2450131062c6ffa18126f337e4aed306f2cc7
deleted: sha256:6dd6c244a3e8aa455575e1b78c93872069c16a5dda4ab8db1a1bdf350721c87b
deleted: sha256:920f387943a029b0bb2146e2162d096d031b4e371e3cf6116f0f4cf15546b0fb

Total reclaimed space: 458.6MB
```