### PR TITLE
test: make sure environment vars are reset after tests

### DIFF
--- a/cli/command/image/trust_test.go
+++ b/cli/command/image/trust_test.go
@@ -11,19 +11,12 @@ import (
 	"github.com/theupdateframework/notary/passphrase"
 	"github.com/theupdateframework/notary/trustpinning"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/env"
 )
 
-func unsetENV() {
-	os.Unsetenv("DOCKER_CONTENT_TRUST")
-	os.Unsetenv("DOCKER_CONTENT_TRUST_SERVER")
-}
-
 func TestENVTrustServer(t *testing.T) {
-	defer unsetENV()
+	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "https://notary-test.com:5000"})()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
-	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "https://notary-test.com:5000"); err != nil {
-		t.Fatal("Failed to set ENV variable")
-	}
 	output, err := trust.Server(indexInfo)
 	expectedStr := "https://notary-test.com:5000"
 	if err != nil || output != expectedStr {
@@ -32,11 +25,8 @@ func TestENVTrustServer(t *testing.T) {
 }
 
 func TestHTTPENVTrustServer(t *testing.T) {
-	defer unsetENV()
+	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "http://notary-test.com:5000"})()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
-	if err := os.Setenv("DOCKER_CONTENT_TRUST_SERVER", "http://notary-test.com:5000"); err != nil {
-		t.Fatal("Failed to set ENV variable")
-	}
 	_, err := trust.Server(indexInfo)
 	if err == nil {
 		t.Fatal("Expected error with invalid scheme")

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/env"
 )
 
 var homeKey = "HOME"
@@ -120,12 +121,7 @@ email`: "Invalid auth configuration file",
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
-
-	homeDir, err := os.UserHomeDir()
-	assert.NilError(t, err)
-
-	defer func() { os.Setenv(homeKey, homeDir) }()
-	os.Setenv(homeKey, tmpHome)
+	defer env.Patch(t, homeKey, tmpHome)()
 
 	for content, expectedError := range invalids {
 		fn := filepath.Join(tmpHome, oldConfigfile)
@@ -141,12 +137,7 @@ func TestOldValidAuth(t *testing.T) {
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
-
-	homeDir, err := os.UserHomeDir()
-	assert.NilError(t, err)
-
-	defer func() { os.Setenv(homeKey, homeDir) }()
-	os.Setenv(homeKey, tmpHome)
+	defer env.Patch(t, homeKey, tmpHome)()
 
 	fn := filepath.Join(tmpHome, oldConfigfile)
 	js := `username = am9lam9lOmhlbGxv
@@ -180,12 +171,7 @@ func TestOldJSONInvalid(t *testing.T) {
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
-
-	homeDir, err := os.UserHomeDir()
-	assert.NilError(t, err)
-
-	defer func() { os.Setenv(homeKey, homeDir) }()
-	os.Setenv(homeKey, tmpHome)
+	defer env.Patch(t, homeKey, tmpHome)()
 
 	fn := filepath.Join(tmpHome, oldConfigfile)
 	js := `{"https://index.docker.io/v1/":{"auth":"test","email":"user@example.com"}}`
@@ -204,12 +190,7 @@ func TestOldJSON(t *testing.T) {
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
-
-	homeDir, err := os.UserHomeDir()
-	assert.NilError(t, err)
-
-	defer func() { os.Setenv(homeKey, homeDir) }()
-	os.Setenv(homeKey, tmpHome)
+	defer env.Patch(t, homeKey, tmpHome)()
 
 	fn := filepath.Join(tmpHome, oldConfigfile)
 	js := `{"https://index.docker.io/v1/":{"auth":"am9lam9lOmhlbGxv","email":"user@example.com"}}`


### PR DESCRIPTION
The trust tests were not resetting the environment after they ran, which could result in tests following those tests to fail.

While at it, I also updated some other tests to use gotest.tools