### PR TITLE
Reflect the new github URL for completion/zsh/_docker

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2,8 +2,7 @@
 #
 # zsh completion for docker (http://docker.com)
 #
-# version:  0.3.0
-# github:   https://github.com/felixr/docker-zsh-completion
+# github:   https://github.com/docker/cli
 #
 # contributors:
 #   - Felix Riedel


### PR DESCRIPTION
The old URL pointed to https://github.com/felixr/docker-zsh-completion which says

> DEPRECATED REPO

and points to this repo, where the URL hasn't been updated.