### PR TITLE
[19.03 backport] docs/extend: fix broken link and some markdown touch-ups

### DIFF
--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -34,11 +34,11 @@ Config provides the base accessible fields for working with V0 plugin format
 
 - **`description`** *string*
 
-	description of the plugin
+    description of the plugin
 
 - **`documentation`** *string*
 
-  	link to the documentation about the plugin
+    link to the documentation about the plugin
 
 - **`interface`** *PluginInterface*
 
@@ -96,7 +96,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`name`** *string*
 
-	  name of the mount.
+      name of the mount.
 
     - **`description`** *string*
 
@@ -104,11 +104,11 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`source`** *string*
 
-	  source of the mount.
+      source of the mount.
 
     - **`destination`** *string*
 
-	  destination of the mount.
+      destination of the mount.
 
     - **`type`** *string*
 
@@ -116,7 +116,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`options`** *string array*
 
-	  options of the mount.
+      options of the mount.
 
 - **`ipchost`** *boolean*
    Access to host ipc namespace.
@@ -135,7 +135,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`name`** *string*
 
-	  name of the env.
+      name of the env.
 
     - **`description`** *string*
 
@@ -143,7 +143,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`value`** *string*
 
-	  value of the env.
+      value of the env.
 
 - **`args`** *PluginArgs*
 
@@ -151,7 +151,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`name`** *string*
 
-	  name of the args.
+      name of the args.
 
     - **`description`** *string*
 
@@ -159,7 +159,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`value`** *string array*
 
-	  values of the args.
+      values of the args.
 
 - **`linux`** *PluginLinux*
 
@@ -169,7 +169,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
     - **`allowAllDevices`** *boolean*
 
-	   If `/dev` is bind mounted from the host, and allowAllDevices is set to true, the plugin will have `rwm` access to all devices on the host.
+       If `/dev` is bind mounted from the host, and allowAllDevices is set to true, the plugin will have `rwm` access to all devices on the host.
 
     - **`devices`** *PluginDevice array*
 
@@ -177,7 +177,7 @@ Config provides the base accessible fields for working with V0 plugin format
 
          - **`name`** *string*
 
-	       name of the device.
+           name of the device.
 
          - **`description`** *string*
 
@@ -193,45 +193,45 @@ Config provides the base accessible fields for working with V0 plugin format
 
 ```json
 {
-            "Args": {
-                "Description": "",
-                "Name": "",
-                "Settable": null,
-                "Value": null
-            },
-            "Description": "A sample volume plugin for Docker",
-            "Documentation": "https://docs.docker.com/engine/extend/plugins/",
-            "Entrypoint": [
-                "/usr/bin/sample-volume-plugin",
-                "/data"
-            ],
-            "Env": [
-                {
-                    "Description": "",
-                    "Name": "DEBUG",
-                    "Settable": [
-                        "value"
-                    ],
-                    "Value": "0"
-                }
-            ],
-            "Interface": {
-                "Socket": "plugin.sock",
-                "Types": [
-                    "docker.volumedriver/1.0"
-                ]
-            },
-            "Linux": {
-                "Capabilities": null,
-                "AllowAllDevices": false,
-                "Devices": null
-            },
-            "Mounts": null,
-            "Network": {
-                "Type": ""
-            },
-            "PropagatedMount": "/data",
-            "User": {},
-            "Workdir": ""
+  "Args": {
+    "Description": "",
+    "Name": "",
+    "Settable": null,
+    "Value": null
+  },
+  "Description": "A sample volume plugin for Docker",
+  "Documentation": "https://docs.docker.com/engine/extend/plugins/",
+  "Entrypoint": [
+    "/usr/bin/sample-volume-plugin",
+    "/data"
+  ],
+  "Env": [
+    {
+      "Description": "",
+      "Name": "DEBUG",
+      "Settable": [
+        "value"
+      ],
+      "Value": "0"
+    }
+  ],
+  "Interface": {
+    "Socket": "plugin.sock",
+    "Types": [
+      "docker.volumedriver/1.0"
+    ]
+  },
+  "Linux": {
+    "Capabilities": null,
+    "AllowAllDevices": false,
+    "Devices": null
+  },
+  "Mounts": null,
+  "Network": {
+    "Type": ""
+  },
+  "PropagatedMount": "/data",
+  "User": {},
+  "Workdir": ""
 }
 ```

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -42,14 +42,18 @@ Once running however, network driver plugins are used just like the built-in
 network drivers: by being mentioned as a driver in network-oriented Docker
 commands. For example,
 
-    $ docker network create --driver weave mynet
+```bash
+$ docker network create --driver weave mynet
+```
 
 Some network driver plugins are listed in [plugins](legacy_plugins.md)
 
 The `mynet` network is now owned by `weave`, so subsequent commands
 referring to that network will be sent to the plugin,
 
-    $ docker run --network=mynet busybox top
+```bash
+$ docker run --network=mynet busybox top
+```
 
 
 ## Find network plugins
@@ -61,8 +65,8 @@ or on the third party's site.
 
 ## Write a network plugin
 
-Network plugins implement the [Docker plugin
-API](plugin_api.md) and the network plugin protocol
+Network plugins implement the [Docker plugin API](plugin_api.md) and the network
+plugin protocol
 
 ## Network plugin protocol
 
@@ -74,5 +78,5 @@ documented as part of libnetwork:
 
 To interact with the Docker maintainers and other interested users, see the IRC channel `#docker-network`.
 
--  [Docker networks feature overview](https://docs.docker.com/engine/userguide/networking/)
--  The [LibNetwork](https://github.com/docker/libnetwork) project
+- [Docker networks feature overview](https://docs.docker.com/engine/userguide/networking/)
+- The [LibNetwork](https://github.com/docker/libnetwork) project


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2556
fixes https://github.com/docker/docker.github.io/issues/10917