### PR TITLE
docs: add link to LastPass credential helper

### DIFF
--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -77,6 +77,7 @@ you can download them from:
 - Apple macOS keychain: https://github.com/docker/docker-credential-helpers/releases
 - Microsoft Windows Credential Manager: https://github.com/docker/docker-credential-helpers/releases
 - [pass](https://www.passwordstore.org/): https://github.com/docker/docker-credential-helpers/releases
+- [LastPass](https://lastpass.com): https://gitlab.com/1ace/docker-credential-lastpass
 
 #### Configure the credentials store
 


### PR DESCRIPTION
**- What I did**
I wrote a credentials helper for [LastPass](https://lastpass.com) that I now use myself, and which I think can benefit many people, so I'd like to share it with everyone.

**- How I did it**
I added a link in the documentation listing the existing credential helpers.

**- How to verify it**
Verifying this PR? It's one line of documentation, shouldn't be too hard :)  
As for [`docker-credential-lastpass`](https://gitlab.com/1ace/docker-credential-lastpass), anyone with a LastPass account can download and test it (feel free to make a throw-away LastPass account to test it, it's free).  
The code being barely 140 lines of simple `bash` also makes it easy to audit :+1:

**- Description for the changelog**
Add a link to the LastPass credential helper

**- A picture of a cute animal (not mandatory but encouraged)**
I hope my cat qualifies as cute enough :P
![image](https://user-images.githubusercontent.com/297576/97106500-50ccd600-16c2-11eb-8289-a71166960bb2.png)