### PR TITLE
Add a `fmt` build target and make use of a go build cache.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ test: test-unit ## run tests
 test-coverage: ## run test coverage
 	./scripts/test/unit-with-coverage $(shell go list ./... | grep -vE '/vendor/|/e2e/')
 
+.PHONY: fmt
+fmt:
+	go list -f {{.Dir}} ./... | xargs gofmt -w -s -d
+
 .PHONY: lint
 lint: ## run all the lint tools
 	gometalinter --config gometalinter.json ./...

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -81,6 +81,10 @@ shell: dev ## alias for dev
 lint: build_linter_image ## run linters
 	docker run -ti $(ENVVARS) $(MOUNTS) $(LINTER_IMAGE_NAME)
 
+.PHONY: fmt
+fmt:
+	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make fmt
+
 .PHONY: vendor
 vendor: build_docker_image vendor.conf ## download dependencies (vendor/) listed in vendor.conf
 	docker run -ti --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make vendor

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,7 +10,12 @@ LINTER_IMAGE_NAME = docker-cli-lint$(IMAGE_TAG)
 CROSS_IMAGE_NAME = docker-cli-cross$(IMAGE_TAG)
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate$(IMAGE_TAG)
 E2E_IMAGE_NAME = docker-cli-e2e$(IMAGE_TAG)
+GO_BUILD_CACHE ?= y
 MOUNTS = -v "$(CURDIR)":/go/src/github.com/docker/cli
+CACHE_VOLUME_NAME := docker-cli-dev-cache
+ifeq ($(GO_BUILD_CACHE),y)
+MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
+endif
 VERSION = $(shell cat VERSION)
 ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM
 
@@ -49,6 +54,7 @@ build: binary ## alias for binary
 .PHONY: clean
 clean: build_docker_image ## clean build artifacts
 	docker run --rm $(ENVVARS) $(MOUNTS) $(DEV_DOCKER_IMAGE_NAME) make clean
+	docker volume rm -f $(CACHE_VOLUME_NAME)
 
 .PHONY: test-unit
 test-unit: build_docker_image # run unit tests (using go test)


### PR DESCRIPTION
A couple of (unrelated) tweaks to the build.

Firstly add a `make -f dockerfile.Makefile fmt` target which runs `gofmt` on all the non-vendored Go code as a developer convenience.

Secondly add (optional, but defaulted on) support for using a go build cache when using the `dockerfile.Makefile` targets. This speeds up repeated builds for me by 6x (over 1m to less than 10s), according to `time make build -f docker.Makefile DOCKER_BUILDKIT=1 GO_BUILD_CACHE=y` (or =n).
