### PR TITLE
bump docker/go-units v0.4.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -20,7 +20,7 @@ github.com/docker/go                                d30aec9fd63c35133f8f79c3412a
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
-github.com/docker/go-units                          47565b4f722fb6ceae66b95f853feed578a4a51c # v0.3.3
+github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/docker/licensing                         9781369abdb5281cdc07a2a446c6df01347ec793
 github.com/docker/swarmkit                          59163bf75df38489d4a10392265d27156dc473c5

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -18,7 +18,7 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d seconds", seconds)
 	} else if minutes := int(d.Minutes()); minutes == 1 {
 		return "About a minute"
-	} else if minutes < 46 {
+	} else if minutes < 60 {
 		return fmt.Sprintf("%d minutes", minutes)
 	} else if hours := int(d.Hours() + 0.5); hours == 1 {
 		return "About an hour"

--- a/vendor/github.com/docker/go-units/ulimit.go
+++ b/vendor/github.com/docker/go-units/ulimit.go
@@ -96,8 +96,13 @@ func ParseUlimit(val string) (*Ulimit, error) {
 		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
 	}
 
-	if soft > *hard {
-		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+	if *hard != -1 {
+		if soft == -1 {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: soft: -1 (unlimited), hard: %d", *hard)
+		}
+		if soft > *hard {
+			return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+		}
 	}
 
 	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil


### PR DESCRIPTION
fixes  https://github.com/moby/moby/issues/39125
fixes https://github.com/moby/moby/issues/38807

relevant changes:

- docker/go-units#33 Fix handling of unlimited (-1) ulimit values
  - relates to https://github.com/moby/moby/issues/39125, 
- docker/go-units#34 Revert 46 minute threshold
  - relates to https://github.com/moby/moby/issues/38807
