### PR TITLE
vendor: docker cf31b9622ae9de4b5fb7a1c9456460980ab80281, buildkit v0.8.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e4
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            6c0a036dce2051cc0d73221965e76e3d2e6a8a3a # master (v20.10.0-dev)
+github.com/docker/docker                            cf31b9622ae9de4b5fb7a1c9456460980ab80281 # master (v20.10.0-dev)
 github.com/docker/docker-credential-helpers         54f0238b6bf101fc3ad3b34114cb5520beb562f5 # v0.6.3
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -48,7 +48,7 @@ github.com/Microsoft/go-winio                       5b44b70ab3ab4d291a7c1d28afe7
 github.com/Microsoft/hcsshim                        5bc557dd210ff2caf615e6e22d398123de77fc11 # v0.8.9
 github.com/miekg/pkcs11                             210dc1e16747c5ba98a03bcbcf728c38086ea357 # v1.0.3
 github.com/mitchellh/mapstructure                   d16e9488127408e67948eb43b6d3fbb9f222da10 # v1.3.2
-github.com/moby/buildkit                            fcb87e6b8ccf3631a65799cc56caa76f9117816e # v0.8.0-rc2
+github.com/moby/buildkit                            73fe4736135645a342abc7b587bba0994cccf0f9 # v0.8.0
 github.com/moby/sys                                 1bc8673b57550ddf85262eb0fed0aac651a37dab # symlink/v0.1.0 (latest tag, either mount/vXXX, mountinfo/vXXX or symlink/vXXX)
 github.com/moby/term                                bea5bbe245bf407372d477f1361d2ff042d2f556
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3

--- a/vendor/github.com/docker/docker/errdefs/helpers.go
+++ b/vendor/github.com/docker/docker/errdefs/helpers.go
@@ -10,6 +10,10 @@ func (e errNotFound) Cause() error {
 	return e.error
 }
 
