### PR TITLE
Split the context store interface

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -290,7 +290,7 @@ func newAPIClientFromEndpoint(ep docker.Endpoint, configFile *configfile.ConfigF
 	return client.NewClientWithOpts(clientOpts...)
 }
 
-func resolveDockerEndpoint(s store.Store, contextName string) (docker.Endpoint, error) {
+func resolveDockerEndpoint(s store.Reader, contextName string) (docker.Endpoint, error) {
 	ctxMeta, err := s.GetContextMetadata(contextName)
 	if err != nil {
 		return docker.Endpoint{}, err
@@ -500,7 +500,7 @@ func UserAgent() string {
 // - if DOCKER_CONTEXT is set, use this value
 // - if Config file has a globally set "CurrentContext", use this value
 // - fallbacks to default HOST, uses TLS config from flags/env vars
-func resolveContextName(opts *cliflags.CommonOptions, config *configfile.ConfigFile, contextstore store.Store) (string, error) {
+func resolveContextName(opts *cliflags.CommonOptions, config *configfile.ConfigFile, contextstore store.Reader) (string, error) {
 	if opts.Context != "" && len(opts.Hosts) > 0 {
 		return "", errors.New("Conflicting options: either specify --host or --context, not both")
 	}

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -156,7 +156,7 @@ func TestCreateOrchestratorEmpty(t *testing.T) {
 	assert.NilError(t, err)
 }
 
-func validateTestKubeEndpoint(t *testing.T, s store.Store, name string) {
+func validateTestKubeEndpoint(t *testing.T, s store.Reader, name string) {
 	t.Helper()
 	ctxMetadata, err := s.GetContextMetadata(name)
 	assert.NilError(t, err)

--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -31,7 +31,7 @@ type Endpoint struct {
 }
 
 // WithTLSData loads TLS materials for the endpoint
-func WithTLSData(s store.Store, contextName string, m EndpointMeta) (Endpoint, error) {
+func WithTLSData(s store.Reader, contextName string, m EndpointMeta) (Endpoint, error) {
 	tlsData, err := context.LoadTLSData(s, contextName, DockerEndpoint)
 	if err != nil {
 		return Endpoint{}, err

--- a/cli/context/kubernetes/endpoint_test.go
+++ b/cli/context/kubernetes/endpoint_test.go
@@ -104,22 +104,22 @@ func TestSaveLoadContexts(t *testing.T) {
 
 	rawNoTLSEP, err := rawNoTLS.WithTLSData(store, "raw-notls")
 	assert.NilError(t, err)
-	checkClientConfig(t, store, rawNoTLSEP, "https://test", "test", nil, nil, nil, false)
+	checkClientConfig(t, rawNoTLSEP, "https://test", "test", nil, nil, nil, false)
 	rawNoTLSSkipEP, err := rawNoTLSSkip.WithTLSData(store, "raw-notls-skip")
 	assert.NilError(t, err)
-	checkClientConfig(t, store, rawNoTLSSkipEP, "https://test", "test", nil, nil, nil, true)
+	checkClientConfig(t, rawNoTLSSkipEP, "https://test", "test", nil, nil, nil, true)
 	rawTLSEP, err := rawTLS.WithTLSData(store, "raw-tls")
 	assert.NilError(t, err)
-	checkClientConfig(t, store, rawTLSEP, "https://test", "test", []byte("ca"), []byte("cert"), []byte("key"), true)
+	checkClientConfig(t, rawTLSEP, "https://test", "test", []byte("ca"), []byte("cert"), []byte("key"), true)
 	embededDefaultEP, err := embededDefault.WithTLSData(store, "embed-default-context")
 	assert.NilError(t, err)
-	checkClientConfig(t, store, embededDefaultEP, "https://server1", "namespace1", nil, []byte("cert"), []byte("key"), true)
+	checkClientConfig(t, embededDefaultEP, "https://server1", "namespace1", nil, []byte("cert"), []byte("key"), true)
 	embededContext2EP, err := embededContext2.WithTLSData(store, "embed-context2")
 	assert.NilError(t, err)
-	checkClientConfig(t, store, embededContext2EP, "https://server2", "namespace-override", []byte("ca"), []byte("cert"), []byte("key"), false)
+	checkClientConfig(t, embededContext2EP, "https://server2", "namespace-override", []byte("ca"), []byte("cert"), []byte("key"), false)
 }
 
-func checkClientConfig(t *testing.T, s store.Store, ep Endpoint, server, namespace string, ca, cert, key []byte, skipTLSVerify bool) {
+func checkClientConfig(t *testing.T, ep Endpoint, server, namespace string, ca, cert, key []byte, skipTLSVerify bool) {
 	config := ep.KubernetesConfig()
 	cfg, err := config.ClientConfig()
 	assert.NilError(t, err)
@@ -132,7 +132,7 @@ func checkClientConfig(t *testing.T, s store.Store, ep Endpoint, server, namespa
 	assert.Equal(t, skipTLSVerify, cfg.Insecure)
 }
 
-func save(s store.Store, ep Endpoint, name string) error {
+func save(s store.Writer, ep Endpoint, name string) error {
 	meta := store.ContextMetadata{
 		Endpoints: map[string]interface{}{
 			KubernetesEndpoint: ep.EndpointMeta,

--- a/cli/context/kubernetes/load.go
+++ b/cli/context/kubernetes/load.go
@@ -25,7 +25,7 @@ type Endpoint struct {
 }
 
 // WithTLSData loads TLS materials for the endpoint
-func (c *EndpointMeta) WithTLSData(s store.Store, contextName string) (Endpoint, error) {
+func (c *EndpointMeta) WithTLSData(s store.Reader, contextName string) (Endpoint, error) {
 	tlsData, err := context.LoadTLSData(s, contextName, KubernetesEndpoint)
 	if err != nil {
 		return Endpoint{}, err
@@ -77,7 +77,7 @@ func EndpointFromContext(metadata store.ContextMetadata) *EndpointMeta {
 // ConfigFromContext resolves a kubernetes client config for the specified context.
 // If kubeconfigOverride is specified, use this config file instead of the context defaults.ConfigFromContext
 // if command.ContextDockerHost is specified as the context name, fallsback to the default user's kubeconfig file
-func ConfigFromContext(name string, s store.Store) (clientcmd.ClientConfig, error) {
+func ConfigFromContext(name string, s store.Reader) (clientcmd.ClientConfig, error) {
 	ctxMeta, err := s.GetContextMetadata(name)
 	if err != nil {
 		return nil, err

--- a/cli/context/tlsdata.go
+++ b/cli/context/tlsdata.go
@@ -42,7 +42,7 @@ func (data *TLSData) ToStoreTLSData() *store.EndpointTLSData {
 }
 
 // LoadTLSData loads TLS data from the store
-func LoadTLSData(s store.Store, contextName, endpointName string) (*TLSData, error) {
+func LoadTLSData(s store.Reader, contextName, endpointName string) (*TLSData, error) {
 	tlsFiles, err := s.ListContextTLSFiles(contextName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to retrieve context tls files for context %q", contextName)


### PR DESCRIPTION
**- What I did**

- I split the context store "meta"-interface into smaller ones
- I changed existing code to depend on smaller interfaces

This is to make it easier to implement support for exporting contexts in
3rd party code, or to create mocks in tests.

2 exemples where it simplify things:
- docker-app desktop-specific context decorator (which rewrites parts of
the docker context to simplify UX when using on Docker Desktop contexts)
- ucp for including a context in the connection bundle

**- How I did it**

- simple interface splitting

**- How to verify it**

- everything I changed is covered by existing unit tests

