### PR TITLE
 feat(pull/push): add --registry-token option

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -15,11 +15,12 @@ import (
 
 // PullOptions defines what and how to pull
 type PullOptions struct {
-	remote    string
-	all       bool
-	platform  string
-	quiet     bool
-	untrusted bool
+	remote        string
+	all           bool
+	platform      string
+	quiet         bool
+	untrusted     bool
+	registryToken string
 }
 
 // NewPullCommand creates a new `docker pull` command
@@ -40,6 +41,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Download all tagged images in the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
+	flags.StringVarP(&opts.registryToken, "registry-token", "t", "", "Registry Token")
 
 	command.AddPlatformFlag(flags, &opts.platform)
 	command.AddTrustVerificationFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
@@ -66,6 +68,10 @@ func RunPull(cli command.Cli, opts PullOptions) error {
 	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, AuthResolver(cli), distributionRef.String())
 	if err != nil {
 		return err
+	}
+
+	if opts.registryToken != "" {
+		imgRefAndAuth.AuthConfig().RegistryToken = opts.registryToken
 	}
 
 	// Check if reference has a digest

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -72,11 +72,8 @@ func TestNewPullCommandSuccess(t *testing.T) {
 			expectedTag: "image:latest",
 		},
 		{
-			name: "with-registry-token",
-			args: []string{"image"},
-			flags: map[string]string{
-				"registry-token": "dummy",
-			},
+			name:        "with-registry-token",
+			args:        []string{"--registry-token", "dummy", "image"},
 			expectedTag: "image:latest",
 		},
 	}

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -71,6 +71,14 @@ func TestNewPullCommandSuccess(t *testing.T) {
 			},
 			expectedTag: "image:latest",
 		},
+		{
+			name: "with-registry-token",
+			args: []string{"image"},
+			flags: map[string]string{
+				"registry-token": "dummy",
+			},
+			expectedTag: "image:latest",
+		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -12,8 +12,9 @@ import (
 )
 
 type pushOptions struct {
-	remote    string
-	untrusted bool
+	remote        string
+	untrusted     bool
+	registryToken string
 }
 
 // NewPushCommand creates a new `docker push` command
@@ -33,6 +34,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 
 	command.AddTrustSigningFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
+	flags.StringVarP(&opts.registryToken, "registry-token", "t", "", "Registry Token")
 
 	return cmd
 }
@@ -54,6 +56,9 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 
 	// Resolve the Auth config relevant for this server
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+	if opts.registryToken != "" {
+		authConfig.RegistryToken = opts.registryToken
+	}
 	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, "push")
 
 	if !opts.untrusted {

--- a/cli/command/image/testdata/pull-command-success.with-registry-token.golden
+++ b/cli/command/image/testdata/pull-command-success.with-registry-token.golden
@@ -1,0 +1,2 @@
+Using default tag: latest
+docker.io/library/image:latest


### PR DESCRIPTION
close https://github.com/docker/cli/issues/1018

**- What I did**
Add `--registry-token` option to `pull` and `push`.

**- How I did it**
Rewrite AuthConfig.

**- How to verify it**

```
$ docker push --registry-token $TOKEN [YOUR_IMAGE]
```

```
$ docker pull --registry-token $TOKEN [YOUR_IMAGE]
```

**- Description for the changelog**
Add `--registry-token` option to `pull` and `push`.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2253692/63756697-c2a96400-c8f3-11e9-8979-4026b9ea7ae6.png)

