### PR TITLE
hardening config.Path() to disallow directory traversal

### DIFF
--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -92,10 +92,14 @@ func TestErrPluginNotFound(t *testing.T) {
 func TestGetPluginDirs(t *testing.T) {
 	cli := test.NewFakeCli(nil)
 
-	expected := []string{config.Path("cli-plugins")}
-	expected = append(expected, defaultSystemPluginDirs...)
+	pluginDir, err := config.Path("cli-plugins")
+	assert.NilError(t, err)
+	expected := append([]string{pluginDir}, defaultSystemPluginDirs...)
 
-	assert.Equal(t, strings.Join(expected, ":"), strings.Join(getPluginDirs(cli), ":"))
+	var pluginDirs []string
+	pluginDirs, err = getPluginDirs(cli)
+	assert.Equal(t, strings.Join(expected, ":"), strings.Join(pluginDirs, ":"))
+	assert.NilError(t, err)
 
 	extras := []string{
 		"foo", "bar", "baz",
@@ -104,5 +108,7 @@ func TestGetPluginDirs(t *testing.T) {
 	cli.SetConfigFile(&configfile.ConfigFile{
 		CLIPluginsExtraDirs: extras,
 	})
-	assert.DeepEqual(t, expected, getPluginDirs(cli))
+	pluginDirs, err = getPluginDirs(cli)
+	assert.DeepEqual(t, expected, pluginDirs)
+	assert.NilError(t, err)
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
@@ -43,12 +44,16 @@ func ContextStoreDir() string {
 
 // SetDir sets the directory the configuration file is stored in
 func SetDir(dir string) {
-	configDir = dir
+	configDir = filepath.Clean(dir)
 }
 
 // Path returns the path to a file relative to the config dir
-func Path(p ...string) string {
-	return filepath.Join(append([]string{Dir()}, p...)...)
+func Path(p ...string) (string, error) {
+	path := filepath.Join(append([]string{Dir()}, p...)...)
+	if !strings.HasPrefix(path, Dir()+string(filepath.Separator)) {
+		return "", errors.Errorf("path %q is outside of root config directory %q", path, Dir())
+	}
+	return path, nil
 }
 
 // LegacyLoadFromReader is a convenience function that creates a ConfigFile object from


### PR DESCRIPTION
**- What I did**
Resolving issue raised in [comment](https://github.com/docker/cli/pull/1564#discussion_r251822916), removing the ability to get paths from above the config directory's root path

**- How I did it**
Checks whether the resolved path is underneath the root config directory using a strings.HasPrefix on the cleaned paths. Returns an error if it's not.

**- How to verify it**
Added unit test for attempting to traverse outside of the config directory

**- Description for the changelog**

- hardening config.Path() to disallow directory traversal
