### PR TITLE
vendor: bump github.com/fvbommel/sortorder v1.0.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -21,7 +21,7 @@ github.com/docker/go-metrics                        d466d4f6fd960e01820085bd7e1a
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/swarmkit                          035d564a3686f5e348d861ec0c074ff26854c498
 github.com/evanphx/json-patch                       72bf35d0ff611848c1dc9df0f976c81192392fa5 # v4.1.0
-github.com/fvbommel/sortorder                       6b6b45a52fcc54f788363c1880630248b63402a1 # v1.0.0
+github.com/fvbommel/sortorder                       a1ddee917217bbd0691affdca9c88d24d3f5c27d # v1.0.1
 github.com/gofrs/flock                              392e7fae8f1b0bdbd67dad7237d23f618feb6dbb # v0.7.1
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1

--- a/vendor/github.com/fvbommel/sortorder/README.md
+++ b/vendor/github.com/fvbommel/sortorder/README.md
@@ -1,4 +1,4 @@
-# sortorder [![GoDoc](https://godoc.org/github.com/fvbommel/sortorder?status.svg)](https://godoc.org/github.com/fvbommel/sortorder)
+# sortorder [![PkgGoDev](https://pkg.go.dev/badge/github.com/fvbommel/sortorder)](https://pkg.go.dev/github.com/fvbommel/sortorder)
 
     import "github.com/fvbommel/sortorder"
 

--- a/vendor/github.com/fvbommel/sortorder/go.mod
+++ b/vendor/github.com/fvbommel/sortorder/go.mod
@@ -1,5 +1,3 @@
 module github.com/fvbommel/sortorder
 
 go 1.13
-
-require github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1


### PR DESCRIPTION
drops the dependency on github.com/xlab/handysort from go.mod (https://github.com/fvbommel/sortorder/pull/1)

diff: https://github.com/fvbommel/sortorder/compare/v1.0.0...v1.0.1

