### PR TITLE
TestSigProxyWithTTY: fix

### DIFF
--- a/e2e/container/proxy_signal_test.go
+++ b/e2e/container/proxy_signal_test.go
@@ -17,29 +17,23 @@ import (
 // TestSigProxyWithTTY tests that killing the docker CLI forwards the signal to
 // the container, and kills the container's process. Test-case for moby/moby#28872
 func TestSigProxyWithTTY(t *testing.T) {
-	_, tty, err := pty.Open()
-	assert.NilError(t, err, "could not open pty")
-	defer func() { _ = tty.Close() }()
+	cmd := exec.Command("docker", "run", "-i", "-t", "--init", "--name", t.Name(), fixtures.BusyboxImage, "sleep", "30")
+	p, err := pty.Start(cmd)
+	defer func() {
+		_ = cmd.Wait()
+		_ = p.Close()
+	}()
+	assert.NilError(t, err, "failed to start container")
+	defer icmd.RunCommand("docker", "container", "rm", "-f", t.Name())
 
-	containerName := "repro-28872"
-	cmd := exec.Command("docker", "run", "-i", "-t", "--init", "--name", containerName, fixtures.BusyboxImage, "sleep", "30")
-	cmd.Stdin = tty
-	cmd.Stdout = tty
-	cmd.Stderr = tty
-
-	err = cmd.Start()
-	out, _ := cmd.CombinedOutput()
-	assert.NilError(t, err, "failed to start container: %s", out)
-	defer icmd.RunCommand("docker", "container", "rm", "-f", containerName)
-
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, t.Name(), "running"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
 
 	pid := cmd.Process.Pid
 	t.Logf("terminating PID %d", pid)
 	err = syscall.Kill(pid, syscall.SIGTERM)
 	assert.NilError(t, err)
 
-	poll.WaitOn(t, containerExistsWithStatus(t, containerName, "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
+	poll.WaitOn(t, containerExistsWithStatus(t, t.Name(), "exited"), poll.WithDelay(100*time.Millisecond), poll.WithTimeout(5*time.Second))
 }
 
 func containerExistsWithStatus(t *testing.T, containerID, status string) func(poll.LogT) poll.Result {


### PR DESCRIPTION
`exec.CombinedOutput()` should not be used here because:
 - it redirects cmd Stdout and Stderr and we want it to be the tty
 - it calls `cmd.Run()` which we already did

While at it
 - use `pty.Start()` as it is cleaner
 - make sure we don't leave a zombie running, by calling `Wait()` in defer
 - use `test.Name()` for `containerName`
