### PR TITLE
cli-plugins: alias an existing allowed command (only builder for now)

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -164,6 +164,7 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 			return nil, err
 		}
 		if plugin.Err != nil {
+			// TODO: why are we not returning plugin.Err?
 			return nil, errPluginNotFound(name)
 		}
 		cmd := exec.Command(plugin.Path, args...)

--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/image"
 )
 
 // NewBuilderCommand returns a cobra command for `builder` subcommands
@@ -18,6 +19,7 @@ func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewPruneCommand(dockerCli),
+		image.NewBuildCommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -161,3 +161,34 @@ func ValidateOutputPathFileMode(fileMode os.FileMode) error {
 	}
 	return nil
 }
+
+func stringSliceIndex(s, subs []string) int {
+	j := 0
+	if len(subs) > 0 {
+		for i, x := range s {
+			if j < len(subs) && subs[j] == x {
+				j++
+			} else {
+				j = 0
+			}
+			if len(subs) == j {
+				return i + 1 - j
+			}
+		}
+	}
+	return -1
+}
+
+// StringSliceReplaceAt replaces the sub-slice old, with the sub-slice new, in the string
+// slice s, returning a new slice and a boolean indicating if the replacement happened.
+// requireIdx is the index at which old needs to be found at (or -1 to disregard that).
+func StringSliceReplaceAt(s, old, new []string, requireIndex int) ([]string, bool) {
+	idx := stringSliceIndex(s, old)
+	if (requireIndex != -1 && requireIndex != idx) || idx == -1 {
+		return s, false
+	}
+	out := append([]string{}, s[:idx]...)
+	out = append(out, new...)
+	out = append(out, s[idx+len(old):]...)
+	return out, true
+}

--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestStringSliceReplaceAt(t *testing.T) {
+	out, ok := StringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, -1)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"abc", "baz", "bax"}, out)
+
+	out, ok = StringSliceReplaceAt([]string{"foo"}, []string{"foo", "bar"}, []string{"baz"}, -1)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"foo"}, out)
+
+	out, ok = StringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"abc", "foo", "bar", "bax"}, out)
+
+	out, ok = StringSliceReplaceAt([]string{"foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"baz", "bax"}, out)
+
+	out, ok = StringSliceReplaceAt([]string{"abc", "foo", "bar", "baz"}, []string{"foo", "bar"}, nil, -1)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"abc", "baz"}, out)
+
+	out, ok = StringSliceReplaceAt([]string{"foo"}, nil, []string{"baz"}, -1)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"foo"}, out)
+}

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -50,6 +50,7 @@ type ConfigFile struct {
 	CurrentContext       string                       `json:"currentContext,omitempty"`
 	CLIPluginsExtraDirs  []string                     `json:"cliPluginsExtraDirs,omitempty"`
 	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
+	Aliases              map[string]string            `json:"aliases,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings
@@ -72,6 +73,7 @@ func New(fn string) *ConfigFile {
 		HTTPHeaders: make(map[string]string),
 		Filename:    fn,
 		Plugins:     make(map[string]map[string]string),
+		Aliases:     make(map[string]string),
 	}
 }
 


### PR DESCRIPTION
With this patch it is possible to alias an existing allowed command.
At the moment only builder allows an alias.

This also properly puts the build command under builder, instead of image
where it was for historical reasons.

Signed-off-by: Tibor Vass <tibor@docker.com>