### PR TITLE
Replace deprecated Cobra command.SetOutput() with command.SetOut()

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -128,7 +128,7 @@ func newPluginCommand(dockerCli *command.DockerCli, plugin *cobra.Command, meta 
 	}
 	opts, flags := cli.SetupPluginRootCommand(cmd)
 
-	cmd.SetOutput(dockerCli.Out())
+	cmd.SetOut(dockerCli.Out())
 
 	cmd.AddCommand(
 		plugin,

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -41,7 +41,7 @@ func TestCheckpointCreateErrors(t *testing.T) {
 		})
 		cmd := newCreateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -41,7 +41,7 @@ func TestCheckpointListErrors(t *testing.T) {
 		})
 		cmd := newListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -40,7 +40,7 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 		})
 		cmd := newRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -118,7 +118,7 @@ func (cli *DockerCli) In() *streams.In {
 // ShowHelp shows the command help.
 func ShowHelp(err io.Writer) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		cmd.SetOutput(err)
+		cmd.SetOut(err)
 		cmd.HelpFunc()(cmd, args)
 		return nil
 	}

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -46,7 +46,7 @@ func TestConfigCreateErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -59,7 +59,7 @@ func TestConfigInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -40,7 +40,7 @@ func TestConfigListErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -36,7 +36,7 @@ func TestConfigRemoveErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -73,7 +73,7 @@ func TestConfigRemoveContinueAfterError(t *testing.T) {
 
 	cmd := newConfigRemoveCommand(cli)
 	cmd.SetArgs(names)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.Error(t, cmd.Execute(), "error removing config: foo")
 	assert.Check(t, is.DeepEqual(names, removedConfigs))
 }

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -71,7 +71,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -191,7 +191,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 		}, test.EnableContentTrust)
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewCreateCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)
@@ -250,7 +250,7 @@ func TestNewCreateCommandWithWarnings(t *testing.T) {
 				},
 			})
 			cmd := NewCreateCommand(cli)
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 			assert.NilError(t, err)
@@ -298,7 +298,7 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 		},
 	})
 	cmd := NewCreateCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"image:tag"})
 	err := cmd.Execute()
 	assert.NilError(t, err)

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -220,7 +220,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc})
 		cmd := NewExecCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -21,7 +21,7 @@ func TestContainerExportOutputToFile(t *testing.T) {
 		},
 	})
 	cmd := NewExportCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"-o", dir.Join("foo"), "container"})
 	assert.NilError(t, cmd.Execute())
 
@@ -39,7 +39,7 @@ func TestContainerExportOutputToIrregularFile(t *testing.T) {
 		},
 	})
 	cmd := NewExportCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"-o", "/dev/random", "container"})
 
 	err := cmd.Execute()

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -161,7 +161,7 @@ func TestContainerListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -66,7 +66,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewRunCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		err := cmd.Execute()
 		assert.Assert(t, err != nil)
 		assert.Assert(t, is.Contains(cli.ErrBuffer().String(), tc.expectedError))

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -130,7 +130,7 @@ func TestRunBuildFromGitHubSpecialCase(t *testing.T) {
 	cmd := NewBuildCommand(test.NewFakeCli(&fakeClient{}))
 	// Clone a small repo that exists so git doesn't prompt for credentials
 	cmd.SetArgs([]string{"github.com/docker/for-win"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	err := cmd.Execute()
 	assert.ErrorContains(t, err, "unable to prepare context")
 	assert.ErrorContains(t, err, "docker-build-git")
@@ -154,7 +154,7 @@ func TestRunBuildFromLocalGitHubDir(t *testing.T) {
 	client := test.NewFakeCli(&fakeClient{})
 	cmd := NewBuildCommand(client)
 	cmd.SetArgs([]string{buildDir})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	err = cmd.Execute()
 	assert.NilError(t, err)
 }

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -37,7 +37,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -95,7 +95,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
 		cmd := NewHistoryCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -36,7 +36,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -44,7 +44,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
 	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}))
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
 	assert.ErrorContains(t, cmd.Execute(), "testdata/import-command-success.unexistent-file")
 }
