### PR TITLE
Fix "make build" (non-containerized) on macOS

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -4,7 +4,7 @@ set -eu
 PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-"unknown-version"}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
-BUILDTIME=${BUILDTIME:-$(date --utc --rfc-3339 ns 2> /dev/null | sed -e 's/ /T/')}
+BUILDTIME=${BUILDTIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
 
 PLATFORM_LDFLAGS=
 if test -n "${PLATFORM}"; then


### PR DESCRIPTION
macOS doesn't ship with the GNU version of `date`, which causes the command to fail if the `- rfc-3339 ns` format option is used.

Given that we don't need the build-time with nanosecond precision, this patch changes the format used, so that the CLI binary can be built on the host (outside of a container);

Before this change, `make binary` would fail:

    DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    WARNING: binary creates a Linux executable. Use cross for macOS or Windows.
    ./scripts/build/binary
    make: *** [binary] Error 1

With this change, the binary can be built on the host:

    DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    WARNING: binary creates a Linux executable. Use cross for macOS or Windows.
    ./scripts/build/binary
    Building statically linked build/docker-darwin-amd64

While the previous version formatted (and parsed) the date with nanoseconds precision,
that level of precision is not actually used;

```go
func reformatDate(buildTime string) string {
	t, errTime := time.Parse(time.RFC3339Nano, buildTime)
	if errTime == nil {
		return t.Format(time.ANSIC)
	}
	return buildTime
}
```

Both the old, and new input will yield the same output:

```go
fmt.Println(reformatDate("2019-12-31T13:41:44.846741804+00:00"))
// Tue Dec 31 13:41:44 2019

fmt.Println(reformatDate("2019-12-31T13:41:44Z"))
// Tue Dec 31 13:41:44 2019
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

