### PR TITLE
Fix annotation on docker secret create --template-driver

### DIFF
--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -45,7 +45,7 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&options.driver, "driver", "d", "", "Secret driver")
 	flags.SetAnnotation("driver", "version", []string{"1.31"})
 	flags.StringVar(&options.templateDriver, "template-driver", "", "Template driver")
-	flags.SetAnnotation("driver", "version", []string{"1.37"})
+	flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
 }


### PR DESCRIPTION
Full disclosure: This issue is a copy-cat act inspired by #1769.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed an annotation that was set on an incorrect flag
**- How I did it**
Spotted it while working on deferred client initialization

cc @thaJeztah 