### PR TITLE
Connect to rootless socket by default if /var/run/docker.sock is not accessible

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -54,7 +54,7 @@ func ParseHost(defaultToTLS bool, val string) (string, error) {
 		if defaultToTLS {
 			host = defaultTLSHost
 		} else {
-			host = defaultHost
+			host = DefaultLocalHost()
 		}
 	} else {
 		var err error

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -15,6 +15,7 @@ func TestParseHost(t *testing.T) {
 		"tcp://invalid:port",
 	}
 
+	defaultHost := DefaultLocalHost()
 	valid := map[string]string{
 		"":                         defaultHost,
 		" ":                        defaultHost,

--- a/opts/hosts_unix.go
+++ b/opts/hosts_unix.go
@@ -2,8 +2,71 @@
 
 package opts
 
-// defaultHost constant defines the default host string used by docker on other hosts than Windows
-const defaultHost = "unix://" + defaultUnixSocket
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	chosenDefaultUnixSocket     = defaultUnixSocket
+	chooseDefaultUnixSocketOnce sync.Once
+)
+
+func chooseDefaultUnixSocket() {
+	euid := os.Geteuid()
+	if euid == 0 {
+		return
+	}
+	var userSocketCandidates []string
+	if xrd, ok := os.LookupEnv("XDG_RUNTIME_DIR"); ok {
+		userSocketCandidates = append(userSocketCandidates, filepath.Join(xrd, "docker.sock"))
+	} else {
+		userSocketCandidates = append(userSocketCandidates, filepath.Join("/run/user", strconv.Itoa(euid), "docker.sock"))
+	}
+	if u, err := user.Current(); err != nil && u.HomeDir != "" {
+		// Used on non-systemd hosts. (See dockerd-rootless-setuptool.sh)
+		userSocketCandidates = append(userSocketCandidates, filepath.Join(u.HomeDir, ".docker/run/docker.sock"))
+	}
+	rootSocketOk := isSocketAccessible(defaultUnixSocket)
+	for _, userSocket := range userSocketCandidates {
+		if userSocketOk := isSocketAccessible(userSocket); userSocketOk {
+			if rootSocketOk {
+				// For compatibility, rootful socket is prioritized over rootless socket.
+				logrus.Warnf("Both rootful socket (%q) and rootless socket (%q) are accessible. Choosing the rootful socket as the default one.",
+					defaultUnixSocket, userSocket)
+				return
+			}
+			logrus.Debugf("Automatically chose the default socket %q (rootless)", userSocket)
+			chosenDefaultUnixSocket = userSocket
+			return
+		}
+	}
+}
+
+func isSocketAccessible(s string) bool {
+	return unix.Access(s, unix.R_OK|unix.W_OK) == nil
+}
+
+// DefaultLocalHost returns "unix:///var/run/docker.sock" is in most cases.
+//
+// However, DefaultLocalHost may return the rootless socket if the rootless socket
+// is accessible and the rootless socket is inaccessible.
+//
+// When both the rootful one and the rootless one are accessible, the rootful one
+// is returned (for compatibility).
+//
+// The rootless socket is typically "unix:///run/user/$UID/docker.sock", but
+// can be "unix://$HOME/.docker/run/docker.sock" on non-systemd hosts.
+func DefaultLocalHost() string {
+	chooseDefaultUnixSocketOnce.Do(chooseDefaultUnixSocket)
+	return "unix://" + chosenDefaultUnixSocket
+}
 
 // defaultHTTPHost Default HTTP Host used if only port is provided to -H flag e.g. dockerd -H tcp://:8080
 const defaultHTTPHost = "localhost"

--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -2,8 +2,10 @@
 
 package opts
 
-// defaultHost constant defines the default host string used by docker on Windows
-const defaultHost = "npipe://" + defaultNamedPipe
+// DefaultLocalHost returns the default host string used by docker on Windows
+func DefaultLocalHost() string {
+	return "npipe://" + defaultNamedPipe
+}
 
 // TODO Windows. Identify bug in GOLang 1.5.1+ and/or Windows Server 2016 TP5.
 // @jhowardmsft, @swernli.


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Connect to rootless socket by default if `/var/run/docker.sock` is not accessible.

Fix #2860


**- How I did it**

The rootless socket (`$XDG_RUNTIME_DIR/socker.sock`) is chosen by default when all the following conditions are satisfied:

- `$DOCKER_HOST` is unset
- EUID != 0
- The rootful socket (`/var/run/docker.sock`) is inaccessible
- The rootless socket is accessible

Note that when both the rootful one and the rootless are accessible, the rootful one is chosen for keeping compatibility.

Also, it is still recommended to set `$DOCKER_HOST` explicitly so that other client implementations like `docker-compose` (Python) work with the desired socket.

**- How to verify it**

- Stop rootful, start rootless
- Make sure `docker info` shows `rootless` as a security option

- Start both rootful and rootless as a user outside `docker group`
- Make sure `docker info` shows `rootless` as a security option

- Start both rootful and rootless as a user inside `docker group`
- Make sure `docker info` does NOT show `rootless` as a security option. 
  Also make sure the following warning is printed:
```
WARN[0000] Both rootful socket ("/var/run/docker.sock") and rootless socket ("/run/user/1001/docker.sock") are accessible. Choosing the rootful socket as the default one. 
```



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Connect to rootless socket by default if /var/run/docker.sock is not accessible

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:
