### PR TITLE
Skip IPAddr validation for "host-gateway" string

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"fmt"
+	_ "github.com/docker/docker/daemon/network"
 	"net"
 	"net/url"
 	"strconv"

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/creack/pty                               3a6a957789163cacdfe0e291617a
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            a9507c6f76627fdc092edc542d5a7ef4a6df5eec
+github.com/docker/docker                            10425ed4cb855bc6d0e51b83084d2eaa1bab9ad5 
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -205,7 +205,7 @@ const (
 	// BuilderV1 is the first generation builder in docker daemon
 	BuilderV1 BuilderVersion = "1"
 	// BuilderBuildKit is builder based on moby/buildkit project
-	BuilderBuildKit = "2"
+	BuilderBuildKit BuilderVersion = "2"
 )
 
 // ImageBuildResponse holds information

--- a/vendor/github.com/docker/docker/api/types/swarm/service.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/service.go
@@ -17,6 +17,10 @@ type Service struct {
 	// listing all tasks for a service, an operation that could be
 	// computation and network expensive.
 	ServiceStatus *ServiceStatus `json:",omitempty"`
+
+	// JobStatus is the status of a Service which is in one of ReplicatedJob or
+	// GlobalJob modes. It is absent on Replicated and Global services.
+	JobStatus *JobStatus `json:",omitempty"`
 }
 
 // ServiceSpec represents the spec of a service.
