### PR TITLE
added 'docker build --target' to zsh completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1019,6 +1019,7 @@ __docker_image_subcommand() {
                 "($help)*--shm-size=[Size of '/dev/shm' (format is '<number><unit>')]:shm size: " \
                 "($help)--squash[Squash newly built layers into a single new layer]" \
                 "($help -t --tag)*"{-t=,--tag=}"[Repository, name and tag for the image]: :__docker_complete_repositories_with_tags" \
+                "($help)--target=[Set the target build stage to build.]" \
                 "($help)*--ulimit=[ulimit options]:ulimit: " \
                 "($help)--userns=[Container user namespace]:user namespace:(host)" \
                 "($help -):path or URL:_directories" && ret=0


### PR DESCRIPTION
Signed-off-by: Miroslav Gula <miroslav.gula@naytrolabs.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added 'docker build --targer' completion option for zsh.
**- How I did it**
Added line "($help)--target=[Set the target build stage to build.]" to 'contrib/completion/zsh/_docker' file.
**- How to verify it**
- switch to zsh shell
- try to complete command 'docker build --tar' with TAB key. It should auto-complete the --target switch.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added --target completion option for docker build command in zsh shell.

**- A picture of a cute animal (not mandatory but encouraged)**

