### PR TITLE
Fixes #2543: bug with panic when DOCKER_CLI_EXPERIMENTAL is incorrect

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -144,7 +144,9 @@ func (cli *DockerCli) ServerInfo() ServerInfo {
 // ClientInfo returns the client details for the cli
 func (cli *DockerCli) ClientInfo() ClientInfo {
 	if cli.clientInfo == nil {
-		_ = cli.loadClientInfo()
+		if err := cli.loadClientInfo(); err != nil {
+			panic(err)
+		}
 	}
 	return *cli.clientInfo
 }
@@ -273,6 +275,11 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		}
 	}
 	cli.initializeFromClient()
+
+	if err := cli.loadClientInfo(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I've fixed the bug described in #2543.

**- How I did it**

1. I've added a check in cli initialization.
2. I've added `panic(err)` in the place which caused panic before. It will help to find similar problems easier in the future.

**- How to verify it**

The steps are described in the issue. You can see that after my commit everything works as expected.

**- Description for the changelog**

Fixed bug with panic when DOCKER_CLI_EXPERIMENTAL is set to incorrect value.

