### PR TITLE
Allow vendorers of docker/cli to avoid transitively pulling in a big chunk if k8s too

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	dcontext "github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/docker"
-	kubcontext "github.com/docker/cli/cli/context/kubernetes"
+	kubecontext "github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
@@ -530,6 +530,6 @@ func defaultContextStoreConfig() store.Config {
 	return store.NewConfig(
 		func() interface{} { return &DockerContext{} },
 		store.EndpointTypeGetter(docker.DockerEndpoint, func() interface{} { return &docker.EndpointMeta{} }),
-		store.EndpointTypeGetter(kubcontext.KubernetesEndpoint, func() interface{} { return &kubcontext.EndpointMeta{} }),
+		store.EndpointTypeGetter(kubecontext.KubernetesEndpoint, func() interface{} { return &kubecontext.EndpointMeta{} }),
 	)
 }

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/cli/kubernetes"
 	"github.com/docker/cli/templates"
+	kubeapi "github.com/docker/compose-on-kubernetes/api"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -243,7 +244,7 @@ func getKubernetesVersion(dockerCli command.Cli, kubeConfig string) *kubernetesV
 		err          error
 	)
 	if dockerCli.CurrentContext() == "" {
-		clientConfig = kubernetes.NewKubernetesConfig(kubeConfig)
+		clientConfig = kubeapi.NewKubernetesConfig(kubeConfig)
 	} else {
 		clientConfig, err = kubecontext.ConfigFromContext(dockerCli.CurrentContext(), dockerCli.ContextStore())
 	}

--- a/cli/context/kubernetes/load.go
+++ b/cli/context/kubernetes/load.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/store"
-	"github.com/docker/cli/kubernetes"
+	api "github.com/docker/compose-on-kubernetes/api"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -91,5 +91,5 @@ func ConfigFromContext(name string, s store.Reader) (clientcmd.ClientConfig, err
 		return ep.KubernetesConfig(), nil
 	}
 	// context has no kubernetes endpoint
-	return kubernetes.NewKubernetesConfig(""), nil
+	return api.NewKubernetesConfig(""), nil
 }

--- a/kubernetes/config.go
+++ b/kubernetes/config.go
@@ -1,8 +1,0 @@
-package kubernetes
-
-import api "github.com/docker/compose-on-kubernetes/api"
-
-// NewKubernetesConfig resolves the path to the desired Kubernetes configuration file based on
-// the KUBECONFIG environment variable and command line flags.
-// Deprecated: Use github.com/docker/compose-on-kubernetes/api.NewKubernetesConfig instead
-var NewKubernetesConfig = api.NewKubernetesConfig


### PR DESCRIPTION
The first commit is a (somewhat unrelated) minor cleanup, the second commit is the interesting one:
```
    Use underlying `NewKubernetesConfig` directly from compose-on-kubernetes.
    
    The comment on `github.com/docker/cli/kubernetes.NewKubernetesConfig` said:
    
        // Deprecated: Use github.com/docker/compose-on-kubernetes/api.NewKubernetesConfig instead
    
    By making this switch in `github.com/docker/cli/context/kubernetes/load.go` we
    break a vendoring chain:
    
    `github.com/docker/cli/cli/command`
    → `vendor/github.com/docker/cli/cli/context/kubernetes/load.go`
      → `vendor/github.com/docker/cli/kubernetes`
         → `github.com/docker/compose-on-kubernetes/api/compose/...`
    
    This means that projects which just want `github.com/docker/cli/cli/command`
    (which is itself pulled in transitively by
    `github.com/docker/cli/cli-plugins/plugin`) which do not themselves need the
    compose-on-kubernetes API avoid a huge pile of transitive dependencies.
    
    On one of my private projects the diff on the vendor dir is:
    
        280 files changed, 21 insertions(+), 211346 deletions(-)
    
    and includes dropping:
    
    * `github.com/docker/compose-on-kubernetes/api/compose/{clone,impersonation}`
    * `github.com/docker/compose-on-kubernetes/api/compose/{v1alpha3,v1beta1,v1beta2,v1beta3}`
    * `github.com/google/btree`
    * `github.com/googleapis/gnostic`
    * `github.com/gregjones/httpcache`
    * `github.com/peterbourgon/diskv`
    * `k8s.io/api/*` (_lots_ of subpackages)
    * `k8s.io/client-go/{discovery,kubernetes/scheme}`
    
    and I've gone from:
    
        $ du -sh vendor/k8s.io/
        8.1M        vendor/k8s.io/
    
    to:
    
        $ du -sh vendor/k8s.io/
        2.1M        vendor/k8s.io/
    
    (overall I went from 36M → 29M of vendor dir for this particular project)
    
    The change to `cli/command/system/version.go` is just for consistency and
    allows us to drop the now unused alias.
    
    Signed-off-by: Ian Campbell <ijc@docker.com>
```