### PR TITLE
vendor: update tonistiigi/fsutil ae3a8d753069d0f76fbee396457e8b6cfd7cb8c3

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -66,7 +66,7 @@ github.com/sirupsen/logrus                          60c74ad9be0d874af0ab0daef6ab
 github.com/spf13/cobra                              a684a6d7f5e37385d954dd3b5a14fc6912c6ab9d # v1.0.0
 github.com/spf13/pflag                              2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab # v1.0.5
 github.com/theupdateframework/notary                d6e1431feb32348e0650bf7551ac5cffd01d857b # v0.6.1
-github.com/tonistiigi/fsutil                        c2c7d7b0e1441705cd802e5699c0a10b1dfe39fd
+github.com/tonistiigi/fsutil                        ae3a8d753069d0f76fbee396457e8b6cfd7cb8c3
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/xeipuuv/gojsonpointer                    02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb
 github.com/xeipuuv/gojsonreference                  bd5ef7bd5415a7ac448318e64f11a24cd21e594b

--- a/vendor/github.com/tonistiigi/fsutil/go.mod
+++ b/vendor/github.com/tonistiigi/fsutil/go.mod
@@ -1,28 +1,25 @@
 module github.com/tonistiigi/fsutil
 
+go 1.13
+
 require (
-	github.com/Microsoft/go-winio v0.4.11 // indirect
-	github.com/containerd/continuity v0.0.0-20181001140422-bd77b46c8352
+	github.com/Microsoft/hcsshim v0.8.9 // indirect
+	github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v0.0.0-20180531152204-71cd53e4a197
-	github.com/docker/go-units v0.3.1 // indirect
+	github.com/docker/docker v0.0.0-20200511152416-a93e9eb0e95c
 	github.com/gogo/protobuf v1.3.1
-	github.com/google/go-cmp v0.2.0 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
+	github.com/moby/sys/mount v0.1.0 // indirect
+	github.com/moby/sys/mountinfo v0.1.3 // indirect
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/opencontainers/runc v1.0.0-rc6 // indirect
-	github.com/pkg/errors v0.8.1
-	github.com/sirupsen/logrus v1.0.3 // indirect
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 // indirect
-	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
-	golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
+	github.com/opencontainers/runc v1.0.0-rc10 // indirect
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
-	gotest.tools v2.1.0+incompatible // indirect
 )
-
-go 1.13

--- a/vendor/github.com/tonistiigi/fsutil/stat_unix.go
+++ b/vendor/github.com/tonistiigi/fsutil/stat_unix.go
@@ -14,7 +14,7 @@ import (
 func loadXattr(origpath string, stat *types.Stat) error {
 	xattrs, err := sysx.LListxattr(origpath)
 	if err != nil {
-		if errors.Cause(err) == syscall.ENOTSUP {
+		if errors.Is(err, syscall.ENOTSUP) {
 			return nil
 		}
 		return errors.Wrapf(err, "failed to xattr %s", origpath)

--- a/vendor/github.com/tonistiigi/fsutil/walker.go
+++ b/vendor/github.com/tonistiigi/fsutil/walker.go
@@ -219,12 +219,5 @@ func trimUntilIndex(str, sep string, count int) string {
 }
 
 func isNotExist(err error) bool {
-	err = errors.Cause(err)
-	if os.IsNotExist(err) {
-		return true
-	}
-	if pe, ok := err.(*os.PathError); ok {
-		err = pe.Err
-	}
-	return err == syscall.ENOTDIR
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
 }


### PR DESCRIPTION
full diff: https://github.com/tonistiigi/fsutil/compare/c2c7d7b0e1441705cd802e5699c0a10b1dfe39fd...ae3a8d753069d0f76fbee396457e8b6cfd7cb8c3

Relevant changes

- Update dependencies
    - update docker/docker to current master
    - update opencontainers/runc to v1.0.0-rc10
    - update pkg/errors to v0.9.1 to support Go 1.13 errors
    - update stretchr/testify to the latest version
- Drop support for go1.12, and use errors.Is() for error-detection

