### PR TITLE
Fix version old engine master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,47 @@
-wrappedNode(label: 'linux && x86_64', cleanWorkspace: true) {
-  timeout(time: 60, unit: 'MINUTES') {
-    stage "Git Checkout"
-    checkout scm
+pipeline {
+    agent {
+        label "linux && x86_64"
+    }
 
-    stage "Docker info"
-    sh "docker version"
-    sh "docker info"
+    options {
+        timeout(time: 60, unit: 'MINUTES')
+    }
 
-    stage "e2e (non-experimental)"
-    sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
-        IMAGE_TAG=clie2e${BUILD_NUMBER} \
-        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
-
-    stage "e2e (experimental)"
-    sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
-        IMAGE_TAG=clie2e${BUILD_NUMBER} \
-        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-experimental"
-
-    stage "e2e (ssh connhelper)"
-    sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
-        IMAGE_TAG=clie2e${BUILD_NUMBER} \
-        DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-connhelper-ssh"
-  }
+    stages {
+        stage("Docker info") {
+            steps {
+                sh "docker version"
+                sh "docker info"
+            }
+        }
+        stage("e2e (non-experimental) - stable engine") {
+            steps {
+                sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+                    IMAGE_TAG=clie2e${BUILD_NUMBER} \
+                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
+            }
+        }
+        stage("e2e (non-experimental) - 18.09 engine") {
+            steps {
+                sh "E2E_ENGINE_VERSION=18.09-dind \
+                  E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+                  IMAGE_TAG=clie2e${BUILD_NUMBER} \
+                  DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
+            }
+        }
+        stage("e2e (experimental)") {
+            steps {
+                sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+                    IMAGE_TAG=clie2e${BUILD_NUMBER} \
+                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-experimental"
+            }
+        }
+        stage("e2e (ssh connhelper)") {
+            steps {
+                sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
+                    IMAGE_TAG=clie2e${BUILD_NUMBER} \
+                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-connhelper-ssh"
+            }
+        }
+    }
 }

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -9,7 +9,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/config"
@@ -136,12 +135,9 @@ func (cli *DockerCli) loadConfigFile() {
 	cli.configFile = cliconfig.LoadDefaultConfigFile(cli.err)
 }
 
-var fetchServerInfo sync.Once
-
 // ServerInfo returns the server version details for the host this client is
 // connected to
 func (cli *DockerCli) ServerInfo() ServerInfo {
-	fetchServerInfo.Do(cli.initializeFromClient)
 	return cli.serverInfo
 }
 
@@ -276,6 +272,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 			return err
 		}
 	}
+	cli.initializeFromClient()
 	return nil
 }
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -16,12 +16,13 @@ LINTER_IMAGE_NAME = docker-cli-lint$(IMAGE_TAG)
 CROSS_IMAGE_NAME = docker-cli-cross$(IMAGE_TAG)
 VALIDATE_IMAGE_NAME = docker-cli-shell-validate$(IMAGE_TAG)
 E2E_IMAGE_NAME = docker-cli-e2e$(IMAGE_TAG)
+E2E_ENGINE_VERSION ?=
 CACHE_VOLUME_NAME := docker-cli-dev-cache
 ifeq ($(DOCKER_CLI_GO_BUILD_CACHE),y)
 DOCKER_CLI_MOUNTS += -v "$(CACHE_VOLUME_NAME):/root/.cache/go-build"
 endif
 VERSION = $(shell cat VERSION)
-ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS -e GOOS -e GOARCH -e GOARM
+ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS -e GOOS -e GOARCH -e GOARM -e TEST_ENGINE_VERSION=$(E2E_ENGINE_VERSION)
 
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
@@ -149,7 +150,7 @@ test-e2e-experimental: build_e2e_image # run experimental e2e tests
 
 .PHONY: test-e2e-non-experimental
 test-e2e-non-experimental: build_e2e_image # run non-experimental e2e tests
-	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(ENVVARS) $(E2E_IMAGE_NAME)
+	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock $(ENVVARS) -e TEST_ENGINE_VERSION=$(E2E_ENGINE_VERSION) $(E2E_IMAGE_NAME)
 
 .PHONY: test-e2e-connhelper-ssh
 test-e2e-connhelper-ssh: build_e2e_image # run experimental SSH-connection helper e2e tests


### PR DESCRIPTION
Fixes #2533 

**- What I did**
[#cf663b5](https://github.com/docker/cli/commit/cf663b526a34f3e7911e6e60138138c2023aa844) introduced a regression when the CLI negotiates the API version with an old daemon. This PR reverts it partially and adds regression tests, running all e2e tests against `18.09` daemon.

**- Description for the changelog**
* Fix "Docker client version 19.03.09 doesn't automatically downgrade Docker API version correctly"

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/31478878/82359860-c4c6cc00-9a08-11ea-8bde-82613902e921.png)

