### PR TITLE
Allow pushing a manifest to a registry with self-signed TLS certificate

### DIFF
--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -100,27 +100,36 @@ func (c *client) MountBlob(ctx context.Context, sourceRef reference.Canonical, t
 
 // PutManifest sends the manifest to a registry and returns the new digest
 func (c *client) PutManifest(ctx context.Context, ref reference.Named, manifest distribution.Manifest) (digest.Digest, error) {
-	repoEndpoint, err := newDefaultRepositoryEndpoint(ref, c.insecureRegistry)
+	var dgst digest.Digest
+	put := func(ctx context.Context, repo distribution.Repository, ref reference.Named) (bool, error) {
+		manifestService, err := repo.Manifests(ctx)
+		if err != nil {
+			return false, err
+		}
+
+		_, opts, err := getManifestOptionsFromReference(ref)
+		if err != nil {
+			return false, err
+		}
+
+		dgst, err = manifestService.Put(ctx, manifest, opts...)
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	registryService, err := registryService(ref, c.insecureRegistry)
 	if err != nil {
 		return digest.Digest(""), err
 	}
 
-	repo, err := c.getRepositoryForReference(ctx, ref, repoEndpoint)
+	err = c.iterateEndpoints(ctx, ref, registryService.LookupPushEndpoints, put)
 	if err != nil {
 		return digest.Digest(""), err
 	}
 
-	manifestService, err := repo.Manifests(ctx)
-	if err != nil {
-		return digest.Digest(""), err
-	}
-
-	_, opts, err := getManifestOptionsFromReference(ref)
-	if err != nil {
-		return digest.Digest(""), err
-	}
-
-	dgst, err := manifestService.Put(ctx, manifest, opts...)
 	return dgst, errors.Wrapf(err, "failed to put manifest %s", ref)
 }
 
@@ -169,7 +178,12 @@ func (c *client) GetManifest(ctx context.Context, ref reference.Named) (manifest
 		return result.Ref != nil, err
 	}
 
-	err := c.iterateEndpoints(ctx, ref, fetch)
+	registryService, err := registryService(ref, c.insecureRegistry)
+	if err != nil {
+		return result, err
+	}
+
+	err = c.iterateEndpoints(ctx, ref, registryService.LookupPullEndpoints, fetch)
 	return result, err
 }
 
@@ -182,7 +196,12 @@ func (c *client) GetManifestList(ctx context.Context, ref reference.Named) ([]ma
 		return len(result) > 0, err
 	}
 
-	err := c.iterateEndpoints(ctx, ref, fetch)
+	registryService, err := registryService(ref, c.insecureRegistry)
+	if err != nil {
+		return result, err
+	}
+
+	err = c.iterateEndpoints(ctx, ref, registryService.LookupPullEndpoints, fetch)
 	return result, err
 }
 

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -199,7 +199,11 @@ func continueOnError(err error) bool {
 	return false
 }
 
-func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named, lookup func(hostname string) (endpoints []registry.APIEndpoint, err error), each func(context.Context, distribution.Repository, reference.Named) (bool, error)) error {
+func (c *client) iterateEndpoints(
+	ctx context.Context,
+	namedRef reference.Named,
+	lookup func(hostname string) (endpoints []registry.APIEndpoint, err error),
+	each func(context.Context, distribution.Repository, reference.Named) (bool, error)) error {
 	endpoints, err := lookup(reference.Domain(namedRef))
 	if err != nil {
 		return err


### PR DESCRIPTION
**- What I did**
This change enables iterating over all available registry endpoints when pushing a manifest. Before this change, only one endpoint was used. The scheme of that endpoint was set to HTTP if the registry was marked as insecure even if the registry was available via HTTPS. This resulted in an error because a HTTP request was sent to a HTTPS endpoint.

Fixes #1951
**- How I did it**
The change re-uses the function `client.iterateEndpoints()` that was already available. Because that function was only used for reading previously, another parameter `lookup` of type `func` has been added to it. `lookup` is used to get the endpoints to query.

**- How to verify it**
1. Start a Docker registry using a self-signed certificate. Mine is running at `127.0.0.1:52854`.
2. Use `docker manifest create to create a new manifest`
3. Push to the registry, e.g. `docker manifest push 127.0.0.1:52854/debian:stretch-slim-latest`

**- Description for the changelog**
Allow pushing a manifest to a registry with self-signed TLS certificate