### PR TITLE
[19.03] Backport #1857: Support GOARM and windows .exe in binary target

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -21,7 +21,7 @@ ifeq ($(DOCKER_CLI_GO_BUILD_CACHE),y)
 DOCKER_CLI_MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
 endif
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS -e GOOS -e GOARCH -e GOARM
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -22,5 +22,18 @@ export LDFLAGS="\
 
 GOOS="${GOOS:-$(go env GOHOSTOS)}"
 GOARCH="${GOARCH:-$(go env GOHOSTARCH)}"
-export TARGET="build/docker-$GOOS-$GOARCH"
+if [ "${GOARCH}" = "arm" ]; then
+	GOARM="${GOARM:-$(go env GOHOSTARM)}"
+fi
+
+TARGET="build/docker-$GOOS-$GOARCH"
+if [ "${GOARCH}" = "arm" ] && [ -n "${GOARM}" ]; then
+	TARGET="${TARGET}-v${GOARM}"
+fi
+
+if [ "${GOOS}" = "windows" ]; then
+	TARGET="${TARGET}.exe"
+fi
+export TARGET
+
 export SOURCE="github.com/docker/cli/cmd/docker"


### PR DESCRIPTION
Backports  #1857

Figured lets go ahead and get this on the 19.03 tree.

---

This just makes it easier to build a targeted binary for the
goos/goach/goarm version.

This of course will not work for all cases but is nice to get things
going.
Specifically cross-compiling pkcs for yubikey support requires some
extra work whichis not tackled here.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit 15130e30437ae7ac9f43df36d9e06a2b458fd53d)
Signed-off-by: Brian Goff <cpuguy83@gmail.com>