### PR TITLE
Add warnings when DOCKER_HOST conflicts with contexts

### DIFF
--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/docker/cli/cli"
@@ -76,7 +77,14 @@ func runList(dockerCli command.Cli, opts *listOptions) error {
 	sort.Slice(contexts, func(i, j int) bool {
 		return sortorder.NaturalLess(contexts[i].Name, contexts[j].Name)
 	})
-	return format(dockerCli, opts, contexts)
+	if err := format(dockerCli, opts, contexts); err != nil {
+		return err
+	}
+	if os.Getenv("DOCKER_HOST") != "" {
+		fmt.Fprint(dockerCli.Err(), "Warning: DOCKER_HOST environment variable overrides the active context. "+
+			"To use a context, either set the global --context flag, or unset DOCKER_HOST environment variable.\n")
+	}
+	return nil
 }
 
 func format(dockerCli command.Cli, opts *listOptions, contexts []*formatter.ClientContext) error {

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
@@ -39,5 +40,9 @@ func RunUse(dockerCli command.Cli, name string) error {
 	}
 	fmt.Fprintln(dockerCli.Out(), name)
 	fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
+	if os.Getenv("DOCKER_HOST") != "" {
+		fmt.Fprintf(dockerCli.Err(), "Warning: DOCKER_HOST environment variable overrides the active context. "+
+			"To use %q, either set the global --context flag, or unset DOCKER_HOST environment variable.\n", name)
+	}
 	return nil
 }


### PR DESCRIPTION
**- What I did**

For clarity, on `docker context use` or `docker context ls`, this adds a warning if the DOCKER_HOST variable is set because it overrides the active context.

**- How I did it**

Just a one liner to test if the variable is set, and print a message on stderr

**- How to verify it**

- `DOCKER_HOST=unix:///var/run/docker.sock docker context ls`


