### PR TITLE
Bump compose-on-kubernetes from v0.4.25-alpha1 to v0.5.0-alpha1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/cpuguy83/go-md2man                       20f5889cbdc3c73dbd2862796665
 github.com/creack/pty                               2769f65a3a94eb8f876f44a0459d24ae7ad2e488 # v1.1.7
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/dgrijalva/jwt-go                         a2c85815a77d0f951e33ba4db5ae93629a1530af
-github.com/docker/compose-on-kubernetes             f48765330f6dcda6955f07192b8cc666df8ac580 # v0.4.25-alpha1
+github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            a09e6e323e55e1a9b21df9c2c555f5668df3ac9b
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3


### PR DESCRIPTION

**- Description for the changelog**
* Bump compose-on-kubernetes from v0.4.25-alpha1 to v0.5.0-alpha1

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/31478878/68422907-5c697900-01a1-11ea-87d6-2e25841048ee.png)
