### PR TITLE
[19.03 backport] remove unneeded comment from reference files

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -4,15 +4,6 @@ description: "The attach command description and usage"
 keywords: "attach, running, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # attach
 
 ```markdown

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -4,15 +4,6 @@ description: "The build command description and usage"
 keywords: "build, docker, image"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # build
 
 ```markdown

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -4,15 +4,6 @@ description: "The commit command description and usage"
 keywords: "commit, file, changes"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # commit
 
 ```markdown

--- a/docs/reference/commandline/container.md
+++ b/docs/reference/commandline/container.md
@@ -5,15 +5,6 @@ description: "The container command description and usage"
 keywords: "container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # container
 
 ```markdown

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -4,15 +4,6 @@ description: "Remove all stopped containers"
 keywords: container, prune, delete, remove
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # container prune
 
 ```markdown

--- a/docs/reference/commandline/context_create.md
+++ b/docs/reference/commandline/context_create.md
@@ -4,15 +4,6 @@ description: "The context create command description and usage"
 keywords: "context, create"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context create
 
 ```markdown

--- a/docs/reference/commandline/context_export.md
+++ b/docs/reference/commandline/context_export.md
@@ -4,15 +4,6 @@ description: "The context export command description and usage"
 keywords: "context, export"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context export
 
 ```markdown

--- a/docs/reference/commandline/context_import.md
+++ b/docs/reference/commandline/context_import.md
@@ -4,15 +4,6 @@ description: "The context import command description and usage"
 keywords: "context, import"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context import
 
 ```markdown

--- a/docs/reference/commandline/context_inspect.md
+++ b/docs/reference/commandline/context_inspect.md
@@ -4,15 +4,6 @@ description: "The context inspect command description and usage"
 keywords: "context, inspect"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context inspect
 
 ```markdown

--- a/docs/reference/commandline/context_ls.md
+++ b/docs/reference/commandline/context_ls.md
@@ -4,15 +4,6 @@ description: "The context ls command description and usage"
 keywords: "context, ls"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context ls
 
 ```markdown

--- a/docs/reference/commandline/context_rm.md
+++ b/docs/reference/commandline/context_rm.md
@@ -4,15 +4,6 @@ description: "The context rm command description and usage"
 keywords: "context, rm"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context rm
 
 ```markdown

--- a/docs/reference/commandline/context_update.md
+++ b/docs/reference/commandline/context_update.md
@@ -4,15 +4,6 @@ description: "The context update command description and usage"
 keywords: "context, update"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context update
 
 ```markdown

--- a/docs/reference/commandline/context_use.md
+++ b/docs/reference/commandline/context_use.md
@@ -4,15 +4,6 @@ description: "The context use command description and usage"
 keywords: "context, use"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # context use
 
 ```markdown

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -4,15 +4,6 @@ description: "The cp command description and usage"
 keywords: "copy, container, files, folders"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # cp
 
 ```markdown

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -4,15 +4,6 @@ description: "The create command description and usage"
 keywords: "docker, create, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # create
 
 Creates a new container.

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -4,15 +4,6 @@ description: "The diff command description and usage"
 keywords: "list, changed, files, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # diff
 
 ```markdown

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -4,15 +4,6 @@ description: "The events command description and usage"
 keywords: "events, container, report"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # events
 
 ```markdown

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -4,15 +4,6 @@ description: "The exec command description and usage"
 keywords: "command, container, run, execute"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # exec
 
 ```markdown

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -4,15 +4,6 @@ description: "The export command description and usage"
 keywords: "export, file, system, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # export
 
 ```markdown

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -4,15 +4,6 @@ description: "The history command description and usage"
 keywords: "docker, image, history"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # history
 
 ```markdown

--- a/docs/reference/commandline/image.md
+++ b/docs/reference/commandline/image.md
@@ -5,15 +5,6 @@ description: "The image command description and usage"
 keywords: "image"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # image
 
 ```markdown

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -4,15 +4,6 @@ description: "Remove all stopped images"
 keywords: "image, prune, delete, remove"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # image prune
 
 ```markdown

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -4,15 +4,6 @@ description: "The images command description and usage"
 keywords: "list, docker, images"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # images
 
 ```markdown

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -4,15 +4,6 @@ description: "The import command description and usage"
 keywords: "import, file, system, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # import
 
 ```markdown

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -5,15 +5,6 @@ keywords: "Docker, Docker documentation, CLI, command line"
 identifier: "smn_cli_guide"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # The Docker commands
 
 This section contains reference information on using Docker's command line

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -4,15 +4,6 @@ description: "The info command description and usage"
 keywords: "display, docker, information"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # info
 
 ```markdown

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -4,15 +4,6 @@ description: "The inspect command description and usage"
 keywords: "inspect, container, json"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # inspect
 
 ```markdown

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -4,15 +4,6 @@ description: "The kill command description and usage"
 keywords: "container, kill, signal"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # kill
 
 ```markdown

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -4,15 +4,6 @@ description: "The load command description and usage"
 keywords: "stdin, tarred, repository"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # load
 
 ```markdown

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -4,15 +4,6 @@ description: "The login command description and usage"
 keywords: "registry, login, image"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # login
 
 ```markdown

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -4,15 +4,6 @@ description: "The logout command description and usage"
 keywords: "logout, docker, registry"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # logout
 
 ```markdown

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -4,15 +4,6 @@ description: "The logs command description and usage"
 keywords: "logs, retrieve, docker"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # logs
 
 ```markdown

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -4,15 +4,6 @@ description: "The manifest command description and usage"
 keywords: "docker, manifest"
 ---
 
