### PR TITLE
config: remove redundant os.Stat()

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -95,11 +95,7 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	configFile := configfile.New(filename)
 
 	// Try happy path first - latest config file
-	if _, err := os.Stat(filename); err == nil {
-		file, err := os.Open(filename)
-		if err != nil {
-			return configFile, errors.Wrap(err, filename)
-		}
+	if file, err := os.Open(filename); err == nil {
 		defer file.Close()
 		err = configFile.LoadFromReader(file)
 		if err != nil {
@@ -113,22 +109,16 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 
 	// Can't find latest config file so check for the old one
-	homedir, err := os.UserHomeDir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return configFile, errors.Wrap(err, oldConfigfile)
 	}
-	filename = filepath.Join(homedir, oldConfigfile)
-	if _, err := os.Stat(filename); err != nil {
-		return configFile, nil // missing file is not an error
-	}
-	file, err := os.Open(filename)
-	if err != nil {
-		return configFile, errors.Wrap(err, filename)
-	}
-	defer file.Close()
-	err = configFile.LegacyLoadFromReader(file)
-	if err != nil {
-		return configFile, errors.Wrap(err, filename)
+	filename = filepath.Join(home, oldConfigfile)
+	if file, err := os.Open(filename); err == nil {
+		defer file.Close()
+		if err := configFile.LegacyLoadFromReader(file); err != nil {
+			return configFile, errors.Wrap(err, filename)
+		}
 	}
 	return configFile, nil
 }

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -385,6 +385,7 @@ func TestJSONWithCredentialHelpers(t *testing.T) {
 
 // Save it and make sure it shows up in new form
 func saveConfigAndValidateNewFormat(t *testing.T, config *configfile.ConfigFile, configDir string) string {
+	t.Helper()
 	assert.NilError(t, config.Save())
 
 	buf, err := ioutil.ReadFile(filepath.Join(configDir, ConfigFileName))


### PR DESCRIPTION
There's no need to perform an `os.Stat()` first, because `os.Open()` also returns the same errors if the file does not exist, or couldn't be opened for other reasons.

