### PR TITLE
[19.03 backport] CI and testing improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
+.dockerignore
 .git
+.gitignore
+appveyor.yml
 build
+circle.yml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,9 @@ wrappedNode(label: 'linux && x86_64', cleanWorkspace: true) {
 
     stage "Run end-to-end test suite"
     sh "docker version"
+    sh "docker info"
     sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
         IMAGE_TAG=clie2e${BUILD_NUMBER} \
-        make -f docker.Makefile test-e2e"
+        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e"
   }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 18.03.1-ce
-            reusable: true
-            exclusive: false
+          version: 18.03.1-ce
+          reusable: true
+          exclusive: false
       - run:
           command: docker version
       - run:
@@ -26,9 +26,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 18.03.1-ce
-            reusable: true
-            exclusive: false
+          version: 18.03.1-ce
+          reusable: true
+          exclusive: false
       - run:
           name: "Cross"
           command: |
@@ -50,9 +50,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 18.03.1-ce
-            reusable: true
-            exclusive: false
+          version: 18.03.1-ce
+          reusable: true
+          exclusive: false
       - run:
           name: "Unit Test with Coverage"
           command: |
@@ -86,9 +86,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 18.03.1-ce
-            reusable: true
-            exclusive: false
+          version: 18.03.1-ce
+          reusable: true
+          exclusive: false
       - run:
           name: "Validate Vendor, Docs, and Code Generation"
           command: |
@@ -103,9 +103,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-            version: 18.03.1-ce
-            reusable: true
-            exclusive: false
+          version: 18.03.1-ce
+          reusable: true
+          exclusive: false
       - run:
           name: "Run shellcheck"
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: "Lint"
           command: |
-            docker build -f dockerfiles/Dockerfile.lint --tag cli-linter:$CIRCLE_BUILD_NUM .
+            docker build --progress=plain -f dockerfiles/Dockerfile.lint --tag cli-linter:$CIRCLE_BUILD_NUM .
             docker run --rm cli-linter:$CIRCLE_BUILD_NUM
 
   cross:
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: "Cross"
           command: |
-            docker build -f dockerfiles/Dockerfile.cross --tag cli-builder:$CIRCLE_BUILD_NUM .
+            docker build --progress=plain -f dockerfiles/Dockerfile.cross --tag cli-builder:$CIRCLE_BUILD_NUM .
             name=cross-$CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX
             docker run \
                 -e CROSS_GROUP=$CIRCLE_NODE_INDEX \
@@ -63,7 +63,7 @@ jobs:
           name: "Unit Test with Coverage"
           command: |
             mkdir -p test-results/unit-tests
-            docker build -f dockerfiles/Dockerfile.dev --tag cli-builder:$CIRCLE_BUILD_NUM .
+            docker build --progress=plain -f dockerfiles/Dockerfile.dev --tag cli-builder:$CIRCLE_BUILD_NUM .
             docker run \
                 -e GOTESTSUM_JUNITFILE=/tmp/junit.xml \
                 --name \
@@ -101,7 +101,7 @@ jobs:
           name: "Validate Vendor, Docs, and Code Generation"
           command: |
             rm -f .dockerignore # include .git
-            docker build -f dockerfiles/Dockerfile.dev --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
+            docker build --progress=plain -f dockerfiles/Dockerfile.dev --tag cli-builder-with-git:$CIRCLE_BUILD_NUM .
             docker run --rm cli-builder-with-git:$CIRCLE_BUILD_NUM \
                 make ci-validate
           no_output_timeout: 15m
@@ -119,7 +119,7 @@ jobs:
       - run:
           name: "Run shellcheck"
           command: |
-            docker build -f dockerfiles/Dockerfile.shellcheck --tag cli-validator:$CIRCLE_BUILD_NUM .
+            docker build --progress=plain -f dockerfiles/Dockerfile.shellcheck --tag cli-validator:$CIRCLE_BUILD_NUM .
             docker run --rm cli-validator:$CIRCLE_BUILD_NUM \
                 make shellcheck
 workflows:

--- a/circle.yml
+++ b/circle.yml
@@ -4,11 +4,11 @@ jobs:
 
   lint:
     working_directory: /work
