### PR TITLE
Show plugins as Management commands

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -139,7 +139,7 @@ func hasInvalidPlugins(cmd *cobra.Command) bool {
 func operationSubCommands(cmd *cobra.Command) []*cobra.Command {
 	cmds := []*cobra.Command{}
 	for _, sub := range cmd.Commands() {
-		if isPlugin(sub) && invalidPluginReason(sub) != "" {
+		if isPlugin(sub) {
 			continue
 		}
 		if sub.IsAvailableCommand() && !sub.HasSubCommands() {
@@ -179,7 +179,10 @@ func vendorAndVersion(cmd *cobra.Command) string {
 func managementSubCommands(cmd *cobra.Command) []*cobra.Command {
 	cmds := []*cobra.Command{}
 	for _, sub := range cmd.Commands() {
-		if isPlugin(sub) && invalidPluginReason(sub) != "" {
+		if isPlugin(sub) {
+			if invalidPluginReason(sub) == "" {
+				cmds = append(cmds, sub)
+			}
 			continue
 		}
 		if sub.IsAvailableCommand() && sub.HasSubCommands() {
@@ -245,7 +248,7 @@ Management Commands:
 Commands:
 
 {{- range operationSubCommands . }}
-  {{rpad (decoratedName .) (add .NamePadding 1)}}{{.Short}}{{ if isPlugin .}} {{vendorAndVersion .}}{{ end}}
+  {{rpad .Name .NamePadding }} {{.Short}}
 {{- end}}
 {{- end}}
 

--- a/e2e/cli-plugins/help_test.go
+++ b/e2e/cli-plugins/help_test.go
@@ -41,10 +41,10 @@ func TestGlobalHelp(t *testing.T) {
 		regexp.MustCompile(`^A self-sufficient runtime for containers$`),
 		regexp.MustCompile(`^Management Commands:$`),
 		regexp.MustCompile(`^  container\s+Manage containers$`),
+		helloworldre,
+		regexp.MustCompile(`^  image\s+Manage images$`),
 		regexp.MustCompile(`^Commands:$`),
 		regexp.MustCompile(`^  create\s+Create a new container$`),
-		helloworldre,
-		regexp.MustCompile(`^  ps\s+List containers$`),
 		regexp.MustCompile(`^Invalid Plugins:$`),
 		badmetare,
 		nil, // scan to end of input rather than stopping at badmetare


### PR DESCRIPTION
a quick 5-minute attempt to make plugins with subcommands show as `Management` command, instead of as a top-level command. Ticks the ninth checkbox of https://github.com/docker/cli/issues/1661


Plugins are expected to be management commands ("docker <object> <verb>").

This patch adds a dummy sub-command to the plugin stubs, so that they will
be shown in the "Management commands" section of the help/usage output:

```
Management Commands:
  builder                   Manage builds
  checkpoint                Manage checkpoints
  config                    Manage Docker configs
  container                 Manage containers
  context                   Manage contexts
  engine                    Manage the docker engine
  image                     Manage images
  myplugin     (ACME)       Pluginize, by ACME
```

