### PR TITLE
scripts/build/.variables: Support SOURCE_DATE_EPOCH

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -4,7 +4,7 @@ set -eu
 PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-"unknown-version"}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
-BUILDTIME=${BUILDTIME:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}
+BUILDTIME=${BUILDTIME:-$(date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
 
 PLATFORM_LDFLAGS=
 if test -n "${PLATFORM}"; then


### PR DESCRIPTION
Repeated builds of docker is currently unreproducible as the embedded
time does not support SOURCE_DATE_EPOCH. This patch ensures we check for
the defined variable before utilizing current date.

This has been fixed previously with manpages as well

https://github.com/docker/cli/commit/2d7091aaeb3dac6388d81cbb9b6847c75ee4b7b9

Signed-off-by: Morten Linderud <morten@linderud.pw>

**- How to verify it**
```
λ cli morten/reprobuilds» export SOURCE_DATE_EPOCH=1606660000
λ cli morten/reprobuilds» export DISABLE_WARN_OUTSIDE_CONTAINER=1
λ cli morten/reprobuilds» make
WARNING: binary creates a Linux executable. Use cross for macOS or Windows.
./scripts/build/binary
Building statically linked build/docker-linux-amd64
+ go build -o build/docker-linux-amd64 --ldflags '    -w 
  -X "github.com/docker/cli/cli/version.GitCommit=9d40c7464e" 
  -X "github.com/docker/cli/cli/version.BuildTime=2020-11-29T14:26:40Z" 
  -X "github.com/docker/cli/cli/version.Version=unknown-version"      ' github.com/docker/cli/cmd/docker
++ basename build/docker-linux-amd64
+ ln -sf docker-linux-amd64 build/docker
```

**- Description for the changelog**
Support reproducible builds by checking SOURCE_DATE_EPOCH before build.


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://lh3.googleusercontent.com/pw/ACtC-3cgT25ldYLbK1PwSyb-4WfKCKGAKKFmGnrEcWRKEUxfJyzu9-kZ3mLUsRgv8vmP-kKUN7b-Y3AIiqnMSPP61HnuWpO2IBeyn_L-nH33NKikGjEc5-ItjujCnHqgUtMADIP-jjGUTYjoxPDu_tLKd721=w1400-h1050-no)
