### PR TITLE
Fix "warning" output on docker system prune

### DIFF
--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
@@ -11,6 +12,7 @@ import (
 func TestPrunePromptPre131DoesNotIncludeBuildCache(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{version: "1.30"})
 	cmd := newPruneCommand(cli)
+	cmd.SetArgs([]string{})
 	assert.NilError(t, cmd.Execute())
 	expected := `WARNING! This will remove:
         - all stopped containers
@@ -18,5 +20,23 @@ func TestPrunePromptPre131DoesNotIncludeBuildCache(t *testing.T) {
         - all dangling images
 Are you sure you want to continue? [y/N] `
 	assert.Check(t, is.Equal(expected, cli.OutBuffer().String()))
+}
 
+func TestPrunePromptFilters(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{version: "1.30"})
+	cli.SetConfigFile(&configfile.ConfigFile{
+		PruneFilters: []string{"label!=never=remove-me", "label=remove=me"},
+	})
+	cmd := newPruneCommand(cli)
+	cmd.SetArgs([]string{"--filter", "until=24h", "--filter", "label=hello-world", "--filter", "label!=foo=bar", "--filter", "label=bar=baz"})
+
+	assert.NilError(t, cmd.Execute())
+	expected := `WARNING! This will remove:
+        - all stopped containers
+        - all networks not used by at least one container
+        - all dangling images
+        - Elements to be pruned will be filtered with:
+        - filter={"label":{"bar=baz":true,"hello-world":true,"remove=me":true},"label!":{"foo=bar":true,"never=remove-me":true},"until":{"24h":true}}
+Are you sure you want to continue? [y/N] `
+	assert.Check(t, is.Equal(expected, cli.OutBuffer().String()))
 }

--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -15,15 +15,16 @@ func TestPrunePromptPre131DoesNotIncludeBuildCache(t *testing.T) {
 	cmd.SetArgs([]string{})
 	assert.NilError(t, cmd.Execute())
 	expected := `WARNING! This will remove:
-        - all stopped containers
-        - all networks not used by at least one container
-        - all dangling images
+  - all stopped containers
+  - all networks not used by at least one container
+  - all dangling images
+
 Are you sure you want to continue? [y/N] `
 	assert.Check(t, is.Equal(expected, cli.OutBuffer().String()))
 }
 
 func TestPrunePromptFilters(t *testing.T) {
-	cli := test.NewFakeCli(&fakeClient{version: "1.30"})
+	cli := test.NewFakeCli(&fakeClient{version: "1.31"})
 	cli.SetConfigFile(&configfile.ConfigFile{
 		PruneFilters: []string{"label!=never=remove-me", "label=remove=me"},
 	})
@@ -32,11 +33,19 @@ func TestPrunePromptFilters(t *testing.T) {
 
 	assert.NilError(t, cmd.Execute())
 	expected := `WARNING! This will remove:
-        - all stopped containers
-        - all networks not used by at least one container
-        - all dangling images
-        - Elements to be pruned will be filtered with:
-        - filter={"label":{"bar=baz":true,"hello-world":true,"remove=me":true},"label!":{"foo=bar":true,"never=remove-me":true},"until":{"24h":true}}
+  - all stopped containers
+  - all networks not used by at least one container
+  - all dangling images
+  - all dangling build cache
+
+  Items to be pruned will be filtered with:
+  - label!=foo=bar
+  - label!=never=remove-me
+  - label=bar=baz
+  - label=hello-world
+  - label=remove=me
+  - until=24h
+
 Are you sure you want to continue? [y/N] `
 	assert.Check(t, is.Equal(expected, cli.OutBuffer().String()))
 }


### PR DESCRIPTION
This PR has two commits;


### 1. Fix system prune warning missing filters from config-file

The warning, printed before runing docker system prune was missing any filter
that was set in the configuration file. In addition, the warning prefixes the
filters with `label=`, which is no longer accurate, now that the prune command
also supports "until" as a filter.

Before this change, only the filters set on the command-line were shown,
and any filter set in the configuration file was missing;

```
mkdir -p ./test-config
echo '{"pruneFilters": ["label!=never=remove-me", "label=remove=me"]}' > test-config/config.json
docker --config=./test-config system prune --filter until=24h --filter label=hello-world --filter label!=foo=bar --filter label=bar=baz

WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all dangling images
        - all dangling build cache
        - Elements to be pruned will be filtered with:
        - label={"label":{"bar=baz":true,"hello-world":true},"label!":{"foo=bar":true},"until":{"24h":true}}
Are you sure you want to continue? [y/N] 
```

With this patch applied, both options from the commandline and options set
in the configuration file are shown;

```
mkdir -p ./test-config
echo '{"pruneFilters": ["label!=never=remove-me", "label=remove=me"]}' > test-config/config.json
docker --config=./test-config system prune --filter until=24h --filter label=hello-world --filter label!=foo=bar --filter label=bar=baz

WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all dangling images
        - all dangling build cache
        - Elements to be pruned will be filtered with:
        - filter={"label":{"bar=baz":true,"hello-world":true,"remove=me":true},"label!":{"foo=bar":true,"never=remove-me":true},"until":{"24h":true}}
```


### 2. Make system prune warning filters human-readable

The warning, printed before running `docker system prune` was printing the
filters in JSON format.

This patch attempts to make the output human readable;

- updating the code, and template to print filters individually
- reducing the indentation (which was quite deep)

Before this patch was applied;

```
docker system prune --filter until=24h --filter label=hello-world --filter label!=foo=bar --filter label=bar=baz

WARNING! This will remove:
        - all stopped containers
        - all networks not used by at least one container
        - all dangling images
        - all dangling build cache
        - Elements to be pruned will be filtered with:
        - label={"label":{"bar=baz":true,"hello-world":true},"label!":{"foo=bar":true},"until":{"24h":true}}
Are you sure you want to continue? [y/N] 
```

With this patch applied;

```
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all dangling images
  - all dangling build cache

  Elements to be pruned will be filtered with:
  - label!=foo=bar
  - label!=never=remove-me
  - label=bar=baz
  - label=hello-world
  - label=remove=me
  - until=24h

Are you sure you want to continue? [y/N]
```
