### PR TITLE
Bump Go to 1.11.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.11.1
+  GOVERSION: 1.11.2
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.11.1-alpine
+FROM    golang:1.11.2-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.11.1@sha256:57ce59bec5445d27cc00f9e27fc171bea44eed7a9890df6eea6540f214300a01
+FROM	dockercore/golang-cross:1.11.2@sha256:7e8945e30dae5d6455a3e75e5091e642f79110301a86d08f8c93991518e930b3
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.11.1-alpine
+FROM    golang:1.11.2-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11.1
+ARG GO_VERSION=1.11.2
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.11.1-alpine
+FROM    golang:1.11.2-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.11.2 (released 2018/11/02) includes fixes to the compiler, linker,
documentation, go command, and the database/sql and go/types packages.

See the milestone on the issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.11.2

