### PR TITLE
[19.03 backport] assorted documentation changes

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -28,7 +28,7 @@ Practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-pr
 
 ## Usage
 
-The [`docker build`](commandline/build.md) command builds an image from
+The [docker build](commandline/build.md) command builds an image from
 a `Dockerfile` and a *context*. The build's context is the set of files at a
 specified location `PATH` or `URL`. The `PATH` is a directory on your local
 filesystem. The `URL` is a Git repository location.
@@ -93,8 +93,7 @@ instructions.
 Whenever possible, Docker will re-use the intermediate images (cache),
 to accelerate the `docker build` process significantly. This is indicated by
 the `Using cache` message in the console output.
-(For more information, see the [Build cache section](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache) in the
-`Dockerfile` best practices guide):
+(For more information, see the [`Dockerfile` best practices guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/):
 
     $ docker build -t svendowideit/ambassador .
     Sending build context to Docker daemon 15.36 kB
@@ -137,7 +136,7 @@ implementation. For example, BuildKit can:
 * Avoid side-effects with rest of the API (intermediate images and containers)
 * Prioritize your build cache for automatic pruning
 
-To use the BuildKit backend, you need to set an environment variable 
+To use the BuildKit backend, you need to set an environment variable
 `DOCKER_BUILDKIT=1` on the CLI before invoking `docker build`.
 
 To learn about the experimental Dockerfile syntax available to BuildKit-based
@@ -269,7 +268,7 @@ This feature is only enabled if the [BuildKit](#buildkit) backend is used.
 
 The syntax directive defines the location of the Dockerfile builder that is used for
 building the current Dockerfile. The BuildKit backend allows to seamlessly use
-external implementations of builders that are distributed as Docker images and 
+external implementations of builders that are distributed as Docker images and
 execute inside a container sandbox environment.
 
 Custom Dockerfile implementation allows you to:
@@ -280,9 +279,9 @@ Custom Dockerfile implementation allows you to:
 
 ### Official releases
 
-Docker distributes official versions of the images that can be used for building 
-Dockerfiles under `docker/dockerfile` repository on Docker Hub. There are two 
-channels where new images are released: stable and experimental. 
+Docker distributes official versions of the images that can be used for building
+Dockerfiles under `docker/dockerfile` repository on Docker Hub. There are two
+channels where new images are released: stable and experimental.
 
 Stable channel follows semantic versioning. For example:
 
@@ -298,9 +297,9 @@ component from the stable channel on the time of the release. For example:
   - docker/dockerfile:1.0-experimental - latest experimental releases after 1.0
   - docker/dockerfile:experimental - latest release on experimental channel
 
-You should choose a channel that best fits your needs. If you only want 
+You should choose a channel that best fits your needs. If you only want
 bugfixes, you should use `docker/dockerfile:1.0`. If you want to benefit from
-experimental features, you should use the experimental channel. If you are using 
+experimental features, you should use the experimental channel. If you are using
 the experimental channel, newer releases may not be backwards compatible, so it
 is recommended to use an immutable full version variant.
 
@@ -571,7 +570,7 @@ Or
     FROM [--platform=<platform>] <image>[@<digest>] [AS <name>]
 
 The `FROM` instruction initializes a new build stage and sets the
-[*Base Image*](glossary.md#base-image) for subsequent instructions. As such, a
+[*Base Image*](../../glossary/#base-image) for subsequent instructions. As such, a
 valid `Dockerfile` must start with a `FROM` instruction. The image can be
 any valid image – it is especially easy to start by **pulling an image** from
 the [*Public Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/).
@@ -694,7 +693,7 @@ cache for `RUN` instructions can be invalidated by using the `--no-cache`
 flag, for example `docker build --no-cache`.
 
 See the [`Dockerfile` Best Practices
-guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) for more information.
+guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/) for more information.
 
 The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
 [below](#add) for details.
@@ -1015,7 +1014,7 @@ of whether or not the file has changed and the cache should be updated.
 > following instructions from the Dockerfile if the contents of `<src>` have
 > changed. This includes invalidating the cache for `RUN` instructions.
 > See the [`Dockerfile` Best Practices
-guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) for more information.
+guide](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/) for more information.
 
 
 `ADD` obeys the following rules:
@@ -1436,7 +1435,7 @@ containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
 /var/db`. For more information/examples and mounting instructions via the
 Docker client, refer to
-[*Share Directories via Volumes*](https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume)
+[*Share Directories via Volumes*](https://docs.docker.com/engine/tutorials/dockervolumes/)
 documentation.
 
 The `docker run` command initializes the newly created volume with any data
@@ -2055,13 +2054,12 @@ The `SHELL` feature was added in Docker 1.12.
 This feature is only available when using the  [BuildKit](#buildkit) backend.
 
 Docker build supports experimental features like cache mounts, build secrets and
-ssh forwarding that are enabled by using an external implementation of the 
+ssh forwarding that are enabled by using an external implementation of the
 builder with a syntax directive. To learn about these features, [refer to the documentation in BuildKit repository](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md).
 
 ## Dockerfile examples
 
-Below you can see some examples of Dockerfile syntax. If you're interested in
-something more realistic, take a look at the list of [Dockerization examples](https://docs.docker.com/engine/examples/).
+Below you can see some examples of Dockerfile syntax.
 
 ```
 # Nginx

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -221,6 +221,23 @@ running `docker stack` management commands. Valid values are `"swarm"`,
 `"kubernetes"`, and `"all"`. This property can be overridden with the
 `DOCKER_STACK_ORCHESTRATOR` environment variable, or the `--orchestrator` flag.
 
+The property `proxies` specifies proxy environment variables to be automatically
+set on containers, and set as `--build-arg` on containers used during `docker build`.
+A `"default"` set of proxies can be configured, and will be used for any docker
+daemon that the client connects to, or a configuration per host (docker daemon),
+for example, "https://docker-daemon1.example.com". The following properties can
+be set for each environment:
+
+* `httpProxy` (sets the value of `HTTP_PROXY` and `http_proxy`)
+* `httpsProxy` (sets the value of `HTTPS_PROXY` and `https_proxy`)
+* `ftpProxy` (sets the value of `FTP_PROXY` and `ftp_proxy`)
+* `noProxy` (sets the value of `NO_PROXY` and `no_proxy`)
+
+> **Warning**: Proxy settings may contain sensitive information (for example,
+> if the proxy requires authentication). Environment variables are stored as
+> plain text in the container's configuration, and as such can be inspected
+> through the remote API or committed to an image when using `docker commit`.
+
 Once attached to a container, users detach from it and leave it running using
 the using `CTRL-p CTRL-q` key sequence. This detach key sequence is customizable
 using the `detachKeys` property. Specify a `<sequence>` value for the
@@ -275,6 +292,18 @@ Following is a sample `config.json` file:
       "anotheroption": "anothervalue",
       "athirdoption": "athirdvalue"
     }
+  },
+  "proxies": {
+    "default": {
+      "httpProxy":  "http://user:pass@example.com:3128",
+      "httpsProxy": "http://user:pass@example.com:3128",
+      "noProxy":    "http://user:pass@example.com:3128",
+      "ftpProxy":   "http://user:pass@example.com:3128"
+    },
+    "https://manager1.mycorp.example.com:2377": {
+      "httpProxy":  "http://user:pass@example.com:3128",
+      "httpsProxy": "http://user:pass@example.com:3128"
+    },
   }
 }
 {% endraw %}

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -159,12 +159,12 @@ a single overlay network. Each of the subnetworks has 126 usable addresses.
 
 ```bash
 $ docker network create -d overlay \
-  --subnet=192.168.1.0/25 \
-  --subnet=192.170.2.0/25 \
-  --gateway=192.168.1.100 \
-  --gateway=192.170.2.100 \
-  --aux-address="my-router=192.168.1.5" --aux-address="my-switch=192.168.1.6" \
-  --aux-address="my-printer=192.170.1.5" --aux-address="my-nas=192.170.1.6" \
+  --subnet=192.168.10.0/25 \
+  --subnet=192.168.20.0/25 \
+  --gateway=192.168.10.100 \
+  --gateway=192.168.20.100 \
+  --aux-address="my-router=192.168.10.5" --aux-address="my-switch=192.168.10.6" \
+  --aux-address="my-printer=192.168.20.5" --aux-address="my-nas=192.168.20.6" \
   my-multihost-network
 ```
 

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -27,9 +27,11 @@ Options:
 
 ## Description
 
