### PR TITLE
[18.09 backport] use official shellcheck 0.6.0, and don't patch Dockerfiles in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,9 +16,7 @@ jobs:
       - run:
           name: "Lint"
           command: |
-            dockerfile=dockerfiles/Dockerfile.lint
-            echo "COPY . ." >> $dockerfile
-            docker build -f $dockerfile --tag cli-linter:$CIRCLE_BUILD_NUM .
+            docker build -f dockerfiles/Dockerfile.lint --tag cli-linter:$CIRCLE_BUILD_NUM .
             docker run --rm cli-linter:$CIRCLE_BUILD_NUM
 
   cross:
@@ -34,9 +32,7 @@ jobs:
       - run:
           name: "Cross"
           command: |
-            dockerfile=dockerfiles/Dockerfile.cross
-            echo "COPY . ." >> $dockerfile
-            docker build -f $dockerfile --tag cli-builder:$CIRCLE_BUILD_NUM .
+            docker build -f dockerfiles/Dockerfile.cross --tag cli-builder:$CIRCLE_BUILD_NUM .
             name=cross-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX
             docker run \
                 -e CROSS_GROUP=$CIRCLE_NODE_INDEX \
@@ -60,9 +56,7 @@ jobs:
       - run:
           name: "Unit Test with Coverage"
           command: |
-            dockerfile=dockerfiles/Dockerfile.dev
-            echo "COPY . ." >> $dockerfile
-            docker build -f $dockerfile --tag cli-builder:$CIRCLE_BUILD_NUM .
+            docker build -f dockerfiles/Dockerfile.dev --tag cli-builder:$CIRCLE_BUILD_NUM .
             docker run --name \
                 test-$CIRCLE_BUILD_NUM cli-builder:$CIRCLE_BUILD_NUM \
                 make test-coverage
@@ -89,10 +83,8 @@ jobs:
       - run:
           name: "Validate Vendor, Docs, and Code Generation"
           command: |
-            dockerfile=dockerfiles/Dockerfile.dev
-            echo "COPY . ." >> $dockerfile
             rm -f .dockerignore # include .git
-            docker build -f $dockerfile --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
+            docker build -f dockerfiles/Dockerfile.dev --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
             docker run --rm cli-builder-with-git:$CIRCLE_BUILD_NUM \
                 make ci-validate
   shellcheck:
@@ -107,9 +99,7 @@ jobs:
       - run:
           name: "Run shellcheck"
           command: |
-            dockerfile=dockerfiles/Dockerfile.shellcheck
-            echo "COPY . ." >> $dockerfile
-            docker build -f $dockerfile --tag cli-validator:$CIRCLE_BUILD_NUM .
+            docker build -f dockerfiles/Dockerfile.shellcheck --tag cli-validator:$CIRCLE_BUILD_NUM .
             docker run --rm cli-validator:$CIRCLE_BUILD_NUM \
                 make shellcheck
 workflows:

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016,SC2119,SC2155
+# shellcheck disable=SC2016,SC2119,SC2155,SC2206,SC2207
 #
 # Shellcheck ignore list:
 #  - SC2016: Expressions don't expand in single quotes, use double quotes for that.
 #  - SC2119: Use foo "$@" if function's $1 should mean script's $1.
 #  - SC2155: Declare and assign separately to avoid masking return values.
-# 
-# You can find more details for each warning at the following page: 
+#  - SC2206: Quote to prevent word splitting, or split robustly with mapfile or read -a.
+#  - SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
+#
+# You can find more details for each warning at the following page:
 #    https://github.com/koalaman/shellcheck/wiki/<SCXXXX>
 #
 # bash completion file for core docker commands

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -17,24 +17,29 @@ ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
 build_docker_image:
