### PR TITLE
Add checks for dependencies that are not vendored

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 appveyor.yml
 build
 circle.yml
+/vndr.log

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cli/winresources/rsrc_amd64.syso
 /docs/yaml/gen/
 coverage.txt
 profile.out
+/vndr.log

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ dynbinary: ## build dynamically linked binary
 
 vendor: vendor.conf ## check that vendor matches vendor.conf
 	rm -rf vendor
-	bash -c 'vndr |& grep -v -i clone'
+	bash -c 'vndr |& grep -v -i clone | tee ./vndr.log'
 	scripts/validate/check-git-diff vendor
+	scripts/validate/check-all-packages-vendored
 
 .PHONY: authors
 authors: ## generate AUTHORS file from git history

--- a/scripts/validate/check-all-packages-vendored
+++ b/scripts/validate/check-all-packages-vendored
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eu
+
+WARN_MISS_VENDOR='WARNING: dependency is not vendored'
+
+if grep -q "$WARN_MISS_VENDOR" "./vndr.log"; then
+	echo 
+	echo "Some dependencies are not vendored."
+	echo
+	exit 1
+fi


### PR DESCRIPTION
Signed-off-by: Madhur Batra <madhurbatra097@gmail.com>

**- What I did**
    Fix #2332: `make vendor` now regards 'WARNING: dependency is not vendored' as an
                         error and fails when some non vendored dependencies exist.

**- How I did it**
     Added a new validation script that runs against the `vndr` output to find any 
     'WARNING: dependency is not vendored' line. If found script exits with non zero status.

**- How to verify it**
     Added a new import in a go file, and ran go get to install the same in GOPATH.
     Now `vndr check` failed due to unvendored dependency.

**- Description for the changelog**
Enhanced existing Makefile to store the `vndr` logs in a tmp file.
Ran a new script against the log to verify that there is no unvendored dependency.

**- A picture of a cute animal (not mandatory but encouraged)**

