### PR TITLE
Do not disable sig-proxy when using a TTY

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -117,11 +117,6 @@ func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptio
 		config.StdinOnce = false
 	}
 
-	// Disable sigProxy when in TTY mode
-	if config.Tty {
-		opts.sigProxy = false
-	}
-
 	// Telling the Windows daemon the initial size of the tty during start makes
 	// a far better user experience rather than relying on subsequent resizes
 	// to cause things to catch up.

--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -1,0 +1,56 @@
+package container
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/e2e/internal/fixtures"
+	"github.com/kr/pty"
+	"gotest.tools/assert"
+	"gotest.tools/icmd"
+	"gotest.tools/poll"
+)
+
+// TestSigProxyWithTTY tests that killing the docker CLI forwards the signal to
+// the container, and kills the container's process. Test-case for moby/moby#28872
+func TestSigProxyWithTTY(t *testing.T) {
+	_, tty, err := pty.Open()
+	assert.NilError(t, err, "could not open pty")
+	defer func() { _ = tty.Close() }()
+
+	containerName := "repro-28872"
+	cmd := exec.Command("docker", "run", "-i", "-t", "--init", "--name", containerName, fixtures.BusyboxImage, "sleep", "30")
+	cmd.Stdin = tty
+	cmd.Stdout = tty
+	cmd.Stderr = tty
+
+	err = cmd.Start()
+	out, _ := cmd.CombinedOutput()
+	assert.NilError(t, err, "failed to start container: %s", out)
+	defer icmd.RunCommand("docker", "container", "rm", "-f", containerName)
+
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+
+	pid := cmd.Process.Pid
+	t.Logf("terminating PID %d", pid)
+	err = syscall.Kill(pid, syscall.SIGTERM)
+	assert.NilError(t, err)
+
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+}
+
+func containerExistsWithStatus(t *testing.T, containerID, status string) func(poll.LogT) poll.Result {
+	return func(poll.LogT) poll.Result {
+		result := icmd.RunCommand("docker", "inspect", "-f", "{{ .State.Status }}", containerID)
+		// ignore initial failures as the container may not yet exist (i.e., don't result.Assert(t, icmd.Success))
+
+		actual := strings.TrimSpace(result.Stdout())
+		if actual == status {
+			return poll.Success()
+		}
+		return poll.Continue("expected status %s != %s", status, actual)
+	}
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -46,6 +46,7 @@ github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce8
 github.com/jaguilar/vt100                           ad4c4a5743050fb7f88ce968dca9422f72a0e3f2 git://github.com/tonistiigi/vt100.git
 github.com/json-iterator/go                         0ff49de124c6f76f8494e194af75bde0f1a49a29 # 1.1.6
 github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/kr/pty                                   521317be5ebc228a0f0ede099fa2a0b5ece22e49 # v1.1.4
 github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/Microsoft/go-winio                       84b4ab48a50763fe7b3abcef38e5205c12027fac

--- a/vendor/github.com/kr/pty/License
+++ b/vendor/github.com/kr/pty/License
@@ -1,0 +1,23 @@
+Copyright (c) 2011 Keith Rarick
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kr/pty/README.md
+++ b/vendor/github.com/kr/pty/README.md
@@ -1,0 +1,100 @@
+# pty
+
+Pty is a Go package for using unix pseudo-terminals.
+
+## Install
+
+    go get github.com/kr/pty
+
+## Example
+
+### Command
+
+```go
+package main
+
+import (
+	"github.com/kr/pty"
+	"io"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	c := exec.Command("grep", "--color=auto", "bar")
+	f, err := pty.Start(c)
+	if err != nil {
+		panic(err)
+	}
+
+	go func() {
+		f.Write([]byte("foo\n"))
+		f.Write([]byte("bar\n"))
+		f.Write([]byte("baz\n"))
+		f.Write([]byte{4}) // EOT
+	}()
+	io.Copy(os.Stdout, f)
+}
+```
+
+### Shell
+
+```go
+package main
+
+import (
+        "io"
+        "log"
+        "os"
+        "os/exec"
+        "os/signal"
+        "syscall"
+
+        "github.com/kr/pty"
+        "golang.org/x/crypto/ssh/terminal"
+)
+
+func test() error {
+        // Create arbitrary command.
+        c := exec.Command("bash")
+
+        // Start the command with a pty.
+        ptmx, err := pty.Start(c)
+        if err != nil {
+                return err
+        }
+        // Make sure to close the pty at the end.
+        defer func() { _ = ptmx.Close() }() // Best effort.
+
+        // Handle pty size.
+        ch := make(chan os.Signal, 1)
+        signal.Notify(ch, syscall.SIGWINCH)
+        go func() {
+                for range ch {
+                        if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
+                                log.Printf("error resizing pty: %s", err)
+                        }
+                }
+        }()
+        ch <- syscall.SIGWINCH // Initial resize.
+
+        // Set stdin in raw mode.
+        oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+        if err != nil {
+                panic(err)
+        }
+        defer func() { _ = terminal.Restore(int(os.Stdin.Fd()), oldState) }() // Best effort.
+
+        // Copy stdin to the pty and the pty to stdout.
+        go func() { _, _ = io.Copy(ptmx, os.Stdin) }()
+        _, _ = io.Copy(os.Stdout, ptmx)
+
+        return nil
+}
+
+func main() {
+        if err := test(); err != nil {
+                log.Fatal(err)
+        }
+}
+```

--- a/vendor/github.com/kr/pty/doc.go
+++ b/vendor/github.com/kr/pty/doc.go
@@ -1,0 +1,16 @@
+// Package pty provides functions for working with Unix terminals.
+package pty
+
+import (
+	"errors"
+	"os"
+)
+
+// ErrUnsupported is returned if a function is not
+// available on the current platform.
+var ErrUnsupported = errors.New("unsupported")
+
+// Opens a pty and its corresponding tty.
+func Open() (pty, tty *os.File, err error) {
+	return open()
+}

--- a/vendor/github.com/kr/pty/go.mod
+++ b/vendor/github.com/kr/pty/go.mod
@@ -1,0 +1,1 @@
+module github.com/kr/pty

--- a/vendor/github.com/kr/pty/ioctl.go
+++ b/vendor/github.com/kr/pty/ioctl.go
@@ -1,0 +1,13 @@
+// +build !windows
+
+package pty
+
+import "syscall"
+
+func ioctl(fd, cmd, ptr uintptr) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/vendor/github.com/kr/pty/ioctl_bsd.go
+++ b/vendor/github.com/kr/pty/ioctl_bsd.go
@@ -1,0 +1,39 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package pty
+
+// from <sys/ioccom.h>
+const (
+	_IOC_VOID    uintptr = 0x20000000
+	_IOC_OUT     uintptr = 0x40000000
+	_IOC_IN      uintptr = 0x80000000
+	_IOC_IN_OUT  uintptr = _IOC_OUT | _IOC_IN
+	_IOC_DIRMASK         = _IOC_VOID | _IOC_OUT | _IOC_IN
+
+	_IOC_PARAM_SHIFT = 13
+	_IOC_PARAM_MASK  = (1 << _IOC_PARAM_SHIFT) - 1
+)
+
+func _IOC_PARM_LEN(ioctl uintptr) uintptr {
+	return (ioctl >> 16) & _IOC_PARAM_MASK
+}
+
+func _IOC(inout uintptr, group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return inout | (param_len&_IOC_PARAM_MASK)<<16 | uintptr(group)<<8 | ioctl_num
+}
+
+func _IO(group byte, ioctl_num uintptr) uintptr {
+	return _IOC(_IOC_VOID, group, ioctl_num, 0)
+}
+
+func _IOR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_OUT, group, ioctl_num, param_len)
+}
+
+func _IOW(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN, group, ioctl_num, param_len)
+}
+
+func _IOWR(group byte, ioctl_num uintptr, param_len uintptr) uintptr {
+	return _IOC(_IOC_IN_OUT, group, ioctl_num, param_len)
+}

