### PR TITLE
Make healthcheck buffer size configurable

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -121,6 +121,7 @@ type containerOptions struct {
 	healthTimeout      time.Duration
 	healthStartPeriod  time.Duration
 	healthRetries      int
+	healthBufferSize   int
 	runtime            string
 	autoRemove         bool
 	init               bool
@@ -509,7 +510,8 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		copts.healthInterval != 0 ||
 		copts.healthTimeout != 0 ||
 		copts.healthStartPeriod != 0 ||
-		copts.healthRetries != 0
+		copts.healthRetries != 0 ||
+		copts.healthBufferSize != 0
 	if copts.noHealthcheck {
 		if haveHealthSettings {
 			return nil, errors.Errorf("--no-healthcheck conflicts with --health-* options")
@@ -534,6 +536,9 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		if copts.healthStartPeriod < 0 {
 			return nil, fmt.Errorf("--health-start-period cannot be negative")
 		}
+		if copts.healthBufferSize < 0 {
+			return nil, errors.Errorf("--health-buffer-size cannot be negative")
+		}
 
 		healthConfig = &container.HealthConfig{
 			Test:        probe,
@@ -541,6 +546,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 			Timeout:     copts.healthTimeout,
 			StartPeriod: copts.healthStartPeriod,
 			Retries:     copts.healthRetries,
+			BufferSize:  copts.healthBufferSize,
 		}
 	}
 

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -657,8 +657,8 @@ func TestParseHealth(t *testing.T) {
 	checkError("--no-healthcheck conflicts with --health-* options",
 		"--no-healthcheck", "--health-cmd=/check.sh -q", "img", "cmd")
 
-	health = checkOk("--health-timeout=2s", "--health-retries=3", "--health-interval=4.5s", "--health-start-period=5s", "img", "cmd")
-	if health.Timeout != 2*time.Second || health.Retries != 3 || health.Interval != 4500*time.Millisecond || health.StartPeriod != 5*time.Second {
+	health = checkOk("--health-timeout=2s", "--health-retries=3", "--health-interval=4.5s", "--health-start-period=5s", "--health-buffer-size=4096", "img", "cmd")
+	if health.Timeout != 2*time.Second || health.Retries != 3 || health.Interval != 4500*time.Millisecond || health.StartPeriod != 5*time.Second || health.BufferSize != 4096 {
 		t.Fatalf("--health-*: got %#v", health)
 	}
 }

--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -170,6 +170,7 @@ Ports:
   Retries = {{ .Healthcheck.Retries }}
   StartPeriod =	{{ .Healthcheck.StartPeriod }}
   Timeout =	{{ .Healthcheck.Timeout }}
+  BufferSize = {{ .Healthcheck.BufferSize }}
   {{- if .Healthcheck.Test }}
   Tests:
 	{{- range $test := .Healthcheck.Test }}

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -72,6 +72,7 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 
 					Healthcheck: &container.HealthConfig{
 						Test:        []string{"CMD-SHELL", "curl"},
+						BufferSize:  5,
 						Interval:    4,
 						Retries:     3,
 						StartPeriod: 2,

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -423,6 +423,7 @@ type healthCheckOptions struct {
 	timeout       opts.PositiveDurationOpt
 	retries       int
 	startPeriod   opts.PositiveDurationOpt
+	bufferSize    int
 	noHealthcheck bool
 }
 
@@ -431,7 +432,8 @@ func (opts *healthCheckOptions) toHealthConfig() (*container.HealthConfig, error
 	haveHealthSettings := opts.cmd != "" ||
 		opts.interval.Value() != nil ||
 		opts.timeout.Value() != nil ||
-		opts.retries != 0
+		opts.retries != 0 ||
+		opts.bufferSize != 0
 	if opts.noHealthcheck {
 		if haveHealthSettings {
 			return nil, errors.Errorf("--%s conflicts with --health-* options", flagNoHealthcheck)
@@ -458,6 +460,7 @@ func (opts *healthCheckOptions) toHealthConfig() (*container.HealthConfig, error
 			Timeout:     timeout,
 			Retries:     opts.retries,
 			StartPeriod: startPeriod,
+			BufferSize:  opts.bufferSize,
 		}
 	}
 	return healthConfig, nil
@@ -821,6 +824,8 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 	flags.SetAnnotation(flagHealthRetries, "version", []string{"1.25"})
 	flags.Var(&opts.healthcheck.startPeriod, flagHealthStartPeriod, "Start period for the container to initialize before counting retries towards unstable (ms|s|m|h)")
 	flags.SetAnnotation(flagHealthStartPeriod, "version", []string{"1.29"})
+	flags.IntVar(&opts.healthcheck.bufferSize, flagHealthBufferSize, 0, "Longest healthcheck probe output message to store")
+	flags.SetAnnotation(flagHealthBufferSize, "version", []string{"1.42"})
 	flags.BoolVar(&opts.healthcheck.noHealthcheck, flagNoHealthcheck, false, "Disable any container-specified HEALTHCHECK")
 	flags.SetAnnotation(flagNoHealthcheck, "version", []string{"1.25"})
 
@@ -929,6 +934,7 @@ const (
 	flagHealthRetries           = "health-retries"
 	flagHealthTimeout           = "health-timeout"
 	flagHealthStartPeriod       = "health-start-period"
+	flagHealthBufferSize        = "health-buffer-size"
 	flagNoHealthcheck           = "no-healthcheck"
 	flagSecret                  = "secret"
 	flagSecretAdd               = "secret-add"

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -113,6 +113,7 @@ func TestHealthCheckOptionsToHealthConfig(t *testing.T) {
 		timeout:     opts.PositiveDurationOpt{DurationOpt: *opts.NewDurationOpt(&dur)},
 		startPeriod: opts.PositiveDurationOpt{DurationOpt: *opts.NewDurationOpt(&dur)},
 		retries:     10,
+		bufferSize:  4096,
 	}
 	config, err := opt.toHealthConfig()
 	assert.NilError(t, err)
@@ -122,6 +123,7 @@ func TestHealthCheckOptionsToHealthConfig(t *testing.T) {
 		Timeout:     time.Second,
 		StartPeriod: time.Second,
 		Retries:     10,
+		BufferSize:  4096,
 	}, config))
 }
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1196,7 +1196,7 @@ func updateLogDriver(flags *pflag.FlagSet, taskTemplate *swarm.TaskSpec) error {
 }
 
 func updateHealthcheck(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec) error {
-	if !anyChanged(flags, flagNoHealthcheck, flagHealthCmd, flagHealthInterval, flagHealthRetries, flagHealthTimeout, flagHealthStartPeriod) {
+	if !anyChanged(flags, flagNoHealthcheck, flagHealthCmd, flagHealthInterval, flagHealthRetries, flagHealthTimeout, flagHealthStartPeriod, flagHealthBufferSize) {
 		return nil
 	}
 	if containerSpec.Healthcheck == nil {
@@ -1207,7 +1207,7 @@ func updateHealthcheck(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec)
 		return err
 	}
 	if noHealthcheck {
-		if !anyChanged(flags, flagHealthCmd, flagHealthInterval, flagHealthRetries, flagHealthTimeout, flagHealthStartPeriod) {
+		if !anyChanged(flags, flagHealthCmd, flagHealthInterval, flagHealthRetries, flagHealthTimeout, flagHealthStartPeriod, flagHealthBufferSize) {
 			containerSpec.Healthcheck = &container.HealthConfig{
 				Test: []string{"NONE"},
 			}
@@ -1232,6 +1232,9 @@ func updateHealthcheck(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec)
 	}
 	if flags.Changed(flagHealthRetries) {
 		containerSpec.Healthcheck.Retries, _ = flags.GetInt(flagHealthRetries)
+	}
+	if flags.Changed(flagHealthBufferSize) {
+		containerSpec.Healthcheck.BufferSize, _ = flags.GetInt(flagHealthBufferSize)
 	}
 	if flags.Changed(flagHealthCmd) {
 		cmd, _ := flags.GetString(flagHealthCmd)

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -322,6 +322,21 @@ func TestUpdateHealthcheckTable(t *testing.T) {
 			expected: &container.HealthConfig{Test: []string{"CMD", "cmd1"}, StartPeriod: time.Minute},
 		},
 		{
+			flags:    [][2]string{{"health-buffer-size", "4096"}},
+			initial:  &container.HealthConfig{Test: []string{"CMD", "cmd1"}},
+			expected: &container.HealthConfig{Test: []string{"CMD", "cmd1"}, BufferSize: 4096},
+		},
+		{
+			flags:    [][2]string{{"health-buffer-size", "0"}},
+			initial:  &container.HealthConfig{Test: []string{"CMD", "cmd1"}, BufferSize: 4096},
+			expected: &container.HealthConfig{Test: []string{"CMD", "cmd1"}},
+		},
+		{
+			flags:    [][2]string{{"health-cmd", ""}},
+			initial:  &container.HealthConfig{Test: []string{"CMD", "cmd1"}, BufferSize: 4096},
+			expected: &container.HealthConfig{BufferSize: 4096},
+		},
+		{
 			flags: [][2]string{{"health-cmd", "cmd1"}, {"no-healthcheck", "true"}},
 			err:   "--no-healthcheck conflicts with --health-* options",
 		},
@@ -331,6 +346,10 @@ func TestUpdateHealthcheckTable(t *testing.T) {
 		},
 		{
 			flags: [][2]string{{"health-timeout", "1m"}, {"no-healthcheck", "true"}},
+			err:   "--no-healthcheck conflicts with --health-* options",
+		},
+		{
+			flags: [][2]string{{"health-buffer-size", "4096"}, {"no-healthcheck", "true"}},
 			err:   "--no-healthcheck conflicts with --health-* options",
 		},
 	}

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -437,7 +437,7 @@ func convertHealthcheck(healthcheck *composetypes.HealthCheckConfig) (*container
 	}
 	var (
 		timeout, interval, startPeriod time.Duration
-		retries                        int
+		retries, bufferSize            int
 	)
 	if healthcheck.Disable {
 		if len(healthcheck.Test) != 0 {
@@ -460,12 +460,16 @@ func convertHealthcheck(healthcheck *composetypes.HealthCheckConfig) (*container
 	if healthcheck.Retries != nil {
 		retries = int(*healthcheck.Retries)
 	}
+	if healthcheck.BufferSize != nil {
+		bufferSize = int(*healthcheck.BufferSize)
+	}
 	return &container.HealthConfig{
 		Test:        healthcheck.Test,
 		Timeout:     timeout,
 		Interval:    interval,
 		Retries:     retries,
 		StartPeriod: startPeriod,
+		BufferSize:  bufferSize,
 	}, nil
 }
 

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -156,6 +156,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 				Timeout:     durationPtr(1 * time.Second),
 				Retries:     uint64Ptr(5),
 				StartPeriod: durationPtr(15 * time.Second),
+				BufferSize:  uint64Ptr(4096),
 			},
 			Hostname: "foo",
 			Image:    "redis",

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -283,6 +283,7 @@ type HealthCheckConfig struct {
 	Interval    *Duration       `yaml:",omitempty" json:"interval,omitempty"`
 	Retries     *uint64         `yaml:",omitempty" json:"retries,omitempty"`
 	StartPeriod *Duration       `mapstructure:"start_period" yaml:"start_period,omitempty" json:"start_period,omitempty"`
+	BufferSize  *uint64         `mapstructure:"buffer_size" yaml:"buffer_size,omitempty" json:"buffer_size,omitempty"`
 	Disable     bool            `yaml:",omitempty" json:"disable,omitempty"`
 }
 


### PR DESCRIPTION
Healthcheck result is stored in a byte buffer of 4096 bytes. Making the size of this buffer configurable gives us more possibilities to rely on this feature

Please see the related [pull request to moby](https://github.com/moby/moby/pull/40911)

Signed-off-by: Denis Novozhilov <348558+gloomybrain@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I've added a new cli option named `--health-buffer-size` intended to regulate the amount of healthcheck output stored.

**- How I did it**
Changes are pretty much trivial, please see the code changes

**- How to verify it**
This should be verified in conjunction with the corresponding moby PR (see the link above)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![cute-animal](https://user-images.githubusercontent.com/348558/81156525-b4d1d580-8f8e-11ea-98b7-0d43941637d0.jpg)

