### PR TITLE
cli/config: use os.UserHomeDir instead of github.com/docker/docker/pkg/homedir

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +27,11 @@ var (
 
 func init() {
 	if configDir == "" {
-		configDir = filepath.Join(homedir.Get(), configFileDir)
+		homedir, err := os.UserHomeDir()
+		if err != nil {
+			panic(err)
+		}
+		configDir = filepath.Join(homedir, configFileDir)
 	}
 }
 
@@ -106,7 +109,11 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 
 	// Can't find latest config file so check for the old one
-	confFile := filepath.Join(homedir.Get(), oldConfigfile)
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return configFile, errors.Wrap(err, oldConfigfile)
+	}
+	confFile := filepath.Join(homedir, oldConfigfile)
 	if _, err := os.Stat(confFile); err != nil {
 		return configFile, nil //missing file is not an error
 	}

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -7,16 +7,24 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
+
+var homeKey = "HOME"
+
+func init() {
+	if runtime.GOOS == "windows" {
+		homeKey = "USERPROFILE"
+	}
+}
 
 func setupConfigDir(t *testing.T) (string, func()) {
 	tmpdir, err := ioutil.TempDir("", "config-test")
@@ -113,10 +121,10 @@ email`: "Invalid auth configuration file",
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
 
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
+	homeDir, err := os.UserHomeDir()
+	assert.NilError(t, err)
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
+	defer func() { os.Setenv(homeKey, homeDir) }()
 	os.Setenv(homeKey, tmpHome)
 
 	for content, expectedError := range invalids {
@@ -134,10 +142,10 @@ func TestOldValidAuth(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
 
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
+	homeDir, err := os.UserHomeDir()
+	assert.NilError(t, err)
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
+	defer func() { os.Setenv(homeKey, homeDir) }()
 	os.Setenv(homeKey, tmpHome)
 
 	fn := filepath.Join(tmpHome, oldConfigfile)
@@ -173,10 +181,10 @@ func TestOldJSONInvalid(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
 
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
+	homeDir, err := os.UserHomeDir()
+	assert.NilError(t, err)
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
+	defer func() { os.Setenv(homeKey, homeDir) }()
 	os.Setenv(homeKey, tmpHome)
 
 	fn := filepath.Join(tmpHome, oldConfigfile)
@@ -197,10 +205,10 @@ func TestOldJSON(t *testing.T) {
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
 
-	homeKey := homedir.Key()
-	homeVal := homedir.Get()
+	homeDir, err := os.UserHomeDir()
+	assert.NilError(t, err)
 
-	defer func() { os.Setenv(homeKey, homeVal) }()
+	defer func() { os.Setenv(homeKey, homeDir) }()
 	os.Setenv(homeKey, tmpHome)
 
 	fn := filepath.Join(tmpHome, oldConfigfile)


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This is to avoid too many dependencies as outlined in #2082

Note that, this PR greatly (aka over-) simplifies the homedir logic: it requires HOME envvar to be set, and no longer looks at the current user's homedir via user.Current().HomeDir, as pkg/homedir did.