### PR TITLE
Services: use ServiceStatus on API v1.41 and up

### DIFF
--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+
 	// Import builders to get the builder function as package function
 	. "github.com/docker/cli/internal/test/builders"
 )
@@ -18,9 +19,13 @@ type fakeClient struct {
 	taskListFunc              func(context.Context, types.TaskListOptions) ([]swarm.Task, error)
 	infoFunc                  func(ctx context.Context) (types.Info, error)
 	networkInspectFunc        func(ctx context.Context, networkID string, options types.NetworkInspectOptions) (types.NetworkResource, error)
+	nodeListFunc              func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
 }
 
 func (f *fakeClient) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+	if f.nodeListFunc != nil {
+		return f.nodeListFunc(ctx, options)
+	}
 	return nil, nil
 }
 
@@ -69,9 +74,6 @@ func (f *fakeClient) NetworkInspect(ctx context.Context, networkID string, optio
 	return types.NetworkResource{}, nil
 }
 
-func newService(id string, name string) swarm.Service {
-	return swarm.Service{
-		ID:   id,
-		Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: name}},
-	}
+func newService(id string, name string, opts ...func(*swarm.Service)) swarm.Service {
+	return *Service(append(opts, ServiceID(id), ServiceName(name))...)
 }

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -22,6 +22,7 @@ func TestServiceListOrder(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
 	cmd.Flags().Set("format", "{{.Name}}")
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "service-list-sort.golden")

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -2,12 +2,19 @@ package service
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
+	// Import builders to get the builder function as package function
+	. "github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/versions"
 	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
 	"gotest.tools/golden"
 )
 
