### PR TITLE
Remove 'images' alias from 'image ls' command

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -52,7 +52,7 @@ func NewImagesCommand(dockerCli command.Cli) *cobra.Command {
 
 func newListCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := *NewImagesCommand(dockerCli)
-	cmd.Aliases = []string{"images", "list"}
+	cmd.Aliases = []string{"list"}
 	cmd.Use = "ls [OPTIONS] [REPOSITORY[:TAG]]"
 	return &cmd
 }

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -92,7 +92,6 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 
 func TestNewListCommandAlias(t *testing.T) {
 	cmd := newListCommand(test.NewFakeCli(&fakeClient{}))
-	assert.Check(t, cmd.HasAlias("images"))
 	assert.Check(t, cmd.HasAlias("list"))
 	assert.Check(t, !cmd.HasAlias("other"))
 }


### PR DESCRIPTION
Signed-off-by: Dominik Braun <Dominik.Braun@nbsp.de>
Fixes: #2565 

**- What this is about**
In Issue #2565 it was found that `docker image images` is a confusing command that produces the same output as `docker image ls` or the `docker images` legacy command. @thaJeztah proposed that we [could produce an error if the command is called likes this](https://github.com/docker/cli/issues/2565#issuecomment-642616747):

> Perhaps we're able to check if the command is called as docker image ls or as docker images (top-level), and produce an error 🤔.

However, I found that the command `docker image images` is technically not the exact same command as `docker images` - it is merely an alias of `docker image ls` instead. I'm calling this 'not the exact same command' because `docker image ls` _is_ registered as an own cobra command, but nevertheless it is created using the same method as `docker images` is: `NewImagesCommand()`.

![image](https://user-images.githubusercontent.com/36575275/84602606-053f2b80-ae89-11ea-91b9-ccb15cf0b278.png)

Since `docker image ls` and `docker images` are two distinct command objects, IMO it is ok to just throw out the `images` alias for `ls`.

**- What I did**
Removed the alias.

**- How to verify it**
Run `docker image images` and note that it isn't a valid command anymore, while `docker images` still is.

**- Description for the changelog**
Remove 'images' alias from 'docker image ls' command

