### PR TITLE
Long format for flag -w --workdir

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1769,7 +1769,7 @@ the `USER` instruction by passing the `-u` option.
 ### WORKDIR
 
 The default working directory for running binaries within a container is the
-root directory (`/`), but the developer can set a different default with the
+root directory (`/`). It is possible to set a different working directory with the
 Dockerfile `WORKDIR` command. The operator can override this with:
 
-    -w="": Working directory inside the container
+    -w="", --workdir="": Working directory inside the container


### PR DESCRIPTION
Added Long format for the wok directory option in docker run.

**- What I did**
I edited documentation in the Docker Run page

**- How I did it**
added long format for flag and improved the description of the command.

**- How to verify it**
Run a container with long format flag `--workdir`

**- Description for the changelog**
Adds Long Format for -w flag

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/2084646/99740088-1e808e00-2b33-11eb-8fb5-0e4af3806906.png)

