### PR TITLE
fix panic on single-character volumes

### DIFF
--- a/cli/compose/loader/volume.go
+++ b/cli/compose/loader/volume.go
@@ -111,6 +111,9 @@ func isFilePath(source string) bool {
 	case '.', '/', '~':
 		return true
 	}
+	if len([]rune(source)) == 1 {
+		return false
+	}
 
 	// windows named pipes
 	if strings.HasPrefix(source, `\\`) {

--- a/cli/compose/loader/volume_test.go
+++ b/cli/compose/loader/volume_test.go
@@ -162,6 +162,8 @@ func TestParseVolumeWindowsNamedPipe(t *testing.T) {
 
 func TestIsFilePath(t *testing.T) {
 	assert.Check(t, !isFilePath("a界"))
+	assert.Check(t, !isFilePath("1"))
+	assert.Check(t, !isFilePath("c"))
 }
 
 // Preserve the test cases for VolumeSplitN


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/40550 single digit volume name leads to 'panic: runtime error: index out of range'

Before this change, this would cause a panic:

    docker run -it --rm -v 1:/1 alpine
    panic: runtime error: index out of range

    goroutine 1 [running]:
    github.com/docker/cli/cli/compose/loader.isFilePath(0xc42027e058, 0x1, 0x557dcb978c20)
    ...

After this change, a correct error is returned:

    docker run -it --rm -v 1:/1 alpine
    docker: Error response from daemon: create 1: volume name is too short, names should be at least two alphanumeric characters.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
* Fix panic: runtime error: index out of range when trying to use a single-letter volume
```


**- A picture of a cute animal (not mandatory but encouraged)**

