### PR TITLE
cli-plugins: use system dial-stdio to contact the engine.

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ReexecEnvvar is the name of an ennvar which is set to the command
+// used to originally invoke the docker CLI when executing a
+// plugin. Assuming $PATH and $CWD remain unchanged this should allow
+// the plugin to re-execute the original CLI.
+const ReexecEnvvar = "DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND"
+
 // errPluginNotFound is the error returned when a plugin could not be found.
 type errPluginNotFound string
 
@@ -154,6 +160,9 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, ReexecEnvvar+"="+os.Args[0])
 
 		return cmd, nil
 	}

--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -77,7 +77,7 @@ func PersistentPreRunE(cmd *cobra.Command, args []string) error {
 }
 
 func newPluginCommand(dockerCli *command.DockerCli, plugin *cobra.Command, meta manager.Metadata) *cobra.Command {
-	name := plugin.Use
+	name := plugin.Name()
 	fullname := manager.NamePrefix + name
 
 	cmd := &cobra.Command{

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -175,6 +175,9 @@ func TestExperimentalCLI(t *testing.T) {
 			defer dir.Remove()
 			apiclient := &fakeClient{
 				version: defaultVersion,
+				pingFunc: func() (types.Ping, error) {
+					return types.Ping{Experimental: true, OSType: "linux", APIVersion: defaultVersion}, nil
+				},
 			}
 
 			cli := &DockerCli{client: apiclient, err: os.Stderr}

--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -53,6 +53,16 @@ func GetConnectionHelper(daemonURL string) (*ConnectionHelper, error) {
 	return nil, err
 }
 
+// GetCommandConnectionHelper returns a ConnectionHelp constructed from an arbitrary command.
+func GetCommandConnectionHelper(cmd string, flags ...string) (*ConnectionHelper, error) {
+	return &ConnectionHelper{
+		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return newCommandConn(ctx, cmd, flags...)
+		},
+		Host: "http://docker",
+	}, nil
+}
+
 func newCommandConn(ctx context.Context, cmd string, args ...string) (net.Conn, error) {
 	var (
 		c   commandConn

--- a/docs/extend/cli_plugins.md
+++ b/docs/extend/cli_plugins.md
@@ -75,6 +75,19 @@ A plugin is required to support all of the global options of the
 top-level CLI, i.e. those listed by `man docker 1` with the exception
 of `-v`.
 
+## Connecting to the docker engine
+
+For consistency plugins should prefer to dial the engine by using the
+`system dial-stdio` subcommand of the main Docker CLI binary.
+
+To facilitate this plugins will be executed with the
+`$DOCKER_CLI_PLUGIN_ORIGINAL_CLI_COMMAND` environment variable
+pointing back to the main Docker CLI binary.
+
+All global options (everything from after the binary name up to, but
+not including, the primary entry point subcommand name) should be
+passed back to the CLI.
+
 ## Installation
 
 Plugins distributed in packages for system wide installation on

--- a/e2e/cli-plugins/dial_test.go
+++ b/e2e/cli-plugins/dial_test.go
@@ -1,0 +1,26 @@
+package cliplugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli-plugins/manager"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	"gotest.tools/icmd"
+)
+
+func TestDialStdio(t *testing.T) {
+	// Run the helloworld plugin forcing /bin/true as the `system
+	// dial-stdio` target. It should be passed all arguments from
+	// before the `helloworld` arg, but not the --who=foo which
+	// follows. We observe this from the debug level logging from
+	// the connhelper stuff.
+	helloworld := filepath.Join(os.Getenv("DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS"), "docker-helloworld")
+	cmd := icmd.Command(helloworld, "--config=blah", "--tls", "--log-level", "debug", "helloworld", "--who=foo")
+	res := icmd.RunCmd(cmd, icmd.WithEnv(manager.ReexecEnvvar+"=/bin/true"))
+	res.Assert(t, icmd.Success)
+	assert.Assert(t, is.Contains(res.Stderr(), `msg="connhelper: starting /bin/true with [--config=blah --tls --log-level debug system dial-stdio]"`))
+	assert.Assert(t, is.Equal(res.Stdout(), "Hello foo!\n"))
+}


### PR DESCRIPTION
**- What I did**

Arranged so that cli-plugins will use `docker system dial-stdio` to connect to the engine as proposed by @tonistiigi in https://github.com/docker/cli/issues/1534#issuecomment-446206041.

**- How I did it**

The main commit message goes into some detail:
```
    cli-plugins: use `docker system dial-stdio` to call the daemon
    
    This means that plugins can use whatever methods the monolithic CLI supports,
    which is good for consistency.
    
    This relies on `os.Args[0]` being something which can be executed again to
    reach the same binary, since it is propagated (via an envvar) to the plugin for
    this purpose. This essentially requires that the current working directory and
    path are not modified by the monolithic CLI before it launches the plugin nor
    by the plugin before it initializes the client. This should be the case.
    
    Previously the fake apiclient used by `TestExperimentalCLI` was not being used,
    since `cli.Initialize` was unconditionally overwriting it with a real one
    (talking to a real daemon during unit testing, it seems). This wasn't expected
    nor desirable and no longer happens with the new arrangements, exposing the
    fact that no `pingFunc` is provided, leading to a panic. Add a `pingFunc` to
    the fake client to avoid this.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
```

It's a bit tricky, so could use some careful thought around the possible pitfalls. 

Things I've considered doing differently:
* Passing the original CLI via a new global argument instead of an envvar.
* Passing the entire `dial-stdio` command line to use explicitly to the plugin. Not sure how best to do that without getting into confusion around quoting all the way through.

**- How to verify it**

There is an e2e test which confirms correct argument parsing. Also the existing `TestCliInitialized` happens to use the mechanism.

**- Description for the changelog**

N/A should be covered by #1564's entry.

**- A picture of a cute animal (not mandatory but encouraged)**

