### PR TITLE
[carry 2663] Add capabilities support to stack/service commands

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -97,6 +97,15 @@ ContainerSpec:
 {{- if .ContainerUser }}
  User: {{ .ContainerUser }}
 {{- end }}
+{{- if .HasCapabilities }}
+Capabilities:
+{{- if .HasCapabilityAdd }}
+ Add: {{ .CapabilityAdd }}
+{{- end }}
+{{- if .HasCapabilityDrop }}
+ Drop: {{ .CapabilityDrop }}
+{{- end }}
+{{- end }}
 {{- if .ContainerSysCtls }}
 SysCtls:
 {{- range $k, $v := .ContainerSysCtls }}
@@ -530,6 +539,26 @@ func (ctx *serviceInspectContext) EndpointMode() string {
 
 func (ctx *serviceInspectContext) Ports() []swarm.PortConfig {
 	return ctx.Service.Endpoint.Ports
+}
+
+func (ctx *serviceInspectContext) HasCapabilities() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd) > 0 || len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop) > 0
+}
+
+func (ctx *serviceInspectContext) HasCapabilityAdd() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd) > 0
+}
+
+func (ctx *serviceInspectContext) HasCapabilityDrop() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop) > 0
+}
+
+func (ctx *serviceInspectContext) CapabilityAdd() string {
+	return strings.Join(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityAdd, ", ")
+}
+
+func (ctx *serviceInspectContext) CapabilityDrop() string {
+	return strings.Join(ctx.Service.Spec.TaskTemplate.ContainerSpec.CapabilityDrop, ", ")
 }
 
 const (

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -506,6 +506,8 @@ type serviceOptions struct {
 	dnsOption       opts.ListOpts
 	hosts           opts.ListOpts
 	sysctls         opts.ListOpts
+	capAdd          opts.ListOpts
+	capDrop         opts.ListOpts
 
 	resources resourceOptions
 	stopGrace opts.DurationOpt
@@ -549,6 +551,8 @@ func newServiceOptions() *serviceOptions {
 		dnsSearch:       opts.NewListOpts(opts.ValidateDNSSearch),
 		hosts:           opts.NewListOpts(opts.ValidateExtraHost),
 		sysctls:         opts.NewListOpts(nil),
+		capAdd:          opts.NewListOpts(nil),
+		capDrop:         opts.NewListOpts(nil),
 	}
 }
 
@@ -716,6 +720,8 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				Healthcheck:     healthConfig,
 				Isolation:       container.Isolation(options.isolation),
 				Sysctls:         opts.ConvertKVStringsToMap(options.sysctls.GetAll()),
+				CapabilityAdd:   options.capAdd.GetAll(),
+				CapabilityDrop:  options.capDrop.GetAll(),
 			},
 			Networks:      networks,
 			Resources:     resources,
@@ -818,6 +824,10 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 	flags.StringVar(&opts.hostname, flagHostname, "", "Container hostname")
 	flags.SetAnnotation(flagHostname, "version", []string{"1.25"})
 	flags.Var(&opts.entrypoint, flagEntrypoint, "Overwrite the default ENTRYPOINT of the image")
+	flags.Var(&opts.capAdd, flagCapAdd, "Add Linux capabilities")
+	flags.SetAnnotation(flagCapAdd, "version", []string{"1.41"})
+	flags.Var(&opts.capDrop, flagCapDrop, "Drop Linux capabilities")
+	flags.SetAnnotation(flagCapDrop, "version", []string{"1.41"})
 
 	flags.Var(&opts.resources.limitCPU, flagLimitCPU, "Limit CPUs")
 	flags.Var(&opts.resources.limitMemBytes, flagLimitMemory, "Limit Memory")
@@ -1001,6 +1011,8 @@ const (
 	flagConfigAdd               = "config-add"
 	flagConfigRemove            = "config-rm"
 	flagIsolation               = "isolation"
+	flagCapAdd                  = "cap-add"
+	flagCapDrop                 = "cap-drop"
 )
 
 func validateAPIVersion(c swarm.ServiceSpec, serverAPIVersion string) error {

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -689,6 +689,8 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 		return service, err
 	}
 
