### PR TITLE
Context switch - Plugin and Docker Desktop integration

### DIFF
--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -1,10 +1,14 @@
 package command
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strconv"
 
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/docker/cli/cli/context/kubernetes"
+	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/streams"
 	clitypes "github.com/docker/cli/types"
 	"github.com/docker/docker/pkg/term"
@@ -84,6 +88,19 @@ func WithContentTrust(enabled bool) DockerCliOption {
 func WithContainerizedClient(containerizedFn func(string) (clitypes.ContainerizedClient, error)) DockerCliOption {
 	return func(cli *DockerCli) error {
 		cli.newContainerizeClient = containerizedFn
+		return nil
+	}
+}
+
+// WithContextEndpointType add support for an additional typed endpoint in the context store
+// Plugins should use this to store additional endpoints configuration in the context store
+func WithContextEndpointType(endpointName string, endpointType store.TypeGetter) DockerCliOption {
+	return func(cli *DockerCli) error {
+		switch endpointName {
+		case docker.DockerEndpoint, kubernetes.KubernetesEndpoint:
+			return fmt.Errorf("cannot change %q endpoint type", endpointName)
+		}
+		cli.contextStoreConfig.SetEndpoint(endpointName, endpointType)
 		return nil
 	}
 }

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -46,68 +46,68 @@ func TestCreateInvalids(t *testing.T) {
 	defer cleanup()
 	assert.NilError(t, cli.ContextStore().CreateOrUpdateContext(store.ContextMetadata{Name: "existing-context"}))
 	tests := []struct {
-		options     createOptions
+		options     CreateOptions
 		expecterErr string
 	}{
 		{
 			expecterErr: `context name cannot be empty`,
 		},
 		{
-			options: createOptions{
-				name: " ",
+			options: CreateOptions{
+				Name: " ",
 			},
 			expecterErr: `context name " " is invalid`,
 		},
 		{
-			options: createOptions{
-				name: "existing-context",
+			options: CreateOptions{
+				Name: "existing-context",
 			},
 			expecterErr: `context "existing-context" already exists`,
 		},
 		{
-			options: createOptions{
-				name: "invalid-docker-host",
-				docker: map[string]string{
+			options: CreateOptions{
+				Name: "invalid-docker-host",
+				Docker: map[string]string{
 					keyHost: "some///invalid/host",
 				},
 			},
 			expecterErr: `unable to parse docker host`,
 		},
 		{
-			options: createOptions{
-				name:                     "invalid-orchestrator",
-				defaultStackOrchestrator: "invalid",
+			options: CreateOptions{
+				Name:                     "invalid-orchestrator",
+				DefaultStackOrchestrator: "invalid",
 			},
 			expecterErr: `specified orchestrator "invalid" is invalid, please use either kubernetes, swarm or all`,
 		},
 		{
-			options: createOptions{
-				name:                     "orchestrator-swarm-no-endpoint",
-				defaultStackOrchestrator: "swarm",
+			options: CreateOptions{
+				Name:                     "orchestrator-swarm-no-endpoint",
+				DefaultStackOrchestrator: "swarm",
 			},
 			expecterErr: `docker endpoint configuration is required`,
 		},
 		{
-			options: createOptions{
-				name:                     "orchestrator-kubernetes-no-endpoint",
-				defaultStackOrchestrator: "kubernetes",
-				docker:                   map[string]string{},
+			options: CreateOptions{
+				Name:                     "orchestrator-kubernetes-no-endpoint",
+				DefaultStackOrchestrator: "kubernetes",
+				Docker:                   map[string]string{},
 			},
 			expecterErr: `cannot specify orchestrator "kubernetes" without configuring a Kubernetes endpoint`,
 		},
 		{
-			options: createOptions{
-				name:                     "orchestrator-all-no-endpoint",
-				defaultStackOrchestrator: "all",
-				docker:                   map[string]string{},
+			options: CreateOptions{
+				Name:                     "orchestrator-all-no-endpoint",
+				DefaultStackOrchestrator: "all",
+				Docker:                   map[string]string{},
 			},
 			expecterErr: `cannot specify orchestrator "all" without configuring a Kubernetes endpoint`,
 		},
 	}
 	for _, tc := range tests {
 		tc := tc
-		t.Run(tc.options.name, func(t *testing.T) {
-			err := runCreate(cli, &tc.options)
+		t.Run(tc.options.Name, func(t *testing.T) {
+			err := RunCreate(cli, &tc.options)
 			assert.ErrorContains(t, err, tc.expecterErr)
 		})
 	}
@@ -117,10 +117,10 @@ func TestCreateOrchestratorSwarm(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
 
-	err := runCreate(cli, &createOptions{
-		name:                     "test",
-		defaultStackOrchestrator: "swarm",
-		docker:                   map[string]string{},
+	err := RunCreate(cli, &CreateOptions{
+		Name:                     "test",
+		DefaultStackOrchestrator: "swarm",
+		Docker:                   map[string]string{},
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, "test\n", cli.OutBuffer().String())
@@ -131,9 +131,9 @@ func TestCreateOrchestratorEmpty(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
 
-	err := runCreate(cli, &createOptions{
-		name:   "test",
-		docker: map[string]string{},
+	err := RunCreate(cli, &CreateOptions{
+		Name:   "test",
+		Docker: map[string]string{},
 	})
 	assert.NilError(t, err)
 }
@@ -156,13 +156,13 @@ func createTestContextWithKube(t *testing.T, cli command.Cli) {
 	revert := env.Patch(t, "KUBECONFIG", "./testdata/test-kubeconfig")
 	defer revert()
 
-	err := runCreate(cli, &createOptions{
-		name:                     "test",
-		defaultStackOrchestrator: "all",
-		kubernetes: map[string]string{
+	err := RunCreate(cli, &CreateOptions{
+		Name:                     "test",
+		DefaultStackOrchestrator: "all",
+		Kubernetes: map[string]string{
 			keyFromCurrent: "true",
 		},
-		docker: map[string]string{},
+		Docker: map[string]string{},
 	})
 	assert.NilError(t, err)
 }

--- a/cli/command/context/export-import_test.go
+++ b/cli/command/context/export-import_test.go
@@ -21,14 +21,14 @@ func TestExportImportWithFile(t *testing.T) {
 	defer cleanup()
 	createTestContextWithKube(t, cli)
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runExport(cli, &exportOptions{
-		contextName: "test",
-		dest:        contextFile,
+	assert.NilError(t, RunExport(cli, &ExportOptions{
+		ContextName: "test",
+		Dest:        contextFile,
 	}))
 	assert.Equal(t, cli.ErrBuffer().String(), fmt.Sprintf("Written file %q\n", contextFile))
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runImport(cli, "test2", contextFile))
+	assert.NilError(t, RunImport(cli, "test2", contextFile))
 	context1, err := cli.ContextStore().GetContextMetadata("test")
 	assert.NilError(t, err)
 	context2, err := cli.ContextStore().GetContextMetadata("test2")
@@ -48,15 +48,15 @@ func TestExportImportPipe(t *testing.T) {
 	createTestContextWithKube(t, cli)
 	cli.ErrBuffer().Reset()
 	cli.OutBuffer().Reset()
-	assert.NilError(t, runExport(cli, &exportOptions{
-		contextName: "test",
-		dest:        "-",
+	assert.NilError(t, RunExport(cli, &ExportOptions{
+		ContextName: "test",
+		Dest:        "-",
 	}))
 	assert.Equal(t, cli.ErrBuffer().String(), "")
 	cli.SetIn(streams.NewIn(ioutil.NopCloser(bytes.NewBuffer(cli.OutBuffer().Bytes()))))
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runImport(cli, "test2", "-"))
+	assert.NilError(t, RunImport(cli, "test2", "-"))
 	context1, err := cli.ContextStore().GetContextMetadata("test")
 	assert.NilError(t, err)
 	context2, err := cli.ContextStore().GetContextMetadata("test2")
@@ -79,18 +79,18 @@ func TestExportKubeconfig(t *testing.T) {
 	defer cleanup()
 	createTestContextWithKube(t, cli)
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runExport(cli, &exportOptions{
-		contextName: "test",
-		dest:        contextFile,
-		kubeconfig:  true,
+	assert.NilError(t, RunExport(cli, &ExportOptions{
+		ContextName: "test",
+		Dest:        contextFile,
+		Kubeconfig:  true,
 	}))
 	assert.Equal(t, cli.ErrBuffer().String(), fmt.Sprintf("Written file %q\n", contextFile))
-	assert.NilError(t, runCreate(cli, &createOptions{
-		name: "test2",
-		kubernetes: map[string]string{
+	assert.NilError(t, RunCreate(cli, &CreateOptions{
+		Name: "test2",
+		Kubernetes: map[string]string{
 			keyKubeconfig: contextFile,
 		},
-		docker: map[string]string{},
+		Docker: map[string]string{},
 	}))
 	validateTestKubeEndpoint(t, cli.ContextStore(), "test2")
 }
@@ -105,6 +105,6 @@ func TestExportExistingFile(t *testing.T) {
 	createTestContextWithKube(t, cli)
 	cli.ErrBuffer().Reset()
 	assert.NilError(t, ioutil.WriteFile(contextFile, []byte{}, 0644))
-	err = runExport(cli, &exportOptions{contextName: "test", dest: contextFile})
+	err = RunExport(cli, &ExportOptions{ContextName: "test", Dest: contextFile})
 	assert.Assert(t, os.IsExist(err))
 }

--- a/cli/command/context/import.go
+++ b/cli/command/context/import.go
@@ -17,13 +17,14 @@ func newImportCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Import a context from a tar file",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runImport(dockerCli, args[0], args[1])
+			return RunImport(dockerCli, args[0], args[1])
 		},
 	}
 	return cmd
 }
 
-func runImport(dockerCli command.Cli, name string, source string) error {
+// RunImport imports a Docker context
+func RunImport(dockerCli command.Cli, name string, source string) error {
 	if err := checkContextNameForCreation(dockerCli.ContextStore(), name); err != nil {
 		return err
 	}

--- a/cli/command/context/list_test.go
+++ b/cli/command/context/list_test.go
@@ -14,12 +14,12 @@ func createTestContextWithKubeAndSwarm(t *testing.T, cli command.Cli, name strin
 	revert := env.Patch(t, "KUBECONFIG", "./testdata/test-kubeconfig")
 	defer revert()
 
-	err := runCreate(cli, &createOptions{
-		name:                     name,
-		defaultStackOrchestrator: orchestrator,
-		description:              "description of " + name,
-		kubernetes:               map[string]string{keyFromCurrent: "true"},
-		docker:                   map[string]string{keyHost: "https://someswarmserver"},
+	err := RunCreate(cli, &CreateOptions{
+		Name:                     name,
+		DefaultStackOrchestrator: orchestrator,
+		Description:              "description of " + name,
+		Kubernetes:               map[string]string{keyFromCurrent: "true"},
+		Docker:                   map[string]string{keyHost: "https://someswarmserver"},
 	})
 	assert.NilError(t, err)
 }

--- a/cli/command/context/remove.go
+++ b/cli/command/context/remove.go
@@ -10,32 +10,34 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type removeOptions struct {
-	force bool
+// RemoveOptions are the options used to remove contexts
+type RemoveOptions struct {
+	Force bool
 }
 
 func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
-	var opts removeOptions
+	var opts RemoveOptions
 	cmd := &cobra.Command{
 		Use:     "rm CONTEXT [CONTEXT...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more contexts",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(dockerCli, opts, args)
+			return RunRemove(dockerCli, opts, args)
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force the removal of a context in use")
+	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force the removal of a context in use")
 	return cmd
 }
 
-func runRemove(dockerCli command.Cli, opts removeOptions, names []string) error {
+// RunRemove removes one or more contexts
+func RunRemove(dockerCli command.Cli, opts RemoveOptions, names []string) error {
 	var errs []string
 	currentCtx := dockerCli.CurrentContext()
 	for _, name := range names {
 		if name == "default" {
 			errs = append(errs, `default: context "default" cannot be removed`)
-		} else if err := doRemove(dockerCli, name, name == currentCtx, opts.force); err != nil {
+		} else if err := doRemove(dockerCli, name, name == currentCtx, opts.Force); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %s", name, err))
 		} else {
 			fmt.Fprintln(dockerCli.Out(), name)

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -17,7 +17,7 @@ func TestRemove(t *testing.T) {
 	defer cleanup()
 	createTestContextWithKubeAndSwarm(t, cli, "current", "all")
 	createTestContextWithKubeAndSwarm(t, cli, "other", "all")
-	assert.NilError(t, runRemove(cli, removeOptions{}, []string{"other"}))
+	assert.NilError(t, RunRemove(cli, RemoveOptions{}, []string{"other"}))
 	_, err := cli.ContextStore().GetContextMetadata("current")
 	assert.NilError(t, err)
 	_, err = cli.ContextStore().GetContextMetadata("other")
@@ -29,7 +29,7 @@ func TestRemoveNotAContext(t *testing.T) {
 	defer cleanup()
 	createTestContextWithKubeAndSwarm(t, cli, "current", "all")
 	createTestContextWithKubeAndSwarm(t, cli, "other", "all")
-	err := runRemove(cli, removeOptions{}, []string{"not-a-context"})
+	err := RunRemove(cli, RemoveOptions{}, []string{"not-a-context"})
 	assert.ErrorContains(t, err, `context "not-a-context" does not exist`)
 }
 
@@ -39,7 +39,7 @@ func TestRemoveCurrent(t *testing.T) {
 	createTestContextWithKubeAndSwarm(t, cli, "current", "all")
 	createTestContextWithKubeAndSwarm(t, cli, "other", "all")
 	cli.SetCurrentContext("current")
-	err := runRemove(cli, removeOptions{}, []string{"current"})
+	err := RunRemove(cli, RemoveOptions{}, []string{"current"})
 	assert.ErrorContains(t, err, "current: context is in use, set -f flag to force remove")
 }
 
@@ -57,7 +57,7 @@ func TestRemoveCurrentForce(t *testing.T) {
 	createTestContextWithKubeAndSwarm(t, cli, "current", "all")
 	createTestContextWithKubeAndSwarm(t, cli, "other", "all")
 	cli.SetCurrentContext("current")
-	assert.NilError(t, runRemove(cli, removeOptions{force: true}, []string{"current"}))
+	assert.NilError(t, RunRemove(cli, RemoveOptions{Force: true}, []string{"current"}))
 	reloadedConfig, err := config.Load(configDir)
 	assert.NilError(t, err)
 	assert.Equal(t, "", reloadedConfig.CurrentContext)

--- a/cli/command/context/update_test.go
+++ b/cli/command/context/update_test.go
@@ -13,17 +13,17 @@ import (
 func TestUpdateDescriptionOnly(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
-	err := runCreate(cli, &createOptions{
-		name:                     "test",
-		defaultStackOrchestrator: "swarm",
-		docker:                   map[string]string{},
+	err := RunCreate(cli, &CreateOptions{
+		Name:                     "test",
+		DefaultStackOrchestrator: "swarm",
+		Docker:                   map[string]string{},
 	})
 	assert.NilError(t, err)
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runUpdate(cli, &updateOptions{
-		name:        "test",
-		description: "description",
+	assert.NilError(t, RunUpdate(cli, &UpdateOptions{
+		Name:        "test",
+		Description: "description",
 	}))
 	c, err := cli.ContextStore().GetContextMetadata("test")
 	assert.NilError(t, err)
@@ -40,9 +40,9 @@ func TestUpdateDockerOnly(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
 	createTestContextWithKubeAndSwarm(t, cli, "test", "swarm")
-	assert.NilError(t, runUpdate(cli, &updateOptions{
-		name: "test",
-		docker: map[string]string{
+	assert.NilError(t, RunUpdate(cli, &UpdateOptions{
+		Name: "test",
+		Docker: map[string]string{
 			keyHost: "tcp://some-host",
 		},
 	}))
@@ -60,15 +60,15 @@ func TestUpdateDockerOnly(t *testing.T) {
 func TestUpdateStackOrchestratorStrategy(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
-	err := runCreate(cli, &createOptions{
-		name:                     "test",
-		defaultStackOrchestrator: "swarm",
-		docker:                   map[string]string{},
+	err := RunCreate(cli, &CreateOptions{
+		Name:                     "test",
+		DefaultStackOrchestrator: "swarm",
+		Docker:                   map[string]string{},
 	})
 	assert.NilError(t, err)
-	err = runUpdate(cli, &updateOptions{
-		name:                     "test",
-		defaultStackOrchestrator: "kubernetes",
+	err = RunUpdate(cli, &UpdateOptions{
+		Name:                     "test",
+		DefaultStackOrchestrator: "kubernetes",
 	})
 	assert.ErrorContains(t, err, `cannot specify orchestrator "kubernetes" without configuring a Kubernetes endpoint`)
 }
@@ -77,9 +77,9 @@ func TestUpdateStackOrchestratorStrategyRemoveKubeEndpoint(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
 	createTestContextWithKubeAndSwarm(t, cli, "test", "kubernetes")
-	err := runUpdate(cli, &updateOptions{
-		name:       "test",
-		kubernetes: map[string]string{},
+	err := RunUpdate(cli, &UpdateOptions{
+		Name:       "test",
+		Kubernetes: map[string]string{},
 	})
 	assert.ErrorContains(t, err, `cannot specify orchestrator "kubernetes" without configuring a Kubernetes endpoint`)
 }
@@ -87,14 +87,14 @@ func TestUpdateStackOrchestratorStrategyRemoveKubeEndpoint(t *testing.T) {
 func TestUpdateInvalidDockerHost(t *testing.T) {
 	cli, cleanup := makeFakeCli(t)
 	defer cleanup()
-	err := runCreate(cli, &createOptions{
-		name:   "test",
-		docker: map[string]string{},
+	err := RunCreate(cli, &CreateOptions{
+		Name:   "test",
+		Docker: map[string]string{},
 	})
 	assert.NilError(t, err)
-	err = runUpdate(cli, &updateOptions{
-		name: "test",
-		docker: map[string]string{
+	err = RunUpdate(cli, &UpdateOptions{
+		Name: "test",
+		Docker: map[string]string{
 			keyHost: "some///invalid/host",
 		},
 	})

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -14,26 +14,30 @@ func newUseCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-
-			if err := validateContextName(name); err != nil && name != "default" {
-				return err
-			}
-			if _, err := dockerCli.ContextStore().GetContextMetadata(name); err != nil && name != "default" {
-				return err
-			}
-			configValue := name
-			if configValue == "default" {
-				configValue = ""
-			}
-			dockerConfig := dockerCli.ConfigFile()
-			dockerConfig.CurrentContext = configValue
-			if err := dockerConfig.Save(); err != nil {
-				return err
-			}
-			fmt.Fprintln(dockerCli.Out(), name)
-			fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
-			return nil
+			return RunUse(dockerCli, name)
 		},
 	}
 	return cmd
+}
+
+// RunUse set the current Docker context
+func RunUse(dockerCli command.Cli, name string) error {
+	if err := validateContextName(name); err != nil && name != "default" {
+		return err
+	}
+	if _, err := dockerCli.ContextStore().GetContextMetadata(name); err != nil && name != "default" {
+		return err
+	}
+	configValue := name
+	if configValue == "default" {
+		configValue = ""
+	}
+	dockerConfig := dockerCli.ConfigFile()
+	dockerConfig.CurrentContext = configValue
+	if err := dockerConfig.Save(); err != nil {
+		return err
+	}
+	fmt.Fprintln(dockerCli.Out(), name)
+	fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
+	return nil
 }

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -20,9 +20,9 @@ func TestUse(t *testing.T) {
 	testCfg := configfile.New(configFilePath)
 	cli, cleanup := makeFakeCli(t, withCliConfig(testCfg))
 	defer cleanup()
-	err = runCreate(cli, &createOptions{
-		name:   "test",
-		docker: map[string]string{},
+	err = RunCreate(cli, &CreateOptions{
+		Name:   "test",
+		Docker: map[string]string{},
 	})
 	assert.NilError(t, err)
 	assert.NilError(t, newUseCommand(cli).RunE(nil, []string{"test"}))

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -25,6 +25,11 @@ type Config struct {
 	endpointTypes map[string]TypeGetter
 }
 
+// SetEndpoint set an endpoint typing information
+func (c Config) SetEndpoint(name string, getter TypeGetter) {
+	c.endpointTypes[name] = getter
+}
+
 // NewConfig creates a config object
 func NewConfig(contextType TypeGetter, endpoints ...NamedTypeGetter) Config {
 	res := Config{

--- a/cli/context/store/storeconfig_test.go
+++ b/cli/context/store/storeconfig_test.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+type testCtx struct{}
+type testEP1 struct{}
+type testEP2 struct{}
+type testEP3 struct{}
+
+func TestConfigModification(t *testing.T) {
+	cfg := NewConfig(func() interface{} { return &testCtx{} }, EndpointTypeGetter("ep1", func() interface{} { return &testEP1{} }))
+	assert.Equal(t, &testCtx{}, cfg.contextType())
+	assert.Equal(t, &testEP1{}, cfg.endpointTypes["ep1"]())
+	cfgCopy := cfg
+
+	// modify existing endpoint
+	cfg.SetEndpoint("ep1", func() interface{} { return &testEP2{} })
+	// add endpoint
+	cfg.SetEndpoint("ep2", func() interface{} { return &testEP3{} })
+	assert.Equal(t, &testCtx{}, cfg.contextType())
+	assert.Equal(t, &testEP2{}, cfg.endpointTypes["ep1"]())
+	assert.Equal(t, &testEP3{}, cfg.endpointTypes["ep2"]())
+	// check it applied on already initialized store
+	assert.Equal(t, &testCtx{}, cfgCopy.contextType())
+	assert.Equal(t, &testEP2{}, cfgCopy.endpointTypes["ep1"]())
+	assert.Equal(t, &testEP3{}, cfgCopy.endpointTypes["ep2"]())
+}


### PR DESCRIPTION
**- What I did**

- for plugins:
  - Expose the Context Store config
  - Make an existing config modifiable (to add endpoint types)
- for Docker Desktop:
  - Expose all context operations (except listing, which will be done by directly using context store functions)

**- How I did it**

- Just exposed a few existing symbols.
- Added a SetEndpoint function on store.Config

**- How to verify it**

- Modified code covered by unit tests
- Added a test for SetEndpoint, making sure it applied to already created context stores


ping @ijc for the plugin related part
ping @gtardif @pgayvallet @guillaumerose @ebriney for the Docker Desktop part