### PR TITLE
[19.03 backport] Use consistent name for errors

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"runtime"
 	"strings"
 	"syscall"
@@ -280,9 +279,9 @@ func attachContainer(
 func reportError(stderr io.Writer, name string, str string, withHelp bool) {
 	str = strings.TrimSuffix(str, ".") + "."
 	if withHelp {
-		str += "\nSee '" + os.Args[0] + " " + name + " --help'."
+		str += "\nSee 'docker " + name + " --help'."
 	}
-	fmt.Fprintf(stderr, "%s: %s\n", os.Args[0], str)
+	fmt.Fprintln(stderr, "docker:", str)
 }
 
 // if container start fails with 'not found'/'no such' error, return 127


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2569

This prevents inconsistent errors when using a symlink, or when renaming
the binary;

Before this change;

    ln -s $(which docker) toto
    ./toto rune
    docker: 'rune' is not a docker command.

    ./toto run daslkjadslkjdaslkj
    Unable to find image 'adslkjadslakdsj:latest' locally
    ./toto: Error response from daemon: pull access denied for adslkjadslakdsj, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.

After this change:

    ln -s $(which docker) toto
    ./toto rune
    docker: 'rune' is not a docker command.

    ./toto run daslkjadslkjdaslkj
    Unable to find image 'adslkjadslakdsj:latest' locally
    docker: Error response from daemon: pull access denied for adslkjadslakdsj, repository does not exist or may require 'docker login': denied: requested access to the resource is den>

