### PR TITLE
Always initialize context store

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -209,12 +209,13 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 
 	cli.configFile = cliconfig.LoadDefaultConfigFile(cli.err)
 
+	cli.contextStore = store.New(cliconfig.ContextStoreDir(), cli.contextStoreConfig)
+	cli.currentContext, err = resolveContextName(opts.Common, cli.configFile, cli.contextStore)
+	if err != nil {
+		return err
+	}
+
 	if cli.client == nil {
-		cli.contextStore = store.New(cliconfig.ContextStoreDir(), cli.contextStoreConfig)
-		cli.currentContext, err = resolveContextName(opts.Common, cli.configFile, cli.contextStore)
-		if err != nil {
-			return err
-		}
 		endpoint, err := resolveDockerEndpoint(cli.contextStore, cli.currentContext, opts.Common)
 		if err != nil {
 			return errors.Wrap(err, "unable to resolve docker endpoint")

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -295,3 +295,12 @@ func TestNewDockerCliAndOperators(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(errStream), "error")
 }
+
+func TestInitializeShouldAlwaysCreateTheContextStore(t *testing.T) {
+	cli, err := NewDockerCli()
+	assert.NilError(t, err)
+	assert.NilError(t, cli.Initialize(flags.NewClientOptions(), WithInitializeClient(func(cli *DockerCli) (client.APIClient, error) {
+		return client.NewClientWithOpts()
+	})))
+	assert.Check(t, cli.ContextStore() != nil)
+}

--- a/e2e/cli-plugins/dial_test.go
+++ b/e2e/cli-plugins/dial_test.go
@@ -18,9 +18,9 @@ func TestDialStdio(t *testing.T) {
 	// follows. We observe this from the debug level logging from
 	// the connhelper stuff.
 	helloworld := filepath.Join(os.Getenv("DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS"), "docker-helloworld")
-	cmd := icmd.Command(helloworld, "--config=blah", "--tls", "--log-level", "debug", "helloworld", "--who=foo")
+	cmd := icmd.Command(helloworld, "--config=blah", "--log-level", "debug", "helloworld", "--who=foo")
 	res := icmd.RunCmd(cmd, icmd.WithEnv(manager.ReexecEnvvar+"=/bin/true"))
 	res.Assert(t, icmd.Success)
-	assert.Assert(t, is.Contains(res.Stderr(), `msg="commandconn: starting /bin/true with [--config=blah --tls --log-level debug system dial-stdio]"`))
+	assert.Assert(t, is.Contains(res.Stderr(), `msg="commandconn: starting /bin/true with [--config=blah --log-level debug system dial-stdio]"`))
 	assert.Assert(t, is.Equal(res.Stdout(), "Hello foo!\n"))
 }


### PR DESCRIPTION
**- What I did**
Always initialize context store even when the CLI has already a client. It happens when the CLI is initialized from a plugin. 

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/470082/53352988-2098c700-3924-11e9-8d7a-95e9cf163860.png)
