### PR TITLE
Add an exe extension to windows binary during cross build.

### DIFF
--- a/scripts/build/windows
+++ b/scripts/build/windows
@@ -13,7 +13,7 @@ export GOOS=windows
 export GOARCH=amd64
 
 # Override TARGET
-TARGET="build/docker-$GOOS-$GOARCH"
+TARGET="build/docker-$GOOS-$GOARCH.exe"
 
 echo "Generating windows resources"
 go generate ./cli/winresources


### PR DESCRIPTION
**- What I did**
Fix #2359 "make -f docker.Makefile binary-windows after build download to windows, but can't execute."
The `exe` extension was indeed missing, just added it in the cross compiling windows script.

**- How to verify it**
```
$ make -f docker.Makefile binary-windows
...
Building build/docker-windows-amd64.exe
```

**- Description for the changelog**
* Add exe extension to windows cross compiled binary

**- A picture of a cute animal (not mandatory but encouraged)**



