### PR TITLE
[pretty print] pretty print and healthcheck

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/stringid"
@@ -146,6 +147,18 @@ Ports:
   TargetPort = {{ $port.TargetPort }}
   PublishMode = {{ $port.PublishMode }}
 {{- end }} {{ end -}}
+{{- if .Healthcheck }}
+ Healthcheck:
+  Interval = {{ .Healthcheck.Interval }}
+  Retries = {{ .Healthcheck.Retries }}
+  StartPeriod =	{{ .Healthcheck.StartPeriod }}
+  Timeout =	{{ .Healthcheck.Timeout }}
+  {{- if .Healthcheck.Test }}
+  Tests:
+	{{- range $test := .Healthcheck.Test }}
+	 Test = {{ $test }}
+  {{- end }} {{ end -}}
+{{- end }}
 `
 
 // NewFormat returns a Format for rendering using a Context
@@ -225,6 +238,10 @@ func (ctx *serviceInspectContext) Configs() []*swarm.ConfigReference {
 
 func (ctx *serviceInspectContext) Secrets() []*swarm.SecretReference {
 	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Secrets
+}
+
+func (ctx *serviceInspectContext) Healthcheck() *container.HealthConfig {
+	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Healthcheck
 }
 
 func (ctx *serviceInspectContext) IsModeGlobal() bool {

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -61,6 +63,14 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 								Name: "/secrettest.conf",
 							},
 						},
+					},
+
+					Healthcheck: &container.HealthConfig{
+						Test:        []string{"CMD-SHELL", "curl"},
+						Interval:    4,
+						Retries:     3,
+						StartPeriod: 2,
+						Timeout:     1,
 					},
 				},
 				Networks: []swarm.NetworkAttachmentConfig{
@@ -157,4 +167,5 @@ func TestPrettyPrintWithConfigsAndSecrets(t *testing.T) {
 
 	assert.Check(t, is.Contains(s, "Configs:"), "Pretty print missing configs")
 	assert.Check(t, is.Contains(s, "Secrets:"), "Pretty print missing secrets")
+	assert.Check(t, is.Contains(s, "Healthcheck:"), "Pretty print missing healthcheck")
 }


### PR DESCRIPTION
fixes #117

Print healthcheck information in pretty mode.

Signed-off-by: Stephane Jeandeaux <stephane.jeandeaux@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
The pretty print prints the healthcheck information.

**- How I did it**
The pretty template is modified.

**- How to verify it**
The unit test is modified to test if healthcheck is there.


**- Description for the changelog**
<!--
Print the health in pretty mode.
-->

![](https://media.giphy.com/media/s0k30jjI04THq/giphy.gif)
