### PR TITLE
Adjusting glossary reference and clarrifying the start of a Dockerfile

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -157,10 +157,12 @@ be UPPERCASE to distinguish them from arguments more easily.
 
 
 Docker runs instructions in a `Dockerfile` in order. A `Dockerfile` **must
-start with a \`FROM\` instruction**. The `FROM` instruction specifies the [*Base
-Image*](glossary.md#base-image) from which you are building. `FROM` may only be
-preceded by one or more `ARG` instructions, which declare arguments that are used
-in `FROM` lines in the `Dockerfile`.
+begin with a \`FROM\` instruction**. This may be after [parser
+directives](#parser-directives), [comments](#format), and globally scoped
+[ARGs](#arg). The `FROM` instruction specifies the [*Parent
+Image*](glossary.md#parent-image) from which you are building. `FROM`
+may only be preceded by one or more `ARG` instructions, which declare arguments
+that are used in `FROM` lines in the `Dockerfile`.
 
 Docker treats lines that *begin* with `#` as a comment, unless the line is
 a valid [parser directive](#parser-directives). A `#` marker anywhere


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Adjusted glossary link since "base image" in the glossary refers to an image without a parent while "parent image" appears to be a more relevant link (note that I've submitted a separate doc PR on the glossary since every image must have a FROM).

I also adjusted the "Start with a FROM instruction" definition to be clear that parser directives, comments, and ARGs may precede a FROM line.

**- How I did it**

This is just a doc change, no magic here.

**- How to verify it**

I think this is one of the cases where "read the docs" is a valid answer.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<a href="https://www.flickr.com/photos/fairerdingo/2320356661" title="cat reading"><img src="https://live.staticflickr.com/2251/2320356661_00ac803581_n.jpg" width="298" height="320" alt="cat reading"></a>