### PR TITLE
[WIP] cli-plugins: look for plugins in experimental folder when experimental is enabled

### DIFF
--- a/cli-plugins/manager/candidate.go
+++ b/cli-plugins/manager/candidate.go
@@ -8,14 +8,20 @@ import (
 type Candidate interface {
 	Path() string
 	Metadata() ([]byte, error)
+	Experimental() bool
 }
 
 type candidate struct {
-	path string
+	path         string
+	experimental bool
 }
 
 func (c *candidate) Path() string {
 	return c.path
+}
+
+func (c *candidate) Experimental() bool {
+	return c.experimental
 }
 
 func (c *candidate) Metadata() ([]byte, error) {

--- a/cli-plugins/manager/candidate_test.go
+++ b/cli-plugins/manager/candidate_test.go
@@ -19,7 +19,7 @@ type fakeCandidate struct {
 }
 
 func (c *fakeCandidate) Experimental() bool {
-	return c.allowExperimental
+	return strings.Contains(c.path, "-experimental/")
 }
 
 func (c *fakeCandidate) Path() string {
@@ -40,6 +40,8 @@ func TestValidateCandidate(t *testing.T) {
 		builtinName  = NamePrefix + "builtin"
 		builtinAlias = NamePrefix + "alias"
 
+		goodMeta = `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`
+
 		badPrefixPath          = "/usr/local/libexec/cli-plugins/wobble"
 		badNamePath            = "/usr/local/libexec/cli-plugins/docker-123456"
 		goodPluginPath         = "/usr/local/libexec/cli-plugins/" + goodPluginName
@@ -55,43 +57,46 @@ func TestValidateCandidate(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		c *fakeCandidate
+		name string
+		c    *fakeCandidate
 
 		// Either err or invalid may be non-empty, but not both (both can be empty for a good plugin).
 		err     string
 		invalid string
 	}{
 		/* Each failing one of the tests */
-		{c: &fakeCandidate{path: ""}, err: "plugin candidate path cannot be empty"},
-		{c: &fakeCandidate{path: badPrefixPath}, err: fmt.Sprintf("does not have %q prefix", NamePrefix)},
-		{c: &fakeCandidate{path: badNamePath}, invalid: "did not match"},
-		{c: &fakeCandidate{path: builtinName}, invalid: `plugin "builtin" duplicates builtin command`},
-		{c: &fakeCandidate{path: builtinAlias}, invalid: `plugin "alias" duplicates an alias of builtin command "builtin"`},
-		{c: &fakeCandidate{path: goodPluginPath, exec: false}, invalid: fmt.Sprintf("failed to fetch metadata: faked a failure to exec %q", goodPluginPath)},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `xyzzy`}, invalid: "invalid character"},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{}`}, invalid: `plugin SchemaVersion "" is not valid`},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "xyzzy"}`}, invalid: `plugin SchemaVersion "xyzzy" is not valid`},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0"}`}, invalid: "plugin metadata does not define a vendor"},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": ""}`}, invalid: "plugin metadata does not define a vendor"},
-		{c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`}, invalid: "requires experimental CLI"},
+		{name: "empty path", c: &fakeCandidate{path: ""}, err: "plugin candidate path cannot be empty"},
+		{name: "bad prefix", c: &fakeCandidate{path: badPrefixPath}, err: fmt.Sprintf("does not have %q prefix", NamePrefix)},
+		{name: "bad path", c: &fakeCandidate{path: badNamePath}, invalid: "did not match"},
+		{name: "builtin command", c: &fakeCandidate{path: builtinName}, invalid: `plugin "builtin" duplicates builtin command`},
+		{name: "builtin alias", c: &fakeCandidate{path: builtinAlias}, invalid: `plugin "alias" duplicates an alias of builtin command "builtin"`},
+		{name: "fetch failure", c: &fakeCandidate{path: goodPluginPath, exec: false}, invalid: fmt.Sprintf("failed to fetch metadata: faked a failure to exec %q", goodPluginPath)},
+		{name: "metadata not json", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `xyzzy`}, invalid: "invalid character"},
+		{name: "empty schemaversion", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{}`}, invalid: `plugin SchemaVersion "" is not valid`},
+		{name: "invalid schemaversion", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "xyzzy"}`}, invalid: `plugin SchemaVersion "xyzzy" is not valid`},
+		{name: "no vendor", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0"}`}, invalid: "plugin metadata does not define a vendor"},
+		{name: "empty vendor", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": ""}`}, invalid: "plugin metadata does not define a vendor"},
+		{name: "experimental required", c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: goodMeta}, invalid: "requires experimental CLI"},
 		// This one should work
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`}},
-		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`, allowExperimental: true}},
-		{c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`, allowExperimental: true}},
+		{name: "valid", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: goodMeta}},
+		{name: "valid on experimental CLI", c: &fakeCandidate{path: goodPluginPath, exec: true, meta: goodMeta, allowExperimental: true}},
+		{name: "experimental on experimental CLI", c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: goodMeta, allowExperimental: true}},
 	} {
-		p, err := newPlugin(tc.c, fakeroot, tc.c.allowExperimental)
-		if tc.err != "" {
-			assert.ErrorContains(t, err, tc.err)
-		} else if tc.invalid != "" {
-			assert.NilError(t, err)
-			assert.Assert(t, cmp.ErrorType(p.Err, reflect.TypeOf(&pluginError{})))
-			assert.ErrorContains(t, p.Err, tc.invalid)
-		} else {
-			assert.NilError(t, err)
-			assert.Equal(t, NamePrefix+p.Name, goodPluginName)
-			assert.Equal(t, p.SchemaVersion, "0.1.0")
-			assert.Equal(t, p.Vendor, "e2e-testing")
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := newPlugin(tc.c, fakeroot, tc.c.allowExperimental)
+			if tc.err != "" {
+				assert.ErrorContains(t, err, tc.err)
+			} else if tc.invalid != "" {
+				assert.NilError(t, err)
+				assert.Assert(t, cmp.ErrorType(p.Err, reflect.TypeOf(&pluginError{})))
+				assert.ErrorContains(t, p.Err, tc.invalid)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, NamePrefix+p.Name, goodPluginName)
+				assert.Equal(t, p.SchemaVersion, "0.1.0")
+				assert.Equal(t, p.Vendor, "e2e-testing")
+			}
+		})
 	}
 }
 

--- a/cli-plugins/manager/candidate_test.go
+++ b/cli-plugins/manager/candidate_test.go
@@ -12,9 +12,14 @@ import (
 )
 
 type fakeCandidate struct {
-	path string
-	exec bool
-	meta string
+	path              string
+	exec              bool
+	meta              string
+	allowExperimental bool
+}
+
+func (c *fakeCandidate) Experimental() bool {
+	return c.allowExperimental
 }
 
 func (c *fakeCandidate) Path() string {
@@ -35,9 +40,10 @@ func TestValidateCandidate(t *testing.T) {
 		builtinName  = NamePrefix + "builtin"
 		builtinAlias = NamePrefix + "alias"
 
-		badPrefixPath  = "/usr/local/libexec/cli-plugins/wobble"
-		badNamePath    = "/usr/local/libexec/cli-plugins/docker-123456"
-		goodPluginPath = "/usr/local/libexec/cli-plugins/" + goodPluginName
+		badPrefixPath          = "/usr/local/libexec/cli-plugins/wobble"
+		badNamePath            = "/usr/local/libexec/cli-plugins/docker-123456"
+		goodPluginPath         = "/usr/local/libexec/cli-plugins/" + goodPluginName
+		experimentalPluginPath = "/usr/local/libexec/cli-plugins-experimental/" + goodPluginName
 	)
 
 	fakeroot := &cobra.Command{Use: "docker"}
@@ -67,10 +73,13 @@ func TestValidateCandidate(t *testing.T) {
 		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "xyzzy"}`}, invalid: `plugin SchemaVersion "xyzzy" is not valid`},
 		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0"}`}, invalid: "plugin metadata does not define a vendor"},
 		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": ""}`}, invalid: "plugin metadata does not define a vendor"},
