### PR TITLE
Add container_iface_prefix option to documentation

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -170,11 +170,12 @@ equivalent docker daemon flags used for docker0 bridge:
 
 | Option                                           | Equivalent  | Description                                           |
 |--------------------------------------------------|-------------|-------------------------------------------------------|
-| `com.docker.network.bridge.name`                 | -           | bridge name to be used when creating the Linux bridge |
+| `com.docker.network.bridge.name`                 | -           | Bridge name to be used when creating the Linux bridge |
 | `com.docker.network.bridge.enable_ip_masquerade` | `--ip-masq` | Enable IP masquerading                                |
 | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
+| `com.docker.network.container_interface_prefix`  | -           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to `docker daemon`.


### PR DESCRIPTION
Signed-off-by: dominikbraun <braun@sternentstehung.de>
Fixes: https://github.com/docker/cli/issues/2092

**- What I did**
Added the `com.docker.network.container_iface_prefix` option to the documentation for `docker network create`.

**- How I did it**
I updated the [corresponding file](https://github.com/docker/cli/blob/master/docs/reference/commandline/network_create.md#bridge-driver-options).

**- How to verify it**
Read the docs.

**- Description for the changelog**
Added documentation for the `com.docker.network.container_iface_prefix` option

