### PR TITLE
Platform on create

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type fakeClient struct {
@@ -18,6 +19,7 @@ type fakeClient struct {
 	createContainerFunc func(config *container.Config,
 		hostConfig *container.HostConfig,
 		networkingConfig *network.NetworkingConfig,
+		platform *specs.Platform,
 		containerName string) (container.ContainerCreateCreatedBody, error)
 	containerStartFunc      func(container string, options types.ContainerStartOptions) error
 	imageCreateFunc         func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
@@ -69,10 +71,11 @@ func (f *fakeClient) ContainerCreate(
 	config *container.Config,
 	hostConfig *container.HostConfig,
 	networkingConfig *network.NetworkingConfig,
+	platform *specs.Platform,
 	containerName string,
 ) (container.ContainerCreateCreatedBody, error) {
 	if f.createContainerFunc != nil {
-		return f.createContainerFunc(config, hostConfig, networkingConfig, containerName)
+		return f.createContainerFunc(config, hostConfig, networkingConfig, platform, containerName)
 	}
 	return container.ContainerCreateCreatedBody{}, nil
 }

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/google/go-cmp/cmp"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/fs"
@@ -116,6 +117,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 				config *container.Config,
 				hostConfig *container.HostConfig,
 				networkingConfig *network.NetworkingConfig,
+				platform *specs.Platform,
 				containerName string,
 			) (container.ContainerCreateCreatedBody, error) {
 				defer func() { c.ResponseCounter++ }()
@@ -184,6 +186,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 			createContainerFunc: func(config *container.Config,
 				hostConfig *container.HostConfig,
 				networkingConfig *network.NetworkingConfig,
+				platform *specs.Platform,
 				containerName string,
 			) (container.ContainerCreateCreatedBody, error) {
 				return container.ContainerCreateCreatedBody{}, fmt.Errorf("shouldn't try to pull image")
@@ -244,6 +247,7 @@ func TestNewCreateCommandWithWarnings(t *testing.T) {
 				createContainerFunc: func(config *container.Config,
 					hostConfig *container.HostConfig,
 					networkingConfig *network.NetworkingConfig,
+					platform *specs.Platform,
 					containerName string,
 				) (container.ContainerCreateCreatedBody, error) {
 					return container.ContainerCreateCreatedBody{}, nil
@@ -280,6 +284,7 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 		createContainerFunc: func(config *container.Config,
 			hostConfig *container.HostConfig,
 			networkingConfig *network.NetworkingConfig,
+			platform *specs.Platform,
 			containerName string,
 		) (container.ContainerCreateCreatedBody, error) {
 			sort.Strings(config.Env)

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/docker/cli/internal/test/notary"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestRunLabel(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
-		createContainerFunc: func(_ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ string) (container.ContainerCreateCreatedBody, error) {
+		createContainerFunc: func(_ *container.Config, _ *container.HostConfig, _ *network.NetworkingConfig, _ *specs.Platform, _ string) (container.ContainerCreateCreatedBody, error) {
 			return container.ContainerCreateCreatedBody{
 				ID: "id",
 			}, nil
@@ -58,6 +59,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 			createContainerFunc: func(config *container.Config,
 				hostConfig *container.HostConfig,
 				networkingConfig *network.NetworkingConfig,
+				platform *specs.Platform,
 				containerName string,
 			) (container.ContainerCreateCreatedBody, error) {
 				return container.ContainerCreateCreatedBody{}, fmt.Errorf("shouldn't try to pull image")

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/creack/pty                               3a6a957789163cacdfe0e291617a
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            c3b3aedfa4ad51de0a2ebfd08a716f585390b512
+github.com/docker/docker                            41ac6bef8d449b3064ad1378a28d95c79c4b9350
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor/github.com/docker/docker/api/types/configs.go
+++ b/vendor/github.com/docker/docker/api/types/configs.go
@@ -3,6 +3,7 @@ package types // import "github.com/docker/docker/api/types"
 import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // configs holds structs used for internal communication between the
@@ -15,6 +16,7 @@ type ContainerCreateConfig struct {
 	Config           *container.Config
 	HostConfig       *container.HostConfig
 	NetworkingConfig *network.NetworkingConfig
+	Platform         *specs.Platform
 	AdjustCPUShares  bool
 }
 

--- a/vendor/github.com/docker/docker/api/types/container/container_top.go
+++ b/vendor/github.com/docker/docker/api/types/container/container_top.go
@@ -10,7 +10,9 @@ package container // import "github.com/docker/docker/api/types/container"
 // swagger:model ContainerTopOKBody
 type ContainerTopOKBody struct {
 
-	// Each process running in the container, where each is process is an array of values corresponding to the titles
+	// Each process running in the container, where each is process
+	// is an array of values corresponding to the titles.
+	//
 	// Required: true
 	Processes [][]string `json:"Processes"`
 

--- a/vendor/github.com/docker/docker/api/types/volume.go
+++ b/vendor/github.com/docker/docker/api/types/volume.go
@@ -27,10 +27,13 @@ type Volume struct {
 	Name string `json:"Name"`
 
 	// The driver specific options used when creating the volume.
+	//
 	// Required: true
 	Options map[string]string `json:"Options"`
 
-	// The level at which the volume exists. Either `global` for cluster-wide, or `local` for machine level.
+	// The level at which the volume exists. Either `global` for cluster-wide,
+	// or `local` for machine level.
+	//
 	// Required: true
 	Scope string `json:"Scope"`
 

--- a/vendor/github.com/docker/docker/api/types/volume/volume_create.go
+++ b/vendor/github.com/docker/docker/api/types/volume/volume_create.go
@@ -14,7 +14,9 @@ type VolumeCreateBody struct {
 	// Required: true
 	Driver string `json:"Driver"`
 
-	// A mapping of driver options and values. These options are passed directly to the driver and are driver specific.
+	// A mapping of driver options and values. These options are
+	// passed directly to the driver and are driver specific.
+	//
 	// Required: true
 	DriverOpts map[string]string `json:"DriverOpts"`
 
@@ -23,6 +25,7 @@ type VolumeCreateBody struct {
 	Labels map[string]string `json:"Labels"`
 
 	// The new volume's name. If not specified, Docker generates a name.
+	//
 	// Required: true
 	Name string `json:"Name"`
 }

--- a/vendor/github.com/docker/docker/api/types/volume/volume_list.go
+++ b/vendor/github.com/docker/docker/api/types/volume/volume_list.go
@@ -16,7 +16,8 @@ type VolumeListOKBody struct {
 	// Required: true
 	Volumes []*types.Volume `json:"Volumes"`
 
-	// Warnings that occurred when fetching the list of volumes
+	// Warnings that occurred when fetching the list of volumes.
+	//
 	// Required: true
 	Warnings []string `json:"Warnings"`
 }

--- a/vendor/github.com/docker/docker/client/errors.go
+++ b/vendor/github.com/docker/docker/client/errors.go
@@ -24,8 +24,7 @@ func (err errConnectionFailed) Error() string {
 
 // IsErrConnectionFailed returns true if the error is caused by connection failed.
 func IsErrConnectionFailed(err error) bool {
-	_, ok := errors.Cause(err).(errConnectionFailed)
-	return ok
+	return errors.As(err, &errConnectionFailed{})
 }
 
 // ErrorConnectionFailed returns an error with host in the error message when connection to docker daemon failed.
@@ -42,8 +41,9 @@ type notFound interface {
 // IsErrNotFound returns true if the error is a NotFound error, which is returned
 // by the API when some object is not found.
 func IsErrNotFound(err error) bool {
-	if _, ok := err.(notFound); ok {
-		return ok
+	var e notFound
+	if errors.As(err, &e) {
+		return true
 	}
 	return errdefs.IsNotFound(err)
 }

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	volumetypes "github.com/docker/docker/api/types/volume"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // CommonAPIClient is the common methods between stable and experimental versions of APIClient.
@@ -47,7 +48,7 @@ type CommonAPIClient interface {
 type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.IDResponse, error)
-	ContainerCreate(ctx context.Context, config *containertypes.Config, hostConfig *containertypes.HostConfig, networkingConfig *networktypes.NetworkingConfig, containerName string) (containertypes.ContainerCreateCreatedBody, error)
+	ContainerCreate(ctx context.Context, config *containertypes.Config, hostConfig *containertypes.HostConfig, networkingConfig *networktypes.NetworkingConfig, platform *specs.Platform, containerName string) (containertypes.ContainerCreateCreatedBody, error)
 	ContainerDiff(ctx context.Context, container string) ([]containertypes.ContainerChangeResponseItem, error)
 	ContainerExecAttach(ctx context.Context, execID string, config types.ExecStartCheck) (types.HijackedResponse, error)
 	ContainerExecCreate(ctx context.Context, container string, config types.ExecConfig) (types.IDResponse, error)

--- a/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive_linux.go
@@ -152,7 +152,9 @@ func mknodChar0Overlay(cleansedOriginalPath string) error {
 	if err := ioutil.WriteFile(lowerDummy, []byte{}, 0600); err != nil {
 		return errors.Wrapf(err, "failed to create a dummy lower file %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
 		return err
 	}
@@ -236,7 +238,9 @@ func createDirWithOverlayOpaque(tmp string) (string, error) {
 	if err := os.MkdirAll(lowerDummy, 0700); err != nil {
 		return "", errors.Wrapf(err, "failed to create a dummy lower directory %s", lowerDummy)
 	}
-	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower, upper, work)
+	// lowerdir needs ":" to be escaped: https://github.com/moby/moby/issues/40939#issuecomment-627098286
+	lowerEscaped := strings.ReplaceAll(lower, ":", "\\:")
+	mOpts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerEscaped, upper, work)
 	if err := mount.Mount("overlay", merged, "overlay", mOpts); err != nil {
 		return "", err
 	}

--- a/vendor/github.com/docker/docker/pkg/idtools/idtools.go
+++ b/vendor/github.com/docker/docker/pkg/idtools/idtools.go
@@ -236,10 +236,6 @@ func parseSubidFile(path, username string) (ranges, error) {
 
 	s := bufio.NewScanner(subidFile)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return rangeList, err
-		}
-
 		text := strings.TrimSpace(s.Text())
 		if text == "" || strings.HasPrefix(text, "#") {
 			continue
@@ -260,5 +256,6 @@ func parseSubidFile(path, username string) (ranges, error) {
 			rangeList = append(rangeList, subIDRange{startid, length})
 		}
 	}
-	return rangeList, nil
+
+	return rangeList, s.Err()
 }

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -113,6 +113,7 @@ func HasWin32KSupport() bool {
 	return ntuserApiset.Load() == nil
 }
 
+// Deprecated: use golang.org/x/sys/windows.SetNamedSecurityInfo()
 func SetNamedSecurityInfo(objectName *uint16, objectType uint32, securityInformation uint32, sidOwner *windows.SID, sidGroup *windows.SID, dacl *byte, sacl *byte) (result error) {
 	r0, _, _ := syscall.Syscall9(procSetNamedSecurityInfo.Addr(), 7, uintptr(unsafe.Pointer(objectName)), uintptr(objectType), uintptr(securityInformation), uintptr(unsafe.Pointer(sidOwner)), uintptr(unsafe.Pointer(sidGroup)), uintptr(unsafe.Pointer(dacl)), uintptr(unsafe.Pointer(sacl)), 0, 0)
 	if r0 != 0 {
@@ -121,6 +122,7 @@ func SetNamedSecurityInfo(objectName *uint16, objectType uint32, securityInforma
 	return
 }
 
+// Deprecated: uses golang.org/x/sys/windows.SecurityDescriptorFromString() and golang.org/x/sys/windows.SECURITY_DESCRIPTOR.DACL()
 func GetSecurityDescriptorDacl(securityDescriptor *byte, daclPresent *uint32, dacl **byte, daclDefaulted *uint32) (result error) {
 	r1, _, e1 := syscall.Syscall6(procGetSecurityDescriptorDacl.Addr(), 4, uintptr(unsafe.Pointer(securityDescriptor)), uintptr(unsafe.Pointer(daclPresent)), uintptr(unsafe.Pointer(dacl)), uintptr(unsafe.Pointer(daclDefaulted)), 0, 0)
 	if r1 == 0 {

--- a/vendor/github.com/docker/docker/registry/config_unix.go
+++ b/vendor/github.com/docker/docker/registry/config_unix.go
@@ -2,10 +2,25 @@
 
 package registry // import "github.com/docker/docker/registry"
 
-var (
-	// CertsDir is the directory where certificates are stored
-	CertsDir = "/etc/docker/certs.d"
+import (
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/docker/rootless"
 )
+
+// CertsDir is the directory where certificates are stored
+func CertsDir() string {
+	d := "/etc/docker/certs.d"
+
+	if rootless.RunningWithRootlessKit() {
+		configHome, err := homedir.GetConfigHome()
+		if err == nil {
+			d = filepath.Join(configHome, "docker/certs.d")
+		}
+	}
+	return d
+}
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as

--- a/vendor/github.com/docker/docker/registry/config_windows.go
+++ b/vendor/github.com/docker/docker/registry/config_windows.go
@@ -7,7 +7,9 @@ import (
 )
 
 // CertsDir is the directory where certificates are stored
-var CertsDir = os.Getenv("programdata") + `\docker\certs.d`
+func CertsDir() string {
+	return os.Getenv("programdata") + `\docker\certs.d`
+}
 
 // cleanPath is used to ensure that a directory name is valid on the target
 // platform. It will be passed in something *similar* to a URL such as

--- a/vendor/github.com/docker/docker/registry/registry.go
+++ b/vendor/github.com/docker/docker/registry/registry.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/docker/pkg/homedir"
-	"github.com/docker/docker/rootless"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
@@ -28,16 +26,7 @@ var (
 
 // HostCertsDir returns the config directory for a specific host
 func HostCertsDir(hostname string) (string, error) {
-	certsDir := CertsDir
-
-	if rootless.RunningWithRootlessKit() {
-		configHome, err := homedir.GetConfigHome()
-		if err != nil {
-			return "", err
-		}
-
-		certsDir = filepath.Join(configHome, "docker/certs.d")
-	}
+	certsDir := CertsDir()
 
 	hostDir := filepath.Join(certsDir, cleanPath(hostname))
 
@@ -50,7 +39,7 @@ func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
 
 	tlsConfig.InsecureSkipVerify = !isSecure
 
-	if isSecure && CertsDir != "" {
+	if isSecure && CertsDir() != "" {
 		hostDir, err := HostCertsDir(hostname)
 		if err != nil {
 			return nil, err

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,20 +1,20 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        b3f49c06ffaeef24d09c6c08ec8ec8425a0303e2 # v0.8.7
+github.com/Microsoft/hcsshim                        5bc557dd210ff2caf615e6e22d398123de77fc11 # v0.8.9
 github.com/Microsoft/go-winio                       6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921
 github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
-github.com/gorilla/mux                              00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15 # v1.7.3
+github.com/gorilla/mux                              75dcda0896e109a2a22c9315bca3bb21b87b2ba5 # v1.7.4
 github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
-github.com/moby/term                                063f2cd0b49dbb0752774d1cb649998d91424fea
+github.com/moby/term                                73f35e472e8f0a3f91347164138ce6bd73b756a9
 
 github.com/creack/pty                               3a6a957789163cacdfe0e291617a1c8e80612c11 # v1.1.9
-github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
 github.com/mattn/go-shellwords                      36a9b3c57cb5caa559ff63fb7e9b585f1c00df75 # v1.0.6
-github.com/sirupsen/logrus                          839c75faf7f98a33d445d181f3018b5c3409a45e # v1.4.2
+github.com/sirupsen/logrus                          60c74ad9be0d874af0ab0daef6ab07c5c5911f0d # v1.6.0
 github.com/tchap/go-patricia                        a7f0089c6f496e8e70402f61733606daa326cac5 # v2.3.0
 golang.org/x/net                                    0de0cce0169b09b364e001f108dc0399ea8630b3
-golang.org/x/sys                                    d5e6a3e2c0ae16fc7480523ebcb7fd4dd3215489
+golang.org/x/sys                                    85ca7c5b95cdf1e557abb38a283d1e61a5959c31
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 github.com/moby/sys                                 6154f11e6840c0d6b0dbb23f4125a6134b3013c9 # mountinfo/v0.1.3
@@ -84,15 +84,16 @@ google.golang.org/grpc                              f495f5b15ae7ccda3b38c53a1bfc
 # This commit does not need to match RUNC_COMMIT as it is used for helper
 # packages but should be newer or equal.
 github.com/opencontainers/runc                      dc9208a3303feef5b3839f4323d9beb36df0a9dd # v1.0.0-rc10
-github.com/opencontainers/runtime-spec              29686dbc5559d93fb1ef402eeda3e35c38d75af4 # v1.0.1-59-g29686db
+github.com/opencontainers/runtime-spec              c4ee7d12c742ffe806cd9350b6af3b4b19faed6f # v1.0.2
 github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
 github.com/seccomp/libseccomp-golang                689e3c1541a84461afc49c1c87352a6cedf72e9c # v0.9.1
+
+# go-systemd v17 is required by github.com/coreos/pkg/capnslog/journald_formatter.go
+github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
 
 # systemd integration (journald, daemon/listeners, containerd/cgroups)
 github.com/coreos/go-systemd/v22                    2d78030078ef61b3cae27f42ad6d0e46db51b339 # v22.0.0
 github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e3a87dc201472 # v5.0.3
-# go-systemd v17 is required by github.com/coreos/pkg/capnslog/journald_formatter.go
-github.com/coreos/go-systemd                        39ca1b05acc7ad1220e09f133283b8859a8b71ab # v17
 
 # gelf logging driver deps
 github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch
@@ -125,10 +126,10 @@ github.com/containerd/containerd                    4d242818bf55542e5d7876ca276f
 github.com/containerd/fifo                          ff969a566b00877c63489baf6e8c35d60af6142c
 github.com/containerd/continuity                    26c1120b8d4107d2471b93ad78ef7ce1fc84c4c4
 github.com/containerd/cgroups                       44306b6a1d46985d916b48b4199f93a378af314f
-github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6
+github.com/containerd/console                       8375c3424e4d7b114e8a90a4a40c8e1b40d1d4e6 # v1.0.0
 github.com/containerd/go-runc                       7016d3ce2328dd2cb1192b2076ebd565c4e8df0c
-github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0
-github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398
+github.com/containerd/typeurl                       b45ef1f1f737e10bd45b25b669df25f0da8b9ba0 # v1.0.0-13-gb45ef1f
+github.com/containerd/ttrpc                         0be804eadb152bc3b3c20c5edc314c4633833398 # v1.0.0-16-g0be804e
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 github.com/cilium/ebpf                              60c3aa43f488292fe2ee50fb8b833b383ca8ebbb
 
@@ -159,14 +160,24 @@ github.com/grpc-ecosystem/go-grpc-prometheus        c225b8c3b01faf2899099b768856
 github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 
 # cli
-github.com/spf13/cobra                              ef82de70bb3f60c65fb8eebacbb2d122ef517385 # v0.0.3
-github.com/spf13/pflag                              583c0c0531f06d5278b7d917446061adc344b5cd # v1.0.1
+github.com/spf13/cobra                              a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d # v1.0.0
+github.com/spf13/pflag                              2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab # v1.0.5
 github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0.0
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b # v1.0.0
 
 # metrics
 github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a7e6ff905973c # v0.0.1
 
-github.com/opencontainers/selinux                   31f70552238c5e017d78c3f1ba65e85f593f48e0 # v1.3.3
+github.com/opencontainers/selinux                   0d49ba2a6aae052c614dfe5de62a158711a6c461 # v1.5.1
+
+
+# archive/tar
+# rm -rf vendor/archive
+# mkdir -p ./vendor/archive
+# git clone -b go$GOLANG_VERSION --depth=1 git://github.com/golang/go.git ./go
+# git --git-dir ./go/.git --work-tree ./go am ../patches/0001-archive-tar-do-not-populate-user-group-names.patch
+# cp -a go/src/archive/tar ./vendor/archive/tar
+# rm -rf ./go
+# vndr -whitelist=^archive/tar
 
 # DO NOT EDIT BELOW THIS LINE -------- reserved for downstream projects --------


### PR DESCRIPTION
**- What I did**
    Set platform on container create API.
    
    Previously we only set the platform when performing a pull, which is
    only initiated if pull always is set, or if the image reference does not
    exist in the daemon.
    
    The daemon now supports specifying which platform you wanted on
    container create so it can validate the image reference is the platform
    you thought you were getting.

**- How I did it**
Propagate platform to the container create API

**- How to verify it**

Run engine master with DOCKER_API_VERSION=1.41

```
docker run --platform=linux/armhf busybox
docker run busybox
```

Before this change:
The 2nd run would run an armhf image somewhat unexpectedly.

After this change:
The 2nd run will do a new pull to get the host native arch (ie linux/amd64).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Propagate platform flag to container create API

**- A picture of a cute animal (not mandatory but encouraged)**

![imgpsh_mobile_save](https://user-images.githubusercontent.com/799078/83064315-70c67380-a016-11ea-92f8-417d978f1510.jpg)

