### PR TITLE
Add spinner loading to docker cp command

### DIFF
--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -77,7 +77,7 @@ func TestRunCopyFromContainerToFilesystem(t *testing.T) {
 			return readCloser, types.ContainerPathStat{}, err
 		},
 	}
-	options := copyOptions{source: "container:/path", destination: destDir.Path()}
+	options := copyOptions{source: "container:/path", destination: destDir.Path(), quiet: true}
 	cli := test.NewFakeCli(fakeClient)
 	err := runCopy(cli, options)
 	assert.NilError(t, err)


### PR DESCRIPTION
**- What I did**

When a user executes `docker cp` command, a `Copying` message is showed on terminal and a spinner is printed out together, with a small animation.

**- How I did it**

Add animation using a channel and an array of characters to simulate a spinner in cp.go.

**- How to verify it**

Run the environment container with `make -f docker.Makefile shell`, then run the command `./build/docker-linux-amd64 cp file container:path` to see.

**- Description for the changelog**

Addition of animated spinner when copying files using the docker cp command

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/7096390/92287808-402d8a00-eee1-11ea-9fc9-5c3184af4d4c.png)

closes #2564 
closes https://github.com/docker/cli/issues/1281