### PR TITLE
Disable `docker system dial-stdio` on Windows

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/docker/cli/cli"
@@ -74,7 +75,11 @@ func PersistentPreRunE(cmd *cobra.Command, args []string) error {
 		}
 		// flags must be the original top-level command flags, not cmd.Flags()
 		options.opts.Common.SetDefaultOptions(options.flags)
-		err = options.dockerCli.Initialize(options.opts, withPluginClientConn(options.name))
+		var initopts []command.InitializeOpt
+		if runtime.GOOS != "windows" {
+			initopts = append(initopts, withPluginClientConn(options.name))
+		}
+		err = options.dockerCli.Initialize(options.opts, initopts...)
 	})
 	return err
 }

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -1,6 +1,8 @@
 package system
 
 import (
+	"runtime"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -19,8 +21,12 @@ func NewSystemCommand(dockerCli command.Cli) *cobra.Command {
 		NewInfoCommand(dockerCli),
 		newDiskUsageCommand(dockerCli),
 		newPruneCommand(dockerCli),
-		newDialStdioCommand(dockerCli),
 	)
+	if runtime.GOOS != "windows" {
+		cmd.AddCommand(
+			newDialStdioCommand(dockerCli),
+		)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
The `conn` here is `*winio.win32MessageBytePipe` which does not have a
`CloseRead` method (it does have `CloseWrite`) resulting in:

    docker@WIN-NUC0 C:\Users\docker>.\docker-windows-amd64.exe system dial-stdio
    the raw stream connection does not implement halfCloser

Also disable the path which uses this for cli-plugins on Windows.

Signed-off-by: Ian Campbell <ijc@docker.com>

/cc @tonistiigi @AkihiroSuda if Windows can't be fixes soon perhaps we should do this and revert when Windows works?