### PR TITLE
build: remove --stream (was experimental)

### DIFF
--- a/cli/command/image/build_session.go
+++ b/cli/command/image/build_session.go
@@ -1,28 +1,20 @@
 package image
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sync"
-	"time"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image/build"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/docker/docker/pkg/progress"
 	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/filesync"
 	"github.com/pkg/errors"
-	"golang.org/x/time/rate"
 )
 
 const clientSessionRemote = "client-session"
@@ -47,87 +39,6 @@ func trySession(dockerCli command.Cli, contextDir string, forStream bool) (*sess
 		}
 	}
 	return s, nil
-}
-
-func addDirToSession(session *session.Session, contextDir string, progressOutput progress.Output, done chan error) error {
-	excludes, err := build.ReadDockerignore(contextDir)
-	if err != nil {
-		return err
-	}
-
-	p := &sizeProgress{out: progressOutput, action: "Streaming build context to Docker daemon"}
-
-	workdirProvider := filesync.NewFSSyncProvider([]filesync.SyncedDir{
-		{Dir: contextDir, Excludes: excludes},
-	})
-	session.Allow(workdirProvider)
-
-	// this will be replaced on parallel build jobs. keep the current
-	// progressbar for now
-	if snpc, ok := workdirProvider.(interface {
-		SetNextProgressCallback(func(int, bool), chan error)
-	}); ok {
-		snpc.SetNextProgressCallback(p.update, done)
-	}
-
-	return nil
-}
-
-type sizeProgress struct {
-	out     progress.Output
-	action  string
-	limiter *rate.Limiter
-}
-
-func (sp *sizeProgress) update(size int, last bool) {
-	if sp.limiter == nil {
-		sp.limiter = rate.NewLimiter(rate.Every(100*time.Millisecond), 1)
-	}
-	if last || sp.limiter.Allow() {
-		sp.out.WriteProgress(progress.Progress{Action: sp.action, Current: int64(size), LastUpdate: last})
-	}
-}
-
-type bufferedWriter struct {
-	done chan error
-	io.Writer
-	buf     *bytes.Buffer
-	flushed chan struct{}
-	mu      sync.Mutex
-}
-
-func newBufferedWriter(done chan error, w io.Writer) *bufferedWriter {
-	bw := &bufferedWriter{done: done, Writer: w, buf: new(bytes.Buffer), flushed: make(chan struct{})}
-	go func() {
-		<-done
-		bw.flushBuffer()
-	}()
-	return bw
-}
-
-func (bw *bufferedWriter) Write(dt []byte) (int, error) {
-	select {
-	case <-bw.done:
-		bw.flushBuffer()
-		return bw.Writer.Write(dt)
-	default:
-		return bw.buf.Write(dt)
-	}
-}
-
-func (bw *bufferedWriter) flushBuffer() {
-	bw.mu.Lock()
-	select {
-	case <-bw.flushed:
-	default:
-		bw.Writer.Write(bw.buf.Bytes())
-		close(bw.flushed)
-	}
-	bw.mu.Unlock()
-}
-
-func (bw *bufferedWriter) String() string {
-	return fmt.Sprintf("%s", bw.Writer)
 }
 
 func getBuildSharedKey(dir string) (string, error) {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2873,11 +2873,6 @@ _docker_image_build() {
 		boolean_options+="
 			--compress
 		"
-		if __docker_server_is_experimental ; then
-			boolean_options+="
-				--stream
-			"
-		fi
 	fi
 
 	local all_options="$options_with_args $boolean_options"


### PR DESCRIPTION
--stream was always experimental and this patch removes the functionality.

Users should enable BuildKit with DOCKER_BUILDKIT=1

Signed-off-by: Tibor Vass <tibor@docker.com>

Related: https://github.com/moby/moby/pull/39983