### PR TITLE
Fix test for Go 1.12.x

### DIFF
--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -150,9 +150,8 @@ func TestOldValidAuth(t *testing.T) {
 
 	// defaultIndexserver is https://index.docker.io/v1/
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
@@ -213,9 +212,8 @@ func TestOldJSON(t *testing.T) {
 	assert.NilError(t, err)
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
@@ -249,9 +247,8 @@ func TestNewJSON(t *testing.T) {
 	assert.NilError(t, err)
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
@@ -284,9 +281,8 @@ func TestNewJSONNoEmail(t *testing.T) {
 	assert.NilError(t, err)
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
@@ -431,10 +427,8 @@ func TestJSONReaderNoFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
-
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 }
 
 func TestOldJSONReaderNoFile(t *testing.T) {
@@ -444,9 +438,8 @@ func TestOldJSONReaderNoFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Username != "joejoe" || ac.Password != "hello" {
-		t.Fatalf("Missing data from parsing:\n%q", config)
-	}
+	assert.Equal(t, ac.Username, "joejoe")
+	assert.Equal(t, ac.Password, "hello")
 }
 
 func TestJSONWithPsFormatNoFile(t *testing.T) {


### PR DESCRIPTION
After switching to Go 1.12, the format-string causes an error;

```
=== Errors
cli/config/config_test.go:154:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile
cli/config/config_test.go:217:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile
cli/config/config_test.go:253:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile
cli/config/config_test.go:288:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile
cli/config/config_test.go:435:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile
cli/config/config_test.go:448:3: Fatalf format %q has arg config of wrong type *github.com/docker/cli/cli/config/configfile.ConfigFile

DONE 1115 tests, 2 skipped, 6 errors in 215.984s
make: *** [Makefile:22: test-coverage] Error 2
Exited with code 2
```

