### PR TITLE
Corrected max-file option - was incorrectly spelt as max-files

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1312,7 +1312,7 @@ This is a full example of the allowed configuration options on Linux:
 	"log-driver": "json-file",
 	"log-opts": {
 		"max-size": "10m",
-		"max-files":"5",
+		"max-file":"5",
 		"labels": "somelabel",
 		"env": "os,customer"
 	},


### PR DESCRIPTION
Signed-off-by: stevejr <>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
Used the option spelt as max-files and confirmed the docker daemon would not restart. Amended to max-file and it started

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Corrected the spelling of the max-file sub-option for log-opts - was spelt as max-files but should be max-file as per https://docs.docker.com/config/containers/logging/json-file/

**- A picture of a cute animal (not mandatory but encouraged)**
