### PR TITLE
Include plugins in `docker --badopt` help output

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -76,6 +76,9 @@ func setFlagErrorFunc(dockerCli *command.DockerCli, cmd *cobra.Command) {
 	// is called.
 	flagErrorFunc := cmd.FlagErrorFunc()
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		if err := pluginmanager.AddPluginCommandStubs(dockerCli, cmd.Root()); err != nil {
+			return err
+		}
 		if err := isSupported(cmd, dockerCli); err != nil {
 			return err
 		}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -69,7 +69,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	return cli.NewTopLevelCommand(cmd, dockerCli, opts, flags)
 }
 
-func setFlagErrorFunc(dockerCli *command.DockerCli, cmd *cobra.Command) {
+func setFlagErrorFunc(dockerCli command.Cli, cmd *cobra.Command) {
 	// When invoking `docker stack --nonsense`, we need to make sure FlagErrorFunc return appropriate
 	// output if the feature is not supported.
 	// As above cli.SetupRootCommand(cmd) have already setup the FlagErrorFunc, we will add a pre-check before the FlagErrorFunc

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -79,6 +79,9 @@ func setFlagErrorFunc(dockerCli *command.DockerCli, cmd *cobra.Command) {
 		if err := isSupported(cmd, dockerCli); err != nil {
 			return err
 		}
+		if err := hideUnsupportedFeatures(cmd, dockerCli); err != nil {
+			return err
+		}
 		return flagErrorFunc(cmd, err)
 	})
 }

--- a/e2e/cli-plugins/help_test.go
+++ b/e2e/cli-plugins/help_test.go
@@ -92,4 +92,18 @@ func TestGlobalHelp(t *testing.T) {
 		assert.Assert(t, is.Equal(res2.Stdout(), ""))
 		assert.Assert(t, is.Equal(res2.Stderr(), res.Stdout()))
 	})
+
+	t.Run("badopt", func(t *testing.T) {
+		// Running `docker --badopt` should also produce the
+		// same thing, give or take the leading error message
+		// and a trailing carriage return (due to main() using
+		// Println in the error case).
+		res2 := icmd.RunCmd(run("--badopt"))
+		res2.Assert(t, icmd.Expected{
+			ExitCode: 125,
+		})
+		assert.Assert(t, is.Equal(res2.Stdout(), ""))
+		exp := "unknown flag: --badopt\nSee 'docker --help'.\n" + res.Stdout() + "\n"
+		assert.Assert(t, is.Equal(res2.Stderr(), exp))
+	})
 }

--- a/e2e/cli-plugins/help_test.go
+++ b/e2e/cli-plugins/help_test.go
@@ -74,18 +74,22 @@ func TestGlobalHelp(t *testing.T) {
 	assert.Assert(t, is.Equal(badmetacount, 1))
 
 	// Running with `--help` should produce the same.
-	res2 := icmd.RunCmd(run("--help"))
-	res2.Assert(t, icmd.Expected{
-		ExitCode: 0,
+	t.Run("help_flag", func(t *testing.T) {
+		res2 := icmd.RunCmd(run("--help"))
+		res2.Assert(t, icmd.Expected{
+			ExitCode: 0,
+		})
+		assert.Assert(t, is.Equal(res2.Stdout(), res.Stdout()))
+		assert.Assert(t, is.Equal(res2.Stderr(), ""))
 	})
-	assert.Assert(t, is.Equal(res2.Stdout(), res.Stdout()))
-	assert.Assert(t, is.Equal(res2.Stderr(), ""))
 
 	// Running just `docker` (without `help` nor `--help`) should produce the same thing, except on Stderr.
-	res2 = icmd.RunCmd(run())
-	res2.Assert(t, icmd.Expected{
-		ExitCode: 0,
+	t.Run("bare", func(t *testing.T) {
+		res2 := icmd.RunCmd(run())
+		res2.Assert(t, icmd.Expected{
+			ExitCode: 0,
+		})
+		assert.Assert(t, is.Equal(res2.Stdout(), ""))
+		assert.Assert(t, is.Equal(res2.Stderr(), res.Stdout()))
 	})
-	assert.Assert(t, is.Equal(res2.Stdout(), ""))
-	assert.Assert(t, is.Equal(res2.Stderr(), res.Stdout()))
 }


### PR DESCRIPTION
**- What I did**

I arranged to cli plugins include in the output of `docker --badopt`, fixes #1813.

In the process of writing the e2e test I also noticed that the `docker --badopt` unconditionally included experimental (builtin) commands so I fixed that too.

Finally since I was adding a new subtest to an existing test, I took the chance to use `t.Run` for all of the subtests.

**- How I did it**

Including cli plugins is achieved by calling `pluginmanager.AddPluginCommandStubs` in the flag errro callback function. Handling experimental commands properly is handled by calling `hideUnsupportedFeatures` in the same callback.

**- How to verify it**

There is a new e2e test.

**- Description for the changelog**

* Help output now always includes CLI plugins.

/cc @SvenDowideit.