@@ -26,4 +33,311 @@ func TestServiceListOrder(t *testing.T) {
 	cmd.Flags().Set("format", "{{.Name}}")
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "service-list-sort.golden")
+}
+
+// TestServiceListServiceStatus tests that the ServiceStatus struct is correctly
+// propagated. For older API versions, the ServiceStatus is calculated locally,
+// based on the tasks that are present in the swarm, and the nodes that they are
+// running on.
+// If the list command is ran with `--quiet` option, no attempt should be done to
+// propagate the ServiceStatus struct if not present, and it should be set to an
+// empty struct.
+func TestServiceListServiceStatus(t *testing.T) {
+	type listResponse struct {
+		ID       string
+		Replicas string
+	}
+
+	type testCase struct {
+		doc       string
+		withQuiet bool
+		opts      clusterOpts
+		cluster   *cluster
+		expected  []listResponse
+	}
+
+	tests := []testCase{
+		{
+			// Getting no nodes, services or tasks back from the daemon should
+			// not cause any problems
+			doc:      "empty cluster",
+			cluster:  &cluster{}, // force an empty cluster
+			expected: []listResponse{},
+		},
+		{
+			// Services are running, but no active nodes were found. On API v1.40
+			// and below, this will cause looking up the "running" tasks to fail,
+			// as well as looking up "desired" tasks for global services.
+			doc: "API v1.40 no active nodes",
+			opts: clusterOpts{
+				apiVersion:   "1.40",
+				activeNodes:  0,
+				runningTasks: 2,
+				desiredTasks: 4,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "0/4"},
+				{ID: "global", Replicas: "0/0"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+		{
+			doc: "API v1.40 3 active nodes, 1 task running",
+			opts: clusterOpts{
+				apiVersion:   "1.40",
+				activeNodes:  3,
+				runningTasks: 1,
+				desiredTasks: 2,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "1/2"},
+				{ID: "global", Replicas: "1/3"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+		{
+			doc: "API v1.40 3 active nodes, all tasks running",
+			opts: clusterOpts{
+				apiVersion:   "1.40",
+				activeNodes:  3,
+				runningTasks: 3,
+				desiredTasks: 3,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "3/3"},
+				{ID: "global", Replicas: "3/3"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+
+		{
+			// Services are running, but no active nodes were found. On API v1.41
+			// and up, the ServiceStatus is sent by the daemon, so this should not
+			// affect the results.
+			doc: "API v1.41 no active nodes",
+			opts: clusterOpts{
+				apiVersion:   "1.41",
+				activeNodes:  0,
+				runningTasks: 2,
+				desiredTasks: 4,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "2/4"},
+				{ID: "global", Replicas: "0/0"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+		{
+			doc: "API v1.41 3 active nodes, 1 task running",
+			opts: clusterOpts{
+				apiVersion:   "1.41",
+				activeNodes:  3,
+				runningTasks: 1,
+				desiredTasks: 2,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "1/2"},
+				{ID: "global", Replicas: "1/3"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+		{
+			doc: "API v1.41 3 active nodes, all tasks running",
+			opts: clusterOpts{
+				apiVersion:   "1.41",
+				activeNodes:  3,
+				runningTasks: 3,
+				desiredTasks: 3,
+			},
+			expected: []listResponse{
+				{ID: "replicated", Replicas: "3/3"},
+				{ID: "global", Replicas: "3/3"},
+				{ID: "none-id", Replicas: "0/0"},
+			},
+		},
+	}
+
+	matrix := make([]testCase, 0)
+	for _, quiet := range []bool{false, true} {
+		for _, tc := range tests {
+			if quiet {
+				tc.withQuiet = quiet
+				tc.doc = tc.doc + " with quiet"
+			}
+			matrix = append(matrix, tc)
+		}
+	}
+
+	for _, tc := range matrix {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			if tc.cluster == nil {
+				tc.cluster = generateCluster(t, tc.opts)
+			}
+			cli := test.NewFakeCli(&fakeClient{
+				serviceListFunc: func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+					if !options.Status || versions.LessThan(tc.opts.apiVersion, "1.41") {
+						// Don't return "ServiceStatus" if not requested, or on older API versions
+						for i := range tc.cluster.services {
+							tc.cluster.services[i].ServiceStatus = nil
+						}
+					}
+					return tc.cluster.services, nil
+				},
+				taskListFunc: func(context.Context, types.TaskListOptions) ([]swarm.Task, error) {
+					return tc.cluster.tasks, nil
+				},
+				nodeListFunc: func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+					return tc.cluster.nodes, nil
+				},
+			})
+			cmd := newListCommand(cli)
+			cmd.SetArgs([]string{})
+			if tc.withQuiet {
+				cmd.SetArgs([]string{"--quiet"})
+			}
+			_ = cmd.Flags().Set("format", "{{ json .}}")
+			assert.NilError(t, cmd.Execute())
+
+			lines := strings.Split(strings.TrimSpace(cli.OutBuffer().String()), "\n")
+			jsonArr := fmt.Sprintf("[%s]", strings.Join(lines, ","))
+			results := make([]listResponse, 0)
+			assert.NilError(t, json.Unmarshal([]byte(jsonArr), &results))
+
+			if tc.withQuiet {
+				// With "quiet" enabled, ServiceStatus should not be propagated
+				for i := range tc.expected {
+					tc.expected[i].Replicas = "0/0"
+				}
+			}
+			assert.Check(t, is.DeepEqual(tc.expected, results), "%+v", results)
+		})
+	}
+}
+
+type clusterOpts struct {
+	apiVersion   string
+	activeNodes  uint64
+	desiredTasks uint64
+	runningTasks uint64
+}
+
+type cluster struct {
+	services []swarm.Service
+	tasks    []swarm.Task
+	nodes    []swarm.Node
+}
+
+func generateCluster(t *testing.T, opts clusterOpts) *cluster {
+	t.Helper()
+	c := cluster{
+		services: generateServices(t, opts),
+		nodes:    generateNodes(t, opts.activeNodes),
+	}
+	c.tasks = generateTasks(t, c.services, c.nodes, opts)
+	return &c
+}
+
+func generateServices(t *testing.T, opts clusterOpts) []swarm.Service {
+	t.Helper()
+
+	// Can't have more global tasks than nodes
+	globalTasks := opts.runningTasks
+	if globalTasks > opts.activeNodes {
+		globalTasks = opts.activeNodes
+	}
+
+	return []swarm.Service{
+		*Service(
+			ServiceID("replicated"),
+			ServiceName("01-replicated-service"),
+			ReplicatedService(opts.desiredTasks),
+			ServiceStatus(opts.desiredTasks, opts.runningTasks),
+		),
+		*Service(
+			ServiceID("global"),
+			ServiceName("02-global-service"),
+			GlobalService(),
+			ServiceStatus(opts.activeNodes, globalTasks),
+		),
+		*Service(
+			ServiceID("none-id"),
+			ServiceName("03-none-service"),
+		),
+	}
+}
+
+func generateTasks(t *testing.T, services []swarm.Service, nodes []swarm.Node, opts clusterOpts) []swarm.Task {
+	t.Helper()
+	tasks := make([]swarm.Task, 0)
+
+	for _, s := range services {
+		if s.Spec.Mode.Replicated == nil && s.Spec.Mode.Global == nil {
+			continue
+		}
+		var runningTasks, failedTasks, desiredTasks uint64
+
+		// Set the number of desired tasks to generate, based on the service's mode
+		if s.Spec.Mode.Replicated != nil {
+			desiredTasks = *s.Spec.Mode.Replicated.Replicas
+		} else if s.Spec.Mode.Global != nil {
+			desiredTasks = opts.activeNodes
+		}
+
+		for _, n := range nodes {
+			if runningTasks < opts.runningTasks && n.Status.State != swarm.NodeStateDown {
+				tasks = append(tasks, swarm.Task{
+					NodeID:       n.ID,
+					ServiceID:    s.ID,
+					Status:       swarm.TaskStatus{State: swarm.TaskStateRunning},
+					DesiredState: swarm.TaskStateRunning,
+				})
+				runningTasks++
+			}
+
+			// If the number of "running" tasks is lower than the desired number
+			// of tasks of the service, fill in the remaining number of tasks
+			// with failed tasks. These tasks have a desired "running" state,
+			// and thus will be included when calculating the "desired" tasks
+			// for services.
+			if failedTasks < (desiredTasks - opts.runningTasks) {
+				tasks = append(tasks, swarm.Task{
+					NodeID:       n.ID,
+					ServiceID:    s.ID,
+					Status:       swarm.TaskStatus{State: swarm.TaskStateFailed},
+					DesiredState: swarm.TaskStateRunning,
+				})
+				failedTasks++
+			}
+
+			// Also add tasks with DesiredState: Shutdown. These should not be
+			// counted as running or desired tasks.
+			tasks = append(tasks, swarm.Task{
+				NodeID:       n.ID,
+				ServiceID:    s.ID,
+				Status:       swarm.TaskStatus{State: swarm.TaskStateShutdown},
+				DesiredState: swarm.TaskStateShutdown,
+			})
+		}
+	}
+	return tasks
+}
+
+// generateNodes generates a "nodes" endpoint API response with the requested
+// number of "ready" nodes. In addition, a "down" node is generated.
+func generateNodes(t *testing.T, activeNodes uint64) []swarm.Node {
+	t.Helper()
+	nodes := make([]swarm.Node, 0)
+	var i uint64
+	for i = 0; i < activeNodes; i++ {
+		nodes = append(nodes, swarm.Node{
+			ID:     fmt.Sprintf("node-ready-%d", i),
+			Status: swarm.NodeStatus{State: swarm.NodeStateReady},
+		})
+		nodes = append(nodes, swarm.Node{
+			ID:     fmt.Sprintf("node-down-%d", i),
+			Status: swarm.NodeStatus{State: swarm.NodeStateDown},
+		})
+	}
+	return nodes
 }

--- a/cli/command/service/testdata/service-context-write-raw.golden
+++ b/cli/command/service/testdata/service-context-write-raw.golden
@@ -1,14 +1,28 @@
-id: id_baz
-name: baz
-mode: global
-replicas: 2/4
-image: 
-ports: *:80->8080/tcp
-
-id: id_bar
+id: 02_bar
 name: bar
 mode: replicated
 replicas: 2/4
 image: 
+ports: *:80->8090/udp
+
+id: 01_baz
+name: baz
+mode: global
+replicas: 1/3
+image: 
 ports: *:80->8080/tcp
+
+id: 04_qux2
+name: qux2
+mode: replicated
+replicas: 3/3 (max 2 per node)
+image: 
+ports: 
+
+id: 03_qux10
+name: qux10
+mode: replicated
+replicas: 2/3 (max 1 per node)
+image: 
+ports: 
 

--- a/cli/command/stack/kubernetes/services.go
+++ b/cli/command/stack/kubernetes/services.go
@@ -109,15 +109,11 @@ func RunServices(dockerCli *KubeCli, opts options.Services) error {
 	}
 
 	// Convert Replicas sets and kubernetes services to swarm services and formatter information
-	services, info, err := convertToServices(replicasList, daemonsList, servicesList)
+	services, err := convertToServices(replicasList, daemonsList, servicesList)
 	if err != nil {
 		return err
 	}
 	services = filterServicesByName(services, filters.Get("name"), stackName)
-
-	if opts.Quiet {
-		info = map[string]service.ListInfo{}
-	}
 
 	format := opts.Format
 	if len(format) == 0 {
@@ -132,7 +128,7 @@ func RunServices(dockerCli *KubeCli, opts options.Services) error {
 		Output: dockerCli.Out(),
 		Format: service.NewListFormat(format, opts.Quiet),
 	}
-	return service.ListFormatWrite(servicesCtx, services, info)
+	return service.ListFormatWrite(servicesCtx, services)
 }
 
 func filterServicesByName(services []swarm.Service, names []string, stackName string) []swarm.Service {

--- a/cli/command/stack/swarm/services.go
+++ b/cli/command/stack/swarm/services.go
@@ -3,55 +3,59 @@ package swarm
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service"
 	"github.com/docker/cli/cli/command/stack/formatter"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
-	"vbom.ml/util/sortorder"
 )
 
 // RunServices is the swarm implementation of docker stack services
 func RunServices(dockerCli command.Cli, opts options.Services) error {
-	ctx := context.Background()
-	client := dockerCli.Client()
+	var (
+		err    error
+		ctx    = context.Background()
+		client = dockerCli.Client()
+	)
 
-	filter := getStackFilterFromOpt(opts.Namespace, opts.Filter)
-	services, err := client.ServiceList(ctx, types.ServiceListOptions{Filters: filter})
+	listOpts := types.ServiceListOptions{
+		Filters: getStackFilterFromOpt(opts.Namespace, opts.Filter),
+		// When not running "quiet", also get service status (number of running
+		// and desired tasks). Note that this is only supported on API v1.41 and
+		// up; older API versions ignore this option, and we will have to collect
+		// the information manually below.
+		Status: !opts.Quiet,
+	}
+
+	services, err := client.ServiceList(ctx, listOpts)
 	if err != nil {
 		return err
 	}
 
 	// if no services in this stack, print message and exit 0
 	if len(services) == 0 {
-		fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", opts.Namespace)
+		_, _ = fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", opts.Namespace)
 		return nil
 	}
 
-	sort.Slice(services, func(i, j int) bool {
-		return sortorder.NaturalLess(services[i].Spec.Name, services[j].Spec.Name)
-	})
-	info := map[string]service.ListInfo{}
-	if !opts.Quiet {
-		taskFilter := filters.NewArgs()
-		for _, service := range services {
-			taskFilter.Add("service", service.ID)
-		}
-
-		tasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: taskFilter})
+	if listOpts.Status {
+		// Now that a request was made, we know what API version was used (either
+		// through configuration, or after client and daemon negotiated a version).
+		// If API version v1.41 or up was used; the daemon should already have done
+		// the legwork for us, and we don't have to calculate the number of desired
+		// and running tasks. On older API versions, we need to do some extra requests
+		// to get that information.
+		//
+		// So theoretically, this step can be skipped based on API version, however,
+		// some of our unit tests don't set the API version, and there may be other
+		// situations where the client uses the "default" version. To account for
+		// these situations, we do a quick check for services that do not have
+		// a ServiceStatus set, and perform a lookup for those.
+		services, err = service.AppendServiceStatus(ctx, client, services)
 		if err != nil {
 			return err
 		}
-
-		nodes, err := client.NodeList(ctx, types.NodeListOptions{})
-		if err != nil {
-			return err
-		}
-
-		info = service.GetServicesStatus(services, nodes, tasks)
 	}
 
 	format := opts.Format
@@ -67,5 +71,5 @@ func RunServices(dockerCli command.Cli, opts options.Services) error {
 		Output: dockerCli.Out(),
 		Format: service.NewListFormat(format, opts.Quiet),
 	}
-	return service.ListFormatWrite(servicesCtx, services, info)
+	return service.ListFormatWrite(servicesCtx, services)
 }

--- a/internal/test/builders/service.go
+++ b/internal/test/builders/service.go
@@ -46,10 +46,31 @@ func ServiceLabels(labels map[string]string) func(*swarm.Service) {
 	}
 }
 
-// ReplicatedService sets the number of replicas for the service
+// GlobalService sets the service to use "global" mode
+func GlobalService() func(*swarm.Service) {
+	return func(service *swarm.Service) {
+		service.Spec.Mode = swarm.ServiceMode{Global: &swarm.GlobalService{}}
+	}
+}
+
+// ReplicatedService sets the service to use "replicated" mode with the specified number of replicas
 func ReplicatedService(replicas uint64) func(*swarm.Service) {
 	return func(service *swarm.Service) {
 		service.Spec.Mode = swarm.ServiceMode{Replicated: &swarm.ReplicatedService{Replicas: &replicas}}
+		if service.ServiceStatus == nil {
+			service.ServiceStatus = &swarm.ServiceStatus{}
+		}
+		service.ServiceStatus.DesiredTasks = replicas
+	}
+}
+
+// ServiceStatus sets the services' ServiceStatus (API v1.41 and above)
+func ServiceStatus(desired, running uint64) func(*swarm.Service) {
+	return func(service *swarm.Service) {
+		service.ServiceStatus = &swarm.ServiceStatus{
+			RunningTasks: running,
+			DesiredTasks: desired,
+		}
 	}
 }
 


### PR DESCRIPTION
depends on:

- [x] ~https://github.com/docker/cli/pull/2162 build static binaries with -tags osusergo~
- [x] moby/moby#40134 Revert "homedir: add cgo or osusergo buildtag constraints for unix"
- [x] https://github.com/docker/cli/pull/2163 Fix-up (gometalinter) linting config
- [x] https://github.com/docker/cli/pull/2158 bump docker/docker to a09e6e323e55e1a9b21df9c2c555f5668df3ac9b

#### Services: use ServiceStatus on API v1.41 and up

API v1.41 adds a new option to get the number of desired and running tasks when listing services. This patch enables this functionality, and provides a fallback mechanism when the ServiceStatus is not available, which would be when using an older API version.

Now that the swarm.Service struct captures this information, the `ListInfo` type is no longer needed, so it is removed, and the related list- and formatting functions have been modified accordingly.

To reduce repetition, sorting the services has been moved to the formatter. This is a slight change in behavior, but all calls to the formatter performed this sort first, so the change will not lead to user-facing changes.