### PR TITLE
Upgrade shellcheck 0.6.0

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016,SC2119,SC2155
+# shellcheck disable=SC2016,SC2119,SC2155,SC2206,SC2207
 #
 # Shellcheck ignore list:
 #  - SC2016: Expressions don't expand in single quotes, use double quotes for that.
 #  - SC2119: Use foo "$@" if function's $1 should mean script's $1.
 #  - SC2155: Declare and assign separately to avoid masking return values.
+#  - SC2206: Quote to prevent word splitting, or split robustly with mapfile or read -a.
+#  - SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
 #
 # You can find more details for each warning at the following page:
 #    https://github.com/koalaman/shellcheck/wiki/<SCXXXX>

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,10 +1,7 @@
-FROM    debian:stretch-slim
-
-RUN     apt-get update && \
-        apt-get -y install make shellcheck && \
-        apt-get clean
-
+FROM    koalaman/shellcheck-alpine:v0.4.6
+RUN     apk add --no-cache bash make
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-CMD     bash
+ENTRYPOINT [""]
+CMD     ["/bin/sh"]
 COPY    . .

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,7 +1,5 @@
-FROM    koalaman/shellcheck-alpine:v0.4.6
+FROM    koalaman/shellcheck-alpine:v0.6.0
 RUN     apk add --no-cache bash make
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-ENTRYPOINT [""]
-CMD     ["/bin/sh"]
 COPY    . .

--- a/scripts/gen/windows-resources
+++ b/scripts/gen/windows-resources
@@ -7,7 +7,7 @@ set -eu -o pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=/go/src/github.com/docker/cli/scripts/build/.variables
-source $SCRIPTDIR/../build/.variables
+source "$SCRIPTDIR"/../build/.variables
 
 RESOURCES=$SCRIPTDIR/../winresources
 
@@ -26,9 +26,9 @@ VERSION_QUAD=$(echo -n "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
 
 # Pass version and commit information into the resource compiler
 defs=
-[ ! -z "$VERSION" ]      && defs+=( "-D DOCKER_VERSION=\"$VERSION\"")
-[ ! -z "$VERSION_QUAD" ] && defs+=( "-D DOCKER_VERSION_QUAD=$VERSION_QUAD")
-[ ! -z "$GITCOMMIT" ]    && defs+=( "-D DOCKER_COMMIT=\"$GITCOMMIT\"")
+[ -n "$VERSION" ]      && defs+=( "-D DOCKER_VERSION=\"$VERSION\"")
+[ -n "$VERSION_QUAD" ] && defs+=( "-D DOCKER_VERSION_QUAD=$VERSION_QUAD")
+[ -n "$GITCOMMIT" ]    && defs+=( "-D DOCKER_COMMIT=\"$GITCOMMIT\"")
 
 function makeres {
 	"$WINDRES" \

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -70,7 +70,7 @@ function runtests {
         GOPATH="$GOPATH" \
         PATH="$PWD/build/:/usr/bin:/usr/local/bin:/usr/local/go/bin" \
         DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS="$PWD/build/plugins-linux-amd64" \
-        "$(which gotestsum)" -- ./e2e/... ${TESTFLAGS-}
+        "$(command -v gotestsum)" -- ./e2e/... ${TESTFLAGS-}
 }
 
 export unique_id="${E2E_UNIQUE_ID:-cliendtoendsuite}"

--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 
 target="${1:-}"
 
-if [[ "$target" != "help" && -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]]; then
+if [ "$target" != "help" ] && [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
     (
         echo
         echo


### PR DESCRIPTION
Follow-up to https://github.com/docker/cli/pull/1538 (decided to keep it separate in case we needed to discuss the new exclusions)

As a bonus; changing to the official, alpine-based image makes this image substantially smaller;

current master:

```
docker-cli-shell-validate            latest     91.2MB
```

with official shellcheck v0.4.6 image

```
docker-cli-shell-validate            latest     22.4MB
```

with official shellcheck v0.6.0 image

```
docker-cli-shell-validate            latest     12MB
```


