### PR TITLE
Remove deprecated docker search --automated and --stars flags

### DIFF
--- a/cli/command/registry/formatter_search.go
+++ b/cli/command/registry/formatter_search.go
@@ -28,13 +28,9 @@ func NewSearchFormat(source string) formatter.Format {
 }
 
 // SearchWrite writes the context
-func SearchWrite(ctx formatter.Context, results []registry.SearchResult, auto bool, stars int) error {
+func SearchWrite(ctx formatter.Context, results []registry.SearchResult) error {
 	render := func(format func(subContext formatter.SubContext) error) error {
 		for _, result := range results {
-			// --automated and -s, --stars are deprecated since Docker 1.12
-			if (auto && !result.IsAutomated) || (stars > result.StarCount) {
-				continue
-			}
 			searchCtx := &searchContext{trunc: ctx.Trunc, s: result}
 			if err := format(searchCtx); err != nil {
 				return err

--- a/cli/command/registry/formatter_search_test.go
+++ b/cli/command/registry/formatter_search_test.go
@@ -155,79 +155,7 @@ result2 5
 		}
 		out := bytes.NewBufferString("")
 		testcase.context.Output = out
-		err := SearchWrite(testcase.context, results, false, 0)
-		if err != nil {
-			assert.Check(t, is.ErrorContains(err, testcase.expected))
-		} else {
-			assert.Check(t, is.Equal(out.String(), testcase.expected))
-		}
-	}
-}
-
-func TestSearchContextWriteAutomated(t *testing.T) {
-	cases := []struct {
-		context  formatter.Context
-		expected string
-	}{
-
-		// Table format
-		{
-			formatter.Context{Format: NewSearchFormat("table")},
-			`NAME                DESCRIPTION         STARS               OFFICIAL            AUTOMATED
-result2             Not official        5                                       [OK]
-`,
-		},
-		{
-			formatter.Context{Format: NewSearchFormat("table {{.Name}}")},
-			`NAME
-result2
-`,
-		},
-	}
-
-	for _, testcase := range cases {
-		results := []registrytypes.SearchResult{
-			{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
-			{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
-		}
-		out := bytes.NewBufferString("")
-		testcase.context.Output = out
-		err := SearchWrite(testcase.context, results, true, 0)
-		if err != nil {
-			assert.Check(t, is.ErrorContains(err, testcase.expected))
-		} else {
-			assert.Check(t, is.Equal(out.String(), testcase.expected))
-		}
-	}
-}
-
-func TestSearchContextWriteStars(t *testing.T) {
-	cases := []struct {
-		context  formatter.Context
-		expected string
-	}{
-
-		// Table format
-		{
-			formatter.Context{Format: NewSearchFormat("table")},
-			string(golden.Get(t, "search-context-write-stars-table.golden")),
-		},
-		{
-			formatter.Context{Format: NewSearchFormat("table {{.Name}}")},
-			`NAME
-result1
-`,
-		},
-	}
-
-	for _, testcase := range cases {
-		results := []registrytypes.SearchResult{
-			{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true, IsAutomated: false},
-			{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
-		}
-		out := bytes.NewBufferString("")
-		testcase.context.Output = out
-		err := SearchWrite(testcase.context, results, false, 6)
+		err := SearchWrite(testcase.context, results)
 		if err != nil {
 			assert.Check(t, is.ErrorContains(err, testcase.expected))
 		} else {
@@ -247,7 +175,7 @@ func TestSearchContextWriteJSON(t *testing.T) {
 	}
 
 	out := bytes.NewBufferString("")
-	err := SearchWrite(formatter.Context{Format: "{{json .}}", Output: out}, results, false, 0)
+	err := SearchWrite(formatter.Context{Format: "{{json .}}", Output: out}, results)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +195,7 @@ func TestSearchContextWriteJSONField(t *testing.T) {
 		{Name: "result2", Description: "Not official", StarCount: 5, IsOfficial: false, IsAutomated: true},
 	}
 	out := bytes.NewBufferString("")
-	err := SearchWrite(formatter.Context{Format: "{{json .Name}}", Output: out}, results, false, 0)
+	err := SearchWrite(formatter.Context{Format: "{{json .Name}}", Output: out}, results)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -19,10 +19,6 @@ type searchOptions struct {
 	noTrunc bool
 	limit   int
 	filter  opts.FilterOpt
-
-	// Deprecated
-	stars     uint
-	automated bool
 }
 
 // NewSearchCommand creates a new `docker search` command
@@ -45,12 +41,6 @@ func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 	flags.IntVar(&options.limit, "limit", registry.DefaultSearchLimit, "Max number of search results")
 	flags.StringVar(&options.format, "format", "", "Pretty-print search using a Go template")
-
-	flags.BoolVar(&options.automated, "automated", false, "Only show automated builds")
-	flags.UintVarP(&options.stars, "stars", "s", 0, "Only displays with at least x stars")
-
-	flags.MarkDeprecated("automated", "use --filter=is-automated=true instead")
-	flags.MarkDeprecated("stars", "use --filter=stars=3 instead")
 
 	return cmd
 }
@@ -93,5 +83,5 @@ func runSearch(dockerCli command.Cli, options searchOptions) error {
 		Format: NewSearchFormat(options.format),
 		Trunc:  !options.noTrunc,
 	}
-	return SearchWrite(searchCtx, results, options.automated, int(options.stars))
+	return SearchWrite(searchCtx, results)
 }

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -54,7 +54,7 @@ Removed    | [Duplicate keys with conflicting values in engine labels](#duplicat
 Deprecated | [`MAINTAINER` in Dockerfile](#maintainer-in-dockerfile)                                                                            | v1.13.0    | -
 Deprecated | [API calls without a version](#api-calls-without-a-version)                                                                        | v1.13.0    | v17.12.0
 Removed    | [Backing filesystem without `d_type` support for overlay/overlay2](#backing-filesystem-without-d_type-support-for-overlayoverlay2) | v1.13.0    | v17.12.0
-Deprecated | [`--automated` and `--stars` flags on `docker search`](#--automated-and---stars-flags-on-docker-search)                            | v1.12.0    | v17.09.0
+Removed    | [`--automated` and `--stars` flags on `docker search`](#--automated-and---stars-flags-on-docker-search)                            | v1.12.0    | v20.03.0
 Deprecated | [`-h` shorthand for `--help`](#-h-shorthand-for---help)                                                                            | v1.12.0    | v17.09.0
 Removed    | [`-e` and `--email` flags on `docker login`](#-e-and---email-flags-on-docker-login)                                                | v1.11.0    | v17.06.0
 Deprecated | [Separator (`:`) of `--security-opt` flag on `docker run`](#separator--of---security-opt-flag-on-docker-run)                       | v1.11.0    | v17.06.0
@@ -335,10 +335,10 @@ further information.
 
 **Deprecated in Release: [v1.12.0](https://github.com/docker/docker/releases/tag/v1.12.0)**
 
-**Target For Removal In Release: v17.09**
+**Removed In Release: v20.03**
 
 The `docker search --automated` and `docker search --stars` options are deprecated.
-Use `docker search --filter=is-automated=...` and `docker search --filter=stars=...` instead.
+Use `docker search --filter=is-automated=<true|false>` and `docker search --filter=stars=...` instead.
 
 
 ### `-h` shorthand for `--help`


### PR DESCRIPTION
The `docker search --automated` and `docker search --stars` options were
deprecated in release v1.12.0, and scheduled for removal in v17.09.

This patch removes the deprecated flags, in favor of their equivalent
`--filter` options (`docker search --filter=is-automated=<true|false>` and
`docker search --filter=stars=...`).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



