### PR TITLE
Add stack config command

### DIFF
--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -65,6 +65,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 		newPsCommand(dockerCli, &opts),
 		newRemoveCommand(dockerCli, &opts),
 		newServicesCommand(dockerCli, &opts),
+		newConfigCommand(dockerCli),
 	)
 	flags := cmd.PersistentFlags()
 	flags.String("kubeconfig", "", "Kubernetes config file")

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -32,11 +32,7 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 			}
 
 			_, err = fmt.Fprintf(dockerCli.Out(), "%s", cfg)
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return err
 		},
 	}
 

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -34,6 +34,7 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 			_, err = fmt.Fprintf(dockerCli.Out(), "%s", cfg)
 			return err
 		},
+		Annotations: map[string]string{"experimental": ""},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -26,7 +26,7 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 				return err
 			}
 
-			cfg, err := OutputConfig(configDetails, opts.SkipInterpolation)
+			cfg, err := outputConfig(configDetails, opts.SkipInterpolation)
 			if err != nil {
 				return err
 			}
@@ -47,8 +47,8 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-// OutputConfig returns the merged and interpolated config file
-func OutputConfig(configFiles composetypes.ConfigDetails, skipInterpolation bool) (string, error) {
+// outputConfig returns the merged and interpolated config file
+func outputConfig(configFiles composetypes.ConfigDetails, skipInterpolation bool) (string, error) {
 	optsFunc := func(options *composeLoader.Options) {
 		options.SkipInterpolation = skipInterpolation
 	}

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -17,10 +17,9 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 	var opts options.Config
 
 	cmd := &cobra.Command{
-		Use:     "config [OPTIONS]",
-		Aliases: []string{"cfg"},
-		Short:   "Outputs the final config file, after doing merges and interpolations",
-		Args:    cli.NoArgs,
+		Use:   "config [OPTIONS]",
+		Short: "Outputs the final config file, after doing merges and interpolations",
+		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDetails, err := loader.GetConfigDetails(opts.Composefiles, dockerCli.In())
 			if err != nil {

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -31,7 +31,11 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("%s", cfg)
+			_, err = fmt.Fprintf(dockerCli.Out(), "%s", cfg)
+			if err != nil {
+				return err
+			}
+
 			return nil
 		},
 	}

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -1,0 +1,62 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/stack/loader"
+	"github.com/docker/cli/cli/command/stack/options"
+	composeLoader "github.com/docker/cli/cli/compose/loader"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func newConfigCommand(dockerCli command.Cli) *cobra.Command {
+	var opts options.Config
+
+	cmd := &cobra.Command{
+		Use:     "config [OPTIONS]",
+		Aliases: []string{"cfg"},
+		Short:   "Outputs the final config file, after doing merges and interpolations",
+		Args:    cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configDetails, err := loader.GetConfigDetails(opts.Composefiles, dockerCli.In())
+			if err != nil {
+				return err
+			}
+
+			cfg, err := OutputConfig(configDetails, opts.SkipInterpolation)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s", cfg)
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, `Path to a Compose file, or "-" to read from stdin`)
+	flags.SetAnnotation("compose-file", "version", []string{"1.25"})
+	flags.BoolVar(&opts.SkipInterpolation, "skip-interpolation", false, "Skip interpolation and output only merged config")
+	return cmd
+}
+
+// OutputConfig returns the merged and interpolated config file
+func OutputConfig(configFiles composetypes.ConfigDetails, skipInterpolation bool) (string, error) {
+	optsFunc := func(options *composeLoader.Options) {
+		options.SkipInterpolation = skipInterpolation
+	}
+	config, err := composeLoader.Load(configFiles, optsFunc)
+	if err != nil {
+		return "", err
+	}
+
+	d, err := yaml.Marshal(&config)
+	if err != nil {
+		return "", err
+	}
+	return string(d), nil
+}

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -38,7 +38,6 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, `Path to a Compose file, or "-" to read from stdin`)
-	flags.SetAnnotation("compose-file", "version", []string{"1.25"})
 	flags.BoolVar(&opts.SkipInterpolation, "skip-interpolation", false, "Skip interpolation and output only merged config")
 	return cmd
 }

--- a/cli/command/stack/config_test.go
+++ b/cli/command/stack/config_test.go
@@ -43,7 +43,7 @@ services:
 		"VERSION": "1.0",
 	}
 