@@ -90,7 +90,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NilError(t, cmd.Execute())
 	}

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -26,7 +26,7 @@ func TestNewInspectCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := newInspectCommand(test.NewFakeCli(&fakeClient{}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -78,7 +78,7 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 		imageInspectInvocationCount = 0
 		cli := test.NewFakeCli(&fakeClient{imageInspectFunc: tc.imageInspectFunc})
 		cmd := newInspectCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -82,7 +82,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc})
 		cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
 		cmd := NewImagesCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -44,7 +44,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 		cli.In().SetIsTerminal(tc.isTerminalIn)
 		cmd := NewLoadCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -53,7 +53,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
 	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}))
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
 	err := cmd.Execute()
 	assert.ErrorContains(t, err, expectedError)
@@ -92,7 +92,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 		cmd := NewLoadCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -39,7 +39,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 		cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
 			imagesPruneFunc: tc.imagesPruneFunc,
 		}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -93,7 +93,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imagesPruneFunc: tc.imagesPruneFunc})
 		cmd := NewPruneCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -40,7 +40,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := NewPullCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -76,7 +76,7 @@ func TestNewPullCommandSuccess(t *testing.T) {
 			},
 		})
 		cmd := NewPullCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)
@@ -118,7 +118,7 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 		}, test.EnableContentTrust)
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewPullCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -41,7 +41,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
 		cmd := NewPushCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -73,7 +73,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 				},
 			})
 			cmd := NewPushCommand(cli)
-			cmd.SetOutput(cli.OutBuffer())
+			cmd.SetOut(cli.OutBuffer())
 			cmd.SetArgs(tc.args)
 			assert.NilError(t, cmd.Execute())
 			if tc.output != "" {

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -68,7 +68,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 			cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
 				imageRemoveFunc: tc.imageRemoveFunc,
 			}))
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
@@ -124,7 +124,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc})
 			cmd := NewRemoveCommand(cli)
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			cmd.SetArgs(tc.args)
 			assert.NilError(t, cmd.Execute())
 			assert.Check(t, is.Equal(tc.expectedStderr, cli.ErrBuffer().String()))

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -56,7 +56,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 		cli.Out().SetIsTerminal(tc.isTerminal)
 		cmd := NewSaveCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -98,7 +98,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 		}))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NilError(t, cmd.Execute())
 		if tc.deferredFunc != nil {

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -19,7 +19,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 	for _, args := range testCases {
 		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), expectedError)
 	}
 }
@@ -34,7 +34,7 @@ func TestCliNewTagCommand(t *testing.T) {
 			},
 		}))
 	cmd.SetArgs([]string{"image1", "image2"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.NilError(t, cmd.Execute())
 	value, _ := cmd.Flags().GetBool("interspersed")
 	assert.Check(t, !value)

--- a/cli/command/manifest/annotate_test.go
+++ b/cli/command/manifest/annotate_test.go
@@ -33,7 +33,7 @@ func TestManifestAnnotateError(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newAnnotateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -51,7 +51,7 @@ func TestManifestAnnotate(t *testing.T) {
 
 	cmd := newAnnotateCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/fake:0.0"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	expectedError := "manifest for image example.com/fake:0.0 does not exist"
 	assert.ErrorContains(t, cmd.Execute(), expectedError)
 

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -33,7 +33,7 @@ func TestManifestCreateErrors(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newCreateListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -58,7 +58,7 @@ func TestManifestCreateAmend(t *testing.T) {
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.1"})
 	cmd.Flags().Set("amend", "true")
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	err = cmd.Execute()
 	assert.NilError(t, err)
 
@@ -87,7 +87,7 @@ func TestManifestCreateRefuseAmend(t *testing.T) {
 
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	err = cmd.Execute()
 	assert.Error(t, err, "refusing to amend an existing manifest list with no --amend flag")
 }
@@ -110,7 +110,7 @@ func TestManifestCreateNoManifest(t *testing.T) {
 
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	err := cmd.Execute()
 	assert.Error(t, err, "No such image: example.com/alpine:3.0")
 }

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -77,7 +77,7 @@ func TestInspectCommandLocalManifestNotFound(t *testing.T) {
 	cli.SetManifestStore(store)
 
 	cmd := newInspectCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
 	err := cmd.Execute()
 	assert.Error(t, err, "No such manifest: example.com/alpine:3.0")
@@ -99,7 +99,7 @@ func TestInspectCommandNotFound(t *testing.T) {
 	})
 
 	cmd := newInspectCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"example.com/alpine:3.0"})
 	err := cmd.Execute()
 	assert.Error(t, err, "No such manifest: example.com/alpine:3.0")
@@ -137,7 +137,7 @@ func TestInspectcommandRemoteManifest(t *testing.T) {
 	})
 
 	cmd := newInspectCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"example.com/alpine:3.0"})
 	assert.NilError(t, cmd.Execute())
 	actual := cli.OutBuffer()

--- a/cli/command/manifest/push_test.go
+++ b/cli/command/manifest/push_test.go
@@ -42,7 +42,7 @@ func TestManifestPushErrors(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newPushListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -37,7 +37,7 @@ func TestNetworkConnectErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 
 	}

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -137,7 +137,7 @@ func TestNetworkCreateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			assert.NilError(t, cmd.Flags().Set(key, value))
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 
 	}

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -35,7 +35,7 @@ func TestNetworkDisconnectErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -35,7 +35,7 @@ func TestNetworkListErrors(t *testing.T) {
 				networkListFunc: tc.networkListFunc,
 			}),
 		)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -43,7 +43,7 @@ func TestNodeDemoteErrors(t *testing.T) {
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -73,7 +73,7 @@ func TestNodeInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -47,7 +47,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 			infoFunc:     tc.infoFunc,
 		})
 		cmd := newListCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -43,7 +43,7 @@ func TestNodePromoteErrors(t *testing.T) {
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -59,7 +59,7 @@ func TestNodePsErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/remove_test.go
+++ b/cli/command/node/remove_test.go
@@ -32,7 +32,7 @@ func TestNodeRemoveErrors(t *testing.T) {
 				nodeRemoveFunc: tc.nodeRemoveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -63,7 +63,7 @@ func TestNodeUpdateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/create_test.go
+++ b/cli/command/plugin/create_test.go
@@ -41,7 +41,7 @@ func TestCreateErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := newCreateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -53,7 +53,7 @@ func TestCreateErrorOnFileAsContextDir(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpFile.Path()})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "context must be a directory")
 }
 
