### PR TITLE
[WIP] Support containerd shim v2

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -118,6 +118,7 @@ type containerOptions struct {
 	healthStartPeriod  time.Duration
 	healthRetries      int
 	runtime            string
+	runtimeType        string
 	autoRemove         bool
 	init               bool
 
@@ -283,6 +284,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.Var(&copts.shmSize, "shm-size", "Size of /dev/shm")
 	flags.StringVar(&copts.utsMode, "uts", "", "UTS namespace to use")
 	flags.StringVar(&copts.runtime, "runtime", "", "Runtime to use for this container")
+	flags.StringVar(&copts.runtimeType, "runtime-type", "", "Type of runtime to use for this container")
 
 	flags.BoolVar(&copts.init, "init", false, "Run an init inside the container that forwards signals and reaps processes")
 	flags.SetAnnotation("init", "version", []string{"1.25"})
@@ -617,6 +619,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, err
 		Tmpfs:          tmpfs,
 		Sysctls:        copts.sysctls.GetAll(),
 		Runtime:        copts.runtime,
+		RuntimeType:    copts.runtimeType,
 		Mounts:         mounts,
 	}
 

--- a/vendor/github.com/docker/docker/api/types/container/host_config.go
+++ b/vendor/github.com/docker/docker/api/types/container/host_config.go
@@ -391,6 +391,7 @@ type HostConfig struct {
 	ShmSize         int64             // Total shm memory usage
 	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
 	Runtime         string            `json:",omitempty"` // Runtime to use with this container
+	RuntimeType     string            `json:",omitempty"` // Type of runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]uint   // Initial console size (height,width)


### PR DESCRIPTION
Add 'runtime-type' argument to invoke a customized version of shim

Relates to https://github.com/moby/moby/pull/38630

Signed-off-by: NingBo <ning.bo9@zte.com.cn>

