### PR TITLE
Improve service tasks grouping on printing

### DIFF
--- a/cli/command/task/print.go
+++ b/cli/command/task/print.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/api/types/swarm"
+	"vbom.ml/util/sortorder"
 )
 
 type tasksSortable []swarm.Task
@@ -23,23 +24,10 @@ func (t tasksSortable) Swap(i, j int) {
 }
 
 func (t tasksSortable) Less(i, j int) bool {
-	// Sort by service ID.
-	if t[i].ServiceID != t[j].ServiceID {
-		return t[i].ServiceID < t[j].ServiceID
+	if t[i].Name != t[j].Name {
+		return sortorder.NaturalLess(t[i].Name, t[j].Name)
 	}
-
-	// If same service, sort by slot.
-	if t[i].Slot != t[j].Slot {
-		return t[i].Slot < t[j].Slot
-	}
-
-	// If same service and slot, sort by node ID.
-	// This sorting is relevant only for global services.
-	if t[i].NodeID != t[j].NodeID {
-		return t[i].NodeID < t[j].NodeID
-	}
-
-	// If same service, slot and node - sort by most recent.
+	// Sort tasks for the same service and slot by most recent.
 	return t[j].Meta.CreatedAt.Before(t[i].CreatedAt)
 }
 
@@ -47,6 +35,14 @@ func (t tasksSortable) Less(i, j int) bool {
 // Besides this, command `docker node ps <node>`
 // and `docker stack ps` will call this, too.
 func Print(ctx context.Context, dockerCli command.Cli, tasks []swarm.Task, resolver *idresolver.IDResolver, trunc, quiet bool, format string) error {
+	tasks, err := generateTaskNames(ctx, tasks, resolver)
+	if err != nil {
+		return err
+	}
+
+	// First sort tasks, so that all tasks (including previous ones) of the same
+	// service and slot are together. This must be done first, to print "previous"
+	// tasks indented
 	sort.Stable(tasksSortable(tasks))
 
 	names := map[string]string{}
@@ -58,40 +54,55 @@ func Print(ctx context.Context, dockerCli command.Cli, tasks []swarm.Task, resol
 		Trunc:  trunc,
 	}
 
+	var indent string
+	if tasksCtx.Format.IsTable() {
+		indent = ` \_ `
+	}
 	prevName := ""
 	for _, task := range tasks {
-		serviceName, err := resolver.Resolve(ctx, swarm.Service{}, task.ServiceID)
-		if err != nil {
-			return err
+		if task.Name == prevName {
+			// Indent previous tasks of the same slot
+			names[task.ID] = indent
+		} else {
+			names[task.ID] = ""
 		}
+		prevName = task.Name
 
 		nodeValue, err := resolver.Resolve(ctx, swarm.Node{}, task.NodeID)
 		if err != nil {
 			return err
 		}
-
-		var name string
-		if task.Slot != 0 {
-			name = fmt.Sprintf("%v.%v", serviceName, task.Slot)
-		} else {
-			name = fmt.Sprintf("%v.%v", serviceName, task.NodeID)
-		}
-
-		// Indent the name if necessary
-		indentedName := name
-		if name == prevName {
-			indentedName = fmt.Sprintf(" \\_ %s", indentedName)
-		}
-		prevName = name
-
-		names[task.ID] = name
-		if tasksCtx.Format.IsTable() {
-			names[task.ID] = indentedName
-		}
 		nodes[task.ID] = nodeValue
 	}
 
 	return FormatWrite(tasksCtx, tasks, names, nodes)
+}
+
+// generateTaskNames generates names for the given tasks, and returns a copy of
+// the slice with the 'Name' field set.
+//
+// Depending if the "--no-resolve" option is set, names have the following pattern:
+//
+// - ServiceName.Slot or ServiceID.Slot for tasks that are part of a replicated service
+// - ServiceName.NodeName or ServiceID.NodeID for tasks that are part of a global service
+//
+// Task-names are not unique in cases where "tasks" contains previous/rotated tasks.
+func generateTaskNames(ctx context.Context, tasks []swarm.Task, resolver *idresolver.IDResolver) ([]swarm.Task, error) {
+	// Use a copy of the tasks list, to not modify the original slice
+	t := append(tasks[:0:0], tasks...)
+
+	for i, task := range t {
+		serviceName, err := resolver.Resolve(ctx, swarm.Service{}, task.ServiceID)
+		if err != nil {
+			return nil, err
+		}
+		if task.Slot != 0 {
+			t[i].Name = fmt.Sprintf("%v.%v", serviceName, task.Slot)
+		} else {
+			t[i].Name = fmt.Sprintf("%v.%v", serviceName, task.NodeID)
+		}
+	}
+	return t, nil
 }
 
 // DefaultFormat returns the default format from the config file, or table


### PR DESCRIPTION
When printing services' tasks with `docker service ps` command, tasks are grouped only by task slot.
This leads to interleaving tasks from different services when `docker service ps` is called with multiple services.

Besides this, global services do not have slots at all and printing tasks for them doesn't group and
doesn't properly indent tasks with \_.

With this patch all tasks are grouped by service ID, slot and node ID (relevant only for global services) and it fixes issue https://github.com/docker/cli/issues/533.

Signed-off-by: Andrii Berehuliak <berkusandrew@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Improved tasks grouping on `docker service ps` for multiple services and fixed issue with global services. Fixes #533 

**- How I did it**

Changed printing func.

**- How to verify it**

1. Create multiple services (including at least one global service) on multiple nodes
2. Run docker service ps svc1 svc2 ...
3. See that tasks are properly sorted

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Improves tasks printing for docker services

