### PR TITLE
Remove shebang to bash completion file

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# bash completion for docker                                -*- shell-script -*-
 # shellcheck disable=SC2016,SC2119,SC2155,SC2206,SC2207,SC2254
 #
 # Shellcheck ignore list:
@@ -5637,3 +5637,5 @@ eval "$__docker_previous_extglob_setting"
 unset __docker_previous_extglob_setting
 
 complete -F _docker docker docker.exe dockerd dockerd.exe
+
+# ex: filetype=sh


### PR DESCRIPTION
Bash completion files are meant to be sourced, not executed, hence there
should be no shebang at the beginning of the file.

For reference, this is what Lintian (Debian tool to find errors in
packages) says about it (see [1]):

> This file starts with the #! sequence that marks interpreted scripts,
> but it is a bash completion script that is merely intended to be
> sourced.
>
> Please remove the line with hashbang, including any designated
> interpreter.

On my Debian system, I looked at the other bash completions scripts, and
indeed the utmost majority has no shebang:

    $ pwd
    /usr/share/bash-completion/completions
    
    $ ls -1 | wc -l
    1077
    
    $ grep '^#!' * | wc -l
    15

Hence this commit removes the shebang, and in order to preserve
indentation and highlighting in common code editors, it adds two hints:
- an Emacs "file variable" on the first line ('-*- ... -*-'), see [2]
- a Vim modeline on the last line ('ex: '), see [3]

Once again, one can look at other bash completion files in
`/usr/share/bash-completion` to see that these 2 hints are present in the
majority of the files.

[1] https://lintian.debian.org/tags/bash-completion-with-hashbang.html
[2] https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html
[3] https://vi.stackexchange.com/a/11558
