### PR TITLE
bump docker/docker to a09e6e323e55e1a9b21df9c2c555f5668df3ac9b

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -16,7 +16,7 @@ github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff7826
 github.com/dgrijalva/jwt-go                         a2c85815a77d0f951e33ba4db5ae93629a1530af
 github.com/docker/compose-on-kubernetes             cc4914dfd1b6684a9750a59f3613fc0a95291824 # v0.4.23
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            b6684a403c99aaf6be5b8ce0bef3c6650fcdcd12
+github.com/docker/docker                            a09e6e323e55e1a9b21df9c2c555f5668df3ac9b
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -50,7 +50,7 @@ github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d
 github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
-github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
+github.com/Microsoft/hcsshim                        2226e083fc390003ae5aa8325c3c92789afa0e7a
 github.com/miekg/pkcs11                             cb39313ec884f2cd77f4762875fe96aecf68f8e3 # v1.0.2
 github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
 github.com/moby/buildkit                            10cef0c6e178bcaca1ad02b041a96b1091f52071

--- a/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
+++ b/vendor/github.com/Microsoft/hcsshim/osversion/osversion_windows.go
@@ -46,6 +46,12 @@ func Get() OSVersion {
 	return osv
 }
 
+// Build gets the build-number on Windows
+// The calling application must be manifested to get the correct version information.
+func Build() uint16 {
+	return Get().Build
+}
+
 func (osv OSVersion) ToString() string {
 	return fmt.Sprintf("%d.%d.%d", osv.MajorVersion, osv.MinorVersion, osv.Build)
 }

