### PR TITLE
Typo in documentation of volume create

### DIFF
--- a/man/src/volume/create.md
+++ b/man/src/volume/create.md
@@ -6,7 +6,7 @@ configure the container to use it, for example:
     hello
     $ docker run -d -v hello:/world busybox ls /world
 
-The mount is created inside the container's `/src` directory. Docker doesn't
+The mount is created inside the container's `/src` directory. Docker does
 not support relative paths for mount points inside the container.
 
 Multiple containers can use the same volume in the same time period. This is


### PR DESCRIPTION
remove doubled negation (doesn't not => does not)

**- What I did**
fix a typo in the documentation of volume create (which is also used in the man page)

**- How I did it**
remove doubled negation (doesn't not => does not)

**- How to verify it**
have a look at the documentation before and after

**- Description for the changelog**
fix typo in documentation: remove doubled negation (doesn't not => does not)

**- A picture of a cute animal (not mandatory but encouraged)**
     w  c(..)o   (
      \__(-)    __)
          /\   (
         /(_)___)
         w /|
          | \
         m  m