### PR TITLE
[18.09 backport] various docs fixes

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -44,8 +44,8 @@ from different sessions on the Docker host.
 
 To stop a container, use `CTRL-c`. This key sequence sends `SIGKILL` to the
 container. If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT` to
-the container. You can detach from a container and leave it running using the
- `CTRL-p CTRL-q` key sequence.
+the container. If the container was run with `-i` and `-t`, you can detach from
+a container and leave it running using the `CTRL-p CTRL-q` key sequence.
 
 > **Note:**
 > A process running as PID 1 inside a container is treated specially by

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -504,13 +504,13 @@ stable.
 
 
 Squashing layers can be beneficial if your Dockerfile produces multiple layers
-modifying the same files, for example, file that are created in one step, and
+modifying the same files, for example, files that are created in one step, and
 removed in another step. For other use-cases, squashing images may actually have
 a negative impact on performance; when pulling an image consisting of multiple
 layers, layers can be pulled in parallel, and allows sharing layers between
 images (saving space).
 
-For most use cases, multi-stage are a better alternative, as they give more
+For most use cases, multi-stage builds are a better alternative, as they give more
 fine-grained control over your build, and can take advantage of future
 optimizations in the builder. Refer to the [use multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
 section in the userguide for more information.
@@ -531,7 +531,7 @@ The `--squash` option has a number of known limitations:
   downloading a single layer cannot be parallelized.
 - When attempting to squash an image that does not make changes to the
   filesystem (for example, the Dockerfile only contains `ENV` instructions),
-  the squash step will fail (see [issue #33823](https://github.com/moby/moby/issues/33823)
+  the squash step will fail (see [issue #33823](https://github.com/moby/moby/issues/33823)).
 
 #### Prerequisites
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1312,7 +1312,7 @@ This is a full example of the allowed configuration options on Linux:
 	"log-driver": "json-file",
 	"log-opts": {
 		"max-size": "10m",
-		"max-files":"5",
+		"max-file":"5",
 		"labels": "somelabel",
 		"env": "os,customer"
 	},

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1231,9 +1231,13 @@ The `--metrics-addr` option takes a tcp address to serve the metrics API.
 This feature is still experimental, therefore, the daemon must be running in experimental
 mode for this feature to work.
 
-To serve the metrics API on localhost:1337 you would specify `--metrics-addr 127.0.0.1:1337`
-allowing you to make requests on the API at `127.0.0.1:1337/metrics` to receive metrics in the
+To serve the metrics API on `localhost:9323` you would specify `--metrics-addr 127.0.0.1:9323`,
+allowing you to make requests on the API at `127.0.0.1:9323/metrics` to receive metrics in the
 [prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/) format.
+
+Port `9323` is the [default port associated with Docker
+metrics](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)
+to avoid collisions with other prometheus exporters and services.
 
 If you are running a prometheus server you can add this address to your scrape configs
 to have prometheus collect metrics on Docker.  For more information
@@ -1243,7 +1247,7 @@ on prometheus you can view the website [here](https://prometheus.io/).
 scrape_configs:
   - job_name: 'docker'
     static_configs:
-      - targets: ['127.0.0.1:1337']
+      - targets: ['127.0.0.1:9323']
 ```
 
 Please note that this feature is still marked as experimental as metrics and metric

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -303,7 +303,7 @@ the same file can share a single page cache entry (or entries), it makes
 > **Note**: As promising as `overlay` is, the feature is still quite young and
 > should not be used in production. Most notably, using `overlay` can cause
 > excessive inode consumption (especially as the number of images grows), as
