### PR TITLE
[19.03 backport] Add interpolation type cast for max_replicas_per_node

### DIFF
--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -19,6 +19,7 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
 	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
 	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
+	servicePath("deploy", "placement", "max_replicas_per_node"):      toInt,
 	servicePath("ports", interp.PathMatchList, "target"):             toInt,
 	servicePath("ports", interp.PathMatchList, "published"):          toInt,
 	servicePath("ulimits", interp.PathMatchAll):                      toInt,

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -582,7 +582,7 @@ volumes:
 
 func TestLoadWithInterpolationCastFull(t *testing.T) {
 	dict, err := ParseYAML([]byte(`
-version: "3.7"
+version: "3.8"
 services:
   web:
     configs:
@@ -604,6 +604,8 @@ services:
         max_failure_ratio: $thefloat
       restart_policy:
         max_attempts: $theint
+      placement:
+        max_replicas_per_node: $theint
     ports:
       - $theint
       - "34567"
@@ -652,7 +654,7 @@ networks:
 	assert.NilError(t, err)
 	expected := &types.Config{
 		Filename: "filename.yml",
-		Version:  "3.7",
+		Version:  "3.8",
 		Services: []types.ServiceConfig{
 			{
 				Name: "web",
@@ -684,6 +686,9 @@ networks:
 					},
 					RestartPolicy: &types.RestartPolicy{
 						MaxAttempts: uint64Ptr(555),
+					},
+					Placement: types.Placement{
+						MaxReplicas: 555,
 					},
 				},
 				Ports: []types.ServicePortConfig{


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2182

Fixes https://github.com/docker/app/issues/688

**- What I did**
Added interpolation type cast mapping for missing `deploy.placement.max_replicas_per_node`.

**- How to verify it**

Changed the unit test

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/68124221-1c8b6300-ff0f-11e9-8d09-53392743c76a.png)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