@@ -64,7 +64,7 @@ func TestCreateErrorOnContextDirWithoutConfig(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 
 	expectedErr := "config.json: no such file or directory"
 	if runtime.GOOS == "windows" {
@@ -82,7 +82,7 @@ func TestCreateErrorOnInvalidConfig(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "invalid")
 }
 
@@ -100,7 +100,7 @@ func TestCreateErrorFromDaemon(t *testing.T) {
 
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "Error creating plugin")
 }
 

--- a/cli/command/plugin/disable_test.go
+++ b/cli/command/plugin/disable_test.go
@@ -40,7 +40,7 @@ func TestPluginDisableErrors(t *testing.T) {
 				pluginDisableFunc: tc.pluginDisableFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/enable_test.go
+++ b/cli/command/plugin/enable_test.go
@@ -51,7 +51,7 @@ func TestPluginEnableErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/inspect_test.go
+++ b/cli/command/plugin/inspect_test.go
@@ -73,7 +73,7 @@ func TestInspectErrors(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
 	}

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -58,7 +58,7 @@ func TestInstallErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{pluginInstallFunc: tc.installFunc})
 		cmd := newInstallCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -100,7 +100,7 @@ func TestInstallContentTrustErrors(t *testing.T) {
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := newInstallCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -52,7 +52,7 @@ func TestListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/remove_test.go
+++ b/cli/command/plugin/remove_test.go
@@ -37,7 +37,7 @@ func TestRemoveErrors(t *testing.T) {
 		})
 		cmd := newRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -44,7 +44,7 @@ func TestSecretCreateErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -59,7 +59,7 @@ func TestSecretInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -40,7 +40,7 @@ func TestSecretListErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -36,7 +36,7 @@ func TestSecretRemoveErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -72,7 +72,7 @@ func TestSecretRemoveContinueAfterError(t *testing.T) {
 	})
 
 	cmd := newSecretRemoveCommand(cli)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs(names)
 	assert.Error(t, cmd.Execute(), "error removing secret: foo")
 	assert.Check(t, is.DeepEqual(names, removedSecrets))