+	capAdd, capDrop := opts.EffectiveCapAddCapDrop(options.capAdd.GetAll(), options.capDrop.GetAll())
+
 	service = swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   options.name,
@@ -720,8 +722,8 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				Healthcheck:     healthConfig,
 				Isolation:       container.Isolation(options.isolation),
 				Sysctls:         opts.ConvertKVStringsToMap(options.sysctls.GetAll()),
-				CapabilityAdd:   options.capAdd.GetAll(),
-				CapabilityDrop:  options.capDrop.GetAll(),
+				CapabilityAdd:   capAdd,
+				CapabilityDrop:  capDrop,
 			},
 			Networks:      networks,
 			Resources:     resources,

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1427,7 +1427,7 @@ func TestUpdateCaps(t *testing.T) {
 			spec: &swarm.ContainerSpec{
 				CapabilityDrop: []string{"CAP_NET_ADMIN"},
 			},
-			expectedAdd:  []string{"CAP_NET_ADMIN"},
+			expectedAdd:  nil,
 			expectedDrop: nil,
 		},
 		{
@@ -1437,8 +1437,8 @@ func TestUpdateCaps(t *testing.T) {
 			spec: &swarm.ContainerSpec{
 				CapabilityAdd: []string{"CAP_NET_ADMIN"},
 			},
-			expectedDrop: []string{"CAP_NET_ADMIN"},
 			expectedAdd:  []string{"CAP_CHOWN"},
+			expectedDrop: nil,
 		},
 		{
 			name:    "Add caps to service that has ALL caps has no effect",
@@ -1447,6 +1447,16 @@ func TestUpdateCaps(t *testing.T) {
 				CapabilityAdd: []string{"ALL"},
 			},
 			expectedAdd:  []string{"ALL"},
+			expectedDrop: nil,
+		},
+		{
+			name:     "Drop ALL caps, then add new caps to service that has ALL caps",
+			flagAdd:  []string{"CAP_NET_ADMIN"},
+			flagDrop: []string{"ALL"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd: []string{"ALL"},
+			},
+			expectedAdd:  []string{"CAP_NET_ADMIN"},
 			expectedDrop: nil,
 		},
 		{
@@ -1488,7 +1498,7 @@ func TestUpdateCaps(t *testing.T) {
 				CapabilityDrop: []string{"CAP_CHOWN"},
 			},
 			expectedAdd:  []string{"ALL"},
-			expectedDrop: []string{"CAP_CHOWN", "CAP_NET_ADMIN", "CAP_SYS_ADMIN"},
+			expectedDrop: []string{"CAP_CHOWN", "CAP_SYS_ADMIN"},
 		},
 		{
 			name:     "Drop all, and add all",

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -117,6 +117,8 @@ func Service(
 		}
 	}
 
+	capAdd, capDrop := opts.EffectiveCapAddCapDrop(service.CapAdd, service.CapDrop)
+
 	serviceSpec := swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   name,
@@ -147,8 +149,8 @@ func Service(
 				Isolation:       container.Isolation(service.Isolation),
 				Init:            service.Init,
 				Sysctls:         service.Sysctls,
-				CapabilityAdd:   service.CapAdd,
-				CapabilityDrop:  service.CapDrop,
+				CapabilityAdd:   capAdd,
+				CapabilityDrop:  capDrop,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -147,6 +147,8 @@ func Service(
 				Isolation:       container.Isolation(service.Isolation),
 				Init:            service.Init,
 				Sysctls:         service.Sysctls,
+				CapabilityAdd:   service.CapAdd,
+				CapabilityDrop:  service.CapDrop,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -623,3 +623,29 @@ func TestConvertUpdateConfigParallelism(t *testing.T) {
 	})
 	assert.Check(t, is.Equal(parallel, updateConfig.Parallelism))
 }
+
+func TestConvertServiceCapAddAndCapDrop(t *testing.T) {
+	// test default behavior
+	result, err := Service("1.41", Namespace{name: "foo"}, composetypes.ServiceConfig{}, nil, nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityAdd, []string(nil)))
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityDrop, []string(nil)))
+
+	// with some values
+	service := composetypes.ServiceConfig{
+		CapAdd: []string{
+			"SYS_NICE",
+			"CAP_NET_ADMIN",
+		},
+		CapDrop: []string{
+			"CHOWN",
+			"DAC_OVERRIDE",
+			"CAP_FSETID",
+			"CAP_FOWNER",
+		},
+	}
+	result, err = Service("1.41", Namespace{name: "foo"}, service, nil, nil, nil, nil)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityAdd, service.CapAdd))
+	assert.Check(t, is.DeepEqual(result.TaskTemplate.ContainerSpec.CapabilityDrop, service.CapDrop))
+}

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -9,8 +9,6 @@ import (
 // UnsupportedProperties not yet supported by this implementation of the compose file
 var UnsupportedProperties = []string{
 	"build",
-	"cap_add",
-	"cap_drop",
 	"cgroupns_mode",
 	"cgroup_parent",
 	"devices",

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3672,6 +3672,8 @@ _docker_service_update() {
 # and `docker service update`
 _docker_service_update_and_create() {
 	local options_with_args="
+		--cap-add
+		--cap-drop
 		--endpoint-mode
 		--entrypoint
 		--health-cmd
@@ -3830,6 +3832,14 @@ _docker_service_update_and_create() {
 	esac
 
 	case "$prev" in
+		--cap-add)
+			__docker_complete_capabilities_addable
+			return
+			;;
+		--cap-drop)
+			__docker_complete_capabilities_droppable
+			return
+			;;
 		--config|--config-add|--config-rm)
 			__docker_complete_configs
 			return

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1961,6 +1961,8 @@ __docker_service_subcommand() {
 
     opts_help=("(: -)--help[Print usage]")
     opts_create_update=(
+        "($help)*--cap-add=[Add Linux capabilities]:capability: "
+        "($help)*--cap-drop=[Drop Linux capabilities]:capability: "
         "($help)*--constraint=[Placement constraints]:constraint: "
         "($help)--endpoint-mode=[Placement constraints]:mode:(dnsrr vip)"
         "($help)*"{-e=,--env=}"[Set environment variables]:env: "

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -12,6 +12,8 @@ Usage:  docker service create [OPTIONS] IMAGE [COMMAND] [ARG...]
 Create a new service
 
 Options:
+      --cap-add list                       Add Linux capabilities
+      --cap-drop list                      Drop Linux capabilities
       --config config                      Specify configurations to expose to the service
       --constraint list                    Placement constraints
       --container-label list               Container labels

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -13,6 +13,8 @@ Update a service
 
 Options:
       --args command                       Service command args
+      --cap-add list                       Add Linux capabilities
+      --cap-drop list                      Drop Linux capabilities
       --config-add config                  Add or update a config file on a service
       --config-rm list                     Remove a configuration file
       --constraint-add list                Add or update a placement constraint

--- a/opts/capabilities.go
+++ b/opts/capabilities.go
@@ -1,0 +1,78 @@
+package opts
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	// AllCapabilities is a special value to add or drop all capabilities
+	AllCapabilities = "ALL"
+)
+
+// NormalizeCapability normalizes a capability by upper-casing, trimming white space
+// and adding a CAP_ prefix (if not yet present). This function also accepts the
+// "ALL" magic-value, as used by CapAdd/CapDrop.
+//
+// This function only handles rudimentary formatting; no validation is performed,
+// as the list of available capabilities can be updated over time, thus should be
+// handled by the daemon.
+func NormalizeCapability(cap string) string {
+	cap = strings.ToUpper(strings.TrimSpace(cap))
+	if cap == AllCapabilities {
+		return cap
+	}
+	if !strings.HasPrefix(cap, "CAP_") {
+		cap = "CAP_" + cap
+	}
+	return cap
+}
+
+// CapabilitiesMap normalizes the given capabilities and converts them to a map.
+func CapabilitiesMap(caps []string) map[string]bool {
+	normalized := make(map[string]bool)
+	for _, c := range caps {
+		normalized[NormalizeCapability(c)] = true
+	}
+	return normalized
+}
+
+// EffectiveCapAddCapDrop normalizes and sorts capabilities to "add" and "drop",
+// and returns the effective capabilities to include in both.
+//
+// "CapAdd" takes precedence over "CapDrop", so capabilities included in both
+// lists are removed from the list of capabilities to drop. The special "ALL"
+// capability is also taken into account.
+//
+// Duplicates are removed, and the resulting lists are sorted.
+func EffectiveCapAddCapDrop(add, drop []string) (capAdd, capDrop []string) {
+	var (
+		addCaps  = CapabilitiesMap(add)
+		dropCaps = CapabilitiesMap(drop)
+	)
+
+	if addCaps[AllCapabilities] {
+		// Special case: "ALL capabilities" trumps any other capability added.
+		addCaps = map[string]bool{AllCapabilities: true}
+	}
+	if dropCaps[AllCapabilities] {
+		// Special case: "ALL capabilities" trumps any other capability added.
+		dropCaps = map[string]bool{AllCapabilities: true}
+	}
+	for c := range dropCaps {
+		if addCaps[c] {
+			// Adding a capability takes precedence, so skip dropping
+			continue
+		}
+		capDrop = append(capDrop, c)
+	}
+
+	for c := range addCaps {
+		capAdd = append(capAdd, c)
+	}
+
+	sort.Strings(capAdd)
+	sort.Strings(capDrop)
+
+	return capAdd, capDrop
+}

--- a/opts/capabilities_test.go
+++ b/opts/capabilities_test.go
@@ -1,0 +1,119 @@
+package opts
+
+import (
+	"strconv"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestNormalizeCapability(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{in: "ALL", out: "ALL"},
+		{in: "FOO", out: "CAP_FOO"},
+		{in: "CAP_FOO", out: "CAP_FOO"},
+		{in: "CAPFOO", out: "CAP_CAPFOO"},
+
+		// case-insensitive handling
+		{in: "aLl", out: "ALL"},
+		{in: "foO", out: "CAP_FOO"},
+		{in: "cAp_foO", out: "CAP_FOO"},
+
+		// white space handling. strictly, these could be considered "invalid",
+		// but are a likely situation, so handling these for now.
+		{in: "  ALL  ", out: "ALL"},
+		{in: "  FOO  ", out: "CAP_FOO"},
+		{in: "  CAP_FOO  ", out: "CAP_FOO"},
+		{in: " 	 ALL 	 ", out: "ALL"},
+		{in: " 	 FOO 	 ", out: "CAP_FOO"},
+		{in: " 	 CAP_FOO 	 ", out: "CAP_FOO"},
+
+		// weird values: no validation takes place currently, so these
+		// are handled same as values above; we could consider not accepting
+		// these in future
+		{in: "SOME CAP", out: "CAP_SOME CAP"},
+		{in: "_FOO", out: "CAP__FOO"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, NormalizeCapability(tc.in), tc.out)
+		})
+	}
+}
+
+func TestEffectiveCapAddCapDrop(t *testing.T) {
+	type caps struct {
+		add, drop []string
+	}
+
+	tests := []struct {
+		in, out caps
+	}{
+		{
+			in: caps{
+				add:  []string{"one", "two"},
+				drop: []string{"one", "two"},
+			},
+			out: caps{
+				add: []string{"CAP_ONE", "CAP_TWO"},
+			},
+		},
+		{
+			in: caps{
+				add:  []string{"CAP_ONE", "cap_one", "CAP_TWO"},
+				drop: []string{"one", "cap_two"},
+			},
+			out: caps{
+				add: []string{"CAP_ONE", "CAP_TWO"},
+			},
+		},
+		{
+			in: caps{
+				add:  []string{"CAP_ONE", "CAP_TWO"},
+				drop: []string{"CAP_ONE", "CAP_THREE"},
+			},
+			out: caps{
+				add:  []string{"CAP_ONE", "CAP_TWO"},
+				drop: []string{"CAP_THREE"},
+			},
+		},
+		{
+			in: caps{
+				add:  []string{"ALL"},
+				drop: []string{"CAP_ONE", "CAP_TWO"},
+			},
+			out: caps{
+				add:  []string{"ALL"},
+				drop: []string{"CAP_ONE", "CAP_TWO"},
+			},
+		},
+		{
+			in: caps{
+				add: []string{"ALL", "CAP_ONE"},
+			},
+			out: caps{
+				add: []string{"ALL"},
+			},
+		},
+		{
+			in: caps{
+				drop: []string{"ALL", "CAP_ONE"},
+			},
+			out: caps{
+				drop: []string{"ALL"},
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		tc := tc
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			add, drop := EffectiveCapAddCapDrop(tc.in.add, tc.in.drop)
+			assert.DeepEqual(t, add, tc.out.add)
+			assert.DeepEqual(t, drop, tc.out.drop)
+
+		})
+	}
+}


### PR DESCRIPTION
carries https://github.com/docker/cli/pull/2663

closes #1940
closes #2199
closes #2663

Fixes moby/moby#25885


**- What I did**

This PR supersedes #1940 and #2199. I removed the support of `privileged` option from the original PR as I believe privileged containers involve more than just having the complete set of capabilities (eg. no user namespace,  the unconfined AppArmor profile is used, etc...).

1. `docker stack deploy` now supports `cap_add` and `cap_drop` options ;
2. `docker service create|update` now support `--cap-add` and `--cap-drop` flags. For the `update` command and unlike most of other options, those flags don't have `-add` & `-rm` variants as this would make a poor UX (eg. `--cap-add-add` & `--cap-drop-rm`). Instead, `updateCapabilities` takes care of stripping caps provided to `--cap-add` from `CapabilityDrop` (and vice versa)  ;
3. `docker service inspect --pretty` displays the list of added caps and dropped caps ;


**- How I did it**

1. The service converter transforming compose types into API types has been updated to add capabilities to `ServiceSpec`;
2. A new function with the logic described above and named `updateCapabilities()` has been introduced and is called by `updateService` ;
3. The pretty formatter has been updated to include added and dropped caps ;

**- How to verify it**

<details>
<summary><code>docker stack deploy</code></summary>

```
$ cat docker-compose.yaml
version: "3.7"
services:
  test:
    image: ollijanatuinen/capsh
    cap_add:
      - NET_ADMIN
    cap_drop:
      - CAP_MKNOD
$ build/docker stack deploy --compose-file docker-compose.yaml t1
$ docker inspect t1_test.1.m0jmdufuo93fotyyrhm00xx16
        "CapAdd": [
            "CAP_NET_ADMIN"
        ],
        "CapDrop": [
            "CAP_MKNOD"
        ],
```
</details>

<details>
<summary><code>docker service create</code></summary>

```
$ build/docker service create --name test --cap-add NET_ADMIN --cap-drop CAP_MKNOD ollijanatuinen/capsh
$ docker inspect test.1.li7llrgyp8v4mfvo5tvimhzxt
        "CapAdd": [
            "CAP_NET_ADMIN"
        ],
        "CapDrop": [
            "CAP_MKNOD"
        ],
```
</details>

<details>
<summary><code>docker service update</code></summary>

```
$ build/docker service update --cap-add CAP_MKNOD t1_test
$ docker inspect t1_test.1.92sd9omniksbenuv6wm17ft78
        "CapAdd": [
            "CAP_NET_ADMIN",
            "CAP_MKNOD"
        ],
        "CapDrop": null,

$ build/docker service update --cap-drop CAP_MKNOD --cap-drop NET_ADMIN t1_test
        "CapAdd": null,
        "CapDrop": [
            "CAP_MKNOD",
            "CAP_NET_ADMIN"
        ],
```
</details>


<details>
<summary><code>docker service inspect</code></summary>

```
$ build/docker service inspect t1_test
        "CapabilityAdd": [
            "CAP_NET_ADMIN"
        ],
        "CapabilityDrop": [
            "CAP_MKNOD"
        ]
$ build/docker service inspect --pretty t1_test
Capabilities:
 Add: CAP_NET_ADMIN
 Drop: CAP_MKNOD
```
</details>

**- Description for the changelog**

Add `cap_add` and `cap_drop` support to `docker stack deploy` and `--cap-add` and `--cap-drop` flags to `docker service create|update`.

**- A picture of a cute animal (not mandatory but encouraged)**
