### PR TITLE
e2e: assign a default value of 0 to `DOCKERD_EXPERIMENTAL`

### DIFF
--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -17,7 +17,7 @@ function setup {
     local project=$1
     local file=$2
 
-    test "${DOCKERD_EXPERIMENTAL:-}" -eq "1" && file="${file}:./e2e/compose-env.experimental.yaml"
+    test "${DOCKERD_EXPERIMENTAL:-0}" -eq "1" && file="${file}:./e2e/compose-env.experimental.yaml"
 
     if [[ "${TEST_CONNHELPER:-}" = "ssh" ]];then
         test ! -f "${HOME}/.ssh/id_rsa" && ssh-keygen -t rsa -C docker-e2e-dummy -N "" -f "${HOME}/.ssh/id_rsa" -q


### PR DESCRIPTION
Currently running the e2e tests produces a warning/error:

    $ make -f docker.Makefile test-e2e
    «...»
    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker-cli-e2e
    ./scripts/test/e2e/run: line 20: test: : integer expression expected

This is from:

    test "${DOCKERD_EXPERIMENTAL:-}" -eq "1" && «...»

Where `${DOCKERD_EXPERIMENTAL:-}` expands to the empty string, resulting in
`test "" -eq "1"` which produces the warning. This error is enough to trigger
the short-circuiting behaviour of `&&` so the result is as expected, but fix
the issue nonetheless by providing a default `0`.

Signed-off-by: Ian Campbell <ijc@docker.com>

**- What I did/ How I did it**

Removed an error printed by the e2e invocation script by ensuring that only integers (and not empty strings) are passed to `test(1)`'s `-eq` operator.

**- How to verify it**

Run `make -f docker.Makefile test-e2e` and observe the lack of an error message containing `integer expression expected`.

**- Description for the changelog**
Not worth a changelog entry IMHO
