### PR TITLE
Fix ConfigFile.Save() replacing symlink with file

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -209,9 +209,15 @@ func (configFile *ConfigFile) Save() (retErr error) {
 		return errors.Wrap(err, "error closing temp file")
 	}
 
+	// Handle situation where the configfile is a symlink
+	cfgFile := configFile.Filename
+	if f, err := os.Readlink(cfgFile); err == nil {
+		cfgFile = f
+	}
+
 	// Try copying the current config file (if any) ownership and permissions
-	copyFilePermissions(configFile.Filename, temp.Name())
-	return os.Rename(temp.Name(), configFile.Filename)
+	copyFilePermissions(cfgFile, temp.Name())
+	return os.Rename(temp.Name(), cfgFile)
 }
 
 // ParseProxyConfig computes proxy configuration by retrieving the config for the provided host and


### PR DESCRIPTION
As noticed in https://github.com/docker/cli/pull/2595#issuecomment-648123132

In situations where `~/.docker/config.json` was a symlink, saving the file would replace the symlink with a file, instead of updating the target file location;

    mkdir -p ~/.docker
    touch ~/real-config.json
    ln -s ~/real-config.json ~/.docker/config.json

    ls -la ~/.docker/config.json
    # lrwxrwxrwx 1 root root 22 Jun 23 12:34 /root/.docker/config.json -> /root/real-config.json

    docker login
    # Username: thajeztah
    # Password:

    # Login Succeeded

    ls -la ~/.docker/config.json
    -rw-r--r-- 1 root root 229 Jun 23 12:36 /root/.docker/config.json

