### PR TITLE
Bash completion: add '--replicas-max-per-node'

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3632,6 +3632,7 @@ _docker_service_update_and_create() {
 		--log-driver
 		--log-opt
 		--replicas
+		--replicas-max-per-node
 		--reserve-cpu
 		--reserve-memory
 		--restart-condition


### PR DESCRIPTION
whoops; realised we didn't add this one (follow up to https://github.com/docker/cli/pull/1612)