### PR TITLE
Added `CreatedSince`, corrected `RunningFor` psFormat placeholders

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -14,11 +14,11 @@ import (
 )
 
 const (
-	defaultContainerTableFormat = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
+	defaultContainerTableFormat = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedSince}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
 
 	namesHeader      = "NAMES"
 	commandHeader    = "COMMAND"
-	runningForHeader = "CREATED"
+	runningForHeader = "RUNNING"
 	mountsHeader     = "MOUNTS"
 	localVolumes     = "LOCAL VOLUMES"
 	networksHeader   = "NETWORKS"
@@ -94,6 +94,7 @@ func NewContainerContext() *ContainerContext {
 		"Image":        ImageHeader,
 		"Command":      commandHeader,
 		"CreatedAt":    CreatedAtHeader,
+		"CreatedSince": CreatedSinceHeader,
 		"RunningFor":   runningForHeader,
 		"Ports":        PortsHeader,
 		"State":        StateHeader,
@@ -181,14 +182,24 @@ func (c *ContainerContext) CreatedAt() string {
 	return time.Unix(c.c.Created, 0).String()
 }
 
-// RunningFor returns a human-readable representation of the duration for which
-// the container has been running.
+// CreatedSince returns a human-readable representation of the duration since the
+// container has been created.
 //
 // Note that this duration is calculated on the client, and as such is influenced
 // by clock skew between the client and the daemon.
-func (c *ContainerContext) RunningFor() string {
+func (c *ContainerContext) CreatedSince() string {
 	createdAt := time.Unix(c.c.Created, 0)
 	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
+}
+
+// RunningFor returns a human-readable representation of the duration for which
+// the container has been running.
+func (c *ContainerContext) RunningFor() string {
+	if !strings.HasPrefix(c.c.Status, "Up") {
+		return ""
+	}
+
+	return strings.TrimPrefix(c.c.Status, "Up ")
 }
 
 // Ports returns a comma-separated string representing open ports of the container

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -399,22 +399,23 @@ template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder   | Description                                                                                     |
-|:--------------|:------------------------------------------------------------------------------------------------|
-| `.ID`         | Container ID                                                                                    |
-| `.Image`      | Image ID                                                                                        |
-| `.Command`    | Quoted command                                                                                  |
-| `.CreatedAt`  | Time when the container was created.                                                            |
-| `.RunningFor` | Elapsed time since the container was started.                                                   |
-| `.Ports`      | Exposed ports.                                                                                  |
-| `.State`      | Container status (for example; "created", "running", "exited").                                 |
-| `.Status`     | Container status with details about duration and health-status.                                 |
-| `.Size`       | Container disk size.                                                                            |
-| `.Names`      | Container names.                                                                                |
-| `.Labels`     | All labels assigned to the container.                                                           |
-| `.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
-| `.Mounts`     | Names of the volumes mounted in this container.                                                 |
-| `.Networks`   | Names of the networks attached to this container.                                               |
+| Placeholder     | Description                                                                                     |
+|:----------------|:------------------------------------------------------------------------------------------------|
+| `.ID`           | Container ID                                                                                    |
+| `.Image`        | Image ID                                                                                        |
+| `.Command`      | Quoted command                                                                                  |
+| `.CreatedAt`    | Time when the container was created.                                                            |
+| `.CreatedSince` | Elapsed time since the container was created.                                                   |
+| `.RunningFor`   | Elapsed time since the container was last started.                                              |
+| `.Ports`        | Exposed ports.                                                                                  |
+| `.State`        | Container status (for example; "created", "running", "exited").                                 |
+| `.Status`       | Container status with details about duration and health-status.                                 |
+| `.Size`         | Container disk size.                                                                            |
+| `.Names`        | Container names.                                                                                |
+| `.Labels`       | All labels assigned to the container.                                                           |
+| `.Label`        | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
+| `.Mounts`       | Names of the volumes mounted in this container.                                                 |
+| `.Networks`     | Names of the networks attached to this container.                                               |
 
 When using the `--format` option, the `ps` command will either output the data
 exactly as the template declares or, when using the `table` directive, includes


### PR DESCRIPTION
Signed-off-by: Zakhary Kaplan <zakharykaplan@gmail.com>

**- What I did**

Renamed the ps format placeholder `RunningFor`  to `CreatedSince` to be consistent with the images format of the same name. This is in line with the old table header `CREATED` for which `RunningFor` was a confusing placeholder name.

In order to keep `RunningFor`, this functionality has been reimplemented using the `Status` string as a base. If a container is running, the `RunningFor` format placeholder will show how long it has been running for, as the documentation suggests. While this means that any information from `RunningFor` can be seen using `Status`, I nevertheless think it has utility for 2 reasons:

- `Status` has a different width depending on whether it is up the form `Up 10 minutes` or `Exited (1) About an hour ago`. Because of this the space it takes up in the table is unpredictable.
- Users may want the functionality to simply know how long a container was running, which is more modular than `Status`, which gives a general picture of the container's current state.

The new behaviour is consistent with other placeholders in that it returns an empty string if there is no relevant data (see `Ports` as an example).

In order to keep the old behaviour of `docker ps` without `--format`, the `defaultContainerTableFormat` has been updated to use `CreatedSince`.

I have also updated the docs to reflect these changes.

**- How I did it**

- Renamed the function `RunningFor()` to `CreatedSince()`
- Added a new function `RunningFor()` which checks if `Status` has the prefix `"Up"` (as an indicator the container is running) and trims it appropriately. Note that I elected to use `strings.HasPrefix` instead of checking the state, as this is more general.
- Updated `defaultContainerTableFormat` to use `{{.CreatedSince}}`

**- How to verify it**

```sh
docker ps --format "table {{.CreatedSince}}\t{{.RunningFor}}"
```

**- Description for the changelog**

Renamed ps format placeholder `RunningFor` to `CreatedSince`, implemented new behaviour for `RunningFor` consistent with docs.

**- A picture of a cute animal (not mandatory but encouraged)**

![helix](https://user-images.githubusercontent.com/50176264/82979747-dafafc00-9fb5-11ea-9862-dd27306fca64.jpeg)
