### PR TITLE
Fixed bug mentioned in docker/cli#1962

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -382,20 +382,14 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	var ports map[nat.Port]struct{}
 	var portBindings map[nat.Port][]nat.PortBinding
 
-	ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
-
-	// If simple port parsing fails try to parse as long format
+	publishOpts, err = parsePortOpts(publishOpts)
 	if err != nil {
-		publishOpts, err = parsePortOpts(publishOpts)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
 
-		ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
-
-		if err != nil {
-			return nil, err
-		}
+	ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
+	if err != nil {
+		return nil, err
 	}
 
 	// Merge in exposed ports to the map of published ports
@@ -791,15 +785,19 @@ func parsePortOpts(publishOpts []string) ([]string, error) {
 	optsList := []string{}
 	for _, publish := range publishOpts {
 		params := map[string]string{"protocol": "tcp"}
-		for _, param := range strings.Split(publish, ",") {
-			opt := strings.Split(param, "=")
-			if len(opt) < 2 {
-				return optsList, errors.Errorf("invalid publish opts format (should be name=value but got '%s')", param)
-			}
+		if strings.Index(publish, "=") != -1 {
+			for _, param := range strings.Split(publish, ",") {
+				opt := strings.Split(param, "=")
+				if len(opt) < 2 {
+					return optsList, errors.Errorf("invalid publish opts format (should be name=value but got '%s')", param)
+				}
 
-			params[opt[0]] = opt[1]
+				params[opt[0]] = opt[1]
+			}
+			optsList = append(optsList, fmt.Sprintf("%s:%s/%s", params["target"], params["published"], params["protocol"]))
+		} else {
+			optsList = append(optsList, publish)
 		}
-		optsList = append(optsList, fmt.Sprintf("%s:%s/%s", params["target"], params["published"], params["protocol"]))
 	}
 	return optsList, nil
 }

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -854,3 +854,18 @@ func TestParseSystemPaths(t *testing.T) {
 		assert.DeepEqual(t, readonlyPaths, tc.readonly)
 	}
 }
+
+func TestParsePublishPorts(t *testing.T){
+	valids:= []struct{
+		input []string
+		out []string
+	}{
+		{[]string{"8080:80","4040:443"},[]string{"8080:80","4040:443",}},
+		{[]string{"8080:80","target=4040,published=443"},[]string{"8080:80","4040:443/tcp",}},
+	}
+	for _,testCase:= range valids {
+		if o,_:=parsePortOpts(testCase.input); o[0]!=testCase.out[0] || o[1]!=testCase.out[1]{
+			t.Fatalf("Expected %s and %s ,got %s and %s",testCase.out[0],testCase.out[1],o[0],o[1])
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Anshuman Chhapolia <achhap.10.01@gmail.com>


**- What I did**
After Fixing the bug docker command gives an appropriate result for invalid ports.
```
$ ./docker run -p 808080:80 node
./docker: Invalid hostPort: 808080.
See './docker run --help'.
```
It also allows for mixed notations for port publishing in long and short formats.
```
$ ./docker run -d -p 8080:80 -p target=4040,published=443 node
```

**- How I did it**
Instead of expecting the notation in the shorthand format and if it gives an error and then parsing the long format, parse all the items and checked for '=' if an item contains '=' we can surely say that its a long format. Then I converted the long formats to shorthand format.

**- How to verify it**
Function TestParsePublishPorts() added.
Build and tested the binaries myself. Examples are shown above.

**- Description for the changelog**
Fixed #1962 as suggested by @thaJeztah 


![image](https://user-images.githubusercontent.com/37040303/62832225-bc0ac380-bc48-11e9-8b19-c05cb64fd87c.png)

