### PR TITLE
[19.03 backport] Disable TLS for e2e docker-in-docker daemon

### DIFF
--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -8,6 +8,8 @@ services:
       image: 'docker:${TEST_ENGINE_VERSION:-stable-dind}'
       privileged: true
       command: ['--insecure-registry=registry:5000']
+      environment:
+        - DOCKER_TLS_CERTDIR=
 
   notary-server:
       build:

--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -5,7 +5,7 @@ services:
     image: 'registry:2'
 
   engine:
-      image: 'docker:${TEST_ENGINE_VERSION:-edge-dind}'
+      image: 'docker:${TEST_ENGINE_VERSION:-stable-dind}'
       privileged: true
       command: ['--insecure-registry=registry:5000']
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/1992 and https://github.com/docker/cli/pull/2020

The docker-in-docker image now enables TLS by default (added in
docker-library/docker#166), which complicates testing in our
environment, and isn't needed for the tests we're running.

This patch sets the `DOCKER_TLS_CERTDIR` to an empty value to
disable TLS.
