### PR TITLE
Fix lack of completion after docker exec -it

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -750,6 +750,7 @@ __docker_container_subcommand() {
                 "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]" \
                 "($help)--privileged[Give extended Linux capabilities to the command]" \
                 "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \
+                -it \
                 "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users" \
                 "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories" \
                 "($help -):containers:__docker_complete_running_containers" \


### PR DESCRIPTION
I realize that in theory we should have a huge list of flag combinations here, but  (in my own experience) -it seems the most common.

Signed-off-by: Dominique Quatravaux <dominique@quatravaux.org>