### PR TITLE
e2e: remove docker engine testing remnants

### DIFF
--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,7 +1,5 @@
 ARG GO_VERSION=1.12.6
 
-FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
-
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}
 
@@ -9,10 +7,6 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     openssl \
-    btrfs-tools \
-    libapparmor-dev \
-    libseccomp-dev \
-    iptables \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
These changes were made as part of the `docker engine` feature in commit fd2f1b3b6650b53ed1367b84910e0f81e89220cd (https://github.com/docker/cli/pull/1260), but later reverted in f250152bf4932375fd279a4a8f27ca721cbaa948(https://github.com/docker/cli/pull/1381) and b7ec4a42d900c631d912b1ea8493752ee534b15f (https://github.com/docker/cli/pull/1385)

These lines were forgotten to be removed, and should no longer be needed.

