### PR TITLE
docs/build: add note about git subdirectories with BuildKit

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -110,6 +110,11 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 `myrepo.git#mytag:myfolder`     | `refs/tags/mytag`     | `/myfolder`
 `myrepo.git#mybranch:myfolder`  | `refs/heads/mybranch` | `/myfolder`
 
+> **Note**
+>
+> You cannot specify the build-context directory (`myfolder` in the examples above)
+> when using BuildKit as builder (`DOCKER_BUILDKIT=1`). Support for this feature
+> is tracked in [buildkit#1684](https://github.com/moby/buildkit/issues/1684).
 
 ### Tarball contexts
 


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/issues/1684 and https://github.com/docker/build-push-action/issues/120#issuecomment-691510409