### PR TITLE
Allow plugins to have --flags which are the same as the top-level 

### DIFF
--- a/cli-plugins/examples/helloworld/main.go
+++ b/cli-plugins/examples/helloworld/main.go
@@ -44,7 +44,10 @@ func main() {
 			},
 		}
 
-		var who string
+		var (
+			who, context string
+			debug        bool
+		)
 		cmd := &cobra.Command{
 			Use:   "helloworld",
 			Short: "A basic Hello World plugin for tests",
@@ -53,6 +56,18 @@ func main() {
 			// hook.
 			PersistentPreRunE: plugin.PersistentPreRunE,
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if debug {
+					fmt.Fprintf(dockerCli.Err(), "Plugin debug mode enabled")
+				}
+
+				switch context {
+				case "Christmas":
+					fmt.Fprintf(dockerCli.Out(), "Merry Christmas!\n")
+					return nil
+				case "":
+					// nothing
+				}
+
 				if who == "" {
 					who, _ = dockerCli.ConfigFile().PluginConfig("helloworld", "who")
 				}
@@ -68,6 +83,10 @@ func main() {
 
 		flags := cmd.Flags()
 		flags.StringVar(&who, "who", "", "Who are we addressing?")
+		// These are intended to deliberately clash with the CLIs own top
+		// level arguments.
+		flags.BoolVarP(&debug, "debug", "D", false, "Enable debug")
+		flags.StringVarP(&context, "context", "c", "", "Is it Christmas?")
 
 		cmd.AddCommand(goodbye, apiversion, exitStatus2)
 		return cmd

--- a/cli-plugins/examples/helloworld/main.go
+++ b/cli-plugins/examples/helloworld/main.go
@@ -51,10 +51,6 @@ func main() {
 		cmd := &cobra.Command{
 			Use:   "helloworld",
 			Short: "A basic Hello World plugin for tests",
-			// This is redundant but included to exercise
-			// the path where a plugin overrides this
-			// hook.
-			PersistentPreRunE: plugin.PersistentPreRunE,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if debug {
 					fmt.Fprintf(dockerCli.Err(), "Plugin debug mode enabled")

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -2,9 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
+	"github.com/docker/cli/cli/command"
 	cliconfig "github.com/docker/cli/cli/config"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/pkg/term"
@@ -82,6 +84,77 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 		Status:     fmt.Sprintf("%s\nSee '%s --help'.%s", err, cmd.CommandPath(), usage),
 		StatusCode: 125,
 	}
+}
+
+// TopLevelCommand encapsulates a top-level cobra command (either
+// docker CLI or a plugin) and global flag handling logic necessary
+// for plugins.
+type TopLevelCommand struct {
+	cmd       *cobra.Command
+	dockerCli *command.DockerCli
+	opts      *cliflags.ClientOptions
+	flags     *pflag.FlagSet
+	args      []string
+}
+
+// NewTopLevelCommand returns a new TopLevelCommand object
+func NewTopLevelCommand(cmd *cobra.Command, dockerCli *command.DockerCli, opts *cliflags.ClientOptions, flags *pflag.FlagSet) *TopLevelCommand {
+	return &TopLevelCommand{cmd, dockerCli, opts, flags, os.Args[1:]}
+}
+
+// SetArgs sets the args (default os.Args[:1] used to invoke the command
+func (tcmd *TopLevelCommand) SetArgs(args []string) {
+	tcmd.args = args
+	tcmd.cmd.SetArgs(args)
+}
+
+// SetFlag sets a flag in the local flag set of the top-level command
+func (tcmd *TopLevelCommand) SetFlag(name, value string) {
+	tcmd.cmd.Flags().Set(name, value)
+}
+
+// HandleGlobalFlags takes care of parsing global flags defined on the
+// command, it returns the underlying cobra command and the args it
+// will be called with (or an error).
+//
+// On success the caller is responsible for calling Initialize()
+// before calling `Execute` on the returned command.
+func (tcmd *TopLevelCommand) HandleGlobalFlags() (*cobra.Command, []string, error) {
+	cmd := tcmd.cmd
+
+	// We manually parse the global arguments and find the
+	// subcommand in order to properly deal with plugins. We rely
+	// on the root command never having any non-flag arguments.
+	flags := cmd.Flags()
+
+	// We need !interspersed to ensure we stop at the first
+	// potential command instead of accumulating it into
+	// flags.Args() and then continuing on and finding other
+	// arguments which we try and treat as globals (when they are
+	// actually arguments to the subcommand).
+	flags.SetInterspersed(false)
+	defer flags.SetInterspersed(true) // Undo, any subsequent cmd.Execute() in the caller expects this.
+
+	// We need the single parse to see both sets of flags.
+	flags.AddFlagSet(cmd.PersistentFlags())
+	// Now parse the global flags, up to (but not including) the
+	// first command. The result will be that all the remaining
+	// arguments are in `flags.Args()`.
+	if err := flags.Parse(tcmd.args); err != nil {
+		// Our FlagErrorFunc uses the cli, make sure it is initialized
+		if err := tcmd.Initialize(); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, cmd.FlagErrorFunc()(cmd, err)
+	}
+
+	return cmd, flags.Args(), nil
+}
+
+// Initialize finalises global option parsing and initializes the docker client.
+func (tcmd *TopLevelCommand) Initialize(ops ...command.InitializeOpt) error {
+	tcmd.opts.Common.SetDefaultOptions(tcmd.flags)
+	return tcmd.dockerCli.Initialize(tcmd.opts, ops...)
 }
 
 // VisitAll will traverse all commands from the root.

--- a/e2e/cli-plugins/flags_test.go
+++ b/e2e/cli-plugins/flags_test.go
@@ -1,0 +1,19 @@
+package cliplugins
+
+import (
+	"testing"
+
+	"gotest.tools/icmd"
+)
+
+// TestRunGoodArgument ensures correct behaviour when running a valid plugin with an `--argument`.
+func TestRunGoodArgument(t *testing.T) {
+	run, _, cleanup := prepare(t)
+	defer cleanup()
+
+	res := icmd.RunCmd(run("helloworld", "--who", "Cleveland"))
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Out:      "Hello Cleveland!",
+	})
+}

--- a/e2e/cli-plugins/flags_test.go
+++ b/e2e/cli-plugins/flags_test.go
@@ -3,8 +3,6 @@ package cliplugins
 import (
 	"testing"
 
-	"gotest.tools/assert"
-	is "gotest.tools/assert/cmp"
 	"gotest.tools/icmd"
 )
 
@@ -73,28 +71,18 @@ func TestUnknownGlobal(t *testing.T) {
 	run, _, cleanup := prepare(t)
 	defer cleanup()
 
-	t.Run("no-val", func(t *testing.T) {
-		res := icmd.RunCmd(run("--unknown", "helloworld"))
-		res.Assert(t, icmd.Expected{
-			ExitCode: 125,
+	for name, args := range map[string][]string{
+		"no-val":       {"--unknown", "helloworld"},
+		"separate-val": {"--unknown", "foo", "helloworld"},
+		"joined-val":   {"--unknown=foo", "helloworld"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			res := icmd.RunCmd(run(args...))
+			res.Assert(t, icmd.Expected{
+				ExitCode: 125,
+				Out:      icmd.None,
+				Err:      "unknown flag: --unknown",
+			})
 		})
-		assert.Assert(t, is.Equal(res.Stdout(), ""))
-		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
-	})
-	t.Run("separate-val", func(t *testing.T) {
-		res := icmd.RunCmd(run("--unknown", "foo", "helloworld"))
-		res.Assert(t, icmd.Expected{
-			ExitCode: 125,
-		})
-		assert.Assert(t, is.Equal(res.Stdout(), ""))
-		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
-	})
-	t.Run("joined-val", func(t *testing.T) {
-		res := icmd.RunCmd(run("--unknown=foo", "helloworld"))
-		res.Assert(t, icmd.Expected{
-			ExitCode: 125,
-		})
-		assert.Assert(t, is.Equal(res.Stdout(), ""))
-		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
-	})
+	}
 }

--- a/e2e/cli-plugins/flags_test.go
+++ b/e2e/cli-plugins/flags_test.go
@@ -3,6 +3,8 @@ package cliplugins
 import (
 	"testing"
 
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 	"gotest.tools/icmd"
 )
 
@@ -15,5 +17,84 @@ func TestRunGoodArgument(t *testing.T) {
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		Out:      "Hello Cleveland!",
+	})
+}
+
+// TestClashWithGlobalArgs ensures correct behaviour when a plugin
+// has an argument with the same name as one of the globals.
+func TestClashWithGlobalArgs(t *testing.T) {
+	run, _, cleanup := prepare(t)
+	defer cleanup()
+
+	for _, tc := range []struct {
+		name                     string
+		args                     []string
+		expectedOut, expectedErr string
+	}{
+		{
+			name:        "short-without-val",
+			args:        []string{"-D"},
+			expectedOut: "Hello World!",
+			expectedErr: "Plugin debug mode enabled",
+		},
+		{
+			name:        "long-without-val",
+			args:        []string{"--debug"},
+			expectedOut: "Hello World!",
+			expectedErr: "Plugin debug mode enabled",
+		},
+		{
+			name:        "short-with-val",
+			args:        []string{"-c", "Christmas"},
+			expectedOut: "Merry Christmas!",
+			expectedErr: "",
+		},
+		{
+			name:        "short-with-val",
+			args:        []string{"--context", "Christmas"},
+			expectedOut: "Merry Christmas!",
+			expectedErr: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"helloworld"}, tc.args...)
+			res := icmd.RunCmd(run(args...))
+			res.Assert(t, icmd.Expected{
+				ExitCode: 0,
+				Out:      tc.expectedOut,
+				Err:      tc.expectedErr,
+			})
+		})
+	}
+}
+
+// TestUnknownGlobal checks that unknown globals report errors
+func TestUnknownGlobal(t *testing.T) {
+	run, _, cleanup := prepare(t)
+	defer cleanup()
+
+	t.Run("no-val", func(t *testing.T) {
+		res := icmd.RunCmd(run("--unknown", "helloworld"))
+		res.Assert(t, icmd.Expected{
+			ExitCode: 125,
+		})
+		assert.Assert(t, is.Equal(res.Stdout(), ""))
+		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
+	})
+	t.Run("separate-val", func(t *testing.T) {
+		res := icmd.RunCmd(run("--unknown", "foo", "helloworld"))
+		res.Assert(t, icmd.Expected{
+			ExitCode: 125,
+		})
+		assert.Assert(t, is.Equal(res.Stdout(), ""))
+		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
+	})
+	t.Run("joined-val", func(t *testing.T) {
+		res := icmd.RunCmd(run("--unknown=foo", "helloworld"))
+		res.Assert(t, icmd.Expected{
+			ExitCode: 125,
+		})
+		assert.Assert(t, is.Equal(res.Stdout(), ""))
+		assert.Assert(t, is.Contains(res.Stderr(), "unknown flag: --unknown"))
 	})
 }

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -144,18 +144,6 @@ func TestRunGoodSubcommand(t *testing.T) {
 	})
 }
 
