### PR TITLE
[19.03 backport] Add examples for configs

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -689,7 +689,7 @@ using IPv4 or IPv6 networking in your containers. Use the following
 flags for IPv4 address retrieval for a network device named `eth0`:
 
 ```bash
-$ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print \$2}' | cut -d / -f 1`
+$ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print $2}' | cut -d / -f 1 | sed -n 1p`
 $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
 ```
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -200,11 +200,40 @@ $ docker service create --name redis \
 
 To grant a service access to multiple secrets, use multiple `--secret` flags.
 
-Secrets are located in `/run/secrets` in the container.  If no target is
-specified, the name of the secret will be used as the in memory file in the
-container.  If a target is specified, that will be the filename.  In the
-example above, two files will be created: `/run/secrets/ssh` and
+Secrets are located in `/run/secrets` in the container if no target is specified.
+If no target is specified, the name of the secret is used as the in memory file
+in the container. If a target is specified, that is used as the filename. In the
+example above, two files are created: `/run/secrets/ssh` and
 `/run/secrets/app` for each of the secret targets specified.
+
+### Create a service with configs
+
+Use the `--config` flag to give a container access to a
+[config](config_create.md).
+
+Create a service with a config. The config will be mounted into `redis-config`,
+be owned by the user who runs the command inside the container (often `root`),
+and have file mode `0444` or world-readable. You can specify the `uid` and `gid`
+as numerical IDs or names. When using names, the provided group/user names must
+pre-exist in the container. The `mode` is specified as a 4-number sequence such
+as `0755`.
+
+```bash
+$ docker service create --name=redis --config redis-conf redis:3.0.6
+```
+
+Create a service with a config and specify the target location and file mode:
+
+```bash
+$ docker service create --name redis \
+  --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400 redis:3.0.6
+```
+
+To grant a service access to multiple configs, use multiple `--config` flags.
+
+Configs are located in `/` in the container if no target is specified. If no
+target is specified, the name of the config is used as the name of the file in
+the container. If a target is specified, that is used as the filename.
 
 ### Create a service with a rolling update policy
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2312 and https://github.com/docker/cli/pull/2309
fixes https://github.com/docker/docker.github.io/issues/5878