### PR TITLE
Add capabilities support to stack/service commands

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -97,6 +97,15 @@ ContainerSpec:
 {{- if .ContainerUser }}
  User: {{ .ContainerUser }}
 {{- end }}
+{{- if .HasCapabilities }}
+Capabilities:
+{{- if .HasCapabilityAdd }}
+ Add: {{ .CapabilityAdd }}
+{{- end }}
+{{- if .HasCapabilityDrop }}
+ Drop: {{ .CapabilityDrop }}
+{{- end }}
+{{- end }}
 {{- if .ContainerSysCtls }}
 SysCtls:
 {{- range $k, $v := .ContainerSysCtls }}
@@ -527,6 +536,26 @@ func (ctx *serviceInspectContext) EndpointMode() string {
 
 func (ctx *serviceInspectContext) Ports() []swarm.PortConfig {
 	return ctx.Service.Endpoint.Ports
+}
+
+func (ctx *serviceInspectContext) HasCapabilities() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd) > 0 || len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop) > 0
+}
+
+func (ctx *serviceInspectContext) HasCapabilityAdd() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd) > 0
+}
+
+func (ctx *serviceInspectContext) HasCapabilityDrop() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop) > 0
+}
+
+func (ctx *serviceInspectContext) CapabilityAdd() string {
+	return strings.Join(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd, ", ")
+}
+
+func (ctx *serviceInspectContext) CapabilityDrop() string {
+	return strings.Join(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop, ", ")
 }
 
 const (

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -506,6 +506,8 @@ type serviceOptions struct {
 	dnsOption       opts.ListOpts
 	hosts           opts.ListOpts
 	sysctls         opts.ListOpts
+	capAdd          opts.ListOpts
+	capDrop         opts.ListOpts
 
 	resources resourceOptions
 	stopGrace opts.DurationOpt
@@ -549,6 +551,8 @@ func newServiceOptions() *serviceOptions {
 		dnsSearch:       opts.NewListOpts(opts.ValidateDNSSearch),
 		hosts:           opts.NewListOpts(opts.ValidateExtraHost),
 		sysctls:         opts.NewListOpts(nil),
+		capAdd:          opts.NewListOpts(nil),
+		capDrop:         opts.NewListOpts(nil),
 	}
 }
 
@@ -716,6 +720,8 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				Healthcheck:     healthConfig,
 				Isolation:       container.Isolation(options.isolation),
 				Sysctls:         opts.ConvertKVStringsToMap(options.sysctls.GetAll()),
+				CapabilityAdd:   options.capAdd.GetAll(),
+				CapabilityDrop:  options.capDrop.GetAll(),
 			},
 			Networks:      networks,
 			Resources:     resources,
@@ -818,6 +824,10 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 	flags.StringVar(&opts.hostname, flagHostname, "", "Container hostname")
 	flags.SetAnnotation(flagHostname, "version", []string{"1.25"})
 	flags.Var(&opts.entrypoint, flagEntrypoint, "Overwrite the default ENTRYPOINT of the image")
+	flags.Var(&opts.capAdd, flagCapAdd, "Add Linux capabilities")
+	flags.SetAnnotation(flagCapAdd, "version", []string{"1.41"})
+	flags.Var(&opts.capDrop, flagCapDrop, "Drop Linux capabilities")
+	flags.SetAnnotation(flagCapDrop, "version", []string{"1.41"})
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
@@ -1001,6 +1011,8 @@ const (
 	flagConfigAdd               = "config-add"
 	flagConfigRemove            = "config-rm"
 	flagIsolation               = "isolation"
+	flagCapAdd                  = "cap-add"
+	flagCapDrop                 = "cap-drop"
 )
 
 func validateAPIVersion(c swarm.ServiceSpec, serverAPIVersion string) error {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -505,6 +505,7 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 	}
 
 	updateString(flagStopSignal, &cspec.StopSignal)
+	updateCapabilities(flags, cspec)
 
 	return nil
 }
@@ -1349,5 +1350,43 @@ func updateCredSpecConfig(flags *pflag.FlagSet, containerSpec *swarm.ContainerSp
 		}
 
 		containerSpec.Privileges.CredentialSpec = credSpec
