### PR TITLE
[18.09 backport] dial-stdio: handle connections which lack CloseRead method

### DIFF
--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -34,6 +34,7 @@ func runDialStdio(dockerCli command.Cli) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open the raw stream connection")
 	}
+	defer conn.Close()
 
 	var connHalfCloser halfCloser
 	switch t := conn.(type) {

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -34,10 +34,17 @@ func runDialStdio(dockerCli command.Cli) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to open the raw stream connection")
 	}
-	connHalfCloser, ok := conn.(halfCloser)
-	if !ok {
+
+	var connHalfCloser halfCloser
+	switch t := conn.(type) {
+	case halfCloser:
+		connHalfCloser = t
+	case halfReadWriteCloser:
+		connHalfCloser = &nopCloseReader{t}
+	default:
 		return errors.New("the raw stream connection does not implement halfCloser")
 	}
+
 	stdin2conn := make(chan error)
 	conn2stdout := make(chan error)
 	go func() {
@@ -88,6 +95,19 @@ type halfWriteCloser interface {
 type halfCloser interface {
 	halfReadCloser
 	halfWriteCloser
+}
+
+type halfReadWriteCloser interface {
+	io.Reader
+	halfWriteCloser
+}
+
+type nopCloseReader struct {
+	halfReadWriteCloser
+}
+
+func (x *nopCloseReader) CloseRead() error {
+	return nil
 }
 
 type halfReadCloserWrapper struct {


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1718 for 18.09 (omitting the "revert" commit (https://github.com/docker/cli/pull/1718/commits/0449ad8d06829459f367e51e85aef36b14bdceac), which is not needed for this branch)