### PR TITLE
fixes 1492: tty initial size error

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -12,20 +12,24 @@ import (
 
 type fakeClient struct {
 	client.Client
-	inspectFunc           func(string) (types.ContainerJSON, error)
-	execInspectFunc       func(execID string) (types.ContainerExecInspect, error)
-	execCreateFunc        func(container string, config types.ExecConfig) (types.IDResponse, error)
-	createContainerFunc   func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (container.ContainerCreateCreatedBody, error)
-	containerStartFunc    func(container string, options types.ContainerStartOptions) error
-	imageCreateFunc       func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
-	infoFunc              func() (types.Info, error)
-	containerStatPathFunc func(container, path string) (types.ContainerPathStat, error)
-	containerCopyFromFunc func(container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
-	logFunc               func(string, types.ContainerLogsOptions) (io.ReadCloser, error)
-	waitFunc              func(string) (<-chan container.ContainerWaitOKBody, <-chan error)
-	containerListFunc     func(types.ContainerListOptions) ([]types.Container, error)
-	containerExportFunc   func(string) (io.ReadCloser, error)
-	Version               string
+	inspectFunc         func(string) (types.ContainerJSON, error)
+	execInspectFunc     func(execID string) (types.ContainerExecInspect, error)
+	execCreateFunc      func(container string, config types.ExecConfig) (types.IDResponse, error)
+	createContainerFunc func(config *container.Config,
+		hostConfig *container.HostConfig,
+		networkingConfig *network.NetworkingConfig,
+		containerName string) (container.ContainerCreateCreatedBody, error)
+	containerStartFunc      func(container string, options types.ContainerStartOptions) error
+	imageCreateFunc         func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
+	infoFunc                func() (types.Info, error)
+	containerStatPathFunc   func(container, path string) (types.ContainerPathStat, error)
+	containerCopyFromFunc   func(container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
+	logFunc                 func(string, types.ContainerLogsOptions) (io.ReadCloser, error)
+	waitFunc                func(string) (<-chan container.ContainerWaitOKBody, <-chan error)
+	containerListFunc       func(types.ContainerListOptions) ([]types.Container, error)
+	containerExportFunc     func(string) (io.ReadCloser, error)
+	containerExecResizeFunc func(id string, options types.ResizeOptions) error
+	Version                 string
 }
 
 func (f *fakeClient) ContainerList(_ context.Context, options types.ContainerListOptions) ([]types.Container, error) {
@@ -131,4 +135,11 @@ func (f *fakeClient) ContainerExport(_ context.Context, container string) (io.Re
 		return f.containerExportFunc(container)
 	}
 	return nil, nil
+}
+
+func (f *fakeClient) ContainerExecResize(_ context.Context, id string, options types.ResizeOptions) error {
+	if f.containerExecResizeFunc != nil {
+		return f.containerExecResizeFunc(id, options)
+	}
+	return nil
 }

--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -16,9 +16,9 @@ import (
 )
 
 // resizeTtyTo resizes tty to specific height and width
-func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id string, height, width uint, isExec bool) {
+func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id string, height, width uint, isExec bool) error {
 	if height == 0 && width == 0 {
-		return
+		return nil
 	}
 
 	options := types.ResizeOptions{
@@ -34,19 +34,42 @@ func resizeTtyTo(ctx context.Context, client client.ContainerAPIClient, id strin
 	}
 
 	if err != nil {
-		logrus.Debugf("Error resize: %s", err)
+		logrus.Debugf("Error resize: %s\r", err)
+	}
+	return err
+}
+
+// resizeTty is to resize the tty with cli out's tty size
+func resizeTty(ctx context.Context, cli command.Cli, id string, isExec bool) error {
+	height, width := cli.Out().GetTtySize()
+	return resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
+}
+
+// initTtySize is to init the tty's size to the same as the window, if there is an error, it will retry 5 times.
+func initTtySize(ctx context.Context, cli command.Cli, id string, isExec bool, resizeTtyFunc func(ctx context.Context, cli command.Cli, id string, isExec bool) error) {
+	rttyFunc := resizeTtyFunc
+	if rttyFunc == nil {
+		rttyFunc = resizeTty
+	}
+	if err := rttyFunc(ctx, cli, id, isExec); err != nil {
+		go func() {
+			var err error
+			for retry := 0; retry < 5; retry++ {
+				time.Sleep(10 * time.Millisecond)
+				if err = rttyFunc(ctx, cli, id, isExec); err == nil {
+					break
+				}
+			}
+			if err != nil {
+				fmt.Fprintln(cli.Err(), "failed to resize tty, using default size")
+			}
+		}()
 	}
 }
 
 // MonitorTtySize updates the container tty size when the terminal tty changes size
 func MonitorTtySize(ctx context.Context, cli command.Cli, id string, isExec bool) error {
-	resizeTty := func() {
-		height, width := cli.Out().GetTtySize()
-		resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
-	}
-
-	resizeTty()
-
+	initTtySize(ctx, cli, id, isExec, resizeTty)
 	if runtime.GOOS == "windows" {
 		go func() {
 			prevH, prevW := cli.Out().GetTtySize()
@@ -55,7 +78,7 @@ func MonitorTtySize(ctx context.Context, cli command.Cli, id string, isExec bool
 				h, w := cli.Out().GetTtySize()
 
 				if prevW != w || prevH != h {
-					resizeTty()
+					resizeTty(ctx, cli, id, isExec)
 				}
 				prevH = h
 				prevW = w
@@ -66,7 +89,7 @@ func MonitorTtySize(ctx context.Context, cli command.Cli, id string, isExec bool
 		gosignal.Notify(sigchan, signal.SIGWINCH)
 		go func() {
 			for range sigchan {
-				resizeTty()
+				resizeTty(ctx, cli, id, isExec)
 			}
 		}()
 	}

--- a/cli/command/container/tty_test.go
+++ b/cli/command/container/tty_test.go
@@ -1,0 +1,30 @@
+package container
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestInitTtySizeErrors(t *testing.T) {
+	expectedError := "failed to resize tty, using default size\n"
+	fakeContainerExecResizeFunc := func(id string, options types.ResizeOptions) error {
+		return errors.Errorf("Error response from daemon: no such exec")
+	}
+	fakeResizeTtyFunc := func(ctx context.Context, cli command.Cli, id string, isExec bool) error {
+		height, width := uint(1024), uint(768)
+		return resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
+	}
+	ctx := context.Background()
+	cli := test.NewFakeCli(&fakeClient{containerExecResizeFunc: fakeContainerExecResizeFunc})
+	initTtySize(ctx, cli, "8mm8nn8tt8bb", true, fakeResizeTtyFunc)
+	time.Sleep(100 * time.Millisecond)
+	assert.Check(t, is.Equal(expectedError, cli.ErrBuffer().String()))
+}


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@acmcoder.com>

fixes #1492.

For Ubuntu 16.04.2 LTS (GNU/Linux 4.4.0-62-generic x86_64), Docker version 17.12.0-ce, build c97c6d6 / 18.03.0-ce, build 0520e24
When I run: `docker exec -it ubuntu /bin/bash`
The tty's size is small than window's size.
```
root@iZ2zeesy3n96esegm7tue0Z:~# docker exec -it ubuntu /bin/bash
root@97b3e229a701:/# ls -a
.   .dockerenv  bin   dev  home  lib64  mnt  proc  run   srv  tmp  var
..  .r          boot  etc  lib   media  opt  root  sbin  sys  usr
```
After I fix the bug:
```
root@iZ2zeesy3n96esegm7tue0Z:~# ./docker-linux-amd64 exec -it ubuntu /bin/bash
root@97b3e229a701:/# ls -a
.  ..  .dockerenv  .r  bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
```
If not fix this bug, it's too inconvenient for me to use docker exec -it.

**- What I did**
1. Fix tty initial size error
I think it's a bug of dockerd, but for previous dockerd edition, I think we can fix it in cli.
2. Fix when we use --debug flag, the first shell prompt don't return to the head of line when we got an error in func resizeTtyTo!

**- How I did it**
~~func MonitorTtySize in file cli/command/container/tty.go~~
~~I move the call resizeTty() to last and run it asynchronously.~~
1. Because in sometimes when dockercli call tty resize, the exec have not finished yet. Then we got a message "Error response from daemon: no such exec", but we ignore it, so we need to throw this error and deal with it after 10 milliseconds.
2. Add `\r` when logrus.Debugf.

**- How to verify it**
It's convenient for me to use docker exec -it.
I don't need to resize the window.

**- Description for the changelog**
fixes tty initial size error

**- I have no more cute animal now**
**Before fix:**
vim /etc/mime.types
![sk j _1irw za2kc78iody5](https://user-images.githubusercontent.com/783424/46642368-6dfcdd80-cba9-11e8-8bd5-ef1c761040c2.png)

**After fix:**
vim /etc/mime.types
![x z0 r5jg_i4h x6m2bny 4](https://user-images.githubusercontent.com/783424/45738155-4659cb80-bc22-11e8-93ce-852486ebbf6a.png)

