### PR TITLE
docker context use: modify current kubeconfig

### DIFF
--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -2,38 +2,101 @@ package context
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/context/kubernetes"
+	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/docker/pkg/homedir"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
+type useOptions struct {
+	skipKubeconfig bool
+}
+
 func newUseCommand(dockerCli command.Cli) *cobra.Command {
+	opts := &useOptions{}
 	cmd := &cobra.Command{
-		Use:   "use CONTEXT",
+		Use:   "use CONTEXT [OPTIONS]",
 		Short: "Set the current docker context",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := validateContextName(name); err != nil && name != "default" {
-				return err
-			}
-			if _, err := dockerCli.ContextStore().GetContextMetadata(name); err != nil && name != "default" {
-				return err
-			}
-			configValue := name
-			if configValue == "default" {
-				configValue = ""
-			}
-			dockerConfig := dockerCli.ConfigFile()
-			dockerConfig.CurrentContext = configValue
-			if err := dockerConfig.Save(); err != nil {
-				return err
-			}
-			fmt.Fprintln(dockerCli.Out(), name)
-			fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
-			return nil
+			return runUse(dockerCli, name, *opts)
 		},
 	}
+	cmd.Flags().BoolVar(&opts.skipKubeconfig, "skip-kubeconfig", false, "Do not modify current kubeconfig file (set via KUBECONFIG environment variable, or ~/.kube/config)")
 	return cmd
+}
+
+func runUse(dockerCli command.Cli, name string, opts useOptions) error {
+	if err := validateContextName(name); err != nil && name != "default" {
+		return err
+	}
+	ctxMeta, err := dockerCli.ContextStore().GetContextMetadata(name)
+	if err != nil && name != "default" {
+		return err
+	}
+	configValue := name
+	if configValue == "default" {
+		configValue = ""
+	}
+	if !opts.skipKubeconfig {
+		if err := applyToKubeconfig(dockerCli, configValue, ctxMeta); err != nil {
+			return err
+		}
+	}
+	dockerConfig := dockerCli.ConfigFile()
+	dockerConfig.CurrentContext = configValue
+	if err := dockerConfig.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintln(dockerCli.Out(), name)
+	fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
+	return nil
+}
+
+func applyToKubeconfig(dockerCli command.Cli, contextName string, contextMeta store.ContextMetadata) error {
+	if contextName == "" {
+		return nil
+	}
+	kubeEndpointMeta := kubernetes.EndpointFromContext(contextMeta)
+	if kubeEndpointMeta == nil {
+		return nil
+	}
+	kubeEndpoint, err := kubeEndpointMeta.WithTLSData(dockerCli.ContextStore(), contextName)
+	if err != nil {
+		return err
+	}
+	kubeconfig, err := kubeEndpoint.KubernetesNamedConfig(contextName, contextName, contextName).RawConfig()
+	if err != nil {
+		return err
+	}
+	kubeconfigPath := kubeconfigPath()
+	_, err = os.Stat(kubeconfigPath)
+	switch {
+	case os.IsNotExist(err):
+		return clientcmd.WriteToFile(kubeconfig, kubeconfigPath)
+	case err != nil:
+		return err
+	}
+	targetConfig, err := clientcmd.LoadFromFile(kubeconfigPath)
+	if err != nil {
+		return err
+	}
+	targetConfig.AuthInfos[contextName] = kubeconfig.AuthInfos[contextName]
+	targetConfig.Clusters[contextName] = kubeconfig.Clusters[contextName]
+	targetConfig.Contexts[contextName] = kubeconfig.Contexts[contextName]
+	targetConfig.CurrentContext = contextName
+	return clientcmd.WriteToFile(*targetConfig, kubeconfigPath)
+}
+
+func kubeconfigPath() string {
+	if config := os.Getenv("KUBECONFIG"); config != "" {
+		return config
+	}
+	return filepath.Join(homedir.Get(), ".kube/config")
 }

--- a/cli/context/kubernetes/load.go
+++ b/cli/context/kubernetes/load.go
@@ -38,6 +38,11 @@ func (c *EndpointMeta) WithTLSData(s store.Store, contextName string) (Endpoint,
 
 // KubernetesConfig creates the kubernetes client config from the endpoint
 func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
+	return c.KubernetesNamedConfig("cluster", "authInfo", "context")
+}
+
+// KubernetesNamedConfig creates the kubernetes client config from the endpoint
+func (c *Endpoint) KubernetesNamedConfig(clusterName, authInfoName, contextName string) clientcmd.ClientConfig {
 	cfg := clientcmdapi.NewConfig()
 	cluster := clientcmdapi.NewCluster()
 	cluster.Server = c.Host
@@ -50,14 +55,14 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 	}
 	authInfo.AuthProvider = c.AuthProvider
 	authInfo.Exec = c.Exec
-	cfg.Clusters["cluster"] = cluster
-	cfg.AuthInfos["authInfo"] = authInfo
+	cfg.Clusters[clusterName] = cluster
+	cfg.AuthInfos[authInfoName] = authInfo
 	ctx := clientcmdapi.NewContext()
-	ctx.AuthInfo = "authInfo"
-	ctx.Cluster = "cluster"
+	ctx.AuthInfo = authInfoName
+	ctx.Cluster = clusterName
 	ctx.Namespace = c.DefaultNamespace
-	cfg.Contexts["context"] = ctx
-	cfg.CurrentContext = "context"
+	cfg.Contexts[contextName] = ctx
+	cfg.CurrentContext = contextName
 	return clientcmd.NewDefaultClientConfig(*cfg, &clientcmd.ConfigOverrides{})
 }
 

--- a/docs/reference/commandline/context_use.md
+++ b/docs/reference/commandline/context_use.md
@@ -16,10 +16,17 @@ keywords: "context, use"
 # context use
 
 ```markdown
-Usage:  docker context use CONTEXT
+Usage:  docker context use CONTEXT [OPTIONS]
 
 Set the current docker context
+
+Options:
+      --skip-kubeconfig   Do not modify current kubeconfig file (set via
+                          KUBECONFIG environment variable, or ~/.kube/config)
 ```
 
 ## Description
 Set the default context to use, when `DOCKER_HOST`, `DOCKER_CONTEXT` environment variables and `--host`, `--context` global options are not set.
+
+For contexts with a Kubernetes endpoint, this also modifes the current `kubeconfig` file to make `kubectl` and any other tool working with `kubeconfig` files target the same cluster.
+


### PR DESCRIPTION
**- What I did**

For contexts with a Kubernetes endpoint, `docker context use` now modifies the current kubeconfig file, to make sure `kubectl` and `docker` CLIs target the same cluster. This can be skipped with `--skip-kubeconfig`.

**- How I did it**

Using the k8s clientcmd package, I parse and modify the ambient kubeconfig file with the configuration stored in the context store

**- How to verify it**

This is covered by unit tests

**- A picture of a cute animal (not mandatory but encouraged)**
![captain cat](https://media.giphy.com/media/nk3FmEO5EnhW8/giphy.gif)
