### PR TITLE
Add ulimits support to docker service and docker stack deploy (carry 2660)

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -64,6 +64,8 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagInit, "version", []string{"1.37"})
 	flags.Var(&opts.sysctls, flagSysCtl, "Sysctl options")
 	flags.SetAnnotation(flagSysCtl, "version", []string{"1.40"})
+	flags.Var(&opts.ulimits, flagUlimit, "Ulimit options")
+	flags.SetAnnotation(flagUlimit, "version", []string{"1.41"})
 
 	flags.Var(cliopts.NewListOptsRef(&opts.resources.resGenericResources, ValidateSingleGenericResource), "generic-resource", "User defined resources")
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.32"})

--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -111,6 +111,11 @@ SysCtls:
 {{- range $k, $v := .ContainerSysCtls }}
  {{ $k }}{{if $v }}: {{ $v }}{{ end }}
 {{- end }}{{ end }}
+{{- if .ContainerUlimits }}
+Ulimits:
+{{- range $k, $v := .ContainerUlimits }}
+ {{ $k }}: {{ $v }}
+{{- end }}{{ end }}
 {{- if .ContainerMounts }}
 Mounts:
 {{- end }}
@@ -465,6 +470,20 @@ func (ctx *serviceInspectContext) ContainerSysCtls() map[string]string {
 
 func (ctx *serviceInspectContext) HasContainerSysCtls() bool {
 	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.Sysctls) > 0
+}
+
+func (ctx *serviceInspectContext) ContainerUlimits() map[string]string {
+	ulimits := map[string]string{}
+
+	for _, u := range ctx.Service.Spec.TaskTemplate.ContainerSpec.Ulimits {
+		ulimits[u.Name] = fmt.Sprintf("%d:%d", u.Soft, u.Hard)
+	}
+
+	return ulimits
+}
+
+func (ctx *serviceInspectContext) HasContainerUlimits() bool {
+	return len(ctx.Service.Spec.TaskTemplate.ContainerSpec.Ulimits) > 0
 }
 
 func (ctx *serviceInspectContext) HasResources() bool {

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -508,6 +508,7 @@ type serviceOptions struct {
 	sysctls         opts.ListOpts
 	capAdd          opts.ListOpts
 	capDrop         opts.ListOpts
+	ulimits         opts.UlimitOpt
 
 	resources resourceOptions
 	stopGrace opts.DurationOpt
@@ -553,6 +554,7 @@ func newServiceOptions() *serviceOptions {
 		sysctls:         opts.NewListOpts(nil),
 		capAdd:          opts.NewListOpts(nil),
 		capDrop:         opts.NewListOpts(nil),
+		ulimits:         *opts.NewUlimitOpt(nil),
 	}
 }
 
@@ -724,6 +726,7 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				Sysctls:         opts.ConvertKVStringsToMap(options.sysctls.GetAll()),
 				CapabilityAdd:   capAdd,
 				CapabilityDrop:  capDrop,
+				Ulimits:         options.ulimits.GetList(),
 			},
 			Networks:      networks,
 			Resources:     resources,
