### PR TITLE
Fix buildkit flags not being hidden without buildkit enabled

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -316,8 +316,12 @@ func hideFlagIf(f *pflag.Flag, condition func(string) bool, annotation string) {
 	if f.Hidden {
 		return
 	}
-	if values, ok := f.Annotations[annotation]; ok && len(values) > 0 {
-		if condition(values[0]) {
+	var val string
+	if values, ok := f.Annotations[annotation]; ok {
+		if len(values) > 0 {
+			val = values[0]
+		}
+		if condition(val) {
 			f.Hidden = true
 		}
 	}


### PR DESCRIPTION
These annotations use `nil` as value, which caused the flag-hiding functions to ignore the annotations, and therefore not hiding the flags.

introduced in https://github.com/docker/cli/pull/2424


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

