### PR TITLE
Fix order of processing of some xx-add/xx-rm service update flags

### DIFF
--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -34,27 +34,58 @@ func TestUpdateServiceArgs(t *testing.T) {
 
 func TestUpdateLabels(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("label-add", "toadd=newlabel")
-	flags.Set("label-rm", "toremove")
+	flags.Set("label-add", "add-beats-remove=value")
+	flags.Set("label-add", "to-add=value")
+	flags.Set("label-add", "to-update=new-value")
+	flags.Set("label-add", "to-replace=new-value")
+	flags.Set("label-rm", "add-beats-remove")
+	flags.Set("label-rm", "to-remove")
+	flags.Set("label-rm", "to-replace")
+	flags.Set("label-rm", "no-such-label")
 
 	labels := map[string]string{
-		"toremove": "thelabeltoremove",
-		"tokeep":   "value",
+		"to-keep":    "value",
+		"to-remove":  "value",
+		"to-replace": "value",
+		"to-update":  "value",
 	}
 
 	updateLabels(flags, &labels)
-	assert.Check(t, is.Len(labels, 2))
-	assert.Check(t, is.Equal("value", labels["tokeep"]))
-	assert.Check(t, is.Equal("newlabel", labels["toadd"]))
+	assert.DeepEqual(t, labels, map[string]string{
+		"add-beats-remove": "value",
+		"to-add":           "value",
+		"to-keep":          "value",
+		"to-replace":       "new-value",
+		"to-update":        "new-value",
+	})
 }
 
-func TestUpdateLabelsRemoveALabelThatDoesNotExist(t *testing.T) {
+func TestUpdateContainerLabels(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("label-rm", "dne")
+	flags.Set("container-label-add", "add-beats-remove=value")
+	flags.Set("container-label-add", "to-add=value")
+	flags.Set("container-label-add", "to-update=new-value")
+	flags.Set("container-label-add", "to-replace=new-value")
+	flags.Set("container-label-rm", "add-beats-remove")
+	flags.Set("container-label-rm", "to-remove")
+	flags.Set("container-label-rm", "to-replace")
+	flags.Set("container-label-rm", "no-such-label")
 
-	labels := map[string]string{"foo": "theoldlabel"}
-	updateLabels(flags, &labels)
-	assert.Check(t, is.Len(labels, 1))
+	labels := map[string]string{
+		"to-keep":    "value",
+		"to-remove":  "value",
+		"to-replace": "value",
+		"to-update":  "value",
+	}
+
+	updateContainerLabels(flags, &labels)
+	assert.DeepEqual(t, labels, map[string]string{
+		"add-beats-remove": "value",
+		"to-add":           "value",
+		"to-keep":          "value",
+		"to-replace":       "new-value",
+		"to-update":        "new-value",
+	})
 }
 
 func TestUpdatePlacementConstraints(t *testing.T) {
@@ -115,14 +146,15 @@ func TestUpdateEnvironment(t *testing.T) {
 
 func TestUpdateEnvironmentWithDuplicateValues(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
-	flags.Set("env-add", "foo=newenv")
-	flags.Set("env-add", "foo=dupe")
 	flags.Set("env-rm", "foo")
+	flags.Set("env-add", "foo=first")
+	flags.Set("env-add", "foo=second")
 
 	envs := []string{"foo=value"}
 
 	updateEnvironment(flags, &envs)
-	assert.Check(t, is.Len(envs, 0))
+	assert.Check(t, is.Len(envs, 1))
+	assert.Equal(t, envs[0], "foo=second")
 }
 
 func TestUpdateEnvironmentWithDuplicateKeys(t *testing.T) {


### PR DESCRIPTION
(noticed this while reviewing https://github.com/docker/cli/pull/2663. I thought we fixed these, but apparently not for all flags)

Combining `-add` and `-rm` flags on `docker service update` should be usable to explicitly replace existing options. The current order of processing did not allow this, causing the `-rm` flag to remove properties that were specified in `-add`. This behavior was inconsistent with (for example) `--host-add` and `--host-rm`.

This patch updates the behavior to first remove properties, then add new properties.

Note that there's still some improvements to make, to make the removal more granulas (e.g. to make `--label-rm label=some-value` only remove the label if value matches `some-value`); these changes are left for a follow-up.

Before this change:
-----------------------------

Create a service with two env-vars

```bash
docker service create --env FOO=bar --env BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Env }}' test | jq .
[
  "FOO=bar",
  "BAR=baz"
]
```

Update the service, with the intent to replace the value of `FOO` for a new value

```bash
docker service update  --env-rm FOO --env-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Env }}' test | jq .
[
  "BAR=baz"
]
```

Create a service with two labels

```bash
docker service create --label FOO=bar --label BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "bar"
}
```

Update the service, with the intent to replace the value of `FOO` for a new value

```bash
docker service update  --label-rm FOO --label-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.Labels }}' test | jq .
{
  "BAR": "baz"
}
```

Create a service with two container labels

```bash
docker service create --container-label FOO=bar --container-label BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "bar"
}
```

Update the service, with the intent to replace the value of `FOO` for a new value

```bash
docker service update  --container-label-rm FOO --container-label-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Labels }}' test | jq .
{
  "BAR": "baz",
}
```

With this patch applied:
--------------------------------

Create a service with two env-vars

```bash
docker service create --env FOO=bar --env BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Env }}' test | jq .
[
  "FOO=bar",
  "BAR=baz"
]
```

Update the service, and replace the value of `FOO` for a new value

```bash
docker service update  --env-rm FOO --env-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Env }}' test | jq .
[
  "BAR=baz",
  "FOO=updated-foo"
]
```

Create a service with two labels

```bash
docker service create --label FOO=bar --label BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "bar"
}
```

Update the service, and replace the value of `FOO` for a new value

```bash
docker service update  --label-rm FOO --label-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "updated-foo"
}
```

Create a service with two container labels

```bash
docker service create --container-label FOO=bar --container-label BAR=baz  --name=test nginx:alpine
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "bar"
}
```

Update the service, and replace the value of `FOO` for a new value

```bash
docker service update  --container-label-rm FOO --container-label-add FOO=updated-foo test
docker service inspect --format '{{json .Spec.TaskTemplate.ContainerSpec.Labels }}' test | jq .
{
  "BAR": "baz",
  "FOO": "updated-foo"
}
```

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
Fix order of processing of `--label-add/--label-rm`, `--container-label-add/--container-label-rm`, and `--env-add/--env-rm` flags on  `docker service update` to allow replacing existing values.
```

**- A picture of a cute animal (not mandatory but encouraged)**

