### PR TITLE
[19.03] vendor: stop using docker/engine fork for vendoring

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -15,7 +15,7 @@ github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff7826
 github.com/dgrijalva/jwt-go                         a2c85815a77d0f951e33ba4db5ae93629a1530af
 github.com/docker/compose-on-kubernetes             cc4914dfd1b6684a9750a59f3613fc0a95291824 # v0.4.23
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            a004854097417a591c3f6a3aeaab75efae3c5814 https://github.com/docker/engine.git # 19.03 branch
+github.com/docker/docker                            a004854097417a591c3f6a3aeaab75efae3c5814 # 19.03 branch
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0


### PR DESCRIPTION
Release branches and tags are published on the upstream repository
again, so no need to use the docker/engine repository anymore.

