### PR TITLE
Pretty service inspect fails when TaskTemplate.Resources is nil

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -502,6 +502,9 @@ func (ctx *serviceInspectContext) ResourceLimitMemory() string {
 }
 
 func (ctx *serviceInspectContext) ResourceLimitPids() int64 {
+	if ctx.Service.Spec.TaskTemplate.Resources == nil || ctx.Service.Spec.TaskTemplate.Resources.Limits == nil {
+		return 0
+	}
 	return ctx.Service.Spec.TaskTemplate.Resources.Limits.Pids
 }
 


### PR DESCRIPTION
**- What I did**

When doing `docker service inspect --pretty` on services without
`TaskTemplate.Resources` or `TaskTemplate.Resources.Limits`, the command
fails. This is due to a missing check on `ResourceLimitPids()`.

This bug has been introduced by 395a6d560decb1da85ec66b0913a555ceace738d
and produces following error message:

```
Template parsing error: template: :139:10: executing "" at <.ResourceLimitPids>: error calling ResourceLimitPids: runtime error: invalid memory address or nil pointer dereference
```

**- How I did it**

**- How to verify it**

```
$ make binary # Build the binary from master branch
$ cat docker-compose.yaml
version: "3"

services:
  test:
    image: debian
    command: sleep 15
    deploy:
      mode: replicated
$ docker stack deploy --compose-file docker-compose.yaml test
$ build/docker service inspect --pretty test_test
```

**- Description for the changelog**

`docker service inspect --pretty` fails on tasks declared with no resources constraints.

**- A picture of a cute animal (not mandatory but encouraged)**

