### PR TITLE
Convert ports before parsing.

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -854,3 +854,34 @@ func TestParseSystemPaths(t *testing.T) {
 		assert.DeepEqual(t, readonlyPaths, tc.readonly)
 	}
 }
+
+func TestConvertToStandardNotation(t *testing.T) {
+	valid := map[string][]string{
+		"10:10/tcp":               {"target=10,published=10"},
+		"30:30":                   {"30:30"},
+		"20:20 80:4444":           {"20:20", "80:4444"},
+		"2500:1500/tcp 1300:1300": {"target=2500,published=1500", "1300:1300"},
+		"200:1500/tcp 80:90/tcp":  {"published=1500,target=200", "target=80,published=90"},
+	}
+
+	inValid := [][]string{
+		{"published=1500,target:444"},
+		{"published=1500,444"},
+		{"published=1500,target,444"},
+	}
+
+	for key, ports := range valid {
+		convertedPorts, err := convertToStandardNotation(ports)
+
+		if err != nil {
+			assert.NilError(t, err)
+		}
+		assert.DeepEqual(t, strings.Split(key, " "), convertedPorts)
+	}
+
+	for _, ports := range inValid {
+		if _, err := convertToStandardNotation(ports); err == nil {
+			t.Fatalf("ConvertToStandardNotation(`%q`) should have failed conversion", ports)
+		}
+	}
+}


### PR DESCRIPTION
Refactor code to allow mixing notation with -p
Closes #1962 

Signed-off-by: Aleksander Piotrowski <apiotrowski312@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
After refactoring and bug fixing. Docker provides better error message with invalid port:
`docker run --rm -p 8080:87888888 busybox`

and works with mixed notation like:
`docker run --rm -p 8080:80 -p published=1500,target=444 busybox`

**- How I did it**
I changed parsePortOpts, before it was iterating over all `-p` args and assuming that all of them are in the same notation. My fix is to iterate over all args and change every with `=` to short notation and then parse it. 

**- How to verify it**
`docker run --rm -p 8080:80 -p published=1500,target=444 busybox`
`docker run --rm -p 8080:87888888 busybox`

**- Description for the changelog**
Fix a bug with parsing `-p` flag with mixed notation


**- A picture of a cute animal (not mandatory but encouraged)**