-Demotes an existing manager so that it is no longer a manager. This command
-targets a docker engine that is a manager in the swarm.
+Demotes an existing manager so that it is no longer a manager.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -34,6 +34,10 @@ given template for each result. Go's
 [text/template](http://golang.org/pkg/text/template/) package describes all the
 details of the format.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ### Inspect a node

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -36,6 +36,10 @@ Lists all the nodes that the Docker Swarm manager knows about. You can filter
 using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section
 for more information about available filter options.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -28,6 +28,10 @@ Options:
 
 Promotes a node to manager. This command can only be executed on a manager node.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -32,7 +32,13 @@ Options:
 
 ## Description
 
-Lists all the tasks on a Node that Docker knows about. You can filter using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more information about available filter options.
+Lists all the tasks on a Node that Docker knows about. You can filter using the
+`-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more
+information about available filter options.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -30,8 +30,11 @@ Options:
 
 ## Description
 
-When run from a manager node, removes the specified nodes from a swarm.
+Removes the specified nodes from a swarm.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -32,6 +32,10 @@ Options:
 
 Update metadata about a node, such as its availability, labels, or roles.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ### Add label metadata to a node

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -27,9 +27,13 @@ Options:
 
 ## Description
 
-Creates a secret using standard input or from a file for the secret content. You must run this command on a manager node.
+Creates a secret using standard input or from a file for the secret content.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -27,8 +27,7 @@ Options:
 
 ## Description
 
-Inspects the specified secret. This command has to be run targeting a manager
-node.
+Inspects the specified secret.
 
 By default, this renders all results in a JSON array. If a format is specified,
 the given template will be executed for each result.
@@ -37,6 +36,10 @@ Go's [text/template](http://golang.org/pkg/text/template/) package
 describes all the details of the format.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -36,6 +36,10 @@ Run this command on a manager node to list the secrets in the swarm.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -29,10 +29,13 @@ Options:
 
 ## Description
 
-Removes the specified secrets from the swarm. This command has to be run
-targeting a manager node.
+Removes the specified secrets from the swarm.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service.md
+++ b/docs/reference/commandline/service.md
@@ -40,3 +40,6 @@ Run 'docker service COMMAND --help' for more information on a command.
 
 Manage services.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -92,8 +92,11 @@ Options:
 
 ## Description
 
-Creates a service as described by the specified parameters. You must run this
-command on a manager node.
+Creates a service as described by the specified parameters.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -428,7 +428,7 @@ The following options can only be used for bind mounts (`type=bind`):
 
 Bind propagation refers to whether or not mounts created within a given
 bind mount or named volume can be propagated to replicas of that mount. Consider
-a mount point `/mnt`, which is also mounted on `/tmp`. The propation settings
+a mount point `/mnt`, which is also mounted on `/tmp`. The propagation settings
 control whether a mount on `/tmp/a` would also be available on `/mnt/a`. Each
 propagation setting has a recursive counterpoint. In the case of recursion,
 consider that `/tmp/a` is also mounted as `/foo`. The propagation settings

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -28,14 +28,17 @@ Options:
 
 ## Description
 
-Inspects the specified service. This command has to be run targeting a manager
-node.
+Inspects the specified service.
 
 By default, this renders all results in a JSON array. If a format is specified,
 the given template will be executed for each result.
 
 Go's [text/template](http://golang.org/pkg/text/template/) package
 describes all the details of the format.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_logs.md
+++ b/docs/reference/commandline/service_logs.md
@@ -35,6 +35,10 @@ Options:
 
 The `docker service logs` command batch-retrieves logs present at the time of execution.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 The `docker service logs` command can be used with either the name or ID of a
 service, or with the ID of a task. If a service is passed, it will display logs
 for all of the containers in that service. If a task is passed, it will only

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -32,8 +32,11 @@ Options:
 
 ## Description
 
-This command when run targeting a manager, lists services are running in the
-swarm.
+This command lists services are running in the swarm.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -32,8 +32,11 @@ Options:
 
 ## Description
 
-Lists the tasks that are running as part of the specified services. This command
-has to be run targeting a manager node.
+Lists the tasks that are running as part of the specified services.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -29,8 +29,11 @@ Options:
 
 ## Description
 
-Removes the specified services from the swarm. This command has to be run
-targeting a manager node.
+Removes the specified services from the swarm.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_rollback.md
+++ b/docs/reference/commandline/service_rollback.md
@@ -28,8 +28,11 @@ Options:
 
 ## Description
 
-Roll back a specified service to its previous version from the swarm. This command must be run
-targeting a manager node.
+Roll back a specified service to its previous version from the swarm.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -33,6 +33,10 @@ services which are global mode. The command will return immediately, but the
 actual scaling of the service may take some time. To stop all replicas of a
 service while keeping the service active in the swarm you can set the scale to 0.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ### Scale a single service

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -109,15 +109,19 @@ Options:
 
 ## Description
 
-Updates a service as described by the specified parameters. This command has to be run targeting a manager node.
-The parameters are the same as [`docker service create`](service_create.md). Please look at the description there
-for further information.
+Updates a service as described by the specified parameters. The parameters are
+the same as [`docker service create`](service_create.md). Refer to the description
+there for further information.
 
 Normally, updating a service will only cause the service's tasks to be replaced with new ones if a change to the
 service requires recreating the tasks for it to take effect. For example, only changing the
 `--update-parallelism` setting will not recreate the tasks, because the individual tasks are not affected by this
 setting. However, the `--force` flag will cause the tasks to be recreated anyway. This can be used to perform a
 rolling restart without any changes to the service parameters.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -38,8 +38,12 @@ Options:
 
 ## Description
 
-Create and update a stack from a `compose` or a `dab` file on the swarm. This command
-has to be run targeting a manager node.
+Create and update a stack from a `compose` file on the swarm.
+
+> **Note**: This is a cluster management command. When using swarm as an orchestrator,
+> this command must be executed on a swarm manager node. To learn about managers
+> and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
+> in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -35,6 +35,11 @@ Options:
 
 Lists the stacks.
 
+> **Note**: This is a cluster management command. When using swarm as an orchestrator,
+> this command must be executed on a swarm manager node. To learn about managers
+> and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
+> in the documentation.
+
 ## Examples
 
 The following command shows all stacks and some additional information:

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -34,8 +34,12 @@ Options:
 
 ## Description
 
-Lists the tasks that are running as part of the specified stack. This
-command has to be run targeting a manager node.
+Lists the tasks that are running as part of the specified stack.
+
+> **Note**: This is a cluster management command. When using swarm as an orchestrator,
+> this command must be executed on a swarm manager node. To learn about managers
+> and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
+> in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -32,8 +32,12 @@ Options:
 
 ## Description
 
-Remove the stack from the swarm. This command has to be run targeting
-a manager node.
+Remove the stack from the swarm.
+
+> **Note**: This is a cluster management command. When using swarm as an orchestrator,
+> this command must be executed on a swarm manager node. To learn about managers
+> and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
+> in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -32,8 +32,12 @@ Options:
 
 ## Description
 
-Lists the services that are running as part of the specified stack. This
-command has to be run targeting a manager node.
+Lists the services that are running as part of the specified stack.
+
+> **Note**: This is a cluster management command. When using swarm as an orchestrator,
+> this command must be executed on a swarm manager node. To learn about managers
+> and workers, refer to the [Swarm mode section](https://docs.docker.com/engine/swarm/)
+> in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -33,7 +33,11 @@ Options:
 
 ## Description
 
-View or rotate the current swarm CA certificate. This command must target a manager node.
+View or rotate the current swarm CA certificate.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 

--- a/docs/reference/commandline/swarm_join_token.md
+++ b/docs/reference/commandline/swarm_join_token.md
@@ -34,6 +34,10 @@ role. You pass the token using the `--token` flag when you run
 [swarm join](swarm_join.md). Nodes use the join token only when they join the
 swarm.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 You can view or rotate the join tokens using `swarm join-token`.

--- a/docs/reference/commandline/swarm_unlock.md
+++ b/docs/reference/commandline/swarm_unlock.md
@@ -31,6 +31,10 @@ used to reactivate a manager after its Docker daemon restarts if the autolock
 setting is turned on. The unlock key is printed at the time when autolock is
 enabled, and is also available from the `docker swarm unlock-key` command.
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/swarm_unlock_key.md
+++ b/docs/reference/commandline/swarm_unlock_key.md
@@ -35,6 +35,10 @@ swarm.
 You can view or rotate the unlock key using `swarm unlock-key`. To view the key,
 run the `docker swarm unlock-key` command without any arguments:
 
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
+
 ## Examples
 
 ```bash

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -33,7 +33,11 @@ Options:
 
 ## Description
 
-Updates a swarm with new parameter values. This command must target a manager node.
+Updates a swarm with new parameter values.
+
+> **Note**: This is a cluster management command, and must be executed on a swarm
+> manager node. To learn about managers and workers, refer to the [Swarm mode
+> section](https://docs.docker.com/engine/swarm/) in the documentation.
 
 ## Examples
 


### PR DESCRIPTION
backports of:

- https://github.com/docker/cli/pull/1590 Docs: add note about management commands targeting a manager
    - minor conflict in `stack_deploy.md` due to https://github.com/docker/cli/pull/2216 not being in 19.03
- https://github.com/docker/cli/pull/2054 Update service_create.md
- https://github.com/docker/cli/pull/2202 Fixing some links and deleting an older page reference
- https://github.com/docker/cli/pull/2224 Add docs for proxy configuration in config.json
    - taking the docs changes from https://github.com/moby/moby/pull/37125. Setting proxy-configuration in config.json was added in commit 35f1e301b573f057937c0d3f3232e4f03cd21a5d (https://github.com/docker/cli/pull/93) (docker 17.07), but never found its way to the documentation.
- https://github.com/docker/cli/pull/2231 Change example networks
