### PR TITLE
Issue 2549/autocomplete group and gpus support

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1894,6 +1894,7 @@ _docker_container_run_and_create() {
 		--env -e
 		--env-file
 		--expose
+		--gpus
 		--group-add
 		--health-cmd
 		--health-interval

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -624,7 +624,8 @@ __docker_container_subcommand() {
         "($help)--entrypoint=[Overwrite the default entrypoint of the image]:entry point: "
         "($help)*--env-file=[Read environment variables from a file]:environment file:_files"
         "($help)*--expose=[Expose a port from the container without publishing it]: "
-        "($help)*--group=[Set one or more supplementary user groups for the container]:group:_groups"
+        "($help)*--gpus=[GPU devices to add to the container ('all' to pass all GPUs)]:device: "
+        "($help)*--group-add=[Set one or more supplementary user groups for the container]:group:_groups"
         "($help -h --hostname)"{-h=,--hostname=}"[Container host name]:hostname:_hosts"
         "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
         "($help)--init[Run an init inside the container that forwards signals and reaps processes]"
@@ -2015,6 +2016,7 @@ __docker_service_subcommand() {
                 "($help)*--dns-option=[Set DNS options]:DNS option: " \
                 "($help)*--dns-search=[Set custom DNS search domains]:DNS search: " \
                 "($help)*--env-file=[Read environment variables from a file]:environment file:_files" \
+                "($help)*--group=[Set one or more supplementary user groups for the container]:group: _groups " \
                 "($help)--mode=[Service Mode]:mode:(global replicated)" \
                 "($help)--name=[Service name]:name: " \
                 "($help)*--placement-pref=[Add a placement preference]:pref:__docker_service_complete_placement_pref" \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Confirm the issues presented in https://github.com/docker/cli/issues/2549 and https://github.com/docker/cli/issues/2549#issuecomment-640055524

Fix Auto complete options available:
- Add support for --gpus to run/create container in bash and zsh
- Remove --group from run and update container as it's not a valid flag in zsh
- Add --group-add --group-rm for create and update update service in bash

**- How I did it**
Update the auto complete files

**- How to verify it**
For zsh
```
/usr/local/bin/zsh

source contrib/completion/zsh/_docker
docker container run --g[TAB][TAB]
--gpu and --group-add
docker service create --g[TAB][TAB]
--group
docker service update --g[TAB][TAB]
--group-add and --group-rm

docker container --help
docker service --help
```

For bash
```
/bin/bash
 source contrib/completion/bash/docker

docker container run --g[TAB][TAB]
--gpus and --group-add
docker service create --g[TAB][TAB]
--generic-resource and --group
docker service update --g[TAB][TAB]
--generic-resource-add  --generic-resource-rm   --group-add             --group-rm 

docker container --help
docker service --help
```

I also went through the library option and tested each command and confirmed that those options were valid for docker-cli aka no 'unknown flag:`


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix Auto complete options available:
- Add support for --gpus to run/create container in bash and zsh
- Remove --group from run and update container as it's not a valid flag in zsh
- Add --group-add --group-rm for create and update update service in bash

**- A picture of a cute animal (not mandatory but encouraged)**

https://i.pinimg.com/originals/a7/da/a1/a7daa190107fa107413036bdace84884.jpg