### PR TITLE
info: print Cgroup Version

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -157,6 +157,7 @@ func prettyPrintServerInfo(dockerCli command.Cli, info types.Info) []error {
 	}
 	fprintlnNonEmpty(dockerCli.Out(), " Logging Driver:", info.LoggingDriver)
 	fprintlnNonEmpty(dockerCli.Out(), " Cgroup Driver:", info.CgroupDriver)
+	fprintlnNonEmpty(dockerCli.Out(), " Cgroup Version:", info.CgroupVersion)
 
 	fmt.Fprintln(dockerCli.Out(), " Plugins:")
 	fmt.Fprintln(dockerCli.Out(), "  Volume:", strings.Join(info.Plugins.Volume, " "))

--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/creack/pty                               3a6a957789163cacdfe0e291617a
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            f6a5ccf492e8eab969ffad8404117806b4a15a35
+github.com/docker/docker                            c3b3aedfa4ad51de0a2ebfd08a716f585390b512
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -175,6 +175,7 @@ type Info struct {
 	SystemTime         string
 	LoggingDriver      string
 	CgroupDriver       string
+	CgroupVersion      string `json:",omitempty"`
 	NEventsListener    int
 	KernelVersion      string
 	OperatingSystem    string

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -40,7 +40,7 @@ github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d2
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        ef149a924dfde2e506ea3cb3f617d7d0fa96b8ee
+github.com/docker/libnetwork                        1a17fb36132631a95fe6bb055b91e24a516ad81d
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -54,7 +54,7 @@ github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e
 github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
 github.com/vishvananda/netns                        0a2b9b5464df8343199164a0321edf3313202f7e
 github.com/vishvananda/netlink                      f049be6f391489d3f374498fe0c8df8449258372 # v1.1.0
-github.com/moby/ipvs                                8f137da6850a975020f4f739c589d293dd3a9d7b # v1.0.0
+github.com/moby/ipvs                                4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
@@ -130,6 +130,7 @@ github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076eb
 github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0
 github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
+github.com/cilium/ebpf                              60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 
 # cluster
 github.com/docker/swarmkit                          ebe39a32e3ed4c3a3783a02c11cccf388818694c


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added `Cgroup Version` to `docker info`

**- How I did it**

https://github.com/moby/moby/pull/40662

**- How to verify it**

```console
$ docker info
...
Cgroup Version: 2
...
```

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 