### PR TITLE
docs: fix broken link in dockerd.md

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -124,7 +124,7 @@ the `daemon.json` file.
 
 ### Daemon socket option
 
-The Docker daemon can listen for [Docker Engine API](../api/)
+The Docker daemon can listen for [Docker Engine API](https://docs.docker.com/engine/api/)
 requests via three different types of Socket: `unix`, `tcp`, and `fd`.
 
 By default, a `unix` domain socket (or IPC socket) is created at


### PR DESCRIPTION
The Engine API docs are not available in this GitHub repository, so linking to the docs.docker.com website instead.


addresses https://github.com/docker/docker.github.io/issues/10846