### PR TITLE
[19.03 backport] fix(pull_test): for quiet option

### DIFF
--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -50,7 +50,6 @@ func TestNewPullCommandSuccess(t *testing.T) {
 	testCases := []struct {
 		name        string
 		args        []string
-		flags       map[string]string
 		expectedTag string
 	}{
 		{
@@ -64,11 +63,8 @@ func TestNewPullCommandSuccess(t *testing.T) {
 			expectedTag: "image:latest",
 		},
 		{
-			name: "simple-quiet",
-			args: []string{"image"},
-			flags: map[string]string{
-				"quiet": "true",
-			},
+			name:        "simple-quiet",
+			args:        []string{"--quiet", "image"},
 			expectedTag: "image:latest",
 		},
 	}

--- a/cli/command/image/testdata/pull-command-success.simple-quiet.golden
+++ b/cli/command/image/testdata/pull-command-success.simple-quiet.golden
@@ -1,2 +1,1 @@
-Using default tag: latest
 docker.io/library/image:latest


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2069