@@ -39,8 +43,10 @@ type ServiceSpec struct {
 
 // ServiceMode represents the mode of a service.
 type ServiceMode struct {
-	Replicated *ReplicatedService `json:",omitempty"`
-	Global     *GlobalService     `json:",omitempty"`
+	Replicated    *ReplicatedService `json:",omitempty"`
+	Global        *GlobalService     `json:",omitempty"`
+	ReplicatedJob *ReplicatedJob     `json:",omitempty"`
+	GlobalJob     *GlobalJob         `json:",omitempty"`
 }
 
 // UpdateState is the state of a service update.
@@ -76,6 +82,32 @@ type ReplicatedService struct {
 
 // GlobalService is a kind of ServiceMode.
 type GlobalService struct{}
+
+// ReplicatedJob is the a type of Service which executes a defined Tasks
+// in parallel until the specified number of Tasks have succeeded.
+type ReplicatedJob struct {
+	// MaxConcurrent indicates the maximum number of Tasks that should be
+	// executing simultaneously for this job at any given time. There may be
+	// fewer Tasks that MaxConcurrent executing simultaneously; for example, if
+	// there are fewer than MaxConcurrent tasks needed to reach
+	// TotalCompletions.
+	//
+	// If this field is empty, it will default to a max concurrency of 1.
+	MaxConcurrent *uint64 `json:",omitempty"`
+
+	// TotalCompletions is the total number of Tasks desired to run to
+	// completion.
+	//
+	// If this field is empty, the value of MaxConcurrent will be used.
+	TotalCompletions *uint64 `json:",omitempty"`
+}
+
+// GlobalJob is the type of a Service which executes a Task on every Node
+// matching the Service's placement constraints. These tasks run to completion
+// and then exit.
+//
+// This type is deliberately empty.
+type GlobalJob struct{}
 
 const (
 	// UpdateFailureActionPause PAUSE
@@ -142,4 +174,29 @@ type ServiceStatus struct {
 	// services, this is computed by taking the number of tasks with desired
 	// state of not-Shutdown.
 	DesiredTasks uint64
+
+	// CompletedTasks is the number of tasks in the state Completed, if this
+	// service is in ReplicatedJob or GlobalJob mode. This field must be
+	// cross-referenced with the service type, because the default value of 0
+	// may mean that a service is not in a job mode, or it may mean that the
+	// job has yet to complete any tasks.
+	CompletedTasks uint64
+}
+
+// JobStatus is the status of a job-type service.
+type JobStatus struct {
+	// JobIteration is a value increased each time a Job is executed,
+	// successfully or otherwise. "Executed", in this case, means the job as a
+	// whole has been started, not that an individual Task has been launched. A
+	// job is "Executed" when its ServiceSpec is updated. JobIteration can be
+	// used to disambiguate Tasks belonging to different executions of a job.
+	//
+	// Though JobIteration will increase with each subsequent execution, it may
+	// not necessarily increase by 1, and so JobIteration should not be used to
+	// keep track of the number of times a job has been executed.
+	JobIteration Version
+
+	// LastExecution is the time that the job was last executed, as observed by
+	// Swarm manager.
+	LastExecution time.Time `json:",omitempty"`
 }

--- a/vendor/github.com/docker/docker/api/types/swarm/task.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/task.go
@@ -56,6 +56,12 @@ type Task struct {
 	DesiredState        TaskState           `json:",omitempty"`
 	NetworksAttachments []NetworkAttachment `json:",omitempty"`
 	GenericResources    []GenericResource   `json:",omitempty"`
+
+	// JobIteration is the JobIteration of the Service that this Task was
+	// spawned from, if the Service is a ReplicatedJob or GlobalJob. This is
+	// used to determine which Tasks belong to which run of the job. This field
+	// is absent if the Service mode is Replicated or Global.
+	JobIteration *Version `json:",omitempty"`
 }
 
 // TaskSpec represents the spec of a task.

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -154,7 +154,7 @@ type Info struct {
 	Images             int
 	Driver             string
 	DriverStatus       [][2]string
-	SystemStatus       [][2]string
+	SystemStatus       [][2]string `json:",omitempty"` // SystemStatus is only propagated by the Swarm standalone API
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
@@ -318,7 +318,7 @@ type ContainerState struct {
 }
 
 // ContainerNode stores information about the node that a container
-// is running on.  It's only available in Docker Swarm
+// is running on.  It's only used by the Docker Swarm standalone API
 type ContainerNode struct {
 	ID        string
 	IPAddress string `json:"IP"`
@@ -342,7 +342,7 @@ type ContainerJSONBase struct {
 	HostnamePath    string
 	HostsPath       string
 	LogPath         string
-	Node            *ContainerNode `json:",omitempty"`
+	Node            *ContainerNode `json:",omitempty"` // Node is only propagated by Docker Swarm standalone API
 	Name            string
 	RestartCount    int
 	Driver          string

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -17,7 +17,7 @@ func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
 
 	// Using cli.buildRequest() + cli.doRequest() instead of cli.sendRequest()
-	// because ping requests are used during  API version negotiation, so we want
+	// because ping requests are used during API version negotiation, so we want
 	// to hit the non-versioned /_ping endpoint, not /v1.xx/_ping
 	req, err := cli.buildRequest(http.MethodHead, path.Join(cli.basePath, "/_ping"), nil, nil)
 	if err != nil {

--- a/vendor/github.com/docker/docker/daemon/cluster/provider/network.go
+++ b/vendor/github.com/docker/docker/daemon/cluster/provider/network.go
@@ -1,0 +1,37 @@
+package provider // import "github.com/docker/docker/daemon/cluster/provider"
+
+import "github.com/docker/docker/api/types"
+
+// NetworkCreateRequest is a request when creating a network.
+type NetworkCreateRequest struct {
+	ID string
+	types.NetworkCreateRequest
+}
+
+// NetworkCreateResponse is a response when creating a network.
+type NetworkCreateResponse struct {
+	ID string `json:"Id"`
+}
+
+// VirtualAddress represents a virtual address.
+type VirtualAddress struct {
+	IPv4 string
+	IPv6 string
+}
+
+// PortConfig represents a port configuration.
+type PortConfig struct {
+	Name          string
+	Protocol      int32
+	TargetPort    uint32
+	PublishedPort uint32
+}
+
+// ServiceConfig represents a service configuration.
+type ServiceConfig struct {
+	ID               string
+	Name             string
+	Aliases          map[string][]string
+	VirtualAddresses map[string]*VirtualAddress
+	ExposedPorts     []*PortConfig
+}

--- a/vendor/github.com/docker/docker/daemon/network/constants.go
+++ b/vendor/github.com/docker/docker/daemon/network/constants.go
@@ -1,0 +1,8 @@
+package network
+
+const (
+	// HostGatewayName is the string value that can be passed
+	// to the IPAddr section in --add-host that is replaced by
+	// the value of HostGatewayIP daemon config value
+	HostGatewayName = "host-gateway"
+)

--- a/vendor/github.com/docker/docker/daemon/network/filter.go
+++ b/vendor/github.com/docker/docker/daemon/network/filter.go
@@ -1,0 +1,130 @@
+package network // import "github.com/docker/docker/daemon/network"
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/runconfig"
+	"github.com/pkg/errors"
+)
+
+// FilterNetworks filters network list according to user specified filter
+// and returns user chosen networks
+func FilterNetworks(nws []types.NetworkResource, filter filters.Args) ([]types.NetworkResource, error) {
+	// if filter is empty, return original network list
+	if filter.Len() == 0 {
+		return nws, nil
+	}
+
+	displayNet := nws[:0]
+	for _, nw := range nws {
+		if filter.Contains("driver") {
+			if !filter.ExactMatch("driver", nw.Driver) {
+				continue
+			}
+		}
+		if filter.Contains("name") {
+			if !filter.Match("name", nw.Name) {
+				continue
+			}
+		}
+		if filter.Contains("id") {
+			if !filter.Match("id", nw.ID) {
+				continue
+			}
+		}
+		if filter.Contains("label") {
+			if !filter.MatchKVList("label", nw.Labels) {
+				continue
+			}
+		}
+		if filter.Contains("scope") {
+			if !filter.ExactMatch("scope", nw.Scope) {
+				continue
+			}
+		}
+
+		if filter.Contains("idOrName") {
+			if !filter.Match("name", nw.Name) && !filter.Match("id", nw.Name) {
+				continue
+			}
+		}
+		displayNet = append(displayNet, nw)
+	}
+
+	if values := filter.Get("dangling"); len(values) > 0 {
+		if len(values) > 1 {
+			return nil, errdefs.InvalidParameter(errors.New(`got more than one value for filter key "dangling"`))
+		}
+
+		var danglingOnly bool
+		switch values[0] {
+		case "0", "false":
+			// dangling is false already
+		case "1", "true":
+			danglingOnly = true
+		default:
+			return nil, errdefs.InvalidParameter(errors.New(`invalid value for filter 'dangling', must be "true" (or "1"), or "false" (or "0")`))
+		}
+
+		displayNet = filterNetworkByUse(displayNet, danglingOnly)
+	}
+
+	if filter.Contains("type") {
+		typeNet := []types.NetworkResource{}
+		errFilter := filter.WalkValues("type", func(fval string) error {
+			passList, err := filterNetworkByType(displayNet, fval)
+			if err != nil {
+				return err
+			}
+			typeNet = append(typeNet, passList...)
+			return nil
+		})
+		if errFilter != nil {
+			return nil, errFilter
+		}
+		displayNet = typeNet
+	}
+
+	return displayNet, nil
+}
+
+func filterNetworkByUse(nws []types.NetworkResource, danglingOnly bool) []types.NetworkResource {
+	retNws := []types.NetworkResource{}
+
+	filterFunc := func(nw types.NetworkResource) bool {
+		if danglingOnly {
+			return !runconfig.IsPreDefinedNetwork(nw.Name) && len(nw.Containers) == 0 && len(nw.Services) == 0
+		}
+		return runconfig.IsPreDefinedNetwork(nw.Name) || len(nw.Containers) > 0 || len(nw.Services) > 0
+	}
+
+	for _, nw := range nws {
+		if filterFunc(nw) {
+			retNws = append(retNws, nw)
+		}
+	}
+
+	return retNws
+}
+
+func filterNetworkByType(nws []types.NetworkResource, netType string) ([]types.NetworkResource, error) {
+	retNws := []types.NetworkResource{}
+	switch netType {
+	case "builtin":
+		for _, nw := range nws {
+			if runconfig.IsPreDefinedNetwork(nw.Name) {
+				retNws = append(retNws, nw)
+			}
+		}
+	case "custom":
+		for _, nw := range nws {
+			if !runconfig.IsPreDefinedNetwork(nw.Name) {
+				retNws = append(retNws, nw)
+			}
+		}
+	default:
+		return nil, errors.Errorf("invalid filter: 'type'='%s'", netType)
+	}
+	return retNws, nil
+}

--- a/vendor/github.com/docker/docker/daemon/network/settings.go
+++ b/vendor/github.com/docker/docker/daemon/network/settings.go
@@ -1,0 +1,81 @@
+package network // import "github.com/docker/docker/daemon/network"
+
+import (
+	"net"
+	"sync"
+
+	networktypes "github.com/docker/docker/api/types/network"
+	clustertypes "github.com/docker/docker/daemon/cluster/provider"
+	"github.com/docker/go-connections/nat"
+	"github.com/pkg/errors"
+)
+
+// Settings stores configuration details about the daemon network config
+// TODO Windows. Many of these fields can be factored out.,
+type Settings struct {
+	Bridge                 string
+	SandboxID              string
+	HairpinMode            bool
+	LinkLocalIPv6Address   string
+	LinkLocalIPv6PrefixLen int
+	Networks               map[string]*EndpointSettings
+	Service                *clustertypes.ServiceConfig
+	Ports                  nat.PortMap
+	SandboxKey             string
+	SecondaryIPAddresses   []networktypes.Address
+	SecondaryIPv6Addresses []networktypes.Address
+	IsAnonymousEndpoint    bool
+	HasSwarmEndpoint       bool
+}
+
+// EndpointSettings is a package local wrapper for
+// networktypes.EndpointSettings which stores Endpoint state that
+// needs to be persisted to disk but not exposed in the api.
+type EndpointSettings struct {
+	*networktypes.EndpointSettings
+	IPAMOperational bool
+}
+
+// AttachmentStore stores the load balancer IP address for a network id.
+type AttachmentStore struct {
+	sync.Mutex
+	// key: networkd id
+	// value: load balancer ip address
+	networkToNodeLBIP map[string]net.IP
+}
+
+// ResetAttachments clears any existing load balancer IP to network mapping and
+// sets the mapping to the given attachments.
+func (store *AttachmentStore) ResetAttachments(attachments map[string]string) error {
+	store.Lock()
+	defer store.Unlock()
+	store.clearAttachments()
+	for nid, nodeIP := range attachments {
+		ip, _, err := net.ParseCIDR(nodeIP)
+		if err != nil {
+			store.networkToNodeLBIP = make(map[string]net.IP)
+			return errors.Wrapf(err, "Failed to parse load balancer address %s", nodeIP)
+		}
+		store.networkToNodeLBIP[nid] = ip
+	}
+	return nil
+}
+
+// ClearAttachments clears all the mappings of network to load balancer IP Address.
+func (store *AttachmentStore) ClearAttachments() {
+	store.Lock()
+	defer store.Unlock()
+	store.clearAttachments()
+}
+
+func (store *AttachmentStore) clearAttachments() {
+	store.networkToNodeLBIP = make(map[string]net.IP)
+}
+
+// GetIPForNetwork return the load balancer IP address for the given network.
+func (store *AttachmentStore) GetIPForNetwork(networkID string) (net.IP, bool) {
+	store.Lock()
+	defer store.Unlock()
+	ip, exists := store.networkToNodeLBIP[networkID]
+	return ip, exists
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/parsers.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/parsers.go
@@ -1,0 +1,97 @@
+// Package parsers provides helper functions to parse and validate different type
+// of string. It can be hosts, unix addresses, tcp addresses, filters, kernel
+// operating system versions.
+package parsers // import "github.com/docker/docker/pkg/parsers"
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseKeyValueOpt parses and validates the specified string as a key/value pair (key=value)
+func ParseKeyValueOpt(opt string) (string, string, error) {
+	parts := strings.SplitN(opt, "=", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+// ParseUintListMaximum parses and validates the specified string as the value
+// found in some cgroup file (e.g. `cpuset.cpus`, `cpuset.mems`), which could be
+// one of the formats below. Note that duplicates are actually allowed in the
+// input string. It returns a `map[int]bool` with available elements from `val`
+// set to `true`. Values larger than `maximum` cause an error if max is non zero,
+// in order to stop the map becoming excessively large.
+// Supported formats:
+//     7
+//     1-6
+//     0,3-4,7,8-10
+//     0-0,0,1-7
+//     03,1-3      <- this is gonna get parsed as [1,2,3]
+//     3,2,1
+//     0-2,3,1
+func ParseUintListMaximum(val string, maximum int) (map[int]bool, error) {
+	return parseUintList(val, maximum)
+}
+
+// ParseUintList parses and validates the specified string as the value
+// found in some cgroup file (e.g. `cpuset.cpus`, `cpuset.mems`), which could be
+// one of the formats below. Note that duplicates are actually allowed in the
+// input string. It returns a `map[int]bool` with available elements from `val`
+// set to `true`.
+// Supported formats:
+//     7
+//     1-6
+//     0,3-4,7,8-10
+//     0-0,0,1-7
+//     03,1-3      <- this is gonna get parsed as [1,2,3]
+//     3,2,1
+//     0-2,3,1
+func ParseUintList(val string) (map[int]bool, error) {
+	return parseUintList(val, 0)
+}
+
+func parseUintList(val string, maximum int) (map[int]bool, error) {
+	if val == "" {
+		return map[int]bool{}, nil
+	}
+
+	availableInts := make(map[int]bool)
+	split := strings.Split(val, ",")
+	errInvalidFormat := fmt.Errorf("invalid format: %s", val)
+
+	for _, r := range split {
+		if !strings.Contains(r, "-") {
+			v, err := strconv.Atoi(r)
+			if err != nil {
+				return nil, errInvalidFormat
+			}
+			if maximum != 0 && v > maximum {
+				return nil, fmt.Errorf("value of out range, maximum is %d", maximum)
+			}
+			availableInts[v] = true
+		} else {
+			split := strings.SplitN(r, "-", 2)
+			min, err := strconv.Atoi(split[0])
+			if err != nil {
+				return nil, errInvalidFormat
+			}
+			max, err := strconv.Atoi(split[1])
+			if err != nil {
+				return nil, errInvalidFormat
+			}
+			if max < min {
+				return nil, errInvalidFormat
+			}
+			if maximum != 0 && max > maximum {
+				return nil, fmt.Errorf("value of out range, maximum is %d", maximum)
+			}
+			for i := min; i <= max; i++ {
+				availableInts[i] = true
+			}
+		}
+	}
+	return availableInts, nil
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/README.md
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/README.md
@@ -1,0 +1,1 @@
+SysInfo stores information about which features a kernel supports.

--- a/vendor/github.com/docker/docker/pkg/sysinfo/numcpu.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/numcpu.go
@@ -1,0 +1,12 @@
+// +build !linux,!windows
+
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+import (
+	"runtime"
+)
+
+// NumCPU returns the number of CPUs
+func NumCPU() int {
+	return runtime.NumCPU()
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/numcpu_linux.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/numcpu_linux.go
@@ -1,0 +1,33 @@
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// numCPU queries the system for the count of threads available
+// for use to this process.
+//
+// Issues two syscalls.
+// Returns 0 on errors. Use |runtime.NumCPU| in that case.
+func numCPU() int {
+	// Gets the affinity mask for a process: The very one invoking this function.
+	pid := unix.Getpid()
+
+	var mask unix.CPUSet
+	err := unix.SchedGetaffinity(pid, &mask)
+	if err != nil {
+		return 0
+	}
+
+	return mask.Count()
+}
+
+// NumCPU returns the number of CPUs which are currently online
+func NumCPU() int {
+	if ncpu := numCPU(); ncpu > 0 {
+		return ncpu
+	}
+	return runtime.NumCPU()
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/numcpu_windows.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/numcpu_windows.go
@@ -1,0 +1,45 @@
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32               = windows.NewLazySystemDLL("kernel32.dll")
+	getCurrentProcess      = kernel32.NewProc("GetCurrentProcess")
+	getProcessAffinityMask = kernel32.NewProc("GetProcessAffinityMask")
+)
+
+// Returns bit count of 1, used by NumCPU
+func popcnt(x uint64) (n byte) {
+	x -= (x >> 1) & 0x5555555555555555
+	x = (x>>2)&0x3333333333333333 + x&0x3333333333333333
+	x += x >> 4
+	x &= 0x0f0f0f0f0f0f0f0f
+	x *= 0x0101010101010101
+	return byte(x >> 56)
+}
+
+func numCPU() int {
+	// Gets the affinity mask for a process
+	var mask, sysmask uintptr
+	currentProcess, _, _ := getCurrentProcess.Call()
+	ret, _, _ := getProcessAffinityMask.Call(currentProcess, uintptr(unsafe.Pointer(&mask)), uintptr(unsafe.Pointer(&sysmask)))
+	if ret == 0 {
+		return 0
+	}
+	// For every available thread a bit is set in the mask.
+	ncpu := int(popcnt(uint64(mask)))
+	return ncpu
+}
+
+// NumCPU returns the number of CPUs which are currently online
+func NumCPU() int {
+	if ncpu := numCPU(); ncpu > 0 {
+		return ncpu
+	}
+	return runtime.NumCPU()
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,148 @@
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+import "github.com/docker/docker/pkg/parsers"
+
+// SysInfo stores information about which features a kernel supports.
+// TODO Windows: Factor out platform specific capabilities.
+type SysInfo struct {
+	// Whether the kernel supports AppArmor or not
+	AppArmor bool
+	// Whether the kernel supports Seccomp or not
+	Seccomp bool
+
+	cgroupMemInfo
+	cgroupCPUInfo
+	cgroupBlkioInfo
+	cgroupCpusetInfo
+	cgroupPids
+
+	// Whether the kernel supports cgroup namespaces or not
+	CgroupNamespaces bool
+
+	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
+	IPv4ForwardingDisabled bool
+
+	// Whether bridge-nf-call-iptables is supported or not
+	BridgeNFCallIPTablesDisabled bool
+
+	// Whether bridge-nf-call-ip6tables is supported or not
+	BridgeNFCallIP6TablesDisabled bool
+
+	// Whether the cgroup has the mountpoint of "devices" or not
+	CgroupDevicesEnabled bool
+}
+
+type cgroupMemInfo struct {
+	// Whether memory limit is supported or not
+	MemoryLimit bool
+
+	// Whether swap limit is supported or not
+	SwapLimit bool
+
+	// Whether soft limit is supported or not
+	MemoryReservation bool
+
+	// Whether OOM killer disable is supported or not
+	OomKillDisable bool
+
+	// Whether memory swappiness is supported or not
+	MemorySwappiness bool
+
+	// Whether kernel memory limit is supported or not
+	KernelMemory bool
+
+	// Whether kernel memory TCP limit is supported or not
+	KernelMemoryTCP bool
+}
+
+type cgroupCPUInfo struct {
+	// Whether CPU shares is supported or not
+	CPUShares bool
+
+	// Whether CPU CFS(Completely Fair Scheduler) period is supported or not
+	CPUCfsPeriod bool
+
+	// Whether CPU CFS(Completely Fair Scheduler) quota is supported or not
+	CPUCfsQuota bool
+
+	// Whether CPU real-time period is supported or not
+	CPURealtimePeriod bool
+
+	// Whether CPU real-time runtime is supported or not
+	CPURealtimeRuntime bool
+}
+
+type cgroupBlkioInfo struct {
+	// Whether Block IO weight is supported or not
+	BlkioWeight bool
+
+	// Whether Block IO weight_device is supported or not
+	BlkioWeightDevice bool
+
+	// Whether Block IO read limit in bytes per second is supported or not
+	BlkioReadBpsDevice bool
+
+	// Whether Block IO write limit in bytes per second is supported or not
+	BlkioWriteBpsDevice bool
+
+	// Whether Block IO read limit in IO per second is supported or not
+	BlkioReadIOpsDevice bool
+
+	// Whether Block IO write limit in IO per second is supported or not
+	BlkioWriteIOpsDevice bool
+}
+
+type cgroupCpusetInfo struct {
+	// Whether Cpuset is supported or not
+	Cpuset bool
+
+	// Available Cpuset's cpus
+	Cpus string
+
+	// Available Cpuset's memory nodes
+	Mems string
+}
+
+type cgroupPids struct {
+	// Whether Pids Limit is supported or not
+	PidsLimit bool
+}
+
+// IsCpusetCpusAvailable returns `true` if the provided string set is contained
+// in cgroup's cpuset.cpus set, `false` otherwise.
+// If error is not nil a parsing error occurred.
+func (c cgroupCpusetInfo) IsCpusetCpusAvailable(provided string) (bool, error) {
+	return isCpusetListAvailable(provided, c.Cpus)
+}
+
+// IsCpusetMemsAvailable returns `true` if the provided string set is contained
+// in cgroup's cpuset.mems set, `false` otherwise.
+// If error is not nil a parsing error occurred.
+func (c cgroupCpusetInfo) IsCpusetMemsAvailable(provided string) (bool, error) {
+	return isCpusetListAvailable(provided, c.Mems)
+}
+
+func isCpusetListAvailable(provided, available string) (bool, error) {
+	parsedAvailable, err := parsers.ParseUintList(available)
+	if err != nil {
+		return false, err
+	}
+	// 8192 is the normal maximum number of CPUs in Linux, so accept numbers up to this
+	// or more if we actually have more CPUs.
+	max := 8192
+	for m := range parsedAvailable {
+		if m > max {
+			max = m
+		}
+	}
+	parsedProvided, err := parsers.ParseUintListMaximum(provided, max)
+	if err != nil {
+		return false, err
+	}
+	for k := range parsedProvided {
+		if !parsedAvailable[k] {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_linux.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_linux.go
@@ -1,0 +1,332 @@
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func findCgroupMountpoints() (map[string]string, error) {
+	cgMounts, err := cgroups.GetCgroupMounts(false)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse cgroup information: %v", err)
+	}
+	mps := make(map[string]string)
+	for _, m := range cgMounts {
+		for _, ss := range m.Subsystems {
+			mps[ss] = m.Mountpoint
+		}
+	}
+	return mps, nil
+}
+
+type infoCollector func(info *SysInfo, cgMounts map[string]string) (warnings []string)
+
+// New returns a new SysInfo, using the filesystem to detect which features
+// the kernel supports. If `quiet` is `false` warnings are printed in logs
+// whenever an error occurs or misconfigurations are present.
+func New(quiet bool) *SysInfo {
+	var ops []infoCollector
+	var warnings []string
+	sysInfo := &SysInfo{}
+	cgMounts, err := findCgroupMountpoints()
+	if err != nil {
+		logrus.Warn(err)
+	} else {
+		ops = append(ops, []infoCollector{
+			applyMemoryCgroupInfo,
+			applyCPUCgroupInfo,
+			applyBlkioCgroupInfo,
+			applyCPUSetCgroupInfo,
+			applyPIDSCgroupInfo,
+			applyDevicesCgroupInfo,
+		}...)
+	}
+
+	ops = append(ops, []infoCollector{
+		applyNetworkingInfo,
+		applyAppArmorInfo,
+		applySeccompInfo,
+		applyCgroupNsInfo,
+	}...)
+
+	for _, o := range ops {
+		w := o(sysInfo, cgMounts)
+		warnings = append(warnings, w...)
+	}
+	if cgroups.IsCgroup2UnifiedMode() {
+		warnings = append(warnings, "Your system is running cgroup v2 (unsupported)")
+	}
+	if !quiet {
+		for _, w := range warnings {
+			logrus.Warn(w)
+		}
+	}
+	return sysInfo
+}
+
+// applyMemoryCgroupInfo reads the memory information from the memory cgroup mount point.
+func applyMemoryCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.MemoryLimit = true
+		info.SwapLimit = true
+		info.MemoryReservation = true
+		info.OomKillDisable = true
+		info.MemorySwappiness = true
+		return nil
+	}
+	var warnings []string
+	mountPoint, ok := cgMounts["memory"]
+	if !ok {
+		warnings = append(warnings, "Your kernel does not support cgroup memory limit")
+		return warnings
+	}
+	info.MemoryLimit = ok
+
+	info.SwapLimit = cgroupEnabled(mountPoint, "memory.memsw.limit_in_bytes")
+	if !info.SwapLimit {
+		warnings = append(warnings, "Your kernel does not support swap memory limit")
+	}
+	info.MemoryReservation = cgroupEnabled(mountPoint, "memory.soft_limit_in_bytes")
+	if !info.MemoryReservation {
+		warnings = append(warnings, "Your kernel does not support memory reservation")
+	}
+	info.OomKillDisable = cgroupEnabled(mountPoint, "memory.oom_control")
+	if !info.OomKillDisable {
+		warnings = append(warnings, "Your kernel does not support oom control")
+	}
+	info.MemorySwappiness = cgroupEnabled(mountPoint, "memory.swappiness")
+	if !info.MemorySwappiness {
+		warnings = append(warnings, "Your kernel does not support memory swappiness")
+	}
+	info.KernelMemory = cgroupEnabled(mountPoint, "memory.kmem.limit_in_bytes")
+	if !info.KernelMemory {
+		warnings = append(warnings, "Your kernel does not support kernel memory limit")
+	}
+	info.KernelMemoryTCP = cgroupEnabled(mountPoint, "memory.kmem.tcp.limit_in_bytes")
+	if !info.KernelMemoryTCP {
+		warnings = append(warnings, "Your kernel does not support kernel memory TCP limit")
+	}
+
+	return warnings
+}
+
+// applyCPUCgroupInfo reads the cpu information from the cpu cgroup mount point.
+func applyCPUCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.CPUShares = true
+		info.CPUCfsPeriod = true
+		info.CPUCfsQuota = true
+		info.CPURealtimePeriod = true
+		info.CPURealtimeRuntime = true
+		return nil
+	}
+	var warnings []string
+	mountPoint, ok := cgMounts["cpu"]
+	if !ok {
+		warnings = append(warnings, "Unable to find cpu cgroup in mounts")
+		return warnings
+	}
+
+	info.CPUShares = cgroupEnabled(mountPoint, "cpu.shares")
+	if !info.CPUShares {
+		warnings = append(warnings, "Your kernel does not support cgroup cpu shares")
+	}
+
+	info.CPUCfsPeriod = cgroupEnabled(mountPoint, "cpu.cfs_period_us")
+	if !info.CPUCfsPeriod {
+		warnings = append(warnings, "Your kernel does not support cgroup cfs period")
+	}
+
+	info.CPUCfsQuota = cgroupEnabled(mountPoint, "cpu.cfs_quota_us")
+	if !info.CPUCfsQuota {
+		warnings = append(warnings, "Your kernel does not support cgroup cfs quotas")
+	}
+
+	info.CPURealtimePeriod = cgroupEnabled(mountPoint, "cpu.rt_period_us")
+	if !info.CPURealtimePeriod {
+		warnings = append(warnings, "Your kernel does not support cgroup rt period")
+	}
+
+	info.CPURealtimeRuntime = cgroupEnabled(mountPoint, "cpu.rt_runtime_us")
+	if !info.CPURealtimeRuntime {
+		warnings = append(warnings, "Your kernel does not support cgroup rt runtime")
+	}
+
+	return warnings
+}
+
+// applyBlkioCgroupInfo reads the blkio information from the blkio cgroup mount point.
+func applyBlkioCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.BlkioWeight = true
+		info.BlkioReadBpsDevice = true
+		info.BlkioWriteBpsDevice = true
+		info.BlkioReadIOpsDevice = true
+		info.BlkioWriteIOpsDevice = true
+		return nil
+	}
+	var warnings []string
+	mountPoint, ok := cgMounts["blkio"]
+	if !ok {
+		warnings = append(warnings, "Unable to find blkio cgroup in mounts")
+		return warnings
+	}
+
+	info.BlkioWeight = cgroupEnabled(mountPoint, "blkio.weight")
+	if !info.BlkioWeight {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio weight")
+	}
+
+	info.BlkioWeightDevice = cgroupEnabled(mountPoint, "blkio.weight_device")
+	if !info.BlkioWeightDevice {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio weight_device")
+	}
+
+	info.BlkioReadBpsDevice = cgroupEnabled(mountPoint, "blkio.throttle.read_bps_device")
+	if !info.BlkioReadBpsDevice {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio throttle.read_bps_device")
+	}
+
+	info.BlkioWriteBpsDevice = cgroupEnabled(mountPoint, "blkio.throttle.write_bps_device")
+	if !info.BlkioWriteBpsDevice {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio throttle.write_bps_device")
+	}
+	info.BlkioReadIOpsDevice = cgroupEnabled(mountPoint, "blkio.throttle.read_iops_device")
+	if !info.BlkioReadIOpsDevice {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio throttle.read_iops_device")
+	}
+
+	info.BlkioWriteIOpsDevice = cgroupEnabled(mountPoint, "blkio.throttle.write_iops_device")
+	if !info.BlkioWriteIOpsDevice {
+		warnings = append(warnings, "Your kernel does not support cgroup blkio throttle.write_iops_device")
+	}
+
+	return warnings
+}
+
+// applyCPUSetCgroupInfo reads the cpuset information from the cpuset cgroup mount point.
+func applyCPUSetCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.Cpuset = true
+		return nil
+	}
+	var warnings []string
+	mountPoint, ok := cgMounts["cpuset"]
+	if !ok {
+		warnings = append(warnings, "Unable to find cpuset cgroup in mounts")
+		return warnings
+	}
+	info.Cpuset = ok
+
+	var err error
+
+	cpus, err := ioutil.ReadFile(path.Join(mountPoint, "cpuset.cpus"))
+	if err != nil {
+		return warnings
+	}
+	info.Cpus = strings.TrimSpace(string(cpus))
+
+	mems, err := ioutil.ReadFile(path.Join(mountPoint, "cpuset.mems"))
+	if err != nil {
+		return warnings
+	}
+	info.Mems = strings.TrimSpace(string(mems))
+
+	return warnings
+}
+
+// applyPIDSCgroupInfo reads the pids information from the pids cgroup mount point.
+func applyPIDSCgroupInfo(info *SysInfo, _ map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.PidsLimit = true
+		return nil
+	}
+	var warnings []string
+	_, err := cgroups.FindCgroupMountpoint("", "pids")
+	if err != nil {
+		warnings = append(warnings, err.Error())
+		return warnings
+	}
+	info.PidsLimit = true
+	return warnings
+}
+
+// applyDevicesCgroupInfo reads the pids information from the devices cgroup mount point.
+func applyDevicesCgroupInfo(info *SysInfo, cgMounts map[string]string) []string {
+	if cgroups.IsCgroup2UnifiedMode() {
+		// TODO: check cgroup2 info correctly
+		info.CgroupDevicesEnabled = true
+		return nil
+	}
+	var warnings []string
+	_, ok := cgMounts["devices"]
+	info.CgroupDevicesEnabled = ok
+	return warnings
+}
+
+// applyNetworkingInfo adds networking information to the info.
+func applyNetworkingInfo(info *SysInfo, _ map[string]string) []string {
+	var warnings []string
+	info.IPv4ForwardingDisabled = !readProcBool("/proc/sys/net/ipv4/ip_forward")
+	info.BridgeNFCallIPTablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-iptables")
+	info.BridgeNFCallIP6TablesDisabled = !readProcBool("/proc/sys/net/bridge/bridge-nf-call-ip6tables")
+	return warnings
+}
+
+// applyAppArmorInfo adds AppArmor information to the info.
+func applyAppArmorInfo(info *SysInfo, _ map[string]string) []string {
+	var warnings []string
+	if _, err := os.Stat("/sys/kernel/security/apparmor"); !os.IsNotExist(err) {
+		if _, err := ioutil.ReadFile("/sys/kernel/security/apparmor/profiles"); err == nil {
+			info.AppArmor = true
+		}
+	}
+	return warnings
+}
+
+// applyCgroupNsInfo adds cgroup namespace information to the info.
+func applyCgroupNsInfo(info *SysInfo, _ map[string]string) []string {
+	var warnings []string
+	if _, err := os.Stat("/proc/self/ns/cgroup"); !os.IsNotExist(err) {
+		info.CgroupNamespaces = true
+	}
+	return warnings
+}
+
+// applySeccompInfo checks if Seccomp is supported, via CONFIG_SECCOMP.
+func applySeccompInfo(info *SysInfo, _ map[string]string) []string {
+	var warnings []string
+	// Check if Seccomp is supported, via CONFIG_SECCOMP.
+	if err := unix.Prctl(unix.PR_GET_SECCOMP, 0, 0, 0, 0); err != unix.EINVAL {
+		// Make sure the kernel has CONFIG_SECCOMP_FILTER.
+		if err := unix.Prctl(unix.PR_SET_SECCOMP, unix.SECCOMP_MODE_FILTER, 0, 0, 0); err != unix.EINVAL {
+			info.Seccomp = true
+		}
+	}
+	return warnings
+}
+
+func cgroupEnabled(mountPoint, name string) bool {
+	_, err := os.Stat(path.Join(mountPoint, name))
+	return err == nil
+}
+
+func readProcBool(path string) bool {
+	val, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(val)) == "1"
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_unix.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_unix.go
@@ -1,0 +1,9 @@
+// +build !linux,!windows
+
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+// New returns an empty SysInfo for non linux for now.
+func New(quiet bool) *SysInfo {
+	sysInfo := &SysInfo{}
+	return sysInfo
+}

--- a/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_windows.go
+++ b/vendor/github.com/docker/docker/pkg/sysinfo/sysinfo_windows.go
@@ -1,0 +1,7 @@
+package sysinfo // import "github.com/docker/docker/pkg/sysinfo"
+
+// New returns an empty SysInfo for windows for now.
+func New(quiet bool) *SysInfo {
+	sysInfo := &SysInfo{}
+	return sysInfo
+}

--- a/vendor/github.com/docker/docker/registry/registry.go
+++ b/vendor/github.com/docker/docker/registry/registry.go
@@ -14,11 +14,10 @@ import (
 	"time"
 
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/go-connections/tlsconfig"
-	"github.com/sirupsen/logrus"
-
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/rootless"
+	"github.com/docker/go-connections/tlsconfig"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/vendor/github.com/docker/docker/runconfig/config.go
+++ b/vendor/github.com/docker/docker/runconfig/config.go
@@ -1,0 +1,81 @@
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/pkg/sysinfo"
+)
+
+// ContainerDecoder implements httputils.ContainerDecoder
+// calling DecodeContainerConfig.
+type ContainerDecoder struct{}
+
+// DecodeConfig makes ContainerDecoder to implement httputils.ContainerDecoder
+func (r ContainerDecoder) DecodeConfig(src io.Reader) (*container.Config, *container.HostConfig, *networktypes.NetworkingConfig, error) {
+	return decodeContainerConfig(src)
+}
+
+// DecodeHostConfig makes ContainerDecoder to implement httputils.ContainerDecoder
+func (r ContainerDecoder) DecodeHostConfig(src io.Reader) (*container.HostConfig, error) {
+	return decodeHostConfig(src)
+}
+
+// decodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper
+// struct and returns both a Config and a HostConfig struct
+// Be aware this function is not checking whether the resulted structs are nil,
+// it's your business to do so
+func decodeContainerConfig(src io.Reader) (*container.Config, *container.HostConfig, *networktypes.NetworkingConfig, error) {
+	var w ContainerConfigWrapper
+
+	decoder := json.NewDecoder(src)
+	if err := decoder.Decode(&w); err != nil {
+		return nil, nil, nil, err
+	}
+
+	hc := w.getHostConfig()
+
+	// Perform platform-specific processing of Volumes and Binds.
+	if w.Config != nil && hc != nil {
+
+		// Initialize the volumes map if currently nil
+		if w.Config.Volumes == nil {
+			w.Config.Volumes = make(map[string]struct{})
+		}
+	}
+
+	// Certain parameters need daemon-side validation that cannot be done
+	// on the client, as only the daemon knows what is valid for the platform.
+	if err := validateNetMode(w.Config, hc); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Validate isolation
+	if err := validateIsolation(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Validate QoS
+	if err := validateQoS(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Validate Resources
+	if err := validateResources(hc, sysinfo.New(true)); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Validate Privileged
+	if err := validatePrivileged(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Validate ReadonlyRootfs
+	if err := validateReadonlyRootfs(hc); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return w.Config, hc, w.NetworkingConfig, nil
+}

--- a/vendor/github.com/docker/docker/runconfig/config_unix.go
+++ b/vendor/github.com/docker/docker/runconfig/config_unix.go
@@ -1,0 +1,59 @@
+// +build !windows
+
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+)
+
+// ContainerConfigWrapper is a Config wrapper that holds the container Config (portable)
+// and the corresponding HostConfig (non-portable).
+type ContainerConfigWrapper struct {
+	*container.Config
+	InnerHostConfig       *container.HostConfig          `json:"HostConfig,omitempty"`
+	Cpuset                string                         `json:",omitempty"` // Deprecated. Exported for backwards compatibility.
+	NetworkingConfig      *networktypes.NetworkingConfig `json:"NetworkingConfig,omitempty"`
+	*container.HostConfig                                // Deprecated. Exported to read attributes from json that are not in the inner host config structure.
+}
+
+// getHostConfig gets the HostConfig of the Config.
+// It's mostly there to handle Deprecated fields of the ContainerConfigWrapper
+func (w *ContainerConfigWrapper) getHostConfig() *container.HostConfig {
+	hc := w.HostConfig
+
+	if hc == nil && w.InnerHostConfig != nil {
+		hc = w.InnerHostConfig
+	} else if w.InnerHostConfig != nil {
+		if hc.Memory != 0 && w.InnerHostConfig.Memory == 0 {
+			w.InnerHostConfig.Memory = hc.Memory
+		}
+		if hc.MemorySwap != 0 && w.InnerHostConfig.MemorySwap == 0 {
+			w.InnerHostConfig.MemorySwap = hc.MemorySwap
+		}
+		if hc.CPUShares != 0 && w.InnerHostConfig.CPUShares == 0 {
+			w.InnerHostConfig.CPUShares = hc.CPUShares
+		}
+		if hc.CpusetCpus != "" && w.InnerHostConfig.CpusetCpus == "" {
+			w.InnerHostConfig.CpusetCpus = hc.CpusetCpus
+		}
+
+		if hc.VolumeDriver != "" && w.InnerHostConfig.VolumeDriver == "" {
+			w.InnerHostConfig.VolumeDriver = hc.VolumeDriver
+		}
+
+		hc = w.InnerHostConfig
+	}
+
+	if hc != nil {
+		if w.Cpuset != "" && hc.CpusetCpus == "" {
+			hc.CpusetCpus = w.Cpuset
+		}
+	}
+
+	// Make sure NetworkMode has an acceptable value. We do this to ensure
+	// backwards compatible API behavior.
+	SetDefaultNetModeIfBlank(hc)
+
+	return hc
+}

--- a/vendor/github.com/docker/docker/runconfig/config_windows.go
+++ b/vendor/github.com/docker/docker/runconfig/config_windows.go
@@ -1,0 +1,19 @@
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"github.com/docker/docker/api/types/container"
+	networktypes "github.com/docker/docker/api/types/network"
+)
+
+// ContainerConfigWrapper is a Config wrapper that holds the container Config (portable)
+// and the corresponding HostConfig (non-portable).
+type ContainerConfigWrapper struct {
+	*container.Config
+	HostConfig       *container.HostConfig          `json:"HostConfig,omitempty"`
+	NetworkingConfig *networktypes.NetworkingConfig `json:"NetworkingConfig,omitempty"`
+}
+
+// getHostConfig gets the HostConfig of the Config.
+func (w *ContainerConfigWrapper) getHostConfig() *container.HostConfig {
+	return w.HostConfig
+}

--- a/vendor/github.com/docker/docker/runconfig/errors.go
+++ b/vendor/github.com/docker/docker/runconfig/errors.go
@@ -1,0 +1,42 @@
+package runconfig // import "github.com/docker/docker/runconfig"
+
+const (
+	// ErrConflictContainerNetworkAndLinks conflict between --net=container and links
+	ErrConflictContainerNetworkAndLinks validationError = "conflicting options: container type network can't be used with links. This would result in undefined behavior"
+	// ErrConflictSharedNetwork conflict between private and other networks
+	ErrConflictSharedNetwork validationError = "container sharing network namespace with another container or host cannot be connected to any other network"
+	// ErrConflictHostNetwork conflict from being disconnected from host network or connected to host network.
+	ErrConflictHostNetwork validationError = "container cannot be disconnected from host network or connected to host network"
+	// ErrConflictNoNetwork conflict between private and other networks
+	ErrConflictNoNetwork validationError = "container cannot be connected to multiple networks with one of the networks in private (none) mode"
+	// ErrConflictNetworkAndDNS conflict between --dns and the network mode
+	ErrConflictNetworkAndDNS validationError = "conflicting options: dns and the network mode"
+	// ErrConflictNetworkHostname conflict between the hostname and the network mode
+	ErrConflictNetworkHostname validationError = "conflicting options: hostname and the network mode"
+	// ErrConflictHostNetworkAndLinks conflict between --net=host and links
+	ErrConflictHostNetworkAndLinks validationError = "conflicting options: host type networking can't be used with links. This would result in undefined behavior"
+	// ErrConflictContainerNetworkAndMac conflict between the mac address and the network mode
+	ErrConflictContainerNetworkAndMac validationError = "conflicting options: mac-address and the network mode"
+	// ErrConflictNetworkHosts conflict between add-host and the network mode
+	ErrConflictNetworkHosts validationError = "conflicting options: custom host-to-IP mapping and the network mode"
+	// ErrConflictNetworkPublishPorts conflict between the publish options and the network mode
+	ErrConflictNetworkPublishPorts validationError = "conflicting options: port publishing and the container type network mode"
+	// ErrConflictNetworkExposePorts conflict between the expose option and the network mode
+	ErrConflictNetworkExposePorts validationError = "conflicting options: port exposing and the container type network mode"
+	// ErrUnsupportedNetworkAndIP conflict between network mode and requested ip address
+	ErrUnsupportedNetworkAndIP validationError = "user specified IP address is supported on user defined networks only"
+	// ErrUnsupportedNetworkNoSubnetAndIP conflict between network with no configured subnet and requested ip address
+	ErrUnsupportedNetworkNoSubnetAndIP validationError = "user specified IP address is supported only when connecting to networks with user configured subnets"
+	// ErrUnsupportedNetworkAndAlias conflict between network mode and alias
+	ErrUnsupportedNetworkAndAlias validationError = "network-scoped alias is supported only for containers in user defined networks"
+	// ErrConflictUTSHostname conflict between the hostname and the UTS mode
+	ErrConflictUTSHostname validationError = "conflicting options: hostname and the UTS mode"
+)
+
+type validationError string
+
+func (e validationError) Error() string {
+	return string(e)
+}
+
+func (e validationError) InvalidParameter() {}

--- a/vendor/github.com/docker/docker/runconfig/hostconfig.go
+++ b/vendor/github.com/docker/docker/runconfig/hostconfig.go
@@ -1,0 +1,79 @@
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// DecodeHostConfig creates a HostConfig based on the specified Reader.
+// It assumes the content of the reader will be JSON, and decodes it.
+func decodeHostConfig(src io.Reader) (*container.HostConfig, error) {
+	decoder := json.NewDecoder(src)
+
+	var w ContainerConfigWrapper
+	if err := decoder.Decode(&w); err != nil {
+		return nil, err
+	}
+
+	hc := w.getHostConfig()
+	return hc, nil
+}
+
+// SetDefaultNetModeIfBlank changes the NetworkMode in a HostConfig structure
+// to default if it is not populated. This ensures backwards compatibility after
+// the validation of the network mode was moved from the docker CLI to the
+// docker daemon.
+func SetDefaultNetModeIfBlank(hc *container.HostConfig) {
+	if hc != nil {
+		if hc.NetworkMode == container.NetworkMode("") {
+			hc.NetworkMode = container.NetworkMode("default")
+		}
+	}
+}
+
+// validateNetContainerMode ensures that the various combinations of requested
+// network settings wrt container mode are valid.
+func validateNetContainerMode(c *container.Config, hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	parts := strings.Split(string(hc.NetworkMode), ":")
+	if parts[0] == "container" {
+		if len(parts) < 2 || parts[1] == "" {
+			return validationError("Invalid network mode: invalid container format container:<name|id>")
+		}
+	}
+
+	if hc.NetworkMode.IsContainer() && c.Hostname != "" {
+		return ErrConflictNetworkHostname
+	}
+
+	if hc.NetworkMode.IsContainer() && len(hc.Links) > 0 {
+		return ErrConflictContainerNetworkAndLinks
+	}
+
+	if hc.NetworkMode.IsContainer() && len(hc.DNS) > 0 {
+		return ErrConflictNetworkAndDNS
+	}
+
+	if hc.NetworkMode.IsContainer() && len(hc.ExtraHosts) > 0 {
+		return ErrConflictNetworkHosts
+	}
+
+	if (hc.NetworkMode.IsContainer() || hc.NetworkMode.IsHost()) && c.MacAddress != "" {
+		return ErrConflictContainerNetworkAndMac
+	}
+
+	if hc.NetworkMode.IsContainer() && (len(hc.PortBindings) > 0 || hc.PublishAllPorts) {
+		return ErrConflictNetworkPublishPorts
+	}
+
+	if hc.NetworkMode.IsContainer() && len(c.ExposedPorts) > 0 {
+		return ErrConflictNetworkExposePorts
+	}
+	return nil
+}

--- a/vendor/github.com/docker/docker/runconfig/hostconfig_unix.go
+++ b/vendor/github.com/docker/docker/runconfig/hostconfig_unix.go
@@ -1,0 +1,110 @@
+// +build !windows
+
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/sysinfo"
+)
+
+// DefaultDaemonNetworkMode returns the default network stack the daemon should
+// use.
+func DefaultDaemonNetworkMode() container.NetworkMode {
+	return container.NetworkMode("bridge")
+}
+
+// IsPreDefinedNetwork indicates if a network is predefined by the daemon
+func IsPreDefinedNetwork(network string) bool {
+	n := container.NetworkMode(network)
+	return n.IsBridge() || n.IsHost() || n.IsNone() || n.IsDefault()
+}
+
+// validateNetMode ensures that the various combinations of requested
+// network settings are valid.
+func validateNetMode(c *container.Config, hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+
+	err := validateNetContainerMode(c, hc)
+	if err != nil {
+		return err
+	}
+
+	if hc.UTSMode.IsHost() && c.Hostname != "" {
+		return ErrConflictUTSHostname
+	}
+
+	if hc.NetworkMode.IsHost() && len(hc.Links) > 0 {
+		return ErrConflictHostNetworkAndLinks
+	}
+
+	return nil
+}
+
+// validateIsolation performs platform specific validation of
+// isolation in the hostconfig structure. Linux only supports "default"
+// which is LXC container isolation
+func validateIsolation(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if !hc.Isolation.IsValid() {
+		return fmt.Errorf("Invalid isolation: %q - %s only supports 'default'", hc.Isolation, runtime.GOOS)
+	}
+	return nil
+}
+
+// validateQoS performs platform specific validation of the QoS settings
+func validateQoS(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+
+	if hc.IOMaximumBandwidth != 0 {
+		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum bandwidth", runtime.GOOS)
+	}
+
+	if hc.IOMaximumIOps != 0 {
+		return fmt.Errorf("Invalid QoS settings: %s does not support configuration of maximum IOPs", runtime.GOOS)
+	}
+	return nil
+}
+
+// validateResources performs platform specific validation of the resource settings
+// cpu-rt-runtime and cpu-rt-period can not be greater than their parent, cpu-rt-runtime requires sys_nice
+func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+
+	if hc.Resources.CPURealtimePeriod > 0 && !si.CPURealtimePeriod {
+		return fmt.Errorf("Your kernel does not support cgroup cpu real-time period")
+	}
+
+	if hc.Resources.CPURealtimeRuntime > 0 && !si.CPURealtimeRuntime {
+		return fmt.Errorf("Your kernel does not support cgroup cpu real-time runtime")
+	}
+
+	if hc.Resources.CPURealtimePeriod != 0 && hc.Resources.CPURealtimeRuntime != 0 && hc.Resources.CPURealtimeRuntime > hc.Resources.CPURealtimePeriod {
+		return fmt.Errorf("cpu real-time runtime cannot be higher than cpu real-time period")
+	}
+	return nil
+}
+
+// validatePrivileged performs platform specific validation of the Privileged setting
+func validatePrivileged(hc *container.HostConfig) error {
+	return nil
+}
+
+// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
+func validateReadonlyRootfs(hc *container.HostConfig) error {
+	return nil
+}

--- a/vendor/github.com/docker/docker/runconfig/hostconfig_windows.go
+++ b/vendor/github.com/docker/docker/runconfig/hostconfig_windows.go
@@ -1,0 +1,96 @@
+package runconfig // import "github.com/docker/docker/runconfig"
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/sysinfo"
+)
+
+// DefaultDaemonNetworkMode returns the default network stack the daemon should
+// use.
+func DefaultDaemonNetworkMode() container.NetworkMode {
+	return container.NetworkMode("nat")
+}
+
+// IsPreDefinedNetwork indicates if a network is predefined by the daemon
+func IsPreDefinedNetwork(network string) bool {
+	return !container.NetworkMode(network).IsUserDefined()
+}
+
+// validateNetMode ensures that the various combinations of requested
+// network settings are valid.
+func validateNetMode(c *container.Config, hc *container.HostConfig) error {
+	if hc == nil {
+		return nil
+	}
+
+	err := validateNetContainerMode(c, hc)
+	if err != nil {
+		return err
+	}
+
+	if hc.NetworkMode.IsContainer() && hc.Isolation.IsHyperV() {
+		return fmt.Errorf("Using the network stack of another container is not supported while using Hyper-V Containers")
+	}
+
+	return nil
+}
+
+// validateIsolation performs platform specific validation of the
+// isolation in the hostconfig structure. Windows supports 'default' (or
+// blank), 'process', or 'hyperv'.
+func validateIsolation(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if !hc.Isolation.IsValid() {
+		return fmt.Errorf("Invalid isolation: %q. Windows supports 'default', 'process', or 'hyperv'", hc.Isolation)
+	}
+	return nil
+}
+
+// validateQoS performs platform specific validation of the Qos settings
+func validateQoS(hc *container.HostConfig) error {
+	return nil
+}
+
+// validateResources performs platform specific validation of the resource settings
+func validateResources(hc *container.HostConfig, si *sysinfo.SysInfo) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if hc.Resources.CPURealtimePeriod != 0 {
+		return fmt.Errorf("Windows does not support CPU real-time period")
+	}
+	if hc.Resources.CPURealtimeRuntime != 0 {
+		return fmt.Errorf("Windows does not support CPU real-time runtime")
+	}
+	return nil
+}
+
+// validatePrivileged performs platform specific validation of the Privileged setting
+func validatePrivileged(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if hc.Privileged {
+		return fmt.Errorf("Windows does not support privileged mode")
+	}
+	return nil
+}
+
+// validateReadonlyRootfs performs platform specific validation of the ReadonlyRootfs setting
+func validateReadonlyRootfs(hc *container.HostConfig) error {
+	// We may not be passed a host config, such as in the case of docker commit
+	if hc == nil {
+		return nil
+	}
+	if hc.ReadonlyRootfs {
+		return fmt.Errorf("Windows does not support root filesystem in read-only mode")
+	}
+	return nil
+}

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,5 +1,5 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2
+github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921
@@ -17,7 +17,7 @@ golang.org/x/sys                                    6d18c012aee9febd81bbf9806760
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 golang.org/x/text                                   f21a4dfb5e38f5895301dc265a8def02365cc3d0 # v0.3.0
-gotest.tools                                        1083505acf35a0bd8a696b26837e1fb3187a7a83 # v2.3.0
+gotest.tools/v3                                     ab4a870b92ce57a83881fbeb535a137a20d664b7 # v3.0.1
 github.com/google/go-cmp                            3af367b6b30c263d47e8895973edcca9a49cf029 # v0.2.0
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
 
@@ -27,10 +27,10 @@ golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af
 
 # buildkit
 github.com/moby/buildkit                            4f4e03067523b2fc5ca2f17514a5e75ad63e02fb
-github.com/tonistiigi/fsutil                        3bbb99cdbd76619ab717299830c60f6f2a533a6b
+github.com/tonistiigi/fsutil                        0f039a052ca1da01626278199624b62aed9b3729
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
-github.com/google/shlex                             6f45313302b9c56850fc17f99e40caebce98c716
+github.com/google/shlex                             e7afc7fbc51079733e9468cdfd1efcd7d196cd1d
 github.com/opentracing-contrib/go-stdlib            b1a47cfbdd7543e70e9ef3e73d0802ad306cc1cc
 github.com/mitchellh/hashstructure                  2bca23e0e452137f789efbc8610126fd8b94f73b
 github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d23f618feb6dbb # v0.7.1
@@ -38,7 +38,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        90afbb01e1d8acacb505a092744ea42b9f167377
+github.com/docker/libnetwork                        feeff4f0a3fd2a2bb19cf67c826082c66ffaaed9
 github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -80,7 +80,7 @@ google.golang.org/grpc                              39e8a7b072a67ca2a75f57fa2e0d
 # the containerd project first, and update both after that is merged.
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
-github.com/opencontainers/runc                      d736ef14f0288d6993a1845745d6756cfc9ddd5a # v1.0.0-rc9
+github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
 github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
@@ -101,9 +101,8 @@ github.com/tinylib/msgp                             af6442a0fcf6e2a1b824f70dd0c7
 github.com/fsnotify/fsnotify                        1485a34d5d5723fea214f5710708e19a831720e4 # v1.4.7-11-g1485a34
 
 # awslogs deps
-github.com/aws/aws-sdk-go                           9ed0c8de252f04ac45a65358377103d5a1aa2d92 # v1.12.66
-github.com/go-ini/ini                               300e940a926eb277d3901b20bdfcc54928ad3642 # v1.25.4
-github.com/jmespath/go-jmespath                     0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
+github.com/aws/aws-sdk-go                           2590bc875c54c9fda225d8e4e56a9d28d90c6a47 # v1.28.11
+github.com/jmespath/go-jmespath                     c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5 # see https://github.com/aws/aws-sdk-go/blob/2590bc875c54c9fda225d8e4e56a9d28d90c6a47/Gopkg.toml#L42
 
 # logentries
 github.com/bsphere/le_go                            7a984a84b5492ae539b79b62fb4a10afc63c7bcf
@@ -119,7 +118,7 @@ google.golang.org/genproto                          694d95ba50e67b2e363f3483057d
 # containerd
 github.com/containerd/containerd                    acdcf13d5eaf0dfe0eaeabe7194a82535549bc2b
 github.com/containerd/fifo                          bda0ff6ed73c67bfb5e62bc9c697f146b7fd7f13
-github.com/containerd/continuity                    f2a389ac0a02ce21c09edd7344677a601970f41c
+github.com/containerd/continuity                    26c1120b8d4107d2471b93ad78ef7ce1fc84c4c4
 github.com/containerd/cgroups                       5fbad35c2a7e855762d3c60f2e474ffcad0d470a
 github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/go-runc                       a2952bc25f5116103a8b78f3817f6df759aa7def
@@ -128,13 +127,13 @@ github.com/containerd/ttrpc                         92c8520ef9f86600c650dd540266
 github.com/gogo/googleapis                          d31c731455cb061f42baff3bda55bad0118b126b # v1.2.0
 
 # cluster
-github.com/docker/swarmkit                          7dded76ec532741c1ad9736cd2bb6d6661f0a386
+github.com/docker/swarmkit                          49e35619b18200845c9365c1e953440c28868002
 github.com/gogo/protobuf                            ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
 github.com/golang/protobuf                          aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
-golang.org/x/crypto                                 88737f569e3a9c7ab309cdc09a07fe7fc87233c3
+golang.org/x/crypto                                 69ecbb4d6d5dab05e49161c6e77ea40a030884e1
 golang.org/x/time                                   fbb02b2291d28baffd63558aa44b4b56f178d650
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
@@ -143,14 +142,15 @@ github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef89
 code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec
 
 # prometheus
-github.com/prometheus/client_golang                 c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
-github.com/beorn7/perks                             e7f67b54abbeac9c40a31de0f81159e4cafebd6a
-github.com/prometheus/client_model                  6f3806018612930941127f2a7c6c453ba2c527d2
-github.com/prometheus/common                        7600349dcfe1abd18d72d3a1770870d9800a7801
-github.com/prometheus/procfs                        7d6f385de8bea29190f15ba9931442a0eaef9af7
+github.com/prometheus/client_golang                 c42bebe5a5cddfc6b28cd639103369d8a75dfa89 # v1.3.0
+github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
+github.com/prometheus/client_model                  d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e # v0.1.0
+github.com/prometheus/common                        287d3e634a1e550c9e463dd7e5a75a422c614505 # v0.7.0
+github.com/prometheus/procfs                        6d489fc7f1d9cd890a250f3ea3431b1744b9623f # v0.0.8
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/grpc-ecosystem/go-grpc-prometheus        c225b8c3b01faf2899099b768856a9e916e5087b # v1.2.0
+github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 
 # cli
 github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
@@ -159,8 +159,8 @@ github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce8
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b
 
 # metrics
-github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
+github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a7e6ff905973c # v0.0.1
 
-github.com/opencontainers/selinux                   3a1f366feb7aecbf7a0e71ac4cea88b31597de9e # v1.2.2
+github.com/opencontainers/selinux                   5215b1806f52b1fcc2070a8826c542c9d33cd3cf
 
 # DO NOT EDIT BELOW THIS LINE -------- reserved for downstream projects --------


### PR DESCRIPTION
Relates to - https://github.com/moby/moby/pull/40007
The above PR added support in moby, that detects if
a special string "host-gateway" is added to the IP
section of --add-host, and if true, replaces it with
a special IP value (value of --host-gateway-ip Daemon flag
which defaults to the IP of the default bridge).

This PR is needed to skip the validation for the above
feature

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>