-> well as > being incompatible with the use of RPMs.
+> well as being incompatible with the use of RPMs.
 
 The `overlay2` uses the same fast union filesystem but takes advantage of
 [additional features](https://lkml.org/lkml/2015/2/11/106) added in Linux

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -177,7 +177,7 @@ This is similar to tagging an image and pushing it to a foreign registry.
 
 After you have created your local copy of the manifest list, you may optionally
 `annotate` it. Annotations allowed are the architecture and operating system (overriding the image's current values),
-os features, and an archictecure variant. 
+os features, and an architecture variant. 
 
 Finally, you need to `push` your manifest list to the desired registry. Below are descriptions of these three commands,
 and an example putting them all together.
@@ -270,5 +270,5 @@ $ docker manifest create --insecure myprivateregistry.mycompany.com/repo/image:1
 $ docker manifest push --insecure myprivateregistry.mycompany.com/repo/image:tag
 ```
 
-Note that the `--insecure` flag is not required to annotate a manifest list, since annotations are to a locally-stored copy of a manifest list. You may also skip the `--insecure` flag if you are performaing a `docker manifest inspect` on a locally-stored manifest list. Be sure to keep in mind that locally-stored manifest lists are never used by the engine on a `docker pull`.
+Note that the `--insecure` flag is not required to annotate a manifest list, since annotations are to a locally-stored copy of a manifest list. You may also skip the `--insecure` flag if you are performing a `docker manifest inspect` on a locally-stored manifest list. Be sure to keep in mind that locally-stored manifest lists are never used by the engine on a `docker pull`.
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -116,6 +116,7 @@ Valid placeholders for the Go template are listed below:
 
 Placeholder     | Description
 ----------------|------------------------------------------------------------------------------------------
+`.ID`           | Task ID
 `.Name`         | Task name
 `.Image`        | Task image
 `.Node`         | Node ID

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -26,6 +26,17 @@ Options:
       --no-prune   Do not delete untagged parents
 ```
 
+## Description
+
+Removes (and un-tags) one or more images from the host node. If an image has
+multiple tags, using this command with the tag as a parameter only removes the
+tag. If the tag is the only one for the image, both the image and the tag are
+removed.
+
+This does not remove images from a registry. You cannot remove an image of a
+running container unless you use the `-f` option. To see all images on a host
+use the [`docker image ls`](images.md) command.
+
 ## Examples
 
 You can remove an image using its short or long ID, its tag, or its digest. If

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -717,11 +717,11 @@ $ docker run -d --isolation default busybox top
 On Windows, `--isolation` can take one of these values:
 
 
-| Value     | Description                                                                                |
-|:----------|:-------------------------------------------------------------------------------------------|
-| `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below). |
-| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809).     |
-| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
+| Value     | Description                                                                                                       |
+|:----------|:------------------------------------------------------------------------------------------------------------------|
+| `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below).                        |
+| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809). |
+| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                     |
 
 The default isolation on Windows server operating systems is `process`. The default
 isolation on Windows client operating systems is `hyperv`. An attempt to start a container on a client

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -720,12 +720,12 @@ On Windows, `--isolation` can take one of these values:
 | Value     | Description                                                                                |
 |:----------|:-------------------------------------------------------------------------------------------|
 | `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below). |
-| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems).     |
+| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809).     |
 | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
-The default isolation on Windows server operating systems is `process`. The default (and only supported)
+The default isolation on Windows server operating systems is `process`. The default
 isolation on Windows client operating systems is `hyperv`. An attempt to start a container on a client
-operating system with `--isolation process` will fail.
+operating system older than Windows 10 1809 with `--isolation process` will fail.
 
 On Windows server, assuming the default configuration, these commands are equivalent
 and result in `process` isolation:

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -219,7 +219,7 @@ tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
 ### Set environment variables (-e, --env)
 
-This sets an environmental variable for all tasks in a service. For example:
+This sets an environment variable for all tasks in a service. For example:
 
 ```bash
 $ docker service create \

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -171,5 +171,5 @@ On Windows:
     "table {{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}"
 
 
-> **Note**: On Docker 17.09 and older, the `{{.Container}}` column was used, in
-> stead of `{{.ID}}\t{{.Name}}`.
+> **Note**: On Docker 17.09 and older, the `{{.Container}}` column was used,
+> instead of `{{.ID}}\t{{.Name}}`.

--- a/man/src/container/exec.md
+++ b/man/src/container/exec.md
@@ -23,3 +23,29 @@ the same capabilities as the container, which may be limited. Set
    --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
 
    Without this argument the command will be run as root in the container.
+
+# Exit Status
+
+The exit code from `docker exec` gives information about why the container
+failed to exec or why it exited.  When `docker exec` exits with a non-zero code,
+the exit codes follow the `chroot` standard, see below:
+
+**_126_** if the **_contained command_** cannot be invoked
+
+    $ docker exec busybox /etc; echo $?
+    # exec: "/etc": permission denied
+      docker: Error response from daemon: Contained command could not be invoked
+      126
+
+**_127_** if the **_contained command_** cannot be found
+
+    $ docker exec busybox foo; echo $?
+    # exec: "foo": executable file not found in $PATH
+      docker: Error response from daemon: Contained command not found or does not exist
+      127
+
+**_Exit code_** of **_contained command_** otherwise 
+    
+    $ docker exec busybox /bin/sh -c 'exit 3' 
+    # 3
+

