### PR TITLE
Update deprecation policy to 1 stable release

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -25,7 +25,7 @@ about end of support for Linux distributions, refer to the
 As changes are made to Docker there may be times when existing features need to
 be removed or replaced with newer features. Before an existing feature is removed
 it is labeled as "deprecated" within the documentation and remains in Docker for
-at least 3 stable releases unless specified explicitly otherwise. After that time
+at least one stable release unless specified explicitly otherwise. After that time
 it may be removed.
 
 Users are expected to take note of the list of deprecated features each release


### PR DESCRIPTION
The deprecation policy was written when we had monthly releases
(edge+stable), and stable releases were released every 3 months.

The release cadence has changed to be longer than 3 months for
stable releases, so adjusting the policy accordingly.

Note that the policy continues to be "at least x releases", so
even though we _can_ remove a feature after one release, it does
not mean we _must_ remove it: announcing deprecations early helps
users migrate away from features we do not intent to support in
future.


