### PR TITLE
Complete capabilites with and without "CAP_" prefix.

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -832,55 +832,57 @@ __docker_complete_local_ips() {
 # not granted by default and may be added.
 # see https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities
 __docker_complete_capabilities_addable() {
-	COMPREPLY=( $( compgen -W "
+  local capabilities=(
 		ALL
-		AUDIT_CONTROL
-		BLOCK_SUSPEND
-		DAC_READ_SEARCH
-		IPC_LOCK
-		IPC_OWNER
-		LEASE
-		LINUX_IMMUTABLE
-		MAC_ADMIN
-		MAC_OVERRIDE
-		NET_ADMIN
-		NET_BROADCAST
-		SYS_ADMIN
-		SYS_BOOT
-		SYSLOG
-		SYS_MODULE
-		SYS_NICE
-		SYS_PACCT
-		SYS_PTRACE
-		SYS_RAWIO
-		SYS_RESOURCE
-		SYS_TIME
-		SYS_TTY_CONFIG
-		WAKE_ALARM
-	" -- "$cur" ) )
+		CAP_AUDIT_CONTROL
+		CAP_BLOCK_SUSPEND
+		CAP_DAC_READ_SEARCH
+		CAP_IPC_LOCK
+		CAP_IPC_OWNER
+		CAP_LEASE
+		CAP_LINUX_IMMUTABLE
+		CAP_MAC_ADMIN
+		CAP_MAC_OVERRIDE
+		CAP_NET_ADMIN
+		CAP_NET_BROADCAST
+		CAP_SYS_ADMIN
+		CAP_SYS_BOOT
+		CAP_SYSLOG
+		CAP_SYS_MODULE
+		CAP_SYS_NICE
+		CAP_SYS_PACCT
+		CAP_SYS_PTRACE
+		CAP_SYS_RAWIO
+		CAP_SYS_RESOURCE
+		CAP_SYS_TIME
+		CAP_SYS_TTY_CONFIG
+		CAP_WAKE_ALARM
+  )
+	COMPREPLY=( $( compgen -W "${capabilities[*]} ${capabilities[*]#CAP_}" -- "$cur" ) )
 }
 
 # __docker_complete_capabilities_droppable completes Linux capability options which are
 # allowed by default and can be dropped.
 # see https://docs.docker.com/engine/reference/run/#/runtime-privilege-and-linux-capabilities
 __docker_complete_capabilities_droppable() {
-	COMPREPLY=( $( compgen -W "
+	local capabilities=(
 		ALL
-		AUDIT_WRITE
-		CHOWN
-		DAC_OVERRIDE
-		FOWNER
-		FSETID
-		KILL
-		MKNOD
-		NET_BIND_SERVICE
-		NET_RAW
-		SETFCAP
-		SETGID
-		SETPCAP
-		SETUID
-		SYS_CHROOT
-	" -- "$cur" ) )
+		CAP_AUDIT_WRITE
+		CAP_CHOWN
+		CAP_DAC_OVERRIDE
+		CAP_FOWNER
+		CAP_FSETID
+		CAP_KILL
+		CAP_MKNOD
+		CAP_NET_BIND_SERVICE
+		CAP_NET_RAW
+		CAP_SETFCAP
+		CAP_SETGID
+		CAP_SETPCAP
+		CAP_SETUID
+		CAP_SYS_CHROOT
+	)
+	COMPREPLY=( $( compgen -W "${capabilities[*]} ${capabilities[*]#CAP_}" -- "$cur" ) )
 }
 
 __docker_complete_detach_keys() {


### PR DESCRIPTION
This extends bash completion for the capabilities after `--cap-add` and `--cap-drop` to also include the `CAP_` prefixed variants.
See https://github.com/docker/cli/pull/2687#discussion_r478338544.

Before:
```bash
$ docker run --cap-drop <TAB TAB>
ALL               DAC_OVERRIDE      KILL              NET_RAW           SETPCAP
AUDIT_WRITE       FOWNER            MKNOD             SETFCAP           SETUID
CHOWN             FSETID            NET_BIND_SERVICE  SETGID            SYS_CHROOT
```

Now:
```bash
$ docker run --cap-drop <TAB TAB>
ALL                   CAP_FSETID            CAP_SETGID            FOWNER                SETFCAP
AUDIT_WRITE           CAP_KILL              CAP_SETPCAP           FSETID                SETGID
CAP_AUDIT_WRITE       CAP_MKNOD             CAP_SETUID            KILL                  SETPCAP
CAP_CHOWN             CAP_NET_BIND_SERVICE  CAP_SYS_CHROOT        MKNOD                 SETUID
CAP_DAC_OVERRIDE      CAP_NET_RAW           CHOWN                 NET_BIND_SERVICE      SYS_CHROOT
CAP_FOWNER            CAP_SETFCAP           DAC_OVERRIDE          NET_RAW
```
Note the special treatment of `ALL`:  `CAP_ALL` is not added.

This makes completion consistent with the completion of signals, e.g.
```bash
$ docker run --stop-signal <TAB TAB>
CONT     INT      QUIT     SIGHUP   SIGKILL  SIGSTOP  SIGUSR1  STOP     USR1
HUP      KILL     SIGCONT  SIGINT   SIGQUIT  SIGTERM  SIGUSR2  TERM     USR2
```