### PR TITLE
[19.03 backport] fix formatting issue of encoded url

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -243,9 +243,9 @@ func getWithStatusError(url string) (resp *http.Response, err error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {
-		return nil, errors.Wrapf(err, msg+": error reading body")
+		return nil, errors.Wrapf(err, "%s: error reading body", msg)
 	}
-	return nil, errors.Errorf(msg+": %s", bytes.TrimSpace(body))
+	return nil, errors.Errorf("%s: %s", msg, bytes.TrimSpace(body))
 }
 
 // GetContextFromLocalDir uses the given local directory as context for a


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2087

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes #2086 

**- What I did**
Since the `Errorf` uses `Sprintf`, we need to make sure that the `msg` which contains an encoded URL is also passed thru `Sprintf` , so that it is able to correctly map the arguments to the format string.

Something like this:
![mage](https://user-images.githubusercontent.com/10097486/64823444-460dbb00-d56c-11e9-9663-7bc249732139.png)


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![Shih-Tzu-MP](https://user-images.githubusercontent.com/10097486/64824064-e0bac980-d56d-11e9-8232-0306595c5871.jpg)
