### PR TITLE
e2e: use stable-dind image for testing

### DIFF
--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -5,7 +5,7 @@ services:
     image: 'registry:2'
 
   engine:
-      image: 'docker:${TEST_ENGINE_VERSION:-edge-dind}'
+      image: 'docker:${TEST_ENGINE_VERSION:-stable-dind}'
       privileged: true
       command: ['--insecure-registry=registry:5000']
 


### PR DESCRIPTION
The edge channel is deprecated and no longer updated

