### PR TITLE
[19.03 backport] vendor: update go-events to fix alignment for 32bit systems

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -19,7 +19,7 @@ github.com/docker/docker                            a004854097417a591c3f6a3aeaab
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
-github.com/docker/go-events                         9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a24426ee7ef18
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -203,8 +203,8 @@ type ExponentialBackoffConfig struct {
 // ExponentialBackoff implements random backoff with exponentially increasing
 // bounds as the number consecutive failures increase.
 type ExponentialBackoff struct {
+	failures uint64 // consecutive failure counter (needs to be 64-bit aligned)
 	config   ExponentialBackoffConfig
-	failures uint64 // consecutive failure counter.
 }
 
 // NewExponentialBackoff returns an exponential backoff strategy with the


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2418

- relates to moby/buildkit 1111
- relates to moby/buildkit 1079
- relates to docker/buildx 129

full diff: https://github.com/docker/go-events/compare/9461782956ad83b30282bf90e31fa6a70c255ba9...e31b211e4f1cd09aa76fe4ac244571fab96ae47f

