### PR TITLE
[19.03 backport] fix builder prune flag descriptions

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -44,7 +44,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
-	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
+	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused build cache, not just dangling ones")
 	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'until=24h')")
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -45,7 +45,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images, not just dangling ones")
-	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'unused-for=24h')")
+	flags.Var(&options.filter, "filter", "Provide filter values (e.g. 'until=24h')")
 	flags.Var(&options.keepStorage, "keep-storage", "Amount of disk space to keep for cache")
 
 	return cmd


### PR DESCRIPTION
Backports of:

- https://github.com/docker/cli/pull/2179 unused-for is a deprecated synonym for until
- https://github.com/docker/cli/pull/2343 Fix builder prune -a/--all flag description

I'll regenerate the YAML docs, and open a PR in the documentation repository after this