### PR TITLE
Add bash completion for `builder build` options

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1219,6 +1219,10 @@ _docker_builder() {
 	esac
 }
 
+_docker_builder_build() {
+	_docker_image_build
+}
+
 _docker_builder_prune() {
 	case "$prev" in
 		--filter)


### PR DESCRIPTION
#2116 added bash completion for just the subcommand.
This PR extends completion to its options.
`builder build` is just an [alias to `image build`](https://github.com/docker/cli/blob/master/cli/command/builder/cmd.go#L22), and so is the completion.