### PR TITLE
[18.09] Bump Go to 1.11.12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.11.11
+  GOVERSION: 1.11.12
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-FROM    golang:1.11.11-alpine
+FROM    golang:1.11.12-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,4 +1,4 @@
-FROM	dockercore/golang-cross:1.11.11
+FROM	dockercore/golang-cross:1.11.12
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM    golang:1.11.11-alpine
+FROM    golang:1.11.12-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11.11
+ARG GO_VERSION=1.11.12
 
 FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-FROM    golang:1.11.11-alpine
+FROM    golang:1.11.12-alpine
 
 RUN     apk add -U git
 


### PR DESCRIPTION
go1.11.12 (released 2019/07/08) includes fixes to the compiler and the linker.
See the Go 1.11.12 milestone on our issue tracker for details:

 https://github.com/golang/go/issues?q=milestone%3AGo1.11.12

Full diff: https://github.com/golang/go/compare/go1.11.11...go1.11.12