### PR TITLE
[WIP] Cli: Support --cap-add, --cap-drop and --privileged on services

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -65,6 +65,13 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Var(&opts.sysctls, flagSysCtl, "Sysctl options")
 	flags.SetAnnotation(flagSysCtl, "version", []string{"1.40"})
 
+	flags.Var(newListOptsVar(), flagCapAdd, "Add Linux capabilities")
+	flags.SetAnnotation(flagCapAdd, "version", []string{"1.41"})
+	flags.Var(newListOptsVar(), flagCapDrop, "Drop Linux capabilities")
+	flags.SetAnnotation(flagCapDrop, "version", []string{"1.41"})
+	flags.Bool(flagPrivileged, false, "Give extended privileges to this container")
+	flags.SetAnnotation(flagPrivileged, "version", []string{"1.41"})
+
 	flags.Var(cliopts.NewListOptsRef(&opts.resources.resGenericResources, ValidateSingleGenericResource), "generic-resource", "User defined resources")
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.32"})
 

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1248,3 +1248,18 @@ func TestUpdateCredSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateCapabilities(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("cap-add", "CAP_SYS_NICE")
+	flags.Set("cap-drop", "MKNOD")
+
+	containerSpec := &swarm.ContainerSpec{
+		Capabilities: []string{"CAP_MKNOD", "CAP_NET_RAW"},
+	}
+
+	updateCapabilities(flags, &containerSpec.Capabilities)
+	assert.Assert(t, is.Len(containerSpec.Capabilities, 2))
+	assert.Check(t, is.Equal("CAP_NET_RAW", containerSpec.Capabilities[0]))
+	assert.Check(t, is.Equal("CAP_SYS_NICE", containerSpec.Capabilities[1]))
+}

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/oci/caps"
 	"github.com/pkg/errors"
 )
 
@@ -117,6 +118,11 @@ func Service(
 		}
 	}
 
+	capabilities, err := convertCapabilities(service.CapAdd, service.CapDrop, service.Privileged)
+	if err != nil {
+		return swarm.ServiceSpec{}, err
+	}
+
 	serviceSpec := swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   name,
