### PR TITLE
Help guides link

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -37,6 +37,7 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	cobra.AddTemplateFunc("isPlugin", isPlugin)
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
 	cobra.AddTemplateFunc("displayHelpLink", displayHelpLink)
+	cobra.AddTemplateFunc("cyan", cyan)
 	cobra.AddTemplateFunc("decoratedName", decoratedName)
 
 	rootCmd.SetUsageTemplate(usageTemplate)
@@ -210,6 +211,16 @@ func displayHelpLink(cmd *cobra.Command) bool {
 	return !cmd.HasParent() && !hideGuides
 }
 
+var cyan = color("\033[1;36m%s\033[0m")
+
+func color(colorString string) func(...interface{}) string {
+	sprint := func(args ...interface{}) string {
+		return fmt.Sprintf(colorString,
+			fmt.Sprint(args...))
+	}
+	return sprint
+}
+
 func isPlugin(cmd *cobra.Command) bool {
 	return cmd.Annotations[pluginmanager.CommandAnnotationPlugin] == "true"
 }
@@ -366,7 +377,7 @@ Invalid Plugins:
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
 {{- if displayHelpLink .}}
-To get more help with docker, check out guides at https://docs.docker.com/go/guides/
+{{ cyan "To get more help with docker, check out guides at https://docs.docker.com/go/guides/" }}
 {{- end}}
 `
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -36,8 +36,8 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	cobra.AddTemplateFunc("invalidPluginReason", invalidPluginReason)
 	cobra.AddTemplateFunc("isPlugin", isPlugin)
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
-	cobra.AddTemplateFunc("displayHelpLink", displayHelpLink)
-	cobra.AddTemplateFunc("cyan", cyan)
+	cobra.AddTemplateFunc("hasAdditionalHelp", hasAdditionalHelp)
+	cobra.AddTemplateFunc("additionalHelp", additionalHelp)
 	cobra.AddTemplateFunc("decoratedName", decoratedName)
 
 	rootCmd.SetUsageTemplate(usageTemplate)
@@ -48,6 +48,8 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage")
 	rootCmd.PersistentFlags().MarkShorthandDeprecated("help", "please use --help")
 	rootCmd.PersistentFlags().Lookup("help").Hidden = true
+
+	rootCmd.Annotations = map[string]string{"additionalHelp": brightCyan("To get more help with docker, check out guides at https://docs.docker.com/go/guides/")}
 
 	return opts, flags, helpCommand
 }
@@ -206,12 +208,18 @@ func isExperimental(cmd *cobra.Command) bool {
 	return experimental
 }
 
-func displayHelpLink(cmd *cobra.Command) bool {
-	hideGuides := os.Getenv("DOCKER_HIDE_HELP_GUIDES") != ""
-	return !cmd.HasParent() && !hideGuides
+func additionalHelp(cmd *cobra.Command) string {
+	if additionalHelp, ok := cmd.Annotations["additionalHelp"]; ok {
+		return additionalHelp
+	}
+	return ""
 }
 
-var cyan = color("\033[1;36m%s\033[0m")
+func hasAdditionalHelp(cmd *cobra.Command) bool {
+	return additionalHelp(cmd) != ""
+}
+
+var brightCyan = color("\033[1;96m%s\033[0m")
 
 func color(colorString string) func(...interface{}) string {
 	sprint := func(args ...interface{}) string {
@@ -376,8 +384,8 @@ Invalid Plugins:
 
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
-{{- if displayHelpLink .}}
-{{ cyan "To get more help with docker, check out guides at https://docs.docker.com/go/guides/" }}
+{{- if hasAdditionalHelp .}}
+{{ additionalHelp . }}
 {{- end}}
 `
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -206,7 +206,8 @@ func isExperimental(cmd *cobra.Command) bool {
 }
 
 func displayHelpLink(cmd *cobra.Command) bool {
-	return !cmd.HasParent()
+	hideGuides := os.Getenv("DOCKER_HIDE_HELP_GUIDES") != ""
+	return !cmd.HasParent() && !hideGuides
 }
 
 func isPlugin(cmd *cobra.Command) bool {
@@ -365,7 +366,7 @@ Invalid Plugins:
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- end}}
 {{- if displayHelpLink .}}
-To get more help with docker, check out guides at https://docs.docker.com/go/guides.md
+To get more help with docker, check out guides at https://docs.docker.com/go/guides/
 {{- end}}
 `
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -36,6 +36,7 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	cobra.AddTemplateFunc("invalidPluginReason", invalidPluginReason)
 	cobra.AddTemplateFunc("isPlugin", isPlugin)
 	cobra.AddTemplateFunc("isExperimental", isExperimental)
+	cobra.AddTemplateFunc("displayHelpLink", displayHelpLink)
 	cobra.AddTemplateFunc("decoratedName", decoratedName)
 
 	rootCmd.SetUsageTemplate(usageTemplate)
@@ -185,7 +186,6 @@ var helpCommand = &cobra.Command{
 		if cmd == nil || e != nil || len(args) > 0 {
 			return errors.Errorf("unknown help topic: %v", strings.Join(args, " "))
 		}
-
 		helpFunc := cmd.HelpFunc()
 		helpFunc(cmd, args)
 		return nil
@@ -203,6 +203,10 @@ func isExperimental(cmd *cobra.Command) bool {
 		}
 	})
 	return experimental
+}
+
+func displayHelpLink(cmd *cobra.Command) bool {
+	return !cmd.HasParent()
 }
 
 func isPlugin(cmd *cobra.Command) bool {
@@ -359,6 +363,9 @@ Invalid Plugins:
 {{- if .HasSubCommands }}
 
 Run '{{.CommandPath}} COMMAND --help' for more information on a command.
+{{- end}}
+{{- if displayHelpLink .}}
+To get more help with docker, check out guides at https://docs.docker.com/go/guides.md
 {{- end}}
 `
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Add a link to docker help guides (at docs.docker.com) for general help messages 
* gate this with an env var to revert to no link if users want to avoid this additional message

link actually depends on https://github.com/docker/docker.github.io/pull/11812

**- How I did it**
Added section at the bottom of go template, and a function to check if it should display or not

**- How to verify it**
`docker help` will display it, `docker --help` also, but not `docker run --help` 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://thumbs.dreamstime.com/b/turtle-reading-book-white-background-turtle-reading-book-white-background-112038243.jpg)