+		{c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`}, invalid: "requires experimental CLI"},
 		// This one should work
 		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`}},
+		{c: &fakeCandidate{path: goodPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`, allowExperimental: true}},
+		{c: &fakeCandidate{path: experimentalPluginPath, exec: true, meta: `{"SchemaVersion": "0.1.0", "Vendor": "e2e-testing"}`, allowExperimental: true}},
 	} {
-		p, err := newPlugin(tc.c, fakeroot)
+		p, err := newPlugin(tc.c, fakeroot, tc.c.allowExperimental)
 		if tc.err != "" {
 			assert.ErrorContains(t, err, tc.err)
 		} else if tc.invalid != "" {

--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,33 +53,40 @@ func TestListPluginCandidates(t *testing.T) {
 
 	candidates, err := listPluginCandidates(dirs)
 	assert.NilError(t, err)
-	exp := map[string][]string{
+	exp := map[string][]candidate{
 		"plugin1": {
-			dir.Join("plugins1", "docker-plugin1"),
-			dir.Join("plugins2", "docker-plugin1"),
-			dir.Join("plugins3", "docker-plugin1"),
+			{path: dir.Join("plugins1", "docker-plugin1")},
+			{path: dir.Join("plugins2", "docker-plugin1")},
+			{path: dir.Join("plugins3", "docker-plugin1")},
 		},
 		"symlinked1": {
-			dir.Join("plugins1", "docker-symlinked1"),
+			{path: dir.Join("plugins1", "docker-symlinked1")},
 		},
 		"symlinked2": {
-			dir.Join("plugins1", "docker-symlinked2"),
+			{path: dir.Join("plugins1", "docker-symlinked2")},
 		},
 		"hardlink1": {
-			dir.Join("plugins2", "docker-hardlink1"),
+			{path: dir.Join("plugins2", "docker-hardlink1")},
 		},
 		"hardlink2": {
-			dir.Join("plugins2", "docker-hardlink2"),
+			{path: dir.Join("plugins2", "docker-hardlink2")},
 		},
 		"brokensymlink": {
-			dir.Join("plugins3", "docker-brokensymlink"),
+			{path: dir.Join("plugins3", "docker-brokensymlink")},
 		},
 		"symlinked": {
-			dir.Join("plugins3", "docker-symlinked"),
+			{path: dir.Join("plugins3", "docker-symlinked")},
 		},
 	}
 
-	assert.DeepEqual(t, candidates, exp)
+	for name, candidateList := range candidates {
+		for i, c := range candidateList {
+			t.Run(fmt.Sprintf("%s-%d", name, i), func(t *testing.T) {
+				assert.Equal(t, c.path, exp[name][i].path)
+				assert.Equal(t, c.experimental, exp[name][i].experimental)
+			})
+		}
+	}
 }
 
 func TestErrPluginNotFound(t *testing.T) {

--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -33,7 +33,9 @@ type Plugin struct {
 // is set, and is always a `pluginError`, but the `Plugin` is still
 // returned with no error. An error is only returned due to a
 // non-recoverable error.
-func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
+//
+// nolint: gocyclo
+func newPlugin(c Candidate, rootcmd *cobra.Command, allowExperimental bool) (Plugin, error) {
 	path := c.Path()
 	if path == "" {
 		return Plugin{}, errors.New("plugin candidate path cannot be empty")
@@ -56,6 +58,11 @@ func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
 	p := Plugin{
 		Name: strings.TrimPrefix(fullname, NamePrefix),
 		Path: path,
+	}
+
+	if c.Experimental() && !allowExperimental {
+		p.Err = &pluginError{errPluginRequireExperimental(p.Name)}
+		return p, nil
 	}
 
 	// Now apply the candidate tests, so these update p.Err.
@@ -94,7 +101,6 @@ func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
 		p.Err = wrapAsPluginError(err, "invalid metadata")
 		return p, nil
 	}
-
 	if p.Metadata.SchemaVersion != "0.1.0" {
 		p.Err = NewPluginError("plugin SchemaVersion %q is not valid, must be 0.1.0", p.Metadata.SchemaVersion)
 		return p, nil


### PR DESCRIPTION
This is an alternative to #1898

Closes #1897 #1898

Related to https://github.com/docker/docker-ce-packaging/pull/332

This patch expands the cli plugin search paths by adding `-experimental` to each,
only if the CLI has experimental mode enabled.

To test that experimental plugins do not work by default:
```
$ ln -s plugins-linux-amd64 build/plugins-linux-amd64-experimental
$ vim ~/.config/docker.json # add $(pwd)/build/plugins-linux-amd64 to "cliPluginsExtraDirs"
$ make plugins
$ make binary
$ docker helloworld
```

To show it enabled:
```
DOCKER_CLI_EXPERIMENTAL=enabled docker helloworld
```

Signed-off-by: Tibor Vass <tibor@docker.com>
