### PR TITLE
[19.03 backport] restore support for env variables to configure proxy

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"runtime"
 	"testing"
@@ -77,6 +78,24 @@ func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 	apiclient, err := NewAPIClientFromFlags(opts, configFile)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(customVersion, apiclient.ClientVersion()))
+}
+
+func TestNewAPIClientFromFlagsWithHttpProxyEnv(t *testing.T) {
+	defer env.Patch(t, "HTTP_PROXY", "http://proxy.acme.com:1234")()
+	defer env.Patch(t, "DOCKER_HOST", "tcp://docker.acme.com:2376")()
+
+	opts := &flags.CommonOptions{}
+	configFile := &configfile.ConfigFile{}
+	apiclient, err := NewAPIClientFromFlags(opts, configFile)
+	assert.NilError(t, err)
+	transport, ok := apiclient.HTTPClient().Transport.(*http.Transport)
+	assert.Assert(t, ok)
+	assert.Assert(t, transport.Proxy != nil)
+	request, err := http.NewRequest(http.MethodGet, "tcp://docker.acme.com:2376", nil)
+	assert.NilError(t, err)
+	url, err := transport.Proxy(request)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("http://proxy.acme.com:1234", url.String()))
 }
 
 type fakeClient struct {

--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -104,8 +104,8 @@ func (c *Endpoint) ClientOpts() ([]client.Opt, error) {
 				return nil, err
 			}
 			result = append(result,
-				client.WithHost(c.Host),
 				withHTTPClient(tlsConfig),
+				client.WithHost(c.Host),
 			)
 
 		} else {


### PR DESCRIPTION
fixes [ENGCORE-930]

backport of https://github.com/docker/cli/pull/2059

regression introduced by https://github.com/docker/cli/commit/b34f340346f8042dc2968f412c490d301f2658b3 (https://github.com/docker/cli/pull/1501)

fixes https://github.com/docker/cli/issues/2027
fixes https://github.com/moby/moby/issues/39654 

Signed-off-by: Nicolas De Loof <nicolas.deloof@gmail.com>

**- What I did**
fix https://github.com/moby/moby/issues/39654 

**- How I did it**
restored order of client.Opt. WithHttpClient *must* come first

**- How to verify it**
added a test case to cover this scenario

**- Description for the changelog**
restore support for env variables to configure proxy

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/63524461-577b1e80-c4fc-11e9-8335-a3cceaed22e4.png)

[ENGCORE-930]: https://docker.atlassian.net/browse/ENGCORE-930