### PR TITLE
Bump Golang 1.12.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.11.6
+  GOVERSION: 1.12.1
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.11.6-alpine
+FROM    golang:1.12.1-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.11.6@sha256:fc07992ec18c0695fe748460cb3d599178d138ba2c762098283bc49334d7b072
+FROM	dockercore/golang-cross:1.12.1@sha256:8541e3aea7b2cffb7ac310af250e34551abe2ec180c77d5a81ae3d52a47ac779
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.11.6-alpine
+FROM    golang:1.12.1-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11.6
+ARG GO_VERSION=1.12.1
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.11.6-alpine
+FROM    golang:1.12.1-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Counterpart for the engine is in https://github.com/moby/moby/pull/38404

Making this "WIP" for now, as there's a known regression in Go 1.12.0 that's affecting the engine, so let's wait for 1.12.1 https://github.com/moby/moby/pull/38404#issuecomment-468904890