### PR TITLE
REMOVE MULTIPLE CREDENTIAL ERASES

### DIFF
--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -31,24 +31,25 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 
 func runLogout(dockerCli command.Cli, serverAddress string) error {
 	ctx := context.Background()
-	var isDefaultRegistry bool
-
-	if serverAddress == "" {
-		serverAddress = command.ElectAuthServer(ctx, dockerCli)
-		isDefaultRegistry = true
-	}
 
 	var (
-		loggedIn        bool
-		regsToLogout    []string
 		hostnameAddress = serverAddress
-		regsToTry       []string
+		loggedIn        bool     // is set later, when checking for credentials
+		regsToTry       []string // is set based on the type of registry
 	)
-	if !isDefaultRegistry {
+
+	// differentiate between default und private registry
+	if serverAddress == "" {
+		// if no server address given, handle case for default registry
+		serverAddress = command.ElectAuthServer(ctx, dockerCli)
+		regsToTry = []string{serverAddress}
+	} else {
+		// if server address given, handle case for private registry
 		hostnameAddress = registry.ConvertToHostname(serverAddress)
+
 		// the tries below are kept for backward compatibility where a user could have
 		// saved the registry in one of the following format.
-		regsToTry = append(regsToTry, hostnameAddress, "http://"+hostnameAddress, "https://"+hostnameAddress)
+		regsToTry = []string{hostnameAddress, "http://" + hostnameAddress, "https://" + hostnameAddress}
 	}
 
 	// check if we're logged in based on the records in the config file
@@ -56,20 +57,18 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 	for _, s := range regsToTry {
 		if _, ok := dockerCli.ConfigFile().AuthConfigs[s]; ok {
 			loggedIn = true
-			regsToLogout = append(regsToLogout, s)
+
+			// remove credentials, for found auth config
+			fmt.Fprintf(dockerCli.Out(), "Removing login credentials for %s\n", hostnameAddress)
+			if err := dockerCli.ConfigFile().GetCredentialsStore(s).Erase(s); err != nil {
+				fmt.Fprintf(dockerCli.Err(), "WARNING: could not erase credentials: %v\n", err)
+			}
 		}
 	}
 
 	if !loggedIn {
 		fmt.Fprintf(dockerCli.Out(), "Not logged in to %s\n", hostnameAddress)
 		return nil
-	}
-
-	fmt.Fprintf(dockerCli.Out(), "Removing login credentials for %s\n", hostnameAddress)
-	for _, r := range regsToLogout {
-		if err := dockerCli.ConfigFile().GetCredentialsStore(r).Erase(r); err != nil {
-			fmt.Fprintf(dockerCli.Err(), "WARNING: could not erase credentials: %v\n", err)
-		}
 	}
 
 	return nil

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -42,7 +42,7 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 		loggedIn        bool
 		regsToLogout    []string
 		hostnameAddress = serverAddress
-		regsToTry       = []string{serverAddress}
+		regsToTry       []string
 	)
 	if !isDefaultRegistry {
 		hostnameAddress = registry.ConvertToHostname(serverAddress)

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -33,9 +33,8 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 	ctx := context.Background()
 
 	var (
-		hostnameAddress = serverAddress
-		loggedIn        bool     // is set later, when checking for credentials
-		regsToTry       []string // is set based on the type of registry
+		loggedIn  bool     // is set later, when checking for credentials
+		regsToTry []string // is set based on the type of registry
 	)
 
 	// differentiate between default und private registry
@@ -45,7 +44,7 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 		regsToTry = []string{serverAddress}
 	} else {
 		// if server address given, handle case for private registry
-		hostnameAddress = registry.ConvertToHostname(serverAddress)
+		hostnameAddress := registry.ConvertToHostname(serverAddress)
 
 		// the tries below are kept for backward compatibility where a user could have
 		// saved the registry in one of the following format.
@@ -59,7 +58,7 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 			loggedIn = true
 
 			// remove credentials, for found auth config
-			fmt.Fprintf(dockerCli.Out(), "Removing login credentials for %s\n", hostnameAddress)
+			fmt.Fprintf(dockerCli.Out(), "Removing login credentials for %s\n", serverAddress)
 			if err := dockerCli.ConfigFile().GetCredentialsStore(s).Erase(s); err != nil {
 				fmt.Fprintf(dockerCli.Err(), "WARNING: could not erase credentials: %v\n", err)
 			}
@@ -67,7 +66,7 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 	}
 
 	if !loggedIn {
-		fmt.Fprintf(dockerCli.Out(), "Not logged in to %s\n", hostnameAddress)
+		fmt.Fprintf(dockerCli.Out(), "Not logged in to %s\n", serverAddress)
 		return nil
 	}
 


### PR DESCRIPTION
**- What I did**
Fixed the problem of `docker logout` trying to erase credentials multiple times, which leads to an error when credentials no longer exist. This happened with the macOS keychain as well as with pass on Ubuntu 18.04. Fixes #204 

**- How I did it**
When starting to arrange the server addresses to be checked, the program initialized the slice (regsToTry) with the original server address. If this address is already blank (without any prefix or suffix, e.g. "8.8.8.8"), it is inserted twice in the slice. I simply removed the original server address from the initialization of the slice.

**- How to verify it**
Since it is pure string manipulation, it is pretty obvious. However, all server addresses are already cleaned up and reduced to the host name, when registering the credentials on `docker login`. Therefore, uncleaned server addresses shall not occur and they don't need to be checked/erased on logout.

**- Description for the changelog**
Remove duplicate credential erases on `docker logout`.

**- A picture of a cute animal**
![Rottnest-Island-Wildlife-Quokka-Australia-Animal-2676171](https://user-images.githubusercontent.com/21663692/58893482-8e594980-86f0-11e9-9452-091135a088af.jpg)