### PR TITLE
[19.03 backport] vendor: Bump gopkg.in/yaml.v2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -88,7 +88,7 @@ golang.org/x/time                                   fbb02b2291d28baffd63558aa44b
 google.golang.org/genproto                          02b4e95473316948020af0b7a4f0f22c73929b0e
 google.golang.org/grpc                              25c4f928eaa6d96443009bd842389fb4fa48664e # v1.20.1
 gopkg.in/inf.v0                                     d2d2541c53f18d2a059457998ce2876cc8e67cbf # v0.9.1
-gopkg.in/yaml.v2                                    5420a8b6744d3b0345ab293f6fcba19c978f1183 # v2.2.1
+gopkg.in/yaml.v2                                    bb4e33bf68bf89cad44d386192cbed201f35b241 # v2.2.3
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 k8s.io/api                                          40a48860b5abbba9aa891b02b32da429b08d96a0 # kubernetes-1.14.0
 k8s.io/apimachinery                                 d7deff9243b165ee192f5551710ea4285dcfd615 # kubernetes-1.14.0

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -81,7 +81,7 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
-var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?(\.[0-9]+|[0-9]+(\.[0-9]*)?)([eE][-+]?[0-9]+)?$`)
 
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2117

To mitigate against malicious YAML (kubernetes/kubernetes#83253), we had implemented our own patch to the yams.v2 library. Now that there's an upstream fix, this PR brings us back to using the upstream library.

### Description for the changelog
* cli: Mitigate against YAML files that has excessive aliasing
