### PR TITLE
Add notice about port binding and overriding of UFW to docker run reference

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -352,6 +352,11 @@ machine. You can also specify `udp` and `sctp` ports.
 The [Docker User Guide](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/)
 explains in detail how to manipulate ports in Docker.
 
+Note that ports which are not bound to the host (i.e., `-p 80:80` instead of
+`-p 127.0.0.1:80:80`) will be accessible from the outside. This also applies if
+you configured UFW to block this specific port, as Docker manages his
+own iptables rules. [Read more](https://docs.docker.com/network/iptables/)
+
 ```bash
 $ docker run --expose 80 ubuntu bash
 ```


### PR DESCRIPTION
**- What I did**

I updated the docs for the docker run reference to include a notice about port binding, which overrides / ignores UFW firewall rules. This goes along with the pull request for the [Docker docs](https://github.com/docker/docker.github.io/pull/9519) (more details in there). I think this is important as this may lead to serious vulnerabilities if ports are open even if you closed them.