### PR TITLE
fix: docker login autocomplete for zsh

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -9,6 +9,7 @@
 #   - Felix Riedel
 #   - Steve Durrheimer
 #   - Vincent Bernat
+#   - Rohan Verma
 #
 # license:
 #
@@ -2784,7 +2785,7 @@ __docker_subcommand() {
                 $opts_help \
                 "($help -p --password)"{-p=,--password=}"[Password]:password: " \
                 "($help)--password-stdin[Read password from stdin]" \
-                "($help -u --user)"{-u=,--user=}"[Username]:username: " \
+                "($help -u --username)"{-u=,--username=}"[Username]:username: " \
                 "($help -)1:server: " && ret=0
             ;;
         (logout)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changed `--user` to `--username`

**- How I did it**

Edited zsh autocomplete file

**- How to verify it**

You can use zsh and press tab after typing `docker login --`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix for docker login username flag in zsh autocomplete 

**- A picture of a cute animal (not mandatory but encouraged)**

