### PR TITLE
Print progress bars to stderr instead of stdout in service commands

### DIFF
--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service/progress"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
 )
 
 // waitOnService waits for the service to converge. It outputs a progress bar,
@@ -25,7 +26,8 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string,
 		return <-errChan
 	}
 
-	err := jsonmessage.DisplayJSONMessagesToStream(pipeReader, dockerCli.Out(), nil)
+	errFD, errIsTerminal := term.GetFdInfo(dockerCli.Err())
+	err := jsonmessage.DisplayJSONMessagesStream(pipeReader, dockerCli.Err(), errFD, errIsTerminal, nil)
 	if err == nil {
 		err = <-errChan
 	}


### PR DESCRIPTION
Signed-off-by: Martin Heralecký <heralecky.martin@gmail.com>
Closes #1647

**- What I did**
Progress bars in `docker service` commands are now printed to `stderr` instead of `stdout`.

**- How I did it**
I modified `waitOnService` function in _command/service/helpers.go_ to use `dockerCli.Err()` instead of `dockerCli.Out()`.

**- How to verify it**
`docker service create nginx:alpine 2> /dev/null` now prints only the `id`, no progress bar.

**- Description for the changelog**
Progress bars in service commands are now printed to stderr instead of stdout.