### PR TITLE
Bump Golang 1.12.3 and fix: nolint directive

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.12.2
+  GOVERSION: 1.12.3
   DEPVERSION: v0.4.1
 
 install:

--- a/cli/command/formatter/reflect_test.go
+++ b/cli/command/formatter/reflect_test.go
@@ -12,7 +12,7 @@ func (d *dummy) Func1() string {
 	return "Func1"
 }
 
-func (d *dummy) func2() string { // nolint: unused
+func (d *dummy) func2() string {
 	return "func2(should not be marshalled)"
 }
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.12.2-alpine
+FROM    golang:1.12.3-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.12.2@sha256:ea93d7ed5b464e5163cf8df40a198ad54afe6a59e1ca335c9bc4a5ed3702f2d0
+FROM	dockercore/golang-cross:1.12.3@sha256:b88a6be2469d321601f87675c49d1b3f166c4c37abc5ce3e74557fc6660481be
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.12.2-alpine
+FROM    golang:1.12.3-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.2
+ARG GO_VERSION=1.12.3
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.12.2-alpine
+FROM    golang:1.12.3-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/1818#issuecomment-482016087
carries  https://github.com/docker/cli/pull/1818
closes  https://github.com/docker/cli/pull/1818

let's see if current go version doesn't complain without this statement 🤷‍♂️ 