### PR TITLE
Updating deprecated command example in search.md

### DIFF
--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -83,7 +83,7 @@ This example displays images with a name containing 'busybox',
 at least 3 stars and the description isn't truncated in the output:
 
 ```bash
-$ docker search --stars=3 --no-trunc busybox
+$ docker search --filter=stars=3 --no-trunc busybox
 NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
 busybox              Busybox base image.                                                                       325       [OK]       
 progrium/busybox                                                                                               50                   [OK]


### PR DESCRIPTION
**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
The current example uses --stars flag (deprecated). Changed to --filter=stars to use the right syntax.

**- A picture of a cute animal (not mandatory but encouraged)**

