### PR TITLE
docker ps: add State field to formatting

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -44,6 +44,7 @@ func NewContainerFormat(source string, quiet bool, size bool) Format {
 image: {{.Image}}
 command: {{.Command}}
 created_at: {{.CreatedAt}}
+state: {{- pad .State 1 0}}
 status: {{- pad .Status 1 0}}
 names: {{.Names}}
 labels: {{- pad .Labels 1 0}}
@@ -87,6 +88,7 @@ func newContainerContext() *containerContext {
 		"CreatedAt":    CreatedAtHeader,
 		"RunningFor":   runningForHeader,
 		"Ports":        PortsHeader,
+		"State":        StateHeader,
 		"Status":       StatusHeader,
 		"Size":         SizeHeader,
 		"Labels":       LabelsHeader,
@@ -167,6 +169,10 @@ func (c *containerContext) RunningFor() string {
 
 func (c *containerContext) Ports() string {
 	return DisplayablePorts(c.c.Ports)
+}
+
+func (c *containerContext) State() string {
+	return c.c.State
 }
 
 func (c *containerContext) Status() string {

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -168,6 +168,10 @@ containerID2        ubuntu              ""                  24 hours ago        
 			Context{Format: NewContainerFormat("table", true, false)},
 			"containerID1\ncontainerID2\n",
 		},
+		{
+			Context{Format: NewContainerFormat("table {{.State}}", false, true)},
+			"STATE\nrunning\nrunning\n",
+		},
 		// Raw Format
 		{
 			Context{Format: NewContainerFormat("raw", false, false)},
@@ -175,6 +179,7 @@ containerID2        ubuntu              ""                  24 hours ago        
 image: ubuntu
 command: ""
 created_at: %s
+state: running
 status:
 names: foobar_baz
 labels:
@@ -184,6 +189,7 @@ container_id: containerID2
 image: ubuntu
 command: ""
 created_at: %s
+state: running
 status:
 names: foobar_bar
 labels:
@@ -197,6 +203,7 @@ ports:
 image: ubuntu
 command: ""
 created_at: %s
+state: running
 status:
 names: foobar_baz
 labels:
@@ -207,6 +214,7 @@ container_id: containerID2
 image: ubuntu
 command: ""
 created_at: %s
+state: running
 status:
 names: foobar_bar
 labels:
@@ -237,8 +245,8 @@ size: 0B
 
 	for _, testcase := range cases {
 		containers := []types.Container{
-			{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unixTime},
-			{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unixTime},
+			{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unixTime, State: "running"},
+			{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unixTime, State: "running"},
 		}
 		out := bytes.NewBufferString("")
 		testcase.context.Output = out
@@ -314,8 +322,8 @@ func TestContainerContextWriteWithNoContainers(t *testing.T) {
 func TestContainerContextWriteJSON(t *testing.T) {
 	unix := time.Now().Add(-65 * time.Second).Unix()
 	containers := []types.Container{
-		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unix},
-		{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unix},
+		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unix, State: "running"},
+		{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unix, State: "running"},
 	}
 	expectedCreated := time.Unix(unix, 0).String()
 	expectedJSONs := []map[string]interface{}{
@@ -332,6 +340,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			"Ports":        "",
 			"RunningFor":   "About a minute ago",
 			"Size":         "0B",
+			"State":        "running",
 			"Status":       "",
 		},
 		{
@@ -347,6 +356,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			"Ports":        "",
 			"RunningFor":   "About a minute ago",
 			"Size":         "0B",
+			"State":        "running",
 			"Status":       "",
 		},
 	}

--- a/cli/command/formatter/custom.go
+++ b/cli/command/formatter/custom.go
@@ -12,6 +12,7 @@ const (
 	DescriptionHeader  = "DESCRIPTION"
 	DriverHeader       = "DRIVER"
 	ScopeHeader        = "SCOPE"
+	StateHeader        = "STATE"
 	StatusHeader       = "STATUS"
 	PortsHeader        = "PORTS"
 	ImageHeader        = "IMAGE"

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -397,7 +397,8 @@ Valid placeholders for the Go template are listed below:
 | `.CreatedAt`  | Time when the container was created.                                                            |
 | `.RunningFor` | Elapsed time since the container was started.                                                   |
 | `.Ports`      | Exposed ports.                                                                                  |
-| `.Status`     | Container status.                                                                               |
+| `.State`      | Container status (for example; "created", "running", "exited").                                 |
+| `.Status`     | Container status with details about duration and health-status.                                 |
 | `.Size`       | Container disk size.                                                                            |
 | `.Names`      | Container names.                                                                                |
 | `.Labels`     | All labels assigned to the container.                                                           |


### PR DESCRIPTION
The State field allows printing the container state without
additional information about uptime, healthcheck, etc.

With this patch, the container's state can be printed independently:

```bash
docker ps -a --format '{{.State}}'
running
paused
exited
created
```

```bash
docker ps -a --format 'table {{.Names}}\t{{.State}}\t{{.Status}}'
NAMES                     STATE               STATUS
elastic_burnell           running             Up About a minute
pausie                    paused              Up 5 minutes (Paused)
peaceful_stonebraker      exited              Exited (0) 10 hours ago
vigilant_shaw             created             Created
```

```bash
docker ps -a --format 'raw'

container_id: 0445f73f3a71
image: docker-cli-dev
command: "ash"
created_at: 2019-07-12 11:16:11 +0000 UTC
state: running
status: Up 2 minutes
names: elastic_burnell
labels:
ports:

container_id: 1aff69a3912c
image: nginx:alpine
command: "nginx -g 'daemon of ..."
created_at: 2019-07-12 11:12:10 +0000 UTC
state: paused
status: Up 6 minutes (Paused)
names: pausie
labels: maintainer=NGINX Docker Maintainers <docker-maint@nginx.com>
ports: 80/tcp

container_id: d48acf66c318
image: alpine:3.9.3
command: "id -u"
created_at: 2019-07-12 00:52:17 +0000 UTC
state: exited
status: Exited (0) 10 hours ago
names: peaceful_stonebraker
labels:
ports:

container_id: a0733fe0dace
image: b7b28af77ffe
command: "/bin/sh -c '#(nop) ..."
created_at: 2019-07-12 00:51:29 +0000 UTC
state: created
status: Created
names: vigilant_shaw
labels:
ports:
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```Markdown
+ The `docker ps --format` flag now has a `.State` placeholder to print the container's state without additional details about uptime and health check [docker/cli#2000](https://github.com/docker/cli/pull/2000)
```

**- A picture of a cute animal (not mandatory but encouraged)**
