### PR TITLE
improve documentation

### DIFF
--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -68,14 +68,7 @@ The main process inside the container referenced under the link `redis` will rec
 
 ### Remove all stopped containers
 
-```bash
-$ docker rm (docker ps -a -f "status=exited" -q)
-```
-
-This command will delete all stopped containers. The command
-`docker ps -a -q` will return all existing container IDs and pass them to
-the `rm` command which will delete them. Any running containers will not be
-deleted.
+To remove stopped container, please refer to [docker prune container documentation](/docs/reference/commandline/container_prune.md) 
 
 ### Remove a container and its volumes
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -69,7 +69,7 @@ The main process inside the container referenced under the link `redis` will rec
 ### Remove all stopped containers
 
 ```bash
-$ docker rm $(docker ps -a -q)
+$ docker rm (docker ps -a -f "status=exited" -q)
 ```
 
 This command will delete all stopped containers. The command


### PR DESCRIPTION
The remove all stopped containers was wrong. It was trying to remove also all running containers
The issue was opened here: [docker.github.io/issues/8065](https://github.com/docker/docker.github.io/issues/8065)

**- What I did**
I ran the command `docker rm $(docker ps -a -q) `as stated in the doc. 
This tried to delete all runnign containers.
**- How I did it**

**- How to verify it**
Have 1 running container and atleast 1 stopped container. 
Run `docker rm $(docker ps -a -q) `. The command will try to delete both containers.
**- Description for the changelog**
Adopt documentation, because the command was wrong. 


**- A picture of a cute animal (not mandatory but encouraged)**
![img_0692](https://user-images.githubusercontent.com/8437563/51754791-8132ab00-20bd-11e9-92c4-1af734e57f54.jpeg)

