### PR TITLE
vendor: mitchellh/mapstructure v1.0.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/Microsoft/hcsshim                        5bc557dd210ff2caf615e6e22d398123de77fc11 # v0.8.9
 github.com/miekg/pkcs11                             210dc1e16747c5ba98a03bcbcf728c38086ea357 # v1.0.3
-github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
+github.com/mitchellh/mapstructure                   fa473d140ef3c6adf42d6b391fe76707f1f243c8 # v1.0.0
 github.com/moby/buildkit                            ae7ff7174f73bcb4df89b97e1623b3fb0bfb0a0c
 github.com/moby/sys                                 6154f11e6840c0d6b0dbb23f4125a6134b3013c9 # mountinfo/v0.1.3
 github.com/moby/term                                73f35e472e8f0a3f91347164138ce6bd73b756a9

--- a/vendor/github.com/mitchellh/mapstructure/go.mod
+++ b/vendor/github.com/mitchellh/mapstructure/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/mapstructure


### PR DESCRIPTION
we were only one commit behind v1.0.0, so updating to that version; we can do a follow-up to update to the latest minor release (v1.3.0)

full diff: https://github.com/mitchellh/mapstructure/compare/f15292f7a699fcc1a38a80977f80a046874ba8ac...v1.0.0

