### PR TITLE
unused-for is a deprecated synonym for until

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -45,7 +45,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
-	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'unused-for=24h')")
+	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'until=24h')")
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 
 	return cmd


### PR DESCRIPTION
**- What I did**

Change `unused-for` to `until` in `docker builder prune --help` output, which should flow through to the docs site.

**- How I did it**

Modifying the command flag description.

**- How to verify it**

Run `docker builder prune --help`

**- Description for the changelog**

Fixed deprecated docker builder prune filter example

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="376" alt="image" src="https://user-images.githubusercontent.com/14028/67828066-29cadb00-fb26-11e9-8c4f-2d0d4e69e415.png">
