### PR TITLE
Reformat plugin's vendor position and add version on --help

### DIFF
--- a/cli-plugins/manager/cobra.go
+++ b/cli-plugins/manager/cobra.go
@@ -16,6 +16,11 @@ const (
 	// that plugin.
 	CommandAnnotationPluginVendor = "com.docker.cli.plugin.vendor"
 
+	// CommandAnnotationPluginVersion is added to every stub command
+	// added by AddPluginCommandStubs and contains the version of
+	// that plugin.
+	CommandAnnotationPluginVersion = "com.docker.cli.plugin.version"
+
 	// CommandAnnotationPluginInvalid is added to any stub command
 	// added by AddPluginCommandStubs for an invalid command (that
 	// is, one which failed it's candidate test) and contains the
@@ -37,8 +42,9 @@ func AddPluginCommandStubs(dockerCli command.Cli, cmd *cobra.Command) error {
 			vendor = "unknown"
 		}
 		annotations := map[string]string{
-			CommandAnnotationPlugin:       "true",
-			CommandAnnotationPluginVendor: vendor,
+			CommandAnnotationPlugin:        "true",
+			CommandAnnotationPluginVendor:  vendor,
+			CommandAnnotationPluginVersion: p.Version,
 		}
 		if p.Err != nil {
 			annotations[CommandAnnotationPluginInvalid] = p.Err.Error()

--- a/e2e/cli-plugins/help_test.go
+++ b/e2e/cli-plugins/help_test.go
@@ -34,7 +34,7 @@ func TestGlobalHelp(t *testing.T) {
 	//  - The `badmeta` plugin under the "Invalid Plugins" heading.
 	//
 	// Regexps are needed because the width depends on `unix.TIOCGWINSZ` or similar.
-	helloworldre := regexp.MustCompile(`^  helloworld\s+\(Docker Inc\.\)\s+A basic Hello World plugin for tests$`)
+	helloworldre := regexp.MustCompile(`^  helloworld\*\s+A basic Hello World plugin for tests \(Docker Inc\., testing\)$`)
 	badmetare := regexp.MustCompile(`^  badmeta\s+invalid metadata: invalid character 'i' looking for beginning of object key string$`)
 	var helloworldcount, badmetacount int
 	for _, expected := range []*regexp.Regexp{


### PR DESCRIPTION
Checks the fourth box on: https://github.com/docker/cli/issues/1661

**- What I did**
- Refactor plugins' vendor location on --help by relocating it at the end of the short description
-  Add ", <version>" to command vendor

**- How I did it**
By changing the `usageTemplate` in cli/cobra.go to replace the information and decorating the command with a '*' when it's a plugin's first level command

**- How to verify it**
- Install a plugin (or make your configuration point to one)
- Execute `docker help` and check that the plugins' first level commands have now a '*' and it's vendor as short description suffix

**- Description for the changelog**
Reformated plugins' first level command description on `--help` by replacing and vendor and adding version

**- A picture of a cute animal (not mandatory but encouraged)**
![salamander](https://user-images.githubusercontent.com/373485/52872906-ed00b480-314d-11e9-9ddf-33f3b4a5b9da.jpg)

