### PR TITLE
Wait on waitgroup instead of using time.Sleep

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -156,6 +156,9 @@ func runStats(dockerCli command.Cli, opts *statsOptions) error {
 		// Start a short-lived goroutine to retrieve the initial list of
 		// containers.
 		getContainerList()
+		
+		// make sure each container get at least one valid stat data
+		waitFirst.Wait()
 	} else {
 		// Artificially send creation events for the containers we were asked to
 		// monitor (same code path than we use when monitoring all containers).
@@ -170,9 +173,9 @@ func runStats(dockerCli command.Cli, opts *statsOptions) error {
 		// We don't expect any asynchronous errors: closeChan can be closed.
 		close(closeChan)
 
-		// Do a quick pause to detect any error with the provided list of
-		// container names.
-		time.Sleep(1500 * time.Millisecond)
+		// make sure each container get at least one valid stat data
+		waitFirst.Wait()
+		
 		var errs []string
 		cStats.mu.Lock()
 		for _, c := range cStats.cs {
@@ -186,8 +189,6 @@ func runStats(dockerCli command.Cli, opts *statsOptions) error {
 		}
 	}
 
-	// before print to screen, make sure each container get at least one valid stat data
-	waitFirst.Wait()
 	format := opts.format
 	if len(format) == 0 {
 		if len(dockerCli.ConfigFile().StatsFormat) > 0 {


### PR DESCRIPTION
Closes #2784

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Replaced the time.Sleep with waiting on the waitFirst waitgroup.

**- Description for the changelog**

Instead of using a fixed time.Sleep when collecting stats for named containers, just wait on the waitFirst waitgroup instead.


**- A picture of a cute animal (not mandatory but encouraged)**

![cute](https://user-images.githubusercontent.com/17193640/95720768-2eb66b00-0c61-11eb-8564-d8f02cfef7e8.png)
