### PR TITLE
Fix experimental README instructions

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -19,7 +19,7 @@ To enable experimental features, start the Docker daemon with the
 
 ```json
 {
-    "experimental": true
+    "experimental": "enabled"
 }
 ```
 


### PR DESCRIPTION
The correct syntax for the "experimental" option in config.json is as a
stribe "enabled" or "disabled, not a boolean. Following the README as is
creates an error during unmarsall when running any docker cli commands.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Tried to follow the instructions in the README, got an error, found the correct syntax
**- How I did it**
Read the error message
**- How to verify it**
Follow the old instructions, get an error. Follow the updated instructions and you don't
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix syntax in experimental README

**- A picture of a cute animal (not mandatory but encouraged)**

