### PR TITLE
Replaces ADD with COPY in the COPY section

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1276,11 +1276,11 @@ COPY test.txt /absoluteDir/
 
 When copying files or directories that contain special characters (such as `[`
 and `]`), you need to escape those paths following the Golang rules to prevent
-them from being treated as a matching pattern. For example, to add a file
+them from being treated as a matching pattern. For example, to copy a file
 named `arr[0].txt`, use the following;
 
 ```dockerfile
-ADD arr[[]0].txt /mydir/
+COPY arr[[]0].txt /mydir/
 ```
 
 All new files and directories are created with a UID and GID of 0, unless the


### PR DESCRIPTION
Possibly a typo from reusing text from the ADD section. The part explaining that square brackets need be escaped contained ADD instead of COPY, so I replaced it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

