### PR TITLE
build: remove PersistentPreRunE hack for experimental --stream

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -113,25 +113,6 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 
-	// Wrap the global pre-run to handle non-BuildKit use of the --platform flag.
-	//
-	// We're doing it here so that we're only contacting the daemon when actually
-	// running the command, and not during initialization.
-	// TODO remove this hack once we no longer support the experimental use of --platform
-	rootFn := cmd.Root().PersistentPreRunE
-	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if ok, _ := command.BuildKitEnabled(dockerCli.ServerInfo()); !ok {
-			f := cmd.Flag("platform")
-			delete(f.Annotations, "buildkit")
-			f.Annotations["version"] = []string{"1.32"}
-			f.Annotations["experimental"] = nil
-		}
-		if rootFn != nil {
-			return rootFn(cmd, args)
-		}
-		return nil
-	}
-
 	flags := cmd.Flags()
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")


### PR DESCRIPTION
This hack was added in an attempt to continue supporting the experimental
(non-buildkit) `--stream` option, by dynamically updating the API version
required if buildkit isn't enabled.

This hack didn't work, however, because at the moment the override is
added, the command is not yet attached to the "root" (`docker`) command,
and because of that, the command itself is the `root` command;
`cmd.Root()` returned the `build` command.

As a result, validation steps defined as `PersistentPreRunE` on the root
command were not executed, causing invalid flags/options to not producing
an error.

Attempts to use an alternative approach (for example, cobra supports both
a `PersistentPreRun` and `PersistentPreRunE`) did not work either, because
`PersistentPreRunE` takes precedence over `PersistentPreRun`, and only one
will be executed.

Given that the `--stream` option (without BuildKit) was experimental in
older API versions, we are "allowed" to break this behavior, so removing
this hack.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