+	}
+}
+
+func updateCapabilities(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec) {
+	var addToRemove, dropToRemove map[string]struct{}
+	capAdd := containerSpec.CapabilityAdd
+	capDrop := containerSpec.CapabilityDrop
+
+	// First add the capabilities passed to --cap-add to the list of requested caps
+	if flags.Changed(flagCapAdd) {
+		caps := flags.Lookup(flagCapAdd).Value.(*opts.ListOpts).GetAll()
+		capAdd = append(capAdd, caps...)
+
+		dropToRemove = buildToRemoveSet(flags, flagCapAdd)
+	}
+
+	// And add the capabilities passed to --cap-drop to the list of dropped caps
+	if flags.Changed(flagCapDrop) {
+		caps := flags.Lookup(flagCapDrop).Value.(*opts.ListOpts).GetAll()
+		capDrop = append(capDrop, caps...)
+
+		addToRemove = buildToRemoveSet(flags, flagCapDrop)
+	}
+
+	// Then take care of removing caps passed to --cap-drop from the list of requested caps
+	containerSpec.CapabilityAdd = make([]string, 0, len(capAdd))
+	for _, cap := range capAdd {
+		if _, exists := addToRemove[cap]; !exists {
+			containerSpec.CapabilityAdd = append(containerSpec.CapabilityAdd, cap)
+		}
+	}
+
+	// And remove the caps passed to --cap-add from the list of caps to drop
+	containerSpec.CapabilityDrop = make([]string, 0, len(capDrop))
+	for _, cap := range capDrop {
+		if _, exists := dropToRemove[cap]; !exists {
+			containerSpec.CapabilityDrop = append(containerSpec.CapabilityDrop, cap)
+		}
 	}
 }

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1310,3 +1310,74 @@ func TestUpdateCredSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateCaps(t *testing.T) {
+	tests := []struct {
+		// name is the name of the testcase
+		name string
+		// flagAdd is the value passed to --cap-add
+		flagAdd []string
+		// flagDrop is the value passed to --cap-drop
+		flagDrop []string
+		// spec is the original ContainerSpec, before being updated
+		spec *swarm.ContainerSpec
+		// expectedAdd is the set of requested caps the ContainerSpec should have once updated
+		expectedAdd []string
+		// expectedDrop is the set of dropped caps the ContainerSpec should have once updated
+		expectedDrop []string
+	}{
+		{
+			name:         "Add new caps",
+			flagAdd:      []string{"NET_ADMIN"},
+			flagDrop:     []string{},
+			spec:         &swarm.ContainerSpec{},
+			expectedAdd:  []string{"NET_ADMIN"},
+			expectedDrop: []string{},
+		},
+		{
+			name:         "Drop new caps",
+			flagAdd:      []string{},
+			flagDrop:     []string{"CAP_MKNOD"},
+			spec:         &swarm.ContainerSpec{},
+			expectedAdd:  []string{},
+			expectedDrop: []string{"CAP_MKNOD"},
+		},
+		{
+			name:     "Add a previously dropped cap",
+			flagAdd:  []string{"NET_ADMIN"},
+			flagDrop: []string{},
+			spec: &swarm.ContainerSpec{
+				CapabilityDrop: []string{"NET_ADMIN"},
+			},
+			expectedAdd:  []string{"NET_ADMIN"},
+			expectedDrop: []string{},
+		},
+		{
+			name:     "Drop a previously requested cap",
+			flagAdd:  []string{},
+			flagDrop: []string{"CAP_MKNOD"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd: []string{"CAP_MKNOD"},
+			},
+			expectedAdd:  []string{},
+			expectedDrop: []string{"CAP_MKNOD"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := newUpdateCommand(nil).Flags()
+			for _, cap := range tc.flagAdd {
+				flags.Set(flagCapAdd, cap)
+			}
+			for _, cap := range tc.flagDrop {
+				flags.Set(flagCapDrop, cap)
+			}
+
+			updateCapabilities(flags, tc.spec)
+
+			assert.DeepEqual(t, tc.spec.CapabilityAdd, tc.expectedAdd)
+			assert.DeepEqual(t, tc.spec.CapabilityDrop, tc.expectedDrop)
+		})
+	}
+}

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -147,6 +147,8 @@ func Service(
 				Isolation:       container.Isolation(service.Isolation),
 				Init:            service.Init,
 				Sysctls:         service.Sysctls,
+				CapabilityAdd:   service.CapAdd,
+				CapabilityDrop:  service.CapDrop,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -623,3 +623,29 @@ func TestConvertUpdateConfigParallelism(t *testing.T) {
 	})
 	assert.Check(t, is.Equal(parallel, updateConfig.Parallelism))
 }
