### PR TITLE
Fix cli-plugins build.

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -63,7 +63,7 @@ binary: build_binary_native_image ## build the CLI
 build: binary ## alias for binary
 
 plugins: build_binary_native_image ## build the CLI plugin examples
-	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(BINARY_NATIVE_IMAGE_NAME) ./scripts/build/plugins
+	$(DOCKER_RUN) $(BINARY_NATIVE_IMAGE_NAME) ./scripts/build/plugins
 
 .PHONY: clean
 clean: build_docker_image ## clean build artifacts
@@ -87,7 +87,7 @@ binary-windows: build_cross_image ## build the CLI for Windows
 
 .PHONY: plugins-windows
 plugins-windows: build_cross_image ## build the example CLI plugins for Windows
-	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	$(DOCKER_RUN) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: binary-osx
 binary-osx: build_cross_image ## build the CLI for macOS
@@ -95,7 +95,7 @@ binary-osx: build_cross_image ## build the CLI for macOS
 
 .PHONY: plugins-osx
 plugins-osx: build_cross_image ## build the example CLI plugins for macOS
-	docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(CROSS_IMAGE_NAME) make $@
+	$(DOCKER_RUN) $(CROSS_IMAGE_NAME) make $@
 
 .PHONY: dev
 dev: build_docker_image ## start a build container in interactive mode for in-container development


### PR DESCRIPTION
Seems I rebased over b039db985a4b ("Make it possible to override the volume
mounts and shell for the dev container") at some point and failed to notice
that some of the variable names had changed.

Signed-off-by: Ian Campbell <ijc@docker.com>
