### PR TITLE
Fix phrasing when referring to the freezer cgroup

### DIFF
--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -27,14 +27,14 @@ Options:
 ## Description
 
 The `docker pause` command suspends all processes in the specified containers.
-On Linux, this uses the cgroups freezer. Traditionally, when suspending a process
+On Linux, this uses the freezer cgroup. Traditionally, when suspending a process
 the `SIGSTOP` signal is used, which is observable by the process being suspended.
-With the cgroups freezer the process is unaware, and unable to capture,
+With the freezer cgroup the process is unaware, and unable to capture,
 that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
 containers can be paused.
 
 See the
-[cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+[freezer cgroup documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
 for further details.
 
 ## Examples

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -27,10 +27,10 @@ Options:
 ## Description
 
 The `docker unpause` command un-suspends all processes in the specified containers.
-On Linux, it does this using the cgroups freezer.
+On Linux, it does this using the freezer cgroup.
 
 See the
-[cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+[freezer cgroup documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
 for further details.
 
 ## Examples

--- a/man/src/container/pause.md
+++ b/man/src/container/pause.md
@@ -1,11 +1,11 @@
 The `docker container pause` command suspends all processes in the specified containers.
-On Linux, this uses the cgroups freezer. Traditionally, when suspending a process
+On Linux, this uses the freezer cgroup. Traditionally, when suspending a process
 the `SIGSTOP` signal is used, which is observable by the process being suspended.
-With the cgroups freezer the process is unaware, and unable to capture,
+With the freezer cgroup the process is unaware, and unable to capture,
 that it is being suspended, and subsequently resumed. On Windows, only Hyper-V
 containers can be paused.
 
-See the [cgroups freezer documentation]
+See the [freezer cgroup documentation]
 (https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt) for
 further details.
 

--- a/man/src/container/unpause.md
+++ b/man/src/container/unpause.md
@@ -1,6 +1,6 @@
 The `docker container unpause` command un-suspends all processes in a container.
-On Linux, it does this using the cgroups freezer.
+On Linux, it does this using the freezer cgroup.
 
-See the [cgroups freezer documentation]
+See the [freezer cgroup documentation]
 (https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt) for
 further details.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix phrasing when referring to the freezer cgroup

ref. http://man7.org/linux/man-pages/man7/cgroups.7.html

Also see: https://github.com/moby/moby/pull/39759

**- How I did it**
`N/A`

**- How to verify it**
`N/A`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix phrasing when referring to the freezer cgroup

