### PR TITLE
[18.09 backport] Add bash completion for `import --platform`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2681,14 +2681,16 @@ _docker_image_images() {
 
 _docker_image_import() {
 	case "$prev" in
-		--change|-c|--message|-m)
+		--change|-c|--message|-m|--platform)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--change -c --help --message -m" -- "$cur" ) )
+			local options="--change -c --help --message -m"
+			__docker_server_is_experimental && options+=" --platform"
+			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag '--change|-c|--message|-m')


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1546 for 18.09

relates to https://github.com/docker/cli/pull/1371 / https://github.com/docker/cli/pull/1375

cherry-pick was clean; no conflicts