### PR TITLE
Allow publishing same port as UDP and TCP using docker stack deploy

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -111,7 +111,7 @@ func toServicePortConfigsMap(s interface{}) (map[interface{}]interface{}, error)
 	}
 	m := map[interface{}]interface{}{}
 	for _, p := range ports {
-		m[p.Published] = p
+		m[p] = p
 	}
 	return m, nil
 }


### PR DESCRIPTION
fixes #2407 

**- What I did**
Simple fix for #2407, to ensure that TCP and UDP publishing for the same port doesn't go away during compose file merging.

**- How I did it**

I changed the key of the map from the port number to the full port specification (including published port number and protocol).

This may not be the ideal solution since it includes not just the protocol, but also the published port number in the map key.  I did it this way because it's all I can figure out how do do with my meager golang skills.  I also have not included a unit test for the same reason.

**- How to verify it**

Try the example in #2407.

**- Description for the changelog**

* fix bug: now possible to publish same port as TCP and UDP using docker stack deploy

**- A picture of a cute animal (not mandatory but encouraged)**

```
   |\---/|
   | ,_, |
    \_`_/-..----.
 ___/ `   ' ,""+ \  sk
(__...'   __\    |`.___.';
  (_,...'(_,.`__)/'.....+
```
(source: https://www.asciiart.eu/animals/cats)