--- a/cli/command/service/rollback_test.go
+++ b/cli/command/service/rollback_test.go
@@ -49,7 +49,7 @@ func TestRollback(t *testing.T) {
 		cmd := newRollbackCommand(cli)
 		cmd.SetArgs(tc.args)
 		cmd.Flags().Set("quiet", "true")
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.NilError(t, cmd.Execute())
 		assert.Check(t, is.Equal(strings.TrimSpace(cli.ErrBuffer().String()), tc.expectedDockerCliErr))
 	}
@@ -98,7 +98,7 @@ func TestRollbackWithErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		cmd.Flags().Set("quiet", "true")
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -11,7 +11,7 @@ import (
 func TestDeployWithEmptyName(t *testing.T) {
 	cmd := newDeployCommand(test.NewFakeCli(&fakeClient{}), nil)
 	cmd.SetArgs([]string{"'   '"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -54,7 +54,7 @@ func TestListErrors(t *testing.T) {
 			serviceListFunc: tc.serviceListFunc,
 		}), &orchestrator)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -45,7 +45,7 @@ func TestStackPsErrors(t *testing.T) {
 			taskListFunc: tc.taskListFunc,
 		}), &orchestrator)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -169,7 +169,7 @@ func TestStackPs(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 
 			if tc.expectedErr != "" {
 				assert.Error(t, cmd.Execute(), tc.expectedErr)

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -44,7 +44,7 @@ func fakeClientForRemoveStackTest(version string) *fakeClient {
 func TestRemoveWithEmptyName(t *testing.T) {
 	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}), &orchestrator)
 	cmd.SetArgs([]string{"good", "'   '", "alsogood"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }
@@ -155,7 +155,7 @@ func TestRemoveContinueAfterError(t *testing.T) {
 		},
 	}
 	cmd := newRemoveCommand(test.NewFakeCli(cli), &orchestrator)
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.Error(t, cmd.Execute(), "Failed to remove some resources from stack: foo")

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -79,7 +79,7 @@ func TestStackServicesErrors(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
 	}
@@ -88,7 +88,7 @@ func TestStackServicesErrors(t *testing.T) {
 func TestRunServicesWithEmptyName(t *testing.T) {
 	cmd := newServicesCommand(test.NewFakeCli(&fakeClient{}), &orchestrator)
 	cmd.SetArgs([]string{"'   '"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }

--- a/cli/command/swarm/ca_test.go
+++ b/cli/command/swarm/ca_test.go
@@ -145,7 +145,7 @@ func TestDisplayTrustRootInvalidFlags(t *testing.T) {
 				},
 			}))
 		assert.Check(t, cmd.Flags().Parse(testCase.args))
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), testCase.errorMsg)
 	}
 }
@@ -187,7 +187,7 @@ func TestUpdateSwarmSpecDefaultRotate(t *testing.T) {
 	})
 	cmd := newCACommand(cli)
 	cmd.SetArgs([]string{"--rotate", "--detach"})
-	cmd.SetOutput(cli.OutBuffer())
+	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
 	expected := swarmSpecWithFullCAConfig()
@@ -218,7 +218,7 @@ func TestUpdateSwarmSpecCertAndKey(t *testing.T) {
 		"--ca-cert=" + certfile,
 		"--ca-key=" + keyfile,
 		"--cert-expiry=3m"})
-	cmd.SetOutput(cli.OutBuffer())
+	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
 	expected := swarmSpecWithFullCAConfig()
@@ -244,7 +244,7 @@ func TestUpdateSwarmSpecCertAndExternalCA(t *testing.T) {
 		"--detach",
 		"--ca-cert=" + certfile,
 		"--external-ca=protocol=cfssl,url=https://some.external.ca"})
-	cmd.SetOutput(cli.OutBuffer())
+	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
 	expected := swarmSpecWithFullCAConfig()
@@ -282,7 +282,7 @@ func TestUpdateSwarmSpecCertAndKeyAndExternalCA(t *testing.T) {
 		"--ca-cert=" + certfile,
 		"--ca-key=" + keyfile,
 		"--external-ca=protocol=cfssl,url=https://some.external.ca"})
-	cmd.SetOutput(cli.OutBuffer())
+	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
 	expected := swarmSpecWithFullCAConfig()

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -73,7 +73,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -54,7 +54,7 @@ func TestSwarmJoinErrors(t *testing.T) {
 				infoFunc:      tc.infoFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -98,7 +98,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -37,7 +37,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 				swarmLeaveFunc: tc.swarmLeaveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -90,7 +90,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -70,7 +70,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 				swarmUnlockFunc: tc.swarmUnlockFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -75,7 +75,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -176,7 +176,7 @@ func TestSwarmUpdate(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(cli.OutBuffer())
+		cmd.SetOut(cli.OutBuffer())
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("update-%s.golden", tc.name))
 	}

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -21,7 +21,7 @@ func TestVersionWithoutServer(t *testing.T) {
 		},
 	})
 	cmd := NewVersionCommand(cli)
