### PR TITLE
[18.09] bump engine 200b524eff60a9c95a22bc2518042ac2ff617d07 (18.09 branch)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/cpuguy83/go-md2man v1.0.8
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76 # v1.1.0
 github.com/dgrijalva/jwt-go a2c85815a77d0f951e33ba4db5ae93629a1530af
 github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
-github.com/docker/docker d2ecc7bad104139c118249ad159b45315a022754 https://github.com/docker/engine # 18.09 branch
+github.com/docker/docker 200b524eff60a9c95a22bc2518042ac2ff617d07 https://github.com/docker/engine # 18.09 branch
 github.com/docker/docker-credential-helpers 5241b46610f2491efdf9d1c85f1ddf5b02f6d962
 # the docker/go package contains a customized version of canonical/json
 # and is used by Notary. The package is periodically rebased on current Go versions.

--- a/vendor/github.com/docker/docker/builder/remotecontext/git/gitutils.go
+++ b/vendor/github.com/docker/docker/builder/remotecontext/git/gitutils.go
@@ -102,6 +102,11 @@ func parseRemoteURL(remoteURL string) (gitRepo, error) {
 		u.Fragment = ""
 		repo.remote = u.String()
 	}
+
+	if strings.HasPrefix(repo.ref, "-") {
+		return gitRepo{}, errors.Errorf("invalid refspec: %s", repo.ref)
+	}
+
 	return repo, nil
 }
 
@@ -124,7 +129,7 @@ func fetchArgs(remoteURL string, ref string) []string {
 		args = append(args, "--depth", "1")
 	}
 
-	return append(args, "origin", ref)
+	return append(args, "origin", "--", ref)
 }
 
 // Check if a given git URL supports a shallow git clone,

--- a/vendor/github.com/docker/docker/client/request.go
+++ b/vendor/github.com/docker/docker/client/request.go
@@ -195,9 +195,17 @@ func (cli *Client) checkResponseErr(serverResp serverResponse) error {
 		return nil
 	}
 
