### PR TITLE
[19.03 backport] docker cp: prevent NPE when failing to stat destination

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -139,6 +139,10 @@ func ValidateOutputPath(path string) error {
 	// check whether `path` points to a regular file
 	// (if the path exists and doesn't point to a directory)
 	if fileInfo, err := os.Stat(path); !os.IsNotExist(err) {
+		if err != nil {
+			return err
+		}
+
 		if fileInfo.Mode().IsDir() || fileInfo.Mode().IsRegular() {
 			return nil
 		}


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2221
fixes https://github.com/docker/cli/issues/2219 for 19.03