### PR TITLE
Adding experimental feature info

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -282,6 +282,14 @@ Following is a sample `config.json` file:
 
 ### Experimental features
 
+Experimental features provide early access to future product functionality.
+These features are intended only for testing and feedback as they may change
+between releases without warning or can be removed entirely from a future
+release.
+
+> Experimental features must not be used in production environments.
+{: .warning }
+
 To enable experimental features, edit the `config.json` file and set
 `experimental` to `enabled`. The example below enables experimental features
 in a `config.json` file that already enables a debug feature.


### PR DESCRIPTION
Added some information about experimental features. We lost some information about experimental features with https://github.com/docker/docker.github.io/pull/9483, so I'm putting it into the cli configuration files section. Once this is released, I'll change the experimental note to point exclusively to here.

Down the line, we'll have to split this page apart and bring this info into docker.github.io. 

Original page: https://docs.docker.com/engine/reference/commandline/cli/#configuration-files

Signed-off-by: Adrian Plata <adrian.plata@docker.com>