--- a/man/src/image/rm.md
+++ b/man/src/image/rm.md
@@ -1,6 +1,11 @@
-Removes one or more images from the host node. This does not remove images from
-a registry. You cannot remove an image of a running container unless you use the
-**-f** option. To see all images on a host use the **docker image ls** command.
+Removes (and un-tags) one or more images from the host node. If an image has
+multiple tags, using this command with the tag as a parameter only removes the
+tag. If the tag is the only one for the image, both the image and the tag are
+removed.
+
+This does not remove images from a registry. You cannot remove an image of a
+running container unless you use the **-f** option. To see all images on a host
+use the **docker image ls** command.
 
 # EXAMPLES
 


### PR DESCRIPTION
Backporting various docs fixes for 18.09:

- https://github.com/docker/cli/pull/1444 Improve `docker image rm` documentation
- https://github.com/docker/cli/pull/1536 Replace environmental with environment
- https://github.com/docker/cli/pull/1565 Removed extra ">" in docs
- https://github.com/docker/cli/pull/1589 docs(metrics-addr): Use port 9323, allocated for Docker in prometheus
- https://github.com/docker/cli/pull/1598 docs: add missing ID placeholder for docker node ps
- https://github.com/docker/cli/pull/1624 Fix some typos in manifest.md
- https://github.com/docker/cli/pull/1627 Update process isolation description for older Windows 10 versions
- https://github.com/docker/cli/pull/1629 Improve `docker image rm` reference docs
- https://github.com/docker/cli/pull/1646 Fix small typo
- https://github.com/docker/cli/pull/1662 Fix typos
- https://github.com/docker/cli/pull/1665 Note caveat with detaching using key sequence
- https://github.com/docker/cli/pull/1670 Corrected max-file option - was incorrectly spelt as max-files
- https://github.com/docker/cli/pull/1674 Add exit status to docker exec manpage
- https://github.com/docker/cli/pull/1748 Add some spaces in docs for cosmetics and readability reasons


```
# https://github.com/docker/cli/pull/1444 Improve `docker image rm` documentation
git cherry-pick -s -S -x 2ba9601ef13204119bf37a1174673eee4305a702

# https://github.com/docker/cli/pull/1536 Replace environmental with environment
git cherry-pick -s -S -x f1f3d3be177234c936f8ddbbc266b66b0dbfe9e4

# https://github.com/docker/cli/pull/1565 Removed extra ">" in docs
git cherry-pick -s -S -x 4aecd8bda1325f04509ede761a5cba8dcbca0db0

# https://github.com/docker/cli/pull/1589 docs(metrics-addr): Use port 9323, allocated for Docker in prometheus
git cherry-pick -s -S -x 89aa2cf9f68e5fd81c726e10e1e17dc9a308adb7

# https://github.com/docker/cli/pull/1598 docs: add missing ID placeholder for docker node ps
git cherry-pick -s -S -x 24018b9ffdb179ea002dc6a74c4d6f6444d424f9

# https://github.com/docker/cli/pull/1624 Fix some typos in manifest.md
git cherry-pick -s -S -x abe1bb9757932bed0c10cd74014cac6f67dab6d0

# https://github.com/docker/cli/pull/1627 Update process isolation description for older Windows 10 versions
git cherry-pick -s -S -x 7229920e2e9c0028aee56e18803245cc1d6dc021

# https://github.com/docker/cli/pull/1629 Improve `docker image rm` reference docs
git cherry-pick -s -S -x 89bc5fbbae3b0fc309e894707970fcf237a38d1d

# https://github.com/docker/cli/pull/1646 Fix small typo
git cherry-pick -s -S -x 7a9fc782c52be1e03a0e5d3bb05ec55325d14caa

# https://github.com/docker/cli/pull/1662 Fix typos
git cherry-pick -s -S -x 0e469c1d1d85a134ce2c3233231cad2379af83c4

# https://github.com/docker/cli/pull/1665 Note caveat with detaching using key sequence
git cherry-pick -s -S -x 767b25fc52a463b4e84be59dd4dbd7e4bc8ac385

# https://github.com/docker/cli/pull/1670 Corrected max-file option - was incorrectly spelt as max-files
git cherry-pick -s -S -x 04f88005c924ab416c1641ced14d39f9efe4845e

# https://github.com/docker/cli/pull/1674 Add exit status to docker exec manpage
git cherry-pick -s -S -x 23670968ccfb985bc977947adb24d1f2824f5d6b

# https://github.com/docker/cli/pull/1748 Add some spaces in docs for cosmetics and readability reasons
git cherry-pick -s -S -x 8401c81b46549ce81a5cf0693019cef89da0dfdb
```