### PR TITLE
Defer error to first API call when config file references a missing context

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/docker/cli/cli/config"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
@@ -321,4 +322,21 @@ func TestInitializeShouldAlwaysCreateTheContextStore(t *testing.T) {
 		return client.NewClientWithOpts()
 	})))
 	assert.Check(t, cli.ContextStore() != nil)
+}
+
+func TestMissingContextFromConfigFileShouldDeferError(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	assert.NilError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	config.SetDir(tmpDir)
+	configFile := config.LoadDefaultConfigFile(ioutil.Discard)
+	configFile.CurrentContext = "missing"
+	assert.NilError(t, configFile.Save())
+
+	cli, err := NewDockerCli()
+	assert.NilError(t, err)
+	assert.NilError(t, cli.Initialize(flags.NewClientOptions()))
+	_, err = cli.client.Info(context.Background())
+	assert.ErrorContains(t, err, `Current context "missing" is not found on the file system`)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

~~Previously, when the "CurrentContext" field of the config file referenced a context that did not exist in the store, the CLI would fail (even for simple things like docker context ls).~~
~~This causes an issue with Docker Desktop "Contexts Syncing" feature (that uses the same store between win32 and WSL2):~~
~~If win32 cli removes the "current context" of the WSL 2 CLI (which it can do if it is not the "current context" in the win32 config file), it would make the WSL 2 CLI unusable, asking the user to modify the config file by hand.~~

When a user removes a context from the store without using the CLI (by removing the context directory directly in the store), it can trigger an issue where the CLI does not work at all (even for changing the current context) anymore without editing the config file by hand.

With Docker Desktop and WSL 2, we now link the wsl 2 distros context store to the windows one, so that a context created from Windows can be used in WSL 2 and vice-versa. However we keep the CLI config files independant (at least for now), so this issue can be triggered quite often.

This commit fixes that by changing the way we handle context missing error: if the resolved context name comes from the config file and refers a missing context, the error is reported when the API is actually called instead of at the CLI initialization. Thus, local-only commands continue to work (shuch as `context use`, `context ls`,...).

~~This commit relaxes this behavior a bit: explicitly referencing a missing context (using the --context flag or DOCKER_CONTEXT env var) will still produce an error, but implicitly referencing such a missing context (via the CurrentContext config field) will fallback to use the "default" context.~~

**- How I did it**

~~In the function resolving the current context name, instead of erroring with asking the user to modify its config file when the config file references a missing context, fallback to default~~

The function resolving the current context name does not error when the config file references a missing context. It returns a hint about the source of context name.

The check for a missing context is done in the CLI init code. If we find out that the context is missing and that the source of the selected context name is the config file, instead of failing, we initialize the api client with an always failing client (that reports the error during dialing). This allows to change the current context easily, without having to edit the config file by hand.

**- How to verify it**

~~Edit the config file, set CurrentConfig to a value that is not an existing context name, check that the CLI fallbacks to using "default".~~

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

