### PR TITLE
[WIP][18.09] Bump Golang 1.10.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.10.6
+  GOVERSION: 1.10.7
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.10.6-alpine
+FROM    golang:1.10.7-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,3 @@
-FROM    dockercore/golang-cross:1.10.6@sha256:2054e793010774e9dbafc808dd550a99f8468013731728bea7fce56681510078
+FROM    dockercore/golang-cross:1.10.7@sha256:9cd25b8083ef15fcc4a665c4b778077e2b8207ddede18d2f451f283dddca7a3b
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 
-FROM    golang:1.10.6-alpine
+FROM    golang:1.10.7-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.10.6
+ARG GO_VERSION=1.10.7
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.10.6-alpine
+FROM    golang:1.10.7-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.10.7 (released 2018/12/14) includes a fix to a bug introduced in Go 1.10.6
that broke go get for import path patterns containing "...".

See the Go 1.10.7 milestone for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.10.7+label%3ACherryPickApproved

