### PR TITLE
fix: add dockerignore read check.

### DIFF
--- a/cli/command/image/build/dockerignore.go
+++ b/cli/command/image/build/dockerignore.go
@@ -37,3 +37,17 @@ func TrimBuildFilesFromExcludes(excludes []string, dockerfile string, dockerfile
 	}
 	return excludes
 }
+
+// OpenDockerignore try to open the .dockerignore file in the context directory
+func OpenDockerignore(contextDir string) error {
+	f, err := os.Open(filepath.Join(contextDir, ".dockerignore"))
+	switch {
+	case os.IsNotExist(err):
+		return nil
+	case err != nil:
+		return err
+	}
+	defer f.Close()
+
+	return nil
+}

--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -103,6 +103,11 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 		} else {
 			dockerfileDir = options.context
 		}
+
+		if err := build.OpenDockerignore(contextDir); err != nil {
+			return errors.Errorf("check .dockerignore failed: %s", err)
+		}
+
 		remote = clientSessionRemote
 	case urlutil.IsGitURL(options.context):
 		remote = options.context


### PR DESCRIPTION
Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fix #1938


**- How I did it**

add `OpenDockerignore` function.

**- How to verify it**

```
(MoeLove) ➜  x cat .dockerignore
cat: .dockerignore: Permission denied
(MoeLove) ➜  x /home/tao/go/src/github.com/docker/cli/build/docker build --no-cache  -t local/ignore . 
check .dockerignore failed: open .dockerignore: permission denied
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: add dockerignore read check.

**- A picture of a cute animal (not mandatory but encouraged)**

