### PR TITLE
[19.03 backport] backport BuildKit fixes

### DIFF
--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -215,6 +215,10 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 		})
 	}
 
+	if v := os.Getenv("BUILDKIT_PROGRESS"); v != "" && options.progress == "auto" {
+		options.progress = v
+	}
+
 	eg.Go(func() error {
 		defer func() { // make sure the Status ends cleanly on build errors
 			s.Close()

--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/containerd/console"
+	"github.com/containerd/containerd/platforms"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image/build"
@@ -217,6 +218,10 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 
 	if v := os.Getenv("BUILDKIT_PROGRESS"); v != "" && options.progress == "auto" {
 		options.progress = v
+	}
+
+	if strings.EqualFold(options.platform, "local") {
+		options.platform = platforms.DefaultString()
 	}
 
 	eg.Go(func() error {

--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/Microsoft/go-winio                       84b4ab48a50763fe7b3abcef38e5
 github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
 github.com/miekg/pkcs11                             6120d95c0e9576ccf4a78ba40855809dca31a9ed
 github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
-github.com/moby/buildkit                            8818c67cff663befa7b70f21454e340f71616581
+github.com/moby/buildkit                            646fc0af6d283397b9e47cd0a18779e9d0376e0e # v0.5.1
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
 github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b

--- a/vendor/github.com/moby/buildkit/client/llb/exec.go
+++ b/vendor/github.com/moby/buildkit/client/llb/exec.go
@@ -177,7 +177,7 @@ func (e *ExecOp) Marshal(c *Constraints) (digest.Digest, []byte, *pb.OpMetadata,
 		addCap(&e.constraints, pb.CapExecMetaNetwork)
 	}
 
-	if e.meta.Security != SecurityModeInsecure {
+	if e.meta.Security != SecurityModeSandbox {
 		addCap(&e.constraints, pb.CapExecMetaSecurity)
 	}
 


### PR DESCRIPTION
backports of

- https://github.com/docker/cli/pull/1863 buildx backports: BUILDKIT_PROGRESS env + build --platform local
  - Backport of https://github.com/docker/buildx/pull/69 and https://github.com/docker/buildx/pull/70
- https://github.com/docker/cli/pull/1866 vendor buildkit to 646fc0a (v0.5.1)
