### PR TITLE
[19.03 backport] bump compose-on-kubernetes v0.4.23

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/coreos/etcd                              d57e8b8d97adfc4a6c224fe11671
 github.com/cpuguy83/go-md2man                       20f5889cbdc3c73dbd2862796665e7c465ade7d1 # v1.0.8
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/dgrijalva/jwt-go                         a2c85815a77d0f951e33ba4db5ae93629a1530af
-github.com/docker/compose-on-kubernetes             7a68f5c914c7e06d7a08dc71608f41811c91f0bc # v0.4.21
+github.com/docker/compose-on-kubernetes             cc4914dfd1b6684a9750a59f3613fc0a95291824 # v0.4.23
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            a004854097417a591c3f6a3aeaab75efae3c5814 https://github.com/docker/engine.git # 19.03 branch
 github.com/docker/docker-credential-helpers         5241b46610f2491efdf9d1c85f1ddf5b02f6d962


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1934

no local changes; just keeping up with upstream
