### PR TITLE
vendor: k8s.io/klog v1.0.0-2-g4ad0115

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -89,7 +89,7 @@ k8s.io/apiextensions-apiserver                      e0288c14e6fda28eefbd584da8c6
 k8s.io/apiserver                                    3987e0d46aec47186e5f2c0d61ad84975cb79bd8 # v0.16.9
 k8s.io/client-go                                    002560d5bf54049bf5b5ae99231cb2b591f15954 # v0.16.9
 k8s.io/component-base                               dbd90d7c5d87d80fd674cc40d69ca7b14798eda5 # v0.16.9
-k8s.io/klog                                         2ca9ad30301bf30a8a6e0fa2110db6b8df699a91 # v1.0.0
+k8s.io/klog                                         4ad0115ba9e45c096d06a31d8dfb0e5bd945ec5f # v1.0.0-2-g4ad0115 pending v1.0.1 release to fix https://github.com/docker/cli/issues/2420
 k8s.io/kube-openapi                                 0270cf2f1c1d995d34b36019a6f65d58e6e33ad4
 k8s.io/kubernetes                                   a17149e1a189050796ced469dbd78d380f2ed5ef # v1.16.9
 k8s.io/utils                                        69764acb6e8e900b7c05296c5d3c9c19545475f9

--- a/vendor/k8s.io/klog/klog_file.go
+++ b/vendor/k8s.io/klog/klog_file.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -55,13 +56,31 @@ func init() {
 		host = shortHostname(h)
 	}
 
-	current, err := user.Current()
-	if err == nil {
-		userName = current.Username
-	}
+	// On Windows, the Go 'user' package requires netapi32.dll.
+	// This affects Windows Nano Server:
+	//   https://github.com/golang/go/issues/21867
+	// Fallback to using environment variables.
+	if runtime.GOOS == "windows" {
+		u := os.Getenv("USERNAME")
+		if len(u) == 0 {
+			return
+		}
+		// Sanitize the USERNAME since it may contain filepath separators.
+		u = strings.Replace(u, `\`, "_", -1)
 
-	// Sanitize userName since it may contain filepath separators on Windows.
-	userName = strings.Replace(userName, `\`, "_", -1)
+		// user.Current().Username normally produces something like 'USERDOMAIN\USERNAME'
+		d := os.Getenv("USERDOMAIN")
+		if len(d) != 0 {
+			userName = d + "_" + u
+		} else {
+			userName = u
+		}
+	} else {
+		current, err := user.Current()
+		if err == nil {
+			userName = current.Username
+		}
+	}
 }
 
 // shortHostname returns its argument, truncating at the first period.


### PR DESCRIPTION
Temporarily vendoring tip of the release-1.x branch, to address docker context inspect being slow on Windows because this package performs user lookup through `os.Current()` during `init()`.

Addresses https://github.com/docker/cli/issues/2420


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown
Fix `docker context inspect` being slow on Windows
```

