### PR TITLE
prevent bash process substitution error in cygwin

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -593,7 +593,7 @@ __docker_append_to_completions() {
 # The result is cached for the duration of one invocation of bash completion.
 __docker_fetch_info() {
 	if [ -z "$info_fetched" ] ; then
-		read -r client_experimental server_experimental server_os < <(__docker_q version -f '{{.Client.Experimental}} {{.Server.Experimental}} {{.Server.Os}}')
+		read -r client_experimental server_experimental server_os <<< "$(__docker_q version -f '{{.Client.Experimental}} {{.Server.Experimental}} {{.Server.Os}}')"
 		info_fetched=true
 	fi
 }


### PR DESCRIPTION
Signed-off-by: Matteo Orefice <matteo.orefice@bites4bits.software>

fixes `/dev/fd/62 : No such file or directory` running cli `docker` bash completion in cygwin

I founded cygwin bash cannot handle bash *Process Substitution* in `__docker_fetch_info()` function

**- What I did**

Added code to run in cygwin doesn't use *Process Substitution* and fallbacks to *here string*

**- How I did it**

```bash
read -r client_experimental server_experimental server_os < <(__docker_q version -f '{{.Client.Experimental}} {{.Server.Experimental}} {{.Server.Os}}')
```

could be rewritten as here string avoiding a pipe creation :

```bash
read -r client_experimental server_experimental server_os <<< "$(__docker_q version -f '{{.Client.Experimental}} {{.Server.Experimental}} {{.Server.Os}}')"
```

**- How to verify it**

1. Install cygwin
2. Copy ./contrib/completion/bash/docker onto /etc/bash_completion.d/docker
3. In bash prompt type `docker` and press multiple <TAB> to trigger completion
4. Check errors have not been shown like `/dev/fd/62 : No such file or directory`

**- Description for the changelog**
Prevent bash docker/cli completion error `/dev/fd/62 : No such file or directory` from occurring under cygwin