### PR TITLE
[19.03 backport] docs: more Markdown touch-ups

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -384,14 +384,15 @@ contents of the `debug` file instead of looking for a `Dockerfile` and will use
 directory structure of the build context, regardless of how you refer to it on
 the command line.
 
-> **Note:**
-> `docker build` will return a `no such file or directory` error if the
+> **Note**
+>
+> `docker build` returns a `no such file or directory` error if the
 > file or directory does not exist in the uploaded context. This may
 > happen if there is no context, or if you specify a file that is
 > elsewhere on the Host system. The context is limited to the current
 > directory (and its children) for security reasons, and to ensure
 > repeatable builds on remote Docker hosts. This is also the reason why
-> `ADD ../file` will not work.
+> `ADD ../file` does not work.
 
 ### Use a custom parent cgroup (--cgroup-parent)
 
@@ -672,30 +673,47 @@ The `--squash` option has a number of known limitations:
 
 #### Prerequisites
 
-The example on this page is using experimental mode in Docker 1.13.
+The example on this page is using experimental mode in Docker 19.03.
 
-Experimental mode can be enabled by using the `--experimental` flag when starting the Docker daemon or setting `experimental: true` in the `daemon.json` configuration file.
+Experimental mode can be enabled by using the `--experimental` flag when starting
+the Docker daemon or setting `experimental: true` in the `daemon.json` configuration
+file.
 
-By default, experimental mode is disabled. To see the current configuration, use the `docker version` command.
+By default, experimental mode is disabled. To see the current configuration of
+the docker daemon, use the `docker version` command and check the `Experimental`
+line in the `Engine` section:
 
-```none
-Server:
- Version:      1.13.1
- API version:  1.26 (minimum version 1.12)
- Go version:   go1.7.5
- Git commit:   092cba3
- Built:        Wed Feb  8 06:35:24 2017
- OS/Arch:      linux/amd64
- Experimental: false
+```console
+Client: Docker Engine - Community
+ Version:           19.03.8
+ API version:       1.40
+ Go version:        go1.12.17
+ Git commit:        afacb8b
+ Built:             Wed Mar 11 01:21:11 2020
+ OS/Arch:           darwin/amd64
+ Experimental:      false
 
