### PR TITLE
vendor: pkg/errors v0.9.1

### DIFF
--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -25,6 +25,11 @@ func (e *pluginError) Cause() error {
 	return e.cause
 }
 
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (e *pluginError) Unwrap() error {
+	return e.cause
+}
+
 // MarshalText marshalls the pluginError into a textual form.
 func (e *pluginError) MarshalText() (text []byte, err error) {
 	return []byte(e.cause.Error()), nil

--- a/cli-plugins/manager/error_test.go
+++ b/cli-plugins/manager/error_test.go
@@ -16,7 +16,7 @@ func TestPluginError(t *testing.T) {
 	inner := fmt.Errorf("testing")
 	err = wrapAsPluginError(inner, "wrapping")
 	assert.Error(t, err, "wrapping: testing")
-	assert.Equal(t, inner, errors.Cause(err))
+	assert.Assert(t, errors.Is(err, inner))
 
 	actual, err := yaml.Marshal(err)
 	assert.NilError(t, err)

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -89,7 +89,7 @@ func TestEmptyFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = Load(tmpHome)
-	assert.Equal(t, errors.Cause(err), io.EOF)
+	assert.Assert(t, errors.Is(err, io.EOF))
 	assert.ErrorContains(t, err, ConfigFileName)
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -55,7 +55,7 @@ github.com/opencontainers/go-digest                 279bed98673dd5bef374d3b6e4b0
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
 github.com/opentracing/opentracing-go               1361b9cd60be79c4c3a7fa9841b3c132e40066a7
-github.com/pkg/errors                               ba968bfe8b2f7e042a574c888954fccecfa385b4 # v0.8.1
+github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1
 github.com/prometheus/client_golang                 c5b7fccd204277076155f10851dad72b76a49317 # v0.8.0
 github.com/prometheus/client_model                  6f3806018612930941127f2a7c6c453ba2c527d2
 github.com/prometheus/common                        7600349dcfe1abd18d72d3a1770870d9800a7801

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -41,11 +41,18 @@ default:
 
 [Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
 
+## Roadmap
+
+With the upcoming [Go2 error proposals](https://go.googlesource.com/proposal/+/master/design/go2draft.md) this package is moving into maintenance mode. The roadmap for a 1.0 release is as follows:
+
+- 0.9. Remove pre Go 1.9 and Go 1.10 support, address outstanding pull requests (if possible)
+- 1.0. Final release.
+
 ## Contributing
 
-We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+Because of the Go2 errors changes, this package is not accepting proposals for new functionality. With that said, we welcome pull requests, bug fixes and issue reports. 
 
-Before proposing a change, please discuss your change by raising an issue.
+Before sending a PR, please discuss your change by raising an issue.
 
 ## License
 

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -82,7 +82,7 @@
 //
 //     if err, ok := err.(stackTracer); ok {
 //             for _, f := range err.StackTrace() {
-//                     fmt.Printf("%+s:%d", f)
+//                     fmt.Printf("%+s:%d\n", f, f)
 //             }
 //     }
 //
@@ -158,6 +158,9 @@ type withStack struct {
 }
 
 func (w *withStack) Cause() error { return w.error }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
 
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -240,6 +243,9 @@ type withMessage struct {
 
 func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {

--- a/vendor/github.com/pkg/errors/go113.go
+++ b/vendor/github.com/pkg/errors/go113.go
@@ -1,0 +1,38 @@
+// +build go1.13
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}


### PR DESCRIPTION
full diff: https://github.com/pkg/errors/compare/v0.8.1...v0.9.1

also updated some uses of `errors.Cause()` to `errors.Is()`