### PR TITLE
Deprecation: change --stream error to a warning, and update deprecated.md

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -246,7 +246,11 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 	)
 
 	if options.stream {
-		return errors.New("Experimental flag --stream was removed, enable BuildKit instead with DOCKER_BUILDKIT=1")
+		_, _ = fmt.Fprint(dockerCli.Err(), `DEPRECATED: The experimental --stream flag has been removed and the build context
+            will be sent non-streaming. Enable BuildKit instead with DOCKER_BUILDKIT=1
+            to stream build context, see https://docs.docker.com/go/buildkit/
+
+`)
 	}
 
 	if options.dockerfileFromStdin() {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -56,6 +56,7 @@ Deprecated | [Classic Swarm and overlay networks using external key/value stores
 Deprecated | [Support for the legacy `~/.dockercfg` configuration file for authentication](#support-for-legacy-dockercfg-configuration-files)   | v20.10     | -
 Deprecated | [CLI plugins support](#cli-plugins-support)                                                                                        | v20.10     | -
 Deprecated | [Dockerfile legacy `ENV name value` syntax](#dockerfile-legacy-env-name-value-syntax)                                              | v20.10     | -
+Removed    | [`docker build --stream` flag (experimental)](#docker-build---stream-flag-experimental)                                            | v20.10     | v20.10
 Deprecated | [Configuration options for experimental CLI features](#configuration-options-for-experimental-cli-features)                        | v19.03     | v20.10
 Deprecated | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03     | v20.10
 Removed    | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03     | v20.10
@@ -173,6 +174,23 @@ syntax, for example:
 ```dockerfile
 ENV ONE="" TWO="" THREE="world"
 ```
+
+### `docker build --stream` flag (experimental)
+
+**Deprecated in Release: v20.10**
+**Removed in Release: v20.10**
+
+Docker v17.07 introduced an experimental `--stream` flag on `docker build` which
+allowed the build-context to be incrementally sent to the daemon, instead of
+unconditionally sending the whole build-context.
+
+This functionality has been reimplemented as part of BuildKit, which uses streaming
+by default and the `--stream` option will be ignored when using the classic builder,
+printing a deprecation warning instead.
+
+Users that want to use this feature are encouraged to enable BuildKit by setting
+the `DOCKER_BUILDKIT=1` environment variable or through the daemon or CLI configuration
+files.
 
 ### Pushing and pulling with image manifest v2 schema 1
 


### PR DESCRIPTION
Relates to https://github.com/docker/cli/pull/2105
Relates to https://github.com/moby/moby/pull/39983

Addresses https://github.com/docker/docker-ce/pull/660#discussion_r510536957

### builder: print deprecation warning instead of failing for `--stream`

While performance will be worse, we can safely ignore the `--stream` option when used, and print a deprecation warning instead of failing the build.

With this patch:

    echo -e "FROM scratch\nLABEL foo=bar" | docker build --stream -
    DEPRECATED: The experimental --stream flag has been removed and the build context
                will be sent non-streaming. Enable BuildKit instead with DOCKER_BUILDKIT=1
                to stream build context, see https://docs.docker.com/go/buildkit/

    Sending build context to Docker daemon  2.048kB
    Step 1/2 : FROM scratch
     --->
    Step 2/2 : LABEL foo=bar
     ---> Running in 99e4021085b6
    Removing intermediate container 99e4021085b6
     ---> 1a7a41be241f
    Successfully built 1a7a41be241f

### Deprecation: add experimental docker build --stream option

Docker v17.07 introduced an experimental `--stream` flag on `docker build` which
allowed the build-context to be incrementally sent to the daemon, instead of
unconditionally sending the whole build-context.

This functionality has been reimplemented as part of BuildKit, which uses streaming
by default and the `--stream` option will be ignored when using the classic builder,
printing a deprecation warning instead.

Users that want to use this feature are encouraged to enable BuildKit by setting
the `DOCKER_BUILDKIT=1` environment variable or through the daemon or CLI configuration
files.
