### PR TITLE
Fix broken link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contr
   <tr>
     <td>Community Slack</td>
     <td>
-      The Docker Community has a dedicated Slack chat to discuss features and issues.  You can sign-up <a href="https://community.docker.com/registrations/groups/4316" target="_blank">with this link</a>.
+      The Docker Community has a dedicated Slack chat to discuss features and issues.  You can sign-up <a href="https://dockr.ly/slack" target="_blank">with this link</a>.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
carries the changes of https://github.com/docker/cli/pull/2246, which was missing a DCO

closes https://github.com/docker/cli/pull/2246
fixes https://github.com/docker/cli/issues/2191