### PR TITLE
Hide "builder" and "network" commands on old API versions

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -10,10 +10,11 @@ import (
 // NewBuilderCommand returns a cobra command for `builder` subcommands
 func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "builder",
-		Short: "Manage builds",
-		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		Use:         "builder",
+		Short:       "Manage builds",
+		Args:        cli.NoArgs,
+		RunE:        command.ShowHelp(dockerCli.Err()),
+		Annotations: map[string]string{"version": "1.31"},
 	}
 	cmd.AddCommand(
 		NewPruneCommand(dockerCli),

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -10,10 +10,11 @@ import (
 // NewNetworkCommand returns a cobra command for `network` subcommands
 func NewNetworkCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "network",
-		Short: "Manage networks",
-		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		Use:         "network",
+		Short:       "Manage networks",
+		Args:        cli.NoArgs,
+		RunE:        command.ShowHelp(dockerCli.Err()),
+		Annotations: map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
 		newConnectCommand(dockerCli),


### PR DESCRIPTION
- The `/build/prune` endpoint was added in API v1.31
- The `/network` endpoints were added in API v1.21

This patch hides these commands on older API versions

Before this change:

```
DOCKER_API_VERSION=1.0 docker

...

Management Commands:
  builder     Manage builds
  container   Manage containers
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  network     Manage networks
  system      Manage Docker
  trust       Manage trust on Docker images
```

After this change

```
DOCKER_API_VERSION=1.0 docker

...

Management Commands:
  container   Manage containers
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  system      Manage Docker
  trust       Manage trust on Docker images
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Hide "builder" and "network" commands on old API versions
```