--- a/vendor/github.com/kr/pty/pty_darwin.go
+++ b/vendor/github.com/kr/pty/pty_darwin.go
@@ -1,0 +1,65 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	pFD, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := os.NewFile(uintptr(pFD), "/dev/ptmx")
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := grantpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	if err := unlockpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func ptsname(f *os.File) (string, error) {
+	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
+
+	err := ioctl(f.Fd(), syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range n {
+		if c == 0 {
+			return string(n[:i]), nil
+		}
+	}
+	return "", errors.New("TIOCPTYGNAME string not NUL-terminated")
+}
+
+func grantpt(f *os.File) error {
+	return ioctl(f.Fd(), syscall.TIOCPTYGRANT, 0)
+}
+
+func unlockpt(f *os.File) error {
+	return ioctl(f.Fd(), syscall.TIOCPTYUNLK, 0)
+}

--- a/vendor/github.com/kr/pty/pty_dragonfly.go
+++ b/vendor/github.com/kr/pty/pty_dragonfly.go
@@ -1,0 +1,80 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+// same code as pty_darwin.go
+func open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := grantpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	if err := unlockpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func grantpt(f *os.File) error {
+	_, err := isptmaster(f.Fd())
+	return err
+}
+
+func unlockpt(f *os.File) error {
+	_, err := isptmaster(f.Fd())
+	return err
+}
+
+func isptmaster(fd uintptr) (bool, error) {
+	err := ioctl(fd, syscall.TIOCISPTMASTER, 0)
+	return err == nil, err
+}
+
+var (
+	emptyFiodgnameArg fiodgnameArg
+	ioctl_FIODNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+)
+
+func ptsname(f *os.File) (string, error) {
+	name := make([]byte, _C_SPECNAMELEN)
+	fa := fiodgnameArg{Name: (*byte)(unsafe.Pointer(&name[0])), Len: _C_SPECNAMELEN, Pad_cgo_0: [4]byte{0, 0, 0, 0}}
+
+	err := ioctl(f.Fd(), ioctl_FIODNAME, uintptr(unsafe.Pointer(&fa)))
+	if err != nil {
+		return "", err
+	}
+
+	for i, c := range name {
+		if c == 0 {
+			s := "/dev/" + string(name[:i])
+			return strings.Replace(s, "ptm", "pts", -1), nil
+		}
+	}
+	return "", errors.New("TIOCPTYGNAME string not NUL-terminated")
+}

--- a/vendor/github.com/kr/pty/pty_freebsd.go
+++ b/vendor/github.com/kr/pty/pty_freebsd.go
@@ -1,0 +1,78 @@
+package pty
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func posixOpenpt(oflag int) (fd int, err error) {
+	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
+	fd = int(r0)
+	if e1 != 0 {
+		err = e1
+	}
+	return fd, err
+}
+
+func open() (pty, tty *os.File, err error) {
+	fd, err := posixOpenpt(syscall.O_RDWR | syscall.O_CLOEXEC)
+	if err != nil {
+		return nil, nil, err
+	}
+	p := os.NewFile(uintptr(fd), "/dev/pts")
+	// In case of error after this point, make sure we close the pts fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile("/dev/"+sname, os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func isptmaster(fd uintptr) (bool, error) {
+	err := ioctl(fd, syscall.TIOCPTMASTER, 0)
+	return err == nil, err
+}
+
+var (
+	emptyFiodgnameArg fiodgnameArg
+	ioctlFIODGNAME    = _IOW('f', 120, unsafe.Sizeof(emptyFiodgnameArg))
+)
+
+func ptsname(f *os.File) (string, error) {
+	master, err := isptmaster(f.Fd())
+	if err != nil {
+		return "", err
+	}
+	if !master {
+		return "", syscall.EINVAL
+	}
+
+	const n = _C_SPECNAMELEN + 1
+	var (
+		buf = make([]byte, n)
+		arg = fiodgnameArg{Len: n, Buf: (*byte)(unsafe.Pointer(&buf[0]))}
+	)
+	if err := ioctl(f.Fd(), ioctlFIODGNAME, uintptr(unsafe.Pointer(&arg))); err != nil {
+		return "", err
+	}
+
+	for i, c := range buf {
+		if c == 0 {
+			return string(buf[:i]), nil
+		}
+	}
+	return "", errors.New("FIODGNAME string not NUL-terminated")
+}

--- a/vendor/github.com/kr/pty/pty_linux.go
+++ b/vendor/github.com/kr/pty/pty_linux.go
@@ -1,0 +1,51 @@
+package pty
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	p, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	// In case of error after this point, make sure we close the ptmx fd.
+	defer func() {
+		if err != nil {
+			_ = p.Close() // Best effort.
+		}
+	}()
+
+	sname, err := ptsname(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := unlockpt(p); err != nil {
+		return nil, nil, err
+	}
+
+	t, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return p, t, nil
+}
+
+func ptsname(f *os.File) (string, error) {
+	var n _C_uint
+	err := ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return "", err
+	}
+	return "/dev/pts/" + strconv.Itoa(int(n)), nil
+}
+
+func unlockpt(f *os.File) error {
+	var u _C_int
+	// use TIOCSPTLCK with a pointer to zero to clear the lock
+	return ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}

