### PR TITLE
[master forward-port] list state `ready` for filtering in stack_ps.md

### DIFF
--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -103,7 +103,7 @@ tz6j82jnwrx7        voting_db.1           postgres:9.4                          
 
 #### desired-state
 
-The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
+The `desired-state` filter can take the values `running`, `shutdown`, `ready` or `accepted`.
 
 ```bash
 $ docker stack ps -f "desired-state=running" voting


### PR DESCRIPTION
forward-port of https://github.com/docker/cli/pull/1550 to master, because that PR was merged directly in the 18.06 branch

