### PR TITLE
added ip6tables to daemon CLI and config file documentation

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -70,6 +70,7 @@ Options:
       --ip-forward                            Enable net.ipv4.ip_forward (default true)
       --ip-masq                               Enable IP masquerading (default true)
       --iptables                              Enable addition of iptables rules (default true)
+      --ip6tables                             Enable addition of ip6tables rules (default false)
       --ipv6                                  Enable IPv6 networking
       --label list                            Set key=value labels to the daemon
       --live-restore                          Enable live restore of docker when containers are still running
@@ -1392,6 +1393,7 @@ This is a full example of the allowed configuration options on Linux:
   "ip-forward": false,
   "ip-masq": false,
   "iptables": false,
+  "ip6tables": false,
   "ipv6": false,
   "labels": [],
   "live-restore": true,


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added documentation for new ip6tables config option.

See moby/moby#41622

**- How I did it**

Added 2 lines to dockerd.md (similar to the iptables config).

**- How to verify it**

?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added ip6tables to daemon CLI and config file documentation

