### PR TITLE
vendor: Bump gopkg.in/yaml.v2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -89,7 +89,7 @@ golang.org/x/time                                   fbb02b2291d28baffd63558aa44b
 google.golang.org/genproto                          02b4e95473316948020af0b7a4f0f22c73929b0e
 google.golang.org/grpc                              25c4f928eaa6d96443009bd842389fb4fa48664e # v1.20.1
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
-gopkg.in/yaml.v2                                    5420a8b6744d3b0345ab293f6fcba19c978f1183 # v2.2.1
+gopkg.in/yaml.v2                                    bb4e33bf68bf89cad44d386192cbed201f35b241 # v2.2.3
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 k8s.io/api                                          40a48860b5abbba9aa891b02b32da429b08d96a0 # kubernetes-1.14.0
 k8s.io/apimachinery                                 d7deff9243b165ee192f5551710ea4285dcfd615 # kubernetes-1.14.0

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {


### PR DESCRIPTION
Signed-off-by: Christopher Crone <christopher.crone@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Bumped gopkg.in/yaml.v2

Related issue: https://github.com/kubernetes/kubernetes/issues/83253

**- How I did it**
* Change `vendor.conf`
* Run `vndr`

**- How to verify it**
* Check `vendor.conf`, `vendor/`, run `make vendor`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Mitigate against YAML files that has excessive aliasing


**- A picture of a cute animal (not mandatory but encouraged)**

