### PR TITLE
[19.03 backport] builder: fix broken link

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -941,13 +941,12 @@ the `-p` flag. For example
 docker run -p 80:80/tcp -p 80:80/udp ...
 ```
 
-To set up port redirection on the host system, see [using the -P
-flag](run.md#expose-incoming-ports). The `docker network` command supports
-creating networks for communication among containers without the need to
-expose or publish specific ports, because the containers connected to the
-network can communicate with each other over any port. For detailed information,
-see the
-[overview of this feature](https://docs.docker.com/engine/userguide/networking/)).
+To set up port redirection on the host system, see [using the -P flag](run.md#expose-incoming-ports).
+The `docker network` command supports creating networks for communication among
+containers without the need to expose or publish specific ports, because the
+containers connected to the network can communicate with each other over any
+port. For detailed information, see the
+[overview of this feature](https://docs.docker.com/engine/userguide/networking/).
 
 ## ENV
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2483
fixes https://github.com/docker/docker.github.io/issues/10737

This link was broken when generating the documentation (due to a bug in Jekyll not converting wrapped internal links)
