### PR TITLE
Add content trust tests for run command

### DIFF
--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -50,9 +50,85 @@ func TestRunWithContentTrust(t *testing.T) {
 	})
 }
 
+func TestUntrustedRun(t *testing.T) {
+	dir := fixtures.SetupConfigFile(t)
+	defer dir.Remove()
+	image := registryPrefix + "/alpine:untrusted"
+	// tag the image and upload it to the private registry
+	icmd.RunCommand("docker", "tag", fixtures.AlpineImage, image).Assert(t, icmd.Success)
+	defer func() {
+		icmd.RunCommand("docker", "image", "rm", image).Assert(t, icmd.Success)
+	}()
+
+	// try trusted run on untrusted tag
+	result := icmd.RunCmd(
+		icmd.Command("docker", "run", image),
+		fixtures.WithConfig(dir.Path()),
+		fixtures.WithTrust,
+		fixtures.WithNotary,
+	)
+	result.Assert(t, icmd.Expected{
+		ExitCode: 125,
+		Err:      "does not have trust data for",
+	})
+}
+
+func TestTrustedRunFromBadTrustServer(t *testing.T) {
+	evilImageName := registryPrefix + "/evil-alpine:latest"
+	dir := fixtures.SetupConfigFile(t)
+	defer dir.Remove()
+
+	// tag the image and upload it to the private registry
+	icmd.RunCmd(icmd.Command("docker", "tag", fixtures.AlpineImage, evilImageName),
+		fixtures.WithConfig(dir.Path()),
+	).Assert(t, icmd.Success)
+	icmd.RunCmd(icmd.Command("docker", "image", "push", evilImageName),
+		fixtures.WithConfig(dir.Path()),
+		fixtures.WithPassphrase("root_password", "repo_password"),
+		fixtures.WithTrust,
+		fixtures.WithNotary,
+	).Assert(t, icmd.Success)
+	icmd.RunCmd(icmd.Command("docker", "image", "rm", evilImageName)).Assert(t, icmd.Success)
+
+	// try run
+	icmd.RunCmd(icmd.Command("docker", "run", evilImageName),
+		fixtures.WithConfig(dir.Path()),
+		fixtures.WithTrust,
+		fixtures.WithNotary,
+	).Assert(t, icmd.Success)
+	icmd.RunCmd(icmd.Command("docker", "image", "rm", evilImageName)).Assert(t, icmd.Success)
+
+	// init a client with the evil-server and a new trust dir
+	evilNotaryDir := fixtures.SetupConfigWithNotaryURL(t, "evil-test", fixtures.EvilNotaryURL)
+	defer evilNotaryDir.Remove()
+
+	// tag the same image and upload it to the private registry but signed with evil notary server
+	icmd.RunCmd(icmd.Command("docker", "tag", fixtures.AlpineImage, evilImageName),
+		fixtures.WithConfig(evilNotaryDir.Path()),
+	).Assert(t, icmd.Success)
+	icmd.RunCmd(icmd.Command("docker", "image", "push", evilImageName),
+		fixtures.WithConfig(evilNotaryDir.Path()),
+		fixtures.WithPassphrase("root_password", "repo_password"),
+		fixtures.WithTrust,
+		fixtures.WithNotaryServer(fixtures.EvilNotaryURL),
+	).Assert(t, icmd.Success)
+	icmd.RunCmd(icmd.Command("docker", "image", "rm", evilImageName)).Assert(t, icmd.Success)
+
+	// try running with the original client from the evil notary server. This should failed
+	// because the new root is invalid
+	icmd.RunCmd(icmd.Command("docker", "run", evilImageName),
+		fixtures.WithConfig(dir.Path()),
+		fixtures.WithTrust,
+		fixtures.WithNotaryServer(fixtures.EvilNotaryURL),
+	).Assert(t, icmd.Expected{
+		ExitCode: 125,
+		Err:      "could not rotate trust to a new trusted root",
+	})
+}
+
 // TODO: create this with registry API instead of engine API
 func createRemoteImage(t *testing.T) string {
-	image := "registry:5000/alpine:test-run-pulls"
+	image := registryPrefix + "/alpine:test-run-pulls"
 	icmd.RunCommand("docker", "pull", fixtures.AlpineImage).Assert(t, icmd.Success)
 	icmd.RunCommand("docker", "tag", fixtures.AlpineImage, image).Assert(t, icmd.Success)
 	icmd.RunCommand("docker", "push", image).Assert(t, icmd.Success)


### PR DESCRIPTION
Signed-off-by: glefloch <glfloch@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I add two tests on trust content for the `run` command. This intend to partially close #951 

**- How I did it**
I migrated code from the pull request removing the testsuite from moby repository ( [TestUntrustedRun](https://github.com/moby/moby/pull/36515/files#diff-0189e098e6ba3aeffd9ee321ee6aca8aL3156) and [TestTrustedRunFromBadTrustServer](https://github.com/moby/moby/pull/36515/files#diff-0189e098e6ba3aeffd9ee321ee6aca8aL3172))

**- How to verify it**
You can verify it by running the e2e testsuite

**- Description for the changelog**
Adding trust test for `run` command


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/1827790/50586698-f6261280-0e7a-11e9-8d9c-d3dd12589e76.png)
