### PR TITLE
Improve `docker image rm` reference docs

### DIFF
--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -26,6 +26,17 @@ Options:
       --no-prune   Do not delete untagged parents
 ```
 
+## Description
+
+Removes (and un-tags) one or more images from the host node. If an image has
+multiple tags, using this command with the tag as a parameter only removes the
+tag. If the tag is the only one for the image, both the image and the tag are
+removed.
+
+This does not remove images from a registry. You cannot remove an image of a
+running container unless you use the `-f` option. To see all images on a host
+use the [`docker image ls`](images.md) command.
+
 ## Examples
 
 You can remove an image using its short or long ID, its tag, or its digest. If


### PR DESCRIPTION
Copies the improved description from the man page (made in https://github.com/docker/cli/pull/1444/) to the online reference docs.

/cc @SvenDowideit 👍 
