### PR TITLE
[19.03 backport] Fix PowerShell codehint for rouge

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -812,7 +812,7 @@ Defaults to 20G.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt size=40G
 ```
 
@@ -827,7 +827,7 @@ deployments).
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.globalmode=false
 ```
 
@@ -838,7 +838,7 @@ used for booting a utility VM. Defaults to `%ProgramFiles%\Linux Containers`.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.kirdpath=c:\path\to\files
 ```
 
@@ -849,7 +849,7 @@ Defaults to `bootx64.efi`.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.kernel=kernel.efi
 ```
 
@@ -860,7 +860,7 @@ Defaults to `initrd.img`.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.initrd=myinitrd.img
 ```
 
@@ -872,7 +872,7 @@ are kernel specific.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt "lcow.bootparameters='option=value'"
 ```
 
@@ -883,7 +883,7 @@ and initrd booting. Defaults to `uvm.vhdx` under `lcow.kirdpath`.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.vhdx=custom.vhdx
 ```
 
@@ -894,7 +894,7 @@ to 300.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.timeout=240
 ```
 
@@ -905,7 +905,7 @@ containers. Defaults to 20. Cannot be less than 20.
 
 ###### Example
 
-```PowerShell
+```powershell
 C:\> dockerd --storage-opt lcow.sandboxsize=40
 ```
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -753,7 +753,7 @@ operating system older than Windows 10 1809 with `--isolation process` will fail
 On Windows server, assuming the default configuration, these commands are equivalent
 and result in `process` isolation:
 
-```PowerShell
+```powershell
 PS C:\> docker run -d microsoft/nanoserver powershell echo process
 PS C:\> docker run -d --isolation default microsoft/nanoserver powershell echo process
 PS C:\> docker run -d --isolation process microsoft/nanoserver powershell echo process
@@ -763,7 +763,7 @@ If you have set the `--exec-opt isolation=hyperv` option on the Docker `daemon`,
 are running against a Windows client-based daemon, these commands are equivalent and
 result in `hyperv` isolation:
 
-```PowerShell
+```powershell
 PS C:\> docker run -d microsoft/nanoserver powershell echo hyperv
 PS C:\> docker run -d --isolation default microsoft/nanoserver powershell echo hyperv
 PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1433,7 +1433,7 @@ today=Wednesday
 HOME=/root
 ```
 
-```PowerShell
+```powershell
 PS C:\> docker run --rm -e "foo=bar" microsoft/nanoserver cmd /s /c set
 ALLUSERSPROFILE=C:\ProgramData
 APPDATA=C:\Users\ContainerAdministrator\AppData\Roaming


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1881 for 19.03

Rouge is case-sensitive, and only works with powershell
all lowercase.

