### PR TITLE
Support internal Load Balancing for Kubernetes stacks

### DIFF
--- a/cli/command/stack/kubernetes/testdata/compose-with-expose.yml
+++ b/cli/command/stack/kubernetes/testdata/compose-with-expose.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+services:
+  test:
+    image: "some-image"
+    expose:
+    - "1" # default protocol, single port
+    - "2-4" # default protocol, port range
+    - "5/udp" # specific protocol, single port
+    - "6-8/udp" # specific protocol, port range


### PR DESCRIPTION
**- What I did**

Compose on Kubernetes v0.4.21 introduced a v1alpha3 feature for handling intra-stack networking in a better way: if the user can specify a list of ports/protocol to expose internally, we can now create a ClusterIP service for doing VIP kind of loadbalancing, and avoiding DNS load balancing pitfalls. 
This PR translates the `expose` field in a compose-file to this `InternalPorts` list. It also add an `x-internal-service-type` extra field for explicitly setting the kind of service to setup for internal networking.

**- How I did it**

I used the same pattern as what we have for v1alpha3 specific features (only active on experimental CLI)

**- How to verify it**

Unit-test included :)

**- A picture of a cute animal (not mandatory but encouraged)**
![bear](https://media.giphy.com/media/JKNn9A98JBVlu/giphy.gif)

