### PR TITLE
docs/builder: fix trivial formatting typo

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -2043,7 +2043,7 @@ RUN echo hello
 If you specify `--build-arg CONT_IMG_VER=<value>` on the command line, in both
 cases, the specification on line 2 does not cause a cache miss; line 3 does
 cause a cache miss.`ARG CONT_IMG_VER` causes the RUN line to be identified
-as the same as running `CONT_IMG_VER=<value>` echo hello, so if the `<value>`
+as the same as running `CONT_IMG_VER=<value> echo hello`, so if the `<value>`
 changes, we get a cache miss.
 
 Consider another example under the same command line:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This is a trivial typo fix, the end of the command was not formatted properly.

**- How I did it**
Move the backtick two words further.

**- How to verify it**
:upside_down_face:

**- Description for the changelog**
N/A

**- A picture of a cute animal (not mandatory but encouraged)**
My other cat :smiling_face_with_three_hearts:
![image](https://user-images.githubusercontent.com/297576/97810111-c8c26f80-1c71-11eb-8557-1d7e5e1ac620.png)
