### PR TITLE
[19.03 backport] Allow username/password in config file

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -123,9 +123,11 @@ func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
 	}
 	var err error
 	for addr, ac := range configFile.AuthConfigs {
-		ac.Username, ac.Password, err = decodeAuth(ac.Auth)
-		if err != nil {
-			return err
+		if ac.Auth != "" {
+			ac.Username, ac.Password, err = decodeAuth(ac.Auth)
+			if err != nil {
+				return err
+			}
 		}
 		ac.Auth = ""
 		ac.ServerAddress = addr

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -2,6 +2,7 @@ package configfile
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -378,6 +379,33 @@ func TestGetAllCredentialsCredHelperOverridesDefaultStore(t *testing.T) {
 	assert.Check(t, is.DeepEqual(expected, authConfigs))
 	assert.Check(t, is.Equal(1, testCredsStore.(*mockNativeStore).GetAllCallCount))
 	assert.Check(t, is.Equal(0, testCredHelper.(*mockNativeStore).GetAllCallCount))
+}
+
+func TestLoadFromReaderWithUsernamePassword(t *testing.T) {
+	configFile := New("test-load")
+	defer os.Remove("test-load")
+
+	want := types.AuthConfig{
+		Username: "user",
+		Password: "pass",
+	}
+	cf := ConfigFile{
+		AuthConfigs: map[string]types.AuthConfig{
+			"example.com/foo": want,
+		},
+	}
+
+	b, err := json.Marshal(cf)
+	assert.NilError(t, err)
+
+	err = configFile.LoadFromReader(bytes.NewReader(b))
+	assert.NilError(t, err)
+
+	got, err := configFile.GetAuthConfig("example.com/foo")
+	assert.NilError(t, err)
+
+	assert.Check(t, is.DeepEqual(want.Username, got.Username))
+	assert.Check(t, is.DeepEqual(want.Password, got.Password))
 }
 
 func TestCheckKubernetesConfigurationRaiseAnErrorOnInvalidValue(t *testing.T) {

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -392,7 +392,7 @@ func TestLoadFromReaderWithUsernamePassword(t *testing.T) {
 
 	for _, tc := range []types.AuthConfig{
 		want,
-		types.AuthConfig{
+		{
 			Auth: encodeAuth(&want),
 		},
 	} {


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2122

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Only decode `auth` if it is present. Currently, this overwrites `username` and `password` fields, even if `auth` is empty.

Fixes https://github.com/google/go-containerregistry/issues/555

**- How I did it**

Guard `decodeAuth` with an empty string check.

**- How to verify it**

Run the unit test :)

Alternatively, modify your config file to use username/password instead of auth and try it. I have a branch [here](https://github.com/google/go-containerregistry/compare/master...jonjohnsonjr:auth-fix?expand=1) which seems to work when I try it 👍  

**- Description for the changelog**
Fix reading config files containing "username" and "password" auth.
