### PR TITLE
Add log-driver and options to service inspect "pretty" format

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -123,6 +123,17 @@ Secrets:
  Target:	{{$secret.File.Name}}
   Source:	{{$secret.SecretName}}
 {{- end }}{{ end }}
+{{- if .HasLogDriver }}
+Log Driver:
+{{- if .HasLogDriverName }}
+ Name:		{{ .LogDriverName }}
+{{- end }}
+{{- if .LogOpts }}
+ LogOpts:
+{{- range $k, $v := .LogOpts }}
+  {{ $k }}{{if $v }}:       {{ $v }}{{ end }}
+{{- end }}{{ end }}
+{{ end }}
 {{- if .HasResources }}
 Resources:
 {{- if .HasResourceReservations }}
@@ -236,6 +247,21 @@ func (ctx *serviceInspectContext) Name() string {
 
 func (ctx *serviceInspectContext) Labels() map[string]string {
 	return ctx.Service.Spec.Labels
+}
+
+func (ctx *serviceInspectContext) HasLogDriver() bool {
+	return ctx.Service.Spec.TaskTemplate.LogDriver != nil
+}
+
+func (ctx *serviceInspectContext) HasLogDriverName() bool {
+	return ctx.Service.Spec.TaskTemplate.LogDriver.Name != ""
+}
+func (ctx *serviceInspectContext) LogDriverName() string {
+	return ctx.Service.Spec.TaskTemplate.LogDriver.Name
+}
+
+func (ctx *serviceInspectContext) LogOpts() map[string]string {
+	return ctx.Service.Spec.TaskTemplate.LogDriver.Options
 }
 
 func (ctx *serviceInspectContext) Configs() []*swarm.ConfigReference {

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -43,6 +43,12 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 				Labels: map[string]string{"com.label": "foo"},
 			},
 			TaskTemplate: swarm.TaskSpec{
+				LogDriver: &swarm.Driver{
+					Name: "driver",
+					Options: map[string]string{
+						"max-file": "5",
+					},
+				},
 				ContainerSpec: &swarm.ContainerSpec{
 					Image: "foo/bar@sha256:this_is_a_test",
 					Configs: []*swarm.ConfigReference{
@@ -163,7 +169,7 @@ func TestJSONFormatWithNoUpdateConfig(t *testing.T) {
 
 func TestPrettyPrintWithConfigsAndSecrets(t *testing.T) {
 	s := formatServiceInspect(t, NewFormat("pretty"), time.Now())
-
+	assert.Check(t, is.Contains(s, "Log Driver:"), "Pretty print missing Log Driver")
 	assert.Check(t, is.Contains(s, "Configs:"), "Pretty print missing configs")
 	assert.Check(t, is.Contains(s, "Secrets:"), "Pretty print missing secrets")
 	assert.Check(t, is.Contains(s, "Healthcheck:"), "Pretty print missing healthcheck")


### PR DESCRIPTION
**What I did**

Fixes issue #1943 docker inspect not having log information

**How I did it**

Added template for Log Driver information in _serviceInspectPrettyTemplate_

**How to verify it**

```
docker service create --log-driver=json-file --log-opt max-file=5 --name loggie nginx:alpine
docker service inspect --format=pretty loggie
```

**Description for the changelog**

Added Log Driver information in the prettify template.


