### PR TITLE
[19.03] handle close error on save

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -196,6 +196,9 @@ func (configFile *ConfigFile) Save() error {
 		os.Remove(temp.Name())
 		return err
 	}
+	// Try copying the current config file (if any) ownership and permissions
+	copyFilePermissions(configFile.Filename, temp.Name())
+
 	return os.Rename(temp.Name(), configFile.Filename)
 }
 

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -177,7 +178,7 @@ func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {
 }
 
 // Save encodes and writes out all the authorization information
-func (configFile *ConfigFile) Save() error {
+func (configFile *ConfigFile) Save() (retErr error) {
 	if configFile.Filename == "" {
 		return errors.Errorf("Can't save config with empty filename")
 	}
@@ -190,15 +191,26 @@ func (configFile *ConfigFile) Save() error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		temp.Close()
+		if retErr != nil {
+			if err := os.Remove(temp.Name()); err != nil {
+				logrus.WithError(err).WithField("file", temp.Name()).Debug("Error cleaning up temp file")
+			}
+		}
+	}()
+
 	err = configFile.SaveToWriter(temp)
-	temp.Close()
 	if err != nil {
-		os.Remove(temp.Name())
 		return err
 	}
+
+	if err := temp.Close(); err != nil {
+		return errors.Wrap(err, "error closing temp file")
+	}
+
 	// Try copying the current config file (if any) ownership and permissions
 	copyFilePermissions(configFile.Filename, temp.Name())
-
 	return os.Rename(temp.Name(), configFile.Filename)
 }
 

--- a/cli/config/configfile/file_unix.go
+++ b/cli/config/configfile/file_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package configfile
+
+import (
+	"os"
+	"syscall"
+)
+
+// copyFilePermissions copies file ownership and permissions from "src" to "dst",
+// ignoring any error during the process.
+func copyFilePermissions(src, dst string) {
+	var (
+		mode     os.FileMode = 0600
+		uid, gid int
+	)
+
+	fi, err := os.Stat(src)
+	if err != nil {
+		return
+	}
+	if fi.Mode().IsRegular() {
+		mode = fi.Mode()
+	}
+	if err := os.Chmod(dst, mode); err != nil {
+		return
+	}
+
+	uid = int(fi.Sys().(*syscall.Stat_t).Uid)
+	gid = int(fi.Sys().(*syscall.Stat_t).Gid)
+
+	if uid > 0 && gid > 0 {
+		_ = os.Chown(dst, uid, gid)
+	}
+}

--- a/cli/config/configfile/file_windows.go
+++ b/cli/config/configfile/file_windows.go
@@ -1,0 +1,5 @@
+package configfile
+
+func copyFilePermissions(src, dst string) {
+	// TODO implement for Windows
+}


### PR DESCRIPTION
Backports:
- 22a291f703b2511daaa8e0d325ab48523e817558 https://github.com/docker/cli/pull/2228 config: preserve ownership and permissions on configfile
    - fixes https://github.com/moby/moby/issues/40175 Bug: sudo docker login changes .docker/config.json permissions
- d02173090ff15ffb3ec4a5427ba35dafeb7fa92b https://github.com/docker/cli/pull/2595 Handle errors on close in config file write

The first because it seemed at least relevant and the fact that it was missing caused a merge conflict (simple to fix, but still).
Can remove if needed.