### PR TITLE
docs: fix example output for docker plugin ls

### DIFF
--- a/docs/reference/commandline/plugin_create.md
+++ b/docs/reference/commandline/plugin_create.md
@@ -38,8 +38,8 @@ plugin
 
 $ docker plugin ls
 
-ID                  NAME                TAG                 DESCRIPTION                  ENABLED
-672d8144ec02        plugin              latest              A sample plugin for Docker   false
+ID              NAME            DESCRIPTION                  ENABLED
+672d8144ec02    plugin:latest   A sample plugin for Docker   false
 ```
 
 The plugin can subsequently be enabled for local use or pushed to the public registry.

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -30,8 +30,8 @@ and enabled:
 ```bash
 $ docker plugin ls
 
-ID                  NAME                             TAG                 DESCRIPTION                ENABLED
-69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+ID            NAME                                    DESCRIPTION                ENABLED
+69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
 To disable the plugin, use the following command:
@@ -43,8 +43,8 @@ tiborvass/sample-volume-plugin
 
 $ docker plugin ls
 
-ID                  NAME                             TAG                 DESCRIPTION                ENABLED
-69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   false
+ID            NAME                                    DESCRIPTION                ENABLED
+69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   false
 ```
 
 ## Related commands

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -29,8 +29,8 @@ but disabled:
 ```bash
 $ docker plugin ls
 
-ID                  NAME                             TAG                 DESCRIPTION                ENABLED
-69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   false
+ID            NAME                                    DESCRIPTION                ENABLED
+69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   false
 ```
 
 To enable the plugin, use the following command:
@@ -42,8 +42,8 @@ tiborvass/sample-volume-plugin
 
 $ docker plugin ls
 
-ID                  NAME                             TAG                 DESCRIPTION                ENABLED
-69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+ID            NAME                                    DESCRIPTION                ENABLED
+69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
 ## Related commands

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -49,8 +49,8 @@ After the plugin is installed, it appears in the list of plugins:
 ```bash
 $ docker plugin ls
 
-ID                  NAME                  TAG                 DESCRIPTION                ENABLED
-69553ca1d123        vieux/sshfs           latest              sshFS plugin for Docker    true
+ID             NAME                  DESCRIPTION                ENABLED
+69553ca1d123   vieux/sshfs:latest    sshFS plugin for Docker    true
 ```
 
 ## Related commands

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -34,8 +34,8 @@ Refer to the [filtering](#filtering) section for more information about availabl
 ```bash
 $ docker plugin ls
 
-ID                  NAME                             TAG                 DESCRIPTION                ENABLED
-69553ca1d123        tiborvass/sample-volume-plugin   latest              A test plugin for Docker   true
+ID            NAME                                    DESCRIPTION                ENABLED
+69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
 ### Filtering
@@ -65,7 +65,7 @@ Installed plugin vieux/sshfs
 
 $ docker plugin ls --filter enabled=true
 
-NAME                  TAG                 DESCRIPTION                ENABLED
+ID                  NAME                DESCRIPTION         ENABLED
 ```
 
 ### Formatting
@@ -78,7 +78,7 @@ Valid placeholders for the Go template are listed below:
 Placeholder        | Description
 -------------------|------------------------------------------------------------
 `.ID`              | Plugin ID
-`.Name`            | Plugin name
+`.Name`            | Plugin name and tag
 `.Description`     | Plugin description
 `.Enabled`         | Whether plugin is enabled or not
 `.PluginReference` | The reference used to push/pull from a registry

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -29,8 +29,8 @@ The following example shows how to push a sample `user/plugin`.
 ```bash
 $ docker plugin ls
 
-ID                  NAME                  TAG                 DESCRIPTION                ENABLED
-69553ca1d456        user/plugin           latest              A sample plugin for Docker false
+ID             NAME                    DESCRIPTION                  ENABLED
+69553ca1d456   user/plugin:latest      A sample plugin for Docker   false
 
 $ docker plugin push user/plugin
 ```


### PR DESCRIPTION
The output format was changed to combine tag and name in a single column, but this change was never reflected in the docs.


