### PR TITLE
[18.09 backport] Fix panic (npe) when updating service limits/reservations

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -302,6 +302,12 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 		if task.Resources == nil {
 			task.Resources = &swarm.ResourceRequirements{}
 		}
+		if task.Resources.Limits == nil {
+			task.Resources.Limits = &swarm.Resources{}
+		}
+		if task.Resources.Reservations == nil {
+			task.Resources.Reservations = &swarm.Resources{}
+		}
 		return task.Resources
 	}
 

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -619,6 +619,38 @@ func TestUpdateLimitsReservations(t *testing.T) {
 	spec := swarm.ServiceSpec{
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: &swarm.ContainerSpec{},
+		},
+	}
+
+	// test that updating works if the service did not previously
+	// have limits set (https://github.com/moby/moby/issues/38363)
+	flags := newUpdateCommand(nil).Flags()
+	err := flags.Set(flagLimitCPU, "2")
+	assert.NilError(t, err)
+	err = flags.Set(flagLimitMemory, "200M")
+	assert.NilError(t, err)
+	err = updateService(context.Background(), nil, flags, &spec)
+	assert.NilError(t, err)
+
+	spec = swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{},
+		},
+	}
+
+	// test that updating works if the service did not previously
+	// have reservations set (https://github.com/moby/moby/issues/38363)
+	flags = newUpdateCommand(nil).Flags()
+	err = flags.Set(flagReserveCPU, "2")
+	assert.NilError(t, err)
+	err = flags.Set(flagReserveMemory, "200M")
+	assert.NilError(t, err)
+	err = updateService(context.Background(), nil, flags, &spec)
+	assert.NilError(t, err)
+
+	spec = swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{},
 			Resources: &swarm.ResourceRequirements{
 				Limits: &swarm.Resources{
 					NanoCPUs:    1000000000,
@@ -632,8 +664,8 @@ func TestUpdateLimitsReservations(t *testing.T) {
 		},
 	}
 
-	flags := newUpdateCommand(nil).Flags()
-	err := flags.Set(flagLimitCPU, "2")
+	flags = newUpdateCommand(nil).Flags()
+	err = flags.Set(flagLimitCPU, "2")
 	assert.NilError(t, err)
 	err = flags.Set(flagReserveCPU, "2")
 	assert.NilError(t, err)


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1566 for 18.09
fixes https://github.com/moby/moby/issues/38363 for 18.09