### PR TITLE
docs/builder: fix broken link

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -655,7 +655,7 @@ The `FROM` instruction initializes a new build stage and sets the
 [*Base Image*](https://docs.docker.com/glossary/#base_image) for subsequent instructions. As such, a
 valid `Dockerfile` must start with a `FROM` instruction. The image can be
 any valid image – it is especially easy to start by **pulling an image** from
-the [*Public Repositories*](https://docs.docker.com/engine/tutorials/dockerrepos/).
+the [*Public Repositories*](https://docs.docker.com/docker-hub/repos/).
 
 - `ARG` is the only instruction that may precede `FROM` in the `Dockerfile`.
   See [Understand how ARG and FROM interact](#understand-how-arg-and-from-interact).


### PR DESCRIPTION
Fixes broken link

**From**: https://docs.docker.com/engine/tutorials/dockerrepos/
**To**: https://docs.docker.com/docker-hub/repos/

**Archive**: https://web.archive.org/web/20190202232416/https://docs.docker.com/get-started/

Signed-off-by: Kyle Mitofsky<Kylemit@gmail.com>