### PR TITLE
Allow publishing same port as UDP and TCP using docker stack deploy(T…

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -111,7 +111,7 @@ func toServicePortConfigsMap(s interface{}) (map[interface{}]interface{}, error)
 	}
 	m := map[interface{}]interface{}{}
 	for _, p := range ports {
-		m[p.Published] = p
+		m[p] = p
 	}
 	return m, nil
 }

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -237,7 +237,10 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 			name: "no_override",
 			portBase: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:80",
+					Mode:      "ingress",
+					Published: 8080,
+					Target:    80,
+					Protocol:  "tcp",
 				},
 			},
 			portOverride: map[string]interface{}{},
@@ -254,12 +257,18 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 			name: "override_different_published",
 			portBase: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:80",
+					Mode:      "ingress",
+					Published: 8080,
+					Target:    80,
+					Protocol:  "tcp",
 				},
 			},
 			portOverride: map[string]interface{}{
 				"ports": []interface{}{
-					"8081:80",
+					Mode:      "ingress",
+					Published: 8081,
+					Target:    80,
+					Protocol:  "tcp",
 				},
 			},
 			expected: []types.ServicePortConfig{
@@ -281,12 +290,18 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 			name: "override_same_published",
 			portBase: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:80",
+					Mode:      "ingress",
+					Published: 8080,
+					Target:    80,
+					Protocol:  "tcp",
 				},
 			},
 			portOverride: map[string]interface{}{
 				"ports": []interface{}{
-					"8080:81",
+					Mode:      "ingress",
+					Published: 8080,
+					Target:    81,
+					Protocol:  "tcp",
 				},
 			},
 			expected: []types.ServicePortConfig{
@@ -843,8 +858,18 @@ func TestLoadMultipleConfigs(t *testing.T) {
 					"dockerfile": "bar.Dockerfile",
 				},
 				"ports": []interface{}{
-					"8080:80",
-					"9090:90",
+					{
+						Mode:      "ingress",
+						Published: 8080,
+						Target:    80,
+						Protocol:  "tcp",
+					},
+					{
+						Mode:      "ingress",
+						Published: 9090,
+						Target:    90,
+						Protocol:  "tcp",
+					}
 				},
 				"labels": []interface{}{
 					"foo=bar",
@@ -873,8 +898,10 @@ func TestLoadMultipleConfigs(t *testing.T) {
 				},
 				"ports": []interface{}{
 					map[string]interface{}{
+						"Mode":      "ingress",
 						"target":    81,
 						"published": 8080,
+						"Protocol":  "tcp",
 					},
 				},
 				"labels": map[string]interface{}{


### PR DESCRIPTION
fixes #2407

- What I did
Simple fix for #2407, to ensure that TCP and UDP publishing for the same port doesn't go away during compose file merging. and added some testing.

- How I did it

I changed the key of the map from the port number to the full port specification (including published port number and protocol).

This may not be the ideal solution since it includes not just the protocol, but also the published port number in the map key. I did it this way because it's all I can figure out how do do with my meager golang skills. 

- How to verify it

Try the example in #2407.

- Description for the changelog

fix bug: now possible to publish same port as TCP and UDP using docker stack deploy