### PR TITLE
Add support for Kubernetes Pull secrets and Pull policies

### DIFF
--- a/cli/command/stack/kubernetes/stackclient.go
+++ b/cli/command/stack/kubernetes/stackclient.go
@@ -125,7 +125,7 @@ func verify(services corev1.ServiceInterface, stackName string, service string) 
 
 // stackV1Beta2 implements stackClient interface and talks to compose component v1beta2.
 type stackV1Beta2 struct {
-	stackV1Beta2OrHigherConverter
+	stackV1Beta2Converter
 	stacks composev1beta2.StackInterface
 }
 
@@ -203,7 +203,7 @@ func (s *stackV1Beta2) IsColliding(servicesClient corev1.ServiceInterface, st St
 
 // stackV1Beta2 implements stackClient interface and talks to compose component v1beta2.
 type stackV1Alpha3 struct {
-	stackV1Beta2OrHigherConverter
+	stackV1Alpha3Converter
 	stacks composev1alpha3.StackInterface
 }
 

--- a/cli/command/stack/kubernetes/testdata/compose-with-pull-policy.yml
+++ b/cli/command/stack/kubernetes/testdata/compose-with-pull-policy.yml
@@ -1,0 +1,5 @@
+version: "3.7"
+services:
+  test:
+    image: "some-image"
+    x-pull-policy: "Never"

--- a/cli/command/stack/kubernetes/testdata/compose-with-pull-secret.yml
+++ b/cli/command/stack/kubernetes/testdata/compose-with-pull-secret.yml
@@ -1,0 +1,5 @@
+version: "3.7"
+services:
+  test:
+    image: "some-private-image"
+    x-pull-secret: "some-secret"

--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76 # v1.1.0
 github.com/dgrijalva/jwt-go a2c85815a77d0f951e33ba4db5ae93629a1530af
 github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
 github.com/docker/docker f76d6a078d881f410c00e8d900dcdfc2e026c841
-github.com/docker/compose-on-kubernetes 1559927c6b456d56cc9c9b05438252ebb646640b # master w/ v1alpha3
+github.com/docker/compose-on-kubernetes 356b2919c496f7e988f6e0dfe7e67d919602e14e # master w/ v1alpha3+pullsecrets+pull-policy
 github.com/docker/docker-credential-helpers 5241b46610f2491efdf9d1c85f1ddf5b02f6d962
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.

--- a/vendor/github.com/docker/compose-on-kubernetes/api/compose/v1alpha3/stack.go
+++ b/vendor/github.com/docker/compose-on-kubernetes/api/compose/v1alpha3/stack.go
@@ -97,6 +97,8 @@ type ServiceConfig struct {
 	User            *int64                   `json:"user,omitempty"`
 	Volumes         []ServiceVolumeConfig    `json:"volumes,omitempty"`
 	WorkingDir      string                   `json:"working_dir,omitempty"`
+	PullSecret      string                   `json:"pull_secret,omitempty"`
+	PullPolicy      string                   `json:"pull_policy,omitempty"`
 }
 
 // ServicePortConfig is the port configuration for a service


### PR DESCRIPTION
Based on #1615 

**- What I did**

Added support for referencing pull secrets in Compose Files deployed to Kubernetes, and specifying a Pull Policy

**- How I did it**

Interpret `x-pull-secret` and `x-pull-policy` extra fields on ServiceConfig to be mapped to the PullSecret and PullPolicy fields in Compose on Kubernetes v1alpha3 ServiceConfig.

**- How to verify it**

The PR comes with unit tests covering:
- correct mapping from x-pull-secret/x-pull-policy to the Compose on Kubernetes Stack representation
- failure when reading a x-pull-secret/x-pull-policy field when using v1beta1 or v1beta2 endpoints (to avoid updating an existing service and as a side effect remove the pull secret reference)

**- Description for the changelog**

- (Experimental) When targetting Kubernetes, add support for `x-pull-secret: some-pull-secret` in compose-files service configs.
- (Experimental) When targetting Kubernetes, add support for `x-pull-policy: <Never|Always|IfNotPresent>` in compose-files service configs.

**- A picture of a cute animal (not mandatory but encouraged)**
![spy cat](https://media.giphy.com/media/1X3blP3QM4oRG/giphy.gif)

