### PR TITLE
fix the help message on "docker trust signer add"

### DIFF
--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -31,7 +31,7 @@ type signerAddOptions struct {
 func newSignerAddCommand(dockerCli command.Cli) *cobra.Command {
 	var options signerAddOptions
 	cmd := &cobra.Command{
-		Use:   "add OPTIONS NAME REPOSITORY [REPOSITORY...] ",
+		Use:   "add [OPTIONS] NAME REPOSITORY [REPOSITORY...] ",
 		Short: "Add a signer",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
adds [] for consistency sake

Signed-off-by: djalal <djalal@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fix help message output

**- How I did it**

add brackets [] around OPTIONS

**- How to verify it**

type "docker trust signer add" and verify that brackets are now ready

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

more consistent display of help message for "docker trust signer add" 

**- A picture of a cute animal (not mandatory but encouraged)**

🐻 