### PR TITLE
Documenting ENTRYPOINT can empty value of CMD

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1339,6 +1339,10 @@ The table below shows what command is executed for different `ENTRYPOINT` / `CMD
 | **CMD ["p1_cmd", "p2_cmd"]**   | p1_cmd p2_cmd              | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry p1_cmd p2_cmd              |
 | **CMD exec_cmd p1_cmd**        | /bin/sh -c exec_cmd p1_cmd | /bin/sh -c exec_entry p1_entry | exec_entry p1_entry /bin/sh -c exec_cmd p1_cmd |
 
+> **Note**: If `CMD` is defined from the base image, setting `ENTRYPOINT` will
+> reset `CMD` to an empty value. In this scenario, `CMD` must be defined in the
+> current image to have a value.
+
 ## VOLUME
 
     VOLUME ["/data"]


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

**- What I did**

Documented a behavior where ENTRYPOINT will empty out the value of CMD when CMD is defined from a base image. This behavior has confused others, [e.g. this post on stackoverflow](https://stackoverflow.com/q/53298532/596285) and I feel it should be documented somewhere better than an old issue. The original issue where this behavior is described is [moby/moby #5147](https://github.com/moby/moby/issues/5147).

**- How I did it**

This is just a documentation change, no magic here.

**- How to verify it**

You can see the undocumented behavior with the following Dockerfile:

```
FROM busybox as base
CMD ["hello", "world"]

FROM base as override
CMD ["hello", "world"]
ENTRYPOINT ["echo"]

FROM base as extended
ENTRYPOINT ["echo"]
```

```
$ docker build -t test-cmd-ep --target override .
...
$ docker run --rm test-cmd-ep
hello world
$ docker build -f df.cmd-ep -t test-cmd-ep --target extended .
...
$ docker run --rm test-cmd-ep

$ 
```
**- Description for the changelog**

No change.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute animal pic](https://i.pinimg.com/474x/f5/9a/bf/f59abff1ee26c71a895edce1935bf47d--cute-hamsters-dwarf-hamsters.jpg)