-<!-- This file is maintained within the docker/cli Github
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 ```markdown
 Usage:  docker manifest COMMAND
 

--- a/docs/reference/commandline/network.md
+++ b/docs/reference/commandline/network.md
@@ -4,15 +4,6 @@ description: "The network command description and usage"
 keywords: "network"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network
 
 ```markdown

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -4,15 +4,6 @@ description: "The network connect command description and usage"
 keywords: "network, connect, user-defined"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network connect
 
 ```markdown

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -4,15 +4,6 @@ description: "The network create command description and usage"
 keywords: "network, create"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network create
 
 ```markdown

--- a/docs/reference/commandline/network_disconnect.md
+++ b/docs/reference/commandline/network_disconnect.md
@@ -4,15 +4,6 @@ description: "The network disconnect command description and usage"
 keywords: "network, disconnect, user-defined"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network disconnect
 
 ```markdown

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -4,15 +4,6 @@ description: "The network inspect command description and usage"
 keywords: "network, inspect, user-defined"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network inspect
 
 ```markdown

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -4,15 +4,6 @@ description: "The network ls command description and usage"
 keywords: "network, list, user-defined"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # docker network ls
 
 ```markdown

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -4,15 +4,6 @@ description: "the network rm command description and usage"
 keywords: "network, rm, user-defined"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # network rm
 
 ```markdown

--- a/docs/reference/commandline/node.md
+++ b/docs/reference/commandline/node.md
@@ -5,15 +5,6 @@ description: "The node command description and usage"
 keywords: "node"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node
 
 ```markdown

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -4,15 +4,6 @@ description: "The node demote command description and usage"
 keywords: "node, demote"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node demote
 
 ```markdown

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -4,15 +4,6 @@ description: "The node inspect command description and usage"
 keywords: "node, inspect"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node inspect
 
 ```markdown

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -4,15 +4,6 @@ description: "The node ls command description and usage"
 keywords: "node, list"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node ls
 
 ```markdown

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -4,15 +4,6 @@ description: "The node promote command description and usage"
 keywords: "node, promote"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node promote
 
 ```markdown

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -5,15 +5,6 @@ keywords: node, tasks, ps
 aliases: ["/engine/reference/commandline/node_tasks/"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node ps
 
 ```markdown

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -4,15 +4,6 @@ description: "The node rm command description and usage"
 keywords: "node, remove"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # node rm
 
 ```markdown

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -4,15 +4,6 @@ description: "The node update command description and usage"
 keywords: "resources, update, dynamically"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # update
 
 ```markdown

--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -4,15 +4,6 @@ description: "The pause command description and usage"
 keywords: "cgroups, container, suspend, SIGSTOP"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # pause
 
 ```markdown

--- a/docs/reference/commandline/plugin.md
+++ b/docs/reference/commandline/plugin.md
@@ -4,15 +4,6 @@ description: "The plugin command description and usage"
 keywords: "plugin"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin
 
 ```markdown

