### PR TITLE
revert "connhelper: use ssh multiplexing"

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -5,10 +5,7 @@ import (
 	"context"
 	"net"
 	"net/url"
-	"os"
-	"strconv"
 
-	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/connhelper/commandconn"
 	"github.com/docker/cli/cli/connhelper/ssh"
 	"github.com/pkg/errors"
@@ -37,7 +34,7 @@ func GetConnectionHelper(daemonURL string) (*ConnectionHelper, error) {
 		}
 		return &ConnectionHelper{
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return commandconn.New(ctx, "ssh", append(multiplexingArgs(), append(sp.Args(), []string{"--", "docker", "system", "dial-stdio"}...)...)...)
+				return commandconn.New(ctx, "ssh", append(sp.Args(), []string{"--", "docker", "system", "dial-stdio"}...)...)
 			},
 			Host: "http://docker",
 		}, nil
@@ -55,20 +52,4 @@ func GetCommandConnectionHelper(cmd string, flags ...string) (*ConnectionHelper,
 		},
 		Host: "http://docker",
 	}, nil
-}
-
-func multiplexingArgs() []string {
-	if v := os.Getenv("DOCKER_SSH_NO_MUX"); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil && b {
-			return nil
-		}
-	}
-	if err := os.MkdirAll(config.Dir(), 0700); err != nil {
-		return nil
-	}
-	args := []string{"-o", "ControlMaster=auto", "-o", "ControlPath=" + config.Dir() + "/%r@%h:%p"}
-	if v := os.Getenv("DOCKER_SSH_MUX_PERSIST"); v != "" {
-		args = append(args, "-o", "ControlPersist="+v)
-	}
-	return args
 }

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -86,8 +86,6 @@ by the `docker` command line:
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 * `DOCKER_CONTEXT` Specify the context to use (overrides DOCKER_HOST env var and default context set with "docker context use")
 * `DOCKER_DEFAULT_PLATFORM` Specify the default platform for the commands that take the `--platform` flag.
-* `DOCKER_SSH_NO_MUX` If set will turn off SSH multiplexing when connecting to daemon through SSH.
-* `DOCKER_SSH_MUX_PERSIST` Set a duration for keeping SSH multiplexing socket alive between commands (e.g `60s`).
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:


### PR DESCRIPTION
this reverts https://github.com/docker/cli/pull/2132, which looks to be responsible for flakiness in CI; 

closes https://github.com/docker/cli/issues/2256
closes https://github.com/docker/cli/issues/2257 

https://ci.docker.com/public/blue/organizations/jenkins/cli/detail/PR-2132/3/pipeline

```
=== Failed
=== FAIL: e2e/image TestBuildFromContextDirectoryWithTag (0.32s)
    build_test.go:37: assertion failed: 
        Command:  docker build -t myimage .
        ExitCode: 1
        Error:    exit status 1
        Stdout:   Sending build context to Docker daemon  4.608kB

        
        Stderr:   error during connect: Post http://docker/v1.40/build?buildargs=%7B%7D&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&labels=%7B%7D&memory=0&memswap=0&networkmode=default&rm=1&shmsize=0&t=myimage&target=&ulimits=null&version=1: command [ssh -o ControlMaster=auto -o ControlPath=/root/.docker/%r@%h:%p -l penguin 172.20.0.2 -- docker system dial-stdio] has exited with exit status 255, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
        
        
        Failures:
        ExitCode was 1 expected 0
        Expected stderr to contain "[NOTHING]"
        Expected no error

=== FAIL: e2e/image TestPullWithContentTrustUsesCacheWhenNotaryUnavailable (3.39s)
    pull_test.go:51: assertion failed: 
        Command:  docker image rm registry:5000/trust-pull-unreachable:latest
        ExitCode: 1
        Error:    exit status 1
        Stdout:   
        Stderr:   error during connect: Delete http://docker/v1.40/images/registry:5000/trust-pull-unreachable:latest: command [ssh -o ControlMaster=auto -o ControlPath=/root/.docker/%r@%h:%p -l penguin 172.20.0.2 -- docker system dial-stdio] has exited with exit status 255, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
        
        
        Failures:
        ExitCode was 1 expected 0
        Expected no error
```