-	cmd.SetOutput(cli.Err())
+	cmd.SetOut(cli.Err())
 	assert.ErrorContains(t, cmd.Execute(), "no server")
 	out := cli.OutBuffer().String()
 	// TODO: use an assertion like e2e/image/build_test.go:assertBuildOutput()

--- a/cli/command/trust/inspect_pretty_test.go
+++ b/cli/command/trust/inspect_pretty_test.go
@@ -65,7 +65,7 @@ func TestTrustInspectPrettyCommandErrors(t *testing.T) {
 		cmd := newInspectCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.Flags().Set("pretty", "true")
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -77,7 +77,7 @@ func TestTrustInspectPrettyCommandOfflineErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"nonexistent-reg-name.io/image"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access nonexistent-reg-name.io/image")
 
 	cli = test.NewFakeCli(&fakeClient{})
@@ -85,7 +85,7 @@ func TestTrustInspectPrettyCommandOfflineErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"nonexistent-reg-name.io/image:tag"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access nonexistent-reg-name.io/image")
 }
 
@@ -95,7 +95,7 @@ func TestTrustInspectPrettyCommandUninitializedErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/unsigned-img"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access reg/unsigned-img")
 
 	cli = test.NewFakeCli(&fakeClient{})
@@ -103,7 +103,7 @@ func TestTrustInspectPrettyCommandUninitializedErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/unsigned-img:tag"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access reg/unsigned-img:tag")
 }
 
@@ -113,7 +113,7 @@ func TestTrustInspectPrettyCommandEmptyNotaryRepoErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/img:unsigned-tag"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "No signatures for reg/img:unsigned-tag"))
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "Administrative keys for reg/img"))
@@ -123,7 +123,7 @@ func TestTrustInspectPrettyCommandEmptyNotaryRepoErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/img"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "No signatures for reg/img"))
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "Administrative keys for reg/img"))

--- a/cli/command/trust/inspect_test.go
+++ b/cli/command/trust/inspect_test.go
@@ -38,7 +38,7 @@ func TestTrustInspectCommandErrors(t *testing.T) {
 			test.NewFakeCli(&fakeClient{}))
 		cmd.Flags().Set("pretty", "true")
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -85,7 +85,7 @@ func TestTrustInspectCommandRepositoryErrors(t *testing.T) {
 			cli.SetNotaryClient(tc.notaryRepository)
 			cmd := newInspectCommand(cli)
 			cmd.SetArgs(tc.args)
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.err)
 			if tc.golden != "" {
 				golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/trust/key_generate_test.go
+++ b/cli/command/trust/key_generate_test.go
@@ -44,7 +44,7 @@ func TestTrustKeyGenerateErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := newKeyGenerateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/trust/key_load_test.go
+++ b/cli/command/trust/key_load_test.go
@@ -65,7 +65,7 @@ func TestTrustKeyLoadErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := newKeyLoadCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		assert.Check(t, is.Contains(cli.OutBuffer().String(), tc.expectedOutput))
 	}

