### PR TITLE
vendor buildkit to 646fc0a (v0.5.1)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/Microsoft/go-winio                       84b4ab48a50763fe7b3abcef38e5
 github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
 github.com/miekg/pkcs11                             6120d95c0e9576ccf4a78ba40855809dca31a9ed
 github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
-github.com/moby/buildkit                            8818c67cff663befa7b70f21454e340f71616581
+github.com/moby/buildkit                            646fc0af6d283397b9e47cd0a18779e9d0376e0e # v0.5.1
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
 github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b

--- a/vendor/github.com/moby/buildkit/client/llb/exec.go
+++ b/vendor/github.com/moby/buildkit/client/llb/exec.go
@@ -177,7 +177,7 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		addCap(&e.constraints, pb.CapExecMetaNetwork)
 	}
 
-	if e.meta.Security != SecurityModeInsecure {
+	if e.meta.Security != SecurityModeSandbox {
 		addCap(&e.constraints, pb.CapExecMetaSecurity)
 	}
 


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This fixes a hang when querying credentials on OS X.