### PR TITLE
fix 1417 hide experimental subcmds in non experimental environment.

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -88,6 +88,9 @@ func setFlagErrorFunc(dockerCli *command.DockerCli, cmd *cobra.Command, flags *p
 		if err := isSupported(cmd, dockerCli); err != nil {
 			return err
 		}
+		if err := hideUnsupportedFeatures(cmd, dockerCli); err != nil {
+			return err
+		}
 		return flagErrorFunc(cmd, err)
 	})
 }

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -49,3 +49,17 @@ func TestVersion(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.Contains(b.String(), "Docker version"))
 }
+
+func TestNeededArgumentFlagCmdForHideExperimentalCmds(t *testing.T) {
+	discard := ioutil.Discard
+	cmd := newDockerCommand(command.NewDockerCli(os.Stdin, discard, discard, false, nil))
+	cmd.SetArgs([]string{"-H"})
+	err := cmd.Execute()
+	assert.Check(t, is.ErrorContains(err, "flag needs an argument"))
+
+	for _, subcmd := range cmd.Commands() {
+		if _, ok := subcmd.Annotations["experimentalCLI"]; ok {
+			assert.Check(t, is.Equal(subcmd.Hidden, true))
+		}
+	}
+}


### PR DESCRIPTION
Please provide the following information:
--> fixes #1417 

**- What I did**
modify cmd/docker/docker.go for hiding experimental sub commands in non experimental environment.

**- How I did it**
Add a hide function(hideUnsupportedFeatures) in setFlagErrorFunc()

**- How to verify it**
Add a new test function(TestNeededArgumentFlagCmdForHideExperimentalCmds) in cmd/docker/docker_test.go

