### PR TITLE
Bump golang 1.12.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.12.6
+  GOVERSION: 1.12.7
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.12.6-alpine
+FROM    golang:1.12.7-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.12.6
+FROM	dockercore/golang-cross:1.12.7
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.12.6-alpine
+FROM    golang:1.12.7-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.12.6
+ARG GO_VERSION=1.12.7
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.12.6-alpine
+FROM    golang:1.12.7-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.12.7 (released 2019/07/08) includes fixes to cgo, the compiler, and the
linker. See the Go 1.12.7 milestone on our issue tracker for details:
https://github.com/golang/go/issues?q=milestone%3AGo1.12.7

full diff: https://github.com/golang/go/compare/go1.12.6...go1.12.7

