### PR TITLE
Fix login logout when engine is down and credential helper is in use

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -28,21 +28,22 @@ func ElectAuthServer(ctx context.Context, cli Cli) string {
 	// used. This is essential in cross-platforms environment, where for
 	// example a Linux client might be interacting with a Windows daemon, hence
 	// the default registry URL might be Windows specific.
-	serverAddress := registry.IndexServer
-	if info, err := cli.Client().Info(ctx); err != nil {
+	info, err := cli.Client().Info(ctx)
+	if err != nil {
 		// Daemon is not responding so use system default.
 		if debug.IsEnabled() {
 			// Only report the warning if we're in debug mode to prevent nagging during engine initialization workflows
-			fmt.Fprintf(cli.Err(), "Warning: failed to get default registry endpoint from daemon (%v). Using system default: %s\n", err, serverAddress)
+			fmt.Fprintf(cli.Err(), "Warning: failed to get default registry endpoint from daemon (%v). Using system default: %s\n", err, registry.IndexServer)
 		}
-	} else if info.IndexServerAddress == "" {
-		if debug.IsEnabled() {
-			fmt.Fprintf(cli.Err(), "Warning: Empty registry endpoint from daemon. Using system default: %s\n", serverAddress)
-		}
-	} else {
-		serverAddress = info.IndexServerAddress
+		return registry.IndexServer
 	}
-	return serverAddress
+	if info.IndexServerAddress == "" {
+		if debug.IsEnabled() {
+			fmt.Fprintf(cli.Err(), "Warning: Empty registry endpoint from daemon. Using system default: %s\n", registry.IndexServer)
+		}
+		return registry.IndexServer
+	}
+	return info.IndexServerAddress
 }
 
 // EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -29,11 +29,16 @@ func ElectAuthServer(ctx context.Context, cli Cli) string {
 	// example a Linux client might be interacting with a Windows daemon, hence
 	// the default registry URL might be Windows specific.
 	serverAddress := registry.IndexServer
-	if info, err := cli.Client().Info(ctx); err != nil && debug.IsEnabled() {
-		// Only report the warning if we're in debug mode to prevent nagging during engine initialization workflows
-		fmt.Fprintf(cli.Err(), "Warning: failed to get default registry endpoint from daemon (%v). Using system default: %s\n", err, serverAddress)
-	} else if info.IndexServerAddress == "" && debug.IsEnabled() {
-		fmt.Fprintf(cli.Err(), "Warning: Empty registry endpoint from daemon. Using system default: %s\n", serverAddress)
+	if info, err := cli.Client().Info(ctx); err != nil {
+		// Daemon is not responding so use system default.
+		if debug.IsEnabled() {
+			// Only report the warning if we're in debug mode to prevent nagging during engine initialization workflows
+			fmt.Fprintf(cli.Err(), "Warning: failed to get default registry endpoint from daemon (%v). Using system default: %s\n", err, serverAddress)
+		}
+	} else if info.IndexServerAddress == "" {
+		if debug.IsEnabled() {
+			fmt.Fprintf(cli.Err(), "Warning: Empty registry endpoint from daemon. Using system default: %s\n", serverAddress)
+		}
 	} else {
 		serverAddress = info.IndexServerAddress
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed `docker login` and `docker logout` when the engine is not running and when using a credential helper.

**- How I did it**

The logic in `ElectAuthServer` accidentally combined together checking the error from the engine with the state of the debug flag when deciding which value to return.

**- How to verify it**

I used Docker Desktop on Mac with the `docker-credential-osxkeychain` enabled (which is the default). I shutdown the app. Without this patch I ran:

```
$ docker logout
Not logged in to
```
-- note the missing server URL

```
$ docker --debug logout
Warning: failed to get default registry endpoint from daemon (Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?). Using system default: https://index.docker.io/v1/
Not logged in to https://index.docker.io/v1/
```    
-- note the server URL is present

This shows that the `--debug` flag is changing the actual behaviour of the program.

I ran `docker login` and observed an error from the credential helper
```
Error saving credentials: error storing credentials - err: no credentials server URL, out: `no credentials server URL`
```

When I rebuilt the CLI with this PR `docker login` and `docker logout` operated as expected.

I separated this PR into 2 patches:
1. the actual bugfix
2. a small refactoring which I think makes `ElectAuthServer` easier to read but which is optional

**- Description for the changelog**
Fix `docker login` and `docker logout` when the engine is not running and a credential helper is in use.

**- A picture of a cute animal (not mandatory but encouraged)**

![39df0ec8dab014008eb217865bc4635b](https://user-images.githubusercontent.com/198586/55218753-e8bec100-51fa-11e9-9d7f-bb9fd026c3fe.jpg)
