### PR TITLE
Bump vndr v0.1.0, mjibson/esc v0.2.0, gotestsum v0.4.0

### DIFF
--- a/cli/compose/schema/bindata.go
+++ b/cli/compose/schema/bindata.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -100,7 +102,24 @@ func (f *_escFile) Close() error {
 }
 
 func (f *_escFile) Readdir(count int) ([]os.FileInfo, error) {
-	return nil, nil
+	if !f.isDir {
+		return nil, fmt.Errorf(" escFile.Readdir: '%s' is not directory", f.name)
+	}
+
+	fis, ok := _escDirs[f.local]
+	if !ok {
+		return nil, fmt.Errorf(" escFile.Readdir: '%s' is directory, but we have no info about content of this dir, local=%s", f.name, f.local)
+	}
+	limit := count
+	if count <= 0 || limit > len(fis) {
+		limit = len(fis)
+	}
+
+	if len(fis) == 0 && count > 0 {
+		return nil, io.EOF
+	}
+
+	return fis[0:limit], nil
 }
 
 func (f *_escFile) Stat() (os.FileInfo, error) {
@@ -191,6 +210,7 @@ func _escFSMustString(useLocal bool, name string) string {
 var _escData = map[string]*_escFile{
 
 	"/data/config_schema_v3.0.json": {
+		name:    "config_schema_v3.0.json",
 		local:   "data/config_schema_v3.0.json",
 		size:    11063,
 		modtime: 1518458244,
@@ -226,6 +246,7 @@ xHv6XdkMqA34L74ys3aKw8XE5Pt4DNh+IZaN/DMhad9yDyAlGzbxc2F0fns2HUJ234BlbrgaD1QS+++Y
 	},
 
 	"/data/config_schema_v3.1.json": {
+		name:    "config_schema_v3.1.json",
 		local:   "data/config_schema_v3.1.json",
 		size:    12209,
 		modtime: 1518458244,
@@ -262,6 +283,7 @@ f55aMuPsI9DxPLh9jLlw/TGcbUX23yn6OwAA//8cyfJJsS8AAA==
 	},
 
 	"/data/config_schema_v3.2.json": {
+		name:    "config_schema_v3.2.json",
 		local:   "data/config_schema_v3.2.json",
 		size:    13755,
 		modtime: 1518458244,
@@ -300,6 +322,7 @@ ZbmZv+QaLHpS4rzkKyabuw8zkGHuhdMrnbUrtIOnbTqoMzZd83f41N8R/735o4f/lZziOLoU+2E3AJpH
 	},
 
 	"/data/config_schema_v3.3.json": {
+		name:    "config_schema_v3.3.json",
 		local:   "data/config_schema_v3.3.json",
 		size:    15491,
 		modtime: 1518458244,
@@ -340,6 +363,7 @@ b/Iu7P/nxf8DAAD//7pHo+CDPAAA
 	},
 
 	"/data/config_schema_v3.4.json": {
+		name:    "config_schema_v3.4.json",
 		local:   "data/config_schema_v3.4.json",
 		size:    15874,
 		modtime: 1518458244,
@@ -381,6 +405,7 @@ PS1sPmQbucDQbzovyv9fFv8LAAD//+uCPa4CPgAA
 	},
 
 	"/data/config_schema_v3.5.json": {
+		name:    "config_schema_v3.5.json",
 		local:   "data/config_schema_v3.5.json",
 		size:    16802,
 		modtime: 1518458244,
@@ -423,6 +448,7 @@ Pum2n6FuR/KZkNgb9IOAvY0qfF0fuE7P2bsPTT1Xf8bV4ab+/7z5fwAAAP//yoGbgKJBAAA=
 	},
 
 	"/data/config_schema_v3.6.json": {
+		name:    "config_schema_v3.6.json",
 		local:   "data/config_schema_v3.6.json",
 		size:    17084,
 		modtime: 1518458244,
@@ -466,6 +492,7 @@ oqbZ4ab+/7z5fwAAAP//nm8U9rxCAAA=
 	},
 
 	"/data/config_schema_v3.7.json": {
+		name:    "config_schema_v3.7.json",
 		local:   "data/config_schema_v3.7.json",
 		size:    17854,
 		modtime: 1518458244,
@@ -509,6 +536,7 @@ bnBpPlHfjORjkTRf1wyAwiYqMXd9/G6313QfoXs6/sbZ66r6e179PwAA//8ZL3SpvkUAAA==
 	},
 
 	"/data/config_schema_v3.8.json": {
+		name:    "config_schema_v3.8.json",
 		local:   "data/config_schema_v3.8.json",
 		size:    18246,
 		modtime: 1518458244,
@@ -553,6 +581,7 @@ ean7MQBPP+U4w19V/z+t/hsAAP//Fd/bF0ZHAAA=
 	},
 
 	"/data/config_schema_v3.9.json": {
+		name:    "config_schema_v3.9.json",
 		local:   "data/config_schema_v3.9.json",
 		size:    18246,
 		modtime: 1518458244,
@@ -596,13 +625,25 @@ vNT9GICnn3Kc4a+q/59W/w0AAP//CCwovkZHAAA=
 `,
 	},
 
-	"/": {
-		isDir: true,
-		local: "",
-	},
-
 	"/data": {
+		name:  "data",
+		local: `data`,
 		isDir: true,
-		local: "data",
+	},
+}
+
+var _escDirs = map[string][]os.FileInfo{
+
+	"data": {
+		_escData["/data/config_schema_v3.0.json"],
+		_escData["/data/config_schema_v3.1.json"],
+		_escData["/data/config_schema_v3.2.json"],
+		_escData["/data/config_schema_v3.3.json"],
+		_escData["/data/config_schema_v3.4.json"],
+		_escData["/data/config_schema_v3.5.json"],
+		_escData["/data/config_schema_v3.6.json"],
+		_escData["/data/config_schema_v3.7.json"],
+		_escData["/data/config_schema_v3.8.json"],
+		_escData["/data/config_schema_v3.9.json"],
 	},
 }

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN     go get -d github.com/mjibson/esc && \
         go build -v -o /usr/bin/esc . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     GOTESTSUM_VERSION=0.3.5
+ARG     GOTESTSUM_VERSION=0.4.0
 RUN     curl -Ls https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz && \
         tar -xf gotestsum.tar.gz gotestsum -C /usr/bin && \
         rm gotestsum.tar.gz

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -20,7 +20,7 @@ RUN     go get -d github.com/mjibson/esc && \
         go build -v -o /usr/bin/esc . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     GOTESTSUM_VERSION=0.3.4
+ARG     GOTESTSUM_VERSION=0.3.5
 RUN     curl -Ls https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz && \
         tar -xf gotestsum.tar.gz gotestsum -C /usr/bin && \
         rm gotestsum.tar.gz

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -4,7 +4,8 @@ FROM    golang:${GO_VERSION}-alpine
 
 RUN     apk add -U git make bash coreutils ca-certificates curl
 
-ARG     VNDR_SHA=b177b583eb9d44bd5abfca3083a4aeb971b75861
+# v0.1.0
+ARG     VNDR_SHA=d385c05e4c23b602dd16b3d2a1a6c710919bf02f
 RUN     go get -d github.com/LK4D4/vndr && \
         cd /go/src/github.com/LK4D4/vndr && \
         git checkout -q "$VNDR_SHA" && \

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -12,7 +12,8 @@ RUN     go get -d github.com/LK4D4/vndr && \
         go build -v -o /usr/bin/vndr . && \
         rm -rf /go/src/* /go/pkg/* /go/bin/*
 
-ARG     ESC_SHA=58d9cde84f237ecdd89bd7f61c2de2853f4c5c6e
+# v0.2.0
+ARG     ESC_SHA=0ea7db170df78dcddf3e223365f444163147fe89
 RUN     go get -d github.com/mjibson/esc && \
         cd /go/src/github.com/mjibson/esc && \
         git checkout -q "$ESC_SHA" && \

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -18,7 +18,7 @@ ARG NOTARY_VERSION=v0.6.1
 RUN curl -Ls https://github.com/theupdateframework/notary/releases/download/${NOTARY_VERSION}/notary-Linux-amd64 -o /usr/local/bin/notary \
     && chmod +x /usr/local/bin/notary
 
-ARG GOTESTSUM_VERSION=0.3.4
+ARG GOTESTSUM_VERSION=0.3.5
 RUN curl -Ls https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz \
     && tar -xf gotestsum.tar.gz gotestsum \
     && mv gotestsum /usr/local/bin/gotestsum \

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -18,7 +18,7 @@ ARG NOTARY_VERSION=v0.6.1
 RUN curl -Ls https://github.com/theupdateframework/notary/releases/download/${NOTARY_VERSION}/notary-Linux-amd64 -o /usr/local/bin/notary \
     && chmod +x /usr/local/bin/notary
 
-ARG GOTESTSUM_VERSION=0.3.5
+ARG GOTESTSUM_VERSION=0.4.0
 RUN curl -Ls https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz \
     && tar -xf gotestsum.tar.gz gotestsum \
     && mv gotestsum /usr/local/bin/gotestsum \


### PR DESCRIPTION
### bump vndr v0.1.0 to support versioned import paths
With this change, go packages/modules that use versioned
import paths (github.com/foo/bar/v2), but don't use a directory
in the repository, can now be supported.

For example:

```
github.com/coreos/go-systemd/v22 v22.0.0
```

will vendor the github.com/coreos/go-systemd repository
into `vendor/github.com/coreos/go-systemd/v22`.

full diff: https://github.com/LK4D4/vndr/compare/b177b583eb9d44bd5abfca3083a4aeb971b75861...v0.1.0

- LK4D4/vndr#79 Add more clear messages around clone failures
- LK4D4/vndr#80 add riscv64 support
- LK4D4/vndr#83 migrate bitbucket to api 2.0
    - fixes LK4D4/vndr#82 https://api.bitbucket.org/1.0/repositories/ww/goautoneg: 410 Gone
- LK4D4/vndr#86 Replace sort.Sort with sort.Strings
- LK4D4/vndr#87 support `github.com/coreos/go-systemd/v22`

### bump mjibson/esc v0.2.0

full diff: https://github.com/mjibson/esc/compare/v0.1.0...v0.2.0

includes:

- mjibson/esc#51 Readdir Implementation - and covering with tests
- mjibson/esc#53 update go versions and golint import location
- mjibson/esc#58 Avoid unnecessary conversion and so pass with unconvert linter


### bump gotestsum v0.3.5

full diff: https://github.com/gotestyourself/gotestsum/compare/v0.3.4...v0.3.5

- gotestyourself/gotestsum#52 Add a --version flag that goreleaser will populate for us
- gotestyourself/gotestsum#57 Identify and, filter or display coverage output


### bump gotestsum v0.4.0

full diff: https://github.com/gotestyourself/gotestsum/compare/v0.3.5...v0.4.0

includes:

- gotestyourself/gotestsum#59 Report if a package was cached in short formats
- gotestyourself/gotestsum#63 always colorize output unless specifically requested not to
- gotestyourself/gotestsum#61 Improve short-verbose output for tests in CWD
- gotestyourself/gotestsum#70 https://github.com/gotestyourself/gotestsum/pull/70
- gotestyourself/gotestsum#73 Add short-with-failures format