### PR TITLE
parse ports separately

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -383,7 +383,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	var portBindings map[nat.Port][]nat.PortBinding
 
 	for _, publishOpt := range publishOpts {
-		publishOptList = []string{publishOpt}
+		publishOptList := []string{publishOpt}
 		if strings.Index(publishOpt, "=") > 0 {
 			publishOptList, err = parsePortOpts(publishOptList)
 			if err != nil {
@@ -401,20 +401,6 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 			portBindings[k] = v
 		}
 	}
-	// If simple port parsing fails try to parse as long format
-	if err != nil {
-		publishOpts, err = parsePortOpts(publishOpts)
-		if err != nil {
-			return nil, err
-		}
-
-		ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// Merge in exposed ports to the map of published ports
 	for _, e := range copts.expose.GetAll() {
 		if strings.Contains(e, ":") {

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -385,6 +385,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	for _, publishOpt := range publishOpts {
 		publishOptList := []string{publishOpt}
 		if strings.Index(publishOpt, "=") > 0 {
+			var err error 
 			publishOptList, err = parsePortOpts(publishOptList)
 			if err != nil {
 				return nil, err

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -382,8 +382,25 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	var ports map[nat.Port]struct{}
 	var portBindings map[nat.Port][]nat.PortBinding
 
-	ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
-
+	for _, publishOpt := range publishOpts {
+		publishOptList = []string{publishOpt}
+		if strings.Index(publishOpt, "=") > 0 {
+			publishOptList, err = parsePortOpts(publishOptList)
+			if err != nil {
+				return nil, err
+			}
+		}
+		p, pb, err := nat.ParsePortSpecs(publishOptList)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range p {
+			ports[k] = v
+		}
+		for k, v := range pb {
+			portBindings[k] = v
+		}
+	}
 	// If simple port parsing fails try to parse as long format
 	if err != nil {
 		publishOpts, err = parsePortOpts(publishOpts)

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -385,7 +385,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	for _, publishOpt := range publishOpts {
 		publishOptList := []string{publishOpt}
 		if strings.Index(publishOpt, "=") > 0 {
-			var err error 
+			var err error
 			publishOptList, err = parsePortOpts(publishOptList)
 			if err != nil {
 				return nil, err

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -379,8 +379,8 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	}
 
 	publishOpts := copts.publish.GetAll()
-	var ports map[nat.Port]struct{}
-	var portBindings map[nat.Port][]nat.PortBinding
+	ports := make(map[nat.Port]struct{})
+	portBindings := make(map[nat.Port][]nat.PortBinding)
 
 	for _, publishOpt := range publishOpts {
 		publishOptList := []string{publishOpt}


### PR DESCRIPTION
Signed-off-by: Aram Asatryan <aram808@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Separate parsing of ports args to allow combine short and longform:
docker run -p 8080:80 -p target=3306,published=3306 busybox
 
**- How I did it**
Iterate over arg opts and parse it separately, based on "=" in value

**- How to verify it**
Build docker binary and run:
docker run -p 8080:80 -p target=3306,published=3306 busybox

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

