### PR TITLE
Add deprecation note for non-compliant registries

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -95,6 +95,38 @@ Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-
 Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13
 Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12
 
+### Pulling images from non-compliant image registries
+
+**Deprecated in Release: v20.10**
+
+Docker Engine v20.10 and up includes optimizations to verify if images in the
+local image cache need updating before pulling, preventing the Docker Engine
+from making unnecessary API requests. These optimizations require the container
+image registry to conform to the [Open Container Initiative Distribution Specification](https://github.com/opencontainers/distribution-spec).
+
+While most registries conform to the specification, we encountered some registries
+to be non-compliant, resulting in `docker pull` to fail.
+
+As a temporary solution, Docker Engine v20.10 includes a fallback mechanism to
+allow `docker pull` to be functional when using a non-compliant registry. A
+warning message is printed in this situation:
+
+    WARNING Failed to pull manifest by the resolved digest. This registry does not
+            appear to conform to the distribution registry specification; falling back to
+            pull by tag. This fallback is DEPRECATED, and will be removed in a future
+            release.
+
+The fallback is added to allow users to either migrate their images to a compliant
+registry, or for these registries to become compliant.
+
+Note that this fallback only addresses failures on `docker pull`. Other commands,
+such as `docker stack deploy`, or pulling images with `containerd` will continue
+to fail.
+
+Given that other functionality is still broken with these registries, we consider
+this fallback a _temporary_ solution, and will remove the fallback in an upcoming
+major release.
+
 ### Linux containers on Windows (LCOW) (experimental)
 
 **Deprecated in Release: v20.10**


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/41749 Add fallback for pull by tag
- relates to https://github.com/moby/moby/issues/41687 docker.pkg.github.com Docker pull is not working on 20.10 RC1
- relates to https://github.com/moby/moby/pull/41607 cache manifests on pull 
- relates to https://github.com/moby/moby/issues/40403 docker stack deploy fails to pull images from docker.pkg.github.com registry
- relates to https://github.com/moby/moby/issues/34153 Docker service update --image "could not accessed on a registry to record its digest"
- relates to https://github.com/containerd/containerd/issues/3291 containerd can't pull image from Github Docker Package Registry

Docker Engine v20.10 and up includes optimizations to verify if images in the
local image cache need updating before pulling, preventing the Docker Engine
from making unnecessary API requests. These optimizations require the container
image registry to conform to the Open Container Initiative Distribution Specification
(https://github.com/opencontainers/distribution-spec).

While most registries conform to the specification, we encountered some registries
to be non-compliant, resulting in `docker pull` to fail.

As a temporary solution, Docker Engine v20.10 includes a fallback mechanism to
allow `docker pull` to be functional when using a non-compliant registry. A
warning message is printed in this situation:

    WARNING Failed to pull manifest by the resolved digest. This registry does not
            appear to conform to the distribution registry specification; falling back to
            pull by tag. This fallback is DEPRECATED, and will be removed in a future
            release.

The fallback is added to allow users to either migrate their images to a compliant
registry, or for these registries to become compliant.

Note that this fallback only addresses failures on `docker pull`. Other commands,
such as `docker stack deploy`, or pulling images with `containerd` will continue
to fail.

Given that other functionality is still broken with these registries, we consider
this fallback a _temporary_ solution, and will remove the fallback in an upcoming
major release.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

