### PR TITLE
Fix annnotation on docker config create --template-driver

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -41,7 +41,7 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.Labels, "label", "l", "Config labels")
 	flags.StringVar(&createOpts.TemplateDriver, "template-driver", "", "Template driver")
-	flags.SetAnnotation("driver", "version", []string{"1.37"})
+	flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
 }


### PR DESCRIPTION
**- What I did**
Fixed an annotation that was set on an incorrect flag
**- How I did it**
Spotted it while working on deferred client initialization

cc @thaJeztah

