### PR TITLE
vendor: github.com/fvbommel/sortorder v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -22,7 +22,7 @@ github.com/docker/go-metrics                        b619b3592b65de4f087d9f16863a
 github.com/docker/go-units                          519db1ee28dcc9fd2474ae59fca29a810482bfb1 # v0.4.0
 github.com/docker/swarmkit                          d6592ddefd8a5319aadff74c558b816b1a0b2590
 github.com/evanphx/json-patch                       72bf35d0ff611848c1dc9df0f976c81192392fa5 # v4.1.0
-github.com/fvbommel/sortorder                       a1ddee917217bbd0691affdca9c88d24d3f5c27d # v1.0.1
+github.com/fvbommel/sortorder                       26fad50c6b32a3064c09ed089865c16f2f3615f6 # v1.0.2
 github.com/gofrs/flock                              6caa7350c26b838538005fae7dbee4e69d9398db # v0.7.3
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1

--- a/vendor/github.com/fvbommel/sortorder/doc.go
+++ b/vendor/github.com/fvbommel/sortorder/doc.go
@@ -2,4 +2,4 @@
 //
 // Currently, it only implements so-called "natural order", where integers
 // embedded in strings are compared by value.
-package sortorder
+package sortorder // import "github.com/fvbommel/sortorder"


### PR DESCRIPTION
no significant changes: enforces the new module name to be used


