### PR TITLE
Allow flags to be passed to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean: ## remove build artifacts
 
 .PHONY: test-unit
 test-unit: ## run unit tests, to change the output format use: GOTESTSUM_FORMAT=(dots|short|standard-quiet|short-verbose|standard-verbose) make test-unit 
-	gotestsum -- $(shell go list ./... | grep -vE '/vendor/|/e2e/')
+	gotestsum $(TESTFLAGS) -- $(shell go list ./... | grep -vE '/vendor/|/e2e/')
 
 .PHONY: test
 test: test-unit ## run tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean: ## remove build artifacts
 
 .PHONY: test-unit
 test-unit: ## run unit tests, to change the output format use: GOTESTSUM_FORMAT=(dots|short|standard-quiet|short-verbose|standard-verbose) make test-unit 
-	gotestsum $(TESTFLAGS) -- $(shell go list ./... | grep -vE '/vendor/|/e2e/')
+	gotestsum $(TESTFLAGS) -- $${TESTDIRS:-$(shell go list ./... | grep -vE '/vendor/|/e2e/')}
 
 .PHONY: test
 test: test-unit ## run tests

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -21,7 +21,7 @@ ifeq ($(DOCKER_CLI_GO_BUILD_CACHE),y)
 DOCKER_CLI_MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
 endif
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -21,7 +21,7 @@ ifeq ($(DOCKER_CLI_GO_BUILD_CACHE),y)
 DOCKER_CLI_MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
 endif
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
@@ -141,15 +141,15 @@ test-e2e: test-e2e-non-experimental test-e2e-experimental test-e2e-connhelper-ss
 
 .PHONY: test-e2e-experimental
 test-e2e-experimental: build_e2e_image # run experimental e2e tests
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e DOCKERD_EXPERIMENTAL=1 $(E2E_IMAGE_NAME)
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(ENVVARS) -e DOCKERD_EXPERIMENTAL=1 $(E2E_IMAGE_NAME)
 
 .PHONY: test-e2e-non-experimental
 test-e2e-non-experimental: build_e2e_image # run non-experimental e2e tests
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(E2E_IMAGE_NAME)
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(ENVVARS) $(E2E_IMAGE_NAME)
 
 .PHONY: test-e2e-connhelper-ssh
 test-e2e-connhelper-ssh: build_e2e_image # run experimental SSH-connection helper e2e tests
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e DOCKERD_EXPERIMENTAL=1 -e TEST_CONNHELPER=ssh $(E2E_IMAGE_NAME)
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(ENVVARS) -e DOCKERD_EXPERIMENTAL=1 -e TEST_CONNHELPER=ssh $(E2E_IMAGE_NAME)
 
 .PHONY: help
 help: ## print this help

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -70,7 +70,7 @@ function runtests {
         GOPATH="$GOPATH" \
         PATH="$PWD/build/:/usr/bin:/usr/local/bin:/usr/local/go/bin" \
         DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS="$PWD/build/plugins-linux-amd64" \
-        "$(command -v gotestsum)" -- ./e2e/... ${TESTFLAGS-}
+        "$(command -v gotestsum)" -- ${TESTDIRS:-./e2e/...} ${TESTFLAGS-}
 }
 
 export unique_id="${E2E_UNIQUE_ID:-cliendtoendsuite}"


### PR DESCRIPTION
This allows e.g.

    $ make -f docker.Makefile fmt test-e2e-non-experimental E2E_TESTFLAGS="-test.run TestRunGoodArgument|TestRunGood"

Signed-off-by: Ian Campbell <ijc@docker.com>