--- a/vendor/github.com/kr/pty/pty_openbsd.go
+++ b/vendor/github.com/kr/pty/pty_openbsd.go
@@ -1,0 +1,33 @@
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func open() (pty, tty *os.File, err error) {
+	/*
+	 * from ptm(4):
+	 * The PTMGET command allocates a free pseudo terminal, changes its
+	 * ownership to the caller, revokes the access privileges for all previous
+	 * users, opens the file descriptors for the pty and tty devices and
+	 * returns them to the caller in struct ptmget.
+	 */
+
+	p, err := os.OpenFile("/dev/ptm", os.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer p.Close()
+
+	var ptm ptmget
+	if err := ioctl(p.Fd(), uintptr(ioctl_PTMGET), uintptr(unsafe.Pointer(&ptm))); err != nil {
+		return nil, nil, err
+	}
+
+	pty = os.NewFile(uintptr(ptm.Cfd), "/dev/ptm")
+	tty = os.NewFile(uintptr(ptm.Sfd), "/dev/ptm")
+
+	return pty, tty, nil
+}

--- a/vendor/github.com/kr/pty/pty_unsupported.go
+++ b/vendor/github.com/kr/pty/pty_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux,!darwin,!freebsd,!dragonfly,!openbsd
+
+package pty
+
+import (
+	"os"
+)
+
+func open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrUnsupported
+}

