### PR TITLE
[19.03 backport] docs: un-wrap line to prevent YAML docs from using "compact" formatting

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -402,14 +402,12 @@ the command line.
 ### Use a custom parent cgroup (--cgroup-parent)
 
 When `docker build` is run with the `--cgroup-parent` option the containers
-used in the build will be run with the 
-[corresponding `docker run` flag](../run.md#specify-custom-cgroups).
+used in the build will be run with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
 
 ### Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` will cause each build step's
-container to be started using those 
-[`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
+container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
 
 ### Set build-time variables (--build-arg)
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2869

Looks like the YAML conversion doesn't like lines starting with `[`, and
causing it to use the "compact" formatting in the generated YAML.

This patch un-wraps these lines to prevent this.

