### PR TITLE
vendor: sirupsen/logrus v1.6.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -64,7 +64,7 @@ github.com/prometheus/common                        7600349dcfe1abd18d72d3a17708
 github.com/prometheus/procfs                        7d6f385de8bea29190f15ba9931442a0eaef9af7
 github.com/russross/blackfriday                     1d6b8e9301e720b08a8938b8c25c018285885438
 github.com/shurcooL/sanitized_anchor_name           10ef21a441db47d8b13ebcc5fd2310f636973c77
-github.com/sirupsen/logrus                          d417be0fe654de640a82370515129985b407c7e3 # v1.5.0
+github.com/sirupsen/logrus                          60c74ad9be0d874af0ab0daef6ab07c5c5911f0d # v1.6.0
 github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
 github.com/spf13/pflag                              4cb166e4f25ac4e8016a3595bbf7ea2e9aa85a2c https://github.com/thaJeztah/pflag.git # temporary fork with https://github.com/spf13/pflag/pull/170 applied, which isn't merged yet upstream
 github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2

--- a/vendor/github.com/sirupsen/logrus/entry.go
+++ b/vendor/github.com/sirupsen/logrus/entry.go
@@ -122,8 +122,6 @@ func (entry *Entry) WithField(key string, value interface{}) *Entry {
 
 // Add a map of fields to the Entry.
 func (entry *Entry) WithFields(fields Fields) *Entry {
-	entry.Logger.mu.Lock()
-	defer entry.Logger.mu.Unlock()
 	data := make(Fields, len(entry.Data)+len(fields))
 	for k, v := range entry.Data {
 		data[k] = v

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -2,7 +2,7 @@ module github.com/sirupsen/logrus
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.1
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894

--- a/vendor/github.com/sirupsen/logrus/text_formatter.go
+++ b/vendor/github.com/sirupsen/logrus/text_formatter.go
@@ -37,6 +37,11 @@ type TextFormatter struct {
 	// Force quoting of all values
 	ForceQuote bool
 
+	// DisableQuote disables quoting for all values.
+	// DisableQuote will have a lower priority than ForceQuote.
+	// If both of them are set to true, quote will be forced on all values.
+	DisableQuote bool
+
 	// Override coloring based on CLICOLOR and CLICOLOR_FORCE. - https://bixense.com/clicolors/
 	EnvironmentOverrideColors bool
 
@@ -291,6 +296,9 @@ func (f *TextFormatter) needsQuoting(text string) bool {
 	}
 	if f.QuoteEmptyFields && len(text) == 0 {
 		return true
+	}
+	if f.DisableQuote {
+		return false
 	}
 	for _, ch := range text {
 		if !((ch >= 'a' && ch <= 'z') ||


### PR DESCRIPTION
v1.6.0 was just released to fix some regressions in v1.5.0

full diff: https://github.com/sirupsen/logrus/compare/v1.5.0...v1.6.0

- Add flag to disable quotes in TextFormatter
- Revert "fix race conditions on entry"
    - fixes Deadlock during Entry.Infof after upgrade to v1.5.0
    - fixes Deadlock when using WithField inside of hook
    - fixes Overly-aggressive mutex locks
