### PR TITLE
[18.09 backport] Update daemon.json example to show that log-opts must be a string

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1305,8 +1305,13 @@ This is a full example of the allowed configuration options on Linux:
 	"storage-opts": [],
 	"labels": [],
 	"live-restore": true,
-	"log-driver": "",
-	"log-opts": {},
+	"log-driver": "json-file",
+	"log-opts": {
+		"max-size": "10m",
+		"max-files":"5",
+		"labels": "somelabel",
+		"env": "os,customer"
+	},
 	"mtu": 0,
 	"pidfile": "",
 	"cluster-store": "",


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1528 for 18.09


```
git checkout -b 18.09_backport_add_logging_driver_example upstream/18.09
git cherry-pick -s -S -x fd33e0d93383287c16368de21fcd78a34ed94fee
git push -u origin
```

cherry-pick was clean

relates to https://github.com/moby/moby/issues/38242

log-opts are passed to logging-drivers as-is, so the daemon is not
aware what value-type each option takes.

For this reason, all options must be provided as a string, even if
they are used as numeric values by the logging driver.

For example, to pass the "max-file" option to the default (json-file)
logging driver, this value has to be passed as a string;

```json
{
  "log-driver": "json-file",
  "log-opts": {
    "max-size": "10m",
    "max-file": "3"
  }
}
```

When passed as a _number_ (`"max-file": 3`), the daemon will invalidate
the configuration file, and fail to start;

    unable to configure the Docker daemon with file /etc/docker/daemon.json: json: cannot unmarshal number into Go value of type string

This patch adds an example to the daemon.json to show these  values
have to be passed as strings.
