### PR TITLE
Add support for maximum replicas per node without stack

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -49,6 +49,9 @@ Placement:
 {{- if .TaskPlacementPreferences }}
  Preferences:   {{ .TaskPlacementPreferences }}
 {{- end }}
+{{- if .MaxReplicas }}
+ Max Replicas Per Node:   {{ .MaxReplicas }}
+{{- end }}
 {{- if .HasUpdateConfig }}
 UpdateConfig:
  Parallelism:	{{ .UpdateParallelism }}
@@ -282,6 +285,13 @@ func (ctx *serviceInspectContext) TaskPlacementPreferences() []string {
 		}
 	}
 	return strings
+}
+
+func (ctx *serviceInspectContext) MaxReplicas() uint64 {
+	if ctx.Service.Spec.TaskTemplate.Placement != nil {
+		return ctx.Service.Spec.TaskTemplate.Placement.MaxReplicas
+	}
+	return 0
 }
 
 func (ctx *serviceInspectContext) HasUpdateConfig() bool {

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -120,9 +120,16 @@ func GetServicesStatus(services []swarm.Service, nodes []swarm.Node, tasks []swa
 	for _, service := range services {
 		info[service.ID] = ListInfo{}
 		if service.Spec.Mode.Replicated != nil && service.Spec.Mode.Replicated.Replicas != nil {
-			info[service.ID] = ListInfo{
-				Mode:     "replicated",
-				Replicas: fmt.Sprintf("%d/%d", running[service.ID], *service.Spec.Mode.Replicated.Replicas),
+			if service.Spec.TaskTemplate.Placement != nil && service.Spec.TaskTemplate.Placement.MaxReplicas > 0 {
+				info[service.ID] = ListInfo{
+					Mode:     "replicated",
+					Replicas: fmt.Sprintf("%d/%d (max %d per node)", running[service.ID], *service.Spec.Mode.Replicated.Replicas, service.Spec.TaskTemplate.Placement.MaxReplicas),
+				}
+			} else {
+				info[service.ID] = ListInfo{
+					Mode:     "replicated",
+					Replicas: fmt.Sprintf("%d/%d", running[service.ID], *service.Spec.Mode.Replicated.Replicas),
+				}
 			}
 		} else if service.Spec.Mode.Global != nil {
 			info[service.ID] = ListInfo{

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -224,3 +224,12 @@ func TestToServiceUpdateRollback(t *testing.T) {
 	assert.Check(t, is.DeepEqual(service.UpdateConfig, expected.UpdateConfig))
 	assert.Check(t, is.DeepEqual(service.RollbackConfig, expected.RollbackConfig))
 }
+
+func TestToServiceMaxReplicasGlobalModeConflict(t *testing.T) {
+	opt := serviceOptions{
+		mode:        "global",
+		maxReplicas: 1,
+	}
+	_, err := opt.ToServiceMode()
+	assert.Error(t, err, "replicas-max-per-node can only be used with replicated mode")
+}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -387,6 +387,10 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 		return err
 	}
 
+	if anyChanged(flags, flagMaxReplicas) {
+		updateUint64(flagMaxReplicas, &task.Placement.MaxReplicas)
+	}
+
 	if anyChanged(flags, flagUpdateParallelism, flagUpdateDelay, flagUpdateMonitor, flagUpdateFailureAction, flagUpdateMaxFailureRatio, flagUpdateOrder) {
 		if spec.UpdateConfig == nil {
 			spec.UpdateConfig = updateConfigFromDefaults(defaults.Service.Update)

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -808,3 +808,23 @@ func TestUpdateNetworks(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id999"}}, svc.TaskTemplate.Networks))
 }
+
+func TestUpdateMaxReplicas(t *testing.T) {
+	ctx := context.Background()
+
+	svc := swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{},
+			Placement: &swarm.Placement{
+				MaxReplicas: 1,
+			},
+		},
+	}
+
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set(flagMaxReplicas, "2")
+	err := updateService(ctx, nil, flags, &svc)
+	assert.NilError(t, err)
+
+	assert.DeepEqual(t, svc.TaskTemplate.Placement, &swarm.Placement{MaxReplicas: uint64(2)})
+}

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -61,6 +61,7 @@ Options:
   -q, --quiet                              Suppress progress output
       --read-only                          Mount the container's root filesystem as read only
       --replicas uint                      Number of tasks
+      --replicas-max-per-node uint         Maximum number of tasks per node (default 0 = unlimited)
       --reserve-cpu decimal                Reserve CPUs
       --reserve-memory bytes               Reserve Memory
       --restart-condition string           Restart when condition is met ("none"|"on-failure"|"any") (default "any")
@@ -756,6 +757,26 @@ When updating a service with `docker service update`, `--placement-pref-add`
 appends a new placement preference after all existing placement preferences.
 `--placement-pref-rm` removes an existing placement preference that matches the
 argument.
+
+### Specify maximum replicas per node (--replicas-max-per-node)
+
+Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
+The following command creates a nginx service with 2 replica tasks but only one replica task per node.
+
+One example where this can be useful is to balance tasks over a set of data centers together with `--placement-pref`
+and let `--replicas-max-per-node` setting make sure that replicas are not migrated to another datacenter during
+maintenance or datacenter failure.
+
+The example below illustrates this:
+
+```bash
+$ docker service create \
+  --name nginx \
+  --replicas 2 \
+  --replicas-max-per-node 1 \
+  --placement-pref 'spread=node.labels.datacenter' \
+  nginx
+```
 
 ### Attach a service to an existing network (--network)
 


### PR DESCRIPTION
**- What I did**
Added support for maximum replicas per node

Third step to be able solve:
* moby/moby#26259


**- How I did it**
Added new switch --replicas-max-per-node switch to docker service

**- How to verify it**
Create two services and specify ```--replicas-max-per-node``` one of them:
```
docker service create --detach=true --name web1 --replicas 2 nginx
docker service create --detach=true --name web2 --replicas 2 --replicas-max-per-node 1 nginx
```

See difference on command outputs:
```
$ docker service ls
ID                  NAME                MODE                REPLICAS               IMAGE               PORTS
0inbv7q148nn        web1                replicated          2/2                    nginx:latest        
9kry59rk4ecr        web2                replicated          1/2 (max 1 per node)   nginx:latest
        
$ docker service ps --no-trunc web2
ID                          NAME                IMAGE                                                                                  NODE                DESIRED STATE       CURRENT STATE            ERROR                                                     PORTS
bf90bhy72o2ry2pj50xh24cfp   web2.1              nginx:latest@sha256:b543f6d0983fbc25b9874e22f4fe257a567111da96fd1d8f1b44315f1236398c   limint              Running             Running 34 seconds ago                                                             
xedop9dwtilok0r56w4g7h5jm   web2.2              nginx:latest@sha256:b543f6d0983fbc25b9874e22f4fe257a567111da96fd1d8f1b44315f1236398c                       Running             Pending 35 seconds ago   "no suitable node (max replicas per node limit exceed)"   
```

**- Description for the changelog**
- Split from #1410 to simplify review