### PR TITLE
Refactor the `stack services` command to be uniform [carry 2131]

### DIFF
--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -1,14 +1,21 @@
 package stack
 
 import (
+	"fmt"
+	"sort"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/service"
+	"github.com/docker/cli/cli/command/stack/formatter"
 	"github.com/docker/cli/cli/command/stack/kubernetes"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
 	cliopts "github.com/docker/cli/opts"
+	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"vbom.ml/util/sortorder"
 )
 
 func newServicesCommand(dockerCli command.Cli, common *commonOptions) *cobra.Command {
@@ -36,7 +43,51 @@ func newServicesCommand(dockerCli command.Cli, common *commonOptions) *cobra.Com
 
 // RunServices performs a stack services against the specified orchestrator
 func RunServices(dockerCli command.Cli, flags *pflag.FlagSet, commonOrchestrator command.Orchestrator, opts options.Services) error {
-	return runOrchestratedCommand(dockerCli, flags, commonOrchestrator,
-		func() error { return swarm.RunServices(dockerCli, opts) },
-		func(kli *kubernetes.KubeCli) error { return kubernetes.RunServices(kli, opts) })
+	services, err := GetServices(dockerCli, flags, commonOrchestrator, opts)
+	if err != nil {
+		return err
+	}
+	return formatWrite(dockerCli, services, opts)
+}
+
+// GetServices returns the services for the specified orchestrator
+func GetServices(dockerCli command.Cli, flags *pflag.FlagSet, commonOrchestrator command.Orchestrator, opts options.Services) ([]swarmtypes.Service, error) {
+	switch {
+	case commonOrchestrator.HasAll():
+		return nil, errUnsupportedAllOrchestrator
+	case commonOrchestrator.HasKubernetes():
+		kli, err := kubernetes.WrapCli(dockerCli, kubernetes.NewOptions(flags, commonOrchestrator))
+		if err != nil {
+			return nil, err
+		}
+		return kubernetes.GetServices(kli, opts)
+	default:
+		return swarm.GetServices(dockerCli, opts)
+	}
+}
+
+func formatWrite(dockerCli command.Cli, services []swarmtypes.Service, opts options.Services) error {
+	// if no services in the stack, print message and exit 0
+	if len(services) == 0 {
+		_, _ = fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", opts.Namespace)
+		return nil
+	}
+	sort.Slice(services, func(i, j int) bool {
+		return sortorder.NaturalLess(services[i].Spec.Name, services[j].Spec.Name)
+	})
+
+	format := opts.Format
+	if len(format) == 0 {
+		if len(dockerCli.ConfigFile().ServicesFormat) > 0 && !opts.Quiet {
+			format = dockerCli.ConfigFile().ServicesFormat
+		} else {
+			format = formatter.TableFormatKey
+		}
+	}
+
+	servicesCtx := formatter.Context{
+		Output: dockerCli.Out(),
+		Format: service.NewListFormat(format, opts.Quiet),
+	}
+	return service.ListFormatWrite(servicesCtx, services)
 }


### PR DESCRIPTION
carries https://github.com/docker/cli/pull/2131
closes https://github.com/docker/cli/pull/2131

depends on:

- [x] ~https://github.com/docker/cli/pull/2162 build static binaries with -tags osusergo~
- [x] moby/moby#40134 Revert "homedir: add cgo or osusergo buildtag constraints for unix"
- [x] https://github.com/docker/cli/pull/2163 Fix-up (gometalinter) linting config
- [x] https://github.com/docker/cli/pull/2158 bump docker/docker to a09e6e323e55e1a9b21df9c2c555f5668df3ac9b
- [x] https://github.com/docker/cli/pull/2157 Services: use ServiceStatus on API v1.41 and up
- [x] https://github.com/docker/cli/pull/2172 Gometalinter: raise deadline to 3 minutes


**- What I did**

Running `docker stack services <STACK> --orchestrator swarm` would yield the message "Noting found in stack: asdf" with an exit code 0. The same command with kubernetes orchestrator would yield "nothing found in stack: adsf" (note the lower-case "nothing") and a non-zero exit code. This change makes the `stack services` command uniform for both orchestrators. The logic of getting and printing services is split to reuse the same formatting code.

**- How to verify it**

Run:
```
$ docker stack services unknown --orchestrator swarm
$ docker stack services unknown --orchestrator kubernetes
```

Both commands should return `0` and show the error message `Noting found in stack: unknown`.

**- Description for the changelog**
Stack services will return the same exit code for all orchestrators.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/66569801-9af12100-eb6c-11e9-8d97-2c415e4d3ec5.png)
