### PR TITLE
vendor konsorten/go-windows-terminal-sequences v1.0.3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -39,7 +39,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0.0
 github.com/jaguilar/vt100                           ad4c4a5743050fb7f88ce968dca9422f72a0e3f2 git://github.com/tonistiigi/vt100.git
 github.com/json-iterator/go                         0ff49de124c6f76f8494e194af75bde0f1a49a29 # 1.1.6
-github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
 github.com/mattn/go-shellwords                      36a9b3c57cb5caa559ff63fb7e9b585f1c00df75 # v1.0.6
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
@@ -27,6 +27,7 @@ We thank all the authors who provided code to this library:
 
 * Felix Kollmann
 * Nicolas Perraut
+* @dirty49374
 
 ## License
 

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
@@ -4,7 +4,6 @@ package sequences
 
 import (
 	"syscall"
-	"unsafe"
 )
 
 var (
@@ -27,7 +26,7 @@ func EnableVirtualTerminalProcessing(stream syscall.Handle, enable bool) error {
 		mode &^= ENABLE_VIRTUAL_TERMINAL_PROCESSING
 	}
 
-	ret, _, err := setConsoleMode.Call(uintptr(unsafe.Pointer(stream)), uintptr(mode))
+	ret, _, err := setConsoleMode.Call(uintptr(stream), uintptr(mode))
 	if ret == 0 {
 		return err
 	}


### PR DESCRIPTION
full diff: https://github.com/konsorten/go-windows-terminal-sequences/compare/v1.0.2...v1.0.3

Fixes a panic when using logrus on Go 1.14

