### PR TITLE
[docs] Updated docker cp documentation

### DIFF
--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -49,13 +49,14 @@ be an absolute or relative value. The command interprets a local machine's
 relative paths as relative to the current working directory where `docker cp` is
 run.
 
-The `cp` command behaves like the Unix `cp -a` command in that directories are
-copied recursively with permissions preserved if possible. Ownership is set to
-the user and primary group at the destination. For example, files copied to a
-container are created with `UID:GID` of the root user. Files copied to the local
-machine are created with the `UID:GID` of the user which invoked the `docker cp`
-command. However, if you specify the `-a` option, `docker cp` sets the ownership
-to the user and primary group at the source.
+When copying from the host into a container, the `cp` command behaves like the
+Unix `cp -a` command in that directories are copied recursively with ownership and
+permissions preserved if possible. For example, files copied to a container are
+created with the same `UID:GID` that was associated with the file in the host. When
+copying from a container into a host, directories are copied recursively and permissions
+are preserved, but ownership is changed to the `UID:GID` of the user who invoked the
+`docker cp` command.
+
 If you specify the `-L` option, `docker cp` follows any symbolic link
 in the `SRC_PATH`.  `docker cp` does *not* create parent directories for
 `DEST_PATH` if they do not exist.

--- a/man/src/container/cp.md
+++ b/man/src/container/cp.md
@@ -14,11 +14,10 @@ relative paths as relative to the current working directory where `docker contai
 run.
 
 The `cp` command behaves like the Unix `cp -a` command in that directories are
-copied recursively with permissions preserved if possible. Ownership is set to
-the user and primary group at the destination. For example, files copied to a
-container are created with `UID:GID` of the root user. Files copied to the local
+copied recursively with ownership and permissions preserved if possible. For example, files copied to a
+container are created with `UID:GID` of the user which invoked the `docker container cp` command. Likewise, files copied to the local
 machine are created with the `UID:GID` of the user which invoked the `docker container cp`
-command.  If you specify the `-L` option, `docker container cp` follows any symbolic link
+command. If you specify the `-L` option, `docker container cp` follows any symbolic link
 in the `SRC_PATH`. `docker container cp` does *not* create parent directories for
 `DEST_PATH` if they do not exist.
 


### PR DESCRIPTION
**- What I did**
Docs claim that ownership of files copied into a container is changed
to the default user of the container. Experimental evidence shows that
in fact the original ownership is preserved, with or without the -a
option.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
Updated docker cp documentation

**- A picture of a cute animal (not mandatory but encouraged)**
![baby penguin](https://user-images.githubusercontent.com/47338631/63799278-a5a76d80-c8c0-11e9-98c1-6559287a3986.jpg)
