### PR TITLE
[18.09] prune: move image pruning before build cache pruning

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -73,11 +73,10 @@ func runPrune(dockerCli command.Cli, options pruneOptions) error {
 	if options.pruneVolumes {
 		pruneFuncs = append(pruneFuncs, volume.RunPrune)
 	}
+	pruneFuncs = append(pruneFuncs, image.RunPrune)
 	if options.pruneBuildCache {
 		pruneFuncs = append(pruneFuncs, builder.CachePrune)
 	}
-	// FIXME: modify image.RunPrune to not modify options.filter, otherwise this has to be last in the list.
-	pruneFuncs = append(pruneFuncs, image.RunPrune)
 
 	var spaceReclaimed uint64
 	for _, pruneFn := range pruneFuncs {


### PR DESCRIPTION
This is cleaner because running system prune twice in a row
now results in a no-op the second time.

Signed-off-by: Tibor Vass <tibor@docker.com>
(cherry picked from commit 6c10abb24776efb695253e6756109a44490480f7)
Signed-off-by: Tibor Vass <tibor@docker.com>

From https://github.com/docker/cli/pull/1527