### PR TITLE
Hide legacy top-level "deploy" command with DOCKER_HIDE_LEGACY_COMMANDS=1

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -75,7 +75,6 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 
 		// stack
 		stack.NewStackCommand(dockerCli),
-		stack.NewTopLevelDeployCommand(dockerCli),
 
 		// swarm
 		swarm.NewSwarmCommand(dockerCli),
@@ -87,6 +86,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		volume.NewVolumeCommand(dockerCli),
 
 		// legacy commands may be hidden
+		hide(stack.NewTopLevelDeployCommand(dockerCli)),
 		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInfoCommand(dockerCli)),
 		hide(system.NewInspectCommand(dockerCli)),


### PR DESCRIPTION
The `DOCKER_HIDE_LEGACY_COMMANDS` environment variable allows hiding legacy top-level commands that are now available under `docker <object> <verb>`. The `docker deploy` top-level command is experimental, and replaced by `docker stack deploy`.

This patch hides the top-level `docker deploy` if the `DOCKER_HIDE_LEGACY_COMMANDS` environment variable is set.

Before this change:

    DOCKER_HIDE_LEGACY_COMMANDS=1 docker --help

    ...

    Commands:
      build       Build an image from a Dockerfile
      deploy      Deploy a new stack or update an existing stack
      login       Log in to a Docker registry
      logout      Log out from a Docker registry
      run         Run a command in a new container
      search      Search the Docker Hub for images
      version     Show the Docker version information
    ...

With this patch applied:

    DOCKER_HIDE_LEGACY_COMMANDS=1 docker --help

    ...

    Commands:
      build       Build an image from a Dockerfile
      login       Log in to a Docker registry
      logout      Log out from a Docker registry
      run         Run a command in a new container
      search      Search the Docker Hub for images
      version     Show the Docker version information
    ...

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
+ Hide legacy top-level "deploy" command with DOCKER_HIDE_LEGACY_COMMANDS=1
```