+func (e errNotFound) Unwrap() error {
+	return e.error
+}
+
 // NotFound is a helper to create an error of the class with the same name from any error type
 func NotFound(err error) error {
 	if err == nil || IsNotFound(err) {
@@ -23,6 +27,10 @@ type errInvalidParameter struct{ error }
 func (errInvalidParameter) InvalidParameter() {}
 
 func (e errInvalidParameter) Cause() error {
+	return e.error
+}
+
+func (e errInvalidParameter) Unwrap() error {
 	return e.error
 }
 
@@ -42,6 +50,10 @@ func (e errConflict) Cause() error {
 	return e.error
 }
 
+func (e errConflict) Unwrap() error {
+	return e.error
+}
+
 // Conflict is a helper to create an error of the class with the same name from any error type
 func Conflict(err error) error {
 	if err == nil || IsConflict(err) {
@@ -55,6 +67,10 @@ type errUnauthorized struct{ error }
 func (errUnauthorized) Unauthorized() {}
 
 func (e errUnauthorized) Cause() error {
+	return e.error
+}
+
+func (e errUnauthorized) Unwrap() error {
 	return e.error
 }
 
@@ -74,6 +90,10 @@ func (e errUnavailable) Cause() error {
 	return e.error
 }
 
+func (e errUnavailable) Unwrap() error {
+	return e.error
+}
+
 // Unavailable is a helper to create an error of the class with the same name from any error type
 func Unavailable(err error) error {
 	if err == nil || IsUnavailable(err) {
@@ -87,6 +107,10 @@ type errForbidden struct{ error }
 func (errForbidden) Forbidden() {}
 
 func (e errForbidden) Cause() error {
+	return e.error
+}
+
+func (e errForbidden) Unwrap() error {
 	return e.error
 }
 
@@ -106,6 +130,10 @@ func (e errSystem) Cause() error {
 	return e.error
 }
 
+func (e errSystem) Unwrap() error {
+	return e.error
+}
+
 // System is a helper to create an error of the class with the same name from any error type
 func System(err error) error {
 	if err == nil || IsSystem(err) {
@@ -119,6 +147,10 @@ type errNotModified struct{ error }
 func (errNotModified) NotModified() {}
 
 func (e errNotModified) Cause() error {
+	return e.error
+}
+
+func (e errNotModified) Unwrap() error {
 	return e.error
 }
 
@@ -138,6 +170,10 @@ func (e errNotImplemented) Cause() error {
 	return e.error
 }
 
+func (e errNotImplemented) Unwrap() error {
+	return e.error
+}
+
 // NotImplemented is a helper to create an error of the class with the same name from any error type
 func NotImplemented(err error) error {
 	if err == nil || IsNotImplemented(err) {
@@ -151,6 +187,10 @@ type errUnknown struct{ error }
 func (errUnknown) Unknown() {}
 
 func (e errUnknown) Cause() error {
+	return e.error
+}
+
+func (e errUnknown) Unwrap() error {
 	return e.error
 }
 
@@ -170,6 +210,10 @@ func (e errCancelled) Cause() error {
 	return e.error
 }
 
+func (e errCancelled) Unwrap() error {
+	return e.error
+}
+
 // Cancelled is a helper to create an error of the class with the same name from any error type
 func Cancelled(err error) error {
 	if err == nil || IsCancelled(err) {
@@ -186,6 +230,10 @@ func (e errDeadline) Cause() error {
 	return e.error
 }
 
+func (e errDeadline) Unwrap() error {
+	return e.error
+}
+
 // Deadline is a helper to create an error of the class with the same name from any error type
 func Deadline(err error) error {
 	if err == nil || IsDeadline(err) {
@@ -199,6 +247,10 @@ type errDataLoss struct{ error }
 func (errDataLoss) DataLoss() {}
 
 func (e errDataLoss) Cause() error {
+	return e.error
+}
+
+func (e errDataLoss) Unwrap() error {
 	return e.error
 }
 

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -33,8 +33,8 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            6861f17f15364de0fe1fd1e6e8da07598a485123
-github.com/tonistiigi/fsutil                        c3ed55f3b48161fd3dc42c17ba09e12ac52d57dc
+github.com/moby/buildkit                            950603da215ae03b843f3f66fbe86c4876a6f5a1
+github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
 github.com/opentracing/opentracing-go               d34af3eaa63c4d08ab54863a4bdd0daa45212e12 # v1.2.0
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        6b51d028f4bbb9a4cc8d3eaba13baa9f848af546 
+github.com/docker/libnetwork                        a543cbc4871f904b0efe205708eb45d72e65fd8b
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec
@@ -130,14 +130,14 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    d4e78200d6da62480c85bf6f26b7221ea938f396
-github.com/containerd/fifo                          f15a3290365b9d2627d189e619ab4008e0069caf
+github.com/containerd/containerd                    0edc412565dcc6e3d6125ff9e4b009ad4b89c638 # master (v1.5.0-dev)
+github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
-github.com/containerd/cgroups                       318312a373405e5e91134d8063d04d59768a1bff
+github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
 github.com/containerd/console                       5d7e1412f07b502a01029ea20e20e0d2be31fa7c # v1.0.1
 github.com/containerd/go-runc                       16b287bc67d069a60fa48db15f330b790b74365b
 github.com/containerd/typeurl                       cd3ce7159eae562a4f60ceff37dada11a939d247 # v1.0.1
-github.com/containerd/ttrpc                         72bb1b21c5b0a4a107f59dd85f6ab58e564b68d6 # v1.0.1
+github.com/containerd/ttrpc                         bfba540dc45464586c106b1f31c8547933c1eb41 # v1.0.2
 github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2a5cdf5cff46c # v1.3.2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
@@ -148,7 +148,7 @@ github.com/golang/protobuf                          84668698ea25b64748563aa20726
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
 github.com/fernet/fernet-go                         9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093e26687138edf # v1.0.20
-golang.org/x/crypto                                 75b288015ac94e66e3d6715fb68a9b41bf046ec2
+golang.org/x/crypto                                 c1f2f97bffc9c53fc40a1a28a5b460094c0050d9
 golang.org/x/time                                   555d28b269f0569763d25dbe1a237ae74c6bcc82
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git

--- a/vendor/github.com/moby/buildkit/README.md
+++ b/vendor/github.com/moby/buildkit/README.md
@@ -3,8 +3,9 @@
 # BuildKit
 
 [![GoDoc](https://godoc.org/github.com/moby/buildkit?status.svg)](https://godoc.org/github.com/moby/buildkit/client/llb)
-[![Build Status](https://travis-ci.org/moby/buildkit.svg?branch=master)](https://travis-ci.org/moby/buildkit)
+[![Build Status](https://travis-ci.com/moby/buildkit.svg?branch=master)](https://travis-ci.com/moby/buildkit)
 [![Go Report Card](https://goreportcard.com/badge/github.com/moby/buildkit)](https://goreportcard.com/report/github.com/moby/buildkit)
+[![codecov](https://codecov.io/gh/moby/buildkit/branch/master/graph/badge.svg)](https://codecov.io/gh/moby/buildkit)
 
 BuildKit is a toolkit for converting source code to build artifacts in an efficient, expressive and repeatable manner.
 

--- a/vendor/github.com/moby/buildkit/solver/errdefs/context.go
+++ b/vendor/github.com/moby/buildkit/solver/errdefs/context.go
@@ -1,0 +1,13 @@
+package errdefs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/moby/buildkit/util/grpcerrors"
+	"google.golang.org/grpc/codes"
+)
+
+func IsCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || grpcerrors.Code(err) == codes.Canceled
+}


### PR DESCRIPTION
### vendor: github.com/docker/docker cf31b9622ae9de4b5fb7a1c9456460980ab80281

full diff: https://github.com/docker/docker/compare/6c0a036dce2051cc0d73221965e76e3d2e6a8a3a...cf31b9622ae9de4b5fb7a1c9456460980ab80281

changes affecting vendored code:

- client: Fix error handling

Other changes:

- handleContainerExit: timeout on containerd DeleteTask
- vendor libnetwork to fix mix up between IPv4 and IPv6
- update containerd binary to v1.4.2
- update containerd binary to v1.4.3 (CVE-2020-15257)
- vendor: BuildKit v0.8.0-rc2, containerd, and dependencies
- Add fallback for pull by tag
- vendor: BuildKit 950603da215ae03b843f3f66fbe86c4876a6f5a1
- IPv6 iptables config option

### vendor: BuildKit v0.8.0

full diff: https://github.com/moby/buildkit/compare/v0.8.0-rc2...v0.8.0

note that this is currently a few commits "behind" the version used in docker,
but changes since v0.8.0 do not affect the code that's vendored in the CLI,
so prefering to use a tagged version.
