### PR TITLE
use char to check blockIO type

### DIFF
--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -202,10 +201,13 @@ func calculateCPUPercentWindows(v *types.StatsJSON) float64 {
 func calculateBlockIO(blkio types.BlkioStats) (uint64, uint64) {
 	var blkRead, blkWrite uint64
 	for _, bioEntry := range blkio.IoServiceBytesRecursive {
-		switch strings.ToLower(bioEntry.Op) {
-		case "read":
+		if len(bioEntry.Op) == 0 {
+			continue
+		}
+		switch bioEntry.Op[0] {
+		case 'r', 'R':
 			blkRead = blkRead + bioEntry.Value
-		case "write":
+		case 'w', 'W':
 			blkWrite = blkWrite + bioEntry.Value
 		}
 	}

--- a/cli/command/container/stats_unit_test.go
+++ b/cli/command/container/stats_unit_test.go
@@ -11,15 +11,20 @@ func TestCalculateBlockIO(t *testing.T) {
 		IoServiceBytesRecursive: []types.BlkioStatEntry{
 			{Major: 8, Minor: 0, Op: "read", Value: 1234},
 			{Major: 8, Minor: 1, Op: "read", Value: 4567},
+			{Major: 8, Minor: 0, Op: "Read", Value: 6},
+			{Major: 8, Minor: 1, Op: "Read", Value: 8},
 			{Major: 8, Minor: 0, Op: "write", Value: 123},
 			{Major: 8, Minor: 1, Op: "write", Value: 456},
+			{Major: 8, Minor: 0, Op: "Write", Value: 6},
+			{Major: 8, Minor: 1, Op: "Write", Value: 8},
+			{Major: 8, Minor: 1, Op: "", Value: 456},
 		},
 	}
 	blkRead, blkWrite := calculateBlockIO(blkio)
-	if blkRead != 5801 {
-		t.Fatalf("blkRead = %d, want 5801", blkRead)
+	if blkRead != 5815 {
+		t.Fatalf("blkRead = %d, want 5815", blkRead)
 	}
-	if blkWrite != 579 {
-		t.Fatalf("blkWrite = %d, want 579", blkWrite)
+	if blkWrite != 593 {
+		t.Fatalf("blkWrite = %d, want 593", blkWrite)
 	}
 }


### PR DESCRIPTION
**- What I did**
when check the block IO type(read or write), (https://github.com/docker/cli/blob/master/cli/command/container/stats_helpers.go#L205), This method will switch the type string to lower using `strings.ToLower` , then check the type, This change will use char to check the type, no need to switch first, so the performance is better, and 0 alloc on heap.
**
BenchmarkChar-4 2000000000	0.79 ns/op	0 B/op	0 allocs/op
BenchmarkStringsToLower-4 20000000	66.8 ns/op	8 B/op	2 allocs/op
**
**- How I did it**
check the first char in type string, to see if it is 'r' ,"R" or 'w','W'
**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**