### PR TITLE
Fix builder prune -a/--all flag description

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -44,7 +44,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
-	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
+	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused build cache, not just dangling ones")
 	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'until=24h')")
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 


### PR DESCRIPTION
The flag description mentioned `images`, but this is pruning `build cache`