### PR TITLE
service update: fix service create example

### DIFF
--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -158,16 +158,13 @@ service name.
 ```bash
 $ docker service create \
     --name=myservice \
-    --mount \
-      type=volume,source=test-data,target=/somewhere \
-    nginx:alpine \
-    myservice
+    --mount type=volume,source=test-data,target=/somewhere \
+    nginx:alpine
 
 myservice
 
 $ docker service update \
-    --mount-add \
-      type=volume,source=other-volume,target=/somewhere-else \
+    --mount-add type=volume,source=other-volume,target=/somewhere-else \
     myservice
 
 myservice


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/10673

Service create expects the name to be passed using the `--name` flag, not as a positional parameter

