### PR TITLE
Jenkinsfile: split e2e tests to separate stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,11 +3,23 @@ wrappedNode(label: 'linux && x86_64', cleanWorkspace: true) {
     stage "Git Checkout"
     checkout scm
 
-    stage "Run end-to-end test suite"
+    stage "Docker info"
     sh "docker version"
     sh "docker info"
+
+    stage "e2e (non-experimental)"
     sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
         IMAGE_TAG=clie2e${BUILD_NUMBER} \
-        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e"
+        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
+
+    stage "e2e (experimental)"
+    sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+        IMAGE_TAG=clie2e${BUILD_NUMBER} \
+        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-experimental"
+
+    stage "e2e (ssh connhelper)"
+    sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+        IMAGE_TAG=clie2e${BUILD_NUMBER} \
+        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-connhelper-ssh"
   }
 }


### PR DESCRIPTION
The non-experimental, experimental, and ssh-connhelper stages are running the same tests, which makes it difficult to find _which_ variant of the test failed if they all run in the same stage.

With this change:

<img width="720" alt="Screenshot 2020-04-10 at 16 23 07" src="https://user-images.githubusercontent.com/1804568/78997811-991e0f80-7b47-11ea-9013-c819f944ffdd.png">


