### PR TITLE
[19.03 backport] docs: add redirect for old location of daemon reference

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1,8 +1,9 @@
 ---
 title: "dockerd"
-aliases: ["/engine/reference/commandline/daemon/"]
 description: "The daemon command description and usage"
 keywords: "container, daemon, runtime"
+redirect_from:
+- /engine/reference/commandline/daemon/
 ---
 
 <!-- This file is maintained within the docker/cli GitHub


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2351