### PR TITLE
[18.09 backport] bump buildkit 05766c5c21a1e528eeb1c3522b2f05493fe9ac47 (docker-18.09 branch)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -76,7 +76,7 @@ github.com/spf13/cobra v0.0.3
 github.com/spf13/pflag 4cb166e4f25ac4e8016a3595bbf7ea2e9aa85a2c https://github.com/thaJeztah/pflag.git
 github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 github.com/theupdateframework/notary v0.6.1
-github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
+github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
 github.com/tonistiigi/units 6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/xeipuuv/gojsonpointer 4e3ac2762d5f479393488629ee9370b50873b3a6
 github.com/xeipuuv/gojsonreference bd5ef7bd5415a7ac448318e64f11a24cd21e594b

--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/Microsoft/hcsshim 44c060121b68e8bdc40b411beba551f3b4ee9e55
 github.com/Microsoft/go-winio v0.4.10
 github.com/miekg/pkcs11 6120d95c0e9576ccf4a78ba40855809dca31a9ed
 github.com/mitchellh/mapstructure f15292f7a699fcc1a38a80977f80a046874ba8ac
-github.com/moby/buildkit 520201006c9dc676da9cf9655337ac711f7f127d
+github.com/moby/buildkit 05766c5c21a1e528eeb1c3522b2f05493fe9ac47
 github.com/modern-go/concurrent bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
 github.com/modern-go/reflect2 4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b

--- a/vendor/github.com/moby/buildkit/client/llb/source.go
+++ b/vendor/github.com/moby/buildkit/client/llb/source.go
@@ -126,30 +126,11 @@ func Image(ref string, opts ...ImageOption) State {
 		if err != nil {
 			src.err = err
 		} else {
-			var img struct {
-				Config struct {
-					Env        []string `json:"Env,omitempty"`
-					WorkingDir string   `json:"WorkingDir,omitempty"`
-					User       string   `json:"User,omitempty"`
-				} `json:"config,omitempty"`
-			}
-			if err := json.Unmarshal(dt, &img); err != nil {
-				src.err = err
-			} else {
-				st := NewState(src.Output())
-				for _, env := range img.Config.Env {
-					parts := strings.SplitN(env, "=", 2)
-					if len(parts[0]) > 0 {
-						var v string
-						if len(parts) > 1 {
-							v = parts[1]
-						}
-						st = st.AddEnv(parts[0], v)
-					}
-				}
-				st = st.Dir(img.Config.WorkingDir)
+			st, err := NewState(src.Output()).WithImageConfig(dt)
+			if err == nil {
 				return st
 			}
+			src.err = err
 		}
 	}
 	return NewState(src.Output())

--- a/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
+++ b/vendor/github.com/moby/buildkit/frontend/gateway/grpcclient/client.go
@@ -356,6 +356,9 @@ func (r *reference) ReadFile(ctx context.Context, req client.ReadRequest) ([]byt
 }
 
 func (r *reference) ReadDir(ctx context.Context, req client.ReadDirRequest) ([]*fstypes.Stat, error) {
+	if err := r.c.caps.Supports(pb.CapReadDir); err != nil {
+		return nil, err
+	}
 	rdr := &pb.ReadDirRequest{
 		DirPath:        req.Path,
 		IncludePattern: req.IncludePattern,
@@ -369,6 +372,9 @@ func (r *reference) ReadDir(ctx context.Context, req client.ReadDirRequest) ([]*
 }
 
 func (r *reference) StatFile(ctx context.Context, req client.StatRequest) (*fstypes.Stat, error) {
+	if err := r.c.caps.Supports(pb.CapStatFile); err != nil {
+		return nil, err
+	}
 	rdr := &pb.StatFileRequest{
 		Path: req.Path,
 		Ref:  r.id,

--- a/vendor/github.com/moby/buildkit/session/session.go
+++ b/vendor/github.com/moby/buildkit/session/session.go
@@ -24,7 +24,7 @@ const (
 // Dialer returns a connection that can be used by the session
 type Dialer func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error)
 
-// Attachable defines a feature that can be expsed on a session
+// Attachable defines a feature that can be exposed on a session
 type Attachable interface {
 	Register(*grpc.Server)
 }
@@ -66,7 +66,7 @@ func NewSession(ctx context.Context, name, sharedKey string) (*Session, error) {
 	return s, nil
 }
 
-// Allow enable a given service to be reachable through the grpc session
+// Allow enables a given service to be reachable through the grpc session
 func (s *Session) Allow(a Attachable) {
 	a.Register(s.grpcServer)
 }

--- a/vendor/github.com/moby/buildkit/vendor.conf
+++ b/vendor/github.com/moby/buildkit/vendor.conf
@@ -6,7 +6,7 @@ github.com/davecgh/go-spew v1.1.0
 github.com/pmezard/go-difflib v1.0.0
 golang.org/x/sys 1b2967e3c290b7c545b3db0deeda16e9be4f98a2
 
-github.com/containerd/containerd d97a907f7f781c0ab8340877d8e6b53cc7f1c2f6
+github.com/containerd/containerd 1a5f9a3434ac53c0e9d27093ecc588e0c281c333
 github.com/containerd/typeurl a93fcdb778cd272c6e9b3028b2f42d813e785d40
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/sirupsen/logrus v1.0.0
@@ -16,9 +16,9 @@ golang.org/x/net 0ed95abb35c445290478a5348a7b38bb154135fd
 github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis b23578765ee54ff6bceff57f397d833bf4ca6869
 github.com/golang/protobuf v1.1.0
-github.com/containerd/continuity f44b615e492bdfb371aae2f76ec694d9da1db537
+github.com/containerd/continuity bd77b46c8352f74eb12c85bdc01f4b90f69d66b4
 github.com/opencontainers/image-spec v1.0.1
-github.com/opencontainers/runc 20aff4f0488c6d4b8df4d85b4f63f1f704c11abd
+github.com/opencontainers/runc a00bf0190895aa465a5fbed0268888e2c8ddfe85
 github.com/Microsoft/go-winio v0.4.11
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
@@ -28,8 +28,9 @@ google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/syndtr/gocapability db04d3cc01c8b54962a58ec7e491717d06cfcc16
-github.com/Microsoft/hcsshim v0.7.3
+github.com/Microsoft/hcsshim v0.7.9
 golang.org/x/crypto 0709b304e793a5edb4a2c0145f281ecdc20838a4
+github.com/containerd/cri 8506fe836677cc3bb23a16b68145128243d843b5 # release/1.2 branch
 
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b
@@ -40,8 +41,8 @@ golang.org/x/time f51c12702a4d776e4c1fa9b0fabab841babae631
 github.com/docker/docker 71cd53e4a197b303c6ba086bd584ffd67a884281
 github.com/pkg/profile 5b67d428864e92711fcbd2f8629456121a56d91f
 
-github.com/tonistiigi/fsutil f567071bed2416e4d87d260d3162722651182317
-github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+github.com/tonistiigi/fsutil 2862f6bc5ac9b97124e552a5c108230b38a1b0ca
+github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 https://github.com/tonistiigi/go-immutable-radix
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/mitchellh/hashstructure 2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
@@ -66,6 +67,3 @@ github.com/opentracing-contrib/go-stdlib b1a47cfbdd7543e70e9ef3e73d0802ad306cc1c
 # used by dockerfile tests
 gotest.tools v2.1.0
 github.com/google/go-cmp v0.2.0
-
-# used by rootless spec conv test
-github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0


### PR DESCRIPTION
Also bumps fsutil to match the same version