### PR TITLE
Add --device support for Windows

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -72,7 +72,7 @@ func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, options *createOptio
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
-	containerConfig, err := parse(flags, copts)
+	containerConfig, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
 	if err != nil {
 		reportError(dockerCli.Err(), "create", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -78,7 +78,7 @@ func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copt
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
-	containerConfig, err := parse(flags, copts)
+	containerConfig, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
 	// just in case the parse does not exit
 	if err != nil {
 		reportError(dockerCli.Err(), "run", err.Error(), true)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Adds support for --device in Windows. This must take the form of: --device='class/clsid'. See https://blogs.technet.microsoft.com/virtualization/2018/08/13/bringing-device-support-to-windows-server-containers/ for more info. The server-side fix was merged in https://github.com/moby/moby/pull/37638 back in November 2018.

@thaJeztah As discussed offline. Annoyingly, due to the code pattern having flag validation happening before the _ping is sent to the daemon, I had to move the validation in the Linux case to during parsing. i.e. after the server OS is known. Fortunately, that avoided the need for a global as was the option on the table before. If (at a later time), the device can be validated entirely daemon side for Linux, it will greatly simplify things.

This replaces https://github.com/docker/cli/pull/1290. @jterry75 FYI.  You should be able to close the previous PR.