### PR TITLE
build static binaries with -tags osusergo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ clean: ## remove build artifacts
 
 .PHONY: test-unit
 test-unit: ## run unit tests, to change the output format use: GOTESTSUM_FORMAT=(dots|short|standard-quiet|short-verbose|standard-verbose) make test-unit 
-	gotestsum $(TESTFLAGS) -- $${TESTDIRS:-$(shell go list ./... | grep -vE '/vendor/|/e2e/')}
+	gotestsum $(TESTFLAGS) -- -tags osusergo $${TESTDIRS:-$(shell go list ./... | grep -vE '/vendor/|/e2e/')}
 
 .PHONY: test
 test: test-unit ## run tests
 
 .PHONY: test-coverage
 test-coverage: ## run test coverage
-	gotestsum -- -coverprofile=coverage.txt $(shell go list ./... | grep -vE '/vendor/|/e2e/')
+	gotestsum -- -tags osusergo -coverprofile=coverage.txt $(shell go list ./... | grep -vE '/vendor/|/e2e/')
 
 .PHONY: fmt
 fmt:

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -9,6 +9,6 @@ source ./scripts/build/.variables
 
 echo "Building statically linked $TARGET"
 export CGO_ENABLED=0
-go build -o "${TARGET}" --ldflags "${LDFLAGS}" "${SOURCE}"
+go build -tags osusergo -o "${TARGET}" --ldflags "${LDFLAGS}" "${SOURCE}"
 
 ln -sf "$(basename "${TARGET}")" build/docker

--- a/scripts/build/plugins
+++ b/scripts/build/plugins
@@ -17,5 +17,5 @@ for p in cli-plugins/examples/* "$@" ; do
 
     echo "Building statically linked $TARGET"
     export CGO_ENABLED=0
-    go build -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
+    go build -tags osusergo -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
 done

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -7,7 +7,7 @@ mkdir -p ./man/man1
 go install ./vendor/github.com/cpuguy83/go-md2man
 
 # Generate man pages from cobra commands
-go build -o /tmp/gen-manpages github.com/docker/cli/man
+go build -tags osusergo -o /tmp/gen-manpages github.com/docker/cli/man
 /tmp/gen-manpages --root "$(pwd)" --target "$(pwd)/man/man1"
 
 # Generate legacy pages from markdown

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -4,5 +4,5 @@ set -eu -o pipefail
 
 mkdir -p docs/yaml/gen
 
-go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
+go build -tags osusergo -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
 build/yaml-docs-generator --root "$(pwd)" --target "$(pwd)/docs/yaml/gen"


### PR DESCRIPTION
When building a static binary, the osusergo build-tag
should be used so that a pure go implementation of the
`os/user` package is used.

relates to:

- golang/go#23265 os/user: add build tags to select cgo-vs-go
  implementation, like net package
    - https://github.com/golang/go/commit/62f0127d8104d8266d9a3fb5a87e2f09ec8b6f5b
- golang/go#24787 os/user: LookupId panics on Linux+glibc static build
- golang/go#26492 cmd/go: build: add -static flag
- golang/go#12058 cmd/go: #cgo pkg-config: add conditional --static flag to pkg-config
- moby/moby#39994 homedir: add cgo or osusergo buildtag constraints for unix


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Use pure Go implementation of os/user package for static binaries
```


