### PR TITLE
[carry 317] Cli change to pass driver specific options to docker run

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -17,6 +17,7 @@ import (
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
@@ -654,60 +655,9 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		EndpointsConfig: make(map[string]*networktypes.EndpointSettings),
 	}
 
-	if copts.ipv4Address != "" || copts.ipv6Address != "" || copts.linkLocalIPs.Len() > 0 {
-		epConfig := &networktypes.EndpointSettings{}
-		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
-
-		epConfig.IPAMConfig = &networktypes.EndpointIPAMConfig{
-			IPv4Address: copts.ipv4Address,
-			IPv6Address: copts.ipv6Address,
-		}
-
-		if copts.linkLocalIPs.Len() > 0 {
-			epConfig.IPAMConfig.LinkLocalIPs = make([]string, copts.linkLocalIPs.Len())
-			copy(epConfig.IPAMConfig.LinkLocalIPs, copts.linkLocalIPs.GetAll())
-		}
-	}
-
-	if hostConfig.NetworkMode.IsUserDefined() && len(hostConfig.Links) > 0 {
-		epConfig := networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)]
-		if epConfig == nil {
-			epConfig = &networktypes.EndpointSettings{}
-		}
-		epConfig.Links = make([]string, len(hostConfig.Links))
-		copy(epConfig.Links, hostConfig.Links)
-		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
-	}
-	value := copts.netMode.Value()
-
-	if value != nil && hostConfig.NetworkMode.IsUserDefined() {
-		epConfig := networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)]
-		if epConfig == nil {
-			epConfig = &networktypes.EndpointSettings{}
-		}
-
-		if len(value[0].Aliases) > 0 {
-			if copts.aliases.Len() > 0 {
-				return nil, fmt.Errorf("ambiguity in alias options provided")
-			}
-			epConfig.Aliases = append(epConfig.Aliases, value[0].Aliases...)
-		}
-
-		if len(value[0].DriverOpts) > 0 {
-			epConfig.DriverOpts = make(map[string]string)
-			epConfig.DriverOpts = value[0].DriverOpts
-		}
-		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
-	}
-
-	if copts.aliases.Len() > 0 {
-		epConfig := networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)]
-		if epConfig == nil {
-			epConfig = &networktypes.EndpointSettings{}
-		}
-		epConfig.Aliases = make([]string, copts.aliases.Len())
-		copy(epConfig.Aliases, copts.aliases.GetAll())
-		networkingConfig.EndpointsConfig[string(hostConfig.NetworkMode)] = epConfig
+	networkingConfig.EndpointsConfig, err = parseNetworkOpts(copts)
+	if err != nil {
+		return nil, err
 	}
 
 	return &containerConfig{
@@ -715,6 +665,112 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		HostConfig:       hostConfig,
 		NetworkingConfig: networkingConfig,
 	}, nil
