### PR TITLE
Ensure context store initialization for plugins

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -208,13 +208,12 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 	}
 
 	cli.configFile = cliconfig.LoadDefaultConfigFile(cli.err)
-
+	cli.contextStore = store.New(cliconfig.ContextStoreDir(), cli.contextStoreConfig)
+	cli.currentContext, err = resolveContextName(opts.Common, cli.configFile, cli.contextStore)
+	if err != nil {
+		return err
+	}
 	if cli.client == nil {
-		cli.contextStore = store.New(cliconfig.ContextStoreDir(), cli.contextStoreConfig)
-		cli.currentContext, err = resolveContextName(opts.Common, cli.configFile, cli.contextStore)
-		if err != nil {
-			return err
-		}
 		endpoint, err := resolveDockerEndpoint(cli.contextStore, cli.currentContext, opts.Common)
 		if err != nil {
 			return errors.Wrap(err, "unable to resolve docker endpoint")

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -295,3 +295,12 @@ func TestNewDockerCliAndOperators(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, string(errStream), "error")
 }
+
+func TestInitializeShouldAlwaysCreateTheContextStore(t *testing.T) {
+	cli, err := NewDockerCli()
+	assert.NilError(t, err)
+	assert.NilError(t, cli.Initialize(flags.NewClientOptions(), WithInitializeClient(func(cli *DockerCli) (client.APIClient, error) {
+		return client.NewClientWithOpts()
+	})))
+	assert.Check(t, cli.ContextStore() != nil)
+}


### PR DESCRIPTION
**- What I did**

Fixed a bug in cli-plugin initialization where the context store was not correctly initialized

Plugins have their cli initialized with a docker client pre-configured
(for dial-stdio). The problem here is that the cli initialization logic
skipped initializing the context store on this condition.

**- How I did it**

This PR adds a non-regression test for that alongside a fix (context
store and current context name are now resolved unconditionally)

**- How to verify it**

Run the unit tests

cc @ijc

