### PR TITLE
parseNetworkOpts, updatePorts: pin variables in scope (scopelint)

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -686,6 +686,7 @@ func parseNetworkOpts(copts *containerOptions) (map[string]*networktypes.Endpoin
 	)
 
 	for i, n := range copts.netMode.Value() {
+		n := n
 		if container.NetworkMode(n.Target).IsUserDefined() {
 			hasUserDefined = true
 		} else {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1004,6 +1004,7 @@ func updatePorts(flags *pflag.FlagSet, portConfig *[]swarm.PortConfig) error {
 
 	// Build the current list of portConfig
 	for _, entry := range *portConfig {
+		entry := entry
 		if _, ok := portSet[portConfigToString(&entry)]; !ok {
 			portSet[portConfigToString(&entry)] = entry
 		}
@@ -1031,6 +1032,7 @@ portLoop:
 		ports := flags.Lookup(flagPublishAdd).Value.(*opts.PortOpt).Value()
 
 		for _, port := range ports {
+			port := port
 			if _, ok := portSet[portConfigToString(&port)]; ok {
 				continue
 			}


### PR DESCRIPTION
```
cli/command/service/update.go:1007:43: Using a reference for the variable on range scope `entry` (scopelint)
		if _, ok := portSet[portConfigToString(&entry)]; !ok {
		                                        ^
cli/command/service/update.go:1008:32: Using a reference for the variable on range scope `entry` (scopelint)
			portSet[portConfigToString(&entry)] = entry
			                            ^
cli/command/service/update.go:1034:44: Using a reference for the variable on range scope `port` (scopelint)
			if _, ok := portSet[portConfigToString(&port)]; ok {
			                                        ^


cli/command/container/opts.go:700:37: Using a reference for the variable on range scope `n` (scopelint)
			if err := applyContainerOptions(&n, copts); err != nil {
			                                 ^
```