### PR TITLE
2030 fixed link when bridge stated

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -763,8 +763,9 @@ func parseNetworkAttachmentOpt(ep opts.NetworkAttachmentOpts) (*networktypes.End
 		if len(ep.Aliases) > 0 {
 			return nil, errors.New("network-scoped aliases are only supported for user-defined networks")
 		}
-		if len(ep.Links) > 0 {
-			return nil, errors.New("links are only supported for user-defined networks")
+		if len(ep.Links) > 0 &&
+			!container.NetworkMode(ep.Target).IsBridge() {
+			return nil, errors.New("links are only supported for user-defined networks and bridge network")
 		}
 	}
 


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/2030

added additional check if it is not default network named 'bridge'
If it is then links can be passed

Can be checked by running:
docker run --network=bridge --link containera:aliasa busybox

Signed-off-by: Wojciech Kosowicz <pcellix@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

