### PR TITLE
build: remove PersistentPreRunE hack for experimental --platform

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -113,25 +113,6 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 
-	// Wrap the global pre-run to handle non-BuildKit use of the --platform flag.
-	//
-	// We're doing it here so that we're only contacting the daemon when actually
-	// running the command, and not during initialization.
-	// TODO remove this hack once we no longer support the experimental use of --platform
-	rootFn := cmd.Root().PersistentPreRunE
-	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		if ok, _ := command.BuildKitEnabled(dockerCli.ServerInfo()); !ok {
-			f := cmd.Flag("platform")
-			delete(f.Annotations, "buildkit")
-			f.Annotations["version"] = []string{"1.32"}
-			f.Annotations["experimental"] = nil
-		}
-		if rootFn != nil {
-			return rootFn(cmd, args)
-		}
-		return nil
-	}
-
 	flags := cmd.Flags()
 
 	flags.VarP(&options.tags, "tag", "t", "Name and optionally a tag in the 'name:tag' format")

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -125,7 +125,6 @@ func PruneFilters(dockerCli Cli, pruneFilters filters.Args) filters.Args {
 func AddPlatformFlag(flags *pflag.FlagSet, target *string) {
 	flags.StringVar(target, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"), "Set platform if server is multi-platform capable")
 	flags.SetAnnotation("platform", "version", []string{"1.32"})
-	flags.SetAnnotation("platform", "experimental", nil)
 }
 
 // ValidateOutputPath validates the output paths of the `export` and `save` commands.


### PR DESCRIPTION
replaces https://github.com/docker/cli/pull/2737

This hack was added in an attempt to continue supporting the experimental
(non-buildkit) `--platform` option, by dynamically updating the API version
required if buildkit isn't enabled.

This hack didn't work, however, because at the moment the override is
added, the command is not yet attached to the "root" (`docker`) command,
and because of that, the command itself is the `root` command;
`cmd.Root()` returned the `build` command.

As a result, validation steps defined as `PersistentPreRunE` on the root
command were not executed, causing invalid flags/options to not producing
an error.

Attempts to use an alternative approach (for example, cobra supports both
a `PersistentPreRun` and `PersistentPreRunE`) did not work either, because
`PersistentPreRunE` takes precedence over `PersistentPreRun`, and only one
will be executed.

Now that `--platform` should be supported for other cases than just for
experimental (LCOW), let's remove the 'experimental' check, and just assume
it's supported for API v1.32 and up.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
* remove "experimental" check for `--platform` flags
```


**- A picture of a cute animal (not mandatory but encouraged)**

