### PR TITLE
add a 10s timeout to the client object.

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -122,6 +122,7 @@ func (c *Endpoint) ClientOpts() ([]client.Opt, error) {
 				client.WithDialContext(helper.Dialer),
 			)
 		}
+		result = append(result, client.WithTimeout(10*time.Second))
 	}
 
 	version := os.Getenv("DOCKER_API_VERSION")


### PR DESCRIPTION
This partially mitigates #1739 ("Docker commands take 1 minute to timeout if
context endpoint is unreachable") and is a simpler alternative to #1747 (which
completely defers the client connection until an actual call is attempted).

Note that the previous 60s delay was the culmination of two separate 30s
timeouts since the ping is tried twice. This with this patch the overall
timeout is 20s. https://github.com/moby/moby/pull/39206 will remove the second
ping and once that propagates to this tree the timeout will be 10s.

Signed-off-by: Ian Campbell <ijc@docker.com>