--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -363,6 +363,10 @@ type ServiceUpdateOptions struct {
 // ServiceListOptions holds parameters to list services with.
 type ServiceListOptions struct {
 	Filters filters.Args
+
+	// Status indicates whether the server should include the service task
+	// count of running and desired tasks.
+	Status bool
 }
 
 // ServiceInspectOptions holds parameters related to the "service inspect"

--- a/vendor/github.com/docker/docker/api/types/filters/parse.go
+++ b/vendor/github.com/docker/docker/api/types/filters/parse.go
@@ -36,6 +36,15 @@ func NewArgs(initialArgs ...KeyValuePair) Args {
 	return args
 }
 
+// Keys returns all the keys in list of Args
+func (args Args) Keys() []string {
+	keys := make([]string, 0, len(args.fields))
+	for k := range args.fields {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // MarshalJSON returns a JSON byte representation of the Args
 func (args Args) MarshalJSON() ([]byte, error) {
 	if len(args.fields) == 0 {

--- a/vendor/github.com/docker/docker/api/types/swarm/service.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/service.go
@@ -10,6 +10,13 @@ type Service struct {
 	PreviousSpec *ServiceSpec  `json:",omitempty"`
 	Endpoint     Endpoint      `json:",omitempty"`
 	UpdateStatus *UpdateStatus `json:",omitempty"`
+
+	// ServiceStatus is an optional, extra field indicating the number of
+	// desired and running tasks. It is provided primarily as a shortcut to
+	// calculating these values client-side, which otherwise would require
+	// listing all tasks for a service, an operation that could be
+	// computation and network expensive.
+	ServiceStatus *ServiceStatus `json:",omitempty"`
 }
 
 // ServiceSpec represents the spec of a service.
@@ -121,4 +128,18 @@ type UpdateConfig struct {
 	// task. Either the old task is shut down before the new task is
 	// started, or the new task is started before the old task is shut down.
 	Order string
+}
+
+// ServiceStatus represents the number of running tasks in a service and the
+// number of tasks desired to be running.
+type ServiceStatus struct {
+	// RunningTasks is the number of tasks for the service actually in the
+	// Running state
+	RunningTasks uint64
+
+	// DesiredTasks is the number of tasks desired to be running by the
+	// service. For replicated services, this is the replica count. For global
+	// services, this is computed by taking the number of tasks with desired
+	// state of not-Shutdown.
+	DesiredTasks uint64
 }

--- a/vendor/github.com/docker/docker/client/container_list.go
+++ b/vendor/github.com/docker/docker/client/container_list.go
@@ -35,7 +35,7 @@ func (cli *Client) ContainerList(ctx context.Context, options types.ContainerLis
 	}
 
 	if options.Filters.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 
 		if err != nil {

--- a/vendor/github.com/docker/docker/client/events.go
+++ b/vendor/github.com/docker/docker/client/events.go
@@ -90,7 +90,7 @@ func buildEventsQueryParams(cliVersion string, options types.EventsOptions) (url
 	}
 
 	if options.Filters.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cliVersion, options.Filters)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -24,7 +24,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	}
 
 	apiPath := cli.getAPIPath(ctx, path, query)
-	req, err := http.NewRequest("POST", apiPath, bodyEncoded)
+	req, err := http.NewRequest(http.MethodPost, apiPath, bodyEncoded)
 	if err != nil {
 		return types.HijackedResponse{}, err
 	}
@@ -40,7 +40,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 
 // DialHijack returns a hijacked connection with negotiated protocol proto.
 func (cli *Client) DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error) {
-	req, err := http.NewRequest("POST", url, nil)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (cli *Client) setupHijackConn(ctx context.Context, req *http.Request, proto
 	// Server hijacks the connection, error 'connection closed' expected
 	resp, err := clientconn.Do(req)
 
-	//lint:ignore SA1019 for connecting to old (pre go1.8) daemons
+	//nolint:staticcheck // ignore SA1019 for connecting to old (pre go1.8) daemons
 	if err != httputil.ErrPersistEOF {
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/docker/docker/client/image_list.go
+++ b/vendor/github.com/docker/docker/client/image_list.go
@@ -24,7 +24,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 		}
 	}
 	if optionFilters.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, optionFilters)
 		if err != nil {
 			return images, err

--- a/vendor/github.com/docker/docker/client/network_list.go
+++ b/vendor/github.com/docker/docker/client/network_list.go
@@ -13,7 +13,7 @@ import (
 func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -19,7 +19,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
 	// because ping requests are used during  API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
-	req, err := cli.buildRequest("HEAD", path.Join(cli.basePath, "/_ping"), nil, nil)
+	req, err := cli.buildRequest(http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
 		return ping, err
 	}
@@ -35,7 +35,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 		return ping, err
 	}
 
-	req, err = cli.buildRequest("GET", path.Join(cli.basePath, "/_ping"), nil, nil)
+	req, err = cli.buildRequest(http.MethodGet, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {
 		return ping, err
 	}

--- a/vendor/github.com/docker/docker/client/plugin_list.go
+++ b/vendor/github.com/docker/docker/client/plugin_list.go
@@ -15,7 +15,7 @@ func (cli *Client) PluginList(ctx context.Context, filter filters.Args) (types.P
 	query := url.Values{}
 
 	if filter.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
 		if err != nil {
 			return plugins, err

--- a/vendor/github.com/docker/docker/client/request.go
+++ b/vendor/github.com/docker/docker/client/request.go
@@ -29,12 +29,12 @@ type serverResponse struct {
 
 // head sends an http request to the docker API using the method HEAD.
 func (cli *Client) head(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
-	return cli.sendRequest(ctx, "HEAD", path, query, nil, headers)
+	return cli.sendRequest(ctx, http.MethodHead, path, query, nil, headers)
 }
 
 // get sends an http request to the docker API using the method GET with a specific Go context.
 func (cli *Client) get(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
-	return cli.sendRequest(ctx, "GET", path, query, nil, headers)
+	return cli.sendRequest(ctx, http.MethodGet, path, query, nil, headers)
 }
 
 // post sends an http request to the docker API using the method POST with a specific Go context.
@@ -43,21 +43,21 @@ func (cli *Client) post(ctx context.Context, path string, query url.Values, obj 
 	if err != nil {
 		return serverResponse{}, err
 	}
-	return cli.sendRequest(ctx, "POST", path, query, body, headers)
+	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
 func (cli *Client) postRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
-	return cli.sendRequest(ctx, "POST", path, query, body, headers)
+	return cli.sendRequest(ctx, http.MethodPost, path, query, body, headers)
 }
 
 // putRaw sends an http request to the docker API using the method PUT.
 func (cli *Client) putRaw(ctx context.Context, path string, query url.Values, body io.Reader, headers map[string][]string) (serverResponse, error) {
-	return cli.sendRequest(ctx, "PUT", path, query, body, headers)
+	return cli.sendRequest(ctx, http.MethodPut, path, query, body, headers)
 }
 
 // delete sends an http request to the docker API using the method DELETE.
 func (cli *Client) delete(ctx context.Context, path string, query url.Values, headers map[string][]string) (serverResponse, error) {
-	return cli.sendRequest(ctx, "DELETE", path, query, nil, headers)
+	return cli.sendRequest(ctx, http.MethodDelete, path, query, nil, headers)
 }
 
 type headers map[string][]string
@@ -79,7 +79,7 @@ func encodeBody(obj interface{}, headers headers) (io.Reader, headers, error) {
 }
 
 func (cli *Client) buildRequest(method, path string, body io.Reader, headers headers) (*http.Request, error) {
-	expectedPayload := (method == "POST" || method == "PUT")
+	expectedPayload := (method == http.MethodPost || method == http.MethodPut)
 	if expectedPayload && body == nil {
 		body = bytes.NewReader([]byte{})
 	}

--- a/vendor/github.com/docker/docker/client/service_list.go
+++ b/vendor/github.com/docker/docker/client/service_list.go
@@ -23,6 +23,10 @@ func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOpt
 		query.Set("filters", filterJSON)
 	}
 
+	if options.Status {
+		query.Set("status", "true")
+	}
+
 	resp, err := cli.get(ctx, "/services", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/volume_list.go
+++ b/vendor/github.com/docker/docker/client/volume_list.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (volumet
 	query := url.Values{}
 
 	if filter.Len() > 0 {
-		//lint:ignore SA1019 for old code
+		//nolint:staticcheck // ignore SA1019 for old code
 		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
 		if err != nil {
 			return volumes, err

--- a/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
+++ b/vendor/github.com/docker/docker/pkg/homedir/homedir_unix.go
@@ -16,8 +16,11 @@ func Key() string {
 // Get returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
-// If compiling statically, ensure the osusergo build tag is used.
-// If needing to do nss lookups, do not compile statically.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
 func Get() string {
 	home := os.Getenv(Key())
 	if home == "" {

--- a/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
+++ b/vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go
@@ -139,13 +139,13 @@ type JSONMessage struct {
 	Stream          string        `json:"stream,omitempty"`
 	Status          string        `json:"status,omitempty"`
 	Progress        *JSONProgress `json:"progressDetail,omitempty"`
-	ProgressMessage string        `json:"progress,omitempty"` //deprecated
+	ProgressMessage string        `json:"progress,omitempty"` // deprecated
 	ID              string        `json:"id,omitempty"`
 	From            string        `json:"from,omitempty"`
 	Time            int64         `json:"time,omitempty"`
 	TimeNano        int64         `json:"timeNano,omitempty"`
 	Error           *JSONError    `json:"errorDetail,omitempty"`
-	ErrorMessage    string        `json:"error,omitempty"` //deprecated
+	ErrorMessage    string        `json:"error,omitempty"` // deprecated
 	// Aux contains out-of-band data, such as digests for push signing and image id after building.
 	Aux *json.RawMessage `json:"aux,omitempty"`
 }
@@ -177,7 +177,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	if isTerminal && jm.Stream == "" && jm.Progress != nil {
 		clearLine(out)
 		endl = "\r"
-		fmt.Fprintf(out, endl)
+		fmt.Fprint(out, endl)
 	} else if jm.Progress != nil && jm.Progress.String() != "" { //disable progressbar in non-terminal
 		return nil
 	}
@@ -194,7 +194,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	}
 	if jm.Progress != nil && isTerminal {
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
-	} else if jm.ProgressMessage != "" { //deprecated
+	} else if jm.ProgressMessage != "" { // deprecated
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
 	} else if jm.Stream != "" {
 		fmt.Fprintf(out, "%s%s", jm.Stream, endl)

--- a/vendor/github.com/docker/docker/pkg/mount/mountinfo_linux.go
+++ b/vendor/github.com/docker/docker/pkg/mount/mountinfo_linux.go
@@ -90,7 +90,6 @@ func parseInfoFile(r io.Reader, filter FilterFunc) ([]*Info, error) {
 				   mount propagation flags in fields[6]. The correct
 				   behavior is to ignore any unknown optional fields.
 				*/
-				break
 			}
 		}
 		if i == numFields {

--- a/vendor/github.com/docker/docker/pkg/pools/pools.go
+++ b/vendor/github.com/docker/docker/pkg/pools/pools.go
@@ -62,24 +62,23 @@ type bufferPool struct {
 func newBufferPoolWithSize(size int) *bufferPool {
 	return &bufferPool{
 		pool: sync.Pool{
-			New: func() interface{} { return make([]byte, size) },
+			New: func() interface{} { s := make([]byte, size); return &s },
 		},
 	}
 }
 
-func (bp *bufferPool) Get() []byte {
-	return bp.pool.Get().([]byte)
+func (bp *bufferPool) Get() *[]byte {
+	return bp.pool.Get().(*[]byte)
 }
 
-func (bp *bufferPool) Put(b []byte) {
-	//nolint:staticcheck // TODO changing this to a pointer makes tests fail. Investigate if we should change or not (otherwise remove this TODO)
+func (bp *bufferPool) Put(b *[]byte) {
 	bp.pool.Put(b)
 }
 
 // Copy is a convenience wrapper which uses a buffer to avoid allocation in io.Copy.
 func Copy(dst io.Writer, src io.Reader) (written int64, err error) {
 	buf := buffer32KPool.Get()
-	written, err = io.CopyBuffer(dst, src, buf)
+	written, err = io.CopyBuffer(dst, src, *buf)
 	buffer32KPool.Put(buf)
 	return
 }

--- a/vendor/github.com/docker/docker/pkg/system/init_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/init_windows.go
@@ -18,8 +18,7 @@ var (
 
 // InitLCOW sets whether LCOW is supported or not. Requires RS5+
 func InitLCOW(experimental bool) {
-	v := GetOSVersion()
-	if experimental && v.Build >= osversion.RS5 {
+	if experimental && osversion.Build() >= osversion.RS5 {
 		lcowSupported = true
 	}
 }

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -5,6 +5,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/Microsoft/hcsshim/osversion"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/windows"
 )
@@ -61,12 +62,7 @@ var (
 
 // OSVersion is a wrapper for Windows version information
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
-type OSVersion struct {
-	Version      uint32
-	MajorVersion uint8
-	MinorVersion uint8
-	Build        uint16
-}
+type OSVersion osversion.OSVersion
 
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724833(v=vs.85).aspx
 type osVersionInfoEx struct {
@@ -85,18 +81,9 @@ type osVersionInfoEx struct {
 
 // GetOSVersion gets the operating system version on Windows. Note that
 // dockerd.exe must be manifested to get the correct version information.
+// Deprecated: use github.com/Microsoft/hcsshim/osversion.Get() instead
 func GetOSVersion() OSVersion {
-	var err error
-	osv := OSVersion{}
-	osv.Version, err = windows.GetVersion()
-	if err != nil {
-		// GetVersion never fails.
-		panic(err)
-	}
-	osv.MajorVersion = uint8(osv.Version & 0xFF)
-	osv.MinorVersion = uint8(osv.Version >> 8 & 0xFF)
-	osv.Build = uint16(osv.Version >> 16)
-	return osv
+	return OSVersion(osversion.Get())
 }
 
 func (osv OSVersion) ToString() string {

--- a/vendor/github.com/docker/docker/registry/auth.go
+++ b/vendor/github.com/docker/docker/registry/auth.go
@@ -33,7 +33,7 @@ func loginV1(authConfig *types.AuthConfig, apiEndpoint APIEndpoint, userAgent st
 		return "", "", errdefs.System(errors.New("server Error: Server Address not set"))
 	}
 
-	req, err := http.NewRequest("GET", serverAddress+"users/", nil)
+	req, err := http.NewRequest(http.MethodGet, serverAddress+"users/", nil)
 	if err != nil {
 		return "", "", err
 	}
@@ -140,7 +140,7 @@ func loginV2(authConfig *types.AuthConfig, endpoint APIEndpoint, userAgent strin
 	}
 
 	endpointStr := strings.TrimRight(endpoint.URL.String(), "/") + "/v2/"
-	req, err := http.NewRequest("GET", endpointStr, nil)
+	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
 	if err != nil {
 		if !foundV2 {
 			err = fallbackError{err: err}
@@ -262,7 +262,7 @@ func PingV2Registry(endpoint *url.URL, transport http.RoundTripper) (challenge.M
 		Timeout:   15 * time.Second,
 	}
 	endpointStr := strings.TrimRight(endpoint.String(), "/") + "/v2/"
-	req, err := http.NewRequest("GET", endpointStr, nil)
+	req, err := http.NewRequest(http.MethodGet, endpointStr, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/vendor/github.com/docker/docker/registry/endpoint_v1.go
+++ b/vendor/github.com/docker/docker/registry/endpoint_v1.go
@@ -149,7 +149,7 @@ func (e *V1Endpoint) Ping() (PingResult, error) {
 		return PingResult{Standalone: false}, nil
 	}
 
-	req, err := http.NewRequest("GET", e.Path("_ping"), nil)
+	req, err := http.NewRequest(http.MethodGet, e.Path("_ping"), nil)
 	if err != nil {
 		return PingResult{Standalone: false}, err
 	}

--- a/vendor/github.com/docker/docker/registry/resumable/resumablerequestreader.go
+++ b/vendor/github.com/docker/docker/registry/resumable/resumablerequestreader.go
@@ -56,10 +56,10 @@ func (r *requestReader) Read(p []byte) (n int, err error) {
 		r.cleanUpResponse()
 		return 0, err
 	}
-	if r.currentResponse.StatusCode == 416 && r.lastRange == r.totalSize && r.currentResponse.ContentLength == 0 {
+	if r.currentResponse.StatusCode == http.StatusRequestedRangeNotSatisfiable && r.lastRange == r.totalSize && r.currentResponse.ContentLength == 0 {
 		r.cleanUpResponse()
 		return 0, io.EOF
-	} else if r.currentResponse.StatusCode != 206 && r.lastRange != 0 && isFreshRequest {
+	} else if r.currentResponse.StatusCode != http.StatusPartialContent && r.lastRange != 0 && isFreshRequest {
 		r.cleanUpResponse()
 		return 0, fmt.Errorf("the server doesn't support byte ranges")
 	}

--- a/vendor/github.com/docker/docker/registry/session.go
+++ b/vendor/github.com/docker/docker/registry/session.go
@@ -225,8 +225,8 @@ func (r *Session) GetRemoteHistory(imgID, registry string) ([]string, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != 200 {
-		if res.StatusCode == 401 {
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusUnauthorized {
 			return nil, errcode.ErrorCodeUnauthorized.WithArgs()
 		}
 		return nil, newJSONError(fmt.Sprintf("Server error: %d trying to fetch remote history for %s", res.StatusCode, imgID), res)
@@ -248,7 +248,7 @@ func (r *Session) LookupRemoteImage(imgID, registry string) error {
 		return err
 	}
 	res.Body.Close()
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return newJSONError(fmt.Sprintf("HTTP code %d", res.StatusCode), res)
 	}
 	return nil
@@ -261,7 +261,7 @@ func (r *Session) GetRemoteImageJSON(imgID, registry string) ([]byte, int64, err
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, -1, newJSONError(fmt.Sprintf("HTTP code %d", res.StatusCode), res)
 	}
 	// if the size header is not present, then set it to '-1'
@@ -289,7 +289,7 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
 		imageURL   = fmt.Sprintf("%simages/%s/layer", registry, imgID)
 	)
 
-	req, err := http.NewRequest("GET", imageURL, nil)
+	req, err := http.NewRequest(http.MethodGet, imageURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Error while getting from the server: %v", err)
 	}
@@ -308,7 +308,7 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
 			statusCode, imgID)
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		res.Body.Close()
 		return nil, fmt.Errorf("Server error: Status %d while fetching image layer (%s)",
 			res.StatusCode, imgID)
@@ -347,7 +347,7 @@ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Name
 		if res.StatusCode == 404 {
 			return "", ErrRepoNotFound
 		}
-		if res.StatusCode != 200 {
+		if res.StatusCode != http.StatusOK {
 			continue
 		}
 
@@ -385,7 +385,7 @@ func (r *Session) GetRemoteTags(registries []string, repositoryRef reference.Nam
 		if res.StatusCode == 404 {
 			return nil, ErrRepoNotFound
 		}
-		if res.StatusCode != 200 {
+		if res.StatusCode != http.StatusOK {
 			continue
 		}
 
@@ -423,7 +423,7 @@ func (r *Session) GetRepositoryData(name reference.Named) (*RepositoryData, erro
 
 	logrus.Debugf("[registry] Calling GET %s", repositoryTarget)
 
-	req, err := http.NewRequest("GET", repositoryTarget, nil)
+	req, err := http.NewRequest(http.MethodGet, repositoryTarget, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -441,14 +441,14 @@ func (r *Session) GetRepositoryData(name reference.Named) (*RepositoryData, erro
 		return nil, fmt.Errorf("Error while pulling image: %v", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode == 401 {
+	if res.StatusCode == http.StatusUnauthorized {
 		return nil, errcode.ErrorCodeUnauthorized.WithArgs()
 	}
 	// TODO: Right now we're ignoring checksums in the response body.
 	// In the future, we need to use them to check image validity.
 	if res.StatusCode == 404 {
 		return nil, newJSONError(fmt.Sprintf("HTTP code: %d", res.StatusCode), res)
-	} else if res.StatusCode != 200 {
+	} else if res.StatusCode != http.StatusOK {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			logrus.Debugf("Error reading response body: %s", err)
@@ -490,7 +490,7 @@ func (r *Session) PushImageChecksumRegistry(imgData *ImgData, registry string) e
 
 	logrus.Debugf("[registry] Calling PUT %s", u)
 
-	req, err := http.NewRequest("PUT", u, nil)
+	req, err := http.NewRequest(http.MethodPut, u, nil)
 	if err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (r *Session) PushImageChecksumRegistry(imgData *ImgData, registry string) e
 	if len(res.Cookies()) > 0 {
 		r.client.Jar.SetCookies(req.URL, res.Cookies())
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return fmt.Errorf("HTTP code %d while uploading metadata and error when trying to parse response body: %s", res.StatusCode, err)
@@ -528,7 +528,7 @@ func (r *Session) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regist
 
 	logrus.Debugf("[registry] Calling PUT %s", u)
 
-	req, err := http.NewRequest("PUT", u, bytes.NewReader(jsonRaw))
+	req, err := http.NewRequest(http.MethodPut, u, bytes.NewReader(jsonRaw))
 	if err != nil {
 		return err
 	}
@@ -539,10 +539,10 @@ func (r *Session) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regist
 		return fmt.Errorf("Failed to upload metadata: %s", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode == 401 && strings.HasPrefix(registry, "http://") {
+	if res.StatusCode == http.StatusUnauthorized && strings.HasPrefix(registry, "http://") {
 		return newJSONError("HTTP code 401, Docker will not send auth headers over HTTP.", res)
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return newJSONError(fmt.Sprintf("HTTP code %d while uploading metadata and error when trying to parse response body: %s", res.StatusCode, err), res)
@@ -573,7 +573,7 @@ func (r *Session) PushImageLayerRegistry(imgID string, layer io.Reader, registry
 	h.Write([]byte{'\n'})
 	checksumLayer := io.TeeReader(tarsumLayer, h)
 
-	req, err := http.NewRequest("PUT", u, checksumLayer)
+	req, err := http.NewRequest(http.MethodPut, u, checksumLayer)
 	if err != nil {
 		return "", "", err
 	}
@@ -591,7 +591,7 @@ func (r *Session) PushImageLayerRegistry(imgID string, layer io.Reader, registry
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return "", "", newJSONError(fmt.Sprintf("HTTP code %d while uploading metadata and error when trying to parse response body: %s", res.StatusCode, err), res)
@@ -610,7 +610,7 @@ func (r *Session) PushRegistryTag(remote reference.Named, revision, tag, registr
 	revision = "\"" + revision + "\""
 	path := fmt.Sprintf("repositories/%s/tags/%s", reference.Path(remote), tag)
 
-	req, err := http.NewRequest("PUT", registry+path, strings.NewReader(revision))
+	req, err := http.NewRequest(http.MethodPut, registry+path, strings.NewReader(revision))
 	if err != nil {
 		return err
 	}
@@ -621,7 +621,7 @@ func (r *Session) PushRegistryTag(remote reference.Named, revision, tag, registr
 		return err
 	}
 	res.Body.Close()
-	if res.StatusCode != 200 && res.StatusCode != 201 {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		return newJSONError(fmt.Sprintf("Internal server error: %d trying to push tag %s on %s", res.StatusCode, tag, reference.Path(remote)), res)
 	}
 	return nil
@@ -675,13 +675,13 @@ func (r *Session) PushImageJSONIndex(remote reference.Named, imgList []*ImgData,
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 401 {
+	if res.StatusCode == http.StatusUnauthorized {
 		return nil, errcode.ErrorCodeUnauthorized.WithArgs()
 	}
 
 	var tokens, endpoints []string
 	if !validate {
-		if res.StatusCode != 200 && res.StatusCode != 201 {
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 			errBody, err := ioutil.ReadAll(res.Body)
 			if err != nil {
 				logrus.Debugf("Error reading response body: %s", err)
@@ -699,7 +699,7 @@ func (r *Session) PushImageJSONIndex(remote reference.Named, imgList []*ImgData,
 			return nil, err
 		}
 	} else {
-		if res.StatusCode != 204 {
+		if res.StatusCode != http.StatusNoContent {
 			errBody, err := ioutil.ReadAll(res.Body)
 			if err != nil {
 				logrus.Debugf("Error reading response body: %s", err)
@@ -714,7 +714,7 @@ func (r *Session) PushImageJSONIndex(remote reference.Named, imgList []*ImgData,
 }
 
 func (r *Session) putImageRequest(u string, headers map[string][]string, body []byte) (*http.Response, error) {
-	req, err := http.NewRequest("PUT", u, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPut, u, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func (r *Session) SearchRepositories(term string, limit int) (*registrytypes.Sea
 	logrus.Debugf("Index server: %s", r.indexEndpoint)
 	u := r.indexEndpoint.String() + "search?q=" + url.QueryEscape(term) + "&n=" + url.QueryEscape(fmt.Sprintf("%d", limit))
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, errors.Wrap(errdefs.InvalidParameter(err), "Error building request")
 	}
@@ -752,7 +752,7 @@ func (r *Session) SearchRepositories(term string, limit int) (*registrytypes.Sea
 		return nil, errdefs.System(err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, newJSONError(fmt.Sprintf("Unexpected status code %d", res.StatusCode), res)
 	}
 	result := new(registrytypes.SearchResults)

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,16 +1,16 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
+github.com/Microsoft/hcsshim                        2226e083fc390003ae5aa8325c3c92789afa0e7a
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
-github.com/golang/gddo                              9b12a26f3fbd7397dee4e20939ddca719d840d2a
+github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921
 github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
-github.com/gorilla/mux                              ed099d42384823742bba0bf9a72b53b55c9e2e38 # v1.7.2
+github.com/gorilla/mux                              00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15 # v1.7.3
 github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
 
-github.com/creack/pty                               2769f65a3a94eb8f876f44a0459d24ae7ad2e488 # v1.1.7
+github.com/creack/pty                               3a6a957789163cacdfe0e291617a1c8e80612c11 # v1.1.9
 github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
-github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
-github.com/sirupsen/logrus                          8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
+github.com/mattn/go-shellwords                      36a9b3c57cb5caa559ff63fb7e9b585f1c00df75 # v1.0.6
+github.com/sirupsen/logrus                          839c75faf7f98a33d445d181f3018b5c3409a45e # v1.4.2
 github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
 golang.org/x/sys                                    9eafafc0a87e0fd0aeeba439a4573537970c44c7
@@ -19,25 +19,26 @@ github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79
 golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
 gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
 github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
+github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
 
 github.com/RackSec/srslog                           a4725f04ec91af1a91b380da679d6e0c2f061e59
-github.com/imdario/mergo                            7c29201646fa3de8506f701213473dd407f19646 # v0.3.7
+github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6721b191b0369 # v0.3.8
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c
 
 # buildkit
-github.com/moby/buildkit                            588c73e1e4f0f3d7d3738abaaa7cf8026064b33e
+github.com/moby/buildkit                            f7042823e340d38d1746aa675b83d1aca431cee3
 github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
 github.com/opentracing-contrib/go-stdlib            b1a47cfbdd7543e70e9ef3e73d0802ad306cc1cc
 github.com/mitchellh/hashstructure                  2bca23e0e452137f789efbc8610126fd8b94f73b
-github.com/gofrs/flock                              7f43ea2e6a643ad441fc12d0ecc0d3388b300c53 # v0.7.0
+github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d23f618feb6dbb # v0.7.1
 
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        96bcc0dae898308ed659c5095526788a602f4726
+github.com/docker/libnetwork                        0025177e3dabbe0de151be0957dcaff149d43536
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -79,19 +80,17 @@ google.golang.org/grpc                              6eaf6f47437a6b4e2153a190160e
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc                      425e105d5a03fabd737a126ad93d62a9eeede87f # v1.0.0-rc8
+github.com/opencontainers/runc                      3e425f80a8c931f88e6d94a8c831b9d5aa481657 # v1.0.0-rc8-92-g84373aaa
 github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
 
-# libcontainer deps (see src/github.com/opencontainers/runc/Godeps/Godeps.json)
+# systemd integration (journald, daemon/listeners, containerd/cgroups)
 github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
 github.com/godbus/dbus                              5f6efc7ef2759c81b7ba876593971bfce311eab3 # v4.0.0
-github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
-github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 
 # gelf logging driver deps
-github.com/Graylog2/go-gelf                         4143646226541087117ff2f83334ea48b3201841
+github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch
 
 # fluent-logger-golang deps
 github.com/fluent/fluent-logger-golang              7a6c9dcd7f14c2ed5d8c55c11b894e5455ee311b # v1.4.0
@@ -118,12 +117,12 @@ github.com/googleapis/gax-go                        317e0006254c44a0ac427cc52a0e
 google.golang.org/genproto                          694d95ba50e67b2e363f3483057db5d4910c18f9
 
 # containerd
-github.com/containerd/containerd                    7c1e88399ec0b0b077121d9d5ad97e647b11c870
-github.com/containerd/fifo                          a9fb20d87448d386e6d50b1f2e1fa70dcf0de43c
-github.com/containerd/continuity                    aaeac12a7ffcd198ae25440a9dff125c2e2703a7
-github.com/containerd/cgroups                       4994991857f9b0ae8dc439551e8bebdbb4bf66c1
+github.com/containerd/containerd                    36cf5b690dcc00ff0f34ff7799209050c3d0c59a # v1.3.0
+github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
+github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/containerd/cgroups                       c4b9ac5c7601384c965b9646fc515884e091ebb9
 github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
-github.com/containerd/go-runc                       7d11b49dc0769f6dbb0d1b19f3d48524d1bad9ad
+github.com/containerd/go-runc                       e029b79d8cda8374981c64eba71f28ec38e5526f
 github.com/containerd/typeurl                       2a93cfde8c20b23de8eb84a5adbc234ddf7a9e8d
 github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266a007bf03670f
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
@@ -131,6 +130,7 @@ github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55
 # cluster
 github.com/docker/swarmkit                          7dded76ec532741c1ad9736cd2bb6d6661f0a386
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
+github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
@@ -138,7 +138,7 @@ golang.org/x/crypto                                 88737f569e3a9c7ab309cdc09a07
 golang.org/x/time                                   fbb02b2291d28baffd63558aa44b4b56f178d650
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
-github.com/hashicorp/golang-lru                     7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c # v0.5.1
+github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
 code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec
 


### PR DESCRIPTION
depends on:

- [x] ~https://github.com/docker/cli/pull/2162 build static binaries with -tags osusergo~
- [x] moby/moby#40134 Revert "homedir: add cgo or osusergo buildtag constraints for unix"
- [x] https://github.com/docker/cli/pull/2163 Fix-up (gometalinter) linting config


#### bump Microsoft/hcsshim 2226e083fc390003ae5aa8325c3c92789afa0e7a

full diff: https://github.com/Microsoft/hcsshim/compare/672e52e9209d1e53718c1b6a7d68cc9272654ab5...2226e083fc390003ae5aa8325c3c92789afa0e7a

- microsoft/hcsshim#569 Enhancement: add osversion.Build() utility
    - relates to moby/moby#39100 Use Microsoft/hcsshim constants and deprecate pkg/system.GetOsVersion()

#### bump docker/docker to a09e6e323e55e1a9b21df9c2c555f5668df3ac9b

full diff: https://github.com/docker/docker/compare/b6684a403c99aaf6be5b8ce0bef3c6650fcdcd12...a09e6e323e55e1a9b21df9c2c555f5668df3ac9b

relevant changes:

- moby/moby#39995 Update containerd binary to v1.2.10
- moby/moby#40001 Update runc to v1.0.0-rc8-92-g84373aaa (CVE-2019-16884)
- moby/moby#39999 bump golang 1.13.1 (CVE-2019-16276)
- moby/moby#40102 bump golang 1.13.3 (CVE-2019-17596)
- moby/moby#40134 Revert "homedir: add cgo or osusergo buildtag constraints for unix"
    - reverts moby/moby#39994 homedir: add cgo or osusergo buildtag constraints for unix,
      in favor of documenting when to set the `osusergo` build tag. The `osusergo`
      build-flag must be used when compiling a static binary with `cgo` enabled,
      and linking against `glibc`.
- moby/moby#39983 builder: remove legacy build's session handling
  This feature was used by docker build --stream and it was kept experimental.
  Users of this endpoint should enable BuildKit anyway by setting Version to BuilderBuildKit.
    - Related: #2105 build: remove --stream (was experimental)
- moby/moby #40045 Bump logrus 1.4.2, go-shellwords, mergo, flock, creack/pty,
  golang/gddo, gorilla/mux
- moby/moby#39713 bump containerd and dependencies to v1.3.0
- moby/moby#39987 Add ability to handle index acknowledgment with splunk log driver
- moby/moby#40070 Use ocischema package instead of custom handler
    - relates to moby/moby#39727 Docker 19.03 doesn't support OCI image
    - relates to docker/hub-feedback#1871
    - relates to docker/distribution#3024
- moby/moby#39231 Add support for sending down service Running and Desired task counts
- moby/moby#39822 daemon: Use short libnetwork ID in exec-root
- moby/moby#39100 Use Microsoft/hcsshim constants, deprecate pkg/system.GetOsVersion()
    - updates/requires Microsoft/hscshim@2226e083fc390003ae5aa8325c3c92789afa0e7a


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

