### PR TITLE
[18.09 backport] Fix the stack informer's selector used to track deployment

### DIFF
--- a/cli/command/stack/kubernetes/watcher.go
+++ b/cli/command/stack/kubernetes/watcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeutil "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -240,12 +241,12 @@ func newStackInformer(stacksClient stackListWatch, stackName string) cache.Share
 	return cache.NewSharedInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.LabelSelector = labels.SelectorForStack(stackName)
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", stackName).String()
 				return stacksClient.List(options)
 			},
 
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.LabelSelector = labels.SelectorForStack(stackName)
+				options.FieldSelector = fields.OneTermEqualSelector("metadata.name", stackName).String()
 				return stacksClient.Watch(options)
 			},
 		},


### PR DESCRIPTION
Old selector was wrong (it watched for the label we applied to child
resources when reconciling the stack, instead of the stack itself)

This should be back-ported to older version of the CLI

