### PR TITLE
docker info: list CLI plugins alphabetically

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/spf13/cobra"
+	"vbom.ml/util/sortorder"
 )
 
 // ReexecEnvvar is the name of an ennvar which is set to the command
@@ -140,6 +142,10 @@ func ListPlugins(dockerCli command.Cli, rootcmd *cobra.Command) ([]Plugin, error
 			plugins = append(plugins, p)
 		}
 	}
+
+	sort.Slice(plugins, func(i, j int) bool {
+		return sortorder.NaturalLess(plugins[i].Name, plugins[j].Name)
+	})
 
 	return plugins, nil
 }


### PR DESCRIPTION
Before this change, plugins were listed in a random order:

    Client:
     Debug Mode: false
     Plugins:
      doodle: Docker Doodles  all around! 🐳 🎃 (thaJeztah, v0.0.1)
      shell: Open a browser shell on the Docker Host. (thaJeztah, v0.0.1)
      app: Docker Application (Docker Inc., v0.8.0)
      buildx: Build with BuildKit (Docker Inc., v0.3.1-tp-docker)

With this change, plugins are listed alphabetically:

    Client:
     Debug Mode: false
     Plugins:
      app: Docker Application (Docker Inc., v0.8.0)
      buildx: Build with BuildKit (Docker Inc., v0.3.1-tp-docker)
      doodle: Docker Doodles  all around! 🐳 🎃 (thaJeztah, v0.0.1)
      shell: Open a browser shell on the Docker Host. (thaJeztah, v0.0.1)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

