### PR TITLE
Detect single-value advanced syntax

### DIFF
--- a/opts/config.go
+++ b/opts/config.go
@@ -72,6 +72,9 @@ func (o *ConfigOpt) Set(value string) error {
 	if options.ConfigName == "" {
 		return fmt.Errorf("source is required")
 	}
+	if options.File.Name == "" {
+		options.File.Name = options.ConfigName
+	}
 
 	o.values = append(o.values, options)
 	return nil

--- a/opts/config.go
+++ b/opts/config.go
@@ -32,7 +32,7 @@ func (o *ConfigOpt) Set(value string) error {
 	}
 
 	// support a simple syntax of --config foo
-	if len(fields) == 1 {
+	if len(fields) == 1 && !strings.Contains(fields[0], "=") {
 		options.File.Name = fields[0]
 		options.ConfigName = fields[0]
 		o.values = append(o.values, options)

--- a/opts/config_test.go
+++ b/opts/config_test.go
@@ -33,6 +33,7 @@ func TestConfigOptionsSource(t *testing.T) {
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
 	assert.Check(t, is.Equal("foo", req.ConfigName))
+	assert.Check(t, is.Equal("foo", req.File.Name))
 }
 
 func TestConfigOptionsSourceTarget(t *testing.T) {

--- a/opts/config_test.go
+++ b/opts/config_test.go
@@ -8,23 +8,23 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestSecretOptionsSimple(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsSimple(t *testing.T) {
+	var opt ConfigOpt
 
-	testCase := "app-secret"
+	testCase := "app-config"
 	assert.NilError(t, opt.Set(testCase))
 
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("app-secret", req.SecretName))
-	assert.Check(t, is.Equal("app-secret", req.File.Name))
+	assert.Check(t, is.Equal("app-config", req.ConfigName))
+	assert.Check(t, is.Equal("app-config", req.File.Name))
 	assert.Check(t, is.Equal("0", req.File.UID))
 	assert.Check(t, is.Equal("0", req.File.GID))
 }
 
-func TestSecretOptionsSource(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsSource(t *testing.T) {
+	var opt ConfigOpt
 
 	testCase := "source=foo"
 	assert.NilError(t, opt.Set(testCase))
@@ -32,11 +32,11 @@ func TestSecretOptionsSource(t *testing.T) {
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.ConfigName))
 }
 
-func TestSecretOptionsSourceTarget(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsSourceTarget(t *testing.T) {
+	var opt ConfigOpt
 
 	testCase := "source=foo,target=testing"
 	assert.NilError(t, opt.Set(testCase))
@@ -44,12 +44,12 @@ func TestSecretOptionsSourceTarget(t *testing.T) {
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.ConfigName))
 	assert.Check(t, is.Equal("testing", req.File.Name))
 }
 
-func TestSecretOptionsShorthand(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsShorthand(t *testing.T) {
+	var opt ConfigOpt
 
 	testCase := "src=foo,target=testing"
 	assert.NilError(t, opt.Set(testCase))
@@ -57,11 +57,11 @@ func TestSecretOptionsShorthand(t *testing.T) {
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.ConfigName))
 }
 
-func TestSecretOptionsCustomUidGid(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsCustomUidGid(t *testing.T) {
+	var opt ConfigOpt
 
 	testCase := "source=foo,target=testing,uid=1000,gid=1001"
 	assert.NilError(t, opt.Set(testCase))
@@ -69,14 +69,14 @@ func TestSecretOptionsCustomUidGid(t *testing.T) {
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.ConfigName))
 	assert.Check(t, is.Equal("testing", req.File.Name))
 	assert.Check(t, is.Equal("1000", req.File.UID))
 	assert.Check(t, is.Equal("1001", req.File.GID))
 }
 
-func TestSecretOptionsCustomMode(t *testing.T) {
-	var opt SecretOpt
+func TestConfigOptionsCustomMode(t *testing.T) {
+	var opt ConfigOpt
 
 	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
 	assert.NilError(t, opt.Set(testCase))
@@ -84,7 +84,7 @@ func TestSecretOptionsCustomMode(t *testing.T) {
 	reqs := opt.Value()
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.ConfigName))
 	assert.Check(t, is.Equal("testing", req.File.Name))
 	assert.Check(t, is.Equal("1000", req.File.UID))
 	assert.Check(t, is.Equal("1001", req.File.GID))

--- a/opts/config_test.go
+++ b/opts/config_test.go
@@ -8,86 +8,80 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestConfigOptionsSimple(t *testing.T) {
-	var opt ConfigOpt
+func TestConfigOptions(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		configName string
+		fileName   string
+		uid        string
+		gid        string
+		fileMode   uint
+	}{
+		{
+			name:       "Simple",
+			input:      "app-config",
+			configName: "app-config",
+			fileName:   "app-config",
+			uid:        "0",
+			gid:        "0",
+		},
+		{
+			name:       "Source",
+			input:      "source=foo",
+			configName: "foo",
+			fileName:   "foo",
+		},
+		{
+			name:       "SourceTarget",
+			input:      "source=foo,target=testing",
+			configName: "foo",
+			fileName:   "testing",
+		},
+		{
+			name:       "Shorthand",
+			input:      "src=foo,target=testing",
+			configName: "foo",
+			fileName:   "testing",
+		},
+		{
+			name:       "CustomUidGid",
+			input:      "source=foo,target=testing,uid=1000,gid=1001",
+			configName: "foo",
+			fileName:   "testing",
+			uid:        "1000",
+			gid:        "1001",
+		},
+		{
+			name:       "CustomMode",
+			input:      "source=foo,target=testing,uid=1000,gid=1001,mode=0444",
+			configName: "foo",
+			fileName:   "testing",
+			uid:        "1000",
+			gid:        "1001",
+			fileMode:   0444,
+		},
+	}
 
-	testCase := "app-config"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("app-config", req.ConfigName))
-	assert.Check(t, is.Equal("app-config", req.File.Name))
-	assert.Check(t, is.Equal("0", req.File.UID))
-	assert.Check(t, is.Equal("0", req.File.GID))
-}
-
-func TestConfigOptionsSource(t *testing.T) {
-	var opt ConfigOpt
-
-	testCase := "source=foo"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.ConfigName))
-	assert.Check(t, is.Equal("foo", req.File.Name))
-}
-
-func TestConfigOptionsSourceTarget(t *testing.T) {
-	var opt ConfigOpt
-
-	testCase := "source=foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.ConfigName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-}
-
-func TestConfigOptionsShorthand(t *testing.T) {
-	var opt ConfigOpt
-
-	testCase := "src=foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.ConfigName))
-}
-
-func TestConfigOptionsCustomUidGid(t *testing.T) {
-	var opt ConfigOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.ConfigName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-	assert.Check(t, is.Equal("1000", req.File.UID))
-	assert.Check(t, is.Equal("1001", req.File.GID))
-}
-
-func TestConfigOptionsCustomMode(t *testing.T) {
-	var opt ConfigOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.ConfigName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-	assert.Check(t, is.Equal("1000", req.File.UID))
-	assert.Check(t, is.Equal("1001", req.File.GID))
-	assert.Check(t, is.Equal(os.FileMode(0444), req.File.Mode))
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var opt ConfigOpt
+			assert.NilError(t, opt.Set(tc.input))
+			reqs := opt.Value()
+			assert.Assert(t, is.Len(reqs, 1))
+			req := reqs[0]
+			assert.Check(t, is.Equal(tc.configName, req.ConfigName))
+			assert.Check(t, is.Equal(tc.fileName, req.File.Name))
+			if tc.uid != "" {
+				assert.Check(t, is.Equal(tc.uid, req.File.UID))
+			}
+			if tc.gid != "" {
+				assert.Check(t, is.Equal(tc.gid, req.File.GID))
+			}
+			if tc.fileMode != 0 {
+				assert.Check(t, is.Equal(os.FileMode(tc.fileMode), req.File.Mode))
+			}
+		})
+	}
 }

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -72,6 +72,9 @@ func (o *SecretOpt) Set(value string) error {
 	if options.SecretName == "" {
 		return fmt.Errorf("source is required")
 	}
+	if options.File.Name == "" {
+		options.File.Name = options.SecretName
+	}
 
 	o.values = append(o.values, options)
 	return nil

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -32,7 +32,7 @@ func (o *SecretOpt) Set(value string) error {
 	}
 
 	// support a simple syntax of --secret foo
-	if len(fields) == 1 {
+	if len(fields) == 1 && !strings.Contains(fields[0], "=") {
 		options.File.Name = fields[0]
 		options.SecretName = fields[0]
 		o.values = append(o.values, options)

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -8,86 +8,80 @@ import (
 	is "gotest.tools/assert/cmp"
 )
 
-func TestSecretOptionsSimple(t *testing.T) {
-	var opt SecretOpt
+func TestSecretOptions(t *testing.T) {
+	testCases := []struct {
+		name       string
+		input      string
+		secretName string
+		fileName   string
+		uid        string
+		gid        string
+		fileMode   uint
+	}{
+		{
+			name:       "Simple",
+			input:      "app-secret",
+			secretName: "app-secret",
+			fileName:   "app-secret",
+			uid:        "0",
+			gid:        "0",
+		},
+		{
+			name:       "Source",
+			input:      "source=foo",
+			secretName: "foo",
+			fileName:   "foo",
+		},
+		{
+			name:       "SourceTarget",
+			input:      "source=foo,target=testing",
+			secretName: "foo",
+			fileName:   "testing",
+		},
+		{
+			name:       "Shorthand",
+			input:      "src=foo,target=testing",
+			secretName: "foo",
+			fileName:   "testing",
+		},
+		{
+			name:       "CustomUidGid",
+			input:      "source=foo,target=testing,uid=1000,gid=1001",
+			secretName: "foo",
+			fileName:   "testing",
+			uid:        "1000",
+			gid:        "1001",
+		},
+		{
+			name:       "CustomMode",
+			input:      "source=foo,target=testing,uid=1000,gid=1001,mode=0444",
+			secretName: "foo",
+			fileName:   "testing",
+			uid:        "1000",
+			gid:        "1001",
+			fileMode:   0444,
+		},
+	}
 
-	testCase := "app-secret"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("app-secret", req.SecretName))
-	assert.Check(t, is.Equal("app-secret", req.File.Name))
-	assert.Check(t, is.Equal("0", req.File.UID))
-	assert.Check(t, is.Equal("0", req.File.GID))
-}
-
-func TestSecretOptionsSource(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=foo"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
-	assert.Check(t, is.Equal("foo", req.File.Name))
-}
-
-func TestSecretOptionsSourceTarget(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-}
-
-func TestSecretOptionsShorthand(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "src=foo,target=testing"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
-}
-
-func TestSecretOptionsCustomUidGid(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-	assert.Check(t, is.Equal("1000", req.File.UID))
-	assert.Check(t, is.Equal("1001", req.File.GID))
-}
-
-func TestSecretOptionsCustomMode(t *testing.T) {
-	var opt SecretOpt
-
-	testCase := "source=foo,target=testing,uid=1000,gid=1001,mode=0444"
-	assert.NilError(t, opt.Set(testCase))
-
-	reqs := opt.Value()
-	assert.Assert(t, is.Len(reqs, 1))
-	req := reqs[0]
-	assert.Check(t, is.Equal("foo", req.SecretName))
-	assert.Check(t, is.Equal("testing", req.File.Name))
-	assert.Check(t, is.Equal("1000", req.File.UID))
-	assert.Check(t, is.Equal("1001", req.File.GID))
-	assert.Check(t, is.Equal(os.FileMode(0444), req.File.Mode))
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var opt SecretOpt
+			assert.NilError(t, opt.Set(tc.input))
+			reqs := opt.Value()
+			assert.Assert(t, is.Len(reqs, 1))
+			req := reqs[0]
+			assert.Check(t, is.Equal(tc.secretName, req.SecretName))
+			assert.Check(t, is.Equal(tc.fileName, req.File.Name))
+			if tc.uid != "" {
+				assert.Check(t, is.Equal(tc.uid, req.File.UID))
+			}
+			if tc.gid != "" {
+				assert.Check(t, is.Equal(tc.gid, req.File.GID))
+			}
+			if tc.fileMode != 0 {
+				assert.Check(t, is.Equal(os.FileMode(tc.fileMode), req.File.Mode))
+			}
+		})
+	}
 }

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -33,6 +33,7 @@ func TestSecretOptionsSource(t *testing.T) {
 	assert.Assert(t, is.Len(reqs, 1))
 	req := reqs[0]
 	assert.Check(t, is.Equal("foo", req.SecretName))
+	assert.Check(t, is.Equal("foo", req.File.Name))
 }
 
 func TestSecretOptionsSourceTarget(t *testing.T) {


### PR DESCRIPTION
**- What I did**

Adds the ability to just specify the `source` for config and secret flags using the advanced syntax as per https://docs.docker.com/engine/reference/commandline/service_create/#create-a-service-with-secrets. When the target is not specified the target is set to the source, same as when using the simple syntax.

**- How I did it**

When checking if the user is using the simple syntax check if the field contains an `=` as well as checking if there is more than one field.

**- How to verify it**

Unit tests have been added for just setting the source for both secrets and configs (all existing test cases for secrets have been copied for configs as well).

To manually test, follow the steps in #2058 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixes #2058 allowing the use of the advanced syntax when setting a config or secret with only the source field.

**- A picture of a cute animal (not mandatory but encouraged)**

![hedgehog-2019-11-07](https://user-images.githubusercontent.com/22098752/71898661-c8407180-3151-11ea-8833-1cde98916bca.jpg)
