### PR TITLE
dial-stdio: handle connections which lack CloseRead method.

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
 	"sync"
 
 	"github.com/docker/cli/cli"
@@ -75,11 +74,7 @@ func PersistentPreRunE(cmd *cobra.Command, args []string) error {
 		}
 		// flags must be the original top-level command flags, not cmd.Flags()
 		options.opts.Common.SetDefaultOptions(options.flags)
-		var initopts []command.InitializeOpt
-		if runtime.GOOS != "windows" {
-			initopts = append(initopts, withPluginClientConn(options.name))
-		}
-		err = options.dockerCli.Initialize(options.opts, initopts...)
+		err = options.dockerCli.Initialize(options.opts, withPluginClientConn(options.name))
 	})
 	return err
 }

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -1,8 +1,6 @@
 package system
 
 import (
-	"runtime"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -21,12 +19,8 @@ func NewSystemCommand(dockerCli command.Cli) *cobra.Command {
 		NewInfoCommand(dockerCli),
 		newDiskUsageCommand(dockerCli),
 		newPruneCommand(dockerCli),
+		newDialStdioCommand(dockerCli),
 	)
-	if runtime.GOOS != "windows" {
-		cmd.AddCommand(
-			newDialStdioCommand(dockerCli),
-		)
-	}
 
 	return cmd
 }

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -34,6 +34,7 @@ func runDialStdio(dockerCli command.Cli) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open the raw stream connection")
 	}
+	defer conn.Close()
 
 	var connHalfCloser halfCloser
 	switch t := conn.(type) {

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -34,10 +34,17 @@ func runDialStdio(dockerCli command.Cli) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open the raw stream connection")
 	}
-	connHalfCloser, ok := conn.(halfCloser)
-	if !ok {
+
+	var connHalfCloser halfCloser
+	switch t := conn.(type) {
+	case halfCloser:
+		connHalfCloser = t
+	case halfReadWriteCloser:
+		connHalfCloser = &nopCloseReader{t}
+	default:
 		return errors.New("the raw stream connection does not implement halfCloser")
 	}
+
 	stdin2conn := make(chan error)
 	conn2stdout := make(chan error)
 	go func() {
@@ -88,6 +95,19 @@ type halfWriteCloser interface {
 type halfCloser interface {
 	halfReadCloser
 	halfWriteCloser
+}
+
+type halfReadWriteCloser interface {
+	io.Reader
+	halfWriteCloser
+}
+
+type nopCloseReader struct {
+	halfReadWriteCloser
+}
+
+func (x *nopCloseReader) CloseRead() error {
+	return nil
 }
 
 type halfReadCloserWrapper struct {


### PR DESCRIPTION
This happens on Windows when dialing a named pipe (a path which is used by CLI
plugins), in that case some debugging shows:

    DEBU[0000] conn is a *winio.win32MessageBytePipe
    DEBU[0000] conn is a halfReadCloser: false
    DEBU[0000] conn is a halfWriteCloser: true
    the raw stream connection does not implement halfCloser                                                                                                                                                                         

In such cases we can simply wrap with a nop function since closing for read
isn't too critical.

Signed-off-by: Ian Campbell <ijc@docker.com>

My testing on Windows s is limited to 
```
>docker-windows-amd64.exe -D system dial-stdio                                                                                                                                                   
                                                                                                                                                                                                                                
HTTP/1.1 400 Bad Request                                                                                                                                                                                                        
Content-Type: text/plain; charset=utf-8                                                                                                                                                                                         
Connection: close                                                                                                                                                                                                               
                                                                                                                                                                                                                                
400 Bad Request                                                             
```
Which failed previously.

This is a replacement/alternative for #1710.
