### PR TITLE
scripts/make.ps1: actually define the CommitSuffix parameter

### DIFF
--- a/scripts/make.ps1
+++ b/scripts/make.ps1
@@ -51,6 +51,7 @@ param(
     [Parameter(Mandatory=$False)][switch]$Noisy,
     [Parameter(Mandatory=$False)][switch]$ForceBuildAll,
     [Parameter(Mandatory=$False)][switch]$NoOpt,
+    [Parameter(Mandatory=$False)][string]$CommitSuffix,
     [Parameter(Mandatory=$False)][switch]$TestUnit,
     [Parameter(Mandatory=$False)][switch]$All
 )


### PR DESCRIPTION
Signed-off-by: Paul Mulders <justinkb@gmail.com>

**- What I did**

Fixed the intended CommitSuffix functionality that could be used to add a suffix to the windows resources produced for the docker.exe CLI program

Before this fix the ($CommitSuffix -ne "") check on https://github.com/docker/cli/blob/master/scripts/make.ps1#L98 would always evaluate to ~~false~~true, presumably since $CommitSuffix would be null, leaving "commit-" as the "Original filename" in the Details property tab for the .exe. Now it works properly, making that field "commit" if CommitSuffix is unspecified, or "commit-suffix" if it is actually provided in the command line invocation.

**- How I did it**

Simply defined the CommitSuffix parameter in the PowerShell build script.

**- How to verify it**

Run the script with and without -CommitSuffix something parameter and check the results in the .exe's resources.

**- Description for the changelog**

Fixed make.ps1 script to actually define the CommitSuffix parameter