### PR TITLE
fixes #1923 Update stack command docs --orchestrator

### DIFF
--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -69,7 +69,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.PersistentFlags()
 	flags.String("kubeconfig", "", "Kubernetes config file")
 	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
-	flags.String("orchestrator", "", "Orchestrator to use (swarm|kubernetes|all)")
+	flags.String("orchestrator", "", "Orchestrator to use (swarm|kubernetes)")
 	return cmd
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1136,7 +1136,7 @@ __docker_complete_stack_orchestrator_options() {
 			return 0
 			;;
 		--orchestrator)
-			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur") )
+			COMPREPLY=( $( compgen -W "kubernetes swarm" -- "$cur") )
 			return 0
 			;;
 	esac

--- a/docs/reference/commandline/stack.md
+++ b/docs/reference/commandline/stack.md
@@ -23,7 +23,7 @@ Manage Docker stacks
 Options:
       --help                  Print usage
       --kubeconfig string     Kubernetes config file
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
 
 Commands:
   deploy      Deploy a new stack or update an existing stack

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -29,7 +29,7 @@ Options:
       --help                  Print usage
       --kubeconfig string     Kubernetes config file
       --namespace string      Kubernetes namespace to use
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
       --prune                 Prune services that are no longer referenced
       --resolve-image string  Query the registry to resolve image digest and supported platforms
                               ("always"|"changed"|"never") (default "always")

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -28,7 +28,7 @@ Options:
       --format string         Pretty-print stacks using a Go template
       --kubeconfig string     Kubernetes config file
       --namespace string      Kubernetes namespace to use
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
 ```
 
 ## Description

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -28,7 +28,7 @@ Options:
       --namespace string      Kubernetes namespace to use
       --no-resolve            Do not map IDs to Names
       --no-trunc              Do not truncate output
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
   -q, --quiet                 Only display task IDs
 ```
 

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -27,7 +27,7 @@ Options:
       --help                  Print usage
       --kubeconfig string     Kubernetes config file
       --namespace string      Kubernetes namespace to use
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
 ```
 
 ## Description

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -26,7 +26,7 @@ Options:
       --help                  Print usage
       --kubeconfig string     Kubernetes config file
       --namespace string      Kubernetes namespace to use
-      --orchestrator string   Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string   Orchestrator to use (swarm|kubernetes)
   -q, --quiet                 Only display IDs
 ```
 

--- a/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
+++ b/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
@@ -11,4 +11,4 @@ Options:
                                from stdin
       --kubeconfig string      Kubernetes config file
       --namespace string       Kubernetes namespace to use
-      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string    Orchestrator to use (swarm|kubernetes)

--- a/e2e/stack/testdata/stack-deploy-help-swarm.golden
+++ b/e2e/stack/testdata/stack-deploy-help-swarm.golden
@@ -10,7 +10,7 @@ Options:
       --bundle-file string     Path to a Distributed Application Bundle file
   -c, --compose-file strings   Path to a Compose file, or "-" to read
                                from stdin
-      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
+      --orchestrator string    Orchestrator to use (swarm|kubernetes)
       --prune                  Prune services that are no longer referenced
       --resolve-image string   Query the registry to resolve image digest
                                and supported platforms


### PR DESCRIPTION
Signed-off-by: nabeel-shakeel <nabeel_shakeel@symantec.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Since the option `all` of `--orchestrator` does not have any functionality associated with it.

https://github.com/docker/cli/blob/9e9fbf0699009ed1e52af587dbc88b19c7ba7689/cli/command/stack/common.go#L40

It return this :
https://github.com/docker/cli/blob/9e9fbf0699009ed1e52af587dbc88b19c7ba7689/cli/command/stack/cmd.go#L14
 We can either use **kubernetes** or **swarm**

**- How I did it**
I removed the `all` option to make docs consistent that only two options are supported and if someone try to input other then that, then error handling has already there.


**- How to verify it**
you can verify either looking at the docs: [Stack Deploy](https://github.com/docker/cli/blob/2c7822b0361dd3e78bb0745a5c03f741bc21821e/docs/reference/commandline/stack_deploy.md)
Or by running the command: `docker stack deploy --orchestrator swarm`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->




