### PR TITLE
35991 - Modify CLI docs to specify working of device flag

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -560,7 +560,8 @@ device or audio device can be added to an otherwise unprivileged container
 
 By default, the container will be able to `read`, `write` and `mknod` these devices.
 This can be overridden using a third `:rwm` set of options to each `--device`
-flag:
+flag. If the container is running in privileged mode, then the permissions specified
+will be ignored.
 
 ```bash
 $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Modify the docker run docs, to specify working of --device flag
in containers that are started in privileged mode. The custom device
permissions that are given to a device in privileged mode are ignored
and goes with `rwm` by default

fixes [#35991](https://github.com/moby/moby/issues/35991)

**- How I did it**
The changes are in PR [#40291](https://github.com/moby/moby/pull/40291)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
modify docker run CLI docs to update with the new behaviour of `--device` flag


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://i.pinimg.com/originals/79/a9/41/79a941de1bfe8d9fbea2369fef8c2e35.jpg)
