### PR TITLE
[18.09 backport] Fixes for e2e testing after Alpine bump

### DIFF
--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -1,9 +1,8 @@
 FROM docker:test-dind
 RUN apk --no-cache add shadow openssh-server && \
   groupadd -f docker && \
-  useradd --create-home --shell /bin/sh penguin && \
+  useradd --create-home --shell /bin/sh --password $(head -c32 /dev/urandom | base64) penguin && \
   usermod -aG docker penguin && \
-  usermod -p $(head -c32 /dev/urandom | base64) penguin && \
   ssh-keygen -A
 # workaround: ssh session excludes /usr/local/bin from $PATH
 RUN  ln -s /usr/local/bin/docker /usr/bin/docker

--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -1,7 +1,7 @@
 FROM docker:test-dind
 RUN apk --no-cache add shadow openssh-server && \
   groupadd -f docker && \
-  useradd -m --shell /bin/sh penguin && \
+  useradd --create-home --shell /bin/sh penguin && \
   usermod -aG docker penguin && \
   usermod -p $(head -c32 /dev/urandom | base64) penguin && \
   ssh-keygen -A

--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -1,10 +1,9 @@
 FROM docker:test-dind
 RUN apk --no-cache add shadow openssh-server && \
   groupadd -f docker && \
-  useradd -m penguin && \
+  useradd -m --shell /bin/sh penguin && \
   usermod -aG docker penguin && \
   usermod -p $(head -c32 /dev/urandom | base64) penguin && \
-  chsh -s /bin/sh penguin && \
   ssh-keygen -A
 # workaround: ssh session excludes /usr/local/bin from $PATH
 RUN  ln -s /usr/local/bin/docker /usr/bin/docker


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1728 for 18.09



----

Somewhere between Thursday and Friday last week the `docker:test-dind` image was updated from an alpine 3.9.0 base to 3.9.2. This broke the use of `chsh` in `e2e/testdata/Dockerfile.connhelper-ssh`:
```
Step 1/6 : FROM docker:test-dind
test-dind: Pulling from library/docker
Digest: sha256:ec353956a21300964a7eb2b620a742c2730f618f4df35f60609b30969cd83ce8
Status: Downloaded newer image for docker:test-dind
 ---> 85e924caedbd
Step 2/6 : RUN apk --no-cache add shadow openssh-server &&   groupadd -f docker &&   useradd -m penguin &&   usermod -aG docker penguin &&   usermod -p $(head -c32 /dev/urandom | base64) penguin &&   chsh -s /bin/sh penguin &&   ssh-keygen -A
 ---> Running in 35e0398d93bd
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
(1/5) Installing openssh-keygen (7.9_p1-r4)
(2/5) Installing openssh-server-common (7.9_p1-r4)
(3/5) Installing openssh-server (7.9_p1-r4)
(4/5) Installing linux-pam (1.3.0-r0)
(5/5) Installing shadow (4.5-r0)
Executing busybox-1.29.3-r10.trigger
OK: 22 MiB in 44 packages
[91mCreating mailbox file: No such file or directory
[0m[91mPassword: [0m[91mchsh: PAM: Authentication token manipulation error
[0mService 'engine' failed to build: The command '/bin/sh -c apk --no-cache add shadow openssh-server &&   groupadd -f docker &&   useradd -m penguin &&   usermod -aG docker penguin &&   usermod -p $(head -c32 /dev/urandom | base64) penguin &&   chsh -s /bin/sh penguin &&   ssh-keygen -A' returned a non-zero code: 1
docker.Makefile:152: recipe for target 'test-e2e-connhelper-ssh' failed
make: *** [test-e2e-connhelper-ssh] Error 1
```
(this seems to relate to `root`'s entry in `/etc/shadow` changing from `root:::0:::::\nbin:!::0:::::` to `root:!::0:::::\nbin:!::0:::::`).

Avoid this by just using the `--shell` option to `useradd` instead.

Also simplify things by using `--password` instead of `usermod -p` (even though this was not broken) and also spell out `-m` in full as `--create-home` for clarity.