### PR TITLE
Fix some spelling errors

### DIFF
--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -16,7 +16,7 @@ var patternString = fmt.Sprintf(
 
 var defaultPattern = regexp.MustCompile(patternString)
 
-// DefaultSubstituteFuncs contains the default SubstitueFunc used by the docker cli
+// DefaultSubstituteFuncs contains the default SubstituteFunc used by the docker cli
 var DefaultSubstituteFuncs = []SubstituteFunc{
 	softDefault,
 	hardDefault,

--- a/cli/manifest/types/types.go
+++ b/cli/manifest/types/types.go
@@ -91,7 +91,7 @@ func NewImageManifest(ref reference.Named, desc ocispec.Descriptor, manifest *sc
 	}
 }
 
-// SerializableNamed is a reference.Named that can be serialzied and deserialized
+// SerializableNamed is a reference.Named that can be serialized and deserialized
 // from JSON
 type SerializableNamed struct {
 	reference.Named


### PR DESCRIPTION
Fix some spelling errors:
1. "SubstitueFunc" to "SubstituteFunc" in line 19.
2. "serialzied" to "serialized" in line 94.