### PR TITLE
Docker wait command is now exiting with the container exit code

### DIFF
--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -42,6 +42,9 @@ func runWait(dockerCli command.Cli, opts *waitOptions) error {
 		select {
 		case result := <-resultC:
 			fmt.Fprintf(dockerCli.Out(), "%d\n", result.StatusCode)
+			if result.StatusCode != 0 {
+				return cli.StatusError{StatusCode: int(result.StatusCode)}
+			}
 		case err := <-errC:
 			errs = append(errs, err.Error())
 		}


### PR DESCRIPTION
**- What I did**
Returning the result.StatusCode in the wait command 

**- How to verify it**
Run a container that will fail:
`docker run -d --name test_wait_exitstatus centos:8 testme`

See that the command failed:
/go/src/github.com/docker/cli # `docker ps -a`
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                   PORTS               NAMES
3658455b45a9        centos:8            "testme"            29 seconds ago      Created                                      test_wait_exitstatus

Run the wait command:
/go/src/github.com/docker/cli # `docker wait test_wait_exitstatus`
127

Run `echo $?` to see the wait command exit status
/go/src/github.com/docker/cli # `echo $?`
127


**- Description for the changelog**
Docker wait command is now exiting with the container exit code

Fixes: #1954 

Signed-off-by: Liran Mauda <liran.mauda@gmail.com>