### PR TITLE
man-pages: fix missing manual title in heading

### DIFF
--- a/man/generate.go
+++ b/man/generate.go
@@ -23,6 +23,7 @@ func generateManPages(opts *options) error {
 		Title:   "DOCKER",
 		Section: "1",
 		Source:  "Docker Community",
+		Manual:  "Docker User Manuals",
 	}
 
 	// If SOURCE_DATE_EPOCH is set, in order to allow reproducible package


### PR DESCRIPTION
This was set in our manually written markdowns, but not in the man pages generated through Cobra