### PR TITLE
Dockerfile.e2e: pin to debian stretch variant for now

### DIFF
--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.12.7
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 
 # Use Debian based image as docker-compose requires glibc.
-FROM golang:${GO_VERSION}
+FROM golang:${GO_VERSION}-stretch
 
 RUN apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
We saw a change in behaviour for some tests in moby/moby, and also wondering if this is related to flakiness of the `TestSigProxyWithTTY ` test;  https://github.com/docker/cli/pull/2009#issuecomment-513327698 https://jenkins.dockerproject.org/job/docker/job/cli/job/PR-2009/11/execution/node/28/log/ 

```
01:14:47 === Failed
01:14:47 === FAIL: e2e/container TestSigProxyWithTTY (5.06s)
01:14:47     proxy_signal_test.go:35: timeout hit after 5s: expected status running != 
01:14:47 
01:14:47 
```