### PR TITLE
use char to check block IO type

### DIFF
--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -202,10 +201,10 @@ func calculateCPUPercentWindows(v *types.StatsJSON) float64 {
 func calculateBlockIO(blkio types.BlkioStats) (uint64, uint64) {
 	var blkRead, blkWrite uint64
 	for _, bioEntry := range blkio.IoServiceBytesRecursive {
-		switch strings.ToLower(bioEntry.Op) {
-		case "read":
+		switch bioEntry.Op[0] {
+		case 'r', 'R':
 			blkRead = blkRead + bioEntry.Value
-		case "write":
+		case 'w', 'W':
 			blkWrite = blkWrite + bioEntry.Value
 		}
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
when check the block IO type(read or write), (https://github.com/docker/cli/blob/master/cli/command/container/stats_helpers.go#L205), This method will switch the type string to lower useing `strings.ToLower` , then check the type, This change will use char to check the type, no need to switch first, so the performance is better, and 0 alloc on heap.
**
BenchmarkChar-4             	2000000000	         0.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkStringsToLower-4   	20000000	        66.8 ns/op	       8 B/op	       2 allocs/op
**
**- How I did it**
check the first char in type string, to see if it is 'r' ,"R" or 'w','W'
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

