### PR TITLE
Explain the behavior of `--restart on-failure` on daemon startup.

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -508,9 +508,10 @@ Docker supports the following restart policies:
         </span>
       </td>
       <td>
-        Restart only if the container exits with a non-zero exit status.
+        Restart if the container exits with a non-zero exit status.
         Optionally, limit the number of restart retries the Docker
-        daemon attempts.
+        daemon attempts. The container will also always start
+        on daemon startup, regardless of the current state of the container.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I expanded the description of a restart policy's behavior.

**- How I did it**
I tested the true Docker behavior locally, then wrote my findings.

**- How to verify it**
1. Start a docker container with the `--restart on-failure` option.
2. Stop the docker daemon with a command such as `systemctl stop docker`.
3. Start the docker daemon again with a command such as `systemctl start docker`.
4. Run `docker ps`, and see that the container is running.
5. Repeat these steps, but first running `docker stop <container-id>` before stopping the docker daemon. As before, the container will be started on daemon startup.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Expanded documentation of restart policies.

**- A picture of a cute animal (not mandatory but encouraged)**
![n5AyzRAWnfPG-3yHEqga0u-xwKI27cMYAqMp34sCG3c](https://user-images.githubusercontent.com/35085463/72634042-9fb53600-390e-11ea-995b-4f72a9629ec5.jpg)

