### PR TITLE
Introduce support for GOPROXY

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -27,32 +27,32 @@ ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIR
 .PHONY: build_docker_image
 build_docker_image:
 	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
-	cat ./dockerfiles/Dockerfile.dev | docker build ${DOCKER_BUILD_ARGS} --build-arg=GO_VERSION -t $(DEV_DOCKER_IMAGE_NAME) -
+	cat ./dockerfiles/Dockerfile.dev | docker build ${DOCKER_BUILD_ARGS} --build-arg=GOPROXY --build-arg=GO_VERSION -t $(DEV_DOCKER_IMAGE_NAME) -
 
 # build docker image having the linting tools (dockerfiles/Dockerfile.lint)
 .PHONY: build_linter_image
 build_linter_image:
 	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
-	cat ./dockerfiles/Dockerfile.lint | docker build ${DOCKER_BUILD_ARGS} --build-arg=GO_VERSION -t $(LINTER_IMAGE_NAME) -
+	cat ./dockerfiles/Dockerfile.lint | docker build ${DOCKER_BUILD_ARGS} --build-arg=GOPROXY --build-arg=GO_VERSION -t $(LINTER_IMAGE_NAME) -
 
 .PHONY: build_cross_image
 build_cross_image:
 	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
-	cat ./dockerfiles/Dockerfile.cross | docker build ${DOCKER_BUILD_ARGS} --build-arg=GO_VERSION -t $(CROSS_IMAGE_NAME) -
+	cat ./dockerfiles/Dockerfile.cross | docker build ${DOCKER_BUILD_ARGS} --build-arg=GOPROXY --build-arg=GO_VERSION -t $(CROSS_IMAGE_NAME) -
 
 .PHONY: build_shell_validate_image
 build_shell_validate_image:
 	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
-	cat ./dockerfiles/Dockerfile.shellcheck | docker build --build-arg=GO_VERSION -t $(VALIDATE_IMAGE_NAME) -
+	cat ./dockerfiles/Dockerfile.shellcheck | docker build --build-arg=GOPROXY --build-arg=GO_VERSION -t $(VALIDATE_IMAGE_NAME) -
 
 .PHONY: build_binary_native_image
 build_binary_native_image:
 	# build dockerfile from stdin so that we don't send the build-context; source is bind-mounted in the development environment
-	cat ./dockerfiles/Dockerfile.binary-native | docker build --build-arg=GO_VERSION -t $(BINARY_NATIVE_IMAGE_NAME) -
+	cat ./dockerfiles/Dockerfile.binary-native | docker build --build-arg=GOPROXY --build-arg=GO_VERSION -t $(BINARY_NATIVE_IMAGE_NAME) -
 
 .PHONY: build_e2e_image
 build_e2e_image:
-	docker build -t $(E2E_IMAGE_NAME) --build-arg=GO_VERSION --build-arg VERSION=$(VERSION) --build-arg GITCOMMIT=$(GITCOMMIT) -f ./dockerfiles/Dockerfile.e2e .
+	docker build -t $(E2E_IMAGE_NAME) --build-arg=GOPROXY --build-arg=GO_VERSION --build-arg VERSION=$(VERSION) --build-arg GITCOMMIT=$(GITCOMMIT) -f ./dockerfiles/Dockerfile.e2e .
 
 DOCKER_RUN_NAME_OPTION := $(if $(DOCKER_CLI_CONTAINER_NAME),--name $(DOCKER_CLI_CONTAINER_NAME),)
 DOCKER_RUN := docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(DOCKER_RUN_NAME_OPTION)

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -4,6 +4,7 @@ FROM    golang:${GO_VERSION}-alpine
 
 RUN     apk add -U git bash coreutils gcc musl-dev
 
+ARG     GOPROXY
 ENV     CGO_ENABLED=0 \
         DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,6 +1,7 @@
 ARG GO_VERSION=1.12.9
 
-FROM	dockercore/golang-cross:${GO_VERSION}
+FROM    dockercore/golang-cross:${GO_VERSION}
+ARG     GOPROXY
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 WORKDIR /go/src/github.com/docker/cli
 COPY    . .

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -4,6 +4,7 @@ FROM    golang:${GO_VERSION}-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 
+ARG     GOPROXY
 ARG     VNDR_SHA=b177b583eb9d44bd5abfca3083a4aeb971b75861
 RUN     go get -d github.com/LK4D4/vndr && \
         cd /go/src/github.com/LK4D4/vndr && \

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -24,6 +24,7 @@ RUN curl -Ls https://github.com/gotestyourself/gotestsum/releases/download/v${GO
     && mv gotestsum /usr/local/bin/gotestsum \
     && rm gotestsum.tar.gz 
 
+ARG GOPROXY
 ENV CGO_ENABLED=0 \
     DISABLE_WARN_OUTSIDE_CONTAINER=1 \
     PATH=/go/src/github.com/docker/cli/build:$PATH

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -4,6 +4,7 @@ FROM    golang:${GO_VERSION}-alpine
 
 RUN     apk add -U git
 
+ARG     GOPROXY
 ARG     GOMETALINTER_SHA=v2.0.6
 RUN     go get -d github.com/alecthomas/gometalinter && \
         cd /go/src/github.com/alecthomas/gometalinter && \


### PR DESCRIPTION
**- What I did**
Added support for GOPROXY in build process

**- How I did it**
pass $GOPROXY as a docker build-arg

**- How to verify it**
no trivial way. remove vendor and use a custom proxy to check you can
rebuilt it

**- Description for the changelog**
introduce support for GOPROXY in build process

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/64238066-f68d1680-cefd-11e9-9fe3-02cc2630da43.png)
