### PR TITLE
Revert "add a 10s timeout to the client object."

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -122,7 +122,6 @@ func (c *Endpoint) ClientOpts() ([]client.Opt, error) {
 				client.WithDialContext(helper.Dialer),
 			)
 		}
-		result = append(result, client.WithTimeout(10*time.Second))
 	}
 
 	version := os.Getenv("DOCKER_API_VERSION")


### PR DESCRIPTION
This reverts commit 59defcb34d5be358ebaacaadd21ed7e6307a493e which caused #1892
since the timeout applied not only to the dial phase but to everything, so it
would kill `docker logs -f ...` if the container was not chatty enough.

Signed-off-by: Ian Campbell <ijc@docker.com>

fixes #1892 
fixes https://github.com/docker/for-linux/issues/669.