--- a/vendor/github.com/kr/pty/run.go
+++ b/vendor/github.com/kr/pty/run.go
@@ -1,0 +1,56 @@
+// +build !windows
+
+package pty
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Start assigns a pseudo-terminal tty os.File to c.Stdin, c.Stdout,
+// and c.Stderr, calls c.Start, and returns the File of the tty's
+// corresponding pty.
+func Start(c *exec.Cmd) (pty *os.File, err error) {
+	return StartWithSize(c, nil)
+}
+
+// StartWithSize assigns a pseudo-terminal tty os.File to c.Stdin, c.Stdout,
+// and c.Stderr, calls c.Start, and returns the File of the tty's
+// corresponding pty.
+//
+// This will resize the pty to the specified size before starting the command
+func StartWithSize(c *exec.Cmd, sz *Winsize) (pty *os.File, err error) {
+	pty, tty, err := Open()
+	if err != nil {
+		return nil, err
+	}
+	defer tty.Close()
+	if sz != nil {
+		err = Setsize(pty, sz)
+		if err != nil {
+			pty.Close()
+			return nil, err
+		}
+	}
+	if c.Stdout == nil {
+		c.Stdout = tty
+	}
+	if c.Stderr == nil {
+		c.Stderr = tty
+	}
+	if c.Stdin == nil {
+		c.Stdin = tty
+	}
+	if c.SysProcAttr == nil {
+		c.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	c.SysProcAttr.Setctty = true
+	c.SysProcAttr.Setsid = true
+	err = c.Start()
+	if err != nil {
+		pty.Close()
+		return nil, err
+	}
+	return pty, err
+}

--- a/vendor/github.com/kr/pty/util.go
+++ b/vendor/github.com/kr/pty/util.go
@@ -1,0 +1,64 @@
+// +build !windows
+
+package pty
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// InheritSize applies the terminal size of pty to tty. This should be run
+// in a signal handler for syscall.SIGWINCH to automatically resize the tty when
+// the pty receives a window size change notification.
+func InheritSize(pty, tty *os.File) error {
+	size, err := GetsizeFull(pty)
+	if err != nil {
+		return err
+	}
+	err = Setsize(tty, size)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Setsize resizes t to s.
+func Setsize(t *os.File, ws *Winsize) error {
+	return windowRectCall(ws, t.Fd(), syscall.TIOCSWINSZ)
+}
+
+// GetsizeFull returns the full terminal size description.
+func GetsizeFull(t *os.File) (size *Winsize, err error) {
+	var ws Winsize
+	err = windowRectCall(&ws, t.Fd(), syscall.TIOCGWINSZ)
+	return &ws, err
+}
+
+// Getsize returns the number of rows (lines) and cols (positions
+// in each line) in terminal t.
+func Getsize(t *os.File) (rows, cols int, err error) {
+	ws, err := GetsizeFull(t)
+	return int(ws.Rows), int(ws.Cols), err
+}
+
+// Winsize describes the terminal size.
+type Winsize struct {
+	Rows uint16 // ws_row: Number of rows (in cells)
+	Cols uint16 // ws_col: Number of columns (in cells)
+	X    uint16 // ws_xpixel: Width in pixels
+	Y    uint16 // ws_ypixel: Height in pixels
+}
+
+func windowRectCall(ws *Winsize, fd, a2 uintptr) error {
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		fd,
+		a2,
+		uintptr(unsafe.Pointer(ws)),
+	)
+	if errno != 0 {
+		return syscall.Errno(errno)
+	}
+	return nil
+}

--- a/vendor/github.com/kr/pty/ztypes_386.go
+++ b/vendor/github.com/kr/pty/ztypes_386.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_amd64.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_arm.go
+++ b/vendor/github.com/kr/pty/ztypes_arm.go
@@ -1,0 +1,9 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_arm64.go
+++ b/vendor/github.com/kr/pty/ztypes_arm64.go
@@ -1,0 +1,11 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+// +build arm64
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_dragonfly_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_dragonfly_amd64.go
@@ -1,0 +1,14 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_dragonfly.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Name      *byte
+	Len       uint32
+	Pad_cgo_0 [4]byte
+}

