### PR TITLE
config: don't call homedir on init()

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
@@ -23,10 +24,15 @@ const (
 )
 
 var (
-	configDir = os.Getenv("DOCKER_CONFIG")
+	initConfigDir sync.Once
+	configDir     string
 )
 
-func init() {
+func setConfigDir() {
+	if configDir != "" {
+		return
+	}
+	configDir = os.Getenv("DOCKER_CONFIG")
 	if configDir == "" {
 		configDir = filepath.Join(homedir.Get(), configFileDir)
 	}
@@ -34,6 +40,7 @@ func init() {
 
 // Dir returns the directory the configuration file is stored in
 func Dir() string {
+	initConfigDir.Do(setConfigDir)
 	return configDir
 }
 


### PR DESCRIPTION
The `homedir.Get()` function can call out to external applications to get user information.

This patch changes the package to lazily obtain the user's home-directory on first use, instead of when initializing the package.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

