### PR TITLE
bump miekg/pkcs11 v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -51,7 +51,7 @@ github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f027549450
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/Microsoft/go-winio                       84b4ab48a50763fe7b3abcef38e5205c12027fac
 github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
-github.com/miekg/pkcs11                             6120d95c0e9576ccf4a78ba40855809dca31a9ed
+github.com/miekg/pkcs11                             cb39313ec884f2cd77f4762875fe96aecf68f8e3 # v1.0.2
 github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
 github.com/moby/buildkit                            f238f1efb04f00bf0cc147141fda9ddb55c8bc49
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3

--- a/vendor/github.com/miekg/pkcs11/go.mod
+++ b/vendor/github.com/miekg/pkcs11/go.mod
@@ -1,0 +1,3 @@
+module github.com/miekg/pkcs11
+
+go 1.12

--- a/vendor/github.com/miekg/pkcs11/params.go
+++ b/vendor/github.com/miekg/pkcs11/params.go
@@ -42,19 +42,21 @@ type GCMParams struct {
 // NewGCMParams returns a pointer to AES-GCM parameters that can be used with the CKM_AES_GCM mechanism.
 // The Free() method must be called after the operation is complete.
 //
-// *NOTE*
-// Some HSMs, like CloudHSM, will ignore the IV you pass in and write their
+// Note that some HSMs, like CloudHSM, will ignore the IV you pass in and write their
 // own. As a result, to support all libraries, memory is not freed
 // automatically, so that after the EncryptInit/Encrypt operation the HSM's IV
 // can be read back out. It is up to the caller to ensure that Free() is called
 // on the GCMParams object at an appropriate time, which is after
+//
 // Encrypt/Decrypt. As an example:
 //
-// gcmParams := pkcs11.NewGCMParams(make([]byte, 12), nil, 128)
-// p.ctx.EncryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_AES_GCM, gcmParams)}, aesObjHandle)
-// ct, _ := p.ctx.Encrypt(session, pt)
-// iv := gcmParams.IV()
-// gcmParams.Free()
+//    gcmParams := pkcs11.NewGCMParams(make([]byte, 12), nil, 128)
+//    p.ctx.EncryptInit(session, []*pkcs11.Mechanism{pkcs11.NewMechanism(pkcs11.CKM_AES_GCM, gcmParams)},
+//			aesObjHandle)
+//    ct, _ := p.ctx.Encrypt(session, pt)
+//    iv := gcmParams.IV()
+//    gcmParams.Free()
+//
 func NewGCMParams(iv, aad []byte, tagSize int) *GCMParams {
 	return &GCMParams{
 		iv:      iv,
@@ -112,7 +114,7 @@ func (p *GCMParams) Free() {
 	p.arena = nil
 }
 
-// NewPSSParams creates a CK_RSA_PKCS_PSS_PARAMS structure and returns it as a byte array for use with the CKM_RSA_PKCS_PSS mechanism
+// NewPSSParams creates a CK_RSA_PKCS_PSS_PARAMS structure and returns it as a byte array for use with the CKM_RSA_PKCS_PSS mechanism.
 func NewPSSParams(hashAlg, mgf, saltLength uint) []byte {
 	p := C.CK_RSA_PKCS_PSS_PARAMS{
 		hashAlg: C.CK_MECHANISM_TYPE(hashAlg),
@@ -122,7 +124,7 @@ func NewPSSParams(hashAlg, mgf, saltLength uint) []byte {
 	return C.GoBytes(unsafe.Pointer(&p), C.int(unsafe.Sizeof(p)))
 }
 
-// OAEPParams can be passed to NewMechanism to implement CKM_RSA_PKCS_OAEP
+// OAEPParams can be passed to NewMechanism to implement CKM_RSA_PKCS_OAEP.
 type OAEPParams struct {
 	HashAlg    uint
 	MGF        uint
@@ -130,7 +132,7 @@ type OAEPParams struct {
 	SourceData []byte
 }
 
-// NewOAEPParams creates a CK_RSA_PKCS_OAEP_PARAMS structure suitable for use with the CKM_RSA_PKCS_OAEP mechanism
+// NewOAEPParams creates a CK_RSA_PKCS_OAEP_PARAMS structure suitable for use with the CKM_RSA_PKCS_OAEP mechanism.
 func NewOAEPParams(hashAlg, mgf, sourceType uint, sourceData []byte) *OAEPParams {
 	return &OAEPParams{
 		HashAlg:    hashAlg,
@@ -154,14 +156,14 @@ func cOAEPParams(p *OAEPParams, arena arena) ([]byte, arena) {
 	return C.GoBytes(unsafe.Pointer(&params), C.int(unsafe.Sizeof(params))), arena
 }
 
-// ECDH1DeriveParams can be passed to NewMechanism to implement CK_ECDH1_DERIVE_PARAMS
+// ECDH1DeriveParams can be passed to NewMechanism to implement CK_ECDH1_DERIVE_PARAMS.
 type ECDH1DeriveParams struct {
 	KDF           uint
 	SharedData    []byte
 	PublicKeyData []byte
 }
 
-// NewECDH1DeriveParams creates a CK_ECDH1_DERIVE_PARAMS structure suitable for use with the CKM_ECDH1_DERIVE mechanism
+// NewECDH1DeriveParams creates a CK_ECDH1_DERIVE_PARAMS structure suitable for use with the CKM_ECDH1_DERIVE mechanism.
 func NewECDH1DeriveParams(kdf uint, sharedData []byte, publicKeyData []byte) *ECDH1DeriveParams {
 	return &ECDH1DeriveParams{
 		KDF:           kdf,

--- a/vendor/github.com/miekg/pkcs11/pkcs11.go
+++ b/vendor/github.com/miekg/pkcs11/pkcs11.go
@@ -800,13 +800,13 @@ func (c *Ctx) Destroy() {
 	c.ctx = nil
 }
 
-// Initialize initializes the Cryptoki library. */
+// Initialize initializes the Cryptoki library.
 func (c *Ctx) Initialize() error {
 	e := C.Initialize(c.ctx)
 	return toError(e)
 }
 
-// Finalize indicates that an application is done with the Cryptoki library. */
+// Finalize indicates that an application is done with the Cryptoki library.
 func (c *Ctx) Finalize() error {
 	if c.ctx == nil {
 		return toError(CKR_CRYPTOKI_NOT_INITIALIZED)
@@ -815,7 +815,7 @@ func (c *Ctx) Finalize() error {
 	return toError(e)
 }
 
-// GetInfo returns general information about Cryptoki. */
+// GetInfo returns general information about Cryptoki.
 func (c *Ctx) GetInfo() (Info, error) {
 	var p C.ckInfo
 	e := C.GetInfo(c.ctx, &p)
@@ -829,7 +829,7 @@ func (c *Ctx) GetInfo() (Info, error) {
 	return i, toError(e)
 }
 
-// GetSlotList obtains a list of slots in the system. */
+// GetSlotList obtains a list of slots in the system.
 func (c *Ctx) GetSlotList(tokenPresent bool) ([]uint, error) {
 	var (
 		slotList C.CK_ULONG_PTR
@@ -843,7 +843,7 @@ func (c *Ctx) GetSlotList(tokenPresent bool) ([]uint, error) {
 	return l, nil
 }
 
-// GetSlotInfo obtains information about a particular slot in the system. */
+// GetSlotInfo obtains information about a particular slot in the system.
 func (c *Ctx) GetSlotInfo(slotID uint) (SlotInfo, error) {
 	var csi C.CK_SLOT_INFO
 	e := C.GetSlotInfo(c.ctx, C.CK_ULONG(slotID), &csi)
@@ -885,7 +885,7 @@ func (c *Ctx) GetTokenInfo(slotID uint) (TokenInfo, error) {
 	return s, toError(e)
 }
 
-// GetMechanismList obtains a list of mechanism types supported by a token. */
+// GetMechanismList obtains a list of mechanism types supported by a token.
 func (c *Ctx) GetMechanismList(slotID uint) ([]*Mechanism, error) {
 	var (
 		mech    C.CK_ULONG_PTR // in pkcs#11 we're all CK_ULONGs \o/
@@ -997,11 +997,11 @@ func (c *Ctx) GetOperationState(sh SessionHandle) ([]byte, error) {
 		statelen C.CK_ULONG
 	)
 	e := C.GetOperationState(c.ctx, C.CK_SESSION_HANDLE(sh), &state, &statelen)
+	defer C.free(unsafe.Pointer(state))
 	if toError(e) != nil {
 		return nil, toError(e)
 	}
 	b := C.GoBytes(unsafe.Pointer(state), C.int(statelen))
-	C.free(unsafe.Pointer(state))
 	return b, nil
 }
 

--- a/vendor/github.com/miekg/pkcs11/release.go
+++ b/vendor/github.com/miekg/pkcs11/release.go
@@ -1,0 +1,17 @@
+// +build release
+
+package pkcs11
+
+import "fmt"
+
+// Release is current version of the pkcs11 library.
+var Release = R{1, 0, 2}
+
+// R holds the version of this library.
+type R struct {
+	Major, Minor, Patch int
+}
+
+func (r R) String() string {
+	return fmt.Sprintf("%d.%d.%d", r.Major, r.Minor, r.Patch)
+}


### PR DESCRIPTION
full diff: https://github.com/miekg/pkcs11/compare/6120d95c0e9576ccf4a78ba40855809dca31a9ed...v1.0.2

relevant changes:

- miekg/pkcs11#110 Fix issue freeing memory on GetOperationState when NOT CK_OK
- miekg/pkcs11#106 Move to go modules
- miekg/pkcs11#104 Expose login API for vendor specific login types

