### PR TITLE
Fixes #2753 - add case-insensitive auth

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -69,7 +69,8 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	ctx := context.Background()
 
 	// Resolve the Auth config relevant for this server
-	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+	authConfig := AuthResolver(dockerCli)(ctx, repoInfo.Index)
+
 	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
 	if err != nil {
 		return err

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"sort"
+	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/streams"
@@ -344,6 +345,8 @@ func TagTrusted(ctx context.Context, cli command.Cli, trustedRef reference.Canon
 // AuthResolver returns an auth resolver function from a command.Cli
 func AuthResolver(cli command.Cli) func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
 	return func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig {
+		index.Name = strings.ToLower(index.Name)
+
 		return command.ResolveAuthConfig(ctx, cli, index)
 	}
 }

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -106,7 +106,7 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint: gocycl
 		authServer    = command.ElectAuthServer(ctx, dockerCli)
 	)
 	if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
-		serverAddress = opts.serverAddress
+		serverAddress = strings.ToLower(opts.serverAddress)
 	} else {
 		serverAddress = authServer
 	}

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -43,9 +44,13 @@ func runLogout(dockerCli command.Cli, serverAddress string) error {
 		hostnameAddress = serverAddress
 	)
 	if !isDefaultRegistry {
-		hostnameAddress = registry.ConvertToHostname(serverAddress)
+		hostnameAddress = registry.ConvertToHostname(strings.ToLower(serverAddress))
+
+		// Appending not lowercased version for backward compatibility where user had
+		// saved the registry with an uppercase letters.
+		regsToLogout = append(regsToLogout, registry.ConvertToHostname(serverAddress))
 		// the tries below are kept for backward compatibility where a user could have
-		// saved the registry in one of the following format.
+		// saved the registry in one of the following formats.
 		regsToLogout = append(regsToLogout, hostnameAddress, "http://"+hostnameAddress, "https://"+hostnameAddress)
 	}
 


### PR DESCRIPTION
Closes #2753 

**- What I did**
I fixed the issue with case sensitive authorization. Now it is case-insensitive.

**- How I did it**

I added `strings.ToLower()` in few places.
I refactored  `RunPush()` function a little so now it is using the same `AuthResolver()` function as `RunPull()`.

**- How to verify it**
I tested it on local registry with basicAuth.
I tested login and logout, push and pull images.
I did test push/pull for not lower cased images and that was working fine too.

**- Description for the changelog**
Makes authentication case-insensitive 

**- A picture of a cute animal (not mandatory but encouraged)**
![Edek](https://user-images.githubusercontent.com/22003852/95686543-d058a080-0bfe-11eb-80dc-d98a26978a73.jpeg)
