### PR TITLE
[19.03 backport] docs: fix broken link in dockerd.md

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -121,7 +121,7 @@ the `daemon.json` file.
 
 ### Daemon socket option
 
-The Docker daemon can listen for [Docker Engine API](../api/)
+The Docker daemon can listen for [Docker Engine API](https://docs.docker.com/engine/api/)
 requests via three different types of Socket: `unix`, `tcp`, and `fd`.
 
 By default, a `unix` domain socket (or IPC socket) is created at


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2547
fixes https://github.com/docker/docker.github.io/issues/10846

The Engine API docs are not available in this GitHub repository, so linking to the docs.docker.com website instead.
