### PR TITLE
Skip inspect of builtin networks on service create

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -613,9 +613,16 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 
 	networks := convertNetworks(options.networks)
 	for i, net := range networks {
-		nwID, err := resolveNetworkID(ctx, apiClient, net.Target)
-		if err != nil {
-			return service, err
+		var nwID string
+		if !container.NetworkMode(net.Target).IsUserDefined() {
+			// Networks that are not user defined always exist on all nodes as
+			// local-scoped networks, so there's no need to inspect them.
+			nwID = net.Target
+		} else {
+			nwID, err = resolveNetworkID(ctx, apiClient, net.Target)
+			if err != nil {
+				return service, err
+			}
 		}
 		networks[i].Target = nwID
 	}


### PR DESCRIPTION
**- What I did**

Ported #362 to `service create`.  Note this leaves `service update` still affected.  Patching that path required investigation beyond the scope of available time.

**- How I did it**

Copied logic to skip network inspection if the network is built-in.

**- How to verify it**

Build a docker API server that returns a 404 for the "host" and "bridge" networks (such as https://github.com/docker/swarm) and run the following:

```
docker service create --network host nginx
```

Then, verify the deployed task is attached to the "host" network on the target node.

**- Description for the changelog**

* Service create no longer inspects built-in networks


**- A picture of a cute animal (not mandatory but encouraged)**