### PR TITLE
opts: fix potential integer overflow CWE-190, CWE-681

### DIFF
--- a/opts/weightdevice.go
+++ b/opts/weightdevice.go
@@ -20,7 +20,7 @@ func ValidateWeightDevice(val string) (*blkiodev.WeightDevice, error) {
 	if !strings.HasPrefix(split[0], "/dev/") {
 		return nil, fmt.Errorf("bad format for device path: %s", val)
 	}
-	weight, err := strconv.ParseUint(split[1], 10, 0)
+	weight, err := strconv.ParseUint(split[1], 10, 16)
 	if err != nil {
 		return nil, fmt.Errorf("invalid weight for device: %s", val)
 	}


### PR DESCRIPTION
Caught by CodeQL:

> Incorrect conversion of an integer with architecture-dependent bit size
> from strconv.ParseUint to a lower bit size type uint16 without an upper
> bound check.

fixes https://github.com/docker/cli/security/code-scanning/2


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

