### PR TITLE
Note caveat with detaching using key sequence

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -44,8 +44,8 @@ from different sessions on the Docker host.
 
 To stop a container, use `CTRL-c`. This key sequence sends `SIGKILL` to the
 container. If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT` to
-the container. You can detach from a container and leave it running using the
- `CTRL-p CTRL-q` key sequence.
+the container. If the container was run with `-i` and `-t`, you can detach from
+a container and leave it running using the `CTRL-p CTRL-q` key sequence.
 
 > **Note:**
 > A process running as PID 1 inside a container is treated specially by


### PR DESCRIPTION
This has come up a few times, for example:
* https://stackoverflow.com/questions/19688314/how-do-you-attach-and-detach-from-dockers-process#comment40262294_19689048
* https://github.com/moby/moby/issues/20864 
* https://github.com/moby/moby/issues/35491
* https://github.com/moby/moby/issues/20227#issuecomment-221229241
* https://forums.docker.com/t/ctrl-p-ctrl-q-does-not-detach/40273

**- What I did**
N/A
**- How I did it**
N/A
**- How to verify it**
N/A
**- Description for the changelog**
Update documentation of `docker attach` to note caveat with detaching using key sequence.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/5614134/52505263-ce277e80-2b9f-11e9-9a6c-c34b33ba3d1f.png)
(from https://commons.wikimedia.org/wiki/File:Beagle_puppy_Cadet_2.jpg)
