### PR TITLE
Add clarification when using USER UID:GID

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1478,6 +1478,9 @@ The `USER` instruction sets the user name (or UID) and optionally the user
 group (or GID) to use when running the image and for any `RUN`, `CMD` and
 `ENTRYPOINT` instructions that follow it in the `Dockerfile`.
 
+> Note that when specifying a group for the user, the user will have _only_ the
+> specified group membership. Any other configured group memberships will be ignored.
+
 > **Warning**:
 > When the user doesn't have a primary group then the image (or the next
 > instructions) will be run with the `root` group.


### PR DESCRIPTION
**- What I did**

Added clarification to the docs about unintended side effects when using `USER UID:GID`.

**- How I did it**

Added docs 😄 

**- How to verify it**

Using the following Dockerfile:

```dockerfile
FROM ubuntu
RUN \
  groupadd --gid 123 group1 && \
  groupadd --gid 1000 group2 && \
  useradd --uid 1000 --gid 1000 user && \
  adduser user group1
USER user:group1
RUN groups
```

and building it, you'll see only `group1` as output from the RUN statement. This caused some confusion for a few folks here who weren't realizing that the process is running with the user and only the specified group (not using the user's group memberships). This adds some additional clarification around that to hopefully help someone else.


**- Description for the changelog**

- None needed. Just additional doc clarification.


**- A picture of a cute animal (not mandatory but encouraged)**

My dog (left) and brother's dog (right)
![Dogs](https://michaelandtara.us/wp-content/uploads/2019/08/MG_4008.jpg)