+Server: Docker Engine - Community
+ Engine:
+  Version:          19.03.8
+  API version:      1.40 (minimum version 1.12)
+  Go version:       go1.12.17
+  Git commit:       afacb8b
+  Built:            Wed Mar 11 01:29:16 2020
+  OS/Arch:          linux/amd64
+  Experimental:     true
  [...]
 ```
 
-To enable experimental mode, users need to restart the docker daemon with the experimental flag enabled.
+To enable experimental mode, users need to restart the docker daemon with the
+experimental flag enabled.
 
 #### Enable Docker experimental
 
-Experimental features are now included in the standard Docker binaries as of version 1.13.0. For enabling experimental features, you need to start the Docker daemon with `--experimental` flag. You can also enable the daemon flag via /etc/docker/daemon.json. e.g.
+Experimental features are now included in the standard Docker binaries as of
+version 1.13.0. For enabling experimental features, you need to start the
+Docker daemon with `--experimental` flag. You can also enable the daemon flag
+via `/etc/docker/daemon.json`. e.g.
 
 ```json
 {
@@ -731,7 +749,7 @@ $ docker build --squash -t test .
 [...]
 ```
 
-If everything is right, the history will look like this:
+If everything is right, the history looks like this:
 
 ```bash
 $ docker history test
@@ -747,6 +765,8 @@ IMAGE               CREATED             CREATED BY                              
 <missing>           7 weeks ago         /bin/sh -c #(nop) ADD file:47ca6e777c36a4cfff   1.113 MB
 ```
 
-We could find that all layer's name is `<missing>`, and there is a new layer with COMMENT `merge`.
+We could find that a layer's name is `<missing>`, and there is a new layer with
+COMMENT `merge`.
 
-Test the image, check for `/remove_me` being gone, make sure `hello\nworld` is in `/hello`, make sure the `HELLO` envvar's value is `world`.
+Test the image, check for `/remove_me` being gone, make sure `hello\nworld` is
+in `/hello`, make sure the `HELLO` environment variable's value is `world`.

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -673,7 +673,7 @@ thin pool device deletion is synchronous. Before a container is deleted,
 the Docker daemon removes any associated devices. If the storage driver
 can not remove a device, the container deletion fails and daemon returns.
 
-```none
+```console
 Error deleting container: Error response from daemon: Cannot destroy container
 ```
 
@@ -1261,9 +1261,9 @@ to avoid collisions with other prometheus exporters and services.
 
 If you are running a prometheus server you can add this address to your scrape configs
 to have prometheus collect metrics on Docker.  For more information
-on prometheus you can view the website [here](https://prometheus.io/).
+on prometheus refer to the [prometheus website](https://prometheus.io/).
 
-```none
+```yaml
 scrape_configs:
   - job_name: 'docker'
     static_configs:
@@ -1287,7 +1287,7 @@ the task to run.
 Example of usage:
 ```json
 {
-	"node-generic-resources": ["NVIDIA-GPU=UUID1", "NVIDIA-GPU=UUID2"]
+  "node-generic-resources": ["NVIDIA-GPU=UUID1", "NVIDIA-GPU=UUID2"]
 }
 ```
 
@@ -1316,100 +1316,102 @@ This is a full example of the allowed configuration options on Linux:
 
 ```json
 {
-	"authorization-plugins": [],
-	"data-root": "",
-	"dns": [],
-	"dns-opts": [],
-	"dns-search": [],
-	"exec-opts": [],
-	"exec-root": "",
-	"experimental": false,
-	"features": {},
-	"storage-driver": "",
-	"storage-opts": [],
-	"labels": [],
-	"live-restore": true,
-	"log-driver": "json-file",
-	"log-opts": {
-		"max-size": "10m",
-		"max-file":"5",
-		"labels": "somelabel",
-		"env": "os,customer"
-	},
-	"mtu": 0,
-	"pidfile": "",
-	"cluster-store": "",
-	"cluster-store-opts": {},
-	"cluster-advertise": "",
-	"max-concurrent-downloads": 3,
-	"max-concurrent-uploads": 5,
-	"default-shm-size": "64M",
-	"shutdown-timeout": 15,
-	"debug": true,
-	"hosts": [],
-	"log-level": "",
-	"tls": true,
-	"tlsverify": true,
-	"tlscacert": "",
-	"tlscert": "",
-	"tlskey": "",
-	"swarm-default-advertise-addr": "",
-	"api-cors-header": "",
-	"selinux-enabled": false,
-	"userns-remap": "",
-	"group": "",
-	"cgroup-parent": "",
-	"default-ulimits": {
-		"nofile": {
-			"Name": "nofile",
-			"Hard": 64000,
-			"Soft": 64000
-		}
-	},
-	"init": false,
-	"init-path": "/usr/libexec/docker-init",
-	"ipv6": false,
-	"iptables": false,
-	"ip-forward": false,
-	"ip-masq": false,
-	"userland-proxy": false,
-	"userland-proxy-path": "/usr/libexec/docker-proxy",
-	"ip": "0.0.0.0",
-	"bridge": "",
-	"bip": "",
-	"fixed-cidr": "",
-	"fixed-cidr-v6": "",
-	"default-gateway": "",
-	"default-gateway-v6": "",
-	"icc": false,
-	"raw-logs": false,
-	"allow-nondistributable-artifacts": [],
-	"registry-mirrors": [],
-	"seccomp-profile": "",
-	"insecure-registries": [],
-	"no-new-privileges": false,
-	"default-runtime": "runc",
-	"oom-score-adjust": -500,
-	"node-generic-resources": ["NVIDIA-GPU=UUID1", "NVIDIA-GPU=UUID2"],
-	"runtimes": {
-		"cc-runtime": {
-			"path": "/usr/bin/cc-runtime"
-		},
-		"custom": {
-			"path": "/usr/local/bin/my-runc-replacement",
-			"runtimeArgs": [
-				"--debug"
-			]
-		}
-	},
-	"default-address-pools":[
-		{"base":"172.80.0.0/16","size":24},
-		{"base":"172.90.0.0/16","size":24}
-	]
+  "authorization-plugins": [],
+  "data-root": "",
+  "dns": [],
+  "dns-opts": [],
+  "dns-search": [],
+  "exec-opts": [],
+  "exec-root": "",
+  "experimental": false,
+  "features": {},
+  "storage-driver": "",
+  "storage-opts": [],
+  "labels": [],
+  "live-restore": true,
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file":"5",
+    "labels": "somelabel",
+    "env": "os,customer"
+  },
+  "mtu": 0,
+  "pidfile": "",
+  "cluster-store": "",
+  "cluster-store-opts": {},
+  "cluster-advertise": "",
+  "max-concurrent-downloads": 3,
+  "max-concurrent-uploads": 5,
+  "default-shm-size": "64M",
+  "shutdown-timeout": 15,
+  "debug": true,
+  "hosts": [],
+  "log-level": "",
+  "tls": true,
+  "tlsverify": true,
+  "tlscacert": "",
+  "tlscert": "",
+  "tlskey": "",
+  "swarm-default-advertise-addr": "",
+  "api-cors-header": "",
+  "selinux-enabled": false,
+  "userns-remap": "",
+  "group": "",
+  "cgroup-parent": "",
+  "default-ulimits": {
+    "nofile": {
+      "Name": "nofile",
+      "Hard": 64000,
+      "Soft": 64000
+    }
+  },
+  "init": false,
+  "init-path": "/usr/libexec/docker-init",
+  "ipv6": false,
+  "iptables": false,
+  "ip-forward": false,
+  "ip-masq": false,
+  "userland-proxy": false,
+  "userland-proxy-path": "/usr/libexec/docker-proxy",
+  "ip": "0.0.0.0",
+  "bridge": "",
+  "bip": "",
+  "fixed-cidr": "",
+  "fixed-cidr-v6": "",
+  "default-gateway": "",
+  "default-gateway-v6": "",
+  "icc": false,
+  "raw-logs": false,
+  "allow-nondistributable-artifacts": [],
+  "registry-mirrors": [],
+  "seccomp-profile": "",
+  "insecure-registries": [],
+  "no-new-privileges": false,
+  "default-runtime": "runc",
+  "oom-score-adjust": -500,
+  "node-generic-resources": ["NVIDIA-GPU=UUID1", "NVIDIA-GPU=UUID2"],
+  "runtimes": {
+    "cc-runtime": {
+      "path": "/usr/bin/cc-runtime"
+    },
+    "custom": {
+      "path": "/usr/local/bin/my-runc-replacement",
+      "runtimeArgs": [
+        "--debug"
+      ]
+    }
+  },
+  "default-address-pools":[
+    {"base":"172.80.0.0/16","size":24},
+    {"base":"172.90.0.0/16","size":24}
+  ]
 }
 ```
 
-> **Note:** You cannot set options in `daemon.json` that have already been set on
+> **Note:**
+>
+> You cannot set options in `daemon.json` that have already been set on
 > daemon startup as a flag.
 > On systems that use `systemd` to start the Docker daemon, `-H` is already set, so
 > you cannot use the `hosts` key in `daemon.json` to add listening addresses.
@@ -1426,41 +1428,41 @@ This is a full example of the allowed configuration options on Windows:
 
 ```json
 {
-    "authorization-plugins": [],
-    "data-root": "",
-    "dns": [],
-    "dns-opts": [],
-    "dns-search": [],
-    "exec-opts": [],
-    "experimental": false,
-    "features":{},
-    "storage-driver": "",
-    "storage-opts": [],
-    "labels": [],
-    "log-driver": "",
-    "mtu": 0,
-    "pidfile": "",
-    "cluster-store": "",
-    "cluster-advertise": "",
-    "max-concurrent-downloads": 3,
-    "max-concurrent-uploads": 5,
-    "shutdown-timeout": 15,
-    "debug": true,
-    "hosts": [],
-    "log-level": "",
-    "tlsverify": true,
-    "tlscacert": "",
-    "tlscert": "",
-    "tlskey": "",
-    "swarm-default-advertise-addr": "",
-    "group": "",
-    "default-ulimits": {},
-    "bridge": "",
-    "fixed-cidr": "",
-    "raw-logs": false,
-    "allow-nondistributable-artifacts": [],
-    "registry-mirrors": [],
-    "insecure-registries": []
+  "authorization-plugins": [],
+  "data-root": "",
+  "dns": [],
+  "dns-opts": [],
+  "dns-search": [],
+  "exec-opts": [],
+  "experimental": false,
+  "features":{},
+  "storage-driver": "",
+  "storage-opts": [],
+  "labels": [],
+  "log-driver": "",
+  "mtu": 0,
+  "pidfile": "",
+  "cluster-store": "",
+  "cluster-advertise": "",
+  "max-concurrent-downloads": 3,
+  "max-concurrent-uploads": 5,
+  "shutdown-timeout": 15,
+  "debug": true,
+  "hosts": [],
+  "log-level": "",
+  "tlsverify": true,
+  "tlscacert": "",
+  "tlscert": "",
+  "tlskey": "",
+  "swarm-default-advertise-addr": "",
+  "group": "",
+  "default-ulimits": {},
+  "bridge": "",
+  "fixed-cidr": "",
+  "raw-logs": false,
+  "allow-nondistributable-artifacts": [],
+  "registry-mirrors": [],
+  "insecure-registries": []
 }
 ```
 
@@ -1527,7 +1529,7 @@ by providing them as flags, or by using a [daemon configuration file](#daemon-co
 
 The following daemon options must be configured for each daemon:
 
-```none
+```console
 -b, --bridge=                          Attach containers to a network bridge
 --exec-root=/var/run/docker            Root of the Docker execdriver
 --data-root=/var/lib/docker            Root of persisted Docker data

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -222,7 +222,7 @@ $ docker stop test
 
 **Shell 1: (Again .. now showing events):**
 
-```none
+```console
 2017-01-05T00:35:58.859401177+08:00 container create 0fdb48addc82871eb34eb23a847cfd033dedd1a0a37bef2e6d9eb3870fc7ff37 (image=alpine:latest, name=test)
 2017-01-05T00:36:04.703631903+08:00 network connect e2e1f5ceda09d4300f3a846f0acfaa9a8bb0d89e775eb744c5acecd60e0529e2 (container=0fdb...ff37, name=bridge, type=bridge)
 2017-01-05T00:36:04.795031609+08:00 container start 0fdb...ff37 (image=alpine:latest, name=test)

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -202,7 +202,7 @@ $ docker info --format '{{json .}}'
 
 Here is a sample output for a daemon running on Windows Server 2016:
 
-```none
+```console
 E:\docker>docker info
 Client:
  Debug Mode: false

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -47,52 +47,56 @@ template for each result. Go's
 [text/template](http://golang.org/pkg/text/template/) package describes all the
 details of the format.
 
-```none
+```bash
 $ sudo docker network inspect bridge
+```
 
+The output is in JSON format, for example:
+
+```json
 [
-    {
-        "Name": "bridge",
-        "Id": "b2b1a2cba717161d984383fd68218cf70bbbd17d328496885f7c921333228b0f",
-        "Created": "2016-10-19T04:33:30.360899459Z",
-        "Scope": "local",
-        "Driver": "bridge",
-        "IPAM": {
-            "Driver": "default",
-            "Config": [
-                {
-                    "Subnet": "172.17.42.1/16",
-                    "Gateway": "172.17.42.1"
-                }
-            ]
-        },
-        "Internal": false,
-        "Containers": {
-            "bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727": {
-                "Name": "container2",
-                "EndpointID": "0aebb8fcd2b282abe1365979536f21ee4ceaf3ed56177c628eae9f706e00e019",
-                "MacAddress": "02:42:ac:11:00:02",
-                "IPv4Address": "172.17.0.2/16",
-                "IPv6Address": ""
-            },
-            "f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27": {
-                "Name": "container1",
-                "EndpointID": "a00676d9c91a96bbe5bcfb34f705387a33d7cc365bac1a29e4e9728df92d10ad",
-                "MacAddress": "02:42:ac:11:00:01",
-                "IPv4Address": "172.17.0.1/16",
-                "IPv6Address": ""
-            }
-        },
-        "Options": {
-            "com.docker.network.bridge.default_bridge": "true",
-            "com.docker.network.bridge.enable_icc": "true",
-            "com.docker.network.bridge.enable_ip_masquerade": "true",
-            "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
-            "com.docker.network.bridge.name": "docker0",
-            "com.docker.network.driver.mtu": "1500"
-        },
-        "Labels": {}
-    }
+  {
+    "Name": "bridge",
+    "Id": "b2b1a2cba717161d984383fd68218cf70bbbd17d328496885f7c921333228b0f",
+    "Created": "2016-10-19T04:33:30.360899459Z",
+    "Scope": "local",
+    "Driver": "bridge",
+    "IPAM": {
+      "Driver": "default",
+      "Config": [
+        {
+          "Subnet": "172.17.42.1/16",
+          "Gateway": "172.17.42.1"
+        }
+      ]
+    },
+    "Internal": false,
+    "Containers": {
+      "bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727": {
+        "Name": "container2",
+        "EndpointID": "0aebb8fcd2b282abe1365979536f21ee4ceaf3ed56177c628eae9f706e00e019",
+        "MacAddress": "02:42:ac:11:00:02",
+        "IPv4Address": "172.17.0.2/16",
+        "IPv6Address": ""
+      },
+      "f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27": {
+        "Name": "container1",
+        "EndpointID": "a00676d9c91a96bbe5bcfb34f705387a33d7cc365bac1a29e4e9728df92d10ad",
+        "MacAddress": "02:42:ac:11:00:01",
+        "IPv4Address": "172.17.0.1/16",
+        "IPv6Address": ""
+      }
+    },
+    "Options": {
+      "com.docker.network.bridge.default_bridge": "true",
+      "com.docker.network.bridge.enable_icc": "true",
+      "com.docker.network.bridge.enable_ip_masquerade": "true",
+      "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
+      "com.docker.network.bridge.name": "docker0",
+      "com.docker.network.driver.mtu": "1500"
+    },
+    "Labels": {}
+  }
 ]
 ```
 
@@ -106,29 +110,33 @@ $ docker network create simple-network
 69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a
 ```
 
-```none
+```bash
 $ docker network inspect simple-network
+```
 
+The output is in JSON format, for example:
+
+```json
 [
-    {
-        "Name": "simple-network",
-        "Id": "69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a",
-        "Created": "2016-10-19T04:33:30.360899459Z",
-        "Scope": "local",
-        "Driver": "bridge",
-        "IPAM": {
-            "Driver": "default",
-            "Config": [
-                {
-                    "Subnet": "172.22.0.0/16",
-                    "Gateway": "172.22.0.1"
-                }
-            ]
-        },
-        "Containers": {},
-        "Options": {},
-        "Labels": {}
-    }
+  {
+    "Name": "simple-network",
+    "Id": "69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a",
+    "Created": "2016-10-19T04:33:30.360899459Z",
+    "Scope": "local",
+    "Driver": "bridge",
+    "IPAM": {
+      "Driver": "default",
+      "Config": [
+        {
+          "Subnet": "172.22.0.0/16",
+          "Gateway": "172.22.0.1"
+        }
+      ]
+    },
+    "Containers": {},
+    "Options": {},
+    "Labels": {}
+  }
 ]
 ```
 
@@ -138,57 +146,61 @@ For swarm mode overlay networks `network inspect` also shows the IP address and 
 of the peers. Peers are the nodes in the swarm cluster which have at least one task attached
 to the network. Node name is of the format `<hostname>-<unique ID>`.
 
-```none
+```bash
 $ docker network inspect ingress
+```
 
+The output is in JSON format, for example:
+
+```json
 [
-    {
-        "Name": "ingress",
-        "Id": "j0izitrut30h975vk4m1u5kk3",
-        "Created": "2016-11-08T06:49:59.803387552Z",
-        "Scope": "swarm",
-        "Driver": "overlay",
-        "EnableIPv6": false,
-        "IPAM": {
-            "Driver": "default",
-            "Options": null,
-            "Config": [
-                {
-                    "Subnet": "10.255.0.0/16",
-                    "Gateway": "10.255.0.1"
-                }
-            ]
-        },
-        "Internal": false,
-        "Attachable": false,
-        "Containers": {
-            "ingress-sbox": {
-                "Name": "ingress-endpoint",
-                "EndpointID": "40e002d27b7e5d75f60bc72199d8cae3344e1896abec5eddae9743755fe09115",
-                "MacAddress": "02:42:0a:ff:00:03",
-                "IPv4Address": "10.255.0.3/16",
-                "IPv6Address": ""
-            }
-        },
-        "Options": {
-            "com.docker.network.driver.overlay.vxlanid_list": "256"
-        },
-        "Labels": {},
-        "Peers": [
-            {
-                "Name": "net-1-1d22adfe4d5c",
-                "IP": "192.168.33.11"
-            },
-            {
-                "Name": "net-2-d55d838b34af",
-                "IP": "192.168.33.12"
-            },
-            {
-                "Name": "net-3-8473f8140bd9",
-                "IP": "192.168.33.13"
-            }
-        ]
-    }
+  {
+    "Name": "ingress",
+    "Id": "j0izitrut30h975vk4m1u5kk3",
+    "Created": "2016-11-08T06:49:59.803387552Z",
+    "Scope": "swarm",
+    "Driver": "overlay",
+    "EnableIPv6": false,
+    "IPAM": {
+      "Driver": "default",
+      "Options": null,
+      "Config": [
+        {
+          "Subnet": "10.255.0.0/16",
+          "Gateway": "10.255.0.1"
+        }
+      ]
+    },
+    "Internal": false,
+    "Attachable": false,
+    "Containers": {
+      "ingress-sbox": {
+        "Name": "ingress-endpoint",
+        "EndpointID": "40e002d27b7e5d75f60bc72199d8cae3344e1896abec5eddae9743755fe09115",
+        "MacAddress": "02:42:0a:ff:00:03",
+        "IPv4Address": "10.255.0.3/16",
+        "IPv6Address": ""
+      }
+    },
+    "Options": {
+      "com.docker.network.driver.overlay.vxlanid_list": "256"
+    },
+    "Labels": {},
+    "Peers": [
+      {
+        "Name": "net-1-1d22adfe4d5c",
+        "IP": "192.168.33.11"
+      },
+      {
+        "Name": "net-2-d55d838b34af",
+        "IP": "192.168.33.12"
+      },
+      {
+        "Name": "net-3-8473f8140bd9",
+        "IP": "192.168.33.13"
+      }
+    ]
+  }
 ]
 ```
 
@@ -203,87 +215,92 @@ attached to. service `s1` in this case has three replicas.
 
 ```bash
 $ docker network inspect --verbose ov1
+```
+
+The output is in JSON format, for example:
+
+```json
 [
-    {
-        "Name": "ov1",
-        "Id": "ybmyjvao9vtzy3oorxbssj13b",
-        "Created": "2017-03-13T17:04:39.776106792Z",
-        "Scope": "swarm",
-        "Driver": "overlay",
-        "EnableIPv6": false,
-        "IPAM": {
-            "Driver": "default",
-            "Options": null,
-            "Config": [
-                {
-                    "Subnet": "10.0.0.0/24",
-                    "Gateway": "10.0.0.1"
-                }
-            ]
-        },
-        "Internal": false,
-        "Attachable": false,
-        "Containers": {
-            "020403bd88a15f60747fd25d1ad5fa1272eb740e8a97fc547d8ad07b2f721c5e": {
-                "Name": "s1.1.pjn2ik0sfgkfzed3h0s00gs9o",
-                "EndpointID": "ad16946f416562d658f3bb30b9830d73ad91ccf6feae44411269cd0ff674714e",
-                "MacAddress": "02:42:0a:00:00:04",
-                "IPv4Address": "10.0.0.4/24",
-                "IPv6Address": ""
-            }
-        },
-        "Options": {
-            "com.docker.network.driver.overlay.vxlanid_list": "4097"
-        },
-        "Labels": {},
-        "Peers": [
-            {
-                "Name": "net-3-5d3cfd30a58c",
-                "IP": "192.168.33.13"
-            },
-            {
-                "Name": "net-1-6ecbc0040a73",
-                "IP": "192.168.33.11"
-            },
-            {
-                "Name": "net-2-fb80208efd75",
-                "IP": "192.168.33.12"
-            }
-        ],
-        "Services": {
-            "s1": {
-                "VIP": "10.0.0.2",
-                "Ports": [],
-                "LocalLBIndex": 257,
-                "Tasks": [
-                    {
-                        "Name": "s1.2.q4hcq2aiiml25ubtrtg4q1txt",
-                        "EndpointID": "040879b027e55fb658e8b60ae3b87c6cdac7d291e86a190a3b5ac6567b26511a",
-                        "EndpointIP": "10.0.0.5",
-                        "Info": {
-                            "Host IP": "192.168.33.11"
-                        }
-                    },
-                    {
-                        "Name": "s1.3.yawl4cgkp7imkfx469kn9j6lm",
-                        "EndpointID": "106edff9f120efe44068b834e1cddb5b39dd4a3af70211378b2f7a9e562bbad8",
-                        "EndpointIP": "10.0.0.3",
-                        "Info": {
-                            "Host IP": "192.168.33.12"
-                        }
-                    },
-                    {
-                        "Name": "s1.1.pjn2ik0sfgkfzed3h0s00gs9o",
-                        "EndpointID": "ad16946f416562d658f3bb30b9830d73ad91ccf6feae44411269cd0ff674714e",
-                        "EndpointIP": "10.0.0.4",
-                        "Info": {
-                            "Host IP": "192.168.33.13"
-                        }
-                    }
-                ]
-            }
+  {
+    "Name": "ov1",
+    "Id": "ybmyjvao9vtzy3oorxbssj13b",
+    "Created": "2017-03-13T17:04:39.776106792Z",
+    "Scope": "swarm",
+    "Driver": "overlay",
+    "EnableIPv6": false,
+    "IPAM": {
+      "Driver": "default",
+      "Options": null,
+      "Config": [
+        {
+          "Subnet": "10.0.0.0/24",
+          "Gateway": "10.0.0.1"
         }
+      ]
+    },
+    "Internal": false,
+    "Attachable": false,
+    "Containers": {
+      "020403bd88a15f60747fd25d1ad5fa1272eb740e8a97fc547d8ad07b2f721c5e": {
+        "Name": "s1.1.pjn2ik0sfgkfzed3h0s00gs9o",
+        "EndpointID": "ad16946f416562d658f3bb30b9830d73ad91ccf6feae44411269cd0ff674714e",
+        "MacAddress": "02:42:0a:00:00:04",
+        "IPv4Address": "10.0.0.4/24",
+        "IPv6Address": ""
+      }
+    },
+    "Options": {
+      "com.docker.network.driver.overlay.vxlanid_list": "4097"
+    },
+    "Labels": {},
+    "Peers": [
+      {
+        "Name": "net-3-5d3cfd30a58c",
+        "IP": "192.168.33.13"
+      },
+      {
+        "Name": "net-1-6ecbc0040a73",
+        "IP": "192.168.33.11"
+      },
+      {
+        "Name": "net-2-fb80208efd75",
+        "IP": "192.168.33.12"
+      }
+    ],
+    "Services": {
+      "s1": {
+        "VIP": "10.0.0.2",
+        "Ports": [],
+        "LocalLBIndex": 257,
+        "Tasks": [
+          {
+            "Name": "s1.2.q4hcq2aiiml25ubtrtg4q1txt",
+            "EndpointID": "040879b027e55fb658e8b60ae3b87c6cdac7d291e86a190a3b5ac6567b26511a",
+            "EndpointIP": "10.0.0.5",
+            "Info": {
+              "Host IP": "192.168.33.11"
+            }
+          },
+          {
+            "Name": "s1.3.yawl4cgkp7imkfx469kn9j6lm",
+            "EndpointID": "106edff9f120efe44068b834e1cddb5b39dd4a3af70211378b2f7a9e562bbad8",
+            "EndpointIP": "10.0.0.3",
+            "Info": {
+              "Host IP": "192.168.33.12"
+            }
+          },
+          {
+            "Name": "s1.1.pjn2ik0sfgkfzed3h0s00gs9o",
+            "EndpointID": "ad16946f416562d658f3bb30b9830d73ad91ccf6feae44411269cd0ff674714e",
+            "EndpointIP": "10.0.0.4",
+            "Info": {
+              "Host IP": "192.168.33.13"
+            }
+          }
+        ]
+      }
     }
+  }
 ]
 ```
 

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -64,7 +64,7 @@ networks without the specified labels.
 The following removes networks created more than 5 minutes ago. Note that
 system networks such as `bridge`, `host`, and `none` will never be pruned:
 
-```none
+```bash
 $ docker network ls
 
 NETWORK ID          NAME                DRIVER              SCOPE

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -174,7 +174,7 @@ ea09c3c82f6e        registry:latest   /srv/run.sh            2 weeks ago        
 You can use a filter to locate containers that exited with status of `137`
 meaning a `SIGKILL(9)` killed them.
 
-```none
+```bash
 $ docker ps -a --filter 'exited=137'
 
 CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -433,7 +433,7 @@ variables. (Unlike environment variables, labels are not visible to processes
 running inside a container.) The following example illustrates a label-file
 format:
 
-```none
+```console
 com.example.label1="a label"
 
 # this is a comment

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -32,7 +32,7 @@ Search [Docker Hub](https://hub.docker.com) for images
 
 This example displays images with a name containing 'busybox':
 
-```none
+```bash
 $ docker search busybox
 
 NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -67,7 +67,7 @@ $ docker secret create --label env=dev \
 eo7jnzguqgtpdah3cm5srfb97
 ```
 
-```none
+```bash
 $ docker secret inspect my_secret
 
 [

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -50,25 +50,29 @@ ID                          NAME                CREATED             UPDATED
 eo7jnzguqgtpdah3cm5srfb97   my_secret           3 minutes ago       3 minutes ago
 ```
 
-```none
+```bash
 $ docker secret inspect secret.json
+```
 
+The output is in JSON format, for example:
+
+```json
 [
-    {
-        "ID": "eo7jnzguqgtpdah3cm5srfb97",
-        "Version": {
-            "Index": 17
-        },
-        "CreatedAt": "2017-03-24T08:15:09.735271783Z",
-        "UpdatedAt": "2017-03-24T08:15:09.735271783Z",
-        "Spec": {
-            "Name": "my_secret",
-            "Labels": {
-                "env": "dev",
-                "rev": "20170324"
-            }
-        }
+  {
+    "ID": "eo7jnzguqgtpdah3cm5srfb97",
+    "Version": {
+      "Index": 17
+    },
+    "CreatedAt": "2017-03-24T08:15:09.735271783Z",
+    "UpdatedAt": "2017-03-24T08:15:09.735271783Z",
+    "Spec": {
+      "Name": "my_secret",
+      "Labels": {
+        "env": "dev",
+        "rev": "20170324"
+      }
     }
+  }
 ]
 ```
 

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -53,7 +53,11 @@ produce the same result:
 
 ```bash
 $ docker service inspect redis
+```
 
+The output is in JSON format, for example:
+
+```json
 [
   {
     "ID": "dmu1ept4cxcfe8k8lhtux3ro3",

--- a/docs/reference/commandline/trust_inspect.md
+++ b/docs/reference/commandline/trust_inspect.md
@@ -31,6 +31,11 @@ following example prints trust information for the `alpine:latest` image:
 
 ```bash
 $ docker trust inspect alpine:latest
+```
+
+The output is in JSON format, for example:
+
+```json
 [
   {
     "Name": "alpine:latest",
@@ -76,6 +81,11 @@ commands, `docker trust inspect` includes a `Signers` key:
 
 ```bash
 $ docker trust inspect my-image:purple
+```
+
+The output is in JSON format, for example:
+
+```json
 [
   {
     "Name": "my-image:purple",
@@ -158,7 +168,11 @@ However, if other tags are signed in the same image repository,
 
 ```bash
 $ docker trust inspect alpine:unsigned
+```
 
+The output is in JSON format, for example:
+
+```json
 [
   {
     "Name": "alpine:unsigned",
@@ -192,7 +206,11 @@ signed tags in the repository:
 
 ```bash
 $ docker trust inspect alpine
+```
 
+The output is in JSON format, for example:
+
+```json
 [
   {
     "Name": "alpine",
@@ -257,7 +275,11 @@ and reports the results in an ordered list:
 
 ```bash
 $ docker trust inspect alpine notary
+```
 
+The output is in JSON format, for example:
+
+```json
 [
   {
     "Name": "alpine",

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -46,7 +46,7 @@ Volume names must be unique among drivers. This means you cannot use the same
 volume name with two different drivers. If you attempt this `docker` returns an
 error:
 
-```none
+```console
 A volume named  "hello"  already exists with the "some-other" driver. Choose a different volume name.
 ```
 

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -27,27 +27,39 @@ details of the format.
 ## Examples
 
 ```bash
-$ docker volume create
+$ docker volume create myvolume
 
-8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5
+myvolume
+```
 
-$ docker volume inspect 85bffb0677236974f93955d8ecc4df55ef5070117b0e53333cc1b443777be24d
+Use the `docker volume inspect` comment to inspect the configuration of the volume:
 
+```bash
+$ docker volume inspect myvolume
+```
+
+The output is in JSON format, for example:
+
+```json
 [
   {
     "CreatedAt": "2020-04-19T11:00:21Z",
     "Driver": "local",
     "Labels": {},
     "Mountpoint": "/var/lib/docker/volumes/8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5/_data",
-    "Name": "8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5",
+    "Name": "myvolume",
     "Options": {},
     "Scope": "local"
   }
 ]
+```
+Use the `--format` flag to format the output using a Go template, for example,
+to print the `Mountpoint` property:
 
-$ docker volume inspect --format '{{ .Mountpoint }}' 8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5
+```bash
+$ docker volume inspect --format '{{ .Mountpoint }}' myvolume
 
-/var/lib/docker/volumes/8140a838303144125b4f54653b47ede0486282c623c3551fbc7f390cdc3e9cf5/_data
+/var/lib/docker/volumes/myvolume/_data
 ```
 
 ## Related commands


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2519

- replace the "none" code-hint with "console"
- some changes in the "experimental" instructions
- reformat some notes
- reformat / re-indent JSON output to use 2 spaces (for consistency)
- split JSON outputs to separate code-block so that it can be highlighted


