### PR TITLE
config: preserve ownership and permissions on configfile

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -196,6 +196,9 @@ func (configFile *ConfigFile) Save() error {
 		os.Remove(temp.Name())
 		return err
 	}
+	// Try copying the current config file (if any) ownership and permissions
+	copyFilePermissions(configFile.Filename, temp.Name())
+
 	return os.Rename(temp.Name(), configFile.Filename)
 }
 

--- a/cli/config/configfile/file_unix.go
+++ b/cli/config/configfile/file_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package configfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// copyFilePermissions copies file ownership and permissions from "src" to "dst",
+// ignoring any error during the process.
+func copyFilePermissions(src, dst string) {
+	var (
+		mode     os.FileMode = 0600
+		uid, gid int
+	)
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if fi.Mode().IsRegular() {
+		mode = fi.Mode()
+	}
+	if err := os.Chmod(dst, mode); err != nil {
+		return
+	}
+
+	uid = int(fi.Sys().(*syscall.Stat_t).Uid)
+	gid = int(fi.Sys().(*syscall.Stat_t).Gid)
+
+	if uid > 0 && gid > 0 {
+		_ = os.Chown(dst, uid, gid)
+	}
+}

--- a/cli/config/configfile/file_windows.go
+++ b/cli/config/configfile/file_windows.go
@@ -1,0 +1,5 @@
+package configfile
+
+func copyFilePermissions(src, dst string) {
+	// TODO implement for Windows
+}


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40175

When running `docker login` or `docker logout`, the CLI updates the configuration file by creating a temporary file, to replace the old one (if exists).

When using `sudo`, this caused the file to be created as `root`, making it inaccessible to the current user.

This patch updates the CLI to fetch permissions and ownership of the existing configuration file, and applies those permissions to the new file, so that it has the same permissions as the existing file (if any).

Currently, only done for "Unix-y" systems (Mac, Linux), but can be implemented for Windows in future if there's a need.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

