### PR TITLE
-buildmode=pie is not supported for the mips arch

### DIFF
--- a/scripts/build/dynbinary
+++ b/scripts/build/dynbinary
@@ -9,6 +9,14 @@ source ./scripts/build/.variables
 
 echo "Building dynamically linked $TARGET"
 export CGO_ENABLED=1
-go build -o "${TARGET}" -tags pkcs11 --ldflags "${LDFLAGS}" -buildmode=pie "${SOURCE}"
+GO_BUILDMODE="-buildmode=pie"
+#pie build mode is not supported for the mips arch 
+for arch in mips mipsle mips64 mips64le ppc64
+do
+    if [ $(go env GOARCH) = "${arch}" ];then
+        GO_BUILDMODE=""
+    fi
+done
+go build -o "${TARGET}" -tags pkcs11 --ldflags "${LDFLAGS}" "${GO_BUILDMODE}" "${SOURCE}"
 
 ln -sf "$(basename "${TARGET}")" build/docker


### PR DESCRIPTION
-buildmode=pie is not supported for the mips arch
reference: https://github.com/containerd/containerd/commit/4c99c81326f4026fb8c0b8c5e10542205d99c321

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

