### PR TITLE
[19.03 backport] Add option to remove `env_file` entry once it's merged in the `environment` section

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -32,6 +32,14 @@ type Options struct {
 	SkipInterpolation bool
 	// Interpolation options
 	Interpolate *interp.Options
+	// Discard 'env_file' entries after resolving to 'environment' section
+	discardEnvFiles bool
+}
+
+// WithDiscardEnvFiles sets the Options to discard the `env_file` section after resolving to
+// the `environment` section
+func WithDiscardEnvFiles(opts *Options) {
+	opts.discardEnvFiles = true
 }
 
 // ParseYAML reads the bytes from a file, parses the bytes into a mapping
@@ -105,6 +113,11 @@ func Load(configDetails types.ConfigDetails, options ...func(*Options)) (*types.
 			return nil, err
 		}
 		cfg.Filename = file.Filename
+		if opts.discardEnvFiles {
+			for i := range cfg.Services {
+				cfg.Services[i].EnvFile = nil
+			}
+		}
 
 		configs = append(configs, cfg)
 	}


### PR DESCRIPTION
Backport of #2060

This avoids having redundant output when rendering the compose file once again by adding an option to remove the env_file from the config when already resolved.

