### PR TITLE
config: keep configDir empty when homedir errors

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -28,10 +28,9 @@ var (
 func init() {
 	if configDir == "" {
 		homedir, err := os.UserHomeDir()
-		if err != nil {
-			panic(err)
+		if err == nil {
+			configDir = filepath.Join(homedir, configFileDir)
 		}
-		configDir = filepath.Join(homedir, configFileDir)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

Followup to https://github.com/docker/cli/pull/2101