### PR TITLE
vendor: remove unused dependencies from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -6,7 +6,6 @@ github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c
 github.com/containerd/containerd                    4d242818bf55542e5d7876ca276fea83029e803c
 github.com/containerd/continuity                    26c1120b8d4107d2471b93ad78ef7ce1fc84c4c4
 github.com/containerd/cgroups                       44306b6a1d46985d916b48b4199f93a378af314f
-github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398 # v1.0.0
 github.com/coreos/etcd                              d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9 # v3.3.12
 github.com/cpuguy83/go-md2man                       20f5889cbdc3c73dbd2862796665e7c465ade7d1 # v1.0.8
 github.com/creack/pty                               3a6a957789163cacdfe0e291617a1c8e80612c11 # v1.1.9
@@ -55,7 +54,6 @@ github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9
 github.com/opencontainers/go-digest                 279bed98673dd5bef374d3b6e4b09e2af76183bf # v1.0.0-rc1
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
-github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
 github.com/prometheus/client_golang                 c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
@@ -67,7 +65,6 @@ github.com/shurcooL/sanitized_anchor_name           10ef21a441db47d8b13ebcc5fd23
 github.com/sirupsen/logrus                          d417be0fe654de640a82370515129985b407c7e3 # v1.5.0
 github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
 github.com/spf13/pflag                              4cb166e4f25ac4e8016a3595bbf7ea2e9aa85a2c https://github.com/thaJeztah/pflag.git # temporary fork with https://github.com/spf13/pflag/pull/170 applied, which isn't merged yet upstream
-github.com/syndtr/gocapability                      d98352740cb2c55f81556b63d4a1ec64c5a319c2
 github.com/theupdateframework/notary                d6e1431feb32348e0650bf7551ac5cffd01d857b # v0.6.1
 github.com/tonistiigi/fsutil                        c2c7d7b0e1441705cd802e5699c0a10b1dfe39fd
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2


### PR DESCRIPTION
these dependencies were no longer used since https://github.com/docker/cli/commit/0dc9d17a2ecf26067997b7d3cb3243f73cbc5e8d (https://github.com/docker/cli/pull/2447)

```
2020/05/03 21:45:38 WARNING: package github.com/containerd/ttrpc is unused, consider removing it from vendor.conf
2020/05/03 21:45:38 WARNING: package github.com/opencontainers/runtime-spec is unused, consider removing it from vendor.conf
2020/05/03 21:45:38 WARNING: package github.com/syndtr/gocapability is unused, consider removing it from vendor.conf
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

