### PR TITLE
remove unused imports from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -32,14 +32,12 @@ github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/gogo/protobuf v1.2.0
 github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 github.com/golang/protobuf v1.2.0
-github.com/google/btree e89373fe6b4a7413d7acd6da1725b83ef713e6e4
 github.com/google/go-cmp v0.2.0
 github.com/google/gofuzz 24818f796faf91cd76ec7bddd72458fbced7a6c1
 github.com/google/shlex 6f45313302b9c56850fc17f99e40caebce98c716
 github.com/google/uuid v1.1.1
 github.com/googleapis/gnostic 7c663266750e7d82587642f65e60bc4083f1f84e # v0.2.0
 github.com/gorilla/mux v1.7.0
-github.com/gregjones/httpcache 9cad4c3443a7200dd6400aef47183728de563a38
 github.com/grpc-ecosystem/grpc-gateway 1a03ca3bad1e1ebadaedd3abb76bc58d4ac8143b
 github.com/grpc-ecosystem/grpc-opentracing 8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/hashicorp/golang-lru 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
@@ -62,7 +60,6 @@ github.com/opencontainers/image-spec v1.0.1
 github.com/opencontainers/runc 2b18fe1d885ee5083ef9f0838fee39b62d653e30
 github.com/opencontainers/runtime-spec 29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
-github.com/peterbourgon/diskv 5f041e8faa004a95c88a202771f4cc3e991971e6 # v2.0.1
 github.com/pkg/errors ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/prometheus/client_golang c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
 github.com/prometheus/client_model 6f3806018612930941127f2a7c6c453ba2c527d2


### PR DESCRIPTION
```
2019/04/03 12:47:01 WARNING: package github.com/google/btree is unused, consider removing it from vendor.conf
2019/04/03 12:47:01 WARNING: package github.com/gregjones/httpcache is unused, consider removing it from vendor.conf
2019/04/03 12:47:01 WARNING: package github.com/peterbourgon/diskv is unused, consider removing it from vendor.conf
```