-	docker build ${DOCKER_BUILD_ARGS} -t $(DEV_DOCKER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.dev .
+	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
+	cat ./dockerfiles/Dockerfile.dev | docker build ${DOCKER_BUILD_ARGS} -t $(DEV_DOCKER_IMAGE_NAME) -
 
 # build docker image having the linting tools (dockerfiles/Dockerfile.lint)
 .PHONY: build_linter_image
 build_linter_image:
-	docker build ${DOCKER_BUILD_ARGS} -t $(LINTER_IMAGE_NAME) -f ./dockerfiles/Dockerfile.lint .
+	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
+	cat ./dockerfiles/Dockerfile.lint | docker build ${DOCKER_BUILD_ARGS} -t $(LINTER_IMAGE_NAME) -
 
 .PHONY: build_cross_image
 build_cross_image:
-	docker build ${DOCKER_BUILD_ARGS} -t $(CROSS_IMAGE_NAME) -f ./dockerfiles/Dockerfile.cross .
+	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
+	cat ./dockerfiles/Dockerfile.cross | docker build ${DOCKER_BUILD_ARGS} -t $(CROSS_IMAGE_NAME) -
 
 .PHONY: build_shell_validate_image
 build_shell_validate_image:
-	docker build -t $(VALIDATE_IMAGE_NAME) -f ./dockerfiles/Dockerfile.shellcheck .
+	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
+	cat ./dockerfiles/Dockerfile.shellcheck | docker build -t $(VALIDATE_IMAGE_NAME) -
 
 .PHONY: build_binary_native_image
 build_binary_native_image:
-	docker build -t $(BINARY_NATIVE_IMAGE_NAME) -f ./dockerfiles/Dockerfile.binary-native .
+	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
+	cat ./dockerfiles/Dockerfile.binary-native | docker build -t $(BINARY_NATIVE_IMAGE_NAME) -
 
 .PHONY: build_e2e_image
 build_e2e_image:

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,3 +1,4 @@
 FROM    dockercore/golang-cross:1.10.8@sha256:a93210f55a8137b4aa4b9f033ac7a80b66ab6337e98e7afb62abe93b4ad73cad
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
+COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -22,3 +22,4 @@ ENV     CGO_ENABLED=0 \
         DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 CMD     sh
+COPY    . .

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -15,3 +15,4 @@ ENV     CGO_ENABLED=0
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENTRYPOINT ["/usr/local/bin/gometalinter"]
 CMD     ["--config=gometalinter.json", "./..."]
+COPY    . .

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,10 +1,7 @@
-FROM    debian:stretch-slim
-
-RUN     apt-get update && \
-        apt-get -y install make shellcheck && \
-        apt-get clean
-
+FROM    koalaman/shellcheck-alpine:v0.4.6
+RUN     apk add --no-cache bash make
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-CMD     bash
+ENTRYPOINT [""]
+CMD     ["/bin/sh"]
 COPY    . .

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -7,3 +7,4 @@ RUN     apt-get update && \
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 CMD     bash
+COPY    . .

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,7 +1,5 @@
-FROM    koalaman/shellcheck-alpine:v0.4.6
+FROM    koalaman/shellcheck-alpine:v0.6.0
 RUN     apk add --no-cache bash make
 WORKDIR /go/src/github.com/docker/cli
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-ENTRYPOINT [""]
-CMD     ["/bin/sh"]
 COPY    . .

--- a/scripts/gen/windows-resources
+++ b/scripts/gen/windows-resources
@@ -7,7 +7,7 @@ set -eu -o pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=/go/src/github.com/docker/cli/scripts/build/.variables
-source $SCRIPTDIR/../build/.variables
+source "$SCRIPTDIR"/../build/.variables
 
 RESOURCES=$SCRIPTDIR/../winresources
 
@@ -26,9 +26,9 @@ VERSION_QUAD=$(echo -n "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . ,)
 
 # Pass version and commit information into the resource compiler
 defs=
-[ ! -z "$VERSION" ]      && defs+=( "-D DOCKER_VERSION=\"$VERSION\"")
-[ ! -z "$VERSION_QUAD" ] && defs+=( "-D DOCKER_VERSION_QUAD=$VERSION_QUAD")
-[ ! -z "$GITCOMMIT" ]    && defs+=( "-D DOCKER_COMMIT=\"$GITCOMMIT\"")
+[ -n "$VERSION" ]      && defs+=( "-D DOCKER_VERSION=\"$VERSION\"")
+[ -n "$VERSION_QUAD" ] && defs+=( "-D DOCKER_VERSION_QUAD=$VERSION_QUAD")
+[ -n "$GITCOMMIT" ]    && defs+=( "-D DOCKER_COMMIT=\"$GITCOMMIT\"")
 
 function makeres {
 	"$WINDRES" \

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -70,7 +70,7 @@ function runtests {
         GOPATH="$GOPATH" \
         PATH="$PWD/build/:/usr/bin" \
         HOME="$HOME" \
-        "$(which go)" test -v ./e2e/... ${TESTFLAGS-}
+        "$(command -v go)" test -v ./e2e/... ${TESTFLAGS-}
 }
 
 export unique_id="${E2E_UNIQUE_ID:-cliendtoendsuite}"

--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 
 target="${1:-}"
 
-if [[ "$target" != "help" && -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]]; then
+if [ "$target" != "help" ] && [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
     (
         echo
         echo


### PR DESCRIPTION
backports for the 18.09 branch of:

- https://github.com/docker/cli/pull/1537 do not patch Dockerfiles in CI
- https://github.com/docker/cli/pull/1538 Use official shellcheck image
- https://github.com/docker/cli/pull/1693 Upgrade shellcheck 0.6.0


thought it'd be good to keep this branch a bit up-to-date for CI