### PR TITLE
Fix potential panic at DockerCli creation

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -169,7 +169,7 @@ func noArgs(cmd *cobra.Command, args []string) error {
 func main() {
 	dockerCli, err := command.NewDockerCli()
 	if err != nil {
-		fmt.Fprintln(dockerCli.Err(), err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	logrus.SetOutput(dockerCli.Err())


### PR DESCRIPTION
**- What I did**

Fix using a nil dockerCli if an error occurred during cli creation, using the standard error stream instead.
The code itself wasn't really panicking as `NewDockerCli` never returns an error... yet.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/51918747-64121b00-23e2-11e9-86a1-8dbb7a52cf2c.png)

