### PR TITLE
Refine warning for storing registry passwords

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -143,7 +143,8 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint: gocycl
 	creds := dockerCli.ConfigFile().GetCredentialsStore(serverAddress)
 
 	store, isDefault := creds.(isFileStore)
-	if isDefault {
+	// Display a warning if we're storing the users password (not a token)
+	if isDefault && authConfig.Password != "" {
 		err = displayUnencryptedWarning(dockerCli, store.GetFilename())
 		if err != nil {
 			return err


### PR DESCRIPTION
**- What I did**
This change refines the warning message returned during `docker login` to
only warn for unencrypted storage when the users password is being stored.
If the remote registry supports identity tokens, omit the warning,
since those tokens can be independently managed and revoked.

**- How I did it**

Check the `authConfig` to see if it contains an empty password (implying a token) before displaying the warning message.

**- How to verify it**

If you perform a `docker login` against a registry that does not support identity tokens, you'll see the warning, and the stored information contains the users password (obfuscated)
```
% ./docker login
Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.
Username: dhiltgen
Password: 
WARNING! Your password will be stored unencrypted in /home/daniel/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
```

`~/.docker/config.json` excerpt:
```json
		"https://index.docker.io/v1/": {
			"auth": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
		}
```

Perform a `docker login` against a registry that supports identity tokens (e.g., DTR) and you wont see the warning, and the stored information does *not* contain the users obfuscated password, but an identity token.
```
 % ./docker login https://54.218.110.194
Username: admin	
Password: 
Login Succeeded
```

`~/.docker/config.json` excerpt:
```json
		"54.218.110.194": {
			"auth": "YYYYYYYY",
			"identitytoken": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
		},
```
**- Description for the changelog**

Only warn users of storing unencrypted passwords when the users actual password is being stored

