### PR TITLE
docs: fix "docker logs" example missing container name

### DIFF
--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -71,7 +71,7 @@ In order to retrieve logs before a specific point in time, run:
 $ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
 $ date
 Tue 14 Nov 2017 16:40:00 CET
-$ docker logs -f --until=2s
+$ docker logs -f --until=2s test
 Tue 14 Nov 2017 16:40:00 CET
 Tue 14 Nov 2017 16:40:01 CET
 Tue 14 Nov 2017 16:40:02 CET

--- a/man/src/container/logs.md
+++ b/man/src/container/logs.md
@@ -33,7 +33,7 @@ In order to retrieve logs before a specific point in time, run:
 $ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
 $ date
 Tue 14 Nov 2017 16:40:00 CET
-$ docker logs -f --until=2s
+$ docker logs -f --until=2s test
 Tue 14 Nov 2017 16:40:00 CET
 Tue 14 Nov 2017 16:40:01 CET
 Tue 14 Nov 2017 16:40:02 CET


### PR DESCRIPTION
Thanks to rvsasseen for spotting this, and Maximillian Xavier for the initial pull request.

addresses https://github.com/docker/docker.github.io/issues/11398
relates to https://github.com/docker/docker.github.io/pull/11430

