### PR TITLE
container start wrong error check

### DIFF
--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -154,7 +154,7 @@ func runStart(dockerCli command.Cli, opts *startOptions) error {
 			}
 		}
 		if attachErr := <-cErr; attachErr != nil {
-			if _, ok := err.(term.EscapeError); ok {
+			if _, ok := attachErr.(term.EscapeError); ok {
 				// The user entered the detach escape sequence.
 				return nil
 			}


### PR DESCRIPTION
noticed that when checking for if the user has entered the escape sequence
after starting the container, the code was checking that the error from
inspect was a term.EscapeError rather than the error from attach in order to
mask the error returned to a nil one - I think this is the error that was
intended to be checked here.

I did not add any tests, sorry, and I'm just gonna go with the social experiment to see
if I can get away with it first ;)