### PR TITLE
Fix bash completion typo `docker manifest rm`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4227,7 +4227,7 @@ _docker_manifest_push() {
 	esac
 }
 
-_docker_network_rm() {
+_docker_manifest_rm() {
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )


### PR DESCRIPTION


_Originally posted by @albers in https://github.com/docker/cli/pull/2449#discussion_r490501526_