### PR TITLE
Add BuildKit specific options to bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2863,7 +2863,6 @@ _docker_image_build() {
 	"
 
 	local boolean_options="
-		--compress
 		--disable-content-trust=false
 		--force-rm
 		--help
@@ -2872,14 +2871,33 @@ _docker_image_build() {
 		--quiet -q
 		--rm
 	"
+
 	if __docker_server_is_experimental ; then
 		options_with_args+="
 			--platform
 		"
 		boolean_options+="
 			--squash
-			--stream
 		"
+	fi
+
+	if [ "$DOCKER_BUILDKIT" = "1" ] ; then
+		options_with_args+="
+			--output -o
+			--platform
+			--progress
+			--secret
+			--ssh
+		"
+	else
+		boolean_options+="
+			--compress
+		"
+		if __docker_server_is_experimental ; then
+			boolean_options+="
+				--stream
+			"
+		fi
 	fi
 
 	local all_options="$options_with_args $boolean_options"
@@ -2924,6 +2942,10 @@ _docker_image_build() {
 					fi
 					;;
 			esac
+			return
+			;;
+		--progress)
+			COMPREPLY=( $( compgen -W "auto plain tty" -- "$cur" ) )
 			return
 			;;
 		--tag|-t)


### PR DESCRIPTION
Hints for reviewers: 

### Visibility of the options is not trivial
- `--compress` and `--stream` are not available in BuildKit mode
- `--stream` is experimental

### csv format
There is no easy way to add completion to option values that expect csv format.
This is because bash completion does by default not perform word splitting on `,`.
This can only be modified globally, which will affect all installed completion scripts.

Therefore these values are treated as "any string".