### PR TITLE
Add option to remove `env_file` entry once it's merged in the `environment` section

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -32,6 +32,14 @@ type Options struct {
 	SkipInterpolation bool
 	// Interpolation options
 	Interpolate *interp.Options
+	// Discard 'env_file' entries after resolving to 'environment' section
+	discardEnvFiles bool
+}
+
+// WithDiscardEnvFiles sets the Options to discard the `env_file` section after resolving to
+// the `environment` section
+func WithDiscardEnvFiles(opts *Options) {
+	opts.discardEnvFiles = true
 }
 
 // ParseYAML reads the bytes from a file, parses the bytes into a mapping
@@ -105,6 +113,11 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 			return nil, err
 		}
 		cfg.Filename = file.Filename
+		if opts.discardEnvFiles {
+			for i := range cfg.Services {
+				cfg.Services[i].EnvFile = nil
+			}
+		}
 
 		configs = append(configs, cfg)
 	}


### PR DESCRIPTION
This avoids having redundant output when rendering the compose file once again by adding an option to remove the `env_file` from the config when already resolved.

Causes https://github.com/docker/app/issues/495

**- What I did**
Remove `env_file` entries when the option `RemoveEnvFiles` is set to `true`

**- How I did it**
By setting the serviceConfig's `EnvFile` to `nil` when the `RemoveEnvFiles` option is set to `true`

**- How to verify it**
N/A. Since the rendered is still the same

**- Description for the changelog**
Remove `env_file` entries when the option `RemoveEnvFiles` is set to `true`

**- A picture of a cute animal (not mandatory but encouraged)**
![adult-brown-mask](https://user-images.githubusercontent.com/373485/63528997-3d453e80-c504-11e9-9d81-42c2783ca363.jpg)
