### PR TITLE
yamldocs: add description to base command

### DIFF
--- a/docs/yaml/generate.go
+++ b/docs/yaml/generate.go
@@ -21,7 +21,10 @@ func generateCliYaml(opts *options) error {
 	if err != nil {
 		return err
 	}
-	cmd := &cobra.Command{Use: "docker"}
+	cmd := &cobra.Command{
+		Use:   "docker [OPTIONS] COMMAND [ARG...]",
+		Short: "The base command for the Docker CLI.",
+	}
 	commands.AddCommands(cmd, dockerCli)
 	disableFlagsInUseLine(cmd)
 	source := filepath.Join(opts.source, descriptionSourcePath)


### PR DESCRIPTION
Currently the documentation uses a special case for this command, so adding a description to the YAML in order to remove that special case.


