### PR TITLE
[18.09 backport] fix annotations on --template-driver

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -40,7 +40,7 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.labels, "label", "l", "Config labels")
 	flags.StringVar(&createOpts.templateDriver, "template-driver", "", "Template driver")
-	flags.SetAnnotation("driver", "version", []string{"1.37"})
+	flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
 }

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -45,7 +45,7 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&options.driver, "driver", "d", "", "Secret driver")
 	flags.SetAnnotation("driver", "version", []string{"1.31"})
 	flags.StringVar(&options.templateDriver, "template-driver", "", "Template driver")
-	flags.SetAnnotation("driver", "version", []string{"1.37"})
+	flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
 }


### PR DESCRIPTION
backport of;

- https://github.com/docker/cli/pull/1785 Fix annotation on docker secret create --template-driver
- https://github.com/docker/cli/pull/1769 Fix annnotation on docker config create --template-drive

relates to https://github.com/docker/cli/pull/896