### PR TITLE
Contrib: Make bash completion faster for services

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -561,7 +561,7 @@ __docker_services() {
 		shift
 	fi
 
-  __docker_q service ls -q --format "$format" --filter "name=$1"
+  __docker_q service ls --quiet --format "$format" "$@"
 }
 
 # __docker_complete_services applies completion of services based on the current
@@ -573,7 +573,7 @@ __docker_complete_services() {
 		current="$2"
 		shift 2
 	fi
-	COMPREPLY=( $(__docker_services "$@" "$current") )
+	COMPREPLY=( $(__docker_services "$@" --filter "name=$current") )
 }
 
 # __docker_tasks returns a list of all task IDs.

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -561,7 +561,7 @@ __docker_services() {
 		shift
 	fi
 
-  __docker_q service ls --quiet --format "$format" "$@"
+	__docker_q service ls --quiet --format "$format" "$@"
 }
 
 # __docker_complete_services applies completion of services based on the current

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -551,7 +551,7 @@ __docker_complete_nodes() {
 # precedence over the environment setting.
 __docker_services() {
 	local format='{{.Name}}'  # default: service name only
-	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && format='{{.ID}},{{.Name}}' # ID & name
+	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && format='{{.ID}} {{.Name}}' # ID & name
 
 	if [ "$1" = "--id" ] ; then
 		format='{{.ID}}' # IDs only

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -550,17 +550,18 @@ __docker_complete_nodes() {
 # output to the IDs or names of matching items. This setting takes
 # precedence over the environment setting.
 __docker_services() {
-	local fields='$2'  # default: service name only
-	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && fields='$1,$2' # ID & name
+	local format='{{.Name}}'  # default: service name only
+	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && format='{{.ID}},{{.Name}}' # ID & name
 
 	if [ "$1" = "--id" ] ; then
-		fields='$1' # IDs only
+		format='{{.ID}}' # IDs only
 		shift
 	elif [ "$1" = "--name" ] ; then
-		fields='$2' # names only
+		format='{{.Name}}' # names only
 		shift
 	fi
-        __docker_q service ls "$@" | awk "NR>1 {print $fields}"
+
+  __docker_q service ls -q --format "$format" --filter "name=$1"
 }
 
 # __docker_complete_services applies completion of services based on the current
@@ -572,7 +573,7 @@ __docker_complete_services() {
 		current="$2"
 		shift 2
 	fi
-	COMPREPLY=( $(compgen -W "$(__docker_services "$@")" -- "$current") )
+	COMPREPLY=( $(__docker_services "$@" "$current") )
 }
 
 # __docker_tasks returns a list of all task IDs.


### PR DESCRIPTION
**- What I did**
In `contrib/completion/bash/docker` I changed the `__docker_services` function to use the quiet mode of `docker service ls` which responds with `ID` and `Name` of services.

Using the `-q` quiet mode, is much faster, at least when there are hundreds of services in the Swarm cluster.

I also changed from using `compgen -W` to filter all the services, to using name filtering with the `--filter` argument of `docker service ls`

**- How I did it**
I rewrote the completion code, continuously testing it by running `source ~/.bash_profile` which will reload the docker completion in my local environment. I did this until I were happy with the speed

**- How to verify it**
Source it into your local bash environment and test it by writing e.g. `docker service inspect ` and pressing tab a couple of times. *Note!* you will have to be in an environment with a docker client, connected to a swarm with existing services.

**- Description for the changelog**
Make bash completion faster for services

**- A picture of a cute animal**
![image](https://user-images.githubusercontent.com/618946/64349003-71d1f380-cff6-11e9-83f0-32b9c1c8339b.png)

Pokémon are animals 😄 