### PR TITLE
Dockerfile: fix dynbinary inside dev container

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -2,7 +2,7 @@ ARG GO_VERSION=1.13.15
 
 FROM    golang:${GO_VERSION}-alpine
 
-RUN     apk add -U git make bash coreutils ca-certificates curl
+RUN     apk add --no-cache bash build-base ca-certificates coreutils curl git
 
 # v0.1.1
 ARG     VNDR_SHA=85886e1ac99b8d96590e6e0d9f075dc7a711d132


### PR DESCRIPTION
Running `make dynbinary` inside the dev-container failed because
gcc was not installed. Adding the `build-base` metapackage, which
has gcc, make, g++ and other packages that are needed.

Before this change:

    $ make -f docker.Makefile shell
    $$ make dynbinary
    ./scripts/build/dynbinary
    Building dynamically linked build/docker-linux-amd64
    # github.com/docker/cli/cmd/docker
    /usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exec: "gcc": executable file not found in $PATH
    make: *** [Makefile:63: dynbinary] Error 2

With this patch applied

    $ make -f docker.Makefile shell
    $$ make dynbinary
    ./scripts/build/dynbinary
    Building dynamically linked build/docker-linux-amd64
    $$ echo $?
    0

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
