### PR TITLE
[19.03 backport] Add support for docker push --quiet

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -14,6 +15,7 @@ import (
 type pushOptions struct {
 	remote    string
 	untrusted bool
+	quiet     bool
 }
 
 // NewPushCommand creates a new `docker push` command
@@ -31,7 +33,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
+	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 	command.AddTrustSigningFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
 
 	return cmd
@@ -66,5 +68,9 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	}
 
 	defer responseBody.Close()
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	if !opts.quiet {
+		return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	}
+	fmt.Fprintln(dockerCli.Out(), ref.String())
+	return nil
 }

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -49,23 +49,36 @@ func TestNewPushCommandErrors(t *testing.T) {
 
 func TestNewPushCommandSuccess(t *testing.T) {
 	testCases := []struct {
-		name string
-		args []string
+		name   string
+		args   []string
+		output string
 	}{
 		{
-			name: "simple",
+			name: "push",
 			args: []string{"image:tag"},
+		},
+		{
+			name: "push quiet",
+			args: []string{"--quiet", "image:tag"},
+			output: `docker.io/library/image:tag
+`,
 		},
 	}
 	for _, tc := range testCases {
-		cli := test.NewFakeCli(&fakeClient{
-			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), nil
-			},
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cli := test.NewFakeCli(&fakeClient{
+				imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
+					return ioutil.NopCloser(strings.NewReader("")), nil
+				},
+			})
+			cmd := NewPushCommand(cli)
+			cmd.SetOutput(cli.OutBuffer())
+			cmd.SetArgs(tc.args)
+			assert.NilError(t, cmd.Execute())
+			if tc.output != "" {
+				assert.Equal(t, tc.output, cli.OutBuffer().String())
+			}
 		})
-		cmd := NewPushCommand(cli)
-		cmd.SetOutput(ioutil.Discard)
-		cmd.SetArgs(tc.args)
-		assert.NilError(t, cmd.Execute())
 	}
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3136,7 +3136,7 @@ _docker_image_pull() {
 _docker_image_push() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--disable-content-trust=false --help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--disable-content-trust=false --help --quiet -q" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -14,6 +14,7 @@ Push an image or a repository to a registry
 Options:
       --disable-content-trust   Skip image signing (default true)
       --help                    Print usage
+  -q, --quiet                   Suppress verbose output
 ```
 
 ## Description


### PR DESCRIPTION
**- What I did**

backport of #2197 to 19.03

**- How I did it**

`cherry-pick`'d 756ab2fb

**- How to verify it**

n/a

**- Description for the changelog**

```
+ Add support for docker push --quiet
```

**- A picture of a cute animal (not mandatory but encouraged)**

![pranesh-ravi-IylENDSGRtg-unsplash](https://user-images.githubusercontent.com/10229505/84150782-515f2a00-aa9d-11ea-8601-b1310e0c4e72.jpg)

Photo by [Pranesh Ravi](https://unsplash.com/@praneshr) on [Unsplash](https://unsplash.com/photos/IylENDSGRtg)

Signed-off-by: Justyn Temme <justyntemme@gmail.com>
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>