### PR TITLE
Replace deprecated instruction

### DIFF
--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -160,7 +160,7 @@ Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
 FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-MAINTAINER some maintainer <maintainer@example.com>
+LABEL maintainer="some maintainer <maintainer@example.com>"
 ```
 
 > **Note**

--- a/man/src/image/pull.md
+++ b/man/src/image/pull.md
@@ -111,7 +111,7 @@ pull the above image by digest, run the following command:
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
     FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-    MAINTAINER some maintainer <maintainer@example.com>
+    LABEL maintainer="some maintainer <maintainer@example.com>"
 
 > **Note**: Using this feature "pins" an image to a specific version in time.
 > Docker will therefore not pull updated versions of an image, which may include 


### PR DESCRIPTION
MAINTAINER is deprecated, replacing with LABEL as recommended by
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Related to https://github.com/docker/docker.github.io/pull/11615 from issue https://github.com/docker/docker.github.io/issues/9766.

Please provide the following information:
-->

**- What I did**
Replace deprecated MAINTAINER instructions in docs.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/52953502/97037258-54991500-1569-11eb-912d-e921962c9b42.png)

