### PR TITLE
TestFormatInfo: add extra test-case

### DIFF
--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -377,6 +377,11 @@ func TestFormatInfo(t *testing.T) {
 			template:      "{{}",
 			expectedError: `Status: Template parsing error: template: :1: unexpected "}" in command, Code: 64`,
 		},
+		{
+			doc:           "syntax",
+			template:      "{{.badString}}",
+			expectedError: `template: :1:2: executing "" at <.badString>: can't evaluate field badString in type system.info`,
+		},
 	} {
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})


### PR DESCRIPTION
This case was in a test in the engine repository, where it is being removed, so add it to the list of existing tests here.

relates to https://github.com/moby/moby/pull/40104
