### PR TITLE
Fix comment formatting and minor linting issue

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -164,7 +164,7 @@ func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptio
 
 	statusChan := waitExitOrRemoved(ctx, dockerCli, createResponse.ID, copts.autoRemove)
 
-	//start the container
+	// start the container
 	if err := client.ContainerStart(ctx, createResponse.ID, types.ContainerStartOptions{}); err != nil {
 		// If we have hijackedIOStreamer, we should notify
 		// hijackedIOStreamer we are going to exit and wait

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -40,11 +40,9 @@ func testDefaultMetadata() store.Metadata {
 }
 
 func testStore(t *testing.T, meta store.Metadata, tls store.ContextTLSData) (store.Store, func()) {
-	//meta := testDefaultMetadata()
 	testDir, err := ioutil.TempDir("", t.Name())
 	assert.NilError(t, err)
-	//defer os.RemoveAll(testDir)
-	store := &ContextStoreWithDefault{
+	s := &ContextStoreWithDefault{
 		Store: store.New(testDir, testCfg),
 		Resolver: func() (*DefaultContext, error) {
 			return &DefaultContext{
@@ -53,8 +51,8 @@ func testStore(t *testing.T, meta store.Metadata, tls store.ContextTLSData) (sto
 			}, nil
 		},
 	}
-	return store, func() {
-		os.RemoveAll(testDir)
+	return s, func() {
+		_ = os.RemoveAll(testDir)
 	}
 }
 

--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -233,7 +233,7 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 		buildOptions := imageBuildOptions(dockerCli, options)
 		buildOptions.Version = types.BuilderBuildKit
 		buildOptions.Dockerfile = dockerfileName
-		//buildOptions.AuthConfigs = authConfigs   // handled by session
+		// buildOptions.AuthConfigs = authConfigs   // handled by session
 		buildOptions.RemoteContext = remote
 		buildOptions.SessionID = s.ID()
 		buildOptions.BuildID = buildID

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1036,7 +1036,7 @@ portLoop:
 			if _, ok := portSet[portConfigToString(&port)]; ok {
 				continue
 			}
-			//portSet[portConfigToString(&port)] = port
+			// portSet[portConfigToString(&port)] = port
 			newPorts = append(newPorts, port)
 		}
 	}

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -112,7 +112,7 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 	confFile := filepath.Join(homedir, oldConfigfile)
 	if _, err := os.Stat(confFile); err != nil {
-		return configFile, nil //missing file is not an error
+		return configFile, nil // missing file is not an error
 	}
 	file, err := os.Open(confFile)
 	if err != nil {

--- a/e2e/cli-plugins/plugins/nopersistentprerun/main.go
+++ b/e2e/cli-plugins/plugins/nopersistentprerun/main.go
@@ -15,7 +15,7 @@ func main() {
 		cmd := &cobra.Command{
 			Use:   "nopersistentprerun",
 			Short: "Testing without PersistentPreRun hooks",
-			//PersistentPreRunE: Not specified, we need to test that it works in the absence of an explicit call
+			// PersistentPreRunE: Not specified, we need to test that it works in the absence of an explicit call
 			RunE: func(cmd *cobra.Command, args []string) error {
 				cli := dockerCli.Client()
 				ping, err := cli.Ping(context.Background())

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -10,28 +10,28 @@ import (
 )
 
 const (
-	//NotaryURL is the location of the notary server
+	// NotaryURL is the location of the notary server
 	NotaryURL = "https://notary-server:4443"
-	//EvilNotaryURL is the location of the evil notary server
+	// EvilNotaryURL is the location of the evil notary server
 	EvilNotaryURL = "https://evil-notary-server:4444"
-	//AlpineImage is an image in the test registry
+	// AlpineImage is an image in the test registry
 	AlpineImage = "registry:5000/alpine:3.6"
-	//AlpineSha is the sha of the alpine image
+	// AlpineSha is the sha of the alpine image
 	AlpineSha = "641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d"
-	//BusyboxImage is an image in the test registry
+	// BusyboxImage is an image in the test registry
 	BusyboxImage = "registry:5000/busybox:1.27.2"
-	//BusyboxSha is the sha of the busybox image
+	// BusyboxSha is the sha of the busybox image
 	BusyboxSha = "030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af"
 )
 
-//SetupConfigFile creates a config.json file for testing
+// SetupConfigFile creates a config.json file for testing
 func SetupConfigFile(t *testing.T) fs.Dir {
 	t.Helper()
 	return SetupConfigWithNotaryURL(t, "trust_test", NotaryURL)
 }
 
-//SetupConfigWithNotaryURL creates a config.json file for testing in the given path
-//with the given notaryURL
+// SetupConfigWithNotaryURL creates a config.json file for testing in the given path
+// with the given notaryURL
 func SetupConfigWithNotaryURL(t *testing.T, path, notaryURL string) fs.Dir {
 	t.Helper()
 	dir := fs.NewDir(t, path, fs.WithMode(0700), fs.WithFile("config.json", fmt.Sprintf(`
@@ -50,7 +50,7 @@ func SetupConfigWithNotaryURL(t *testing.T, path, notaryURL string) fs.Dir {
 	return *dir
 }
 
-//WithConfig sets an environment variable for the docker config location
+// WithConfig sets an environment variable for the docker config location
 func WithConfig(dir string) func(cmd *icmd.Cmd) {
 	return func(cmd *icmd.Cmd) {
 		env := append(os.Environ(),
@@ -60,7 +60,7 @@ func WithConfig(dir string) func(cmd *icmd.Cmd) {
 	}
 }
 
-//WithPassphrase sets environment variables for passphrases
+// WithPassphrase sets environment variables for passphrases
 func WithPassphrase(rootPwd, repositoryPwd string) func(cmd *icmd.Cmd) {
 	return func(cmd *icmd.Cmd) {
 		env := append(os.Environ(),
@@ -71,7 +71,7 @@ func WithPassphrase(rootPwd, repositoryPwd string) func(cmd *icmd.Cmd) {
 	}
 }
 
-//WithTrust sets DOCKER_CONTENT_TRUST to 1
+// WithTrust sets DOCKER_CONTENT_TRUST to 1
 func WithTrust(cmd *icmd.Cmd) {
 	env := append(os.Environ(),
 		"DOCKER_CONTENT_TRUST=1",
@@ -79,7 +79,7 @@ func WithTrust(cmd *icmd.Cmd) {
 	cmd.Env = append(cmd.Env, env...)
 }
 
-//WithNotary sets the location of the notary server
+// WithNotary sets the location of the notary server
 func WithNotary(cmd *icmd.Cmd) {
 	env := append(os.Environ(),
 		"DOCKER_CONTENT_TRUST_SERVER="+NotaryURL,
@@ -87,14 +87,14 @@ func WithNotary(cmd *icmd.Cmd) {
 	cmd.Env = append(cmd.Env, env...)
 }
 
-//WithHome sets the HOME environment variable
+// WithHome sets the HOME environment variable
 func WithHome(path string) func(*icmd.Cmd) {
 	return func(cmd *icmd.Cmd) {
 		cmd.Env = append(cmd.Env, "HOME="+path)
 	}
 }
 
-//WithNotaryServer sets the location of the notary server
+// WithNotaryServer sets the location of the notary server
 func WithNotaryServer(notaryURL string) func(*icmd.Cmd) {
 	return func(cmd *icmd.Cmd) {
 		env := append(os.Environ(),

--- a/opts/port.go
+++ b/opts/port.go
@@ -160,7 +160,7 @@ func ConvertPortToPortConfig(
 
 		for i := startHostPort; i <= endHostPort; i++ {
 			ports = append(ports, swarm.PortConfig{
-				//TODO Name: ?
+				// TODO Name: ?
 				Protocol:      swarm.PortConfigProtocol(strings.ToLower(port.Proto())),
 				TargetPort:    uint32(port.Int()),
 				PublishedPort: uint32(i),


### PR DESCRIPTION
Comments should have a leading space unless the comment is for special purposes (go:generate, nolint:)
