### PR TITLE
Added env-file flag to docker exec

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -27,6 +27,7 @@ type execOptions struct {
 	workdir     string
 	container   string
 	command     []string
+	envFile     string
 }
 
 func newExecOptions() execOptions {
@@ -61,12 +62,18 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("env", "version", []string{"1.25"})
 	flags.StringVarP(&options.workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.SetAnnotation("workdir", "version", []string{"1.35"})
+	flags.StringVar(&options.envFile, "env-file", "", "Set environment variables from file")
 
 	return cmd
 }
 
 func runExec(dockerCli command.Cli, options execOptions) error {
-	execConfig := parseExec(options, dockerCli.ConfigFile())
+	execConfig, err := parseExec(options, dockerCli.ConfigFile())
+
+	if err != nil {
+		return err
+	}
+
 	ctx := context.Background()
 	client := dockerCli.Client()
 
@@ -185,30 +192,38 @@ func getExecExitStatus(ctx context.Context, client apiclient.ContainerAPIClient,
 
 // parseExec parses the specified args for the specified command and generates
 // an ExecConfig from it.
-func parseExec(opts execOptions, configFile *configfile.ConfigFile) *types.ExecConfig {
+func parseExec(execOpts execOptions, configFile *configfile.ConfigFile) (*types.ExecConfig, error) {
 	execConfig := &types.ExecConfig{
-		User:       opts.user,
-		Privileged: opts.privileged,
-		Tty:        opts.tty,
-		Cmd:        opts.command,
-		Detach:     opts.detach,
-		Env:        opts.env.GetAll(),
-		WorkingDir: opts.workdir,
+		User:       execOpts.user,
+		Privileged: execOpts.privileged,
+		Tty:        execOpts.tty,
+		Cmd:        execOpts.command,
+		Detach:     execOpts.detach,
+		Env:        execOpts.env.GetAll(),
+		WorkingDir: execOpts.workdir,
+	}
+
+	if execOpts.envFile != "" {
+		envs, err := opts.ParseEnvFile(execOpts.envFile)
+		if err != nil {
+			return nil, err
+		}
+		execConfig.Env = append(execConfig.Env, envs...)
 	}
 
 	// If -d is not set, attach to everything by default
-	if !opts.detach {
+	if !execOpts.detach {
 		execConfig.AttachStdout = true
 		execConfig.AttachStderr = true
-		if opts.interactive {
+		if execOpts.interactive {
 			execConfig.AttachStdin = true
 		}
 	}
 
-	if opts.detachKeys != "" {
-		execConfig.DetachKeys = opts.detachKeys
+	if execOpts.detachKeys != "" {
+		execConfig.DetachKeys = execOpts.detachKeys
 	} else {
 		execConfig.DetachKeys = configFile.DetachKeys
 	}
-	return execConfig
+	return execConfig, nil
 }

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -21,6 +21,7 @@ Options:
   -t, --tty            Allocate a pseudo-TTY
   -u, --user           Username or UID (format: <name|uid>[:<group|gid>])
   -w, --workdir        Working directory inside the container
+      --env-file       Set environment variables from file
 ```
 
 ## Description


### PR DESCRIPTION
Signed-off-by: Brian Wieder <brian@4wieders.com>

This is my first PR for an open source project and I am a college student starting my journey learning GoLang, so I am open to any and all feedback regarding my code, testing, PR, or anything else!

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added a flag to bring in environment variables from a file into docker exec.
Closes #1681  

**- How I did it**
Added a flag to the exec command, and if the value is not the empty string, use the existing logic to parse an env file to add them to the slice that contains the environment variables. 

**- How to verify it**
Run docker exec with --env-file flag with a file containing environment variables and print/use any of the variables inside the file in the command.

Ex:
docker exec --env-file .env 123abc sh -c 'echo $ONE` 

where .env comprises of:
ONE=1

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added flag in the docker exec command for parsing a file for environment variables and adding them into the environment for the exec.

**- A picture of a cute animal (not mandatory but encouraged)**

