### PR TITLE
Search Windows CLI plugins also in ProgramFiles

### DIFF
--- a/cli-plugins/manager/manager_windows.go
+++ b/cli-plugins/manager/manager_windows.go
@@ -7,4 +7,5 @@ import (
 
 var defaultSystemPluginDirs = []string{
 	filepath.Join(os.Getenv("ProgramData"), "Docker", "cli-plugins"),
+	filepath.Join(os.Getenv("ProgramFiles"), "Docker", "cli-plugins"),
 }

--- a/docs/extend/cli_plugins.md
+++ b/docs/extend/cli_plugins.md
@@ -111,7 +111,8 @@ the `/usr/local/lib` or `/usr/local/libexec` equivalents but packages
 should not do so.
 
 Plugins distributed on Windows for system wide installation should be
-installed in `%PROGRAMDATA%\Docker\cli-plugins`.
+installed in either `%ProgramData%\Docker\cli-plugins` or
+`%ProgramFiles%\Docker\cli-plugins`.
 
 User's may on all systems install plugins into `~/.docker/cli-plugins`.
 


### PR DESCRIPTION
**- What I did**

On Windows also search for CLI plugins in the `C:\Program Files\Docker\cli-plugins` folder.
This would simplify the installation of the docker.zip file with the PowerShell module via the DockerMsftProvider or DockerProvider. They both just unzip the file into C:\Program Files
We only have to put the CLI plugins in the zip into `docker/cli-plugins/` and they will be just right in place.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

On Windows also search for CLI plugins in the `C:\Program Files\Docker\cli-plugins` folder.

**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_5280](https://user-images.githubusercontent.com/207759/54624231-346ab100-4a2a-11e9-8579-9664abbc6007.JPG)
