### PR TITLE
[19.03 backport] minor vendor bumps

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -45,7 +45,7 @@ github.com/imdario/mergo                            7c29201646fa3de8506f70121347
 github.com/inconshreveable/mousetrap                76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # v1.0.0
 github.com/jaguilar/vt100                           ad4c4a5743050fb7f88ce968dca9422f72a0e3f2 git://github.com/tonistiigi/vt100.git
 github.com/json-iterator/go                         0ff49de124c6f76f8494e194af75bde0f1a49a29 # 1.1.6
-github.com/konsorten/go-windows-terminal-sequences  f55edac94c9bbba5d6182a4be46d86a2c9b5b50e # v1.0.2
+github.com/konsorten/go-windows-terminal-sequences  edb144dfd453055e1e49a3d8b410a660b5a87613 # v1.0.3
 github.com/kr/pty                                   521317be5ebc228a0f0ede099fa2a0b5ece22e49 # v1.1.4
 github.com/mattn/go-shellwords                      a72fbe27a1b0ed0df2f02754945044ce1456608b # v1.0.5
 github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -52,7 +52,7 @@ github.com/matttproud/golang_protobuf_extensions    c12348ce28de40eed0136aa2b644
 github.com/Microsoft/go-winio                       84b4ab48a50763fe7b3abcef38e5205c12027fac
 github.com/Microsoft/hcsshim                        672e52e9209d1e53718c1b6a7d68cc9272654ab5
 github.com/miekg/pkcs11                             cb39313ec884f2cd77f4762875fe96aecf68f8e3 # v1.0.2
-github.com/mitchellh/mapstructure                   f15292f7a699fcc1a38a80977f80a046874ba8ac
+github.com/mitchellh/mapstructure                   fa473d140ef3c6adf42d6b391fe76707f1f243c8 # v1.0.0
 github.com/moby/buildkit                            ae10b292fefb00e0fbf9fecd1419c5f252e58895
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
 github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@ cloud.google.com/go                                 0ebda48a7f143b1cce9eb37a8c11
 github.com/agl/ed25519                              5312a61534124124185d41f09206b9fef1d88403
 github.com/asaskevich/govalidator                   f9ffefc3facfbe0caee3fea233cbb6e8208f4541
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/beorn7/perks                             e7f67b54abbeac9c40a31de0f81159e4cafebd6a
+github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
 github.com/containerd/console                       0650fd9eeb50bab4fc99dceb9f2e14cf58f36e7f
 github.com/containerd/containerd                    3a3f0aac8819165839a41fee77a4f4ac8b103097
 github.com/containerd/continuity                    aaeac12a7ffcd198ae25440a9dff125c2e2703a7

--- a/vendor/github.com/beorn7/perks/go.mod
+++ b/vendor/github.com/beorn7/perks/go.mod
@@ -1,0 +1,3 @@
+module github.com/beorn7/perks
+
+go 1.11

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/README.md
@@ -27,6 +27,7 @@ We thank all the authors who provided code to this library:
 
 * Felix Kollmann
 * Nicolas Perraut
+* @dirty49374
 
 ## License
 

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/sequences.go
@@ -4,7 +4,6 @@ package sequences
 
 import (
 	"syscall"
-	"unsafe"
 )
 
 var (
@@ -27,7 +26,7 @@ func EnableVirtualTerminalProcessing(stream syscall.Handle, enable bool) error {
 		mode &^= ENABLE_VIRTUAL_TERMINAL_PROCESSING
 	}
 
-	ret, _, err := setConsoleMode.Call(uintptr(unsafe.Pointer(stream)), uintptr(mode))
+	ret, _, err := setConsoleMode.Call(uintptr(stream), uintptr(mode))
 	if ret == 0 {
 		return err
 	}

--- a/vendor/github.com/mitchellh/mapstructure/go.mod
+++ b/vendor/github.com/mitchellh/mapstructure/go.mod
@@ -1,0 +1,1 @@
+module github.com/mitchellh/mapstructure


### PR DESCRIPTION
Mostly to get them to tagged releases, and an update to prevent problems if we would switch to Go 1.14 or Go 1.15

Backports of:

- https://github.com/docker/cli/pull/2522 vendor: beorn7/perks v1.0.1
- https://github.com/docker/cli/pull/2521 vendor: mitchellh/mapstructure v1.0.0
- https://github.com/docker/cli/pull/2477 vendor konsorten/go-windows-terminal-sequences v1.0.3


