### PR TITLE
bump github.com/google/shlex c34317bd91bf98fab745d77b03933cf8769299fe

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -33,7 +33,7 @@ github.com/golang/glog                              23def4e6c14b4da8ac2ed8007337
 github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 github.com/google/gofuzz                            24818f796faf91cd76ec7bddd72458fbced7a6c1
-github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
+github.com/google/shlex                             c34317bd91bf98fab745d77b03933cf8769299fe
 github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
 github.com/googleapis/gnostic                       7c663266750e7d82587642f65e60bc4083f1f84e # v0.2.0
 github.com/gorilla/mux                              a7962380ca08b5a188038c69871b8d3fbdf31e89 # v1.7.0

--- a/vendor/github.com/google/shlex/shlex.go
+++ b/vendor/github.com/google/shlex/shlex.go
@@ -253,7 +253,6 @@ func (t *Tokenizer) scanStream() (*Token, error) {
 					}
 				case spaceRuneClass:
 					{
-						t.input.UnreadRune()
 						token := &Token{
 							tokenType: tokenType,
 							value:     string(value)}


### PR DESCRIPTION
full diff: https://github.com/google/shlex/compare/6f45313302b9c56850fc17f99e40caebce98c716...c34317bd91bf98fab745d77b03933cf8769299fe


