### PR TITLE
Add `--pids-limit` flag to `docker update`

### DIFF
--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -27,6 +27,7 @@ type updateOptions struct {
 	memorySwap         opts.MemSwapBytes
 	kernelMemory       opts.MemBytes
 	restartPolicy      string
+	pidsLimit          int64
 	cpus               opts.NanoCPUs
 
 	nFlag int
@@ -65,6 +66,8 @@ func NewUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Var(&options.memorySwap, "memory-swap", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
 	flags.Var(&options.kernelMemory, "kernel-memory", "Kernel memory limit")
 	flags.StringVar(&options.restartPolicy, "restart", "", "Restart policy to apply when a container exits")
+	flags.Int64Var(&options.pidsLimit, "pids-limit", 0, "Tune container pids limit (set -1 for unlimited)")
+	flags.SetAnnotation("pids-limit", "version", []string{"1.40"})
 
 	flags.Var(&options.cpus, "cpus", "Number of CPUs")
 	flags.SetAnnotation("cpus", "version", []string{"1.29"})
@@ -101,6 +104,10 @@ func runUpdate(dockerCli command.Cli, options *updateOptions) error {
 		CPURealtimePeriod:  options.cpuRealtimePeriod,
 		CPURealtimeRuntime: options.cpuRealtimeRuntime,
 		NanoCPUs:           options.cpus.Value(),
+	}
+
+	if options.pidsLimit != 0 {
+		resources.PidsLimit = &options.pidsLimit
 	}
 
 	updateConfig := containertypes.UpdateConfig{

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2231,6 +2231,7 @@ _docker_container_update() {
 		--memory -m
 		--memory-reservation
 		--memory-swap
+		--pids-limit
 		--restart
 	"
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -676,6 +676,7 @@ __docker_container_subcommand() {
         "($help -m --memory)"{-m=,--memory=}"[Memory limit]:Memory limit: "
         "($help)--memory-reservation=[Memory soft limit]:Memory limit: "
         "($help)--memory-swap=[Total memory limit with swap]:Memory limit: "
+        "($help)--pids-limit[Tune container pids limit (set -1 for unlimited)]"
         "($help)--restart=[Restart policy]:restart policy:(no on-failure always unless-stopped)"
     )
     opts_help=("(: -)--help[Print usage]")

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -35,6 +35,7 @@ Options:
   -m, --memory string               Memory limit
       --memory-reservation string   Memory soft limit
       --memory-swap string          Swap limit equal to memory plus swap: '-1' to enable unlimited swap
+      --pids-limit int              Tune container pids limit (set -1 for unlimited)
       --restart string              Restart policy to apply when a container exits
 ```
 


### PR DESCRIPTION
carry of https://github.com/docker/cli/pull/181
closes https://github.com/docker/cli/pull/181

**- What I did**

Added `pids-limit` flag to docker `update` command. Also added completion for bash and zsh.

**- Description for the changelog**

Add `--pids-limit` flag to `docker update`


Refer: [moby/moby#32519](https://github.com/moby/moby/pull/32519)