### PR TITLE
[19.03 backport] Introduce .zip import for docker context

### DIFF
--- a/cli/command/context/import.go
+++ b/cli/command/context/import.go
@@ -14,7 +14,7 @@ import (
 func newImportCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import CONTEXT FILE|-",
-		Short: "Import a context from a tar file",
+		Short: "Import a context from a tar or zip file",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunImport(dockerCli, args[0], args[1])
@@ -28,6 +28,7 @@ func RunImport(dockerCli command.Cli, name string, source string) error {
 	if err := checkContextNameForCreation(dockerCli.ContextStore(), name); err != nil {
 		return err
 	}
+
 	var reader io.Reader
 	if source == "-" {
 		reader = dockerCli.In()
@@ -43,6 +44,7 @@ func RunImport(dockerCli command.Cli, name string, source string) error {
 	if err := store.Import(name, dockerCli.ContextStore(), reader); err != nil {
 		return err
 	}
+
 	fmt.Fprintln(dockerCli.Out(), name)
 	fmt.Fprintf(dockerCli.Err(), "Successfully imported context %q\n", name)
 	return nil

--- a/cli/context/store/io_utils.go
+++ b/cli/context/store/io_utils.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"errors"
+	"io"
+)
+
+// LimitedReader is a fork of io.LimitedReader to override Read.
+type LimitedReader struct {
+	R io.Reader
+	N int64 // max bytes remaining
+}
+
+// Read is a fork of io.LimitedReader.Read that returns an error when limit exceeded.
+func (l *LimitedReader) Read(p []byte) (n int, err error) {
+	if l.N < 0 {
+		return 0, errors.New("read exceeds the defined limit")
+	}
+	if l.N == 0 {
+		return 0, io.EOF
+	}
+	// have to cap N + 1 otherwise we won't hit limit err
+	if int64(len(p)) > l.N+1 {
+		p = p[0 : l.N+1]
+	}
+	n, err = l.R.Read(p)
+	l.N -= int64(n)
+	return n, err
+}

--- a/cli/context/store/io_utils_test.go
+++ b/cli/context/store/io_utils_test.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestLimitReaderReadAll(t *testing.T) {
+	r := strings.NewReader("Reader")
+
+	_, err := ioutil.ReadAll(r)
+	assert.NilError(t, err)
+
+	r = strings.NewReader("Test")
+	_, err = ioutil.ReadAll(&LimitedReader{R: r, N: 4})
+	assert.NilError(t, err)
+
+	r = strings.NewReader("Test")
+	_, err = ioutil.ReadAll(&LimitedReader{R: r, N: 2})
+	assert.Error(t, err, "read exceeds the defined limit")
+}


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1895 for 19.03


Adds capabilities to import a .zip file with importZip.
Detects the content type of source by checking bytes & DetectContentType.
Adds LimitedReader reader, a fork of io.LimitedReader,
was needed for better error messaging instead of just getting back EOF.
We are using limited reader to avoid very big files causing memory issues.
Adds a new file size limit for context imports,
this limit is used for the main file for .zip & .tar and individual compressed
files for .zip.
Added TestImportZip that will check the import content type
Then will assert no err on Importing .zip file

Signed-off-by: Goksu Toprak <goksu.toprak@docker.com>
(cherry picked from commit 291e86289be4ab78840154933b6e744dd6a5fc8e)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

