### PR TITLE
list state `ready` for filtering in stack_ps.md

### DIFF
--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -106,7 +106,7 @@ tz6j82jnwrx7        voting_db.1           postgres:9.4                          
 
 #### desired-state
 
-The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
+The `desired-state` filter can take the values `running`, `shutdown`, `ready` or `accepted`.
 
 ```bash
 $ docker stack ps -f "desired-state=running" voting


### PR DESCRIPTION
I tested this command for the state now listed in the documentation.

There are other commands where the state is probably also valid, look in https://github.com/docker/cli/search?q=desired-state&unscoped_q=desired-state