### PR TITLE
Fix some issues with docker ps --format

### DIFF
--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -78,7 +78,7 @@ func TestContainerListBuildContainerListOptions(t *testing.T) {
 				last:   5,
 				filter: filters,
 				// With .Size, size should be true
-				format: "{{.Size}} {{.CreatedAt}} {{.Networks}}",
+				format: "{{.Size}} {{.CreatedAt}} {{upper .Networks}}",
 			},
 			expectedAll:   true,
 			expectedSize:  true,

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -241,6 +241,10 @@ size: 0B
 			Context{Format: NewContainerFormat(`table {{truncate .ID 5}}\t{{json .Image}} {{.RunningFor}}/{{title .Status}}/{{pad .Ports 2 2}}.{{upper .Names}} {{lower .Status}}`, false, true)},
 			string(golden.Get(t, "container-context-write-special-headers.golden")),
 		},
+		{
+			Context{Format: NewContainerFormat(`table {{split .Image ":"}}`, false, false)},
+			"IMAGE\n[ubuntu]\n[ubuntu]\n",
+		},
 	}
 
 	for _, testcase := range cases {

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -19,7 +19,7 @@ func TestContainerPsContext(t *testing.T) {
 	containerID := stringid.GenerateRandomID()
 	unix := time.Now().Add(-65 * time.Second).Unix()
 
-	var ctx containerContext
+	var ctx ContainerContext
 	cases := []struct {
 		container types.Container
 		trunc     bool
@@ -87,7 +87,7 @@ func TestContainerPsContext(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		ctx = containerContext{c: c.container, trunc: c.trunc}
+		ctx = ContainerContext{c: c.container, trunc: c.trunc}
 		v := c.call()
 		if strings.Contains(v, ",") {
 			compareMultipleValues(t, v, c.expValue)
@@ -97,7 +97,7 @@ func TestContainerPsContext(t *testing.T) {
 	}
 
 	c1 := types.Container{Labels: map[string]string{"com.docker.swarm.swarm-id": "33", "com.docker.swarm.node_name": "ubuntu"}}
-	ctx = containerContext{c: c1, trunc: true}
+	ctx = ContainerContext{c: c1, trunc: true}
 
 	sid := ctx.Label("com.docker.swarm.swarm-id")
 	node := ctx.Label("com.docker.swarm.node_name")
@@ -110,7 +110,7 @@ func TestContainerPsContext(t *testing.T) {
 	}
 
 	c2 := types.Container{}
-	ctx = containerContext{c: c2, trunc: true}
+	ctx = ContainerContext{c: c2, trunc: true}
 
 	label := ctx.Label("anything.really")
 	if label != "" {

--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -136,7 +136,7 @@ func (ctx *DiskUsageContext) Write() (err error) {
 
 type diskUsageContext struct {
 	Images     []*imageContext
-	Containers []*containerContext
+	Containers []*ContainerContext
 	Volumes    []*volumeContext
 	BuildCache []*buildCacheContext
 }
@@ -144,7 +144,7 @@ type diskUsageContext struct {
 func (ctx *DiskUsageContext) verboseWrite() error {
 	duc := &diskUsageContext{
 		Images:     make([]*imageContext, 0, len(ctx.Images)),
-		Containers: make([]*containerContext, 0, len(ctx.Containers)),
+		Containers: make([]*ContainerContext, 0, len(ctx.Containers)),
 		Volumes:    make([]*volumeContext, 0, len(ctx.Volumes)),
 		BuildCache: make([]*buildCacheContext, 0, len(ctx.BuildCache)),
 	}
@@ -178,7 +178,7 @@ func (ctx *DiskUsageContext) verboseWrite() error {
 	for _, c := range ctx.Containers {
 		// Don't display the virtual size
 		c.SizeRootFs = 0
-		duc.Containers = append(duc.Containers, &containerContext{trunc: trunc, c: *c})
+		duc.Containers = append(duc.Containers, &ContainerContext{trunc: trunc, c: *c})
 	}
 
 	// And volumes
@@ -227,7 +227,7 @@ func (ctx *DiskUsageContext) verboseWriteTable(duc *diskUsageContext) error {
 			return err
 		}
 	}
-	ctx.postFormat(tmpl, newContainerContext())
+	ctx.postFormat(tmpl, NewContainerContext())
 
 	tmpl, err = ctx.startSubsection(defaultDiskUsageVolumeTableFormat)
 	if err != nil {

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -30,9 +30,21 @@ var basicFunctions = template.FuncMap{
 // HeaderFunctions are used to created headers of a table.
 // This is a replacement of basicFunctions for header generation
 // because we want the header to remain intact.
-// Some functions like `split` are irrelevant so not added.
+// Some functions like `pad` are not overridden (to preserve alignment
+// with the columns).
 var HeaderFunctions = template.FuncMap{
 	"json": func(v string) string {
+		return v
+	},
+	"split": func(v string, _ string) string {
+		// we want the table header to show the name of the column, and not
+		// split the table header itself. Using a different signature
+		// here, and return a string instead of []string
+		return v
+	},
+	"join": func(v string, _ string) string {
+		// table headers are always a string, so use a different signature
+		// for the "join" function (string instead of []string)
 		return v
 	},
 	"title": func(v string) string {


### PR DESCRIPTION
#### Fix docker ps --format with templating functions

Before this patch, using a template that used templating functions (such as
`lower` or `json`) caused the command to fail in the pre-processor step (in
`buildContainerListOptions`):

    docker ps --format='{{upper .Names}}'
    template: :1:8: executing "" at <.Names>: invalid value; expected string

This problem was due to the pre-processing using a different "context" type than
was used in the actual template, and custom functions to not be defined when
instantiating the Go template.

With this patch, using functions in templates works correctly:

    docker ps --format='{{upper .Names}}'
    MUSING_NEUMANN
    ELOQUENT_MEITNER


#### Fix docker ps table headers with custom format and "split" or "join"

Update the list of overrides for table headers so that columns using split or
join will produce the correct table header.

Before this patch:

    docker ps --format='table {{split .Names "/"}}'
    [NAMES]
    [unruffled_mclean]
    [eloquent_meitner]
    [sleepy_grothendieck]

With this patch applied:

    docker ps --format='table {{split .Names "/"}}'
    NAMES
    [unruffled_mclean]
    [eloquent_meitner]
    [sleepy_grothendieck]



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