@@ -1015,6 +1018,9 @@ const (
 	flagIsolation               = "isolation"
 	flagCapAdd                  = "cap-add"
 	flagCapDrop                 = "cap-drop"
+	flagUlimit                  = "ulimit"
+	flagUlimitAdd               = "ulimit-add"
+	flagUlimitRemove            = "ulimit-rm"
 )
 
 func validateAPIVersion(c swarm.ServiceSpec, serverAPIVersion string) error {

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -23,7 +23,6 @@ var UnsupportedProperties = []string{
 	"restart",
 	"security_opt",
 	"shm_size",
-	"ulimits",
 	"userns_mode",
 }
 

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3754,6 +3754,7 @@ _docker_service_update_and_create() {
 			--publish -p
 			--secret
 			--sysctl
+			--ulimit
 		"
 
 		case "$prev" in
@@ -3806,6 +3807,8 @@ _docker_service_update_and_create() {
 			--secret-rm
 			--sysctl-add
 			--sysctl-rm
+			--ulimit-add
+			--ulimit-rm
 		"
 
 		boolean_options="$boolean_options

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -74,6 +74,7 @@ Options:
       --stop-signal string                 Signal to stop the container
       --sysctl list                        Sysctl options
   -t, --tty                                Allocate a pseudo-TTY
+      --ulimit ulimit                      Ulimit options (default [])
       --update-delay duration              Delay between updates (ns|us|ms|s|m|h) (default 0s)
       --update-failure-action string       Action on update failure ("pause"|"continue"|"rollback") (default "pause")
       --update-max-failure-ratio float     Failure rate to tolerate during an update (default 0)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -91,6 +91,8 @@ Options:
       --sysctl-add list                    Add or update a Sysctl option
       --sysctl-rm list                     Remove a Sysctl option
   -t, --tty                                Allocate a pseudo-TTY
+      --ulimit-add ulimit                  Add or update a ulimit option (default [])
+      --ulimit-rm list                     Remove a ulimit option
       --update-delay duration              Delay between updates (ns|us|ms|s|m|h)
       --update-failure-action string       Action on update failure ("pause"|"continue"|"rollback")
       --update-max-failure-ratio float     Failure rate to tolerate during an update

--- a/opts/ulimit.go
+++ b/opts/ulimit.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/docker/go-units"
 )
@@ -11,7 +12,7 @@ type UlimitOpt struct {
 	values *map[string]*units.Ulimit
 }
 
-// NewUlimitOpt creates a new UlimitOpt
+// NewUlimitOpt creates a new UlimitOpt. Ulimits are not validated.
 func NewUlimitOpt(ref *map[string]*units.Ulimit) *UlimitOpt {
 	if ref == nil {
 		ref = &map[string]*units.Ulimit{}
@@ -31,23 +32,25 @@ func (o *UlimitOpt) Set(val string) error {
 	return nil
 }
 
-// String returns Ulimit values as a string.
+// String returns Ulimit values as a string. Values are sorted by name.
 func (o *UlimitOpt) String() string {
 	var out []string
 	for _, v := range *o.values {
 		out = append(out, v.String())
 	}
-
+	sort.Strings(out)
 	return fmt.Sprintf("%v", out)
 }
 
-// GetList returns a slice of pointers to Ulimits.
+// GetList returns a slice of pointers to Ulimits. Values are sorted by name.
 func (o *UlimitOpt) GetList() []*units.Ulimit {
 	var ulimits []*units.Ulimit
 	for _, v := range *o.values {
 		ulimits = append(ulimits, v)
 	}
-
+	sort.SliceStable(ulimits, func(i, j int) bool {
+		return ulimits[i].Name < ulimits[j].Name
+	})
 	return ulimits
 }
 


### PR DESCRIPTION
carries https://github.com/docker/cli/pull/2660
closes https://github.com/docker/cli/pull/2660

**- What I did**

1. ~Bump docker/docker to my own fork to have API changes regarding ulimits support on service endpoints ;~
2. Add `--ulimit` to `docker service create` ;
3. Add `--ulimit-add` and `--ulimit-rm` options to `docker service update` ;
4. Add `Ulimits` to `docker service inspect --pretty` ;
5. Support ulimits in docker-compose files, to make them work with `docker stack deploy` ;

This is related to moby/moby#40639.

**- How I did it**

**- How to verify it**

Given the following `docker-compose.yaml`:

```yaml
version: "3"

services:
  test:
    image: debian
    command: /bin/bash -c "ulimit -a && sleep 15"
    ulimits:
      nofile: 100
    deploy:
      mode: replicated
```

<details>
<summary><code>docker service create</code></summary>

```
$ docker service create --name t2 --ulimit=nofile=100 debian /bin/bash -c "ulimit -a && sleep 30"
$ docker service logs -f t2
...
t2.1.dkm9duj5i4rq@aker    | open files                      (-n) 100
t2.1.dkm9duj5i4rq@aker    | real-time priority              (-r) 0
...
```
</details>

<details>
<summary><code>docker service update</code></summary>

```
$ docker service update --ulimit-rm nofile --ulimit-add rtprio=1 t2
$ docker service logs -f t2
...
t2.1.dkm9duj5i4rq@aker    | open files                      (-n) 1048576
t2.1.dkm9duj5i4rq@aker    | real-time priority              (-r) 1
...
```
</details>

<details>
<summary><code>docker service inspect</code></summary>

```
$ docker service update --ulimit-add nofile=100:200 t2
$ docker service inspect --pretty t2
...
Ulimits:
 nofile: 100:200
 nproc: -1:-1
...

$ docker service inspect t2
...
        "Ulimits": [
            {
                "Name": "nproc",
                "Hard": -1,
                "Soft": -1
            },
            {
                "Name": "nofile",
                "Hard": 200,
                "Soft": 100
            }
        ]
...
```
</details>

<details>
<summary><code>docker stack deploy</code></summary>

```
$ cat docker-compose.yaml
version: "3"

services:
  test:
    image: debian
    command: /bin/bash -c "ulimit -a && sleep 15"
    ulimits:
      nofile: 100
    deploy:
      mode: replicated

$ docker stack deploy --compose-file docker-compose.yaml test
$ docker service logs -f test_test | grep "open files"
test_test.1.jezlw4wt08rz@aker    | open files                      (-n) 100
$ docker inspect $(docker ps --filter=name=test_test -q)
...
        "Ulimits": [
            {
                "Name": "nofile",
                "Hard": 100,
                "Soft": 100
            }
        ],
...
```
</details>

**- Description for the changelog**

Add `ulimits` support to `docker service create|update|inspect` and `docker stack deploy`

**- A picture of a cute animal (not mandatory but encouraged)**
