### PR TITLE
e2e: TestSigProxyWithTTY increase timeout

### DIFF
--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -53,6 +53,11 @@ func containerExistsWithStatus(t *testing.T, containerID, status string) func(po
 		if actual == status {
 			return poll.Success()
 		}
+		if result.Error != nil {
+			t.Log(result.Error)
+		}
+		t.Log(result.Stderr())
+		t.Log(result.Stdout())
 		return poll.Continue("expected status %s != %s", status, actual)
 	}
 }

--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -46,7 +46,7 @@ func TestSigProxyWithTTY(t *testing.T) {
 
 func containerExistsWithStatus(t *testing.T, containerID, status string) func(poll.LogT) poll.Result {
 	return func(poll.LogT) poll.Result {
-		result := icmd.RunCommand("docker", "inspect", "-f", "{{ .State.Status }}", containerID)
+		result := icmd.RunCommand("docker", "container", "inspect", "-f", "{{ .State.Status }}", containerID)
 		// ignore initial failures as the container may not yet exist (i.e., don't result.Assert(t, icmd.Success))
 
 		actual := strings.TrimSpace(result.Stdout())

--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -34,14 +34,14 @@ func TestSigProxyWithTTY(t *testing.T) {
 	assert.NilError(t, err, "failed to start container")
 	defer icmd.RunCommand("docker", "container", "rm", "-f", containerName)
 
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
 
 	pid := cmd.Process.Pid
 	t.Logf("terminating PID %d", pid)
 	err = syscall.Kill(pid, syscall.SIGTERM)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
 }
 
 func containerExistsWithStatus(t *testing.T, containerID, status string) func(poll.LogT) poll.Result {

--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -21,7 +21,7 @@ func TestSigProxyWithTTY(t *testing.T) {
 	assert.NilError(t, err, "could not open pty")
 
 	containerName := "repro-28872"
-	cmd := exec.Command("docker", "run", "-i", "-t", "--init", "--name", containerName, fixtures.BusyboxImage, "sleep", "30")
+	cmd := exec.Command("docker", "run", "-i", "-t", "--init", "--name", containerName, fixtures.BusyboxImage, "sleep", "300")
 	cmd.Stdin = tty
 	cmd.Stdout = tty
 	cmd.Stderr = tty
@@ -34,14 +34,14 @@ func TestSigProxyWithTTY(t *testing.T) {
 	assert.NilError(t, err, "failed to start container")
 	defer icmd.RunCommand("docker", "container", "rm", "-f", containerName)
 
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(20*time.Second))
 
 	pid := cmd.Process.Pid
 	t.Logf("terminating PID %d", pid)
 	err = syscall.Kill(pid, syscall.SIGTERM)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(10*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(20*time.Second))
 }
 
 func containerExistsWithStatus(t *testing.T, containerID, status string) func(poll.LogT) poll.Result {


### PR DESCRIPTION
This test started failing now all of a sudden;https://github.com/docker/cli/pull/1990#issuecomment-510002202 https://github.com/docker/cli/pull/1841#issuecomment-484855473

Testing if it's just slowness in Jenkins

```
10:06:29 === FAIL: e2e/container TestSigProxyWithTTY (6.52s)
10:06:29     proxy_signal_test.go:38: terminating PID 3438
10:06:29     proxy_signal_test.go:42: timeout hit after 5s: expected status exited != running
```