### PR TITLE
fix #1549: docker-build man page doesn't reflect new rules for Docker…

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -55,12 +55,11 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
 
 # OPTIONS
 **-f**, **--file**=*PATH/Dockerfile*
-   Path to the Dockerfile to use. If the path is a relative path and you are
-   building from a local directory, then the path must be relative to that
-   directory. If you are building from a remote URL pointing to either a
-   tarball or a Git repository, then the path must be relative to the root of
-   the remote context. In all cases, the file must be within the build context.
-   The default is *Dockerfile*.
+   Path to the Dockerfile to use. If you are building from a local directory, this
+   option means the Dockerfile path is considered relative to the current directory on
+   your local filesystem. Otherwise, if you are building from a remote URL pointing to
+   either a tarball or a Git repository, then the path must be relative to the root of
+   the remote context. In all cases, the default is *Dockerfile* within the build context.
 
 **--squash**=*true*|*false*
    **Experimental Only**


### PR DESCRIPTION
cli/man/docker-build.1.md

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modify docker-build man page which doesn't reflect new rules for Dockerfile path now.

**- How I did it**
The -f option description is modified as fllows:
```
Path to the Dockerfile to use. If you are building from a local directory, this
option means the Dockerfile path is considered relative to the current directory on
your local filesystem. Otherwise, if you are building from a remote URL pointing to
either a tarball or a Git repository, then the path must be relative to the root of
the remote context. In all cases, the default is *Dockerfile* within the build context.
```

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


