### PR TITLE
CircleCI: Increase no-output timeout to 15 minutes for vendoring

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -94,6 +94,7 @@ jobs:
             docker build -f dockerfiles/Dockerfile.dev --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
             docker run --rm cli-builder-with-git:$CIRCLE_BUILD_NUM \
                 make ci-validate
+          no_output_timeout: 15m
   shellcheck:
     working_directory: /work
     docker: [{image: 'docker:18.03-git'}]


### PR DESCRIPTION
Vendoring can take some time, depending on network-speed, so
reduce flakiness by increasing the default timeout, to prevent:

    make[1]: Entering directory '/go/src/github.com/docker/cli'
    rm -rf vendor
    bash -c 'vndr |& grep -v -i clone'
    2019/03/18 11:38:26 Collecting initial packages
    Too long with no output (exceeded 10m0s)

