### PR TITLE
[19.03 backport] assorted docs fixes

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -170,11 +170,12 @@ equivalent docker daemon flags used for docker0 bridge:
 
 | Option                                           | Equivalent  | Description                                           |
 |--------------------------------------------------|-------------|-------------------------------------------------------|
-| `com.docker.network.bridge.name`                 | -           | bridge name to be used when creating the Linux bridge |
+| `com.docker.network.bridge.name`                 | -           | Bridge name to be used when creating the Linux bridge |
 | `com.docker.network.bridge.enable_ip_masquerade` | `--ip-masq` | Enable IP masquerading                                |
 | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
+| `com.docker.network.container_interface_prefix`  | -           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to `docker daemon`.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -158,16 +158,13 @@ service name.
 ```bash
 $ docker service create \
     --name=myservice \
-    --mount \
-      type=volume,source=test-data,target=/somewhere \
-    nginx:alpine \
-    myservice
+    --mount type=volume,source=test-data,target=/somewhere \
+    nginx:alpine
 
 myservice
 
 $ docker service update \
-    --mount-add \
-      type=volume,source=other-volume,target=/somewhere-else \
+    --mount-add type=volume,source=other-volume,target=/somewhere-else \
     myservice
 
 myservice


### PR DESCRIPTION
backports of:

- https://github.com/docker/cli/pull/2465 Add container_iface_prefix option to documentation
    - fixes https://github.com/docker/cli/issues/2092 Add Support for com.docker.network.container_iface_prefix label
- https://github.com/docker/cli/pull/2466 service update: fix service create example
    - fixes https://github.com/docker/docker.github.io/issues/10673 name of the service is mentioned twice
