### PR TITLE
Add docs for --device option in Windows

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -583,6 +583,28 @@ fdisk: unable to open /dev/xvdc: Operation not permitted
 > that may be removed should not be added to untrusted containers with
 > `--device`.
 
+For Windows, the format of the string passed to the `--device` option is in
+the form of `--device=<IdType>/<Id>`. Beginning with Windows Server 2019
+and Windows 10 October 2018 Update, Windows only supports an IdType of
+`class` and the Id as a [device interface class
+GUID](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/overview-of-device-interface-classes).
+Refer to the table defined in the [Windows container
+docs](https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/hardware-devices-in-containers)
+for a list of container-supported device interface class GUIDs.
+
+If this option is specified for a process-isolated Windows container, _all_
+devices that implement the requested device interface class GUID are made
+available in the container. For example, the command below makes all COM
+ports on the host visible in the container.
+
+```powershell
+PS C:\> docker run --device=class/86E0D1E0-8089-11D0-9CE4-08003E301F73 mcr.microsoft.com/windows/servercore:ltsc2019
+```
+
+> **Note**: the `--device` option is only supported on process-isolated
+> Windows containers. This option fails if the container isolation is `hyperv`
+> or when running Linux Containers on Windows (LCOW).
+
 ### Restart policies (--restart)
 
 Use Docker's `--restart` to specify a container's *restart policy*. A restart


### PR DESCRIPTION
Signed-off-by: Craig Wilhite <crwilhit@microsoft.com>

Adds documentation portion for #1606. Includes a reference for how to run with --device on Windows & explain limitations of the feature (no Hyper-V isolation, no LCOW).

@jhowardmsft FYI

