### PR TITLE
cli-plugins: Reinstate deprecated `-h` short form of `--help`.

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -42,6 +42,10 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	rootCmd.SetFlagErrorFunc(FlagErrorFunc)
 	rootCmd.SetHelpCommand(helpCommand)
 
+	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
+	rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
+	rootCmd.PersistentFlags().Lookup("help").Hidden = true
+
 	return opts, flags, helpCommand
 }
 
@@ -52,20 +56,12 @@ func SetupRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *pflag.F
 
 	rootCmd.SetVersionTemplate("Docker version {{.Version}}\n")
 
-	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
-	rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
-	rootCmd.PersistentFlags().Lookup("help").Hidden = true
-
 	return opts, flags, helpCmd
 }
 
 // SetupPluginRootCommand sets default usage, help and error handling for a plugin root command.
 func SetupPluginRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *pflag.FlagSet) {
 	opts, flags, _ := setupCommonRootCommand(rootCmd)
-
-	rootCmd.PersistentFlags().BoolP("help", "", false, "Print usage")
-	rootCmd.PersistentFlags().Lookup("help").Hidden = true
-
 	return opts, flags
 }
 

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -17,8 +17,8 @@ func TestRunNonexisting(t *testing.T) {
 	res := icmd.RunCmd(run("nonexistent"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 1,
+		Out:      icmd.None,
 	})
-	assert.Assert(t, is.Equal(res.Stdout(), ""))
 	golden.Assert(t, res.Stderr(), "docker-nonexistent-err.golden")
 }
 
@@ -30,8 +30,8 @@ func TestHelpNonexisting(t *testing.T) {
 	res := icmd.RunCmd(run("help", "nonexistent"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 1,
+		Out:      icmd.None,
 	})
-	assert.Assert(t, is.Equal(res.Stdout(), ""))
 	golden.Assert(t, res.Stderr(), "docker-help-nonexistent-err.golden")
 }
 
@@ -48,6 +48,7 @@ func TestNonexistingHelp(t *testing.T) {
 		// output, so spot check instead having of a golden
 		// with everything in, which will change too frequently.
 		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Err: icmd.None,
 	})
 }
 
@@ -59,8 +60,8 @@ func TestRunBad(t *testing.T) {
 	res := icmd.RunCmd(run("badmeta"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 1,
+		Out:      icmd.None,
 	})
-	assert.Assert(t, is.Equal(res.Stdout(), ""))
 	golden.Assert(t, res.Stderr(), "docker-badmeta-err.golden")
 }
 
@@ -72,8 +73,8 @@ func TestHelpBad(t *testing.T) {
 	res := icmd.RunCmd(run("help", "badmeta"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 1,
+		Out:      icmd.None,
 	})
-	assert.Assert(t, is.Equal(res.Stdout(), ""))
 	golden.Assert(t, res.Stderr(), "docker-help-badmeta-err.golden")
 }
 
@@ -90,6 +91,7 @@ func TestBadHelp(t *testing.T) {
 		// output, so spot check instead of a golden with
 		// everything in which will change all the time.
 		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Err: icmd.None,
 	})
 }
 
@@ -102,6 +104,7 @@ func TestRunGood(t *testing.T) {
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		Out:      "Hello World!",
+		Err:      icmd.None,
 	})
 }
 
@@ -113,9 +116,11 @@ func TestHelpGood(t *testing.T) {
 	defer cleanup()
 
 	res := icmd.RunCmd(run("-D", "help", "helloworld"))
-	res.Assert(t, icmd.Success)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Err:      icmd.None,
+	})
 	golden.Assert(t, res.Stdout(), "docker-help-helloworld.golden")
-	assert.Assert(t, is.Equal(res.Stderr(), ""))
 }
 
 // TestGoodHelp ensures correct behaviour when calling a valid plugin
@@ -126,10 +131,12 @@ func TestGoodHelp(t *testing.T) {
 	defer cleanup()
 
 	res := icmd.RunCmd(run("-D", "helloworld", "--help"))
-	res.Assert(t, icmd.Success)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Err:      icmd.None,
+	})
 	// This is the same golden file as `TestHelpGood`, above.
 	golden.Assert(t, res.Stdout(), "docker-help-helloworld.golden")
-	assert.Assert(t, is.Equal(res.Stderr(), ""))
 }
 
 // TestRunGoodSubcommand ensures correct behaviour when running a valid plugin with a subcommand
@@ -141,6 +148,7 @@ func TestRunGoodSubcommand(t *testing.T) {
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		Out:      "Goodbye World!",
+		Err:      icmd.None,
 	})
 }
 
@@ -152,9 +160,11 @@ func TestHelpGoodSubcommand(t *testing.T) {
 	defer cleanup()
 
 	res := icmd.RunCmd(run("-D", "help", "helloworld", "goodbye"))
-	res.Assert(t, icmd.Success)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Err:      icmd.None,
+	})
 	golden.Assert(t, res.Stdout(), "docker-help-helloworld-goodbye.golden")
