### PR TITLE
Reverse order of long-form ports

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -808,7 +808,7 @@ func parsePortOpts(publishOpts []string) ([]string, error) {
 
 			params[opt[0]] = opt[1]
 		}
-		optsList = append(optsList, fmt.Sprintf("%s:%s/%s", params["target"], params["published"], params["protocol"]))
+		optsList = append(optsList, fmt.Sprintf("%s:%s/%s", params["published"], params["target"], params["protocol"]))
 	}
 	return optsList, nil
 }

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -872,3 +872,9 @@ func TestParseSystemPaths(t *testing.T) {
 		assert.DeepEqual(t, readonlyPaths, tc.readonly)
 	}
 }
+
+func TestParsePortOpts(t *testing.T) {
+	parsed, err := parsePortOpts([]string{"published=1500,target=200", "target=80,published=90"})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{"1500:200/tcp", "90:80/tcp"}, parsed)
+}


### PR DESCRIPTION
**- What I did**

Reverses the order long-form port options when converted to short-form to correctly match the documentation and `docker service create`. See https://docs.docker.com/engine/reference/commandline/service_create/#publish-service-ports-externally-to-the-swarm--p---publish

Post change `-p published=8111,target=8112` is the equivalent of `8111:8112`

**- How I did it**

Changed the order of the values when converting from long to short-form when the options are parsed

**- How to verify it**

Build and run `docker run -d --name run_test -p published=8111,target=80 nginx`. nginx should be accessible from the host with port 8111

**- Description for the changelog**

Fixes https://github.com/docker/cli/issues/2250

**- A picture of a cute animal (not mandatory but encouraged)**

![cat-2019-11-19](https://user-images.githubusercontent.com/22098752/72359212-c80e1c00-36e5-11ea-910e-374efd57c803.jpg)