--- a/docs/reference/commandline/plugin_create.md
+++ b/docs/reference/commandline/plugin_create.md
@@ -4,15 +4,6 @@ description: "the plugin create command description and usage"
 keywords: "plugin, create"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin create
 
 ```markdown

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -4,15 +4,6 @@ description: "the plugin disable command description and usage"
 keywords: "plugin, disable"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin disable
 
 ```markdown

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -4,15 +4,6 @@ description: "the plugin enable command description and usage"
 keywords: "plugin, enable"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin enable
 
 ```markdown

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -4,15 +4,6 @@ description: "The plugin inspect command description and usage"
 keywords: "plugin, inspect"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin inspect
 
 ```markdown

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -4,15 +4,6 @@ description: "the plugin install command description and usage"
 keywords: "plugin, install"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin install
 
 ```markdown

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -4,15 +4,6 @@ description: "The plugin ls command description and usage"
 keywords: "plugin, list"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin ls
 
 ```markdown

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -4,15 +4,6 @@ description: "the plugin push command description and usage"
 keywords: "plugin, push"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 ```markdown
 Usage:	docker plugin push [OPTIONS] PLUGIN[:TAG]
 

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -4,15 +4,6 @@ description: "the plugin rm command description and usage"
 keywords: "plugin, rm"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin rm
 
 ```markdown

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -4,15 +4,6 @@ description: "the plugin set command description and usage"
 keywords: "plugin, set"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin set
 
 ```markdown

--- a/docs/reference/commandline/plugin_upgrade.md
+++ b/docs/reference/commandline/plugin_upgrade.md
@@ -4,15 +4,6 @@ description: "the plugin upgrade command description and usage"
 keywords: "plugin, upgrade"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # plugin upgrade
 
 ```markdown

