### PR TITLE
[19.03 backport] update authors and upload junit.xml

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -44,6 +44,7 @@ Antonio Murdaca <antonio.murdaca@gmail.com> <runcom@users.noreply.github.com>
 Anuj Bahuguna <anujbahuguna.dev@gmail.com>
 Anuj Bahuguna <anujbahuguna.dev@gmail.com> <abahuguna@fiberlink.com>
 Anusha Ragunathan <anusha.ragunathan@docker.com> <anusha@docker.com>
+Ao Li <la9249@163.com>
 Arnaud Porterie <arnaud.porterie@docker.com>
 Arnaud Porterie <arnaud.porterie@docker.com> <icecrime@gmail.com>
 Arthur Gautier <baloo@gandi.net> <superbaloo+registrations.github@superbaloo.net>
@@ -394,6 +395,8 @@ Stefan Berger <stefanb@linux.vnet.ibm.com>
 Stefan Berger <stefanb@linux.vnet.ibm.com> <stefanb@us.ibm.com>
 Stefan J. Wernli <swernli@microsoft.com> <swernli@ntdev.microsoft.com>
 Stefan S. <tronicum@user.github.com>
+Stefan Scherer <stefan.scherer@docker.com>
+Stefan Scherer <stefan.scherer@docker.com> <scherer_stefan@icloud.com>
 Stephen Day <stevvooe@gmail.com>
 Stephen Day <stevvooe@gmail.com> <stephen.day@docker.com>
 Stephen Day <stevvooe@gmail.com> <stevvooe@users.noreply.github.com>
@@ -402,6 +405,8 @@ Steve Richards <steve.richards@docker.com> stevejr <>
 Sun Gengze <690388648@qq.com>
 Sun Jianbo <wonderflow.sun@gmail.com>
 Sun Jianbo <wonderflow.sun@gmail.com> <wonderflow@zju.edu.cn>
+Sunny Gogoi <indiasuny000@gmail.com>
+Sunny Gogoi <indiasuny000@gmail.com> <me@darkowlzz.space>
 Sven Dowideit <SvenDowideit@home.org.au>
 Sven Dowideit <SvenDowideit@home.org.au> <sven@t440s.home.gateway>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@docker.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Anton Polonskiy <anton.polonskiy@gmail.com>
 Antonio Murdaca <antonio.murdaca@gmail.com>
 Antonis Kalipetis <akalipetis@gmail.com>
 Anusha Ragunathan <anusha.ragunathan@docker.com>
+Ao Li <la9249@163.com>
 Arash Deshmeh <adeshmeh@ca.ibm.com>
 Arnaud Porterie <arnaud.porterie@docker.com>
 Ashwini Oruganti <ashwini.oruganti@gmail.com>
@@ -158,6 +159,7 @@ David Cramer <davcrame@cisco.com>
 David Dooling <dooling@gmail.com>
 David Gageot <david@gageot.net>
 David Lechner <david@lechnology.com>
+David Scott <dave@recoil.org>
 David Sheets <dsheets@docker.com>
 David Williamson <david.williamson@docker.com>
 David Xia <dxia@spotify.com>
@@ -300,6 +302,7 @@ Jim Galasyn <jim.galasyn@docker.com>
 Jimmy Leger <jimmy.leger@gmail.com>
 Jimmy Song <rootsongjc@gmail.com>
 jimmyxian <jimmyxian2004@yahoo.com.cn>
+Jintao Zhang <zhangjintao9020@gmail.com>
 Joao Fernandes <joao.fernandes@docker.com>
 Joe Doliner <jdoliner@pachyderm.io>
 Joe Gordon <joe.gordon0@gmail.com>
@@ -471,9 +474,11 @@ Mrunal Patel <mrunalp@gmail.com>
 muicoder <muicoder@gmail.com>
 Muthukumar R <muthur@gmail.com>
 Máximo Cuadros <mcuadros@gmail.com>
+Mårten Cassel <marten.cassel@gmail.com>
 Nace Oroz <orkica@gmail.com>
 Nahum Shalman <nshalman@omniti.com>
 Nalin Dahyabhai <nalin@redhat.com>
+Nao YONASHIRO <owan.orisano@gmail.com>
 Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>
 Natalie Parker <nparker@omnifone.com>
 Nate Brennand <nate.brennand@clever.com>
@@ -595,7 +600,7 @@ Spencer Brown <spencer@spencerbrown.org>
 squeegels <1674195+squeegels@users.noreply.github.com>
 Srini Brahmaroutu <srbrahma@us.ibm.com>
 Stefan S. <tronicum@user.github.com>
-Stefan Scherer <scherer_stefan@icloud.com>
+Stefan Scherer <stefan.scherer@docker.com>
 Stefan Weil <sw@weilnetz.de>
 Stephane Jeandeaux <stephane.jeandeaux@gmail.com>
 Stephen Day <stevvooe@gmail.com>
@@ -605,7 +610,9 @@ Steve Richards <steve.richards@docker.com>
 Steven Burgess <steven.a.burgess@hotmail.com>
 Subhajit Ghosh <isubuz.g@gmail.com>
 Sun Jianbo <wonderflow.sun@gmail.com>
+Sune Keller <absukl@almbrand.dk>
 Sungwon Han <sungwon.han@navercorp.com>
+Sunny Gogoi <indiasuny000@gmail.com>
 Sven Dowideit <SvenDowideit@home.org.au>
 Sylvain Baubeau <sbaubeau@redhat.com>
 Sébastien HOUZÉ <cto@verylastroom.com>

--- a/circle.yml
+++ b/circle.yml
@@ -77,6 +77,8 @@ jobs:
                 echo 'Codecov failed to upload'
       - store_test_results:
           path:  test-results
+      - store_artifacts:
+          path:  test-results
 
   validate:
     working_directory: /work


### PR DESCRIPTION
no high-priority, but making sure the AUTHORS file is up-to-date on the 19.03 branch, and to upload CI results (junit) in case we want to keep track of those results 

backports https://github.com/docker/cli/pull/1851 and https://github.com/docker/cli/pull/1861