### PR TITLE
Add support for static bearer token authentication for Kubernetes

### DIFF
--- a/cli/context/kubernetes/load.go
+++ b/cli/context/kubernetes/load.go
@@ -8,6 +8,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+const tokenKey = "token"
+
 // EndpointMeta is a typed wrapper around a context-store generic endpoint describing
 // a Kubernetes endpoint, without TLS data
 type EndpointMeta struct {
@@ -21,12 +23,53 @@ type EndpointMeta struct {
 // a Kubernetes endpoint, with TLS data
 type Endpoint struct {
 	EndpointMeta
-	TLSData *context.TLSData
+	TLSData *TLSData
+}
+
+// TLSData holds sensitive Kubernetes endpoint configurations (ca/cert/key and tokens)
+type TLSData struct {
+	context.TLSData
+	Token string
+}
+
+// ToStoreTLSData converts TLSData to the store representation
+func (data *TLSData) ToStoreTLSData() *store.EndpointTLSData {
+	if data == nil {
+		return nil
+	}
+	result := data.TLSData.ToStoreTLSData()
+	if data.Token != "" {
+		result.Files[tokenKey] = []byte(data.Token)
+	}
+	return result
+}
+
+// LoadTLSData loads TLS data from the store
+func LoadTLSData(s store.Reader, contextName string) (*TLSData, error) {
+	tlsData, err := context.LoadTLSData(s, contextName, KubernetesEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	if tlsData == nil {
+		return nil, nil
+	}
+	result := &TLSData{
+		TLSData: *tlsData,
+	}
+	token, err := s.GetTLSData(contextName, KubernetesEndpoint, tokenKey)
+	if store.IsErrTLSDataDoesNotExist(err) {
+		return result, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	result.Token = string(token)
+	return result, nil
 }
 
 // WithTLSData loads TLS materials for the endpoint
 func (c *EndpointMeta) WithTLSData(s store.Reader, contextName string) (Endpoint, error) {
-	tlsData, err := context.LoadTLSData(s, contextName, KubernetesEndpoint)
+	tlsData, err := LoadTLSData(s, contextName)
 	if err != nil {
 		return Endpoint{}, err
 	}
@@ -47,6 +90,7 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 		cluster.CertificateAuthorityData = c.TLSData.CA
 		authInfo.ClientCertificateData = c.TLSData.Cert
 		authInfo.ClientKeyData = c.TLSData.Key
+		authInfo.Token = c.TLSData.Token
 	}
 	authInfo.AuthProvider = c.AuthProvider
 	authInfo.Exec = c.Exec

--- a/cli/context/kubernetes/save.go
+++ b/cli/context/kubernetes/save.go
@@ -21,7 +21,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 	if err != nil {
 		return Endpoint{}, err
 	}
-	var ca, key, cert []byte
+	var ca, key, cert, token []byte
 	if ca, err = readFileOrDefault(clientcfg.CAFile, clientcfg.CAData); err != nil {
 		return Endpoint{}, err
 	}
@@ -31,12 +31,21 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 	if cert, err = readFileOrDefault(clientcfg.CertFile, clientcfg.CertData); err != nil {
 		return Endpoint{}, err
 	}
-	var tlsData *context.TLSData
-	if ca != nil || cert != nil || key != nil {
-		tlsData = &context.TLSData{
-			CA:   ca,
-			Cert: cert,
-			Key:  key,
+	if token, err = readFileOrDefault(clientcfg.BearerTokenFile, []byte(clientcfg.BearerToken)); err != nil {
+		return Endpoint{}, err
+	}
+	if len(token) == 0 {
+		token = nil
+	}
+	var tlsData *TLSData
+	if ca != nil || cert != nil || key != nil || token != nil {
+		tlsData = &TLSData{
+			TLSData: context.TLSData{
+				CA:   ca,
+				Cert: cert,
+				Key:  key,
+			},
+			Token: string(token),
 		}
 	}
 	return Endpoint{

--- a/cli/context/kubernetes/testdata/token-kubeconfig
+++ b/cli/context/kubernetes/testdata/token-kubeconfig
@@ -1,0 +1,17 @@
+apiVersion: v1
+clusters:
+- cluster:    
+    server: https://some-server
+  name: token_sample
+contexts:
+- context:
+    cluster: token_sample
+    user: token_sample
+  name: token_sample
+current-context: token_sample
+kind: Config
+preferences: {}
+users:
+- name: token_sample
+  user:
+    token: token


### PR DESCRIPTION
Fix #1852
**- What I did**

This adds support for importing kubeconfig file using token-based
authentication.

**- How I did it**

The bearer token is stored within the tls store because of its sensitive
nature.

**- How to verify it**

Comes with unit tests


