### PR TITLE
Fix issue where plugin command error exit code is printed out

### DIFF
--- a/cli-plugins/examples/helloworld/main.go
+++ b/cli-plugins/examples/helloworld/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/plugin"
@@ -33,6 +34,16 @@ func main() {
 			},
 		}
 
+		exitStatus2 := &cobra.Command{
+			Use:   "exitstatus2",
+			Short: "Exit with status 2",
+			RunE: func(_ *cobra.Command, _ []string) error {
+				fmt.Fprintln(dockerCli.Err(), "Exiting with error status 2")
+				os.Exit(2)
+				return nil
+			},
+		}
+
 		var who string
 		cmd := &cobra.Command{
 			Use:   "helloworld",
@@ -54,10 +65,11 @@ func main() {
 				return dockerCli.ConfigFile().Save()
 			},
 		}
+
 		flags := cmd.Flags()
 		flags.StringVar(&who, "who", "", "Who are we addressing?")
 
-		cmd.AddCommand(goodbye, apiversion)
+		cmd.AddCommand(goodbye, apiversion, exitStatus2)
 		return cmd
 	},
 		manager.Metadata{

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -194,3 +194,16 @@ func TestCliInitialized(t *testing.T) {
 	assert.Assert(t, res.Stdout() != "")
 	assert.Assert(t, is.Equal(res.Stderr(), ""))
 }
+
+// TestPluginErrorCode tests when the plugin return with a given exit status.
+// We want to verify that the exit status does not get output to stdout and also that we return the exit code.
+func TestPluginErrorCode(t *testing.T) {
+	run, _, cleanup := prepare(t)
+	defer cleanup()
+	res := icmd.RunCmd(run("helloworld", "exitstatus2"))
+	res.Assert(t, icmd.Expected{
+		ExitCode: 2,
+		Err:      "Exiting with error status 2",
+	})
+	assert.Assert(t, is.Equal(res.Stdout(), ""))
+}

--- a/e2e/cli-plugins/testdata/docker-help-helloworld.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld.golden
@@ -8,6 +8,7 @@ Options:
 
 Commands:
   apiversion  Print the API version of the server
+  exitstatus2 Exit with status 2
   goodbye     Say Goodbye instead of Hello
 
 Run 'docker helloworld COMMAND --help' for more information on a command.


### PR DESCRIPTION
**- What I did**
When a plugin is run, it is ran as an `exec.Cmd.Run()`.  (https://golang.org/pkg/os/exec/#Cmd.Run) This is returning an error type of `*ExitError` (https://golang.org/pkg/os/exec/#ExitError) which string error message is `exit status xxx` which is output on the command line.  This change handles that and the command exits with the same error code as the plugin.

**- How I did it**
Modified the code to check for an ExitError, capture that error code and return it.  If it is unable to, return exit code 1 which will be the fallback error code.

**- How to verify it**
Have a plugin run with the following behavior:
1) Run successfully and verify that no behavior change.
2) Have plugin run and error (with arbitrary exit code) and verify when getting the error code of previously ran command 
```
docker <plugin_cmd> ...
echo $?
```
Verify that the exit code matches what the plugin exited with.

