### PR TITLE
Fix 2 typos

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1129,7 +1129,7 @@ type hostMapping struct {
 // were added, as the specification mentions that in case multiple entries for a
 // host exist, the first entry should be used (by default).
 //
-// Note that, even though unsupported by the the CLI, the service specs format
+// Note that, even though unsupported by the CLI, the service specs format
 // allow entries with both a _canonical_ hostname, and one or more aliases
 // in an entry (IP-address canonical_hostname [alias ...])
 //

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1103,7 +1103,7 @@ func TestUpdateGetUpdatedConfigs(t *testing.T) {
 		// flags are the flags we'll be setting
 		flags []flagVal
 		// oldConfigs are the configs that would already be on the service
-		// it is a slice of strings corresponding to the the key of
+		// it is a slice of strings corresponding to the key of
 		// cannedConfigRefs
 		oldConfigs []string
 		// oldCredSpec is the credentialSpec being carried over from the old


### PR DESCRIPTION
**- What I did**

Removed consecutive occurrences of 'the'

**- How I did it**

```
s/the the /the /g
```
**- How to verify it**

`grep -ir --color 'the the ' cli/`

**- Description for the changelog**

Fixed a small typo included in update_test.go and update.go
