### PR TITLE
[19.03 backport] Windows: skip permissions check on key

### DIFF
--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -69,12 +70,14 @@ func loadPrivKey(streams command.Streams, keyPath string, options keyLoadOptions
 }
 
 func getPrivKeyBytesFromPath(keyPath string) ([]byte, error) {
-	fileInfo, err := os.Stat(keyPath)
-	if err != nil {
-		return nil, err
-	}
-	if fileInfo.Mode()&nonOwnerReadWriteMask != 0 {
-		return nil, fmt.Errorf("private key file %s must not be readable or writable by others", keyPath)
+	if runtime.GOOS != "windows" {
+		fileInfo, err := os.Stat(keyPath)
+		if err != nil {
+			return nil, err
+		}
+		if fileInfo.Mode()&nonOwnerReadWriteMask != 0 {
+			return nil, fmt.Errorf("private key file %s must not be readable or writable by others", keyPath)
+		}
 	}
 
 	from, err := os.OpenFile(keyPath, os.O_RDONLY, notary.PrivExecPerms)


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1968 for 19.03

fixes https://github.com/docker/cli/issues/1696

This code was attempting to check Linux file permissions to determine if the key was accessible by other users, which doesn't work, and therefore prevented users on Windows to load keys.

Skipping this check on Windows (correspinding tests were already skipped).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
* Fix docker refusing to load key from delegation.key on Windows
```

**- A picture of a cute animal (not mandatory but encouraged)**
