### PR TITLE
Replace tab with spaces in usage output

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -282,8 +282,8 @@ func invalidPluginReason(cmd *cobra.Command) string {
 
 var usageTemplate = `Usage:
 
-{{- if not .HasSubCommands}}	{{.UseLine}}{{end}}
-{{- if .HasSubCommands}}	{{ .CommandPath}}{{- if .HasAvailableFlags}} [OPTIONS]{{end}} COMMAND{{end}}
+{{- if not .HasSubCommands}}  {{.UseLine}}{{end}}
+{{- if .HasSubCommands}}  {{ .CommandPath}}{{- if .HasAvailableFlags}} [OPTIONS]{{end}} COMMAND{{end}}
 
 {{if ne .Long ""}}{{ .Long | trim }}{{ else }}{{ .Short | trim }}{{end}}
 

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -7,7 +7,7 @@ keywords: container, prune, delete, remove
 # container prune
 
 ```markdown
-Usage:	docker container prune [OPTIONS]
+Usage:  docker container prune [OPTIONS]
 
 Remove all stopped containers
 

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -7,7 +7,7 @@ keywords: "image, prune, delete, remove"
 # image prune
 
 ```markdown
-Usage:	docker image prune [OPTIONS]
+Usage:  docker image prune [OPTIONS]
 
 Remove unused images
 

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -7,7 +7,7 @@ keywords: "network, create"
 # network create
 
 ```markdown
-Usage:	docker network create [OPTIONS] NETWORK
+Usage:  docker network create [OPTIONS] NETWORK
 
 Create a network
 

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -7,7 +7,7 @@ keywords: "network, prune, delete"
 # network prune
 
 ```markdown
-Usage:	docker network prune [OPTIONS]
+Usage:  docker network prune [OPTIONS]
 
 Remove all unused networks
 

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -7,7 +7,7 @@ keywords: "node, remove"
 # node rm
 
 ```markdown
-Usage:	docker node rm [OPTIONS] NODE [NODE...]
+Usage:  docker node rm [OPTIONS] NODE [NODE...]
 
 Remove one or more nodes from the swarm
 

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -7,7 +7,7 @@ keywords: "plugin, inspect"
 # plugin inspect
 
 ```markdown
-Usage:	docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
+Usage:  docker plugin inspect [OPTIONS] PLUGIN [PLUGIN...]
 
 Display detailed information on one or more plugins
 

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -5,7 +5,7 @@ keywords: "plugin, push"
 ---
 
 ```markdown
-Usage:	docker plugin push [OPTIONS] PLUGIN[:TAG]
+Usage:  docker plugin push [OPTIONS] PLUGIN[:TAG]
 
 Push a plugin to a registry
 

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -7,7 +7,7 @@ keywords: ["secret, create"]
 # secret create
 
 ```Markdown
-Usage:	docker secret create [OPTIONS] SECRET [file|-]
+Usage:  docker secret create [OPTIONS] SECRET [file|-]
 
 Create a secret from a file or STDIN as content
 

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -7,7 +7,7 @@ keywords: ["secret, ls"]
 # secret ls
 
 ```Markdown
-Usage:	docker secret ls [OPTIONS]
+Usage:  docker secret ls [OPTIONS]
 
 List secrets
 

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -7,7 +7,7 @@ keywords: ["secret, rm"]
 # secret rm
 
 ```Markdown
-Usage:	docker secret rm SECRET [SECRET...]
+Usage:  docker secret rm SECRET [SECRET...]
 
 Remove one or more secrets
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -7,7 +7,7 @@ keywords: "service, ls"
 # service ls
 
 ```Markdown
-Usage:	docker service ls [OPTIONS]
+Usage:  docker service ls [OPTIONS]
 
 List services
 

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -7,7 +7,7 @@ keywords: "service, rm"
 # service rm
 
 ```Markdown
-Usage:	docker service rm SERVICE [SERVICE...]
+Usage:  docker service rm SERVICE [SERVICE...]
 
 Remove one or more services
 

--- a/docs/reference/commandline/service_rollback.md
+++ b/docs/reference/commandline/service_rollback.md
@@ -7,7 +7,7 @@ keywords: "service, rollback"
 # service rollback
 
 ```markdown
-Usage:	docker service rollback SERVICE
+Usage:  docker service rollback SERVICE
 
 Revert changes to a service's configuration
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -7,7 +7,7 @@ keywords: "stack, ls"
 # stack ls
 
 ```markdown
-Usage:	docker stack ls [OPTIONS]
+Usage:  docker stack ls [OPTIONS]
 
 List stacks
 

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -7,7 +7,7 @@ keywords: "stack, services"
 # stack services
 
 ```markdown
-Usage:	docker stack services [OPTIONS] STACK
+Usage:  docker stack services [OPTIONS] STACK
 
 List the services in the stack
 

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -7,7 +7,7 @@ keywords: "swarm, ca"
 # swarm ca
 
 ```markdown
-Usage:	docker swarm ca [OPTIONS]
+Usage:  docker swarm ca [OPTIONS]
 
 Manage root CA
 

--- a/docs/reference/commandline/swarm_join-token.md
+++ b/docs/reference/commandline/swarm_join-token.md
@@ -7,7 +7,7 @@ keywords: "swarm, join-token"
 # swarm join-token
 
 ```markdown
-Usage:	docker swarm join-token [OPTIONS] (worker|manager)
+Usage:  docker swarm join-token [OPTIONS] (worker|manager)
 
 Manage join tokens
 

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -7,7 +7,7 @@ keywords: "swarm, leave"
 # swarm leave
 
 ```markdown
-Usage:	docker swarm leave [OPTIONS]
+Usage:  docker swarm leave [OPTIONS]
 
 Leave the swarm
 

--- a/docs/reference/commandline/swarm_unlock-key.md
+++ b/docs/reference/commandline/swarm_unlock-key.md
@@ -7,7 +7,7 @@ keywords: "swarm, unlock-key"
 # swarm unlock-key
 
 ```markdown
-Usage:	docker swarm unlock-key [OPTIONS]
+Usage:  docker swarm unlock-key [OPTIONS]
 
 Manage the unlock key
 

--- a/docs/reference/commandline/swarm_unlock.md
+++ b/docs/reference/commandline/swarm_unlock.md
@@ -7,7 +7,7 @@ keywords: "swarm, unlock"
 # swarm unlock
 
 ```markdown
-Usage:	docker swarm unlock
+Usage:  docker swarm unlock
 
 Unlock swarm
 

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -7,7 +7,7 @@ keywords: "system, data, usage, disk"
 # system df
 
 ```markdown
-Usage:	docker system df [OPTIONS]
+Usage:  docker system df [OPTIONS]
 
 Show docker filesystem usage
 

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -7,7 +7,7 @@ keywords: "system, prune, delete, remove"
 # system prune
 
 ```markdown
-Usage:	docker system prune [OPTIONS]
+Usage:  docker system prune [OPTIONS]
 
 Remove unused data
 

--- a/docs/reference/commandline/trust_key_load.md
+++ b/docs/reference/commandline/trust_key_load.md
@@ -7,7 +7,7 @@ keywords: "key, notary, trust"
 # trust key load
 
 ```markdown
-Usage:	docker trust key load [OPTIONS] KEYFILE
+Usage:  docker trust key load [OPTIONS] KEYFILE
 
 Load a private key file for signing
 

--- a/docs/reference/commandline/trust_signer_add.md
+++ b/docs/reference/commandline/trust_signer_add.md
@@ -7,7 +7,7 @@ keywords: "signer, notary, trust"
 # trust signer add
 
 ```markdown
-Usage:	docker trust signer add [OPTIONS] NAME REPOSITORY [REPOSITORY...]
+Usage:  docker trust signer add [OPTIONS] NAME REPOSITORY [REPOSITORY...]
 
 Add a signer
 

--- a/docs/reference/commandline/trust_signer_remove.md
+++ b/docs/reference/commandline/trust_signer_remove.md
@@ -7,7 +7,7 @@ keywords: "signer, notary, trust"
 # trust signer remove
 
 ```markdown
-Usage:	docker trust signer remove [OPTIONS] NAME REPOSITORY [REPOSITORY...]
+Usage:  docker trust signer remove [OPTIONS] NAME REPOSITORY [REPOSITORY...]
 
 Remove a signer
 

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -7,7 +7,7 @@ keywords: "volume, prune, delete"
 # volume prune
 
 ```markdown
-Usage:	docker volume prune [OPTIONS]
+Usage:  docker volume prune [OPTIONS]
 
 Remove all unused local volumes
 

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -49,7 +49,7 @@ func TestNonexistingHelp(t *testing.T) {
 		// This should actually be the whole docker help
 		// output, so spot check instead having of a golden
 		// with everything in, which will change too frequently.
-		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Out: "Usage:  docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
 		Err: icmd.None,
 	})
 	// Short -h should be the same, modulo the deprecation message
@@ -101,7 +101,7 @@ func TestBadHelp(t *testing.T) {
 		// This should be literally the whole docker help
 		// output, so spot check instead of a golden with
 		// everything in which will change all the time.
-		Out: "Usage:	docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
+		Out: "Usage:  docker [OPTIONS] COMMAND\n\nA self-sufficient runtime for containers",
 		Err: icmd.None,
 	})
 	// Short -h should be the same, modulo the deprecation message

--- a/e2e/cli-plugins/testdata/docker-help-helloworld-goodbye.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld-goodbye.golden
@@ -1,4 +1,4 @@
 
-Usage:	docker helloworld goodbye
+Usage:  docker helloworld goodbye
 
 Say Goodbye instead of Hello

--- a/e2e/cli-plugins/testdata/docker-help-helloworld.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld.golden
@@ -1,5 +1,5 @@
 
-Usage:	docker helloworld [OPTIONS] COMMAND
+Usage:  docker helloworld [OPTIONS] COMMAND
 
 A basic Hello World plugin for tests
 

--- a/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
+++ b/e2e/stack/testdata/stack-deploy-help-kubernetes.golden
@@ -1,5 +1,5 @@
 
-Usage:	docker stack deploy [OPTIONS] STACK
+Usage:  docker stack deploy [OPTIONS] STACK
 
 Deploy a new stack or update an existing stack
 

--- a/e2e/stack/testdata/stack-deploy-help-swarm.golden
+++ b/e2e/stack/testdata/stack-deploy-help-swarm.golden
@@ -1,5 +1,5 @@
 
-Usage:	docker stack deploy [OPTIONS] STACK
+Usage:  docker stack deploy [OPTIONS] STACK
 
 Deploy a new stack or update an existing stack
 


### PR DESCRIPTION
All output of the usage / `--help` output uses spaces, and having a tab in the output can be somewhat cumbersome (e.g. our YAML docs generator doesn't like them, and copy/pasing the output in iTerm produces a warning).

This patch changes the output to use two spaces instead.

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

