### PR TITLE
[18.09 backport] Fix panic when pruning images with label-filter

### DIFF
--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -67,8 +67,7 @@ func cloneFilter(args filters.Args) (newArgs filters.Args, err error) {
 	if err != nil {
 		return newArgs, err
 	}
-	err = newArgs.UnmarshalJSON(b)
-	return newArgs, err
+	return filters.FromJSON(string(b))
 }
 
 func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint64, output string, err error) {

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -71,6 +71,14 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 			},
 		},
 		{
+			name: "label-filter",
+			args: []string{"--force", "--filter", "label=foobar"},
+			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {
+				assert.Check(t, is.Equal("foobar", pruneFilter.Get("label")[0]))
+				return types.ImagesPruneReport{}, nil
+			},
+		},
+		{
 			name: "force-untagged",
 			args: []string{"--force"},
 			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {

--- a/cli/command/image/testdata/prune-command-success.label-filter.golden
+++ b/cli/command/image/testdata/prune-command-success.label-filter.golden
@@ -1,0 +1,1 @@
+Total reclaimed space: 0B


### PR DESCRIPTION
Backport of https://github.com/docker/cli/pull/1551 for 18.09.

Cherry-pick was clean; no conflicts


Before this change:

    docker image prune --force --filter "label=foobar"
    panic: assignment to entry in nil map

    goroutine 1 [running]:
    github.com/docker/cli/vendor/github.com/docker/docker/api/types/filters.Args.Add(...)
    /go/src/github.com/docker/cli/vendor/github.com/docker/docker/api/types/filters/parse.go:167
    github.com/docker/cli/cli/command/image.runPrune(0x1db3a20, 0xc000344cf0, 0x16e0001, 0xc00015e600, 0x4, 0x3, 0xc00024e160, 0xc000545c70, 0x5ab4b5)
    /go/src/github.com/docker/cli/cli/command/image/prune.go:79 +0xbaf
    github.com/docker/cli/cli/command/image.NewPruneCommand.func1(0xc00029ef00, 0xc0004a8180, 0x0, 0x3, 0x0, 0x0)
    /go/src/github.com/docker/cli/cli/command/image/prune.go:32 +0x64
    github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).execute(0xc00029ef00, 0xc000038210, 0x3, 0x3, 0xc00029ef00, 0xc000038210)
    /go/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:762 +0x473
    github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000127180, 0xc000272770, 0x1836ce0, 0xc000272780)
    /go/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
    github.com/docker/cli/vendor/github.com/spf13/cobra.(*Command).Execute(0xc000127180, 0xc000127180, 0x1d60880)
    /go/src/github.com/docker/cli/vendor/github.com/spf13/cobra/command.go:800 +0x2b
    main.main()
    /go/src/github.com/docker/cli/cmd/docker/docker.go:180 +0xdc

With this patch applied:

    docker image prune --force --filter "label=foobar"
    Total reclaimed space: 0B


