### PR TITLE
Document `FROM image[[:<tag>]@<digest>]` notation as well

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -568,6 +568,10 @@ Or
 
     FROM <image>[@<digest>] [AS <name>]
 
+Or combined(though `<tag>` is ignored)
+
+    FROM <image>[:<tag>@<digest>] [AS <name>]
+
 The `FROM` instruction initializes a new build stage and sets the
 [*Base Image*](glossary.md#base-image) for subsequent instructions. As such, a
 valid `Dockerfile` must start with a `FROM` instruction. The image can be


### PR DESCRIPTION
## Problem
Seeing usages of comments to document the tag while using `@digest` notation 
```dockerfile
// FROM image:1.2.3
FROM image@sha256:9d6ee4c3dd307
```
But composed notation with tag is valid as well 
```dockerfile
FROM image:1.2.3@sha256:9d6ee4c3dd307
```

## Solution
Document the composed notation

**- Description for the changelog**
Document `FROM image[[:<tag>]@<digest>]` notation as well 

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://media.giphy.com/media/1Ai7bJyDcjAOvEnx4W/giphy.gif)

