### PR TITLE
Remove remaining uses of pkg/homedir

### DIFF
--- a/cli/command/context/options.go
+++ b/cli/command/context/options.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -189,7 +188,9 @@ func getKubernetesEndpoint(dockerCli command.Cli, config map[string]string) (*ku
 		// fallback to env-based kubeconfig
 		kubeconfig := os.Getenv("KUBECONFIG")
 		if kubeconfig == "" {
-			kubeconfig = filepath.Join(homedir.Get(), ".kube/config")
+			// Error is deliberately unhandled to mimic old behavior.
+			homeDir, _ := os.UserHomeDir()
+			kubeconfig = filepath.Join(homeDir, ".kube/config")
 		}
 		ep, err := kubernetes.FromKubeConfig(kubeconfig, "", "")
 		if err != nil {

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 
@@ -27,8 +26,10 @@ var (
 )
 
 func init() {
+	// Error is deliberately unhandled to mimic old behavior.
+	homeDir, _ := os.UserHomeDir()
 	if configDir == "" {
-		configDir = filepath.Join(homedir.Get(), configFileDir)
+		configDir = filepath.Join(homeDir, configFileDir)
 	}
 }
 

--- a/cli/context/kubernetes/load.go
+++ b/cli/context/kubernetes/load.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/store"
 	api "github.com/docker/compose-on-kubernetes/api"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -80,7 +79,9 @@ func (c *Endpoint) KubernetesConfig() clientcmd.ClientConfig {
 func (c *EndpointMeta) ResolveDefault(stackOrchestrator command.Orchestrator) (interface{}, *store.EndpointTLSData, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
-		kubeconfig = filepath.Join(homedir.Get(), ".kube/config")
+		// Error is deliberately unhandled to mimic old behavior.
+		homeDir, _ := os.UserHomeDir()
+		kubeconfig = filepath.Join(homeDir, ".kube/config")
 	}
 	kubeEP, err := FromKubeConfig(kubeconfig, "", "")
 	if err != nil {


### PR DESCRIPTION
This PR was created to address [build failures](https://travis-ci.org/moby/buildkit/jobs/599720422) when updating buildkit to vendor a more recent version of docker which is not currently usable by this package.

**- What I did**

Remove uses of [`"github.com/docker/docker/pkg/homedir".Get`](https://godoc.org/github.com/docker/docker/pkg/homedir#Get).

**- How I did it**

Replaced it with [`os.UserHomeDir`](https://golang.org/pkg/os/#UserHomeDir) which was added in Go 1.12 and is already in use in other places in this package.

**- How to verify it**

Run the tests and ensure everything builds. Comments explain why errors were unhandled to prevent confusion later.

Previous behavior can be found [here](https://github.com/moby/moby/blob/master/pkg/homedir/homedir_unix.go#L21).

**- Description for the changelog**

n/a