### PR TITLE
Add final report to sytem prune command

### DIFF
--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -27,13 +27,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused images",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(dockerCli, options)
+			objectsDeleted, spaceReclaimed, output, err := runPrune(dockerCli, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
 				fmt.Fprintln(dockerCli.Out(), output)
 			}
+			fmt.Fprintln(dockerCli.Out(), "Total images deleted/untagged:", objectsDeleted)
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
@@ -55,7 +56,7 @@ Are you sure you want to continue?`
 Are you sure you want to continue?`
 )
 
-func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint64, output string, err error) {
+func runPrune(dockerCli command.Cli, options pruneOptions) (objectsDeleted int, spaceReclaimed uint64, output string, err error) {
 	pruneFilters := options.filter.Value().Clone()
 	pruneFilters.Add("dangling", fmt.Sprintf("%v", !options.all))
 	pruneFilters = command.PruneFilters(dockerCli, pruneFilters)
@@ -65,12 +66,12 @@ func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint6
 		warning = allImageWarning
 	}
 	if !options.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
-		return 0, "", nil
+		return 0, 0, "", nil
 	}
 
 	report, err := dockerCli.Client().ImagesPrune(context.Background(), pruneFilters)
 	if err != nil {
-		return 0, "", err
+		return 0, 0, "", err
 	}
 
 	if len(report.ImagesDeleted) > 0 {
@@ -91,11 +92,11 @@ func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint6
 		spaceReclaimed = report.SpaceReclaimed
 	}
 
-	return spaceReclaimed, output, nil
+	return len(report.ImagesDeleted), spaceReclaimed, output, nil
 }
 
 // RunPrune calls the Image Prune API
 // This returns the amount of space reclaimed and a detailed output string
-func RunPrune(dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
+func RunPrune(dockerCli command.Cli, all bool, filter opts.FilterOpt) (int, uint64, string, error) {
 	return runPrune(dockerCli, pruneOptions{force: true, all: all, filter: filter})
 }

--- a/cli/command/image/testdata/prune-command-success.all.golden
+++ b/cli/command/image/testdata/prune-command-success.all.golden
@@ -1,2 +1,3 @@
 WARNING! This will remove all images without at least one container associated to them.
-Are you sure you want to continue? [y/N] Total reclaimed space: 0B
+Are you sure you want to continue? [y/N] Total images deleted/untagged: 0
+Total reclaimed space: 0B

--- a/cli/command/image/testdata/prune-command-success.force-deleted.golden
+++ b/cli/command/image/testdata/prune-command-success.force-deleted.golden
@@ -1,4 +1,5 @@
 Deleted Images:
 deleted: image1
 
+Total images deleted/untagged: 1
 Total reclaimed space: 1B

--- a/cli/command/image/testdata/prune-command-success.force-untagged.golden
+++ b/cli/command/image/testdata/prune-command-success.force-untagged.golden
@@ -1,4 +1,5 @@
 Deleted Images:
 untagged: image1
 
+Total images deleted/untagged: 1
 Total reclaimed space: 2B

--- a/cli/command/image/testdata/prune-command-success.label-filter.golden
+++ b/cli/command/image/testdata/prune-command-success.label-filter.golden
@@ -1,1 +1,2 @@
+Total images deleted/untagged: 0
 Total reclaimed space: 0B

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -25,13 +25,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove all unused local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(dockerCli, options)
+			objectsDeleted, spaceReclaimed, output, err := runPrune(dockerCli, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
 				fmt.Fprintln(dockerCli.Out(), output)
 			}
+			fmt.Fprintln(dockerCli.Out(), "Total volumes deleted:", objectsDeleted)
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
@@ -48,16 +49,16 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 const warning = `WARNING! This will remove all local volumes not used by at least one container.
 Are you sure you want to continue?`
 
-func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint64, output string, err error) {
+func runPrune(dockerCli command.Cli, options pruneOptions) (objectsDeleted int, spaceReclaimed uint64, output string, err error) {
 	pruneFilters := command.PruneFilters(dockerCli, options.filter.Value())
 
 	if !options.force && !command.PromptForConfirmation(dockerCli.In(), dockerCli.Out(), warning) {
-		return 0, "", nil
+		return 0, 0, "", nil
 	}
 
 	report, err := dockerCli.Client().VolumesPrune(context.Background(), pruneFilters)
 	if err != nil {
-		return 0, "", err
+		return 0, 0, "", err
 	}
 
 	if len(report.VolumesDeleted) > 0 {
@@ -68,11 +69,11 @@ func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint6
 		spaceReclaimed = report.SpaceReclaimed
 	}
 
-	return spaceReclaimed, output, nil
+	return len(report.VolumesDeleted), spaceReclaimed, output, nil
 }
 
 // RunPrune calls the Volume Prune API
 // This returns the amount of space reclaimed and a detailed output string
-func RunPrune(dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
+func RunPrune(dockerCli command.Cli, all bool, filter opts.FilterOpt) (int, uint64, string, error) {
 	return runPrune(dockerCli, pruneOptions{force: true, filter: filter})
 }

--- a/cli/command/volume/testdata/volume-prune-no.golden
+++ b/cli/command/volume/testdata/volume-prune-no.golden
@@ -1,2 +1,3 @@
 WARNING! This will remove all local volumes not used by at least one container.
-Are you sure you want to continue? [y/N] Total reclaimed space: 0B
+Are you sure you want to continue? [y/N] Total volumes deleted: 0
+Total reclaimed space: 0B

--- a/cli/command/volume/testdata/volume-prune-yes.golden
+++ b/cli/command/volume/testdata/volume-prune-yes.golden
@@ -4,4 +4,5 @@ foo
 bar
 baz
 
+Total volumes deleted: 3
 Total reclaimed space: 2kB

--- a/cli/command/volume/testdata/volume-prune.deletedVolumes.golden
+++ b/cli/command/volume/testdata/volume-prune.deletedVolumes.golden
@@ -3,4 +3,5 @@ foo
 bar
 baz
 
+Total volumes deleted: 3
 Total reclaimed space: 2kB

--- a/cli/command/volume/testdata/volume-prune.empty.golden
+++ b/cli/command/volume/testdata/volume-prune.empty.golden
@@ -1,1 +1,2 @@
+Total volumes deleted: 0
 Total reclaimed space: 0B


### PR DESCRIPTION
Signed-off-by: Gustavo Sampaio <gbritosampaio@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

This closes #2306
This is also my first PR, so let me know if I missed anything from the guidelines. Also let me know if I missed any test case. Thanks :D

**- What I did**

Added a final report into the `system prune` command

**- How I did it**

Refactored the prune function of each resource to return the number of deleted objects in the process.

**- How to verify it**

Run the following command: `./build/docker-linux-amd64 system prune -a --volumes -f` with some dangling resources.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Refactored the prune function of each resource to return the number of deleted objects in the process. Aggregated the results in a final report to be presented after the `system prune` command.

**- A picture of a cute animal (not mandatory but encouraged)**

Here is my dorky cat Penumbra.
![image](https://user-images.githubusercontent.com/1891977/73611702-2a5e8c00-45c3-11ea-8dc9-354917745cd3.png)