--- a/docs/reference/commandline/port.md
+++ b/docs/reference/commandline/port.md
@@ -4,15 +4,6 @@ description: "The port command description and usage"
 keywords: "port, mapping, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # port
 
 ```markdown

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -4,15 +4,6 @@ description: "The ps command description and usage"
 keywords: "container, running, list"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # ps
 
 ```markdown

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -4,15 +4,6 @@ description: "The pull command description and usage"
 keywords: "pull, image, hub, docker"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # pull
 
 ```markdown

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -4,15 +4,6 @@ description: "The push command description and usage"
 keywords: "share, push, image"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # push
 
 ```markdown

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -4,15 +4,6 @@ description: "The rename command description and usage"
 keywords: "rename, docker, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # rename
 
 ```markdown

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -4,15 +4,6 @@ description: "The restart command description and usage"
 keywords: "restart, container, Docker"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # restart
 
 ```markdown

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -4,15 +4,6 @@ description: "The rm command description and usage"
 keywords: "remove, Docker, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # rm
 
 ```markdown

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -4,15 +4,6 @@ description: "The rmi command description and usage"
 keywords: "remove, image, Docker"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # rmi
 
 ```markdown

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -4,15 +4,6 @@ description: "The run command description and usage"
 keywords: "run, command, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # run
 
 ```markdown

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -4,15 +4,6 @@ description: "The save command description and usage"
 keywords: "tarred, repository, backup"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # save
 
 ```markdown

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -4,15 +4,6 @@ description: "The search command description and usage"
 keywords: "search, hub, images"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # search
 
 ```markdown

--- a/docs/reference/commandline/secret.md
+++ b/docs/reference/commandline/secret.md
@@ -4,15 +4,6 @@ description: "The secret command description and usage"
 keywords: "secret"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # secret
 
 ```markdown

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -4,15 +4,6 @@ description: "The secret create command description and usage"
 keywords: ["secret, create"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # secret create
 
 ```Markdown

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -4,15 +4,6 @@ description: "The secret inspect command description and usage"
 keywords: ["secret, inspect"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # secret inspect
 
 ```Markdown

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -4,15 +4,6 @@ description: "The secret ls command description and usage"
 keywords: ["secret, ls"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # secret ls
 
 ```Markdown

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -4,15 +4,6 @@ description: "The secret rm command description and usage"
 keywords: ["secret, rm"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # secret rm
 
 ```Markdown

--- a/docs/reference/commandline/service.md
+++ b/docs/reference/commandline/service.md
@@ -4,15 +4,6 @@ description: "The service command description and usage"
 keywords: "service"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service
 
 ```markdown

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -4,15 +4,6 @@ description: "The service create command description and usage"
 keywords: "service, create"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service create
 
 ```Markdown

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -4,15 +4,6 @@ description: "The service inspect command description and usage"
 keywords: "service, inspect"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service inspect
 
 ```Markdown

--- a/docs/reference/commandline/service_logs.md
+++ b/docs/reference/commandline/service_logs.md
@@ -4,15 +4,6 @@ description: "The service logs command description and usage"
 keywords: "service, task, logs"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service logs
 
 ```Markdown

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -4,15 +4,6 @@ description: "The service ls command description and usage"
 keywords: "service, ls"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service ls
 
 ```Markdown

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -5,15 +5,6 @@ keywords: "service, tasks, ps"
 aliases: ["/engine/reference/commandline/service_tasks/"]
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service ps
 
 ```Markdown

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -4,15 +4,6 @@ description: "The service rm command description and usage"
 keywords: "service, rm"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service rm
 
 ```Markdown

--- a/docs/reference/commandline/service_rollback.md
+++ b/docs/reference/commandline/service_rollback.md
@@ -4,15 +4,6 @@ description: "The service rollback command description and usage"
 keywords: "service, rollback"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service rollback
 
 ```markdown

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -4,15 +4,6 @@ description: "The service scale command description and usage"
 keywords: "service, scale"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service scale
 
 ```markdown

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -4,15 +4,6 @@ description: "The service update command description and usage"
 keywords: "service, update"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # service update
 
 ```Markdown

--- a/docs/reference/commandline/stack.md
+++ b/docs/reference/commandline/stack.md
@@ -4,15 +4,6 @@ description: "The stack command description and usage"
 keywords: "stack"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack
 
 ```markdown

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -4,15 +4,6 @@ description: "The stack deploy command description and usage"
 keywords: "stack, deploy, up"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack deploy
 
 ```markdown

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -4,15 +4,6 @@ description: "The stack ls command description and usage"
 keywords: "stack, ls"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack ls
 
 ```markdown

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -4,15 +4,6 @@ description: "The stack ps command description and usage"
 keywords: "stack, ps"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack ps
 
 ```markdown

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -4,15 +4,6 @@ description: "The stack rm command description and usage"
 keywords: "stack, rm, remove, down"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack rm
 
 ```markdown

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -4,15 +4,6 @@ description: "The stack services command description and usage"
 keywords: "stack, services"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stack services
 
 ```markdown

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -4,15 +4,6 @@ description: "The start command description and usage"
 keywords: "Start, container, stopped"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # start
 
 ```markdown

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -4,15 +4,6 @@ description: "The stats command description and usage"
 keywords: "container, resource, statistics"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stats
 
 ```markdown

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -4,15 +4,6 @@ description: "The stop command description and usage"
 keywords: "stop, SIGKILL, SIGTERM"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # stop
 
 ```markdown

--- a/docs/reference/commandline/swarm.md
+++ b/docs/reference/commandline/swarm.md
@@ -4,15 +4,6 @@ description: "The swarm command description and usage"
 keywords: "swarm"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm
 
 ```markdown

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -4,15 +4,6 @@ description: "The swarm ca command description and usage"
 keywords: "swarm, ca"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm ca
 
 ```markdown

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -4,15 +4,6 @@ description: "The swarm init command description and usage"
 keywords: "swarm, init"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm init
 
 ```markdown

--- a/docs/reference/commandline/swarm_join-token.md
+++ b/docs/reference/commandline/swarm_join-token.md
@@ -4,15 +4,6 @@ description: "The swarm join-token command description and usage"
 keywords: "swarm, join-token"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm join-token
 
 ```markdown

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -4,15 +4,6 @@ description: "The swarm join command description and usage"
 keywords: "swarm, join"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm join
 
 ```markdown

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -4,15 +4,6 @@ description: "The swarm leave command description and usage"
 keywords: "swarm, leave"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm leave
 
 ```markdown

--- a/docs/reference/commandline/swarm_unlock-key.md
+++ b/docs/reference/commandline/swarm_unlock-key.md
@@ -4,15 +4,6 @@ description: "The swarm unlock-keycommand description and usage"
 keywords: "swarm, unlock-key"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm unlock-key
 
 ```markdown

--- a/docs/reference/commandline/swarm_unlock.md
+++ b/docs/reference/commandline/swarm_unlock.md
@@ -4,15 +4,6 @@ description: "The swarm unlock command description and usage"
 keywords: "swarm, unlock"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm unlock
 
 ```markdown

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -4,15 +4,6 @@ description: "The swarm update command description and usage"
 keywords: "swarm, update"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # swarm update
 
 ```markdown

--- a/docs/reference/commandline/system.md
+++ b/docs/reference/commandline/system.md
@@ -4,15 +4,6 @@ description: "The system command description and usage"
 keywords: "system"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # system
 
 ```markdown

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -4,15 +4,6 @@ description: "The system df command description and usage"
 keywords: "system, data, usage, disk"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # system df
 
 ```markdown

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -4,15 +4,6 @@ description: "The system events command description and usage"
 keywords: "system, events, container, report"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # system events
 
 ```markdown

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -4,15 +4,6 @@ description: "Remove unused data"
 keywords: "system, prune, delete, remove"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # system prune
 
 ```markdown

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -4,15 +4,6 @@ description: "The tag command description and usage"
 keywords: "tag, name, image"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # tag
 
 ```markdown

--- a/docs/reference/commandline/top.md
+++ b/docs/reference/commandline/top.md
@@ -4,15 +4,6 @@ description: "The top command description and usage"
 keywords: "container, running, processes"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # top
 
 ```markdown

--- a/docs/reference/commandline/trust_inspect.md
+++ b/docs/reference/commandline/trust_inspect.md
@@ -4,15 +4,6 @@ description: "The inspect command description and usage"
 keywords: "inspect, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust inspect
 
 ```markdown

--- a/docs/reference/commandline/trust_key_generate.md
+++ b/docs/reference/commandline/trust_key_generate.md
@@ -4,15 +4,6 @@ description: "The key generate command description and usage"
 keywords: "key, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli Github
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust key generate
 
 ```markdown

--- a/docs/reference/commandline/trust_key_load.md
+++ b/docs/reference/commandline/trust_key_load.md
@@ -4,15 +4,6 @@ description: "The key load command description and usage"
 keywords: "key, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli Github
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust key load
 
 ```markdown

--- a/docs/reference/commandline/trust_revoke.md
+++ b/docs/reference/commandline/trust_revoke.md
@@ -4,15 +4,6 @@ description: "The revoke command description and usage"
 keywords: "revoke, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust revoke
 
 ```markdown

--- a/docs/reference/commandline/trust_sign.md
+++ b/docs/reference/commandline/trust_sign.md
@@ -4,15 +4,6 @@ description: "The sign command description and usage"
 keywords: "sign, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust sign
 
 ```markdown

--- a/docs/reference/commandline/trust_signer_add.md
+++ b/docs/reference/commandline/trust_signer_add.md
@@ -4,15 +4,6 @@ description: "The signer add command description and usage"
 keywords: "signer, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli Github
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust signer add
 
 ```markdown

--- a/docs/reference/commandline/trust_signer_remove.md
+++ b/docs/reference/commandline/trust_signer_remove.md
@@ -4,15 +4,6 @@ description: "The signer remove command description and usage"
 keywords: "signer, notary, trust"
 ---
 
-<!-- This file is maintained within the docker/cli Github
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # trust signer remove
 
 ```markdown

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -4,15 +4,6 @@ description: "The unpause command description and usage"
 keywords: "cgroups, suspend, container"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # unpause
 
 ```markdown

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -4,15 +4,6 @@ description: "The update command description and usage"
 keywords: "resources, update, dynamically"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 ## update
 
 ```markdown

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -4,15 +4,6 @@ description: "The version command description and usage"
 keywords: "version, architecture, api"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # version
 
 ```markdown

--- a/docs/reference/commandline/volume.md
+++ b/docs/reference/commandline/volume.md
@@ -4,15 +4,6 @@ description: "The volume command description and usage"
 keywords: "volume"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume
 
 ```markdown

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -4,15 +4,6 @@ description: "The volume create command description and usage"
 keywords: "volume, create"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume create
 
 ```markdown

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -4,15 +4,6 @@ description: "The volume inspect command description and usage"
 keywords: "volume, inspect"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume inspect
 
 ```markdown

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -4,15 +4,6 @@ description: "The volume ls command description and usage"
 keywords: "volume, list"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume ls
 
 ```markdown

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -4,15 +4,6 @@ description: "Remove unused local volumes"
 keywords: "volume, prune, delete"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume prune
 
 ```markdown

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -4,15 +4,6 @@ description: "the volume rm command description and usage"
 keywords: "volume, rm"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # volume rm
 
 ```markdown

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -4,15 +4,6 @@ description: "The wait command description and usage"
 keywords: "container, stop, wait"
 ---
 
-<!-- This file is maintained within the docker/cli GitHub
-     repository at https://github.com/docker/cli/. Make all
-     pull requests against that repo. If you see this file in
-     another repository, consider it read-only there, as it will
-     periodically be overwritten by the definitive file. Pull
-     requests which include edits to this file in other repositories
-     will be rejected.
--->
-
 # wait
 
 ```markdown


### PR DESCRIPTION
these markdown files are not consumed directly in the docs,
but only their content is included through the YAML does,
so there's no need to have these comments in them

backport of https://github.com/docker/cli/pull/2398
