### PR TITLE
e2e: add new test package "global" with TestTLSVerify

### DIFF
--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -1,0 +1,24 @@
+package global
+
+import (
+	"testing"
+
+	"github.com/docker/cli/internal/test/environment"
+	"gotest.tools/icmd"
+	"gotest.tools/skip"
+)
+
+func TestTLSVerify(t *testing.T) {
+	// Remote daemons use TLS and this test is not applicable when TLS is required.
+	skip.If(t, environment.RemoteDaemon())
+
+	icmd.RunCmd(icmd.Command("docker", "ps")).Assert(t, icmd.Success)
+
+	// Regardless of whether we specify true or false we need to
+	// test to make sure tls is turned on if --tlsverify is specified at all
+	result := icmd.RunCmd(icmd.Command("docker", "--tlsverify=false", "ps"))
+	result.Assert(t, icmd.Expected{ExitCode: 1, Err: "unable to resolve docker endpoint:"})
+
+	result = icmd.RunCmd(icmd.Command("docker", "--tlsverify=true", "ps"))
+	result.Assert(t, icmd.Expected{ExitCode: 1, Err: "ca.pem"})
+}

--- a/e2e/global/main_test.go
+++ b/e2e/global/main_test.go
@@ -1,0 +1,17 @@
+package global
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/internal/test/environment"
+)
+
+func TestMain(m *testing.M) {
+	if err := environment.Setup(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(3)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Signed-off-by: Tibor Vass <tibor@docker.com>

This is to move TestRunTLSVerify from moby integration-cli tests.