### PR TITLE
Gometalinter: raise deadline to 3 minutes

### DIFF
--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,6 +1,6 @@
 {
   "Vendor": true,
-  "Deadline": "2m",
+  "Deadline": "3m",
   "Sort": ["linter", "severity", "path", "line"],
   "Skip": [
       "cli/compose/schema/bindata.go",


### PR DESCRIPTION
Looks like we're just on the edge of the deadline, and it's sometimes
failing;

```
cli/command/image/trust.go:346:1:warning: nolint directive did not match any issue (nolint)
cli/command/manifest/push.go:211:1:warning: nolint directive did not match any issue (nolint)
internal/pkg/containerized/snapshot.go:95:1:warning: nolint directive did not match any issue (nolint)
internal/pkg/containerized/snapshot.go:138:1:warning: nolint directive did not match any issue (nolint)
WARNING: deadline exceeded by linter interfacer (try increasing --deadline)
Exited with code 3
```

