### PR TITLE
Fix make -f docker.Makefile without buildkit enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
             steps {
                 sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
                     IMAGE_TAG=clie2e${BUILD_NUMBER} \
-                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
+                    make -f docker.Makefile test-e2e-non-experimental"
             }
         }
         stage("e2e (non-experimental) - 18.09 engine") {
@@ -26,21 +26,21 @@ pipeline {
                 sh "E2E_ENGINE_VERSION=18.09-dind \
                   E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
                   IMAGE_TAG=clie2e${BUILD_NUMBER} \
-                  DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-non-experimental"
+                  make -f docker.Makefile test-e2e-non-experimental"
             }
         }
         stage("e2e (experimental)") {
             steps {
                 sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
                     IMAGE_TAG=clie2e${BUILD_NUMBER} \
-                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-experimental"
+                    make -f docker.Makefile test-e2e-experimental"
             }
         }
         stage("e2e (ssh connhelper)") {
             steps {
                 sh "E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
                     IMAGE_TAG=clie2e${BUILD_NUMBER} \
-                    DOCKER_BUILDKIT=1 make -f docker.Makefile test-e2e-connhelper-ssh"
+                    make -f docker.Makefile test-e2e-connhelper-ssh"
             }
         }
     }

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -23,6 +23,9 @@ endif
 VERSION = $(shell cat VERSION)
 ENVVARS = -e VERSION=$(VERSION) -e GITCOMMIT -e PLATFORM -e TESTFLAGS -e TESTDIRS -e GOOS -e GOARCH -e GOARM -e TEST_ENGINE_VERSION=$(E2E_ENGINE_VERSION)
 
+# Some Dockerfiles use features that are only supported with BuildKit enabled
+export DOCKER_BUILDKIT=1
+
 # build docker image (dockerfiles/Dockerfile.build)
 .PHONY: build_docker_image
 build_docker_image:


### PR DESCRIPTION
Commit 01cd748eb6eec123d50637b7b1c835755392717e (https://github.com/docker/cli/pull/2696) started using Dockerfile features that are currently only supported with buildkit enabled.

While we enabled buildkit in our Jenkinsfile, the makefile did not do the same, causing some targets to fail if buildkit was not enabled.

This patch updates the makefile to enable buildkit.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

