### PR TITLE
Don't loose additional metadata fields when read/writing contexts metadata

### DIFF
--- a/cli/command/context.go
+++ b/cli/command/context.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/docker/cli/cli/context/store"
@@ -8,8 +9,48 @@ import (
 
 // DockerContext is a typed representation of what we put in Context metadata
 type DockerContext struct {
-	Description       string       `json:",omitempty"`
-	StackOrchestrator Orchestrator `json:",omitempty"`
+	Description       string
+	StackOrchestrator Orchestrator
+	AdditionalFields  map[string]interface{}
+}
+
+// MarshalJSON implements custom JSON marshalling
+func (dc DockerContext) MarshalJSON() ([]byte, error) {
+	s := map[string]interface{}{}
+	if dc.Description != "" {
+		s["Description"] = dc.Description
+	}
+	if dc.StackOrchestrator != "" {
+		s["StackOrchestrator"] = dc.StackOrchestrator
+	}
+	if dc.AdditionalFields != nil {
+		for k, v := range dc.AdditionalFields {
+			s[k] = v
+		}
+	}
+	return json.Marshal(s)
+}
+
+// UnmarshalJSON implements custom JSON marshalling
+func (dc *DockerContext) UnmarshalJSON(payload []byte) error {
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		return err
+	}
+	for k, v := range data {
+		switch k {
+		case "Description":
+			dc.Description = v.(string)
+		case "StackOrchestrator":
+			dc.StackOrchestrator = Orchestrator(v.(string))
+		default:
+			if dc.AdditionalFields == nil {
+				dc.AdditionalFields = make(map[string]interface{})
+			}
+			dc.AdditionalFields[k] = v
+		}
+	}
+	return nil
 }
 
 // GetDockerContext extracts metadata from stored context metadata

--- a/cli/command/context_test.go
+++ b/cli/command/context_test.go
@@ -1,0 +1,27 @@
+package command
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestDockerContextMetadataKeepAdditionalFields(t *testing.T) {
+	c := DockerContext{
+		Description:       "test",
+		StackOrchestrator: OrchestratorSwarm,
+		AdditionalFields: map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	jsonBytes, err := json.Marshal(c)
+	assert.NilError(t, err)
+	assert.Equal(t, `{"Description":"test","StackOrchestrator":"swarm","foo":"bar"}`, string(jsonBytes))
+
+	var c2 DockerContext
+	assert.NilError(t, json.Unmarshal(jsonBytes, &c2))
+	assert.Equal(t, c2.AdditionalFields["foo"], "bar")
+	assert.Equal(t, c2.StackOrchestrator, OrchestratorSwarm)
+	assert.Equal(t, c2.Description, "test")
+}


### PR DESCRIPTION
**- What I did**

Make the cli accept additional (untyped) fields in its contexts metadata. Primary goal is to unlock interoperability with our Docker experience for Azure ACI work, which needs to add some metadata into docker contexts to work properly.

The fact that additional fields where not supported previously is actually a bug I introduced when introducing "typed endpoints and contexts metadata".

**- How I did it**

DockerContext struct now has a custom implementation of json.Marshaler and json.Unmarshaler, keeping addition fields in a map.

**- How to verify it**

- The PR comes with a synthetic test
- Create a context with `docker context create test --from=default`
- Modify the metadata file (`~/.docker/contexts/meta/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08/meta.json`) to add fields in the "metadata" object such as `{"Name":"test","Metadata":{"StackOrchestrator":"swarm","AdditionalKey":"Value"},"Endpoints":{"docker":{"Host":"unix:///var/run/docker.sock","SkipTLSVerify":false}}}`
- `docker context inspect test` with the modification should have the AdditionalKey field in its output.
- `docker context update test --description=foo` should not drop the AdditionalKey field anymore.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

