### PR TITLE
support emulated version detection

### DIFF
--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -34,6 +34,7 @@ import (
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	fsutiltypes "github.com/tonistiigi/fsutil/types"
+	"github.com/tonistiigi/go-rosetta"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -222,7 +223,9 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 	}
 
 	if strings.EqualFold(options.platform, "local") {
-		options.platform = platforms.DefaultString()
+		p := platforms.DefaultSpec()
+		p.Architecture = rosetta.NativeArch() // current binary architecture might be emulated
+		options.platform = platforms.Format(p)
 	}
 
 	eg.Go(func() error {

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/tonistiigi/go-rosetta"
 	kubernetesClient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -125,6 +126,14 @@ func reformatDate(buildTime string) string {
 	return buildTime
 }
 
+func arch() string {
+	arch := runtime.GOARCH
+	if rosetta.Enabled() {
+		arch += " (rosetta)"
+	}
+	return arch
+}
+
 func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 	var err error
 	tmpl, err := newVersionTemplate(opts.format)
@@ -147,7 +156,7 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 			GitCommit:         version.GitCommit,
 			BuildTime:         reformatDate(version.BuildTime),
 			Os:                runtime.GOOS,
-			Arch:              runtime.GOARCH,
+			Arch:              arch(),
 			Experimental:      dockerCli.ClientInfo().HasExperimental,
 			Context:           dockerCli.CurrentContext(),
 		},

--- a/vendor.conf
+++ b/vendor.conf
@@ -67,6 +67,7 @@ github.com/spf13/cobra                              a684a6d7f5e37385d954dd3b5a14
 github.com/spf13/pflag                              2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab # v1.0.5
 github.com/theupdateframework/notary                d6e1431feb32348e0650bf7551ac5cffd01d857b # v0.6.1
 github.com/tonistiigi/fsutil                        ae3a8d753069d0f76fbee396457e8b6cfd7cb8c3
+github.com/tonistiigi/go-rosetta                    f79598599c5d34ea253b56a1d7c89bc6a96de7db
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/xeipuuv/gojsonpointer                    02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb
 github.com/xeipuuv/gojsonreference                  bd5ef7bd5415a7ac448318e64f11a24cd21e594b

--- a/vendor/github.com/tonistiigi/go-rosetta/LICENSE
+++ b/vendor/github.com/tonistiigi/go-rosetta/LICENSE
@@ -1,0 +1,21 @@
+MIT
+
+Copyright (c) 2020 Tõnis Tiigi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/tonistiigi/go-rosetta/go.mod
+++ b/vendor/github.com/tonistiigi/go-rosetta/go.mod
@@ -1,0 +1,3 @@
+module github.com/tonistiigi/go-rosetta
+
+go 1.13

--- a/vendor/github.com/tonistiigi/go-rosetta/rosetta.go
+++ b/vendor/github.com/tonistiigi/go-rosetta/rosetta.go
@@ -1,0 +1,20 @@
+// +build darwin
+
+package rosetta
+
+import (
+	"runtime"
+	"syscall"
+)
+
+func Enabled() bool {
+	v, err := syscall.SysctlUint32("sysctl.proc_translated")
+	return err == nil && v == 1
+}
+
+func NativeArch() string {
+	if Enabled() && runtime.GOARCH == "amd64" {
+		return "arm64"
+	}
+	return runtime.GOARCH
+}

--- a/vendor/github.com/tonistiigi/go-rosetta/rosetta_unsupported.go
+++ b/vendor/github.com/tonistiigi/go-rosetta/rosetta_unsupported.go
@@ -1,0 +1,15 @@
+// +build !darwin
+
+package rosetta
+
+import (
+	"runtime"
+)
+
+func Enabled() bool {
+	return false
+}
+
+func NativeArch() string {
+	return runtime.GOARCH
+}


### PR DESCRIPTION
Arm64 on Darwin supports emulation of amd64 binaries. This makes emulation visible in `docker version` so it can be detected as a factor in bug reports.

Using `docker build --platform=local` now builds for the actual native platform, not the platform for the binary that is being emulated.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>