### PR TITLE
config: ignore empty config file instead of printing warning

### DIFF
--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/env"
@@ -89,8 +87,7 @@ func TestEmptyFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	_, err = Load(tmpHome)
-	assert.Assert(t, errors.Is(err, io.EOF))
-	assert.ErrorContains(t, err, ConfigFileName)
+	assert.NilError(t, err)
 }
 
 func TestEmptyJSON(t *testing.T) {

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -118,7 +118,7 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 // LoadFromReader reads the configuration data given and sets up the auth config
 // information with given directory and populates the receiver object
 func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
-	if err := json.NewDecoder(configData).Decode(&configFile); err != nil {
+	if err := json.NewDecoder(configData).Decode(&configFile); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 	var err error


### PR DESCRIPTION
Before this change, a warning would be printed if the `~/.docker/config.json`
file was empty:

    mkdir -p ~/.docker && touch ~/.docker/config.json
    docker pull busybox
    WARNING: Error loading config file: /root/.docker/config.json: EOF
    Using default tag: latest
    ....

Given that we also accept an empty "JSON" file (`{}`), it should be
okay to ignore an empty file, as it's effectively a configuration file
with no custom options set.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

