### PR TITLE
Add ip address to advanced options

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -720,6 +720,12 @@ func applyContainerOptions(n *opts.NetworkAttachmentOpts, copts *containerOption
 	if len(n.Links) > 0 && copts.links.Len() > 0 {
 		return errdefs.InvalidParameter(errors.New("conflicting options: cannot specify both --link and per-network links"))
 	}
+	if n.IPv4Address != "" && copts.ipv4Address != "" {
+		return errdefs.InvalidParameter(errors.New("conflicting options: cannot specify both --ip and per-network IPv4 address"))
+	}
+	if n.IPv6Address != "" && copts.ipv6Address != "" {
+		return errdefs.InvalidParameter(errors.New("conflicting options: cannot specify both --ip6 and per-network IPv6 address"))
+	}
 	if copts.aliases.Len() > 0 {
 		n.Aliases = make([]string, copts.aliases.Len())
 		copy(n.Aliases, copts.aliases.GetAll())
@@ -728,10 +734,12 @@ func applyContainerOptions(n *opts.NetworkAttachmentOpts, copts *containerOption
 		n.Links = make([]string, copts.links.Len())
 		copy(n.Links, copts.links.GetAll())
 	}
-
-	// TODO add IPv4/IPv6 options to the csv notation for --network, and error-out in case of conflicting options
-	n.IPv4Address = copts.ipv4Address
-	n.IPv6Address = copts.ipv6Address
+	if copts.ipv4Address != "" {
+		n.IPv4Address = copts.ipv4Address
+	}
+	if copts.ipv6Address != "" {
+		n.IPv6Address = copts.ipv6Address
+	}
 
 	// TODO should linkLocalIPs be added to the _first_ network only, or to _all_ networks? (should this be a per-network option as well?)
 	if copts.linkLocalIPs.Len() > 0 {

--- a/opts/network.go
+++ b/opts/network.go
@@ -8,9 +8,11 @@ import (
 )
 
 const (
-	networkOptName  = "name"
-	networkOptAlias = "alias"
-	driverOpt       = "driver-opt"
+	networkOptName        = "name"
+	networkOptAlias       = "alias"
+	networkOptIPv4Address = "ip"
+	networkOptIPv6Address = "ip6"
+	driverOpt             = "driver-opt"
 )
 
 // NetworkAttachmentOpts represents the network options for endpoint creation
@@ -19,8 +21,8 @@ type NetworkAttachmentOpts struct {
 	Aliases      []string
 	DriverOpts   map[string]string
 	Links        []string // TODO add support for links in the csv notation of `--network`
-	IPv4Address  string   // TODO add support for IPv4-address in the csv notation of `--network`
-	IPv6Address  string   // TODO add support for IPv6-address in the csv notation of `--network`
+	IPv4Address  string
+	IPv6Address  string
 	LinkLocalIPs []string // TODO add support for LinkLocalIPs in the csv notation of `--network` ?
 }
 
@@ -60,6 +62,10 @@ func (n *NetworkOpt) Set(value string) error {
 				netOpt.Target = value
 			case networkOptAlias:
 				netOpt.Aliases = append(netOpt.Aliases, value)
+			case networkOptIPv4Address:
+				netOpt.IPv4Address = value
+			case networkOptIPv6Address:
+				netOpt.IPv6Address = value
 			case driverOpt:
 				key, value, err = parseDriverOpt(value)
 				if err == nil {

--- a/opts/network_test.go
+++ b/opts/network_test.go
@@ -59,6 +59,17 @@ func TestNetworkOptAdvancedSyntax(t *testing.T) {
 			},
 		},
 		{
+			value: "name=docknet1,ip=172.20.88.22,ip6=2001:db8::8822",
+			expected: []NetworkAttachmentOpts{
+				{
+					Target:      "docknet1",
+					Aliases:     []string{},
+					IPv4Address: "172.20.88.22",
+					IPv6Address: "2001:db8::8822",
+				},
+			},
+		},
+		{
 			value: "name=docknet1",
 			expected: []NetworkAttachmentOpts{
 				{


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/1767
partially implements: https://github.com/moby/moby/issues/31964 (RFC: add advanced "csv" syntax for "--net" / "--network")

this allows setting the ip/ipv6 address as a network-option;

```
docker run --network name=mynetwork,ip=172.20.88.22,ip6=2001:db8::8822
```