### PR TITLE
Service cap-add/cap-drop: add special "RESET" value

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1409,9 +1409,17 @@ func updateCapabilities(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec
 	)
 	if flags.Changed(flagCapAdd) {
 		toAdd = opts.CapabilitiesMap(flags.Lookup(flagCapAdd).Value.(*opts.ListOpts).GetAll())
+		if toAdd[opts.ResetCapabilities] {
+			capAdd = make(map[string]bool)
+			delete(toAdd, opts.ResetCapabilities)
+		}
 	}
 	if flags.Changed(flagCapDrop) {
 		toDrop = opts.CapabilitiesMap(flags.Lookup(flagCapDrop).Value.(*opts.ListOpts).GetAll())
+		if toDrop[opts.ResetCapabilities] {
+			capDrop = make(map[string]bool)
+			delete(toDrop, opts.ResetCapabilities)
+		}
 	}
 
 	// First remove the capabilities to "drop" from the service's exiting

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1522,6 +1522,50 @@ func TestUpdateCaps(t *testing.T) {
 			expectedAdd:  []string{"CAP_AAA", "CAP_BBB", "CAP_CCC", "CAP_DDD"},
 			expectedDrop: []string{"CAP_WWW", "CAP_XXX", "CAP_YYY", "CAP_ZZZ"},
 		},
+		{
+			name:     "Reset capabilities",
+			flagAdd:  []string{"RESET"},
+			flagDrop: []string{"RESET"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd:  []string{"CAP_AAA", "CAP_BBB", "CAP_CCC", "CAP_DDD"},
+				CapabilityDrop: []string{"CAP_WWW", "CAP_XXX", "CAP_YYY", "CAP_ZZZ"},
+			},
+			expectedAdd:  nil,
+			expectedDrop: nil,
+		},
+		{
+			name:     "Reset capabilities, and update after",
+			flagAdd:  []string{"RESET", "CAP_ADD_ONE", "CAP_FOO"},
+			flagDrop: []string{"RESET", "CAP_DROP_ONE", "CAP_FOO"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd:  []string{"CAP_AAA", "CAP_BBB", "CAP_CCC", "CAP_DDD"},
+				CapabilityDrop: []string{"CAP_WWW", "CAP_XXX", "CAP_YYY", "CAP_ZZZ"},
+			},
+			expectedAdd:  []string{"CAP_ADD_ONE", "CAP_FOO"},
+			expectedDrop: []string{"CAP_DROP_ONE"},
+		},
+		{
+			name:     "Reset capabilities, and add ALL",
+			flagAdd:  []string{"RESET", "ALL"},
+			flagDrop: []string{"RESET", "ALL"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd:  []string{"CAP_AAA", "CAP_BBB", "CAP_CCC", "CAP_DDD"},
+				CapabilityDrop: []string{"CAP_WWW", "CAP_XXX", "CAP_YYY", "CAP_ZZZ"},
+			},
+			expectedAdd:  []string{"ALL"},
+			expectedDrop: nil,
+		},
+		{
+			name:     "Add ALL and RESET",
+			flagAdd:  []string{"ALL", "RESET"},
+			flagDrop: []string{"ALL", "RESET"},
+			spec: &swarm.ContainerSpec{
+				CapabilityAdd:  []string{"CAP_AAA", "CAP_BBB", "CAP_CCC", "CAP_DDD"},
+				CapabilityDrop: []string{"CAP_WWW", "CAP_XXX", "CAP_YYY", "CAP_ZZZ"},
+			},
+			expectedAdd:  []string{"ALL"},
+			expectedDrop: nil,
+		},
 	}
 
 	for _, tc := range tests {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -857,6 +857,7 @@ __docker_complete_capabilities_addable() {
 		CAP_SYS_TIME
 		CAP_SYS_TTY_CONFIG
 		CAP_WAKE_ALARM
+		RESET
   )
 	COMPREPLY=( $( compgen -W "${capabilities[*]} ${capabilities[*]#CAP_}" -- "$cur" ) )
 }
@@ -881,6 +882,7 @@ __docker_complete_capabilities_droppable() {
 		CAP_SETPCAP
 		CAP_SETUID
 		CAP_SYS_CHROOT
+		RESET
 	)
 	COMPREPLY=( $( compgen -W "${capabilities[*]} ${capabilities[*]#CAP_}" -- "$cur" ) )
 }


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/2687


This implements a special "RESET" value that can be used to reset the
list of capabilities to add/drop when updating a service.

Given the following service;

| CapDrop | CapAdd |
| -------------- | ------------- |
| CAP_SOME_CAP | |

When updating the service, and applying `--cap-drop RESET`, the "drop" list
is reset to its default:

| CapDrop | CapAdd |
| -------------- | ------------- |
| | |

When updating the service, and applying `--cap-drop RESET`, combined with
`--cap-add CAP_SOME_CAP` and `--cap-drop CAP_SOME_OTHER_CAP`:

| CapDrop | CapAdd |
| -------------- | ------------- |
| CAP_FOO_CAP | CAP_SOME_CAP |