### PR TITLE
Fix regression for CLI plugins using PersistentPreRunE

### DIFF
--- a/cli-plugins/examples/helloworld/main.go
+++ b/cli-plugins/examples/helloworld/main.go
@@ -51,7 +51,10 @@ func main() {
 		cmd := &cobra.Command{
 			Use:   "helloworld",
 			Short: "A basic Hello World plugin for tests",
-			PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+				if err := plugin.PersistentPreRunE(cmd, args); err != nil {
+					return err
+				}
 				if preRun {
 					fmt.Fprintf(dockerCli.Err(), "Plugin PersistentPreRunE called")
 				}

--- a/cli-plugins/examples/helloworld/main.go
+++ b/cli-plugins/examples/helloworld/main.go
@@ -45,12 +45,18 @@ func main() {
 		}
 
 		var (
-			who, context string
-			debug        bool
+			who, context  string
+			preRun, debug bool
 		)
 		cmd := &cobra.Command{
 			Use:   "helloworld",
 			Short: "A basic Hello World plugin for tests",
+			PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+				if preRun {
+					fmt.Fprintf(dockerCli.Err(), "Plugin PersistentPreRunE called")
+				}
+				return nil
+			},
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if debug {
 					fmt.Fprintf(dockerCli.Err(), "Plugin debug mode enabled")
@@ -79,6 +85,7 @@ func main() {
 
 		flags := cmd.Flags()
 		flags.StringVar(&who, "who", "", "Who are we addressing?")
+		flags.BoolVar(&preRun, "pre-run", false, "Log from prerun hook")
 		// These are intended to deliberately clash with the CLIs own top
 		// level arguments.
 		flags.BoolVarP(&debug, "debug", "D", false, "Enable debug")

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -177,10 +177,10 @@ func TestCliInitialized(t *testing.T) {
 	run, _, cleanup := prepare(t)
 	defer cleanup()
 
-	res := icmd.RunCmd(run("helloworld", "apiversion"))
+	res := icmd.RunCmd(run("helloworld", "--pre-run", "apiversion"))
 	res.Assert(t, icmd.Success)
 	assert.Assert(t, res.Stdout() != "")
-	assert.Assert(t, is.Equal(res.Stderr(), ""))
+	assert.Assert(t, is.Equal(res.Stderr(), "Plugin PersistentPreRunE called"))
 }
 
 // TestPluginErrorCode tests when the plugin return with a given exit status.

--- a/e2e/cli-plugins/testdata/docker-help-helloworld.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld.golden
@@ -6,6 +6,7 @@ A basic Hello World plugin for tests
 Options:
   -c, --context string   Is it Christmas?
   -D, --debug            Enable debug
+      --pre-run          Log from prerun hook
       --who string       Who are we addressing?
 
 Commands:


### PR DESCRIPTION
I got a bit carried away in d4ced2ef77fcc ("allow plugins to have argument which match a top-level flag.") and broke the ability of a plugin to use the `PersistentPreRun(E)` hook on its top-level command (by unconditionally overwriting it) and also broke the plugin framework if a plugin's subcommand used those hooks (because they would shadow the root one). This could result in either `dockerCli.Client()` returning `nil` or whatever initialisation the plugin hoped to do not occuring.

Unfortunately my carriedawayness extended to thinking the e2e test was no longer necessary (although I'm not completely sure it would have caught this case in fact). So first introduce a new (and better) e2e test case for this, then fix the issue which ends up being easier looking cleaner than the original code (so this isn't a simple partial revert).