@@ -147,6 +153,7 @@ func Service(
 				Isolation:       container.Isolation(service.Isolation),
 				Init:            service.Init,
 				Sysctls:         service.Sysctls,
+				Capabilities:    capabilities,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,
@@ -674,4 +681,32 @@ func convertCredentialSpec(namespace Namespace, spec composetypes.CredentialSpec
 		return nil, errors.Errorf("invalid credential spec: spec specifies config %v, but no such config can be found", swarmCredSpec.Config)
 	}
 	return &swarmCredSpec, nil
+}
+
+func convertCapabilities(capAdd, capDrop []string, privileged bool) ([]string, error) {
+	defaultCapabilities := []string{
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE",
+	}
+	capabilities := []string{}
+	if privileged || len(capAdd) > 0 || len(capDrop) > 0 {
+		capabilities, err := caps.TweakCapabilities(defaultCapabilities, capAdd, capDrop, nil, privileged)
+		if err != nil {
+			return nil, err
+		}
+		return capabilities, nil
+	}
+	return capabilities, nil
 }

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -9,8 +9,6 @@ import (
 // UnsupportedProperties not yet supported by this implementation of the compose file
 var UnsupportedProperties = []string{
 	"build",
-	"cap_add",
-	"cap_drop",
 	"cgroup_parent",
 	"devices",
 	"domainname",
@@ -20,7 +18,6 @@ var UnsupportedProperties = []string{
 	"mac_address",
 	"network_mode",
 	"pid",
-	"privileged",
 	"restart",
 	"security_opt",
 	"shm_size",

--- a/vendor/github.com/docker/docker/oci/caps/utils.go
+++ b/vendor/github.com/docker/docker/oci/caps/utils.go
@@ -1,0 +1,169 @@
+package caps // import "github.com/docker/docker/oci/caps"
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/errdefs"
+	"github.com/syndtr/gocapability/capability"
+)
+
+var capabilityList Capabilities
+
+func init() {
+	last := capability.CAP_LAST_CAP
+	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
+	if last == capability.Cap(63) {
+		last = capability.CAP_BLOCK_SUSPEND
+	}
+	for _, cap := range capability.List() {
+		if cap > last {
+			continue
+		}
+		capabilityList = append(capabilityList,
+			&CapabilityMapping{
+				Key:   "CAP_" + strings.ToUpper(cap.String()),
+				Value: cap,
+			},
+		)
+	}
+}
+
+type (
+	// CapabilityMapping maps linux capability name to its value of capability.Cap type
+	// Capabilities is one of the security systems in Linux Security Module (LSM)
+	// framework provided by the kernel.
+	// For more details on capabilities, see http://man7.org/linux/man-pages/man7/capabilities.7.html
+	CapabilityMapping struct {
+		Key   string         `json:"key,omitempty"`
+		Value capability.Cap `json:"value,omitempty"`
+	}
+	// Capabilities contains all CapabilityMapping
+	Capabilities []*CapabilityMapping
+)
+
+// String returns <key> of CapabilityMapping
+func (c *CapabilityMapping) String() string {
+	return c.Key
+}
+
+// GetCapability returns CapabilityMapping which contains specific key
+func GetCapability(key string) *CapabilityMapping {
+	for _, capp := range capabilityList {
+		if capp.Key == key {
+			cpy := *capp
+			return &cpy
+		}
+	}
+	return nil
+}
+
+// GetAllCapabilities returns all of the capabilities
+func GetAllCapabilities() []string {
+	output := make([]string, len(capabilityList))
+	for i, capability := range capabilityList {
+		output[i] = capability.String()
+	}
+	return output
+}
+
+// inSlice tests whether a string is contained in a slice of strings or not.
+func inSlice(slice []string, s string) bool {
+	for _, ss := range slice {
+		if s == ss {
+			return true
+		}
+	}
+	return false
+}
+
+const allCapabilities = "ALL"
+
+// NormalizeLegacyCapabilities normalizes, and validates CapAdd/CapDrop capabilities
+// by upper-casing them, and adding a CAP_ prefix (if not yet present).
+//
+// This function also accepts the "ALL" magic-value, that's used by CapAdd/CapDrop.
+func NormalizeLegacyCapabilities(caps []string) ([]string, error) {
+	var normalized []string
+
+	valids := GetAllCapabilities()
+	for _, c := range caps {
+		c = strings.ToUpper(c)
+		if c == allCapabilities {
+			normalized = append(normalized, c)
+			continue
+		}
+		if !strings.HasPrefix(c, "CAP_") {
+			c = "CAP_" + c
+		}
+		if !inSlice(valids, c) {
+			return nil, errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
+		}
+		normalized = append(normalized, c)
+	}
+	return normalized, nil
+}
+
+// ValidateCapabilities validates if caps only contains valid capabilities
+func ValidateCapabilities(caps []string) error {
+	valids := GetAllCapabilities()
+	for _, c := range caps {
+		if !inSlice(valids, c) {
+			return errdefs.InvalidParameter(fmt.Errorf("unknown capability: %q", c))
+		}
+	}
+	return nil
+}
+
+// TweakCapabilities tweaks capabilities by adding, dropping, or overriding
+// capabilities in the basics capabilities list.
+func TweakCapabilities(basics, adds, drops, capabilities []string, privileged bool) ([]string, error) {
+	switch {
+	case privileged:
+		// Privileged containers get all capabilities
+		return GetAllCapabilities(), nil
+	case capabilities != nil:
+		// Use custom set of capabilities
+		if err := ValidateCapabilities(capabilities); err != nil {
+			return nil, err
+		}
+		return capabilities, nil
+	case len(adds) == 0 && len(drops) == 0:
+		// Nothing to tweak; we're done
+		return basics, nil
+	}
+
+	capDrop, err := NormalizeLegacyCapabilities(drops)
+	if err != nil {
+		return nil, err
+	}
+	capAdd, err := NormalizeLegacyCapabilities(adds)
+	if err != nil {
+		return nil, err
+	}
+
+	var caps []string
+
+	switch {
+	case inSlice(capAdd, allCapabilities):
+		// Add all capabilities except ones on capDrop
+		for _, c := range GetAllCapabilities() {
+			if !inSlice(capDrop, c) {
+				caps = append(caps, c)
+			}
+		}
+	case inSlice(capDrop, allCapabilities):
+		// "Drop" all capabilities; use what's in capAdd instead
+		caps = capAdd
+	default:
+		// First drop some capabilities
+		for _, c := range basics {
+			if !inSlice(capDrop, c) {
+				caps = append(caps, c)
+			}
+		}
+		// Then add the list of capabilities from capAdd
+		caps = append(caps, capAdd...)
+	}
+	return caps, nil
+}


### PR DESCRIPTION
**- What I did**
* Added --cap-add, --cap-drop and --privileged flags to `docker service create`
* Added --cap-add and --cap-drop to `docker service update`

Closes moby/moby#25885 moby/moby#24862 docker/swarmkit#1030

**- How I did it**
Included logic which converts -cap-add, --cap-drop and --privileged flags to exact capabilities list

**- How to verify it**
Create service based on default capabilities with minor adjustments:
```
docker service create --name test --cap-add "NET_ADMIN" --cap-drop "CAP_CHOWN" ollijanatuinen/capsh
```
Update capabilities for existing service:
```
docker service update --cap-drop "CAP_NET_RAW" --cap-add "SYS_NICE" test
```

Create service with all capabilities and drop some capabilities from it:
```
docker service create --name test2 --privileged ollijanatuinen/capsh
docker service update --cap-drop "CAP_AUDIT_READ" --cap-drop "CAP_BLOCK_SUSPEND" test2
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/6213926/69007196-52830b00-0943-11ea-9827-fe38996912eb.png)

WIP because based on #1940 and it needs to be merged first.