### PR TITLE
Update flag description for docker rm -v

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -35,7 +35,7 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.rmVolumes, "volumes", "v", false, "Remove the volumes associated with the container")
+	flags.BoolVarP(&opts.rmVolumes, "volumes", "v", false, "Remove anonymous volumes associated with the container")
 	flags.BoolVarP(&opts.rmLink, "link", "l", false, "Remove the specified link")
 	flags.BoolVarP(&opts.force, "force", "f", false, "Force the removal of a running container (uses SIGKILL)")
 	return cmd

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -439,7 +439,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -a rm -d 'Remove one or m
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s f -l force -d 'Force the removal of a running container (uses SIGKILL)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s l -l link -d 'Remove the specified link and not the underlying container'
-complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s v -l volumes -d 'Remove the volumes associated with the container'
+complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s v -l volumes -d 'Remove anonymous volumes associated with the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -a '(__fish_print_docker_containers stopped)' -d "Container"
 complete -c docker -A -f -n '__fish_seen_subcommand_from rm' -s f -l force -a '(__fish_print_docker_containers all)' -d "Container"
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -24,7 +24,7 @@ Options:
   -f, --force     Force the removal of a running container (uses SIGKILL)
       --help      Print usage
   -l, --link      Remove the specified link
-  -v, --volumes   Remove the volumes associated with the container
+  -v, --volumes   Remove anonymous volumes associated with the container
 ```
 
 ## Examples


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/2285

The `-v` option removes anonymous volume only, and keeps named volumes.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


```markdown
+ Update flag description for `docker rm -v` to clarify the option only removes anonymous (unnamed) volumes.
```

