### PR TITLE
2839-%SystemDrive% is not always C:\

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1709,7 +1709,7 @@ Keep the following things in mind about volumes in the `Dockerfile`.
   the destination of a volume inside the container must be one of:
 
   - a non-existing or empty directory
-  - a drive other than `C:`
+  - a drive other the `%SystemDrive%`, which is often `C:`
 
 - **Changing the volume from within the Dockerfile**: If any build steps change the
   data within the volume after it has been declared, those changes will be discarded.


### PR DESCRIPTION
On Windows, the OS drive is often `C:\`, but can be changed.
In other words, Windows can be installed on a different drive (e.g. `D:\`).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