--- a/vendor/github.com/kr/pty/ztypes_freebsd_386.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_386.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len int32
+	Buf *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_freebsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_amd64.go
@@ -1,0 +1,14 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len       int32
+	Pad_cgo_0 [4]byte
+	Buf       *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_freebsd_arm.go
+++ b/vendor/github.com/kr/pty/ztypes_freebsd_arm.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_freebsd.go
+
+package pty
+
+const (
+	_C_SPECNAMELEN = 0x3f
+)
+
+type fiodgnameArg struct {
+	Len int32
+	Buf *byte
+}

--- a/vendor/github.com/kr/pty/ztypes_mipsx.go
+++ b/vendor/github.com/kr/pty/ztypes_mipsx.go
@@ -1,0 +1,12 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+// +build linux
+// +build mips mipsle mips64 mips64le
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_openbsd_386.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_386.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd	int32
+	Sfd	int32
+	Cn	[16]int8
+	Sn	[16]int8
+}
+
+var ioctl_PTMGET = 0x40287401

--- a/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
+++ b/vendor/github.com/kr/pty/ztypes_openbsd_amd64.go
@@ -1,0 +1,13 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types_openbsd.go
+
+package pty
+
+type ptmget struct {
+	Cfd int32
+	Sfd int32
+	Cn  [16]int8
+	Sn  [16]int8
+}
+
+var ioctl_PTMGET = 0x40287401

--- a/vendor/github.com/kr/pty/ztypes_ppc64.go
+++ b/vendor/github.com/kr/pty/ztypes_ppc64.go
@@ -1,0 +1,11 @@
+// +build ppc64
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_ppc64le.go
+++ b/vendor/github.com/kr/pty/ztypes_ppc64le.go
@@ -1,0 +1,11 @@
+// +build ppc64le
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)

--- a/vendor/github.com/kr/pty/ztypes_s390x.go
+++ b/vendor/github.com/kr/pty/ztypes_s390x.go
@@ -1,0 +1,11 @@
+// +build s390x
+
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs types.go
+
+package pty
+
+type (
+	_C_int  int32
+	_C_uint uint32
+)


### PR DESCRIPTION
This partially reverts https://github.com/moby/moby/commit/e0b59ab52b87b8fc15dd5534c3231fdd74843f9f (https://github.com/moby/moby/pull/2426), and does not automatically disable proxying signals in TTY-mode

fixes https://github.com/moby/moby/issues/28872 (docker client doesn't pass signals when a terminal is attached)
fixes https://github.com/moby/moby/issues/3793 docker client not passing signals to dockerd

relates to:

- https://github.com/moby/moby/issues/9098 Kill `docker exec` command will not terminate the spawned process
  - This patch does not fix the `docker exec` case; it looks like there's no API to kill an exec'd process, so there's no signal-proxy for this yet



Before this change:
------------------------------------

Start a container with a TTY in one shell:

```
docker run -it --init --name repro-28872 busybox sleep 30
```

then, in another shell, kill the docker cli:

```
kill `pgrep -f repro-28872`
```

Notice that the CLI was killed, but the signal not forwarded to the container;
the container continues running

```
docker container inspect --format '{{ .State.Status }}' repro-28872
running

docker container rm -f repro-28872
```

After this change:
------------------------------------

Start a container with a TTY in one shell:

```
docker run -it --init --name repro-28872 busybox sleep 30
```

then, in another shell, kill the docker cli:

```
kill `pgrep -f repro-28872`
```

Verify that the signal was forwarded to the container, and the container exited

```
docker container inspect --format '{{ .State.Status }}' repro-28872
exited

docker container rm -f repro-28872
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
- Fix docker client doesn't pass signals when a terminal is attached
```

**- A picture of a cute animal (not mandatory but encouraged)**
