### PR TITLE
docs: update for cgroup v2 and rootless

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -290,7 +290,7 @@ $ docker -H tcp://127.0.0.1:2375 pull ubuntu
 ### Daemon storage-driver
 
 On Linux, the Docker daemon has support for several different image layer storage
-drivers: `aufs`, `devicemapper`, `btrfs`, `zfs`, `overlay` and `overlay2`.
+drivers: `aufs`, `devicemapper`, `btrfs`, `zfs`, `overlay`, `overlay2`, and `fuse-overlayfs`.
 
 The `aufs` driver is the oldest, but is based on a Linux kernel patch-set that
 is unlikely to be merged into the main kernel. These are also known to cause
@@ -340,6 +340,9 @@ to use it.
 >
 > Both `overlay` and `overlay2` are currently unsupported on `btrfs`
 > or any Copy on Write filesystem and should only be used over `ext4` partitions.
+
+The `fuse-overlayfs` driver is similar to `overlay2` but works in userspace.
+The `fuse-overlayfs` driver is expected to be used for [Rootless mode](https://docs.docker.com/engine/security/rootless/).
 
 On Windows, the Docker daemon supports a single image layer storage driver
 depending on the image platform: `windowsfilter` for Windows images, and
@@ -999,7 +1002,8 @@ single `native.cgroupdriver` option is available.
 The `native.cgroupdriver` option specifies the management of the container's
 cgroups. You can only specify `cgroupfs` or `systemd`. If you specify
 `systemd` and it is not available, the system errors out. If you omit the
-`native.cgroupdriver` option,` cgroupfs` is used.
+`native.cgroupdriver` option,` cgroupfs` is used on cgroup v1 hosts, `systemd`
+is used on cgroup v2 hosts with systemd available.
 
 This example sets the `cgroupdriver` to `systemd`:
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -178,7 +178,7 @@ division of CPU shares:
    Set the cgroup namespace mode for the container.
      **host**:    run the container in the host's cgroup namespace
      **private**: run the container in its own private cgroup namespace
-     **""**:      (unset) run the container in the host's cgroup namespace
+     **""**:      (unset) use the daemon's default configuration (**host** on cgroup v1, **private** on cgroup v2)
 
 **--cgroup-parent**=""
    Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -181,7 +181,8 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--default-cgroupns-mode**="**host**|**private**"
   Set the default cgroup namespace mode for newly created containers. The argument
-  can either be **host** or **private**. If unset, this defaults to `host`.
+  can either be **host** or **private**. If unset, this defaults to `host` on cgroup v1,
+`private` on cgroup v2.
 
 **--default-gateway**=""
   IPv4 address of the container default gateway; this address must be part of
@@ -833,7 +834,8 @@ option is available.
 The `native.cgroupdriver` option specifies the management of the container's
 cgroups. You can only specify `cgroupfs` or `systemd`. If you specify
 `systemd` and it is not available, the system errors out. If you omit the
-`native.cgroupdriver` option,` cgroupfs` is used.
+`native.cgroupdriver` option,` cgroupfs` is used on cgroup v1 hosts, `systemd`
+is used on cgroup v2 hosts with systemd available.
 
 This example sets the `cgroupdriver` to `systemd`:
 


### PR DESCRIPTION
Updated the description toward v20.0X. (https://github.com/moby/moby/pull/40846 https://github.com/moby/moby/pull/40483)

We also need to have a description for cgroup v2 mode, but not sure where is the right place.