--- a/cli/command/trust/revoke_test.go
+++ b/cli/command/trust/revoke_test.go
@@ -50,7 +50,7 @@ func TestTrustRevokeCommandErrors(t *testing.T) {
 		cmd := newRevokeCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -131,7 +131,7 @@ func TestTrustRevokeCommand(t *testing.T) {
 			cli.SetNotaryClient(tc.notaryRepository)
 			cmd := newRevokeCommand(cli)
 			cmd.SetArgs(tc.args)
-			cmd.SetOutput(ioutil.Discard)
+			cmd.SetOut(ioutil.Discard)
 			if tc.expectedErr != "" {
 				assert.ErrorContains(t, cmd.Execute(), tc.expectedErr)
 				return

--- a/cli/command/trust/sign_test.go
+++ b/cli/command/trust/sign_test.go
@@ -70,7 +70,7 @@ func TestTrustSignCommandErrors(t *testing.T) {
 		cmd := newSignCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -80,7 +80,7 @@ func TestTrustSignCommandOfflineErrors(t *testing.T) {
 	cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)
 	cmd := newSignCommand(cli)
 	cmd.SetArgs([]string{"reg-name.io/image:tag"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "client is offline")
 }
 
@@ -286,7 +286,7 @@ func TestSignCommandChangeListIsCleanedOnError(t *testing.T) {
 	cli.SetNotaryClient(notaryfake.GetLoadedNotaryRepository)
 	cmd := newSignCommand(cli)
 	cmd.SetArgs([]string{"ubuntu:latest"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 
 	err = cmd.Execute()
 	assert.Assert(t, err != nil)
@@ -303,7 +303,7 @@ func TestSignCommandLocalFlag(t *testing.T) {
 	cli.SetNotaryClient(notaryfake.GetEmptyTargetsNotaryRepository)
 	cmd := newSignCommand(cli)
 	cmd.SetArgs([]string{"--local", "reg-name.io/image:red"})
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "error contacting notary server: dial tcp: lookup reg-name.io")
 
 }

--- a/cli/command/trust/signer_add_test.go
+++ b/cli/command/trust/signer_add_test.go
@@ -62,7 +62,7 @@ func TestTrustSignerAddErrors(t *testing.T) {
 		cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)
 		cmd := newSignerAddCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -82,7 +82,7 @@ func TestSignerAddCommandNoTargetsKey(t *testing.T) {
 	cmd := newSignerAddCommand(cli)
 	cmd.SetArgs([]string{"--key", tmpfile.Name(), "alice", "alpine", "linuxkit/alpine"})
 
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.Error(t, cmd.Execute(), fmt.Sprintf("could not parse public key from file: %s: no valid public key found", tmpfile.Name()))
 }
 
@@ -97,7 +97,7 @@ func TestSignerAddCommandBadKeyPath(t *testing.T) {
 	cmd := newSignerAddCommand(cli)
 	cmd.SetArgs([]string{"--key", "/path/to/key.pem", "alice", "alpine"})
 
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	expectedError := "unable to read public key from file: open /path/to/key.pem: no such file or directory"
 	if runtime.GOOS == "windows" {
 		expectedError = "unable to read public key from file: open /path/to/key.pem: The system cannot find the path specified."
@@ -123,7 +123,7 @@ func TestSignerAddCommandInvalidRepoName(t *testing.T) {
 	imageName := "870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd"
 	cmd.SetArgs([]string{"--key", pubKeyFilepath, "alice", imageName})
 
-	cmd.SetOutput(ioutil.Discard)
+	cmd.SetOut(ioutil.Discard)
 	assert.Error(t, cmd.Execute(), "Failed to add signer to: 870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd")
 	expectedErr := fmt.Sprintf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings\n\n", imageName)
 

--- a/cli/command/trust/signer_remove_test.go
+++ b/cli/command/trust/signer_remove_test.go
@@ -32,7 +32,7 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		cmd := newSignerRemoveCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 	testCasesWithOutput := []struct {
@@ -61,7 +61,7 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)
 		cmd := newSignerRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		cmd.Execute()
 		assert.Check(t, is.Contains(cli.ErrBuffer().String(), tc.expectedError))
 	}

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -49,7 +49,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -60,7 +60,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -43,7 +43,7 @@ func TestVolumeListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -48,7 +48,7 @@ func TestVolumePruneErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -32,7 +32,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 				volumeRemoveFunc: tc.volumeRemoveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/required_test.go
+++ b/cli/required_test.go
@@ -119,7 +119,7 @@ func runTestCases(t *testing.T, testCases []testCase) {
 	for _, tc := range testCases {
 		cmd := newDummyCommand(tc.validateFunc)
 		cmd.SetArgs(tc.args)
-		cmd.SetOutput(ioutil.Discard)
+		cmd.SetOut(ioutil.Discard)
 
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -59,7 +59,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	setupHelpCommand(dockerCli, cmd, helpCmd)
 	setHelpFunc(dockerCli, cmd)
 
-	cmd.SetOutput(dockerCli.Out())
+	cmd.SetOut(dockerCli.Out())
 	commands.AddCommands(cmd, dockerCli)
 
 	cli.DisableFlagsInUseLine(cmd)


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/2488