-	cfg, err := OutputConfig(composetypes.ConfigDetails{
+	cfg, err := outputConfig(composetypes.ConfigDetails{
 		ConfigFiles: []composetypes.ConfigFile{
 			{Config: firstConfigData, Filename: "firstConfig"},
 			{Config: secondConfigData, Filename: "secondConfig"},
@@ -89,7 +89,7 @@ services:
 		"VERSION": "1.0",
 	}
 
-	cfg, err := OutputConfig(composetypes.ConfigDetails{
+	cfg, err := outputConfig(composetypes.ConfigDetails{
 		ConfigFiles: []composetypes.ConfigFile{
 			{Config: firstConfigData, Filename: "firstConfig"},
 			{Config: secondConfigData, Filename: "secondConfig"},

--- a/cli/command/stack/config_test.go
+++ b/cli/command/stack/config_test.go
@@ -1,0 +1,110 @@
+package stack
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/cli/cli/compose/loader"
+	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestConfigWithEmptyComposeFile(t *testing.T) {
+	cmd := newConfigCommand(test.NewFakeCli(&fakeClient{}))
+	cmd.SetOut(ioutil.Discard)
+
+	assert.ErrorContains(t, cmd.Execute(), `Please specify a Compose file`)
+}
+
+func TestConfigMergeUsingInterpolation(t *testing.T) {
+
+	firstConfig := []byte(`
+version: "3.7"
+services:
+  foo:
+    image: busybox:latest
+    command: cat file1.txt
+`)
+	secondConfig := []byte(`
+version: "3.7"
+services:
+  foo:
+    image: busybox:${VERSION}
+    command: cat file2.txt
+`)
+
+	firstConfigData, err := loader.ParseYAML(firstConfig)
+	assert.NilError(t, err)
+	secondConfigData, err := loader.ParseYAML(secondConfig)
+	assert.NilError(t, err)
+
+	env := map[string]string{
+		"VERSION": "1.0",
+	}
+
+	cfg, err := OutputConfig(composetypes.ConfigDetails{
+		ConfigFiles: []composetypes.ConfigFile{
+			{Config: firstConfigData, Filename: "firstConfig"},
+			{Config: secondConfigData, Filename: "secondConfig"},
+		},
+		Environment: env,
+	}, false)
+	assert.NilError(t, err)
+
+	var mergedConfig = `version: "3.7"
+services:
+  foo:
+    command:
+    - cat
+    - file2.txt
+    image: busybox:1.0
+`
+	assert.Equal(t, cfg, mergedConfig)
+}
+
+func TestConfigMergeSkipInterpolation(t *testing.T) {
+
+	firstConfig := []byte(`
+version: "3.7"
+services:
+  foo:
+    image: busybox:latest
+    command: cat file1.txt
+`)
+	secondConfig := []byte(`
+version: "3.7"
+services:
+  foo:
+    image: busybox:${VERSION}
+    command: cat file2.txt
+`)
+
+	firstConfigData, err := loader.ParseYAML(firstConfig)
+	assert.NilError(t, err)
+	secondConfigData, err := loader.ParseYAML(secondConfig)
+	assert.NilError(t, err)
+
+	env := map[string]string{
+		"VERSION": "1.0",
+	}
+
+	cfg, err := OutputConfig(composetypes.ConfigDetails{
+		ConfigFiles: []composetypes.ConfigFile{
+			{Config: firstConfigData, Filename: "firstConfig"},
+			{Config: secondConfigData, Filename: "secondConfig"},
+		},
+		Environment: env,
+	}, true)
+	assert.NilError(t, err)
+
+	var mergedConfig = `version: "3.7"
+services:
+  foo:
+    command:
+    - cat
+    - file2.txt
+    image: busybox:${VERSION}
+`
+	assert.Equal(t, cfg, mergedConfig)
+}

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -19,7 +19,7 @@ import (
 
 // LoadComposefile parse the composefile specified in the cli and returns its Config and version.
 func LoadComposefile(dockerCli command.Cli, opts options.Deploy) (*composetypes.Config, error) {
-	configDetails, err := getConfigDetails(opts.Composefiles, dockerCli.In())
+	configDetails, err := GetConfigDetails(opts.Composefiles, dockerCli.In())
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,8 @@ func propertyWarnings(properties map[string]string) string {
 	return strings.Join(msgs, "\n\n")
 }
 
-func getConfigDetails(composefiles []string, stdin io.Reader) (composetypes.ConfigDetails, error) {
+// GetConfigDetails parse the composefiles specified in the cli and returns their ConfigDetails
+func GetConfigDetails(composefiles []string, stdin io.Reader) (composetypes.ConfigDetails, error) {
 	var details composetypes.ConfigDetails
 
 	if len(composefiles) == 0 {

--- a/cli/command/stack/loader/loader_test.go
+++ b/cli/command/stack/loader/loader_test.go
@@ -21,7 +21,7 @@ services:
 	file := fs.NewFile(t, "test-get-config-details", fs.WithContent(content))
 	defer file.Remove()
 
-	details, err := getConfigDetails([]string{file.Path()}, nil)
+	details, err := GetConfigDetails([]string{file.Path()}, nil)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(filepath.Dir(file.Path()), details.WorkingDir))
 	assert.Assert(t, is.Len(details.ConfigFiles, 1))
@@ -36,7 +36,7 @@ services:
   foo:
     image: alpine:3.5
 `
-	details, err := getConfigDetails([]string{"-"}, strings.NewReader(content))
+	details, err := GetConfigDetails([]string{"-"}, strings.NewReader(content))
 	assert.NilError(t, err)
 	cwd, err := os.Getwd()
 	assert.NilError(t, err)

--- a/cli/command/stack/options/opts.go
+++ b/cli/command/stack/options/opts.go
@@ -11,6 +11,12 @@ type Deploy struct {
 	Prune            bool
 }
 
+// Config holds docker stack config options
+type Config struct {
+	Composefiles      []string
+	SkipInterpolation bool
+}
+
 // List holds docker stack ls options
 type List struct {
 	Format        string

--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -59,6 +59,7 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 			reflect.TypeOf([]types.ServiceConfigObjConfig{}): mergeSlice(toServiceConfigObjConfigsMap, toSServiceConfigObjConfigsSlice),
 			reflect.TypeOf(&types.UlimitsConfig{}):           mergeUlimitsConfig,
 			reflect.TypeOf([]types.ServiceVolumeConfig{}):    mergeSlice(toServiceVolumeConfigsMap, toServiceVolumeConfigsSlice),
+			reflect.TypeOf(types.ShellCommand{}):             mergeShellCommand,
 			reflect.TypeOf(&types.ServiceNetworkConfig{}):    mergeServiceNetworkConfig,
 		},
 	}
@@ -235,9 +236,9 @@ func mergeUlimitsConfig(dst, src reflect.Value) error {
 }
 
 //nolint: unparam
-func mergeServiceVolumeConfig(dst, src reflect.Value) error {
-	if dst.Elem().FieldByName("target").String() == src.Elem().FieldByName("target").String() {
-		dst.Set(src.Elem())
+func mergeShellCommand(dst, src reflect.Value) error {
+	if src.Len() != 0 {
+		dst.Set(src)
 	}
 	return nil
 }

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -1017,6 +1017,59 @@ func TestLoadMultipleNetworks(t *testing.T) {
 	}, config)
 }
 
+func TestLoadMultipleServiceCommands(t *testing.T) {
+	base := map[string]interface{}{
+		"version": "3.7",
+		"services": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"image":   "baz",
+				"command": "foo bar",
+			},
+		},
+		"volumes":  map[string]interface{}{},
+		"networks": map[string]interface{}{},
+		"secrets":  map[string]interface{}{},
+		"configs":  map[string]interface{}{},
+	}
+	override := map[string]interface{}{
+		"version": "3.7",
+		"services": map[string]interface{}{
+			"foo": map[string]interface{}{
+				"image":   "baz",
+				"command": "foo baz",
+			},
+		},
+		"volumes":  map[string]interface{}{},
+		"networks": map[string]interface{}{},
+		"secrets":  map[string]interface{}{},
+		"configs":  map[string]interface{}{},
+	}
+	configDetails := types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{
+			{Filename: "base.yml", Config: base},
+			{Filename: "override.yml", Config: override},
+		},
+	}
+	config, err := Load(configDetails)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, &types.Config{
+		Filename: "base.yml",
+		Version:  "3.7",
+		Services: []types.ServiceConfig{
+			{
+				Name:        "foo",
+				Image:       "baz",
+				Command:     types.ShellCommand{"foo", "baz"},
+				Environment: types.MappingWithEquals{},
+			},
+		},
+		Volumes:  map[string]types.VolumeConfig{},
+		Secrets:  map[string]types.SecretConfig{},
+		Configs:  map[string]types.ConfigObjConfig{},
+		Networks: map[string]types.NetworkConfig{},
+	}, config)
+}
+
 func TestLoadMultipleServiceVolumes(t *testing.T) {
 	base := map[string]interface{}{
 		"version": "3.7",

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -159,6 +159,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [stack ps](stack_ps.md) | List the tasks in the stack                        |
 | [stack rm](stack_rm.md) | Remove the stack from the swarm                    |
 | [stack services](stack_services.md) | List the services in the stack         |
+| [stack config](stack_config.md) | Output the Compose file after merges and interpolations |
 
 ### Plugin commands
 

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -1,0 +1,68 @@
+---
+title: "stack config"
+description: "The stack config command description and usage"
+keywords: "stack, config"
+---
+
+# stack config
+
+```markdown
+Usage:	docker stack config [OPTIONS]
+
+Outputs the final config file, after doing merges and interpolations
+
+Aliases:
+  config, cfg
+
+Options:
+  -c, --compose-file strings   Path to a Compose file, or "-" to read from stdin
+      --orchestrator string    Orchestrator to use (swarm|kubernetes|all)
+      --skip-interpolation     Skip interpolation and output only merged config
+```
+
+## Description
+
+Outputs the final Compose file, after doing the merges and interpolations of the input Compose files.
+
+## Examples
+
+The following command outputs the result of the merge and interpolation of two Compose files.
+
+```bash
+$ docker stack config --compose-file docker-compose.yml --compose-file docker-compose.prod.yml
+```
+
+The Compose file can also be provided as standard input with `--compose-file -`:
+
+```bash
+$ cat docker-compose.yml | docker stack config --compose-file -
+```
+
+### Skipping interpolation
+
+In some cases, it might be useful to skip interpolation of environment variables.
+For example, when you want to pipe the output of this command back to `stack deploy`.
+
+If you have a regex for a redirect route in an environment variable for your webserver you would use two `$` signs to prevent `stack deploy` from interpolating `${1}`.
+
+```bash
+  service: webserver
+  environment:
+    REDIRECT_REGEX=http://host/redirect/$${1} 
+```
+
+With interpolation, the `stack config` command will replace the environment variable in the Compose file 
+with `REDIRECT_REGEX=http://host/redirect/${1}`, but then when piping it back to the `stack deploy` 
+command it will be interpolated again and result in undefined behavior. 
+That is why, when piping the output back to `stack deploy` one should always prefer the `--skip-interpolation` option.
+
+```
+$ docker stack config --compose-file web.yml --compose-file web.prod.yml --skip-interpolation | docker stack deploy --compose-file -
+```
+
+## Related commands
+
+* [stack deploy](stack_deploy.md)
+* [stack ps](stack_ps.md)
+* [stack rm](stack_rm.md)
+* [stack services](stack_services.md)

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -114,3 +114,4 @@ axqh55ipl40h  vossibility_vossibility-collector  replicated  1/1       icecrime/
 * [stack ps](stack_ps.md)
 * [stack rm](stack_rm.md)
 * [stack services](stack_services.md)
+* [stack config](stack_config.md)

--- a/e2e/stack/config_test.go
+++ b/e2e/stack/config_test.go
@@ -3,10 +3,12 @@ package stack
 import (
 	"testing"
 
+	"github.com/docker/cli/internal/test/environment"
 	"gotest.tools/v3/icmd"
 )
 
 func TestConfigFullStack(t *testing.T) {
+	environment.SkipIfNotExperimentalDaemon(t)
 	result := icmd.RunCommand("docker", "stack", "config", "--compose-file=./testdata/full-stack.yml")
 	result.Assert(t, icmd.Success)
 }

--- a/e2e/stack/config_test.go
+++ b/e2e/stack/config_test.go
@@ -1,0 +1,12 @@
+package stack
+
+import (
+	"testing"
+
+	"gotest.tools/v3/icmd"
+)
+
+func TestConfigFullStack(t *testing.T) {
+	result := icmd.RunCommand("docker", "stack", "config", "--compose-file=./testdata/full-stack.yml")
+	result.Assert(t, icmd.Success)
+}


### PR DESCRIPTION
Add stack config command.

Fixes #2365 

Usage:

```
# output interpolated and merged config
docker stack config -c docker-compose.prod.yml -c docker-compose.dev.yml
```

```
# also possible to input from stdin, like docker stack deploy
docker stack config -c -
```

```
# output merged config without interpolation
docker stack config -c docker-compose.prod.yml -c docker-compose.dev.yml --skip-interpolation
```

```
# possible to pipe it back to docker stack deploy, like this
# interpolating twice is not a good idea, so one should skip interpolation
docker stack config -c docker-compose.prod.yml -c docker-compose.dev.yml --skip-interpolation | docker stack deploy -c -
```

**- What I did**
Added stack config command that outputs on stdout the merged and/or interpolated config files for docker stack deploy. 
Now it is no longer required to have docker-compose in order to see how configs are interpolated and merged before deploying your stack.

Currently, in our team, we currently use something like this to check our merge/compilation output:
```
docker-compose -f config1 -f config2 config | docker stack deploy -c -
```
The interpolation and merge that `docker-compose config` provides is untrue in a swarm deploy context since docker-compose and docker/cli are two separate projects and use different methods for interpolation and merge. With the latest version of docker-compose we encountered some problems with the merged/interpolated format not being accepted by docker stack deploy. I decided to bring a config command to docker/cli as well so we won't encounter this problem in the future.

Related issues with latest docker-compose version:
https://github.com/docker/compose/issues/7773
https://github.com/docker/compose/pull/7778

I also added relevant unit tests for the two new merges.


**- How I did it**
I used the existing dependencies (the yaml lib) and functionality present in docker cli (the stack loader and the compose loader) in order to load the config files, merge/interpolate them and then output the yaml to stdout.

Testing on our own docker-compose files, I also noticed that when merging with docker stack deploy some properties did not merge in an expected way and produced unexpected consequences.

* the volume property in each service, would not take into account the target of the volume when merging.
I believe that in many cases, you would have a prod compose file with named or anonymous volumes and a dev compose file with a bind mounted volume to the same target. The merge of `docker stack deploy` would just concatenate the volumes array and throw an error since you try to mount to the same target. See the example in (How to verify it section of this PR), on how this PR merges them.

* the command property and entrypoint in each service, would just be concatenated, whereas with `docker-compose config` it would've been replaced. Meaning, for example, that if in configFile1 you had a command like `cat file1.txt` and in configFile2 you have a command like `cat file2.txt` the merge of `docker stack deploy -c configFile1 -c configFile2` would result in the command: `cat file1.txt cat file2.txt` which is definitely not what most people would expect and want. Modified this as well so that the command in configFile2 if exists will override the command in configFile1. See the example in (How to verify it section of this PR), on how this PR merges the command/entrypoint.

**- How to verify it**

All you need is two very simple config files:

```
# docker-compose.test1.yml
version: '3.7'

services:
  bash:
    image: bash
    command: cat randomFile.txt
    volumes:
      - app:/app
    working_dir: /app

volumes:
  app:
```

```
# docker-compose.test2.yml
version: '3.7'

services:
  bash:
    image: bash
    command: echo $ENV_STRING
    volumes:
      - ./src/app:/app
    working_dir: /app
```

Now, if you run `$ENV_STRING=helloworld docker-local stack config -c docker-compose.test1.yml -c docker-compose.test2.yml` (this is with interpolation), you will get something like this:
```
version: "3.7"
services:
  bash:
    command:
    - echo
    - helloworld
    image: bash
    environment:
      ENV_STRING: helloworld
    volumes:
    - type: bind
      source: /Users/flow/Projects/docker-test/src/app
      target: /app
    working_dir: /app
volumes:
  app: {}
```

If you run `docker-local stack config -c docker-compose.test1.yml -c docker-compose.test2.yml --skip-interpolation` (this is without interpolation), you will get something like this:

```
version: "3.7"
services:
  bash:
    command:
    - echo
    - $ENV_STRING
    image: bash
    environment:
      ENV_STRING: helloworld
    volumes:
    - type: bind
      source: /Users/flow/Projects/docker-test/src/app
      target: /app
    working_dir: /app
volumes:
  app: {}
```


**- Description for the changelog**
Added docker stack config command that outputs the merged and interpolated config files as utilised by stack deploy.


**- A picture of a cute animal (not mandatory but encouraged)**
Here is neko ikiru san to apologize for the long read
![image](https://static.boredpanda.com/blog/wp-content/uploads/2020/03/extra-1-5e71d4233e66c__700.jpg)

P.S. I am new to Go, please let me know if I did anything in a not so Go way
