### PR TITLE
Bump Golang 1.12.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.12.3
+  GOVERSION: 1.12.4
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.12.3-alpine
+FROM    golang:1.12.4-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.12.3@sha256:b88a6be2469d321601f87675c49d1b3f166c4c37abc5ce3e74557fc6660481be
+FROM	dockercore/golang-cross:1.12.4
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.12.3-alpine
+FROM    golang:1.12.4-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.3
+ARG GO_VERSION=1.12.4
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.12.3-alpine
+FROM    golang:1.12.4-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

go1.12.4 (released 2019/04/11) fixes an issue where using the prebuilt binary.

https://github.com/golang/go/compare/go1.12.3...go1.12.4

The issue golang/go#31293 has been fixed and closed now.

And docker/golang-cross:1.12.4 image has been published after https://github.com/docker/golang-cross/pull/28 :+1: 

