### PR TITLE
vendor: bump golang.org/x/crypto  bac4c82f6975 (CVE-2020-9283)

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -72,7 +72,7 @@ github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e
 github.com/xeipuuv/gojsonpointer                    02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb
 github.com/xeipuuv/gojsonreference                  bd5ef7bd5415a7ac448318e64f11a24cd21e594b
 github.com/xeipuuv/gojsonschema                     f971f3cd73b2899de6923801c147f075263e0c50 # v1.1.0
-golang.org/x/crypto                                 1d94cc7ab1c630336ab82ccb9c9cda72a875c382
+golang.org/x/crypto                                 bac4c82f69751a6dd76e702d54b3ceb88adab236
 golang.org/x/net                                    f3200d17e092c607f615320ecaad13d87ad9a2b3
 golang.org/x/oauth2                                 ef147856a6ddbb60760db74283d2424e98c87bff
 golang.org/x/sync                                   e225da77a7e68af35c70ccbf71af2b83e6acac3c


### PR DESCRIPTION
full diff: https://github.com/golang/crypto/compare/1d94cc7ab1c630336ab82ccb9c9cda72a875c382...bac4c82f69751a6dd76e702d54b3ceb88adab236

Version v0.0.0-20200220183623-bac4c82f6975 of golang.org/x/crypto fixes a
vulnerability in the golang.org/x/crypto/ssh package which allowed peers to
cause a panic in SSH servers that accept public keys and in any SSH client.

An attacker can craft an ssh-ed25519 or sk-ssh-ed25519@openssh.com public
key, such that the library will panic when trying to verify a signature
with it. Clients can deliver such a public key and signature to any
golang.org/x/crypto/ssh server with a PublicKeyCallback, and servers can
deliver them to any golang.org/x/crypto/ssh client.

This issue was discovered and reported by Alex Gaynor, Fish in a Barrel,
and is tracked as CVE-2020-9283.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

