### PR TITLE
added note about shorter command 'docker build'

### DIFF
--- a/docs/reference/commandline/image.md
+++ b/docs/reference/commandline/image.md
@@ -25,7 +25,7 @@ Options:
       --help   Print usage
 
 Commands:
-  build       Build an image from a Dockerfile
+  build       Build an image from a Dockerfile (same as 'docker build')
   history     Show the history of an image
   import      Import the contents from a tarball to create a filesystem image
   inspect     Display detailed information on one or more images


### PR DESCRIPTION
**- What I did**
Documentation Improvement

**- How I did it**
This will help clarify to users that they are the same command.
As well as make it clear in the auto-generated docs https://docs.docker.com/engine/reference/commandline/image_build/

**- How to verify it**

**- Description for the changelog**
Added note to 'docker image build' about shorter syntax 'docker build'


