### PR TITLE
`docker manifest rm` command to remove manifest list draft from local storage

### DIFF
--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -27,6 +27,7 @@ func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 		newInspectCommand(dockerCli),
 		newAnnotateCommand(dockerCli),
 		newPushListCommand(dockerCli),
+		newRmManifestListCommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/manifest/rm.go
+++ b/cli/command/manifest/rm.go
@@ -1,0 +1,47 @@
+package manifest
+
+import (
+	"strings"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func newRmManifestListCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm MANIFEST_LIST [MANIFEST_LIST...]",
+		Short: "Delete one or more manifest lists from local storage",
+		Args:  cli.RequiresMinArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRm(dockerCli, args)
+		},
+	}
+
+	return cmd
+}
+
+func runRm(dockerCli command.Cli, targets []string) error {
+	var errs []string
+	for _, target := range targets {
+		targetRef, refErr := normalizeReference(target)
+		if refErr != nil {
+			errs = append(errs, refErr.Error())
+			continue
+		}
+		_, searchErr := dockerCli.ManifestStore().GetList(targetRef)
+		if searchErr != nil {
+			errs = append(errs, searchErr.Error())
+			continue
+		}
+		rmErr := dockerCli.ManifestStore().Remove(targetRef)
+		if rmErr != nil {
+			errs = append(errs, rmErr.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "\n"))
+	}
+	return nil
+}

--- a/cli/command/manifest/rm_test.go
+++ b/cli/command/manifest/rm_test.go
@@ -1,0 +1,65 @@
+package manifest
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+)
+
+// create two manifest lists and remove them both
+func TestRmSeveralManifests(t *testing.T) {
+	store, cleanup := newTempManifestStore(t)
+	defer cleanup()
+
+	cli := test.NewFakeCli(nil)
+	cli.SetManifestStore(store)
+
+	list1 := ref(t, "first:1")
+	namedRef := ref(t, "alpine:3.0")
+	err := store.Save(list1, namedRef, fullImageManifest(t, namedRef))
+	assert.NilError(t, err)
+	namedRef = ref(t, "alpine:3.1")
+	err = store.Save(list1, namedRef, fullImageManifest(t, namedRef))
+	assert.NilError(t, err)
+
+	list2 := ref(t, "second:2")
+	namedRef = ref(t, "alpine:3.2")
+	err = store.Save(list2, namedRef, fullImageManifest(t, namedRef))
+	assert.NilError(t, err)
+
+	cmd := newRmManifestListCommand(cli)
+	cmd.SetArgs([]string{"example.com/first:1", "example.com/second:2"})
+	cmd.SetOut(ioutil.Discard)
+	err = cmd.Execute()
+	assert.NilError(t, err)
+
+	_, search1 := cli.ManifestStore().GetList(list1)
+	_, search2 := cli.ManifestStore().GetList(list2)
+	assert.Error(t, search1, "No such manifest: example.com/first:1")
+	assert.Error(t, search2, "No such manifest: example.com/second:2")
+}
+
+// attempt to remove a manifest list which was never created
+func TestRmManifestNotCreated(t *testing.T) {
+	store, cleanup := newTempManifestStore(t)
+	defer cleanup()
+
+	cli := test.NewFakeCli(nil)
+	cli.SetManifestStore(store)
+
+	list2 := ref(t, "second:2")
+	namedRef := ref(t, "alpine:3.2")
+	err := store.Save(list2, namedRef, fullImageManifest(t, namedRef))
+	assert.NilError(t, err)
+
+	cmd := newRmManifestListCommand(cli)
+	cmd.SetArgs([]string{"example.com/first:1", "example.com/second:2"})
+	cmd.SetOut(ioutil.Discard)
+	err = cmd.Execute()
+	assert.Error(t, err, "No such manifest: example.com/first:1")
+
+	_, err = cli.ManifestStore().GetList(list2)
+	assert.Error(t, err, "No such manifest: example.com/second:2")
+}

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4128,6 +4128,7 @@ _docker_manifest() {
 		create
 		inspect
 		push
+		rm
 	"
 	__docker_subcommands "$subcommands" && return
 
@@ -4222,6 +4223,17 @@ _docker_manifest_push() {
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_images --force-tag --id
 			fi
+			;;
+	esac
+}
+
+_docker_network_rm() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_complete_images --force-tag --id
 			;;
 	esac
 }


### PR DESCRIPTION
**- What I did**

Made a typo and wanted to delete my manifest from local storage, yet there was no easy way to do so without using `docker manifest push --purge`.

I implemented a new sub-command `docker manifest rm`

```bash
$ docker manifest rm
"docker manifest rm" requires exactly 1 argument.
See 'docker manifest rm --help'.

Usage:  docker manifest rm MANIFEST_LIST

Delete a manifest list from local storage
```

**- How I did it**

tbh I never programmed in Go before, so I copied and pasted `push.go` to `rm.go` and kept deleting lines until it would compile.

**- How to verify it**

```
make -f docker.Makefile binary
build/docker-linux-amd64 manifest create repo/example:latest amd64/ubuntu:latest ppc64le/ubuntu:latest
build/docker-linux-amd64 manifest inspect repo/example:latest
build/docker-linux-amd64 manifest rm repo/example:latest
build/docker-linux-amd64 manifest create repo/example:latest i386/ubuntu arm64v8/ubuntu
build/docker-linux-amd64 manifest inspect repo/example:latest
```
**- Description for the changelog**

Add sub-command `docker manifest rm`

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/20404439/79624620-d1e25980-80f0-11ea-8eba-29f545d1ec34.png)
