### PR TITLE
[19.03 backport] Fix Rollback config type interpolation

### DIFF
--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -16,6 +16,8 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	servicePath("deploy", "replicas"):                                toInt,
 	servicePath("deploy", "update_config", "parallelism"):            toInt,
 	servicePath("deploy", "update_config", "max_failure_ratio"):      toFloat,
+	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
+	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
 	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
 	servicePath("ports", interp.PathMatchList, "target"):             toInt,
 	servicePath("ports", interp.PathMatchList, "published"):          toInt,

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -582,7 +582,7 @@ volumes:
 
 func TestLoadWithInterpolationCastFull(t *testing.T) {
 	dict, err := ParseYAML([]byte(`
-version: "3.4"
+version: "3.7"
 services:
   web:
     configs:
@@ -597,6 +597,9 @@ services:
     deploy:
       replicas: $theint
       update_config:
+        parallelism: $theint
+        max_failure_ratio: $thefloat
+      rollback_config:
         parallelism: $theint
         max_failure_ratio: $thefloat
       restart_policy:
@@ -649,7 +652,7 @@ networks:
 	assert.NilError(t, err)
 	expected := &types.Config{
 		Filename: "filename.yml",
-		Version:  "3.4",
+		Version:  "3.7",
 		Services: []types.ServiceConfig{
 			{
 				Name: "web",
@@ -672,6 +675,10 @@ networks:
 				Deploy: types.DeployConfig{
 					Replicas: uint64Ptr(555),
 					UpdateConfig: &types.UpdateConfig{
+						Parallelism:     uint64Ptr(555),
+						MaxFailureRatio: 3.14,
+					},
+					RollbackConfig: &types.UpdateConfig{
 						Parallelism:     uint64Ptr(555),
 						MaxFailureRatio: 3.14,
 					},


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1973
**- What I did**

Rollback config type interpolation on fields "parallelism" and "max_failure_ratio" were missing, as it uses the same type as update_config.

It addresses https://github.com/docker/app/issues/559


**- Description for the changelog**
* Fix Rollback config type interpolation

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/60183491-b5ee8e00-9826-11e9-98df-b1ed34ea10ed.png)

