### PR TITLE
bash completion: add node type filter

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5159,7 +5159,7 @@ _docker_system_events() {
 			return
 			;;
 		type)
-			COMPREPLY=( $( compgen -W "config container daemon image network plugin secret service volume" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "config container daemon image network node plugin secret service volume" -- "${cur##*=}" ) )
 			return
 			;;
 		volume)


### PR DESCRIPTION
**- What I did**

Make `docker events -f type=<tab><tab>` in bash emit `node` as one of the completions.

**- How I did it**

Added `node` to the completion entry for `type`.

**- How to verify it**

Copy the modified completion file to `/usr/share/bash-completion/completions/docker` on a centos 7 manager node, then log out and log back in, then tested tab completion.  Join a node to the swarm with the event filter running, and observe events.

**- Description for the changelog**
Add bash tab completion for node event type filter.

**- A picture of a cute animal (not mandatory but encouraged)**

![суперчервячок](https://user-images.githubusercontent.com/3613189/57324165-57821a80-70d5-11e9-91b1-eb6680830948.png)
