### PR TITLE
[18.09 backport] Fix: plugin-tests discarding current environment

### DIFF
--- a/e2e/plugin/trust_test.go
+++ b/e2e/plugin/trust_test.go
@@ -106,7 +106,7 @@ func ensureBasicPluginBin() (string, error) {
 	}
 	installPath := filepath.Join(os.Getenv("GOPATH"), "bin", name)
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./basic")
-	cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
 	}

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -69,6 +69,7 @@ function runtests {
         TEST_SKIP_PLUGIN_TESTS="${SKIP_PLUGIN_TESTS-}" \
         GOPATH="$GOPATH" \
         PATH="$PWD/build/:/usr/bin" \
+        HOME="$HOME" \
         "$(which go)" test -v ./e2e/... ${TESTFLAGS-}
 }
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1713 for 18.09


By default, exec uses the environment of the current process, however,
if `exec.Env` is not `nil`, the environment is discarded:

https://github.com/golang/go/blob/e73f4894949c4ced611881329ff8f37805152585/src/os/exec/exec.go#L57-L60

> If Env is nil, the new process uses the current process's environment.

When adding a new environment variable, prepend the current environment,
to make sure it is not discarded.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 6c4fbb7738cd9b2ad9776b50e5cabb29a55233f0)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

