### PR TITLE
[18.09 backport] Fix bash completion for `service update --force`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3395,7 +3395,6 @@ _docker_service_update_and_create() {
 	local options_with_args="
 		--endpoint-mode
 		--entrypoint
-		--force
 		--health-cmd
 		--health-interval
 		--health-retries
@@ -3518,6 +3517,10 @@ _docker_service_update_and_create() {
 			--rollback
 			--secret-add
 			--secret-rm
+		"
+
+		boolean_options="$boolean_options
+			--force
 		"
 
 		case "$prev" in


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1521 for 18.09

```
git checkout -b 18.09_backport_completion_fix_service__force upstream/18.09
git cherry-pick -s -S -x 5fa5eb1da6996ea9cb0249d098ebdf3eb1452b46
git push -u origin
```

cherry-pick was clean; no conflicts


- `--force` is not available in `service create`
- `--force` is a boolean option

