### PR TITLE
man/docker-build: fix/expand --build-arg

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -84,16 +84,19 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
    Add a line to /etc/hosts. The format is hostname:ip.  The **--add-host**
 option can be set multiple times.
 
-**--build-arg**=*variable*
-   name and value of a **buildarg**.
+**--build-arg**=*name*[=*value*]
+   Set a build-time variable. The *name* is the variable name as it appears
+   in an `ARG` instruction of a Dockerfile. The *value* is optional; if not
+   set, it is taken from the current environment.
+
+   These variables then are accessed like regular environment variables
+   in a `RUN` instruction of the Dockerfile. This mechanism is not meant
+   for passing secret values.
 
    For example, if you want to pass a value for `http_proxy`, use
    `--build-arg=http_proxy="http://some.proxy.url"`
 
-   Users pass these values at build-time. Docker uses the `buildargs` as the
-   environment context for command(s) run via the Dockerfile's `RUN` instruction
-   or for variable expansion in other Dockerfile instructions. This is not meant
-   for passing secret values. [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
+   [Read more about the buildargs instruction](https://docs.docker.com/engine/reference/builder/#arg)
 
 **--cache-from**=""
    Set image that will be used as a build cache source.


### PR DESCRIPTION
* Explain that variable value is optional and is taken from environment if not set.
* Clarify the meaning of ARG.
* Move example to the end.
