### PR TITLE
Add "--containerd-namespace" daemon flags in completion and docs

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2579,6 +2579,8 @@ _docker_daemon() {
 		--cluster-store-opt
 		--config-file
 		--containerd
+		--containerd-namespace
+		--containerd-plugins-namespace
 		--cpu-rt-period
 		--cpu-rt-runtime
 		--data-root

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2646,6 +2646,8 @@ __docker_subcommand() {
                 "($help)*--cluster-store-opt=[Cluster store options]:Cluster options:->cluster-store-options" \
                 "($help)--config-file=[Path to daemon configuration file]:Config File:_files" \
                 "($help)--containerd=[Path to containerd socket]:socket:_files -g \"*.sock\"" \
+                "($help)--containerd-namespace=[Containerd namespace to use]:containerd namespace:" \
+                "($help)--containerd-plugins-namespace=[Containerd namespace to use for plugins]:containerd namespace:" \
                 "($help)--data-root=[Root directory of persisted Docker data]:path:_directories" \
                 "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
                 "($help)--default-gateway[Container default gateway IPv4 address]:IPv4 address: " \

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -32,6 +32,8 @@ Options:
       --cgroup-parent string                  Set parent cgroup for all containers
       --config-file string                    Daemon configuration file (default "/etc/docker/daemon.json")
       --containerd string                     containerd grpc address
+      --containerd-namespace string           Containerd namespace to use (default "moby")
+      --containerd-plugins-namespace string   Containerd namespace to use for plugins (default "plugins.moby")
       --cpu-rt-period int                     Limit the CPU real-time period in microseconds for the
                                               parent cgroup for all containers
       --cpu-rt-runtime int                    Limit the CPU real-time runtime in microseconds for the
@@ -1344,6 +1346,9 @@ This is a full example of the allowed configuration options on Linux:
   "cluster-advertise": "",
   "cluster-store": "",
   "cluster-store-opts": {},
+  "containerd": "/run/containerd/containerd.sock",
+  "containerd-namespace": "docker",
+  "containerd-plugin-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-address-pools": [
@@ -1463,6 +1468,9 @@ This is a full example of the allowed configuration options on Windows:
   "bridge": "",
   "cluster-advertise": "",
   "cluster-store": "",
+  "containerd": "\\\\.\\pipe\\containerd-containerd",
+  "containerd-namespace": "docker",
+  "containerd-plugin-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-ulimits": {},


### PR DESCRIPTION
This also adds the missing `containerd` key in the example daemon configuration files.

This is a follow-up / companion to https://github.com/moby/moby/pull/41640.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/161631/98412416-be66f380-202c-11eb-88e9-f02b0389efe5.png)
