### PR TITLE
compose/loader: fix TestIsAbs not testing all combinations

### DIFF
--- a/cli/compose/loader/windows_path_test.go
+++ b/cli/compose/loader/windows_path_test.go
@@ -43,7 +43,8 @@ var winisabstests = []IsAbsTest{
 }
 
 func TestIsAbs(t *testing.T) {
-	tests := append(isabstests, winisabstests...)
+	tests := winisabstests
+
 	// All non-windows tests should fail, because they have no volume letter.
 	for _, test := range isabstests {
 		tests = append(tests, IsAbsTest{test.path, false})
@@ -53,7 +54,7 @@ func TestIsAbs(t *testing.T) {
 		tests = append(tests, IsAbsTest{"c:" + test.path, test.isAbs})
 	}
 
-	for _, test := range winisabstests {
+	for _, test := range tests {
 		if r := isAbs(test.path); r != test.isAbs {
 			t.Errorf("IsAbs(%q) = %v, want %v", test.path, r, test.isAbs)
 		}


### PR DESCRIPTION
This test was intending to run all tests, but didn't, which was
caught by golangci-lint;

    cli/compose/loader/windows_path_test.go:46:17: SA4010: this result of append is never used, except maybe in other appends (staticcheck)
    	tests := append(isabstests, winisabstests...)
    	               ^


Looks like a whoopsie on my side in https://github.com/docker/cli/pull/1990 (I recall I was testing some variations, probably forgot to change back 😂). Pushing as a PR separate from https://github.com/docker/cli/pull/2173 in case we want to backport this individually.


