### PR TITLE
Fix a typo and enhance a script in an example

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -690,7 +690,7 @@ using IPv4 or IPv6 networking in your containers. Use the following
 flags for IPv4 address retrieval for a network device named `eth0`:
 
 ```bash
-$ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
+$ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print $2}' | cut -d / -f 1 | sed -n 1p`
 $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
 ```
 


### PR DESCRIPTION
Hi everyone,
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

![image](https://user-images.githubusercontent.com/1196941/73939436-6c216680-4924-11ea-8d6d-e0ee646c4111.png)

I can't figure out what does `awk '{print \$2}'` mean, and actually it cannot run with `GNU Awk 4.1.4, API: 1.1 (GNU MPFR 4.0.1, GNU MP 6.1.2)`. So I think it might be a typo. It should be `awk '{print $2}'`.

What's more, if the host has several IPs on `eth0`, the script cannot get `${HOSTIP}` correctly, unless appended by `| sed -n '1p'`.

**- How I did it**

Removed the extra `\`. Appended `| sed -n 1p` at the end.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1196941/73939933-709a4f00-4925-11ea-9dce-d9efe507c0ff.png)