+}
+
+// parseNetworkOpts converts --network advanced options to endpoint-specs, and combines
+// them with the old --network-alias and --links. If returns an error if conflicting options
+// are found.
+//
+// this function may return _multiple_ endpoints, which is not currently supported
+// by the daemon, but may be in future; it's up to the daemon to produce an error
+// in case that is not supported.
+func parseNetworkOpts(copts *containerOptions) (map[string]*networktypes.EndpointSettings, error) {
+	var (
+		endpoints                         = make(map[string]*networktypes.EndpointSettings, len(copts.netMode.Value()))
+		hasUserDefined, hasNonUserDefined bool
+	)
+
+	for i, n := range copts.netMode.Value() {
+		if container.NetworkMode(n.Target).IsUserDefined() {
+			hasUserDefined = true
+		} else {
+			hasNonUserDefined = true
+		}
+		if i == 0 {
+			// The first network corresponds with what was previously the "only"
+			// network, and what would be used when using the non-advanced syntax
+			// `--network-alias`, `--link`, `--ip`, `--ip6`, and `--link-local-ip`
+			// are set on this network, to preserve backward compatibility with
+			// the non-advanced notation
+			if err := applyContainerOptions(&n, copts); err != nil {
+				return nil, err
+			}
+		}
+		ep, err := parseNetworkAttachmentOpt(n)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := endpoints[n.Target]; ok {
+			return nil, errdefs.InvalidParameter(errors.Errorf("network %q is specified multiple times", n.Target))
+		}
+		endpoints[n.Target] = ep
+	}
+	if hasUserDefined && hasNonUserDefined {
+		return nil, errdefs.InvalidParameter(errors.New("conflicting options: cannot attach both user-defined and non-user-defined network-modes"))
+	}
+	return endpoints, nil
+}
+
+func applyContainerOptions(n *opts.NetworkAttachmentOpts, copts *containerOptions) error {
+	// TODO should copts.MacAddress actually be set on the first network? (currently it's not)
+	// TODO should we error if _any_ advanced option is used? (i.e. forbid to combine advanced notation with the "old" flags (`--network-alias`, `--link`, `--ip`, `--ip6`)?
+	if len(n.Aliases) > 0 && copts.aliases.Len() > 0 {
+		return errdefs.InvalidParameter(errors.New("conflicting options: cannot specify both --network-alias and per-network alias"))
+	}
+	if len(n.Links) > 0 && copts.links.Len() > 0 {
+		return errdefs.InvalidParameter(errors.New("conflicting options: cannot specify both --link and per-network links"))
+	}
+	if copts.aliases.Len() > 0 {
+		n.Aliases = make([]string, copts.aliases.Len())
+		copy(n.Aliases, copts.aliases.GetAll())
+	}
+	if copts.links.Len() > 0 {
+		n.Links = make([]string, copts.links.Len())
+		copy(n.Links, copts.links.GetAll())
+	}
+
+	// TODO add IPv4/IPv6 options to the csv notation for --network, and error-out in case of conflicting options
+	n.IPv4Address = copts.ipv4Address
+	n.IPv6Address = copts.ipv6Address
+
+	// TODO should linkLocalIPs be added to the _first_ network only, or to _all_ networks? (should this be a per-network option as well?)
+	if copts.linkLocalIPs.Len() > 0 {
+		n.LinkLocalIPs = make([]string, copts.linkLocalIPs.Len())
+		copy(n.LinkLocalIPs, copts.linkLocalIPs.GetAll())
+	}
+	return nil
+}
+
+func parseNetworkAttachmentOpt(ep opts.NetworkAttachmentOpts) (*networktypes.EndpointSettings, error) {
+	if strings.TrimSpace(ep.Target) == "" {
+		return nil, errors.New("no name set for network")
+	}
+	if !container.NetworkMode(ep.Target).IsUserDefined() {
+		if len(ep.Aliases) > 0 {
+			return nil, errors.New("network-scoped aliases are only supported for user-defined networks")
+		}
+		if len(ep.Links) > 0 {
+			return nil, errors.New("links are only supported for user-defined networks")
+		}
+	}
+
+	epConfig := &networktypes.EndpointSettings{}
+	epConfig.Aliases = append(epConfig.Aliases, ep.Aliases...)
+	if len(ep.DriverOpts) > 0 {
+		epConfig.DriverOpts = make(map[string]string)
+		epConfig.DriverOpts = ep.DriverOpts
+	}
+	if len(ep.Links) > 0 {
+		epConfig.Links = ep.Links
+	}
+	if ep.IPv4Address != "" || ep.IPv6Address != "" || len(ep.LinkLocalIPs) > 0 {
+		epConfig.IPAMConfig = &networktypes.EndpointIPAMConfig{
+			IPv4Address:  ep.IPv4Address,
+			IPv6Address:  ep.IPv6Address,
+			LinkLocalIPs: ep.LinkLocalIPs,
+		}
+	}
+	return epConfig, nil
 }
 
 func parsePortOpts(publishOpts []string) ([]string, error) {

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"context"
-
 	"fmt"
 	"strings"
 

--- a/opts/network.go
+++ b/opts/network.go
@@ -95,6 +95,16 @@ func (n *NetworkOpt) String() string {
 	return ""
 }
 
+// NetworkMode return the network mode for the network option
+func (n *NetworkOpt) NetworkMode() string {
+	networkIDOrName := "default"
+	netOptVal := n.Value()
+	if len(netOptVal) > 0 {
+		networkIDOrName = netOptVal[0].Target
+	}
+	return networkIDOrName
+}
+
 func parseDriverOpt(driverOpt string) (string, string, error) {
 	parts := strings.SplitN(driverOpt, "=", 2)
 	if len(parts) != 2 {

--- a/opts/network.go
+++ b/opts/network.go
@@ -15,9 +15,13 @@ const (
 
 // NetworkAttachmentOpts represents the network options for endpoint creation
 type NetworkAttachmentOpts struct {
-	Target     string
-	Aliases    []string
-	DriverOpts map[string]string
+	Target       string
+	Aliases      []string
+	DriverOpts   map[string]string
+	Links        []string // TODO add support for links in the csv notation of `--network`
+	IPv4Address  string   // TODO add support for IPv4-address in the csv notation of `--network`
+	IPv6Address  string   // TODO add support for IPv6-address in the csv notation of `--network`
+	LinkLocalIPs []string // TODO add support for LinkLocalIPs in the csv notation of `--network` ?
 }
 
 // NetworkOpt represents a network config in swarm mode.

--- a/opts/network_test.go
+++ b/opts/network_test.go
@@ -28,7 +28,7 @@ func TestNetworkOptLegacySyntax(t *testing.T) {
 	}
 }
 
-func TestNetworkOptCompleteSyntax(t *testing.T) {
+func TestNetworkOptAdvancedSyntax(t *testing.T) {
 	testCases := []struct {
 		value    string
 		expected []NetworkAttachmentOpts
@@ -69,13 +69,15 @@ func TestNetworkOptCompleteSyntax(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		var network NetworkOpt
-		assert.NilError(t, network.Set(tc.value))
-		assert.Check(t, is.DeepEqual(tc.expected, network.Value()))
+		t.Run(tc.value, func(t *testing.T) {
+			var network NetworkOpt
+			assert.NilError(t, network.Set(tc.value))
+			assert.Check(t, is.DeepEqual(tc.expected, network.Value()))
+		})
 	}
 }
 
-func TestNetworkOptInvalidSyntax(t *testing.T) {
+func TestNetworkOptAdvancedSyntaxInvalid(t *testing.T) {
 	testCases := []struct {
 		value         string
 		expectedError string
@@ -94,7 +96,9 @@ func TestNetworkOptInvalidSyntax(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		var network NetworkOpt
-		assert.ErrorContains(t, network.Set(tc.value), tc.expectedError)
+		t.Run(tc.value, func(t *testing.T) {
+			var network NetworkOpt
+			assert.ErrorContains(t, network.Set(tc.value), tc.expectedError)
+		})
 	}
 }


### PR DESCRIPTION
carries https://github.com/docker/cli/pull/317
closes https://github.com/docker/cli/pull/317
closes https://github.com/docker/cli/pull/156

- partially implements: https://github.com/moby/moby/issues/31964 (RFC: add advanced "csv" syntax for "--net" / "--network")
- relates to https://github.com/docker/libnetwork/issues/2066 feature: pass IPAM options at docker run

Adds preliminary support for multiple networks on `docker run` now that this syntax would allow this; the daemon does not yet support this, so specifying multiple networks will still produce an error

Opened this PR since docker/cli#156 was closed. 

The commit contains cli changes to support driver options for a network in docker run and docker network connect cli's.
The driver-opt, aliases is now supported in the form of csv as per network option in service commands in swarm mode since docker/cli#62 . This commit extends this support to docker run command as well. 
For docker connect command --driver-opt is added to pass driver specific options for the network the container is connecting to.

Following is supported:
```
docker run -itd --net name=docknet,alias=web1.0,driver-opt=field1=value1 alpine
docker run -itd --net name=docknet,driver-opt=field1=value1 --net-alias=web1.0 alpine
docker run -itd --net name=docknet --net-alias web1 alpine
```
```
docker connect network --driver-opt field1=value1 --alias=web2.0 docknet2 dockcontainer
```
Signed-off-by: Abhinandan Prativadi <abhi@docker.com>
