### PR TITLE
docs: add redirect for old location of daemon reference

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1,8 +1,9 @@
 ---
 title: "dockerd"
-aliases: ["/engine/reference/commandline/daemon/"]
 description: "The daemon command description and usage"
 keywords: "container, daemon, runtime"
+redirect_from:
+- /engine/reference/commandline/daemon/
 ---
 
 <!-- This file is maintained within the docker/cli GitHub


### PR DESCRIPTION
noticed this URL being mentioned in an old ticket, so adding a redirect for the new location