### PR TITLE
Fix unknown $(MOUNTS) variable in makefile plugins target

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -63,7 +63,7 @@ binary: build_binary_native_image ## build the CLI
 build: binary ## alias for binary
 
 plugins: build_binary_native_image ## build the CLI plugin examples
-	docker run --rm $(ENVVARS) $(MOUNTS) $(BINARY_NATIVE_IMAGE_NAME) ./scripts/build/plugins
+	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(BINARY_NATIVE_IMAGE_NAME) ./scripts/build/plugins
 
 .PHONY: clean
 clean: build_docker_image ## clean build artifacts
@@ -87,7 +87,7 @@ binary-windows: build_cross_image ## build the CLI for Windows
 
 .PHONY: plugins-windows
 plugins-windows: build_cross_image ## build the example CLI plugins for Windows
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: binary-osx
 binary-osx: build_cross_image ## build the CLI for macOS
@@ -95,7 +95,7 @@ binary-osx: build_cross_image ## build the CLI for macOS
 
 .PHONY: plugins-osx
 plugins-osx: build_cross_image ## build the example CLI plugins for macOS
-	docker run --rm $(ENVVARS) $(MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: dev
 dev: build_docker_image ## start a build container in interactive mode for in-container development


### PR DESCRIPTION
**- What I did**
Mounts were broken for plugins as #1511 replaced `$(MOUNTS)` by `$(DOCKER_CLI_MOUNTS)`.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/53561903-55896180-3b50-11e9-9b38-fbaed0315a74.png)
