### PR TITLE
Add .IPAddresses as formatting option on docker ps

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -4,8 +4,10 @@
 package formatter
 
 import (
+	"cmp"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -39,6 +41,16 @@ type Platform struct {
 
 func (p Platform) String() string {
 	return platforms.FormatAll(p.Platform)
+}
+
+// NetworkIP describes an IP-address and the network it's associated with.
+type NetworkIP struct {
+	Network string `json:"Network,omitempty"`
+	IP      string `json:"IP"`
+}
+
+func (p NetworkIP) String() string {
+	return p.Network + "/" + p.IP
 }
 
 // NewContainerFormat returns a Format for rendering using a Context
@@ -388,19 +400,30 @@ func (c *ContainerContext) HealthStatus() string {
 // IPAddresses returns the list of IP-addresses assigned to the container
 // IP-addresses are prefixed with the name of the network, separated with a colon.
 // For example: "bridge:192.168.1.10"
-func (c *ContainerContext) IPAddresses() []string {
-	ipAddresses := []string{}
-	if c.c.NetworkSettings == nil {
-		return ipAddresses
+func (c *ContainerContext) IPAddresses() []NetworkIP {
+	if c.c.NetworkSettings == nil || len(c.c.NetworkSettings.Networks) == 0 {
+		return []NetworkIP{}
 	}
+	ipAddresses := make([]NetworkIP, 0, len(c.c.NetworkSettings.Networks))
 	for name, nw := range c.c.NetworkSettings.Networks {
 		if nw.IPAddress.IsValid() {
-			ipAddresses = append(ipAddresses, name+":"+nw.IPAddress.String())
+			ipAddresses = append(ipAddresses, NetworkIP{
+				Network: name,
+				IP:      nw.IPAddress.String(),
+			})
 		}
 		if nw.GlobalIPv6Address.IsValid() {
-			ipAddresses = append(ipAddresses, name+":"+nw.GlobalIPv6Address.String())
+			ipAddresses = append(ipAddresses, NetworkIP{
+				Network: name,
+				IP:      nw.GlobalIPv6Address.String(),
+			})
 		}
 	}
+
+	slices.SortFunc(ipAddresses, func(a, b NetworkIP) int {
+		return cmp.Compare(a.String(), b.String())
+	})
+
 	return ipAddresses
 }
 

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -29,6 +29,7 @@ const (
 	networksHeader     = "NETWORKS"
 	platformHeader     = "PLATFORM"
 	healthStatusHeader = "HEALTH STATUS"
+	ipAddressesHeader  = "IP ADDRESSES"
 )
 
 // Platform wraps a [ocispec.Platform] to implement the stringer interface.
@@ -123,6 +124,7 @@ func NewContainerContext() *ContainerContext {
 		"Networks":     networksHeader,
 		"Platform":     platformHeader,
 		"HealthStatus": healthStatusHeader,
+		"IPAddresses":  ipAddressesHeader,
 	}
 	return &containerCtx
 }
@@ -381,6 +383,25 @@ func (c *ContainerContext) HealthStatus() string {
 	default:
 		return ""
 	}
+}
+
+// IPAddresses returns the list of IP-addresses assigned to the container
+// IP-addresses are prefixed with the name of the network, separated with a colon.
+// For example: "bridge:192.168.1.10"
+func (c *ContainerContext) IPAddresses() []string {
+	ipAddresses := []string{}
+	if c.c.NetworkSettings == nil {
+		return ipAddresses
+	}
+	for name, nw := range c.c.NetworkSettings.Networks {
+		if nw.IPAddress.IsValid() {
+			ipAddresses = append(ipAddresses, name+":"+nw.IPAddress.String())
+		}
+		if nw.GlobalIPv6Address.IsValid() {
+			ipAddresses = append(ipAddresses, name+":"+nw.GlobalIPv6Address.String())
+		}
+	}
+	return ipAddresses
 }
 
 // DisplayablePorts returns formatted string representing open ports of container

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -477,7 +477,18 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			Image:   "ubuntu",
 			Created: unix,
 			State:   container.StateRunning,
-
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"bridge": {
+						IPAddress:         netip.MustParseAddr("172.17.0.1"),
+						GlobalIPv6Address: netip.MustParseAddr("ff02::1"),
+					},
+					"my-net": {
+						IPAddress:         netip.MustParseAddr("172.18.0.1"),
+						GlobalIPv6Address: netip.MustParseAddr("ff02::2"),
+					},
+				},
+			},
 			ImageManifestDescriptor: &ocispec.Descriptor{Platform: &ocispec.Platform{Architecture: "amd64", OS: "linux"}},
 		},
 		{
@@ -497,6 +508,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			"CreatedAt":    expectedCreated,
 			"HealthStatus": "",
 			"ID":           "containerID1",
+			"IPAddresses":  []any{},
 			"Image":        "ubuntu",
 			"Labels":       "",
 			"LocalVolumes": "0",
@@ -515,12 +527,18 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			"CreatedAt":    expectedCreated,
 			"HealthStatus": "",
 			"ID":           "containerID2",
+			"IPAddresses": []any{
+				map[string]any{"IP": "172.17.0.1", "Network": "bridge"},
+				map[string]any{"IP": "ff02::1", "Network": "bridge"},
+				map[string]any{"IP": "172.18.0.1", "Network": "my-net"},
+				map[string]any{"IP": "ff02::2", "Network": "my-net"},
+			},
 			"Image":        "ubuntu",
 			"Labels":       "",
 			"LocalVolumes": "0",
 			"Mounts":       "",
 			"Names":        "foobar_bar",
-			"Networks":     "",
+			"Networks":     "bridge,my-net",
 			"Platform":     map[string]any{"architecture": "amd64", "os": "linux"},
 			"Ports":        "",
 			"RunningFor":   "About a minute ago",
@@ -533,6 +551,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 			"CreatedAt":    expectedCreated,
 			"HealthStatus": "",
 			"ID":           "containerID3",
+			"IPAddresses":  []any{},
 			"Image":        "ubuntu",
 			"Labels":       "",
 			"LocalVolumes": "0",
@@ -605,8 +624,8 @@ func TestContainerContextIPAddresses(t *testing.T) {
 	out := bytes.NewBufferString("")
 	err := ContainerWrite(Context{Format: "{{.IPAddresses}}", Output: out}, containers)
 	assert.NilError(t, err)
-	assert.Equal(t, out.String(), `[one:192.168.1.2 two:192.168.178.2]
-[one:192.168.1.3 two:192.168.178.3]
+	assert.Equal(t, out.String(), `[one/192.168.1.2 two/192.168.178.2]
+[one/192.168.1.3 two/192.168.178.3]
 `)
 }
 

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/cli/internal/test"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -390,7 +391,7 @@ size: 0B
 	}
 
 	containers := []container.Summary{
-		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unixTime, State: container.StateRunning},
+		{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu", Created: unixTime, State: container.StateRunning, NetworkSettings: &container.NetworkSettingsSummary{}},
 		{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu", Created: unixTime, State: container.StateRunning},
 	}
 
@@ -577,6 +578,36 @@ func TestContainerContextWriteJSONField(t *testing.T) {
 		assert.NilError(t, err, msg)
 		assert.Check(t, is.Equal(containers[i].ID, s), msg)
 	}
+}
+
+func TestContainerContextIPAddresses(t *testing.T) {
+	containers := []container.Summary{
+		{
+			ID: "containerID1",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"one": {IPAddress: netip.MustParseAddr("192.168.1.2")},
+					"two": {IPAddress: netip.MustParseAddr("192.168.178.2")},
+				},
+			},
+		},
+		{
+			ID: "containerID2",
+			NetworkSettings: &container.NetworkSettingsSummary{
+				Networks: map[string]*network.EndpointSettings{
+					"one": {IPAddress: netip.MustParseAddr("192.168.1.3")},
+					"two": {IPAddress: netip.MustParseAddr("192.168.178.3")},
+				},
+			},
+		},
+	}
+
+	out := bytes.NewBufferString("")
+	err := ContainerWrite(Context{Format: "{{.IPAddresses}}", Output: out}, containers)
+	assert.NilError(t, err)
+	assert.Equal(t, out.String(), `[one:192.168.1.2 two:192.168.178.2]
+[one:192.168.1.3 two:192.168.178.3]
+`)
 }
 
 func TestContainerBackCompat(t *testing.T) {

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -455,6 +455,6 @@ Show the IP-addresses that containers have:
 $ docker ps --format "table {{.ID}}\\t{{join .IPAddresses \", \"}}"
 
 CONTAINER ID   IP ADDRESSES
-c0cf2877da71   bridge:172.17.0.3
-17e7d1910fc0   bridge:172.17.0.2, mynetwork:172.19.0.2
+c0cf2877da71   bridge/172.17.0.3
+17e7d1910fc0   bridge/172.17.0.2, mynetwork/172.19.0.2
 ```

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -412,6 +412,7 @@ Valid placeholders for the Go template are listed below:
 | `.Label`        | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
 | `.Mounts`       | Names of the volumes mounted in this container.                                                 |
 | `.Networks`     | Names of the networks attached to this container.                                               |
+| `.IPAddresses`  | List of IP-Addresses for each network that the container is attached to.                        |
 
 When using the `--format` option, the `ps` command will either output the data
 exactly as the template declares or, when using the `table` directive, includes
@@ -446,4 +447,14 @@ To list all running containers in JSON format, use the `json` directive:
 ```console
 $ docker ps --format json
 {"Command":"\"/docker-entrypoint.…\"","CreatedAt":"2021-03-10 00:15:05 +0100 CET","ID":"a762a2b37a1d","Image":"nginx","Labels":"maintainer=NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e","LocalVolumes":"0","Mounts":"","Names":"boring_keldysh","Networks":"bridge","Ports":"80/tcp","RunningFor":"4 seconds ago","Size":"0B","State":"running","Status":"Up 3 seconds"}
+```
+
+Show the IP-addresses that containers have:
+
+```console
+$ docker ps --format "table {{.ID}}\\t{{join .IPAddresses \", \"}}"
+
+CONTAINER ID   IP ADDRESSES
+c0cf2877da71   bridge:172.17.0.3
+17e7d1910fc0   bridge:172.17.0.2, mynetwork:172.19.0.2
 ```


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/8786

This allows showing the IP address for each network that the container is attached to,
for example:

    docker network create foo
    docker run -d --name foo nginx:alpine
    docker network connect foo foo

    docker container ls --format 'table {{.ID}}\\t{{join .IPAddresses ", "}}'
    CONTAINER ID   IP ADDRESSES
    17e7d1910fc0   bridge:172.17.0.2, foo:172.19.0.2

    docker container ls --format='{{json .IPAddresses}}' | jq .
    [
      "bridge:172.17.0.2",
      "foo:172.19.0.2"
    ]


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->



