### PR TITLE
connhelper: use ssh multiplexing

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -86,6 +86,8 @@ by the `docker` command line:
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 * `DOCKER_CONTEXT` Specify the context to use (overrides DOCKER_HOST env var and default context set with "docker context use")
 * `DOCKER_DEFAULT_PLATFORM` Specify the default platform for the commands that take the `--platform` flag.
+* `DOCKER_SSH_NO_MUX` If set will turn off SSH multiplexing when connecting to daemon through SSH.
+* `DOCKER_SSH_MUX_PERSIST` Set a duration for keeping SSH multiplexing socket alive between commands (e.g `60s`).
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:


### PR DESCRIPTION
Add multiplexing to ssh connection helper so commands that do multiple requests share the connection. Environment variables for opting out and controlling the persist time for even better connection sharing.

Before:
```
 # time docker run alpine true
docker run alpine true  0.04s user 0.03s system 1% cpu 4.373 total
 # time docker build . 2>/dev/null
docker build . 2> /dev/null  0.05s user 0.03s system 3% cpu 2.312 total
```
After
```
 # time docker run alpine true
docker run alpine true  0.04s user 0.03s system 2% cpu 2.376 total
 # time docker build . 2>/dev/null
docker build . 2> /dev/null  0.04s user 0.03s system 5% cpu 1.295 total
```

@AkihiroSuda @cpuguy83 @tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>