### PR TITLE
vendor.conf: reserve space for downstream projects

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -99,3 +99,5 @@ k8s.io/kubernetes                                   641856db18352033a0d96dbc9915
 k8s.io/utils                                        21c4ce38f2a793ec01e925ddc31216500183b773
 sigs.k8s.io/yaml                                    fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
 vbom.ml/util                                        256737ac55c46798123f754ab7d2c784e2c71783
+
+# DO NOT EDIT BELOW THIS LINE -------- reserved for downstream projects --------


### PR DESCRIPTION
This helps merge conflicts in situations where downstream
projects (such as Docker EE) have additional dependencies.

