### PR TITLE
document deprecation of legacy `~/.dockercfg` config-file

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -52,6 +52,7 @@ Status     | Feature                                                            
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
 Deprecated | [Kernel memory limit](#kernel-memory-limit)                                                                                        | v20.03.0   | -
 Deprecated | [Classic Swarm and overlay networks using external key/value stores](#classic-swarm-and-overlay-networks-using-cluster-store)      | v20.03.0   | -
+Deprecated | [Support for the legacy `~/.dockercfg` configuration file for authentication](#support-for-legacy-dockercfg-configuration-files)   | v20.03.0   | -
 Deprecated | [CLI plugins support](#cli-plugins-support)                                                                                        | v20.03.0   | -
 Deprecated | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03.0   | v20.03.0
 Removed    | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03.0   | v20.03.0
@@ -105,6 +106,22 @@ Standalone ("classic") Swarm has been deprecated, and with that the use of overl
 networks using an external key/value store. The corresponding`--cluster-advertise`,
 `--cluster-store`, and `--cluster-store-opt` daemon options have been marked
 deprecated, and will be disabled or removed in a future release.
+
+
+### Support for legacy `~/.dockercfg` configuration files
+
+**Deprecated in Release: v20.03.0**
+
+The docker CLI up until v1.7.0 used the `~/.dockercfg` file to store credentials
+after authenticating to a registry (`docker login`). Docker v1.7.0 replaced this
+file with a new CLI configuration file, located in `~/.docker/config.json`. When
+implementing the new configuration file, the old file (and file-format) was kept
+as a fall-back, to assist existing users with migrating to the new file.
+
+Given that the old file format encourages insecure storage of credentials
+(credentials are stored unencrypted), and that no version of the CLI since
+Docker v1.7.0 has created this file, the file is marked deprecated, and support
+for this file will be removed in a future release.
 
 ### CLI plugins support
 


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/2504

The docker CLI up until v1.7.0 used the `~/.dockercfg` file to store credentials
after authenticating to a registry (`docker login`). Docker v1.7.0 replaced this
file with a new CLI configuration file, located in `~/.docker/config.json`. When
implementing the new configuration file, the old file (and file-format) was kept
as a fall-back, to assist existing users with migrating to the new file.

Given that the old file format encourages insecure storage of credentials
(credentials are stored unencrypted), and that no version of the CLI since
Docker v1.7.0 has created this file, the file is marked deprecated, and support
for this file will be removed in a future release.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

