### PR TITLE
handle sigterm on running a plugin

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
+	"github.com/moby/buildkit/util/appcontext"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -197,6 +198,11 @@ func tryPluginRun(dockerCli command.Cli, cmd *cobra.Command, subcommand string) 
 	if err != nil {
 		return err
 	}
+
+	go func() {
+		// override SIGTERM handler so we let the plugin shut down first
+		<-appcontext.Context().Done()
+	}()
 
 	if err := plugincmd.Run(); err != nil {
 		statusCode := 1


### PR DESCRIPTION
While running a plugin and canceling with SIGTERM, main process will close right away without letting the plugin close itself down and handle the exit code properly. Add `appcontext` that is useful for handling sigterm, as well as supporting sigkill when things go wrong.

@AkihiroSuda @tiborvass 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>