### PR TITLE
implement docker push -a/--all-tags

### DIFF
--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -31,8 +31,8 @@ type target struct {
 }
 
 // TrustedPush handles content trust pushing of an image
-func TrustedPush(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo, ref reference.Named, authConfig types.AuthConfig, requestPrivilege types.RequestPrivilegeFunc) error {
-	responseBody, err := imagePushPrivileged(ctx, cli, authConfig, ref, requestPrivilege)
+func TrustedPush(ctx context.Context, cli command.Cli, repoInfo *registry.RepositoryInfo, ref reference.Named, authConfig types.AuthConfig, options types.ImagePushOptions) error {
+	responseBody, err := cli.Client().ImagePush(ctx, reference.FamiliarString(ref), options)
 	if err != nil {
 		return err
 	}
@@ -165,20 +165,6 @@ func AddTargetToAllSignableRoles(repo client.Repository, target *client.Target) 
 	}
 
 	return repo.AddTarget(target, signableRoles...)
-}
-
-// imagePushPrivileged push the image
-func imagePushPrivileged(ctx context.Context, cli command.Cli, authConfig types.AuthConfig, ref reference.Reference, requestPrivilege types.RequestPrivilegeFunc) (io.ReadCloser, error) {
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
-	if err != nil {
-		return nil, err
-	}
-	options := types.ImagePushOptions{
-		RegistryAuth:  encodedAuth,
-		PrivilegeFunc: requestPrivilege,
-	}
-
-	return cli.Client().ImagePush(ctx, reference.FamiliarString(ref), options)
 }
 
 // trustedPull handles content trust pulling of an image

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3067,7 +3067,7 @@ _docker_image_pull() {
 _docker_image_push() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--disable-content-trust=false --help --quiet -q" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all-tags -a --disable-content-trust=false --help --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1078,6 +1078,7 @@ __docker_image_subcommand() {
         (push)
             _arguments $(__docker_arguments) \
                 $opts_help \
+                "($help -a --all-tags)"{-a,--all-tags}"[Push all tagged images in the repository]" \
                 "($help)--disable-content-trust[Skip image signing]" \
                 "($help -): :__docker_complete_images" && ret=0
             ;;

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -21,6 +21,7 @@ Usage:  docker push [OPTIONS] NAME[:TAG]
 Push an image or a repository to a registry
 
 Options:
+  -a, --all-tags                Push all tagged images in the repository
       --disable-content-trust   Skip image signing (default true)
       --help                    Print usage
   -q, --quiet                   Suppress verbose output
@@ -28,13 +29,13 @@ Options:
 
 ## Description
 
-Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)
+Use `docker image push` to share your images to the [Docker Hub](https://hub.docker.com)
 registry or to a self-hosted one.
 
-Refer to the [`docker tag`](tag.md) reference for more information about valid
+Refer to the [`docker image tag`](tag.md) reference for more information about valid
 image and tag names.
 
-Killing the `docker push` process, for example by pressing `CTRL-c` while it is
+Killing the `docker image push` process, for example by pressing `CTRL-c` while it is
 running in a terminal, terminates the push operation.
 
 Progress bars are shown during docker push, which show the uncompressed size. The 
@@ -54,12 +55,12 @@ this via the `--max-concurrent-uploads` daemon option. See the
 
 ### Push a new image to a registry
 
-First save the new image by finding the container ID (using [`docker ps`](ps.md))
+First save the new image by finding the container ID (using [`docker container ls`](ps.md))
 and then committing it to a new image name.  Note that only `a-z0-9-_.` are
 allowed when naming images:
 
 ```bash
-$ docker commit c16378f943fe rhel-httpd
+$ docker container commit c16378f943fe rhel-httpd:latest
 ```
 
 Now, push the image to the registry using the image ID. In this example the
@@ -68,16 +69,63 @@ this, tag the image with the host name or IP address, and the port of the
 registry:
 
 ```bash
-$ docker tag rhel-httpd registry-host:5000/myadmin/rhel-httpd
+$ docker image tag rhel-httpd:latest registry-host:5000/myadmin/rhel-httpd:latest
 
-$ docker push registry-host:5000/myadmin/rhel-httpd
+$ docker image push registry-host:5000/myadmin/rhel-httpd:latest
 ```
 
 Check that this worked by running:
 
 ```bash
-$ docker images
+$ docker image ls
 ```
 
 You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
 listed.
+
+### Push all tags of an image
+
+Use the `-a` (or `--all-tags`) option to push To push all tags of a local image.
+
+The following example creates multiple tags for an image, and pushes all those
+tags to Docker Hub.
+
+
+```bash
+$ docker image tag myimage registry-host:5000/myname/myimage:latest
+$ docker image tag myimage registry-host:5000/myname/myimage:v1.0.1
+$ docker image tag myimage registry-host:5000/myname/myimage:v1.0
+$ docker image tag myimage registry-host:5000/myname/myimage:v1
+```
+
+The image is now tagged under multiple names:
+
+```bash
+$ docker image ls
+
+REPOSITORY                          TAG        IMAGE ID       CREATED      SIZE
+myimage                             latest     6d5fcfe5ff17   2 hours ago  1.22MB
+registry-host:5000/myname/myimage   latest     6d5fcfe5ff17   2 hours ago  1.22MB
+registry-host:5000/myname/myimage   v1         6d5fcfe5ff17   2 hours ago  1.22MB
+registry-host:5000/myname/myimage   v1.0       6d5fcfe5ff17   2 hours ago  1.22MB
+registry-host:5000/myname/myimage   v1.0.1     6d5fcfe5ff17   2 hours ago  1.22MB
+```
+
+When pushing with the `--all-tags` option, all tags of the `registry-host:5000/myname/myimage`
+image are pushed:
+
+
+```bash
+$ docker image push --all-tags registry-host:5000/myname/myimage
+
+The push refers to repository [registry-host:5000/myname/myimage]
+195be5f8be1d: Pushed
+latest: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+195be5f8be1d: Layer already exists
+v1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+195be5f8be1d: Layer already exists
+v1.0: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+195be5f8be1d: Layer already exists
+v1.0.1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+```
+

--- a/man/src/image/push.md
+++ b/man/src/image/push.md
@@ -23,8 +23,8 @@ registry is on host named `registry-host` and listening on port `5000`. To do
 this, tag the image with the host name or IP address, and the port of the
 registry:
 
-    # docker image tag rhel-httpd registry-host:5000/myadmin/rhel-httpd
-    # docker image push registry-host:5000/myadmin/rhel-httpd
+    # docker image tag rhel-httpd registry-host:5000/myadmin/rhel-httpd:latest
+    # docker image push registry-host:5000/myadmin/rhel-httpd:latest
 
 Check that this worked by running:
 
@@ -32,3 +32,42 @@ Check that this worked by running:
 
 You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
 listed.
+
+### Push all tags of an image
+
+Use the `-a` (or `--all-tags`) option to push To push all tags of a local image.
+
+The following example creates multiple tags for an image, and pushes all those
+tags to Docker Hub.
+
+    $ docker image tag myimage registry-host:5000/myname/myimage:latest
+    $ docker image tag myimage registry-host:5000/myname/myimage:v1.0.1
+    $ docker image tag myimage registry-host:5000/myname/myimage:v1.0
+    $ docker image tag myimage registry-host:5000/myname/myimage:v1
+
+The image is now tagged under multiple names:
+
+    $ docker image ls
+    
+    REPOSITORY                          TAG        IMAGE ID       CREATED      SIZE
+    myimage                             latest     6d5fcfe5ff17   2 hours ago  1.22MB
+    registry-host:5000/myname/myimage   latest     6d5fcfe5ff17   2 hours ago  1.22MB
+    registry-host:5000/myname/myimage   v1         6d5fcfe5ff17   2 hours ago  1.22MB
+    registry-host:5000/myname/myimage   v1.0       6d5fcfe5ff17   2 hours ago  1.22MB
+    registry-host:5000/myname/myimage   v1.0.1     6d5fcfe5ff17   2 hours ago  1.22MB
+
+When pushing with the `--all-tags` option, all tags of the `registry-host:5000/myname/myimage`
+image are pushed:
+
+
+    $ docker image push --all-tags registry-host:5000/myname/myimage
+    
+    The push refers to repository [registry-host:5000/myname/myimage]
+    195be5f8be1d: Pushed
+    latest: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+    195be5f8be1d: Layer already exists
+    v1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+    195be5f8be1d: Layer already exists
+    v1.0: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527
+    195be5f8be1d: Layer already exists
+    v1.0.1: digest: sha256:edafc0a0fb057813850d1ba44014914ca02d671ae247107ca70c94db686e7de6 size: 4527


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/2214

- [x] depends on https://github.com/docker/cli/pull/2242

depends on https://github.com/moby/moby/pull/40302 client.ImagePush(): default to ":latest" instead of "all tags"

The `docker push` command up until [v0.9.1](https://github.com/moby/moby/blob/v0.9.1/api/client.go#L998)
always pushed all tags of a given image, so `docker push foo/bar` would push (e.g.)
all of  `foo/bar:latest`, `foo:/bar:v1`, `foo/bar:v1.0.0`.

Pushing all tags of an image was not desirable in many case, so docker v0.10.0
enhanced `docker push` to optionally specify a tag to push (`docker push foo/bar:v1`)
(see https://github.com/moby/moby/issues/3411 and the pull request that implemented
this: https://github.com/moby/moby/pull/4948).

This behavior exists up until today, and is confusing, because unlike other commands,
`docker push` does not default to use the `:latest` tag when omitted, but instead
makes it push "all tags of the image"

For example, in the following situation;

```
docker images

REPOSITORY          TAG                        IMAGE ID            CREATED             SIZE
thajeztah/myimage   latest                     b534869c81f0        41 hours ago        1.22MB
```

Running `docker push thajeztah/myimage` seemingly does the expected behavior (it
pushes `thajeztah/myimage:latest` to Docker Hub), however, it does not so for the
reason expected (`:latest` being the default tag), but because `:latest` happens
to be the only tag present for the `thajeztah/myimage` image.

If another tag exists for the image:

```
docker images

REPOSITORY          TAG                        IMAGE ID            CREATED             SIZE
thajeztah/myimage   latest                     b534869c81f0        41 hours ago        1.22MB
thajeztah/myimage   v1.0.0                     b534869c81f0        41 hours ago        1.22MB
```

Running the same command (`docker push thajeztah/myimage`) will push _both_ images
to Docker Hub.


> Note that the behavior described above is currently not (clearly) documented;
> the `docker push` reference documentation (https://docs.docker.com/engine/reference/commandline/push/)
does not mention that omitting the tag will push all tags

This patch changes the default behavior, and if no tag is specified, `:latest` is
assumed. To push _all_ tags, a new flag (`-a` / `--all-tags`) is added, similar
to the flag that's present on `docker pull`.

With this change:

- `docker push myname/myimage` will be the equivalent of `docker push myname/myimage:latest`
- to push all images, the user needs to set a flag (`--all-tags`), so `docker push --all-tags myname/myimage:latest`



**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

