### PR TITLE
Fix: docker push --quiet suppressing errors and exit code

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -3,9 +3,11 @@ package image
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/streams"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
@@ -68,9 +70,12 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	}
 
 	defer responseBody.Close()
-	if !opts.quiet {
-		return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	if opts.quiet {
+		err = jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(ioutil.Discard), nil)
+		if err == nil {
+			fmt.Fprintln(dockerCli.Out(), ref.String())
+		}
+		return err
 	}
-	fmt.Fprintln(dockerCli.Out(), ref.String())
-	return nil
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
 }

--- a/e2e/image/push_test.go
+++ b/e2e/image/push_test.go
@@ -55,6 +55,14 @@ func TestPushWithContentTrust(t *testing.T) {
 	})
 }
 
+func TestPushQuietErrors(t *testing.T) {
+	result := icmd.RunCmd(icmd.Command("docker", "push", "--quiet", "nosuchimage"))
+	result.Assert(t, icmd.Expected{
+		ExitCode: 1,
+		Err:      "An image does not exist locally with the tag: nosuchimage",
+	})
+}
+
 func TestPushWithContentTrustUnreachableServer(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
 


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/2284
relates to https://github.com/docker/cli/pull/2197

Before this patch:

    docker push --quiet nosuchimage
    docker.io/library/nosuchimage

    echo $?
    0

With this patch applied:

    docker push --quiet nosuchimage:latest
    An image does not exist locally with the tag: nosuchimage

    echo $?
    1

