### PR TITLE
1962 invalid port

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -382,7 +382,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	var ports map[nat.Port]struct{}
 	var portBindings map[nat.Port][]nat.PortBinding
 
-	isAdvanced := strings.Contains(strings.Join(publishOpts[:],""),"=")
+	isAdvanced := strings.Contains(strings.Join(publishOpts[:], ""), "=")
 
 	ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
 

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -382,7 +382,13 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	var ports map[nat.Port]struct{}
 	var portBindings map[nat.Port][]nat.PortBinding
 
+	isAdvanced := strings.Contains(strings.Join(publishOpts[:],""),"=")
+
 	ports, portBindings, err = nat.ParsePortSpecs(publishOpts)
+
+	if err != nil && !isAdvanced {
+		return nil, err
+	}
 
 	// If simple port parsing fails try to parse as long format
 	if err != nil {

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -298,7 +298,7 @@ func TestParseHostnameDomainname(t *testing.T) {
 	}
 }
 
-func TestParseWithPublish(t *testing.T) {
+func TestParseWithShorthandPublish(t *testing.T) {
 	invalids := map[string]string{
 		":":          "No port specified:  :<empty>",
 		"80809:80":   "Invalid hostPort:  80809",

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -298,6 +298,19 @@ func TestParseHostnameDomainname(t *testing.T) {
 	}
 }
 
+func TestParseWithPublish(t *testing.T) {
+	invalids := map[string]string{
+		":":          "No port specified:  :<empty>",
+		"80809:80":   "Invalid hostPort:  80809",
+		"8080:80809": "Invalid containerPort: 80809",
+	}
+	for publish, expectedError := range invalids {
+		if _, _, _, err := parseRun([]string{fmt.Sprintf("-p %v", publish), "img", "cmd"}); err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error '%v' with '-p %v', got '%v'", expectedError, publish, err)
+		}
+	}
+}
+
 func TestParseWithExpose(t *testing.T) {
 	invalids := map[string]string{
 		":":                   "invalid port format for --expose: :",


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I fixed the issue described in #1962 pertaining to invalid port passed with the flag `-p`

**- How I did it**
Following the suggestions of @thaJeztah, I checked if the flag is advanced i.e. of the form `-p target=<PORT>,publish=<PORT>` and if it was a shorthand, the parsing error should be reported with an appropriate message and *NOT* try to parse it as advanced.

**- How to verify it**
- Wrote a test under `opts_test.go`.
- Ran previous tests against my change with `make -f docker.Makefile test`
-  Generated a binary and checked it for desired behaviour.

**- Description for the changelog**
Capture erroneous port in shorthand version of the publish flag.

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://i.pinimg.com/originals/95/3e/2a/953e2a2c5e0342642b365fcd8a0ff142.jpg"
    alt="Markdown Monster icon"/>