### PR TITLE
Fix: plugin-tests discarding current environment

### DIFF
--- a/e2e/plugin/trust_test.go
+++ b/e2e/plugin/trust_test.go
@@ -106,7 +106,7 @@ func ensureBasicPluginBin() (string, error) {
 	}
 	installPath := filepath.Join(os.Getenv("GOPATH"), "bin", name)
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./basic")
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
 	}

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -69,6 +69,7 @@ function runtests {
         TEST_SKIP_PLUGIN_TESTS="${SKIP_PLUGIN_TESTS-}" \
         GOPATH="$GOPATH" \
         PATH="$PWD/build/:/usr/bin:/usr/local/bin:/usr/local/go/bin" \
+        HOME="$HOME" \
         DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS="$PWD/build/plugins-linux-amd64" \
         "$(which gotestsum)" -- ./e2e/... ${TESTFLAGS-}
 }


### PR DESCRIPTION
By default, exec uses the environment of the current process, however,
if `exec.Env` is not `nil`, the environment is discarded:

https://github.com/golang/go/blob/e73f4894949c4ced611881329ff8f37805152585/src/os/exec/exec.go#L57-L60

> If Env is nil, the new process uses the current process's environment.

When adding a new environment variable, prepend the current environment,
to make sure it is not discarded.

