### PR TITLE
[19.03 backport] Replace deprecated instruction

### DIFF
--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -160,7 +160,7 @@ Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
 FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-MAINTAINER some maintainer <maintainer@example.com>
+LABEL maintainer="some maintainer <maintainer@example.com>"
 ```
 
 > **Note**

--- a/man/src/image/pull.md
+++ b/man/src/image/pull.md
@@ -111,7 +111,7 @@ pull the above image by digest, run the following command:
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
     FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-    MAINTAINER some maintainer <maintainer@example.com>
+    LABEL maintainer="some maintainer <maintainer@example.com>"
 
 > **Note**: Using this feature "pins" an image to a specific version in time.
 > Docker will therefore not pull updated versions of an image, which may include 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2808
addresses https://github.com/docker/docker.github.io/issues/9766

MAINTAINER is deprecated, replacing with LABEL as recommended by
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Signed-off-by: Charlotte Mach <charlotte.mach@fs.lmu.de>
(cherry picked from commit aa4cb24739a12d82c46eddc8c365c72988fbf8f3)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