+
+func TestConvertServiceCapAddAndCapDrop(t *testing.T) {
+	// test default behavior
+	result, err := Service("1.41", Namespace{name: "foo"}, composetypes.ServiceConfig{}, nil, nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityAdd, []string(nil)))
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityDrop, []string(nil)))
+
+	// with some values
+	service := composetypes.ServiceConfig{
+		CapAdd: []string{
+			"SYS_NICE",
+			"CAP_NET_ADMIN",
+		},
+		CapDrop: []string{
+			"CHOWN",
+			"DAC_OVERRIDE",
+			"CAP_FSETID",
+			"CAP_FOWNER",
+		},
+	}
+	result, err = Service("1.41", Namespace{name: "foo"}, service, nil, nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityAdd, service.CapAdd))
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityDrop, service.CapDrop))
+}

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -9,8 +9,6 @@ import (
 // UnsupportedProperties not yet supported by this implementation of the compose file
 var UnsupportedProperties = []string{
 	"build",
-	"cap_add",
-	"cap_drop",
 	"cgroupns_mode",
 	"cgroup_parent",
 	"devices",


### PR DESCRIPTION
closes #1940
closes #2199

**- What I did**

This PR supersedes #1940 and #2199. I removed the support of `privileged` option from the original PR as I believe privileged containers involve more than just having the complete set of capabilities (eg. no user namespace,  the unconfined AppArmor profile is used, etc...).

1. `docker stack deploy` now supports `cap_add` and `cap_drop` options ;
2. `docker service create|update` now support `--cap-add` and `--cap-drop` flags. For the `update` command and unlike most of other options, those flags don't have `-add` & `-rm` variants as this would make a poor UX (eg. `--cap-add-add` & `--cap-drop-rm`). Instead, `updateCapabilities` takes care of stripping caps provided to `--cap-add` from `CapabilityDrop` (and vice versa)  ;
3. `docker service inspect --pretty` displays the list of added caps and dropped caps ;

Closes moby/moby#25885 docker/cli#1940 docker/cli#2199 

**- How I did it**

1. The service converter transforming compose types into API types has been updated to add capabilities to `ServiceSpec`;
2. A new function with the logic described above and named `updateCapabilities()` has been introduced and is called by `updateService` ;
3. The pretty formatter has been updated to include added and dropped caps ;

**- How to verify it**

<details>
<summary><code>docker stack deploy</code></summary>

```
$ cat docker-compose.yaml
version: "3.7"
services:
  test:
    image: ollijanatuinen/capsh
    cap_add:
      - NET_ADMIN
    cap_drop:
      - CAP_MKNOD
$ build/docker stack deploy --compose-file docker-compose.yaml t1
$ docker inspect t1_test.1.m0jmdufuo93fotyyrhm00xx16
        "CapAdd": [
            "NET_ADMIN"
        ],
        "CapDrop": [
            "CAP_MKNOD"
        ],
```
</details>

<details>
<summary><code>docker service create</code></summary>

```
$ build/docker service create --name test --cap-add NET_ADMIN --cap-drop CAP_MKNOD ollijanatuinen/capsh
$ docker inspect test.1.li7llrgyp8v4mfvo5tvimhzxt
        "CapAdd": [
            "NET_ADMIN"
        ],
        "CapDrop": [
            "CAP_MKNOD"
        ],
```
</details>

<details>
<summary><code>docker service update</code></summary>

```
$ build/docker service update --cap-add CAP_MKNOD t1_test
$ docker inspect t1_test.1.92sd9omniksbenuv6wm17ft78
        "CapAdd": [
            "NET_ADMIN",
            "CAP_MKNOD"
        ],
        "CapDrop": null,

$ build/docker service update --cap-drop CAP_MKNOD --cap-drop NET_ADMIN t1_test
        "CapAdd": null,
        "CapDrop": [
            "CAP_MKNOD",
            "NET_ADMIN"
        ],
```
</details>


<details>
<summary><code>docker service inspect</code></summary>

```
$ build/docker service inspect t1_test
        "CapabilityAdd": [
            "NET_ADMIN"
        ],
        "CapabilityDrop": [
            "CAP_MKNOD"
        ]
$ build/docker service inspect --pretty t1_test
Capabilities:
 Add: NET_ADMIN
 Drop: CAP_MKNOD
```
</details>

**- Description for the changelog**

Add `cap_add` and `cap_drop` support to `docker stack deploy` and `--cap-add` and `--cap-drop` flags to `docker service create|update`.

**- A picture of a cute animal (not mandatory but encouraged)**

