### PR TITLE
Add "host-gateway" to tests for extra_hosts / --add-host

### DIFF
--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -358,15 +358,19 @@ func TestUpdateHosts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("host-add", "example.net:2.2.2.2")
 	flags.Set("host-add", "ipv6.net:2001:db8:abc8::1")
+	// adding the special "host-gateway" target should work
+	flags.Set("host-add", "host.docker.internal:host-gateway")
 	// remove with ipv6 should work
 	flags.Set("host-rm", "example.net:2001:db8:abc8::1")
 	// just hostname should work as well
 	flags.Set("host-rm", "example.net")
+	// removing the special "host-gateway" target should work
+	flags.Set("host-rm", "gateway.docker.internal:host-gateway")
 	// bad format error
 	assert.ErrorContains(t, flags.Set("host-add", "$example.com$"), `bad format for add-host: "$example.com$"`)
 
-	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net"}
-	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net"}
+	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net", "gateway.docker.internal:host-gateway"}
+	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net", "host-gateway host.docker.internal"}
 
 	err := updateHosts(flags, &hosts)
 	assert.NilError(t, err)

--- a/cli/compose/loader/full-example.yml
+++ b/cli/compose/loader/full-example.yml
@@ -140,9 +140,11 @@ services:
     # extra_hosts:
     #   somehost: "162.242.195.82"
     #   otherhost: "50.31.209.229"
+    #   host.docker.internal: "host-gateway"
     extra_hosts:
       - "somehost:162.242.195.82"
       - "otherhost:50.31.209.229"
+      - "host.docker.internal:host-gateway"
 
     hostname: foo
 

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -144,6 +144,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			ExtraHosts: []string{
 				"somehost:162.242.195.82",
 				"otherhost:50.31.209.229",
+				"host.docker.internal:host-gateway",
 			},
 			Extras: map[string]interface{}{
 				"x-bar": "baz",
@@ -626,6 +627,7 @@ services:
     extra_hosts:
     - somehost:162.242.195.82
     - otherhost:50.31.209.229
+    - host.docker.internal:host-gateway
     hostname: foo
     healthcheck:
       test:
@@ -1135,7 +1137,8 @@ func fullExampleJSON(workingDir string) string {
       ],
       "extra_hosts": [
         "somehost:162.242.195.82",
-        "otherhost:50.31.209.229"
+        "otherhost:50.31.209.229",
+        "host.docker.internal:host-gateway"
       ],
       "hostname": "foo",
       "healthcheck": {

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1276,11 +1276,13 @@ services:
     extra_hosts:
       "zulu": "162.242.195.82"
       "alpha": "50.31.209.229"
+      "host.docker.internal": "host-gateway"
 `)
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
 		"alpha:50.31.209.229",
+		"host.docker.internal:host-gateway",
 		"zulu:162.242.195.82",
 	}
 
@@ -1298,6 +1300,7 @@ services:
       - "zulu:162.242.195.82"
       - "alpha:50.31.209.229"
       - "zulu:ff02::1"
+      - "host.docker.internal:host-gateway"
 `)
 	assert.NilError(t, err)
 
@@ -1305,6 +1308,7 @@ services:
 		"zulu:162.242.195.82",
 		"alpha:50.31.209.229",
 		"zulu:ff02::1",
+		"host.docker.internal:host-gateway",
 	}
 
 	assert.Assert(t, is.Len(config.Services, 1))

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -154,6 +154,7 @@ func TestValidateExtraHosts(t *testing.T) {
 		`thathost:10.0.2.1`,
 		`anipv6host:2003:ab34:e::1`,
 		`ipv6local:::1`,
+		`host.docker.internal:host-gateway`,
 	}
 
 	invalid := map[string]string{


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/2337

67ebcd6dcf82c00f133b886a9a343b67124e58ec added an exception for the "host-gateway" magic value to the validation rules, but didn't add thise value to any of the tests.

This patch adds the magic value to tests, to verify the validation is skipped for this magic value.

Note that validation on the client side is "optional" and mostly done to provide a more user friendly error message for regular values (IP-addresses).

