### PR TITLE
calculateMemUsageUnixNoCache: subtract total_inactive_file, not cache

### DIFF
--- a/cli/command/container/stats_helpers_test.go
+++ b/cli/command/container/stats_helpers_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCalculateMemUsageUnixNoCache(t *testing.T) {
 	// Given
-	stats := types.MemoryStats{Usage: 500, Stats: map[string]uint64{"cache": 400}}
+	stats := types.MemoryStats{Usage: 500, Stats: map[string]uint64{"total_inactive_file": 400}}
 
 	// When
 	result := calculateMemUsageUnixNoCache(stats)

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -25,7 +25,10 @@ The `docker stats` command returns a live data stream for running containers. To
 
 If you want more detailed information about a container's resource usage, use the `/containers/(id)/stats` API endpoint.
 
-> **Note**: On Linux, the Docker CLI reports memory usage by subtracting page cache usage from the total memory usage. The API does not perform such a calculation but rather provides the total memory usage and the amount from the page cache so that clients can use the data as needed.
+> **Note**: On Linux, the Docker CLI reports memory usage by subtracting cache usage from the total memory usage. The API does not perform such a calculation but rather provides the total memory usage and the amount from the cache so that clients can use the data as needed.
+The cache usage is defined as the value of `total_inactive_file` field in the `memory.stat` file on cgroup v1 hosts.
+On Docker 19.03 and older, the cache usage was defined as the value of `cache` field.
+On cgroup v2 hosts, the cache usage is defined as the value of `inactive_file` field.
 
 > **Note**: The `PIDS` column contains the number of processes and kernel threads created by that container. Threads is the term used by Linux kernel. Other equivalent terms are "lightweight process" or "kernel task", etc. A large number in the `PIDS` column combined with a small number of processes (as reported by `ps` or `top`) may indicate that something in the container is creating many threads.
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed `mem.Usage - mem.Stats["cache"]` in `calculateMemUsageUnixNoCache()` used by `docker stats` CLI to `mem.Usage - mem.Stats["total_inactive_file"]`.

Fix https://github.com/moby/moby/issues/40727


**- How I did it**

The new stat definition corresponds to containerd/CRI and cadvisor.

https://github.com/containerd/cri/blob/c1115d4e57f55a5f45fb3efd29d3181ce26d5c6a/pkg/server/container_stats_list_unix.go#L106-L129
https://github.com/google/cadvisor/commit/307d1b1cb320fef66fab02db749f07a459245451



**- How to verify it**
See https://github.com/moby/moby/issues/40727

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed `mem.Usage - mem.Stats["cache"]` in `calculateMemUsageUnixNoCache()` used by `docker stats` CLI to `mem.Usage - mem.Stats["total_inactive_file"]`.


**- A picture of a cute animal (not mandatory but encouraged)**
:penguin: