### PR TITLE
Include unset variables when parsing env_file

### DIFF
--- a/opts/envfile_test.go
+++ b/opts/envfile_test.go
@@ -143,8 +143,8 @@ another invalid line`
 // ParseEnvFile with environment variable import definitions
 func TestParseEnvVariableDefinitionsFile(t *testing.T) {
 	content := `# comment=
-UNDEFINED_VAR
 HOME
+UNDEFINED_VAR
 `
 	tmpFile := tmpFileWithContent(content, t)
 	defer os.Remove(tmpFile)
@@ -154,12 +154,16 @@ HOME
 		t.Fatal("There must not be any error")
 	}
 
-	if "HOME="+os.Getenv("HOME") != variables[0] {
-		t.Fatal("the HOME variable is not properly imported as the first variable (but it is the only one to import)")
+	if 2 != len(variables) {
+		t.Fatal("exactly two variable are imported")
 	}
 
-	if 1 != len(variables) {
-		t.Fatal("exactly one variable is imported (as the other one is not set at all)")
+	if "HOME="+os.Getenv("HOME") != variables[0] {
+		t.Fatal("the HOME variable is not properly imported as the first variable")
+	}
+
+	if "UNDEFINED_VAR" != variables[1] {
+		t.Fatal("the UNDEFINED_VAR variable is not properly imported as the second variable")
 	}
 }
 

--- a/opts/file.go
+++ b/opts/file.go
@@ -69,6 +69,8 @@ func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]
 				if present {
 					// if only a pass-through variable is given, clean it up.
 					lines = append(lines, fmt.Sprintf("%s=%s", strings.TrimSpace(line), value))
+				} else {
+					lines = append(lines, strings.TrimSpace(line))
 				}
 			}
 		}


### PR DESCRIPTION
**- What I did**
Made --env_file consistent with --env regarding unset variables

Close #2254 

Also see https://github.com/docker/cli/pull/1019

**- How I did it**
unset variables (VAR without a `=`) which can't be resolved to a value by emptyFn are **not** excluded from result, so that they can override container environment the same way --env do.

This is consistent with https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file

> if no = is provided and that variable is not exported in your local environment, the variable won’t be set in the container. 


**- How to verify it**
Dockerfile:
```
FROM alpine
ENV FOO=BAR
```

env_file:
```
FOO
```

- run `docker run ` and confirm FOO is set by image in container environment
- run `docker run --env FOO` and confirm FOO is not set in container environment
- run `docker run --env_file foo.env` and confirm FOO is not set in container environment

**- Description for the changelog**
Fix environment file parsing for empty variables.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/72515385-18a18880-3850-11ea-8f47-5f97146d6ec3.png)

