### PR TITLE
Pass empty kubeconfig path when loading default Kubernetes configuration

### DIFF
--- a/cli/command/context/options.go
+++ b/cli/command/context/options.go
@@ -2,8 +2,6 @@ package context
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -13,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/homedir"
 	"github.com/pkg/errors"
 )
 

--- a/cli/command/context/options.go
+++ b/cli/command/context/options.go
@@ -186,12 +186,7 @@ func getKubernetesEndpoint(dockerCli command.Cli, config map[string]string) (*ku
 			return &res, nil
 		}
 
-		// fallback to env-based kubeconfig
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			kubeconfig = filepath.Join(homedir.Get(), ".kube/config")
-		}
-		ep, err := kubernetes.FromKubeConfig(kubeconfig, "", "")
+		ep, err := kubernetes.FromKubeConfig("", "", "")
 		if err != nil {
 			return nil, err
 		}

--- a/cli/context/kubernetes/save.go
+++ b/cli/context/kubernetes/save.go
@@ -10,8 +10,13 @@ import (
 
 // FromKubeConfig creates a Kubernetes endpoint from a Kubeconfig file
 func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if kubeconfig != "" {
+		loadingRules = &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	}
+
 	cfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		loadingRules,
 		&clientcmd.ConfigOverrides{CurrentContext: kubeContext, Context: clientcmdapi.Context{Namespace: namespaceOverride}})
 	ns, _, err := cfg.Namespace()
 	if err != nil {

--- a/cli/context/kubernetes/save.go
+++ b/cli/context/kubernetes/save.go
@@ -56,6 +56,7 @@ func FromKubeConfig(kubeconfig, kubeContext, namespaceOverride string) (Endpoint
 			AuthProvider:     clientcfg.AuthProvider,
 			Exec:             clientcfg.ExecProvider,
 			UsernamePassword: usernamePassword,
+			Token:            clientcfg.BearerToken,
 		},
 		TLSData: tlsData,
 	}, nil


### PR DESCRIPTION
Previously, in-cluster configuration could not be used because the
ExplicitPath was always set in the `ClientConfigLoadingRules`.

If `ExplicitPath` is not set, `ClientConfigLoadingRules` will look up
all of the standard environment variables to find the kubeconfig file,
including supporting in cluster authentication.

We leave the `kubeconfig` parameter on `FromKubeConfig` to support
explicitly setting the path and also to not change the signature.

This will fix docker/buildx#256 once the docker/cli dependency is
updated.

Signed-off-by: jbarrick@mesosphere.com <jbarrick@mesosphere.com>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Added support for in-cluster Kubernetes authentication for Kubernetes contexts.