### PR TITLE
config: revert to using pkg/homedir

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
+	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -27,10 +28,7 @@ var (
 
 func init() {
 	if configDir == "" {
-		homedir, err := os.UserHomeDir()
-		if err == nil {
-			configDir = filepath.Join(homedir, configFileDir)
-		}
+		configDir = filepath.Join(homedir.Get(), configFileDir)
 	}
 }
 


### PR DESCRIPTION
In c2626a8 (#2101) homedir logic got extremely simplified to only
checking HOME environment variable on UNIX systems.

Although this should work well enough in traditional environments,
this could break minimal containerized environments.

This patch reverts to using github.com/docker/docker/pkg/homedir
that was recently updated to have less dependencies.

~Dependent on #2110~