-	assert.Assert(t, is.Equal(res.Stderr(), ""))
 }
 
 // TestGoodSubcommandHelp ensures correct behaviour when calling a valid plugin
@@ -165,10 +175,12 @@ func TestGoodSubcommandHelp(t *testing.T) {
 	defer cleanup()
 
 	res := icmd.RunCmd(run("-D", "helloworld", "goodbye", "--help"))
-	res.Assert(t, icmd.Success)
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		Err:      icmd.None,
+	})
 	// This is the same golden file as `TestHelpGoodSubcommand`, above.
 	golden.Assert(t, res.Stdout(), "docker-help-helloworld-goodbye.golden")
-	assert.Assert(t, is.Equal(res.Stderr(), ""))
 }
 
 // TestCliInitialized tests the code paths which ensure that the Cli
@@ -191,7 +203,7 @@ func TestPluginErrorCode(t *testing.T) {
 	res := icmd.RunCmd(run("helloworld", "exitstatus2"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 2,
+		Out:      icmd.None,
 		Err:      "Exiting with error status 2",
 	})
-	assert.Assert(t, is.Equal(res.Stdout(), ""))
 }

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -9,6 +9,8 @@ import (
 	"gotest.tools/icmd"
 )
 
+const shortHFlagDeprecated = "Flag shorthand -h has been deprecated, please use --help\n"
+
 // TestRunNonexisting ensures correct behaviour when running a nonexistent plugin.
 func TestRunNonexisting(t *testing.T) {
 	run, _, cleanup := prepare(t)
@@ -48,6 +50,15 @@ func TestNonexistingHelp(t *testing.T) {
 		// output, so spot check instead having of a golden
 		// with everything in, which will change too frequently.
 		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Err: icmd.None,
+	})
+	// Short -h should be the same, modulo the deprecation message
+	exp := shortHFlagDeprecated + res.Stdout()
+	res = icmd.RunCmd(run("nonexistent", "-h"))
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		// This should be identical to the --help case above
+		Out: exp,
 		Err: icmd.None,
 	})
 }
@@ -91,6 +102,15 @@ func TestBadHelp(t *testing.T) {
 		// output, so spot check instead of a golden with
 		// everything in which will change all the time.
 		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Err: icmd.None,
+	})
+	// Short -h should be the same, modulo the deprecation message
+	exp := shortHFlagDeprecated + res.Stdout()
+	res = icmd.RunCmd(run("badmeta", "-h"))
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		// This should be identical to the --help case above
+		Out: exp,
 		Err: icmd.None,
 	})
 }
@@ -137,6 +157,15 @@ func TestGoodHelp(t *testing.T) {
 	})
 	// This is the same golden file as `TestHelpGood`, above.
 	golden.Assert(t, res.Stdout(), "docker-help-helloworld.golden")
+	// Short -h should be the same, modulo the deprecation message
+	exp := shortHFlagDeprecated + res.Stdout()
+	res = icmd.RunCmd(run("-D", "helloworld", "-h"))
+	res.Assert(t, icmd.Expected{
+		ExitCode: 0,
+		// This should be identical to the --help case above
+		Out: exp,
+		Err: icmd.None,
+	})
 }
 
 // TestRunGoodSubcommand ensures correct behaviour when running a valid plugin with a subcommand


### PR DESCRIPTION
The commit message of the primary commit is informative:
```
cli-plugins: Reinstate deprecated `-h` short form of `--help`.

In the initial implementation I thought it would be good to not pass on the
deprecation to plugins (since they are new). However it turns out this causes
`docker helloworld -h` to print a spurious "pflag: help requested" line:

    $ docker helloworld -h
    pflag: help requested
    See 'docker helloworld --help'.

    Usage:	docker helloworld [OPTIONS] COMMAND

    A basic Hello World plugin for tests
    ...

Compared with:

    $ docker ps -h
    Flag shorthand -h has been deprecated, please use --help

    Usage:	docker ps [OPTIONS]

This is in essence because having the flag undefined hits a different path
within cobra, causing `c.execute()` to return early due to getting an error
(`flag.ErrHelp`) from `c.ParseFlags`, which launders the error through our
`FlagErrorFunc` which wraps it in a `StatusError` which in turn defeats an `if
err == flag.ErrHelp` check further up the call chain. If the flag is defined we
instead hit a path which returns a bare `flag.ErrHelp` without wrapping it.

I considered updating our `FlagErrorFunc` to not wrap `flag.ErrHelp` (and then
following the chain to the next thing) however while doing that I realised that
the code for `-h` (and `--help`) is deeply embedded into cobra (and its flags
library) such that actually using `-h` as a plugin argument meaning something
other than `help` is basically impossible/impractical. Therefore we may as well
have plugins behave identically to the monolithic CLI and support (deprecated)
the `-h` argument.

With this changed the help related blocks of `SetupRootCommand` and
`SetupPluginRootCommand` are now identical, so consolidate into
`setupCommonRootCommand`.

Tests are updated to check `-h` in a variety of scenarios, including the happy
case here.

Signed-off-by: Ian Campbell <ijc@docker.com>
```

The preceding commit just refactors the e2e tests a little for clarity.