### PR TITLE
Bump k8s to v.1.14.3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -95,7 +95,7 @@ k8s.io/apimachinery                                 6a84e37a896db9780c75367af8d2
 k8s.io/client-go                                    b8faab9c5193b482cbf69c78578474b7a40e3e6d # kubernetes-1.14.3
 k8s.io/klog                                         71442cd4037d612096940ceb0f3fec3f7fff66e0 # v0.2.0
 k8s.io/kube-openapi                                 5e45bb682580c9be5ffa4d27d367f0eeba125c7b
-k8s.io/kubernetes                                   641856db18352033a0d96dbc99153fa3b27298e5 # v1.14.0
+k8s.io/kubernetes                                   5e53fd6bc17c0dec8434817e69b04a25d8ae0ff0 # v1.14.3
 k8s.io/utils                                        21c4ce38f2a793ec01e925ddc31216500183b773
 sigs.k8s.io/yaml                                    fd68e9863619f6ec2fdd8625fe1f02e7c877e480 # v1.1.0
 vbom.ml/util                                        256737ac55c46798123f754ab7d2c784e2c71783

--- a/vendor.conf
+++ b/vendor.conf
@@ -90,7 +90,7 @@ google.golang.org/grpc                              25c4f928eaa6d96443009bd84238
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
 gopkg.in/yaml.v2                                    5420a8b6744d3b0345ab293f6fcba19c978f1183 # v2.2.1
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
-k8s.io/api                                          40a48860b5abbba9aa891b02b32da429b08d96a0 # kubernetes-1.14.0
+k8s.io/api                                          af9c91bd2759f97bddda2451d5175c758938f12b # kubernetes-1.14.3
 k8s.io/apimachinery                                 d7deff9243b165ee192f5551710ea4285dcfd615 # kubernetes-1.14.0
 k8s.io/client-go                                    6ee68ca5fd8355d024d02f9db0b3b667e8357a0f # kubernetes-1.14.0
 k8s.io/klog                                         71442cd4037d612096940ceb0f3fec3f7fff66e0 # v0.2.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -92,7 +92,7 @@ gopkg.in/yaml.v2                                    5420a8b6744d3b0345ab293f6fcb
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 k8s.io/api                                          af9c91bd2759f97bddda2451d5175c758938f12b # kubernetes-1.14.3
 k8s.io/apimachinery                                 6a84e37a896db9780c75367af8d2ed2bb944022e # kubernetes-1.14.3
-k8s.io/client-go                                    6ee68ca5fd8355d024d02f9db0b3b667e8357a0f # kubernetes-1.14.0
+k8s.io/client-go                                    b8faab9c5193b482cbf69c78578474b7a40e3e6d # kubernetes-1.14.3
 k8s.io/klog                                         71442cd4037d612096940ceb0f3fec3f7fff66e0 # v0.2.0
 k8s.io/kube-openapi                                 5e45bb682580c9be5ffa4d27d367f0eeba125c7b
 k8s.io/kubernetes                                   641856db18352033a0d96dbc99153fa3b27298e5 # v1.14.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -91,7 +91,7 @@ gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2
 gopkg.in/yaml.v2                                    5420a8b6744d3b0345ab293f6fcba19c978f1183 # v2.2.1
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 k8s.io/api                                          af9c91bd2759f97bddda2451d5175c758938f12b # kubernetes-1.14.3
-k8s.io/apimachinery                                 d7deff9243b165ee192f5551710ea4285dcfd615 # kubernetes-1.14.0
+k8s.io/apimachinery                                 6a84e37a896db9780c75367af8d2ed2bb944022e # kubernetes-1.14.3
 k8s.io/client-go                                    6ee68ca5fd8355d024d02f9db0b3b667e8357a0f # kubernetes-1.14.0
 k8s.io/klog                                         71442cd4037d612096940ceb0f3fec3f7fff66e0 # v0.2.0
 k8s.io/kube-openapi                                 5e45bb682580c9be5ffa4d27d367f0eeba125c7b

--- a/vendor/k8s.io/client-go/rest/transport.go
+++ b/vendor/k8s.io/client-go/rest/transport.go
@@ -74,9 +74,10 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			KeyFile:    c.KeyFile,
 			KeyData:    c.KeyData,
 		},
-		Username:    c.Username,
-		Password:    c.Password,
-		BearerToken: c.BearerToken,
+		Username:        c.Username,
+		Password:        c.Password,
+		BearerToken:     c.BearerToken,
+		BearerTokenFile: c.BearerTokenFile,
 		Impersonate: transport.ImpersonationConfig{
 			UserName: c.Impersonate.UserName,
 			Groups:   c.Impersonate.Groups,

--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -228,6 +228,7 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	// blindly overwrite existing values based on precedence
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
+		mergedConfig.BearerTokenFile = configAuthInfo.TokenFile
 	} else if len(configAuthInfo.TokenFile) > 0 {
 		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
 		if err != nil {
@@ -499,8 +500,9 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		if server := config.overrides.ClusterInfo.Server; len(server) > 0 {
 			icc.Host = server
 		}
-		if token := config.overrides.AuthInfo.Token; len(token) > 0 {
-			icc.BearerToken = token
+		if len(config.overrides.AuthInfo.Token) > 0 || len(config.overrides.AuthInfo.TokenFile) > 0 {
+			icc.BearerToken = config.overrides.AuthInfo.Token
+			icc.BearerTokenFile = config.overrides.AuthInfo.TokenFile
 		}
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile


### PR DESCRIPTION
**- What I did**

Bump k8s.io/api kubernetes-1.14.0 -> kubernetes-1.14.3
Bump k8s.io/apimachinery kubernetes-1.14.0 -> kubernetes-1.14.3
Bump k8s.io/client-go kubernetes-1.14.0 -> kubernetes-1.14.3
Bump k8s.io/kubernetes  v1.14.0 -> v1.14.3

**- Description for the changelog**
* Bump k8s to v.1.14.3

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/59282722-a89fa400-8c69-11e9-9e19-7bebcbda3002.png)

