### PR TITLE
Remove 'numeric' from --quiet flag description

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -40,7 +40,7 @@ func NewPsCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display numeric IDs")
+	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display container IDs")
 	flags.BoolVarP(&options.size, "size", "s", false, "Display total file sizes")
 	flags.BoolVarP(&options.all, "all", "a", false, "Show all containers (default shows just running)")
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Don't truncate output")

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -35,7 +35,7 @@ func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.BoolVarP(&opts.human, "human", "H", true, "Print sizes and dates in human readable format")
-	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only show numeric IDs")
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only show image IDs")
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Don't truncate output")
 	flags.StringVar(&opts.format, "format", "", "Pretty-print images using a Go template")
 

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -40,7 +40,7 @@ func NewImagesCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only show numeric IDs")
+	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only show image IDs")
 	flags.BoolVarP(&options.all, "all", "a", false, "Show all images (default hides intermediate images)")
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Don't truncate output")
 	flags.BoolVar(&options.showDigests, "digests", false, "Show digests")

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -311,7 +311,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from history' -l format -d '
 complete -c docker -A -f -n '__fish_seen_subcommand_from history' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from history' -s H -l human -d 'Print sizes and dates in human readable format'
 complete -c docker -A -f -n '__fish_seen_subcommand_from history' -l no-trunc -d "Don't truncate output"
-complete -c docker -A -f -n '__fish_seen_subcommand_from history' -s q -l quiet -d 'Only show numeric IDs'
+complete -c docker -A -f -n '__fish_seen_subcommand_from history' -s q -l quiet -d 'Only show image IDs'
 complete -c docker -A -f -n '__fish_seen_subcommand_from history' -a '(__fish_print_docker_images)' -d "Image"
 
 # images
@@ -322,7 +322,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from images' -s f -l filter 
 complete -c docker -A -f -n '__fish_seen_subcommand_from images' -l format -d 'Pretty-print images using a Go template'
 complete -c docker -A -f -n '__fish_seen_subcommand_from images' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from images' -l no-trunc -d "Don't truncate output"
-complete -c docker -A -f -n '__fish_seen_subcommand_from images' -s q -l quiet -d 'Only show numeric IDs'
+complete -c docker -A -f -n '__fish_seen_subcommand_from images' -s q -l quiet -d 'Only show image IDs'
 complete -c docker -A -f -n '__fish_seen_subcommand_from images' -a '(__fish_print_docker_repositories)' -d "Repository"
 
 # import
@@ -409,7 +409,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -l help -d 'Print u
 complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -s l -l latest -d 'Show only the latest created container, include non-running ones.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -s n -d 'Show n last created containers, include non-running ones.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -l no-trunc -d "Don't truncate output"
-complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -s q -l quiet -d 'Only display numeric IDs'
+complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -s q -l quiet -d 'Only display container IDs'
 complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -s s -l size -d 'Display total file sizes'
 complete -c docker -A -f -n '__fish_seen_subcommand_from ps' -l since -d 'Show only containers created since Id or Name, include non-running ones.'
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -804,7 +804,7 @@ __docker_container_subcommand() {
                 "($help -l --latest)"{-l,--latest}"[Show only the latest created container]" \
                 "($help -n --last)"{-n=,--last=}"[Show n last created containers (includes all states)]:n:(1 5 10 25 50)" \
                 "($help)--no-trunc[Do not truncate output]" \
-                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show container IDs]" \
                 "($help -s --size)"{-s,--size}"[Display total file sizes]" \
                 "($help)--since=[Show only containers created since...]:containers:__docker_complete_containers" && ret=0
             ;;
@@ -1027,7 +1027,7 @@ __docker_image_subcommand() {
                 $opts_help \
                 "($help -H --human)"{-H,--human}"[Print sizes and dates in human readable format]" \
                 "($help)--no-trunc[Do not truncate output]" \
-                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show image IDs]" \
                 "($help -)*: :__docker_complete_images" && ret=0
             ;;
         (import)
@@ -1059,7 +1059,7 @@ __docker_image_subcommand() {
                 "($help)*"{-f=,--filter=}"[Filter values]:filter:__docker_complete_images_filters" \
                 "($help)--format=[Pretty-print images using a Go template]:template: " \
                 "($help)--no-trunc[Do not truncate output]" \
-                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show image IDs]" \
                 "($help -): :__docker_complete_repositories" && ret=0
             ;;
         (prune)
@@ -1290,7 +1290,7 @@ __docker_network_subcommand() {
                 "($help)--no-trunc[Do not truncate the output]" \
                 "($help)*"{-f=,--filter=}"[Provide filter values]:filter:__docker_network_complete_ls_filters" \
                 "($help)--format=[Pretty-print networks using a Go template]:template: " \
-                "($help -q --quiet)"{-q,--quiet}"[Only display numeric IDs]" && ret=0
+                "($help -q --quiet)"{-q,--quiet}"[Only display network IDs]" && ret=0
             ;;
         (prune)
             _arguments $(__docker_arguments) \

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -25,7 +25,7 @@ Options:
       --help            Print usage
   -H, --human           Print sizes and dates in human readable format (default true)
       --no-trunc        Don't truncate output
-  -q, --quiet           Only show numeric IDs
+  -q, --quiet           Only show image IDs
 ```
 
 

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -32,7 +32,7 @@ Options:
       --format string   Pretty-print images using a Go template
       --help            Print usage
       --no-trunc        Don't truncate output
-  -q, --quiet           Only show numeric IDs
+  -q, --quiet           Only show image IDs
 ```
 
 ## Description


### PR DESCRIPTION
Signed-off-by: Dominik Braun <dominik.braun@nbsp.de>
Fixes: https://github.com/docker/cli/issues/2363

**- What I did**
Currently, the `--quiet` flag for any command prints `Only display numeric IDs` as help text. According to https://github.com/docker/cli/issues/2363, this is neither correct nor does it provide any value, so I replaced it with the respective object type (which has also been proposed in the abovementioned issue).

The output is now `Only display image IDs` for example. This is also consistent with the `--quiet` flag for volumes.

**- How I did it**
I replaced 'numeric' with the object type, e. g. 'image'.

**- How to verify it**
Run a command like `docker container ps -q` or any other command that provides the `--quiet` flag.

**- Description for the changelog**
Print the object type in the --quiet flag description
