### PR TITLE
give `docker save` a gzip usage guide

### DIFF
--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -53,7 +53,7 @@ $ docker save -o fedora-all.tar fedora
 $ docker save -o fedora-latest.tar fedora:latest
 ```
 
-### Save the image to a tar.gz file using gzip
+### Save an image to a tar.gz file using gzip
 
 You can use gzip to save the image file and make the backup smaller.
 

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -60,6 +60,7 @@ You can use gzip to save the image file and make the backup smaller.
 ```bash
 docker save myimage:latest | gzip > myimage_latest.tar.gz
 ```
+
 ### Cherry-pick particular tags
 
 You can even cherry-pick particular tags of an image repository.

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -53,6 +53,13 @@ $ docker save -o fedora-all.tar fedora
 $ docker save -o fedora-latest.tar fedora:latest
 ```
 
+### Save the image to a tar.gz file using gzip
+
+You can use gzip to save the image file and make the backup smaller.
+
+```bash
+docker save myimage:latest | gzip > myimage_latest.tar.gz
+```
 ### Cherry-pick particular tags
 
 You can even cherry-pick particular tags of an image repository.


### PR DESCRIPTION
**- What I did**

Add a gzip usage guide for `docker save`.

```bash
docker save <myimage>:<tag> | gzip > <myimage>_<tag>.tar.gz
```

This command can make the image file smaller.

**- Description for the changelog**

I found that this was not mentioned in the [official guide,](https://docs.docker.com/engine/reference/commandline/save/) so I added it.

