### PR TITLE
Fix-up (gometalinter) linting config

### DIFF
--- a/gometalinter.json
+++ b/gometalinter.json
@@ -2,12 +2,16 @@
   "Vendor": true,
   "Deadline": "2m",
   "Sort": ["linter", "severity", "path", "line"],
-  "Exclude": [
+  "Skip": [
       "cli/compose/schema/bindata.go",
       "cli/command/stack/kubernetes/api/openapi",
       "cli/command/stack/kubernetes/api/client",
       ".*generated.*",
-      "parameter .* always receives"
+      "vendor"
+  ],
+  "Exclude": [
+    "parameter .* always receives",
+    "_esc(Dir|FS|FSString|FSMustString) is unused"
   ],
   "EnableGC": true,
   "Linters": {


### PR DESCRIPTION
#### gometalinter: fix configuration

The configuration abused "Exclude" to exclude file-paths by filtering on the output, however, the `Skip` option was designed for that, whereas `Exclude` is for matching warnings.

An explicit "Skip" was added for "vendor", because even though the vendor directory should already be ignored by the linter, in some situations, it still seemed to warn on issues, so let's explicitly ignore it.

