### PR TITLE
Add riscv64 to manifest annotation and bash completion

### DIFF
--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -35,6 +35,7 @@ var validOSArches = map[osArch]bool{
 	{os: "linux", arch: "ppc64le"}:   true,
 	{os: "linux", arch: "mips64"}:    true,
 	{os: "linux", arch: "mips64le"}:  true,
+	{os: "linux", arch: "riscv64"}:   true,
 	{os: "linux", arch: "s390x"}:     true,
 	{os: "netbsd", arch: "386"}:      true,
 	{os: "netbsd", arch: "amd64"}:    true,

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4186,6 +4186,7 @@ _docker_manifest_annotate() {
 				mips64
 				mips64le
 				ppc64le
+				riscv64
 				s390x" -- "$cur" ) )
 			return
 			;;


### PR DESCRIPTION
Signed-off-by: Carlos de Paula <me@carlosedp.com>

**- What I did**

Added riscv64 architecture to manifest annotation and bash completion.

**- How I did it**

Added to architecture list.

**- Verify**

With updated docker cli, images are correctly tagged and pushed:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/20382/64623892-26399400-d3c0-11e9-8052-dea2122a1fe4.png">

**- Description for the changelog**

Add riscv64 architecture to manifest annotation and bash completion.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="998" alt="image" src="https://user-images.githubusercontent.com/20382/64623791-f7bbb900-d3bf-11e9-87b7-f066a54bc77a.png">
