### PR TITLE
[19.03 backport] Deprecate configuration options for experimental CLI features

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
+Deprecated | [Configuration options for experimental CLI features](#configuration-options-for-experimental-cli-features)                        | v19.03.0   | v20.03.0
 Deprecated | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03.0   | v20.03.0
 Deprecated | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03.0   | v20.03.0
 Deprecated | [Top-level `docker deploy` subcommand (experimental)](#top-level-docker-deploy-subcommand-experimental)                            | v19.03.0   | v20.03.0
@@ -87,6 +88,11 @@ Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-
 Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10.0    | v1.13.0
 Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12.0
 
+### Configuration options for experimental CLI features
+
+The `DOCKER_CLI_EXPERIMENTAL` environment variable and the corresponding `experimental`
+field in the CLI configuration file are deprecated. Experimental features will be
+enabled by default, and these configuration options will no longer be functional.
 
 ### Pushing and pulling with image manifest v2 schema 1
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,43 +50,43 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
-Deprecated | [Configuration options for experimental CLI features](#configuration-options-for-experimental-cli-features)                        | v19.03.0   | v20.03.0
-Deprecated | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03.0   | v20.03.0
-Deprecated | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03.0   | v20.03.0
-Deprecated | [Top-level `docker deploy` subcommand (experimental)](#top-level-docker-deploy-subcommand-experimental)                            | v19.03.0   | v20.03.0
-Deprecated | [`docker stack deploy` using "dab" files (experimental)](#docker-stack-deploy-using-dab-files-experimental)                        | v19.03.0   | v20.03.0
-Deprecated | [AuFS storage driver](#aufs-storage-driver)                                                                                        | v19.03.0   | -
-Deprecated | [Legacy "overlay" storage driver](#legacy-overlay-storage-driver)                                                                  | v18.09.0   | -
-Deprecated | [Device mapper storage driver](#device-mapper-storage-driver)                                                                      | v18.09.0   | -
-Deprecated | [Reserved namespaces in engine labels](#reserved-namespaces-in-engine-labels)                                                      | v18.06.0   | v20.03.0
-Removed    | [`--disable-legacy-registry` override daemon option](#--disable-legacy-registry-override-daemon-option)                            | v17.12.0   | v19.03.0
-Removed    | [Interacting with V1 registries](#interacting-with-v1-registries)                                                                  | v17.06.0   | v17.12.0
-Removed    | [Asynchronous `service create` and `service update` as default](#asynchronous-service-create-and-service-update-as-default)        | v17.05.0   | v17.10.0
-Removed    | [`-g` and `--graph` flags on `dockerd`](#-g-and---graph-flags-on-dockerd)                                                          | v17.05.0   | -
-Deprecated | [Top-level network properties in NetworkSettings](#top-level-network-properties-in-networksettings)                                | v1.13.0    | v17.12.0
-Deprecated | [`filter` param for `/images/json` endpoint](#filter-param-for-imagesjson-endpoint)                                                | v1.13.0    | v17.12.0
-Removed    | [`repository:shortid` image references](#repositoryshortid-image-references)                                                       | v1.13.0    | v17.12.0
-Removed    | [`docker daemon` subcommand](#docker-daemon-subcommand)                                                                            | v1.13.0    | v17.12.0
-Removed    | [Duplicate keys with conflicting values in engine labels](#duplicate-keys-with-conflicting-values-in-engine-labels)                | v1.13.0    | v17.12.0
-Deprecated | [`MAINTAINER` in Dockerfile](#maintainer-in-dockerfile)                                                                            | v1.13.0    | -
-Deprecated | [API calls without a version](#api-calls-without-a-version)                                                                        | v1.13.0    | v17.12.0
-Removed    | [Backing filesystem without `d_type` support for overlay/overlay2](#backing-filesystem-without-d_type-support-for-overlayoverlay2) | v1.13.0    | v17.12.0
-Deprecated | [`--automated` and `--stars` flags on `docker search`](#--automated-and---stars-flags-on-docker-search)                            | v1.12.0    | v17.09.0
-Deprecated | [`-h` shorthand for `--help`](#-h-shorthand-for---help)                                                                            | v1.12.0    | v17.09.0
-Removed    | [`-e` and `--email` flags on `docker login`](#-e-and---email-flags-on-docker-login)                                                | v1.11.0    | v17.06.0
-Deprecated | [Separator (`:`) of `--security-opt` flag on `docker run`](#separator--of---security-opt-flag-on-docker-run)                       | v1.11.0    | v17.06.0
-Deprecated | [Ambiguous event fields in API](#ambiguous-event-fields-in-api)                                                                    | v1.10.0    | -
-Removed    | [`-f` flag on `docker tag`](#-f-flag-on-docker-tag)                                                                                | v1.10.0    | v1.12.0
-Removed    | [HostConfig at API container start](#hostconfig-at-api-container-start)                                                            | v1.10.0    | v1.12.0
-Removed    | [`--before` and `--since` flags on `docker ps`](#--before-and---since-flags-on-docker-ps)                                          | v1.10.0    | v1.12.0
-Removed    | [Driver-specific log tags](#driver-specific-log-tags)                                                                              | v1.9.0     | v1.12.0
-Removed    | [Docker Content Trust `ENV` passphrase variables name change](#docker-content-trust-env-passphrase-variables-name-change)          | v1.9.0     | v1.12.0
-Removed    | [`/containers/(id or name)/copy` endpoint](#containersid-or-namecopy-endpoint)                                                     | v1.8.0     | v1.12.0
-Removed    | [LXC built-in exec driver](#lxc-built-in-exec-driver)                                                                              | v1.8.0     | v1.10.0
-Removed    | [Old Command Line Options](#old-command-line-options)                                                                              | v1.8.0     | v1.10.0
-Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6.0     | v17.09.0
-Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10.0    | v1.13.0
-Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12.0
+Deprecated | [Configuration options for experimental CLI features](#configuration-options-for-experimental-cli-features)                        | v19.03     | v20.03
+Deprecated | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03     | v20.03
+Deprecated | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03     | v20.03
+Deprecated | [Top-level `docker deploy` subcommand (experimental)](#top-level-docker-deploy-subcommand-experimental)                            | v19.03     | v20.03
+Deprecated | [`docker stack deploy` using "dab" files (experimental)](#docker-stack-deploy-using-dab-files-experimental)                        | v19.03     | v20.03
+Deprecated | [AuFS storage driver](#aufs-storage-driver)                                                                                        | v19.03     | -
+Deprecated | [Legacy "overlay" storage driver](#legacy-overlay-storage-driver)                                                                  | v18.09     | -
+Deprecated | [Device mapper storage driver](#device-mapper-storage-driver)                                                                      | v18.09     | -
+Deprecated | [Reserved namespaces in engine labels](#reserved-namespaces-in-engine-labels)                                                      | v18.06     | v20.03
+Removed    | [`--disable-legacy-registry` override daemon option](#--disable-legacy-registry-override-daemon-option)                            | v17.12     | v19.03
+Removed    | [Interacting with V1 registries](#interacting-with-v1-registries)                                                                  | v17.06     | v17.12
+Removed    | [Asynchronous `service create` and `service update` as default](#asynchronous-service-create-and-service-update-as-default)        | v17.05     | v17.10
+Removed    | [`-g` and `--graph` flags on `dockerd`](#-g-and---graph-flags-on-dockerd)                                                          | v17.05     | -
+Deprecated | [Top-level network properties in NetworkSettings](#top-level-network-properties-in-networksettings)                                | v1.13      | v17.12
+Deprecated | [`filter` param for `/images/json` endpoint](#filter-param-for-imagesjson-endpoint)                                                | v1.13      | v17.12
+Removed    | [`repository:shortid` image references](#repositoryshortid-image-references)                                                       | v1.13      | v17.12
+Removed    | [`docker daemon` subcommand](#docker-daemon-subcommand)                                                                            | v1.13      | v17.12
+Removed    | [Duplicate keys with conflicting values in engine labels](#duplicate-keys-with-conflicting-values-in-engine-labels)                | v1.13      | v17.12
+Deprecated | [`MAINTAINER` in Dockerfile](#maintainer-in-dockerfile)                                                                            | v1.13      | -
+Deprecated | [API calls without a version](#api-calls-without-a-version)                                                                        | v1.13      | v17.12
+Removed    | [Backing filesystem without `d_type` support for overlay/overlay2](#backing-filesystem-without-d_type-support-for-overlayoverlay2) | v1.13      | v17.12
+Deprecated | [`--automated` and `--stars` flags on `docker search`](#--automated-and---stars-flags-on-docker-search)                            | v1.12      | v17.09
+Deprecated | [`-h` shorthand for `--help`](#-h-shorthand-for---help)                                                                            | v1.12      | v17.09
+Removed    | [`-e` and `--email` flags on `docker login`](#-e-and---email-flags-on-docker-login)                                                | v1.11      | v17.06
+Deprecated | [Separator (`:`) of `--security-opt` flag on `docker run`](#separator--of---security-opt-flag-on-docker-run)                       | v1.11      | v17.06
+Deprecated | [Ambiguous event fields in API](#ambiguous-event-fields-in-api)                                                                    | v1.10      | -
+Removed    | [`-f` flag on `docker tag`](#-f-flag-on-docker-tag)                                                                                | v1.10      | v1.12
+Removed    | [HostConfig at API container start](#hostconfig-at-api-container-start)                                                            | v1.10      | v1.12
+Removed    | [`--before` and `--since` flags on `docker ps`](#--before-and---since-flags-on-docker-ps)                                          | v1.10      | v1.12
+Removed    | [Driver-specific log tags](#driver-specific-log-tags)                                                                              | v1.9       | v1.12
+Removed    | [Docker Content Trust `ENV` passphrase variables name change](#docker-content-trust-env-passphrase-variables-name-change)          | v1.9       | v1.12
+Removed    | [`/containers/(id or name)/copy` endpoint](#containersid-or-namecopy-endpoint)                                                     | v1.8       | v1.12
+Removed    | [LXC built-in exec driver](#lxc-built-in-exec-driver)                                                                              | v1.8       | v1.10
+Removed    | [Old Command Line Options](#old-command-line-options)                                                                              | v1.8       | v1.10
+Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09
+Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13
+Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12
 
 ### Configuration options for experimental CLI features
 
@@ -96,9 +96,9 @@ enabled by default, and these configuration options will no longer be functional
 
 ### Pushing and pulling with image manifest v2 schema 1
 
-**Deprecated in Release: v19.03.0**
+**Deprecated in Release: v19.03**
 
-**Target For Removal In Release: v20.03.0**
+**Target For Removal In Release: v20.03**
 
 The image manifest
 [v2 schema 1](https://github.com/docker/distribution/blob/fda42e5ef908bdba722d435ff1f330d40dfcd56c/docs/spec/manifest-v2-1.md)
@@ -110,9 +110,9 @@ If the registry you are using still supports v2 schema 1, urge their administrat
 
 ### `docker engine` subcommands
 
-**Deprecated in Release: v19.03.0**
+**Deprecated in Release: v19.03**
 
-**Target For Removal In Release: v20.03.0**
+**Target For Removal In Release: v20.03**
 
 The `docker engine activate`, `docker engine check`, and `docker engine update`
 provided an alternative installation method to upgrade Docker Community engines
@@ -126,9 +126,9 @@ standard package  managers.
 
 ### Top-level `docker deploy` subcommand (experimental)
 
-**Deprecated in Release: v19.03.0**
+**Deprecated in Release: v19.03**
 
-**Target For Removal In Release: v20.03.0**
+**Target For Removal In Release: v20.03**
 
 The top-level `docker deploy` command (using the "Docker Application Bundle"
 (.dab) file format was introduced as an experimental feature in Docker 1.13 /
@@ -138,9 +138,9 @@ subcommand.
 
 ### `docker stack deploy` using "dab" files (experimental)
 
-**Deprecated in Release: v19.03.0**
+**Deprecated in Release: v19.03**
 
-**Target For Removal In Release: v20.03.0**
+**Target For Removal In Release: v20.03**
 
 With no development being done on this feature, and no active use of the file
 format, support for the DAB file format and the top-level docker deploy command
@@ -150,7 +150,7 @@ using compose files.
 
 ### AuFS storage driver
 
-**Deprecated in Release: v19.03.0**
+**Deprecated in Release: v19.03**
 
 The `aufs` storage driver is deprecated in favor of `overlay2`, and will
 be removed in a future release. Users of the `aufs` storage driver are
@@ -169,7 +169,7 @@ maintenance of the `aufs` storage driver.
 
 ### Legacy "overlay" storage driver
 
-**Deprecated in Release: v18.09.0**
+**Deprecated in Release: v18.09**
 
 The `overlay` storage driver is deprecated in favor of the `overlay2` storage
 driver, which has all the benefits of `overlay`, without its limitations (excessive
@@ -184,7 +184,7 @@ backported), there is no reason to keep maintaining the `overlay` storage driver
 
 ### Device mapper storage driver
 
-**Deprecated in Release: v18.09.0**
+**Deprecated in Release: v18.09**
 
 The `devicemapper` storage driver is deprecated in favor of `overlay2`, and will
 be removed in a future release. Users of the `devicemapper` storage driver are
@@ -201,13 +201,13 @@ is no reason to continue maintenance of the `devicemapper` storage driver.
 
 ### Reserved namespaces in engine labels
 
-**Deprecated in Release: v18.06.0**
+**Deprecated in Release: v18.06**
 
 The namespaces `com.docker.*`, `io.docker.*`, and `org.dockerproject.*` in engine labels
 were always documented to be reserved, but there was never any enforcement.
 
 Usage of these namespaces will now cause a warning in the engine logs to discourage their
-use, and will error instead in v20.03.0 and above.
+use, and will error instead in v20.03 and above.
 
 
 ### `--disable-legacy-registry` override daemon option
@@ -243,11 +243,11 @@ start when set.
 
 ### Asynchronous `service create` and `service update` as default
 
-**Deprecated In Release: v17.05.0**
+**Deprecated In Release: v17.05**
 
 **Disabled by default in release: [v17.10](https://github.com/docker/docker-ce/releases/tag/v17.10.0-ce)**
 
-Docker 17.05.0 added an optional `--detach=false` option to make the
+Docker 17.05 added an optional `--detach=false` option to make the
 `docker service create` and `docker service update` work synchronously. This
 option will be enabled by default in Docker 17.10, at which point the `--detach`
 flag can be used to use the previous (asynchronous) behavior.
@@ -257,7 +257,7 @@ and `docker service scale` in Docker 17.10.
 
 ### `-g` and `--graph` flags on `dockerd`
 
-**Deprecated In Release: v17.05.0**
+**Deprecated In Release: v17.05**
 
 The `-g` or `--graph` flag for the `dockerd` or `docker daemon` command was
 used to indicate the directory in which to store persistent data and resource

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -2,6 +2,8 @@
 title: "Use the Docker command line"
 description: "Docker's CLI command description and usage"
 keywords: "Docker, Docker documentation, CLI, command line"
+redirect_from:
+  - /go/experimental/
 ---
 
 <!-- This file is maintained within the docker/cli GitHub


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2773