### PR TITLE
control network interface order for containers

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -804,6 +804,7 @@ func parseNetworkAttachmentOpt(ep opts.NetworkAttachmentOpts) (*networktypes.End
 			LinkLocalIPs: ep.LinkLocalIPs,
 		}
 	}
+	epConfig.Priority = ep.Priority
 	return epConfig, nil
 }
 

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -21,6 +21,7 @@ type connectOptions struct {
 	aliases      []string
 	linklocalips []string
 	driverOpts   []string
+	priority     int
 }
 
 func newConnectCommand(dockerCli command.Cli) *cobra.Command {
@@ -46,6 +47,7 @@ func newConnectCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringSliceVar(&options.aliases, "alias", []string{}, "Add network-scoped alias for the container")
 	flags.StringSliceVar(&options.linklocalips, "link-local-ip", []string{}, "Add a link-local address for the container")
 	flags.StringSliceVar(&options.driverOpts, "driver-opt", []string{}, "driver options for the network")
+	flags.IntVar(&options.priority, "priority", 0, "Set network priority (default 0)")
 	return cmd
 }
 
@@ -65,6 +67,7 @@ func runConnect(dockerCli command.Cli, options connectOptions) error {
 		Links:      options.links.GetAll(),
 		Aliases:    options.aliases,
 		DriverOpts: driverOpts,
+		Priority:   options.priority,
 	}
 
 	return client.NetworkConnect(context.Background(), options.network, options.container, epConfig)

--- a/opts/network.go
+++ b/opts/network.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -13,6 +14,7 @@ const (
 	networkOptIPv4Address = "ip"
 	networkOptIPv6Address = "ip6"
 	driverOpt             = "driver-opt"
+	networkPriority       = "priority"
 )
 
 // NetworkAttachmentOpts represents the network options for endpoint creation
@@ -24,6 +26,7 @@ type NetworkAttachmentOpts struct {
 	IPv4Address  string
 	IPv6Address  string
 	LinkLocalIPs []string // TODO add support for LinkLocalIPs in the csv notation of `--network` ?
+	Priority     int
 }
 
 // NetworkOpt represents a network config in swarm mode.
@@ -76,6 +79,12 @@ func (n *NetworkOpt) Set(value string) error {
 				} else {
 					return err
 				}
+			case networkPriority:
+				prior, err := strconv.Atoi(value)
+				if err != nil {
+					return fmt.Errorf("invalid priority value %s", value)
+				}
+				netOpt.Priority = prior
 			default:
 				return fmt.Errorf("invalid field key %s", key)
 			}


### PR DESCRIPTION
Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
libnetwork allows setting the priority of network interface, but I'm not sure why there's no api to support it. So, I made some changes to allow the user to control the network interface order for containers. 
related issue: [#25181](https://github.com/moby/moby/issues/25181)

Relevant PRs:
[moby/libnetwork#2550](https://github.com/moby/libnetwork/pull/2550) (open)
[moby/moby#40974](https://github.com/moby/moby/pull/40974) (open)

**- How I did it**
add some options for docker create, docker run, docker network connect. i.e.,

$ docker create --network name=my-network,**priority=1** mynginx
$ docker run --network name=my-network,**priority=2** mynginx
$ docker network connect **--priority 3** my-network my-container

priority deafult to 0, and the higher the value, the higher the priority of the network interface

**- How to verify it**

```
$ docker create --name t1 --network name=net1,priority=1 mynginx sleep 1000
$ docker network connect --priority 2 net2 t1
$ docker network connect --priority 3 net3 t1
$ docker start t1
```

network interface order: net3 > net2 > net1

```
$ docker exec t1 ifconfig  
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.20.0.2  netmask 255.255.0.0  broadcast 172.20.255.255  ---net3
		...
eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.19.0.3  netmask 255.255.0.0  broadcast 172.19.255.255  ---net2
		...
eth2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.18.0.3  netmask 255.255.0.0  broadcast 172.18.255.255  ---net1
		...
```

or
	
```
$ docker run -d --name t1 --network name=net1,priority=1 mynginx:v1 sleep 1000
$ docker network connect --priority 2 net2 t1
$ docker network connect --priority 3 net3 t1
$ docker restart t1  (container restart required)

$docker exec t1 ifconfig
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.20.0.2  netmask 255.255.0.0  broadcast 172.20.255.255  ---net3
		...
eth1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.19.0.2  netmask 255.255.0.0  broadcast 172.19.255.255  ---net2
        ether 02:42:ac:13:00:02  txqueuelen 0  (Ethernet)
		...	
eth2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.18.0.2  netmask 255.255.0.0  broadcast 172.18.255.255  ---net1
        ether 02:42:ac:12:00:02  txqueuelen 0  (Ethernet)
		...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

