### PR TITLE
--config also accepts a file path

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -84,7 +84,19 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 		configDir = Dir()
 	}
 
-	filename := filepath.Join(configDir, ConfigFileName)
+	var filename string
+	stat, err := os.Stat(configDir)
+	if err != nil {
+		// configDir does not exists
+		return nil, errors.Wrap(err, configDir)
+	} else if stat.IsDir() {
+		// configDir is a directory, use it as base for config.json
+		filename = filepath.Join(configDir, ConfigFileName)
+	} else {
+		// configDir is a file, use it as filename
+		filename = configDir
+	}
+
 	configFile := configfile.New(filename)
 
 	// Try happy path first - latest config file


### PR DESCRIPTION
**- What I did**

The behavior of the `--config` parameter (and the `DOCKER_CONFIG` variable) has changed. In addition to a directory path, this now also accepts a file path.

**- How I did it**

It is checked whether the specified path is a directory or a file.

**- How to verify it**

```
$ mv -vi ~/.docker/config.json ~/.docker/cli.json
renamed '~/.docker/config.json' -> '~/.docker/cli.json'
$ docker push <some image>
# should fail
$ docker --config ~/.docker/cli.json <some image>
# should work
```

**- Description for the changelog**

- `--config` also accepts a file path

**- A picture of a cute animal (not mandatory but encouraged)**

![animation](https://user-images.githubusercontent.com/343404/79118289-cd830d00-7d8d-11ea-8f82-b23c4b04b2d1.gif)
