### PR TITLE
[19.03 backport] docs: update usage output for dockerd (19.03)

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -24,9 +24,9 @@ A self-sufficient runtime for containers.
 
 Options:
       --add-runtime runtime                   Register an additional OCI compatible runtime (default [])
-      --allow-nondistributable-artifacts list Push nondistributable artifacts to specified registries (default [])
+      --allow-nondistributable-artifacts list Allow push of nondistributable artifacts to registry
       --api-cors-header string                Set CORS headers in the Engine API
-      --authorization-plugin list             Authorization plugins to load (default [])
+      --authorization-plugin list             Authorization plugins to load
       --bip string                            Specify network bridge IP
   -b, --bridge string                         Attach containers to a network bridge
       --cgroup-parent string                  Set parent cgroup for all containers
@@ -34,56 +34,61 @@ Options:
       --cluster-store string                  URL of the distributed storage backend
       --cluster-store-opt map                 Set cluster store options (default map[])
       --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json")
-      --containerd string                     Path to containerd socket
+      --containerd string                     containerd grpc address
       --cpu-rt-period int                     Limit the CPU real-time period in microseconds
       --cpu-rt-runtime int                    Limit the CPU real-time runtime in microseconds
+      --cri-containerd                        start containerd with cri
       --data-root string                      Root directory of persistent Docker state (default "/var/lib/docker")
   -D, --debug                                 Enable debug mode
-      --default-address-pool                  Set the default address pool for local node networks
+      --default-address-pool pool-options     Default address pools for node specific local networks
       --default-gateway ip                    Container default gateway IPv4 address
       --default-gateway-v6 ip                 Container default gateway IPv6 address
+      --default-ipc-mode string               Default mode for containers ipc ("shareable" | "private") (default "private")
       --default-runtime string                Default OCI runtime for containers (default "runc")
+      --default-shm-size bytes                Default shm size for containers (default 64MiB)
       --default-ulimit ulimit                 Default ulimits for containers (default [])
-      --dns list                              DNS server to use (default [])
-      --dns-opt list                          DNS options to use (default [])
-      --dns-search list                       DNS search domains to use (default [])
-      --exec-opt list                         Runtime execution options (default [])
+      --dns list                              DNS server to use
+      --dns-opt list                          DNS options to use
+      --dns-search list                       DNS search domains to use
+      --exec-opt list                         Runtime execution options
       --exec-root string                      Root directory for execution state files (default "/var/run/docker")
       --experimental                          Enable experimental features
       --fixed-cidr string                     IPv4 subnet for fixed IPs
       --fixed-cidr-v6 string                  IPv6 subnet for fixed IPs
   -G, --group string                          Group for the unix socket (default "docker")
       --help                                  Print usage
-  -H, --host list                             Daemon socket(s) to connect to (default [])
+  -H, --host list                             Daemon socket(s) to connect to
       --icc                                   Enable inter-container communication (default true)
       --init                                  Run an init in the container to forward signals and reap processes
       --init-path string                      Path to the docker-init binary
-      --insecure-registry list                Enable insecure registry communication (default [])
+      --insecure-registry list                Enable insecure registry communication
       --ip ip                                 Default IP when binding container ports (default 0.0.0.0)
       --ip-forward                            Enable net.ipv4.ip_forward (default true)
       --ip-masq                               Enable IP masquerading (default true)
       --iptables                              Enable addition of iptables rules (default true)
       --ipv6                                  Enable IPv6 networking
-      --label list                            Set key=value labels to the daemon (default [])
+      --label list                            Set key=value labels to the daemon
       --live-restore                          Enable live restore of docker when containers are still running
       --log-driver string                     Default driver for container logs (default "json-file")
-  -l, --log-level string                      Set the logging level ("debug", "info", "warn", "error", "fatal") (default "info")
+  -l, --log-level string                      Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
       --log-opt map                           Default log driver options for containers (default map[])
       --max-concurrent-downloads int          Set the max concurrent downloads for each pull (default 3)
       --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
       --metrics-addr string                   Set default address and port to serve the metrics api on
       --mtu int                               Set the containers network MTU
+      --network-control-plane-mtu int         Network Control plane MTU (default 1500)
       --no-new-privileges                     Set no-new-privileges by default for new containers
-      --node-generic-resources list           Advertise user-defined resource
+      --node-generic-resource list            Advertise user-defined resource
       --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
-      --registry-mirror list                  Preferred Docker registry mirror (default [])
+      --registry-mirror list                  Preferred Docker registry mirror
+      --rootless                              Enable rootless mode; typically used with RootlessKit (experimental)
       --seccomp-profile string                Path to seccomp profile
       --selinux-enabled                       Enable selinux support
       --shutdown-timeout int                  Set the default shutdown timeout (default 15)
   -s, --storage-driver string                 Storage driver to use
-      --storage-opt list                      Storage driver options (default [])
+      --storage-opt list                      Storage driver options
       --swarm-default-advertise-addr string   Set default address or interface for swarm advertised address
       --tls                                   Use TLS; implied by --tlsverify
       --tlscacert string                      Trust certs signed only by this CA (default "~/.docker/ca.pem")

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -18,7 +18,7 @@ redirect_from:
 # daemon
 
 ```markdown
-Usage:	dockerd COMMAND
+Usage: dockerd COMMAND
 
 A self-sufficient runtime for containers.
 
@@ -39,9 +39,9 @@ Options:
       --cpu-rt-runtime int                    Limit the CPU real-time runtime in microseconds
       --data-root string                      Root directory of persistent Docker state (default "/var/lib/docker")
   -D, --debug                                 Enable debug mode
+      --default-address-pool                  Set the default address pool for local node networks
       --default-gateway ip                    Container default gateway IPv4 address
       --default-gateway-v6 ip                 Container default gateway IPv6 address
-      --default-address-pool                  Set the default address pool for local node networks
       --default-runtime string                Default OCI runtime for containers (default "runc")
       --default-ulimit ulimit                 Default ulimits for containers (default [])
       --dns list                              DNS server to use (default [])
@@ -73,8 +73,8 @@ Options:
       --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
       --metrics-addr string                   Set default address and port to serve the metrics api on
       --mtu int                               Set the containers network MTU
-      --node-generic-resources list           Advertise user-defined resource
       --no-new-privileges                     Set no-new-privileges by default for new containers
+      --node-generic-resources list           Advertise user-defined resource
       --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
@@ -88,7 +88,7 @@ Options:
       --tls                                   Use TLS; implied by --tlsverify
       --tlscacert string                      Trust certs signed only by this CA (default "~/.docker/ca.pem")
       --tlscert string                        Path to TLS certificate file (default "~/.docker/cert.pem")
-      --tlskey string                         Path to TLS key file (default ~/.docker/key.pem")
+      --tlskey string                         Path to TLS key file (default "~/.docker/key.pem")
       --tlsverify                             Use TLS and verify the remote
       --userland-proxy                        Use userland proxy for loopback traffic (default true)
       --userland-proxy-path string            Path to the userland proxy binary


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2491

cherry-pick wasn't fully clean, due to master having some flags documented for 20.03