### PR TITLE
[19.03 backport] Skip IPAddr validation for "host-gateway" string

### DIFF
--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -358,15 +358,19 @@ func TestUpdateHosts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("host-add", "example.net:2.2.2.2")
 	flags.Set("host-add", "ipv6.net:2001:db8:abc8::1")
+	// adding the special "host-gateway" target should work
+	flags.Set("host-add", "host.docker.internal:host-gateway")
 	// remove with ipv6 should work
 	flags.Set("host-rm", "example.net:2001:db8:abc8::1")
 	// just hostname should work as well
 	flags.Set("host-rm", "example.net")
+	// removing the special "host-gateway" target should work
+	flags.Set("host-rm", "gateway.docker.internal:host-gateway")
 	// bad format error
 	assert.ErrorContains(t, flags.Set("host-add", "$example.com$"), `bad format for add-host: "$example.com$"`)
 
-	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net"}
-	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net"}
+	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net", "gateway.docker.internal:host-gateway"}
+	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net", "host-gateway host.docker.internal"}
 
 	err := updateHosts(flags, &hosts)
 	assert.NilError(t, err)

--- a/cli/compose/loader/full-example.yml
+++ b/cli/compose/loader/full-example.yml
@@ -140,9 +140,11 @@ services:
     # extra_hosts:
     #   somehost: "162.242.195.82"
     #   otherhost: "50.31.209.229"
+    #   host.docker.internal: "host-gateway"
     extra_hosts:
       - "somehost:162.242.195.82"
       - "otherhost:50.31.209.229"
+      - "host.docker.internal:host-gateway"
 
     hostname: foo
 

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -144,6 +144,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 			ExtraHosts: []string{
 				"somehost:162.242.195.82",
 				"otherhost:50.31.209.229",
+				"host.docker.internal:host-gateway",
 			},
 			Extras: map[string]interface{}{
 				"x-bar": "baz",
@@ -626,6 +627,7 @@ services:
     extra_hosts:
     - somehost:162.242.195.82
     - otherhost:50.31.209.229
+    - host.docker.internal:host-gateway
     hostname: foo
     healthcheck:
       test:
@@ -1135,7 +1137,8 @@ func fullExampleJSON(workingDir string) string {
       ],
       "extra_hosts": [
         "somehost:162.242.195.82",
-        "otherhost:50.31.209.229"
+        "otherhost:50.31.209.229",
+        "host.docker.internal:host-gateway"
       ],
       "hostname": "foo",
       "healthcheck": {

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1276,11 +1276,13 @@ services:
     extra_hosts:
       "zulu": "162.242.195.82"
       "alpha": "50.31.209.229"
+      "host.docker.internal": "host-gateway"
 `)
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
 		"alpha:50.31.209.229",
+		"host.docker.internal:host-gateway",
 		"zulu:162.242.195.82",
 	}
 
@@ -1298,6 +1300,7 @@ services:
       - "zulu:162.242.195.82"
       - "alpha:50.31.209.229"
       - "zulu:ff02::1"
+      - "host.docker.internal:host-gateway"
 `)
 	assert.NilError(t, err)
 
@@ -1305,6 +1308,7 @@ services:
 		"zulu:162.242.195.82",
 		"alpha:50.31.209.229",
 		"zulu:ff02::1",
+		"host.docker.internal:host-gateway",
 	}
 
 	assert.Assert(t, is.Len(config.Services, 1))

--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -24,6 +24,12 @@ var (
 	DefaultTLSHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultTLSHTTPPort)
 	// DefaultNamedPipe defines the default named pipe used by docker on Windows
 	DefaultNamedPipe = `//./pipe/docker_engine`
+	// hostGatewayName defines a special string which users can append to --add-host
+	// to add an extra entry in /etc/hosts that maps host.docker.internal to the host IP
+	// TODO Consider moving the HostGatewayName constant defined in docker at
+	// github.com/docker/docker/daemon/network/constants.go outside of the "daemon"
+	// package, so that the CLI can consume it.
+	hostGatewayName = "host-gateway"
 )
 
 // ValidateHost validates that the specified string is a valid host and returns it.
@@ -160,8 +166,11 @@ func ValidateExtraHost(val string) (string, error) {
 	if len(arr) != 2 || len(arr[0]) == 0 {
 		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
-	if _, err := ValidateIPAddress(arr[1]); err != nil {
-		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
+	// Skip IPaddr validation for "host-gateway" string
+	if arr[1] != hostGatewayName {
+		if _, err := ValidateIPAddress(arr[1]); err != nil {
+			return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
+		}
 	}
 	return val, nil
 }

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -154,6 +154,7 @@ func TestValidateExtraHosts(t *testing.T) {
 		`thathost:10.0.2.1`,
 		`anipv6host:2003:ab34:e::1`,
 		`ipv6local:::1`,
+		`host.docker.internal:host-gateway`,
 	}
 
 	invalid := map[string]string{


### PR DESCRIPTION
backport of:

- https://github.com/docker/cli/pull/2337 Skip IPAddr validation for "host-gateway" string
    - relates to https://github.com/moby/moby/pull/40007 "Support host.docker.internal in dockerd on Linux"
- https://github.com/docker/cli/pull/2443 Add "host-gateway" to tests for extra_hosts / --add-host

While the 19.03 daemon does not yet support this special value, the 19.03 docker cli might be connecting to a daemon that does support this feature. This PR back ports the client-side changes to allow a 19.03 cli to use the feature on a daemon that supports this; daemons that don't support the special value will still produce an error when used.