-	body, err := ioutil.ReadAll(serverResp.body)
+	bodyMax := 1 * 1024 * 1024 // 1 MiB
+	bodyR := &io.LimitedReader{
+		R: serverResp.body,
+		N: int64(bodyMax),
+	}
+	body, err := ioutil.ReadAll(bodyR)
 	if err != nil {
 		return err
+	}
+	if bodyR.N == 0 {
+		return fmt.Errorf("request returned %s with a message (> %d bytes) for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), bodyMax, serverResp.reqURL)
 	}
 	if len(body) == 0 {
 		return fmt.Errorf("request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), serverResp.reqURL)

--- a/vendor/github.com/docker/docker/pkg/archive/copy.go
+++ b/vendor/github.com/docker/docker/pkg/archive/copy.go
@@ -336,6 +336,14 @@ func RebaseArchiveEntries(srcContent io.Reader, oldBase, newBase string) io.Read
 				return
 			}
 
+			// srcContent tar stream, as served by TarWithOptions(), is
+			// definitely in PAX format, but tar.Next() mistakenly guesses it
+			// as USTAR, which creates a problem: if the newBase is >100
+			// characters long, WriteHeader() returns an error like
+			// "archive/tar: cannot encode header: Format specifies USTAR; and USTAR cannot encode Name=...".
+			//
+			// To fix, set the format to PAX here. See docker/for-linux issue #484.
+			hdr.Format = tar.FormatPAX
 			hdr.Name = strings.Replace(hdr.Name, oldBase, newBase, 1)
 			if hdr.Typeflag == tar.TypeLink {
 				hdr.Linkname = strings.Replace(hdr.Linkname, oldBase, newBase, 1)

--- a/vendor/github.com/docker/docker/pkg/mount/sharedsubtree_linux.go
+++ b/vendor/github.com/docker/docker/pkg/mount/sharedsubtree_linux.go
@@ -48,18 +48,22 @@ func MakeRUnbindable(mountPoint string) error {
 	return ensureMountedAs(mountPoint, "runbindable")
 }
 
-func ensureMountedAs(mountPoint, options string) error {
-	mounted, err := Mounted(mountPoint)
+// MakeMount ensures that the file or directory given is a mount point,
+// bind mounting it to itself it case it is not.
+func MakeMount(mnt string) error {
+	mounted, err := Mounted(mnt)
 	if err != nil {
 		return err
 	}
-
-	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
-			return err
-		}
+	if mounted {
+		return nil
 	}
-	if _, err = Mounted(mountPoint); err != nil {
+
+	return Mount(mnt, mnt, "none", "bind")
+}
+
+func ensureMountedAs(mountPoint, options string) error {
+	if err := MakeMount(mountPoint); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/docker/docker/pkg/progress/progress.go
+++ b/vendor/github.com/docker/docker/pkg/progress/progress.go
@@ -39,6 +39,10 @@ type Output interface {
 type chanOutput chan<- Progress
 
 func (out chanOutput) WriteProgress(p Progress) error {
+	// FIXME: workaround for panic in #37735
+	defer func() {
+		recover()
+	}()
 	out <- p
 	return nil
 }

--- a/vendor/github.com/docker/docker/registry/registry.go
+++ b/vendor/github.com/docker/docker/registry/registry.go
@@ -145,7 +145,7 @@ func trustedLocation(req *http.Request) bool {
 // addRequiredHeadersToRedirectedRequests adds the necessary redirection headers
 // for redirected requests
 func addRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Request) error {
-	if via != nil && via[0] != nil {
+	if len(via) != 0 && via[0] != nil {
 		if trustedLocation(req) && trustedLocation(via[0]) {
 			req.Header = via[0].Header
 			return nil

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,7 +1,7 @@
 # the following lines are in sorted order, FYI
 github.com/Azure/go-ansiterm d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim 44c060121b68e8bdc40b411beba551f3b4ee9e55
-github.com/Microsoft/go-winio v0.4.10
+github.com/Microsoft/hcsshim v0.7.12
+github.com/Microsoft/go-winio v0.4.11
 github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/go-check/check 4ed411733c5785b40214c70bce814c3a3a689609 https://github.com/cpuguy83/check.git
 github.com/golang/gddo 9b12a26f3fbd7397dee4e20939ddca719d840d2a
@@ -26,8 +26,8 @@ github.com/imdario/mergo v0.3.6
 golang.org/x/sync 1d60e4601c6fd243af51cc01ddf169918a5407ca
 
 # buildkit
-github.com/moby/buildkit 6812dac65e0440bb75affce1fb2175e640edc15d
-github.com/tonistiigi/fsutil b19464cd1b6a00773b4f2eb7acf9c30426f9df42
+github.com/moby/buildkit d9f75920678e35090025bb89344c5370e2efc8e7
+github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
@@ -37,7 +37,7 @@ github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 #get libnetwork packages
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy accordingly
-github.com/docker/libnetwork a79d3687931697244b8e03485bf7b2042f8ec6b6
+github.com/docker/libnetwork 4725f2163fb214a6312f3beae5991f838ec36326 # bump_18.09 branch
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -47,7 +47,7 @@ github.com/sean-/seed e2103e2c35297fb7e17febb81e49b312087a2372
 github.com/hashicorp/go-sockaddr 6d291a969b86c4b633730bfc6b8b9d64c3aafed9
 github.com/hashicorp/go-multierror fcdddc395df1ddf4247c69bd436e84cfa0733f7e
 github.com/hashicorp/serf 598c54895cc5a7b1a24a398d635e8c0ea0959870
-github.com/docker/libkv 1d8431073ae03cdaedb198a89722f3aab6d418ef
+github.com/docker/libkv 458977154600b9f23984d9f4b82e79570b5ae12b
 github.com/vishvananda/netns 604eaf189ee867d8c147fafc28def2394e878d25
 github.com/vishvananda/netlink b2de5d10e38ecce8607e6b438b6d174f389a004e
 
@@ -59,13 +59,13 @@ github.com/coreos/etcd v3.2.1
 github.com/coreos/go-semver v0.2.0
 github.com/ugorji/go f1f1a805ed361a0e078bb537e4ea78cd37dcf065
 github.com/hashicorp/consul v0.5.2
-github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/miekg/dns v1.0.7
 github.com/ishidawataru/sctp 07191f837fedd2f13d1ec7b5f885f0f3ec54b1cb
+go.etcd.io/bbolt v1.3.1-etcd.8
 
 # get graph and distribution packages
 github.com/docker/distribution 83389a148052d74ac602f5f1d62f86ff2f3c4aa5
-github.com/vbatts/tar-split v0.10.2
+github.com/vbatts/tar-split v0.11.0
 github.com/opencontainers/go-digest v1.0.0-rc1
 
 # get go-zfs packages
@@ -74,9 +74,13 @@ github.com/pborman/uuid v1.0
 
 google.golang.org/grpc v1.12.0
 
-# This does not need to match RUNC_COMMIT as it is used for helper packages but should be newer or equal
-github.com/opencontainers/runc 20aff4f0488c6d4b8df4d85b4f63f1f704c11abd
-github.com/opencontainers/runtime-spec d810dbc60d8c5aeeb3d054bd1132fab2121968ce # v1.0.1-43-gd810dbc
+# The version of runc should match the version that is used by the containerd
+# version that is used. If you need to update runc, open a pull request in
+# the containerd project first, and update both after that is merged.
+# This commit does not need to match RUNC_COMMIT as it is used for helper
+# packages but should be newer or equal.
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
+github.com/opencontainers/runtime-spec 5684b8af48c1ac3b1451fa499724e30e3c20a294 # v1.0.1-49-g5684b8a
 github.com/opencontainers/image-spec v1.0.1
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0
 
@@ -114,23 +118,24 @@ github.com/googleapis/gax-go v2.0.0
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd v1.2.0-beta.2
+github.com/containerd/containerd 9754871865f7fe2f4e74d43e2fc7ccd237edcbce # v1.2.2
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
-github.com/containerd/continuity d3c23511c1bf5851696cba83143d9cbcd666869b
-github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
+github.com/containerd/continuity 004b46473808b3e7a4a3049c20e4376c91eb966d
+github.com/containerd/cgroups dbea6f2bd41658b84b00417ceefa416b979cbf10
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/go-runc edcf3de1f4971445c42d61f20d506b30612aa031
+github.com/containerd/cri 0d5cabd006cb5319dc965046067b8432d9fa5ef8 # release/1.2 branch
+github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
-github.com/containerd/ttrpc 94dde388801693c54f88a6596f713b51a8b30b2d
+github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 
 # cluster
-github.com/docker/swarmkit cfa742c8abe6f8e922f6e4e920153c408e7d9c3b
+github.com/docker/swarmkit c66ed60822d3fc3bf6e17a505ee79014f449ef05 # bump_v18.09 branch
 github.com/gogo/protobuf v1.0.0
 github.com/cloudflare/cfssl 1.3.2
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
 github.com/google/certificate-transparency-go v1.0.20
-golang.org/x/crypto a2144134853fc9a27a7b1e3eb4f19f1a76df13c9
+golang.org/x/crypto 0709b304e793a5edb4a2c0145f281ecdc20838a4
 golang.org/x/time fbb02b2291d28baffd63558aa44b4b56f178d650
 github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
@@ -143,8 +148,8 @@ github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
 github.com/prometheus/common ebdfc6da46522d58825777cf1f90490a5b1ef1d8
 github.com/prometheus/procfs abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-github.com/pkg/errors 839d9e913e063e28dfd0e6c7b7512793e0a48be9
-github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+github.com/pkg/errors 645ef00459ed84a119197bfb8d8205042c6df63d # v0.8.0
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 
 # cli
 github.com/spf13/cobra v0.0.3
@@ -155,7 +160,7 @@ github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.
 # metrics
 github.com/docker/go-metrics d466d4f6fd960e01820085bd7e1a24426ee7ef18
 
-github.com/opencontainers/selinux b29023b86e4a69d1b46b7e7b4e2b6fda03f0b9cd
+github.com/opencontainers/selinux b6fa367ed7f534f9ba25391cc2d467085dbb445a
 
 
 # archive/tar (for Go 1.10, see https://github.com/golang/go/issues/24787)


### PR DESCRIPTION
full diff https://github.com/docker/engine/compare/d2ecc7bad104139c118249ad159b45315a022754...200b524eff60a9c95a22bc2518042ac2ff617d07

relevant changes;

- https://github.com/moby/moby/pull/38006 / https://github.com/docker/engine/pull/114 client: use io.LimitedReader for reading HTTP error
- https://github.com/moby/moby/pull/38634 / https://github.com/docker/engine/pull/167 pkg/archive:CopyTo(): fix for long dest filename
  - fixes https://github.com/docker/for-linux/issues/484 for 18.09
- https://github.com/moby/moby/pull/38944 / https://github.com/docker/engine/pull/183 gitutils: add validation for ref
- https://github.com/moby/moby/pull/37780 / https://github.com/docker/engine/pull/55 pkg/progress: work around closing closed channel panic
  - addresses https://github.com/moby/moby/issues/37735 pkg/progress: panic due to race on shutdown