### PR TITLE
[19.03] Fix bug with panic when DOCKER_CLI_EXPERIMENTAL environment variable is incorrect

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -148,7 +148,9 @@ func (cli *DockerCli) ServerInfo() ServerInfo {
 // ClientInfo returns the client details for the cli
 func (cli *DockerCli) ClientInfo() ClientInfo {
 	if cli.clientInfo == nil {
-		_ = cli.loadClientInfo()
+		if err := cli.loadClientInfo(); err != nil {
+			panic(err)
+		}
 	}
 	return *cli.clientInfo
 }
@@ -277,6 +279,11 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		}
 	}
 	cli.initializeFromClient()
+
+	if err := cli.loadClientInfo(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Daniil Nikolenko <qoo2p5@gmail.com>
(cherry picked from commit cb010db830a60f53ef1685d99612d23fde93bec9)
Signed-off-by: Tibor Vass <tibor@docker.com>

Backport of #2544 