-    docker: [{image: 'docker:18.03-git'}]
+    docker: [{image: 'docker:18.09-git'}]
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 18.09.3
           reusable: true
           exclusive: false
       - run:
@@ -21,12 +21,12 @@ jobs:
 
   cross:
     working_directory: /work
-    docker: [{image: 'docker:18.03-git'}]
+    docker: [{image: 'docker:18.09-git'}]
     parallelism: 3
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 18.09.3
           reusable: true
           exclusive: false
       - run:
@@ -46,11 +46,11 @@ jobs:
 
   test:
     working_directory: /work
-    docker: [{image: 'docker:18.03-git'}]
+    docker: [{image: 'docker:18.09-git'}]
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 18.09.3
           reusable: true
           exclusive: false
       - run:
@@ -82,11 +82,11 @@ jobs:
 
   validate:
     working_directory: /work
-    docker: [{image: 'docker:18.03-git'}]
+    docker: [{image: 'docker:18.09-git'}]
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 18.09.3
           reusable: true
           exclusive: false
       - run:
@@ -99,11 +99,11 @@ jobs:
           no_output_timeout: 15m
   shellcheck:
     working_directory: /work
-    docker: [{image: 'docker:18.03-git'}]
+    docker: [{image: 'docker:18.09-git'}]
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 18.09.3
           reusable: true
           exclusive: false
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,8 @@ jobs:
   lint:
     working_directory: /work
     docker: [{image: 'docker:18.09-git'}]
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
@@ -22,6 +24,8 @@ jobs:
   cross:
     working_directory: /work
     docker: [{image: 'docker:18.09-git'}]
+    environment:
+      DOCKER_BUILDKIT: 1
     parallelism: 3
     steps:
       - checkout
@@ -47,6 +51,8 @@ jobs:
   test:
     working_directory: /work
     docker: [{image: 'docker:18.09-git'}]
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
@@ -83,6 +89,8 @@ jobs:
   validate:
     working_directory: /work
     docker: [{image: 'docker:18.09-git'}]
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
@@ -100,6 +108,8 @@ jobs:
   shellcheck:
     working_directory: /work
     docker: [{image: 'docker:18.09-git'}]
+    environment:
+      DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,7 +1,5 @@
 ARG GO_VERSION=1.12.8
 
-FROM docker/containerd-shim-process:a4d1531 AS containerd-shim-process
-
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}
 
@@ -9,10 +7,6 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     openssl \
-    btrfs-tools \
-    libapparmor-dev \
-    libseccomp-dev \
-    iptables \
     openssh-client \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Backports of:

- https://github.com/docker/cli/pull/1599 Update CircleCI Docker version to 18.09.3
- ~https://github.com/docker/cli/pull/2008 Dockerfile: use GO_VERSION build-arg for overriding Go version~
  - already included in https://github.com/docker/cli/pull/2044 [19.03 backport] Bump golang 1.12.8 (CVE-2019-9512, CVE-2019-9514)
- https://github.com/docker/cli/pull/2009 CircleCI/Jenkins: use buildkit
- ~https://github.com/docker/cli/pull/2020 Disable TLS for e2e docker-in-docker daemon~
  - already included in https://github.com/docker/cli/pull/2022 [19.03 backport] Disable TLS for e2e docker-in-docker daemon
- https://github.com/docker/cli/pull/1993 e2e: remove docker engine testing remnants


```
# https://github.com/docker/cli/pull/1599 Update CircleCI Docker version to 18.09.3
git cherry-pick -s -S -x 53fc63a93fbceb6af91c50506c197f5af478b5e0 8b19c1d73af85110f819a27f42b5e0a4c3020e48

# https://github.com/docker/cli/pull/2009 CircleCI/Jenkins: use buildkit
git cherry-pick -s -S -x 82e01807bca65843210ef6639679cdd2c063b9ef 9a6519db7696a08bd7ebd78f94641082240127fc ae58e356eadbd1eca6a1c1fe825d236795d0eec8 893db86d6e813223e1e55c81f847e905bccd51a5

# https://github.com/docker/cli/pull/1993 e2e: remove docker engine testing remnants
git cherry-pick -s -S -x de01e72455433f6befee371e8e83ad5f83270461
```