### PR TITLE
note `--user` args usage restriction

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1772,6 +1772,7 @@ the `USER` instruction by passing the `-u` option.
     --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]
 
 > **Note:** if you pass a numeric uid, it must be in the range of 0-2147483647.
+> If you pass a username, the user must exist in the container.
 
 ### WORKDIR
 


### PR DESCRIPTION
Signed-off-by: Yucheng Wu <wyc123wyc@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
note `--user` args usage restriction
fixes and closes: https://github.com/docker/docker.github.io/issues/8831

**- How I did it**
add additional explanation

**- How to verify it**
xref: https://github.com/moby/moby/issues/22323#issuecomment-215449380

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
the user name specified by docker run `--user` args must be exist in the container
```

**- A picture of a cute animal (not mandatory but encouraged)**
![peiqi](https://user-images.githubusercontent.com/13599124/58153263-2a229880-7ca1-11e9-8c26-0ab01e23f130.jpg)
haha, his name is peiqi
