### PR TITLE
Use official shellcheck image

### DIFF
--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,10 +1,7 @@
-FROM    debian:stretch-slim
-
-RUN     apt-get update && \
-        apt-get -y install make shellcheck && \
-        apt-get clean
-
+FROM    koalaman/shellcheck-alpine:v0.4.6
+RUN     apk add --no-cache bash make
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-CMD     bash
+ENTRYPOINT [""]
+CMD     ["/bin/sh"]
 COPY    . .

--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 
 target="${1:-}"
 
-if [[ "$target" != "help" && -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]]; then
+if [ "$target" != "help" ] && [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
     (
         echo
         echo


### PR DESCRIPTION
This patch switches the shellcheck image to use the official image from Docker Hub.

Note that this does not yet update shellcheck to the latest version (v0.5.x); Shellcheck v0.4.7 added some new checks, which makes CI currently fail, so will be done in a follow-up PR. Instead, the v0.4.6 version is used in this PR, which is closest to the same version as was installed in the image before this change;

```
docker run --rm docker-cli-shell-validate shellcheck --version
ShellCheck - shell script analysis tool
version: 0.4.4
license: GNU General Public License, version 3
website: http://www.shellcheck.net
```
