### PR TITLE
Fix advanced options for backward compatibility

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -706,6 +707,15 @@ func parseNetworkOpts(copts *containerOptions) (map[string]*networktypes.Endpoin
 		}
 		if _, ok := endpoints[n.Target]; ok {
 			return nil, errdefs.InvalidParameter(errors.Errorf("network %q is specified multiple times", n.Target))
+		}
+
+		// For backward compatibility: if no custom options are provided for the network,
+		// and only a single network is specified, omit the endpoint-configuration
+		// on the client (the daemon will still create it when creating the container)
+		if i == 0 && len(copts.netMode.Value()) == 1 {
+			if ep == nil || reflect.DeepEqual(*ep, networktypes.EndpointSettings{}) {
+				continue
+			}
 		}
 		endpoints[n.Target] = ep
 	}

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -401,13 +401,13 @@ func TestParseNetworkConfig(t *testing.T) {
 		{
 			name:        "single-network-legacy",
 			flags:       []string{"--network", "net1"},
-			expected:    map[string]*networktypes.EndpointSettings{"net1": {}},
+			expected:    map[string]*networktypes.EndpointSettings{},
 			expectedCfg: container.HostConfig{NetworkMode: "net1"},
 		},
 		{
 			name:        "single-network-advanced",
 			flags:       []string{"--network", "name=net1"},
-			expected:    map[string]*networktypes.EndpointSettings{"net1": {}},
+			expected:    map[string]*networktypes.EndpointSettings{},
 			expectedCfg: container.HostConfig{NetworkMode: "net1"},
 		},
 		{


### PR DESCRIPTION
For backward compatibility: if no custom options are provided for the network,
and only a single network is specified, omit the endpoint-configuration
on the client (the daemon will still create it when creating the container)

This fixes an issue on older versions of legacy Swarm, which did not support
`NetworkingConfig.EndpointConfig`.

This was introduced in 5bc09639cc0aa382fdfcd9ca94d7817c8b3073c0 (#1767)

fixes https://github.com/docker/cli/issues/1854
