### PR TITLE
Do not print warning of --password switch on non TTY devices

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -71,7 +71,9 @@ type isFileStore interface {
 }
 
 func verifyloginOptions(dockerCli command.Cli, opts *loginOptions) error {
-	if opts.password != "" {
+	// Warn user that TTY devices should use --password-stdin but skip that
+	// for non TTY devices because interactive login is not possible on non TTY devices
+	if opts.password != "" && dockerCli.In().IsTerminal() {
 		fmt.Fprintln(dockerCli.Err(), "WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
 		if opts.passwordStdin {
 			return errors.New("--password and --password-stdin are mutually exclusive")


### PR DESCRIPTION
**- What I did**
Disabled login error messages which prevents Azure DevOps [SSH Deployment task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/ssh?view=vsts) to be used with **Fail on STDERR** setting.

**- How I did it**
Disabled warning ```WARNING! Using --password via the CLI is insecure. Use --password-stdin.``` on non TTY devices because these cannot use **--password-stdin** switch:
https://github.com/docker/cli/blob/fd2f1b3b6650b53ed1367b84910e0f81e89220cd/cli/command/registry.go#L107-L116

**- How to verify it**
- Put docker CLI inside of container
- Run first with TTY mode ```docker run -it test /docker-linux-amd64 login -u a -p b```
```
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
INFO[0000] Error logging in to v2 endpoint, trying next endpoint: Get https://registry-1.docker.io/v2/: x509: certificate signed by unknown authority 
Get https://registry-1.docker.io/v2/: x509: certificate signed by unknown authority
```
- Then run on non TTY mode ```docker run -i test /docker-linux-amd64 login -u a -p b```
```
time="2018-11-29T15:19:30Z" level=info msg="Error logging in to v2 endpoint, trying next endpoint: Get https://registry-1.docker.io/v2/: x509: certificate signed by unknown authority"
Get https://registry-1.docker.io/v2/: x509: certificate signed by unknown authority
```

**- A picture of a cute animal (not mandatory but encouraged)**
![cute-baby-animals-2](https://user-images.githubusercontent.com/6213926/49232222-374e8100-f3fc-11e8-8625-a25a1f68eea2.jpg)
