### PR TITLE
improve "network prune" output to mention custom networks only

### DIFF
--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -43,7 +43,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-const warning = `WARNING! This will remove all networks not used by at least one container.
+const warning = `WARNING! This will remove all custom networks not used by at least one container.
 Are you sure you want to continue?`
 
 func runPrune(dockerCli command.Cli, options pruneOptions) (output string, err error) {

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -27,7 +27,7 @@ by any containers.
 ```bash
 $ docker network prune
 
-WARNING! This will remove all networks not used by at least one container.
+WARNING! This will remove all custom networks not used by at least one container.
 Are you sure you want to continue? [y/N] y
 Deleted Networks:
 n1


### PR DESCRIPTION
The `docker network prune` command removes unused custom networks,
but built-in networks won't be removed. This patch updates the
message to mention that it's only removing custom networks.

addresses https://github.com/moby/moby/issues/30364#issuecomment-611994955
