### PR TITLE
TestRunLabel: pass detach as argument

### DIFF
--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -23,8 +23,7 @@ func TestRunLabel(t *testing.T) {
 		Version: "1.36",
 	})
 	cmd := NewRunCommand(cli)
-	cmd.Flags().Set("detach", "true")
-	cmd.SetArgs([]string{"--label", "foo", "busybox"})
+	cmd.SetArgs([]string{"--detach=true", "--label", "foo", "busybox"})
 	assert.NilError(t, cmd.Execute())
 }
 


### PR DESCRIPTION
My IDE was complaining about not checking the error returned by `cmd.Flags().Set()`

Wasn't sure why detach was set this way, but passing it as `arg` looks to work as well