-// TestRunGoodArgument ensures correct behaviour when running a valid plugin with an `--argument`.
-func TestRunGoodArgument(t *testing.T) {
-	run, _, cleanup := prepare(t)
-	defer cleanup()
-
-	res := icmd.RunCmd(run("helloworld", "--who", "Cleveland"))
-	res.Assert(t, icmd.Expected{
-		ExitCode: 0,
-		Out:      "Hello Cleveland!",
-	})
-}
-
 // TestHelpGoodSubcommand ensures correct behaviour when invoking help on a
 // valid plugin subcommand. A global argument is included to ensure it does not
 // interfere.

--- a/e2e/cli-plugins/testdata/docker-help-helloworld.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld.golden
@@ -4,7 +4,9 @@ Usage:	docker helloworld [OPTIONS] COMMAND
 A basic Hello World plugin for tests
 
 Options:
-      --who string   Who are we addressing?
+  -c, --context string   Is it Christmas?
+  -D, --debug            Enable debug
+      --who string       Who are we addressing?
 
 Commands:
   apiversion  Print the API version of the server


### PR DESCRIPTION
This was complicated. The final commit message explains it best:
```
    allow plugins to have argument which match a top-level flag.
    
    The issue with plugin options clashing with globals is that when cobra is
    parsing the command line and it comes across an argument which doesn't start
    with a `-` it (in the absence of plugins) distinguishes between "argument to
    current command" and "new subcommand" based on the list of registered sub
    commands.
    
    Plugins breaks that model. When presented with `docker -D plugin -c foo` cobra
    parses up to the `plugin`, sees it isn't a registered sub-command of the
    top-level docker (because it isn't, it's a plugin) so it accumulates it as an
    argument to the top-level `docker` command. Then it sees the `-c`, and thinks
    it is the global `-c` (for AKA `--context`) option and tries to treat it as
    that, which fails.
    
    In the specific case of the top-level `docker` subcommand we know that it has
    no arguments which aren't `--flags` (or `-f` short flags) and so anything which
    doesn't start with a `-` must either be a (known) subcommand or an attempt to
    execute a plugin.
    
    We could simply scan for and register all installed plugins at start of day, so
    that cobra can do the right thing, but we want to avoid that since it would
    involve executing each plugin to fetch the metadata, even if the command wasn't
    going to end up hitting a plugin.
    
    Instead we can parse the initial set of global arguments separately before
    hitting the main cobra `Execute` path, which works here exactly because we know
    that the top-level has no non-flag arguments.
    
    One slight wrinkle is that the top-level `PersistentPreRunE` is no longer
    called on the plugins path (since it no longer goes via `Execute`), so we
    arrange for the initialisation done there (which has to be done after global
    flags are parsed to handle e.g. `--config`) to happen explictly after the
    global flags are parsed. Rather than make `newDockerCommand` return the
    complicated set of results needed to make this happen, instead return a closure
    which achieves this.
    
    The new functionality is introduced via a common `TopLevelCommand` abstraction
    which lets us adjust the plugin entrypoint to use the same strategy for parsing
    the global arguments. This isn't strictly required (in this case the stuff in
    cobra's `Execute` works fine) but doing it this way avoids the possibility of
    subtle differences in behaviour.
    
    Fixes #1699, and also, as a side-effect, the first item in #1661.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
```
