### PR TITLE
Update process isolation description for older Windows 10 versions

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -721,12 +721,12 @@ On Windows, `--isolation` can take one of these values:
 | Value     | Description                                                                                |
 |:----------|:-------------------------------------------------------------------------------------------|
 | `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below). |
-| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems).     |
+| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809).     |
 | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
-The default isolation on Windows server operating systems is `process`. The default (and only supported)
+The default isolation on Windows server operating systems is `process`. The default
 isolation on Windows client operating systems is `hyperv`. An attempt to start a container on a client
-operating system with `--isolation process` will fail.
+operating system older than Windows 10 1809 with `--isolation process` will fail.
 
 On Windows server, assuming the default configuration, these commands are equivalent
 and result in `process` isolation:


### PR DESCRIPTION
**- What I did**

I've updated the docs a little bit, because someone told me in https://github.com/StefanScherer/dockerfiles-windows/issues/383#issuecomment-455961341 that the Docker CLI docs show no support for process isolation mode on Windows client OS.
Well on Windows 10 1809 it is possible with Docker 18.09.1 as we already know from docker/for-win#600 or Twitter https://twitter.com/EltonStoneman/status/1083751357100765185/photo/1 ;-)

**- How I did it**

**- How to verify it**

**- Description for the changelog**

Update the description for process isolation mode, that it's not supported on Windows clients older than Windows 10 1809.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="911" alt="bildschirmfoto 2019-01-21 um 08 17 13" src="https://user-images.githubusercontent.com/207759/51458289-f8caa800-1d54-11e9-81b2-20e291435043.png">
