### PR TITLE
Fix CREATED field when listing image if date is not specified

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultImageTableFormat           = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}"
-	defaultImageTableFormatWithDigest = "table {{.Repository}}\t{{.Tag}}\t{{.Digest}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}"
+	defaultImageTableFormat           = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{if .CreatedSince }}{{.CreatedSince}}{{else}}N/A{{end}}\t{{.Size}}"
+	defaultImageTableFormatWithDigest = "table {{.Repository}}\t{{.Tag}}\t{{.Digest}}\t{{.ID}}\t{{if .CreatedSince }}{{.CreatedSince}}{{else}}N/A{{end}}\t{{.Size}}"
 
 	imageIDHeader    = "IMAGE ID"
 	repositoryHeader = "REPOSITORY"
@@ -235,6 +235,11 @@ func (c *imageContext) Digest() string {
 
 func (c *imageContext) CreatedSince() string {
 	createdAt := time.Unix(c.i.Created, 0)
+
+	if createdAt.IsZero() {
+		return ""
+	}
+
 	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 }
 


### PR DESCRIPTION
Signed-off-by: Jonatas Baldin <jonatas.baldin@gmail.com>

Fixes #2047.

**- What I did**
When listing images with the `docker images` command, returns `<none>` in the `CREATED` field if the date is not specified during the image build. Without this fix, a `292 years ago` string was displayed.

**- How I did it**
Added a special case in the CLI formatter. 

**- How to verify it**
- Get an image that has no created date `docker pull nixery.dev/hello`

Before the fix:
- Run `docker images`
```
REPOSITORY                           TAG                 IMAGE ID            CREATED             SIZE
nixery.dev/hello                     latest              866a9896ca80        292 years ago             28.1MB
```

After the fix:
```
REPOSITORY                           TAG                 IMAGE ID            CREATED             SIZE
nixery.dev/hello                     latest              866a9896ca80        <none>              28.1MB
```

**- Description for the changelog**
Fix CREATED field when listing image if date is not specified.

**- A picture of a cute animal (not mandatory but encouraged)**
_an alpaca an me_
![2019-09-14 17 53 24](https://user-images.githubusercontent.com/8570364/65655394-76d10400-dff2-11e9-9658-86317ab96c15.jpg)

