### PR TITLE
Clarifying the service ls filter on name only uses the prefix

### DIFF
--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -113,12 +113,16 @@ w7y0v2yrn620        top                 global              1/1                 
 
 #### name
 
-The `name` filter matches on all or part of a service's name.
+The `name` filter matches on all or a prefix of the service's name.
 
-The following filter matches services with a name containing `redis`.
+The following filter commands match services with a name containing `redis`.
 
 ```bash
 $ docker service ls --filter name=redis
+ID            NAME   MODE        REPLICAS  IMAGE
+0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
+
+$ docker service ls --filter name=red
 ID            NAME   MODE        REPLICAS  IMAGE
 0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
 ```


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Doc clarification since a name filter will not match on a service name's suffix.

**- How I did it**

Edit to the markdown. No code changes.

**- How to verify it**

Create any service and attempt to filter on the suffix rather than prefix of the service name. This does not work so the docs should be updated to match the behavior.

**- Description for the changelog**

See the following references to users confused by this behavior:

https://github.com/moby/moby/issues/37054
https://stackoverflow.com/q/56325695/596285

**- A picture of a cute animal (not mandatory but encouraged)**

![turtle pic](https://www.maxpixel.net/static/photo/1x/Turtle-Cute-Reptile-Macro-Animal-Bubble-1868436.jpg)