### PR TITLE
Change createdAt type to date to enable formatting #2747

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -243,8 +243,8 @@ func (c *imageContext) CreatedSince() string {
 	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 }
 
-func (c *imageContext) CreatedAt() string {
-	return time.Unix(c.i.Created, 0).String()
+func (c *imageContext) CreatedAt() time.Time {
+	return time.Unix(c.i.Created, 0)
 }
 
 func (c *imageContext) Size() string {

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -42,7 +42,7 @@ func TestImageContext(t *testing.T) {
 		},
 		{
 			imageCtx: imageContext{i: types.ImageSummary{Created: unix}, trunc: true},
-			expValue: time.Unix(unix, 0).String(), call: ctx.CreatedAt,
+			expValue: time.Unix(unix, 0), call: ctx.CreatedAt,
 		},
 		// FIXME
 		// {imageContext{


### PR DESCRIPTION
Signed-off-by: Maximillian Fan Xavier <maximillianfx@gmail.com>

Change the type of CreatedAt field to time.Time, enabling formatting.

How I did it
Changing the return type of CreatedAt function, from String to time.Time

How to verify it
Run the environment container with make -f docker.Makefile shell, then run the command ./build/docker-linux-amd64 images --format '{{ printf "%d/%d/%d" .CreatedAt.Day .CreatedAt.Month .CreatedAt.Year }}'

Description for the changelog
Change the type of CreatedAt field.

Related issues
Fixes #2747

A picture of a cute animal (not mandatory but encouraged)

![image](https://user-images.githubusercontent.com/7096390/94757616-1d23b800-0371-11eb-8e48-7e23247f1e7b.png)
