### PR TITLE
Optional stream suppression for "container logs" command.

### DIFF
--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -18,6 +18,8 @@ type logsOptions struct {
 	timestamps bool
 	details    bool
 	tail       string
+	noStdout   bool
+	noStderr   bool
 
 	container string
 }
@@ -44,6 +46,8 @@ func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.timestamps, "timestamps", "t", false, "Show timestamps")
 	flags.BoolVar(&opts.details, "details", false, "Show extra details provided to logs")
 	flags.StringVar(&opts.tail, "tail", "all", "Number of lines to show from the end of the logs")
+	flags.BoolVar(&opts.noStdout, "no-stdout", false, "Suppress messages from stream \"stdout\".")
+	flags.BoolVar(&opts.noStderr, "no-stderr", false, "Suppress messages from stream \"stderr\".")
 	return cmd
 }
 
@@ -56,8 +60,8 @@ func runLogs(dockerCli command.Cli, opts *logsOptions) error {
 	}
 
 	options := types.ContainerLogsOptions{
-		ShowStdout: true,
-		ShowStderr: true,
+		ShowStdout: !opts.noStdout,
+		ShowStderr: !opts.noStderr,
 		Since:      opts.since,
 		Until:      opts.until,
 		Timestamps: opts.timestamps,

--- a/man/src/container/logs.md
+++ b/man/src/container/logs.md
@@ -27,6 +27,9 @@ The `docker container logs --details` command will add on extra attributes, such
 environment variables and labels, provided to `--log-opt` when creating the
 container.
 
+The --no-stdout and --no-stderr options can be used to suppress output from the
+container's stdout or stderr streams.
+
 In order to retrieve logs before a specific point in time, run:
 
 ```bash


### PR DESCRIPTION
**- What I did**
In the "container log" command it's now possible to suppress output of the stdout or stderr stream using the "--no-stdout" or "--no-stderr" option.

**- How I did it**
Exposing inversion of the already existing flags `ShowStdout` and `ShowStderr` from `types.ContainerLogsOptions` to the command line options `--no-stdout` or `--no-stderr`.

**- How to verify it**
Run `docker container logs --no-stdout` or `docker container logs --no-stderr` on a container that generated outputs to both of those streams.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added options "--no-stdout" and "--no-stderr" to the "container log" command.

**- A picture of a cute animal (not mandatory but encouraged)**
![Image of Koala climbing tree](https://en.wikipedia.org/wiki/Koala#/media/File:Koala_climbing_tree.jpg)