### PR TITLE
[18.09] Fix compose parser fails 3.4+ schema for `volume`

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -567,13 +567,17 @@ func LoadVolumes(source map[string]interface{}, version string) (map[string]type
 		if !volume.External.External {
 			continue
 		}
+		if versions.LessThan(version, "3.4") {
+			switch {
+			case volume.Driver != "":
+				return nil, externalVolumeError(name, "driver")
+			case len(volume.DriverOpts) > 0:
+				return nil, externalVolumeError(name, "driver_opts")
+			case len(volume.Labels) > 0:
+				return nil, externalVolumeError(name, "labels")
+			}
+		}
 		switch {
-		case volume.Driver != "":
-			return nil, externalVolumeError(name, "driver")
-		case len(volume.DriverOpts) > 0:
-			return nil, externalVolumeError(name, "driver_opts")
-		case len(volume.Labels) > 0:
-			return nil, externalVolumeError(name, "labels")
 		case volume.External.Name != "":
 			if volume.Name != "" {
 				return nil, errors.Errorf("volume %s: volume.external.name and volume.name conflict; only use volume.name", name)

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -806,6 +806,107 @@ volumes:
 	assert.ErrorContains(t, err, "external_volume")
 }
 
+func TestValidNotExternalVolumeDriverOpsLabelCombination(t *testing.T) {
+	config, err := loadYAML(`
+version: "3"
+volumes:
+  my_volume:
+    driver: foobar
+    driver_opts:
+      beep: boop
+      click: clack
+    labels:
+    - tick=tock
+    - ping=pong
+`)
+
+	assert.NilError(t, err)
+	expected := map[string]types.VolumeConfig{
+		"my_volume": {
+			Driver: "foobar",
+			DriverOpts: map[string]string{
+				"beep":  "boop",
+				"click": "clack",
+			},
+			Labels: types.Labels{
+				"tick": "tock",
+				"ping": "pong",
+			},
+		},
+	}
+	assert.Assert(t, is.Len(config.Volumes, 1))
+	assert.Check(t, is.DeepEqual(expected, config.Volumes))
+}
+
+func TestValidExternalAndDriverCombination34(t *testing.T) {
+	config, err := loadYAML(`
+version: "3.4"
+volumes:
+  external_volume:
+    external: true
+    driver: foobar
+`)
+
+	assert.NilError(t, err)
+	expected := map[string]types.VolumeConfig{
+		"external_volume": {
+			Name:     "external_volume",
+			External: types.External{External: true},
+			Driver:   "foobar",
+		},
+	}
+	assert.Assert(t, is.Len(config.Volumes, 1))
+	assert.Check(t, is.DeepEqual(expected, config.Volumes))
+}
+
+func TestValidExternalAndDirverOptsCombination35(t *testing.T) {
+	config, err := loadYAML(`
+version: "3.5"
+volumes:
+  external_volume:
+    external: true
+    driver_opts:
+      beep: boop
+`)
+
+	assert.NilError(t, err)
+	expected := map[string]types.VolumeConfig{
+		"external_volume": {
+			Name:     "external_volume",
+			External: types.External{External: true},
+			DriverOpts: map[string]string{
+				"beep": "boop",
+			},
+		},
+	}
+	assert.Assert(t, is.Len(config.Volumes, 1))
+	assert.Check(t, is.DeepEqual(expected, config.Volumes))
+}
+
+func TestValidExternalAndLabelsCombination36(t *testing.T) {
+	config, err := loadYAML(`
+version: "3.6"
+volumes:
+  external_volume:
+    external: true
+    labels:
+      - beep=boop
+`)
+
+	assert.NilError(t, err)
+	expected := map[string]types.VolumeConfig{
+		"external_volume": {
+			Name:     "external_volume",
+			External: types.External{External: true},
+			Labels: types.Labels{
+				"beep": "boop",
+			},
+		},
+	}
+	assert.Assert(t, is.Len(config.Volumes, 1))
+	assert.Check(t, is.DeepEqual(expected, config.Volumes))
+}
+
 func TestLoadVolumeInvalidExternalNameAndNameCombination(t *testing.T) {
 	_, err := loadYAML(`
 version: "3.4"


### PR DESCRIPTION
Fixes #2272 on the 18.09 branch. If this PR is merged, I will submit two other identical PRs for the 18.06, 19.03, and master branches

**- What I did**

* Correct volume schema rule for compose 3.4+
* Discussion in issue #2272 with details
* Added 4 unit tests

**- How I did it**

Added `if` conditional to only apply restrictive rule on `< 3.4`

**- How to verify it**

* `make -f docker.Makefile test-unit` to test this PR's fix
* See prior errant behavior in issue #2272 repo steps
* Unable to e2e test due to issue (don't want github autolink) 2282

**- Description for the changelog**

fix compose 3.4+ schema rule to allow external volumes with driver, driver_opts, labels

**- A picture of a cute animal (not mandatory but encouraged)**

![photo-1578423185054-3cad37eeb502](https://user-images.githubusercontent.com/679350/74144512-28b54980-4bfd-11ea-8ac7-f57b2d5a0c2e.jpg)
Photo by Kerin Gedge on Unsplash