### PR TITLE
execv into context-specific binary is context type is not "" (default)

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -160,6 +160,20 @@ func (tcmd *TopLevelCommand) Initialize(ops ...command.InitializeOpt) error {
 	return tcmd.dockerCli.Initialize(tcmd.opts, ops...)
 }
 
+// ContextType return the current context type, "" for default
+func (tcmd *TopLevelCommand) ContextType() (string, error) {
+	context := tcmd.dockerCli.CurrentContext()
+	metadata, err := tcmd.dockerCli.ContextStore().GetMetadata(context)
+	if err != nil {
+		return "", err
+	}
+	meta := metadata.Metadata.(command.DockerContext)
+	if s, ok := meta.AdditionalFields["Type"]; ok {
+		return s.(string), nil
+	}
+	return "", nil
+}
+
 // VisitAll will traverse all commands from the root.
 // This is different from the VisitAll of cobra.Command where only parents
 // are checked.

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -11,7 +11,7 @@ type NamedTypeGetter struct {
 	typeGetter TypeGetter
 }
 
-// EndpointTypeGetter returns a NamedTypeGetter with the spcecified name and getter
+// EndpointTypeGetter returns a NamedTypeGetter with the specified name and getter
 func EndpointTypeGetter(name string, getter TypeGetter) NamedTypeGetter {
 	return NamedTypeGetter{
 		name:       name,

--- a/cli/context/types.go
+++ b/cli/context/types.go
@@ -1,0 +1,29 @@
+package context
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const (
+	// ContextTypeECS is Amazon ECS context type
+	ContextTypeECS = "ecs"
+
+	// ContextTypeACI is MS Azure Container Instances context type
+	ContextTypeACI = "aci"
+)
+
+// RunContextCLI replace the current process with dedicated CLI for this context type
+func RunContextCLI(context string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	x := executable + "-" + context
+	if _, err := os.Stat(x); os.IsNotExist(err) {
+		// TODO we could be more restrictive about supported types to prevent abuses using ContextType enum values
+		return fmt.Errorf("unsupported context type %q", context)
+	}
+	return syscall.Exec(x, os.Args[1:], os.Environ())
+}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
+	"github.com/docker/cli/cli/context"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/docker/api/types/versions"
@@ -262,6 +263,14 @@ func runDocker(dockerCli *command.DockerCli) error {
 
 	if err := tcmd.Initialize(); err != nil {
 		return err
+	}
+
+	ctx, err := tcmd.ContextType()
+	if err != nil {
+		return err
+	}
+	if ctx != "" {
+		return context.RunContextCLI(ctx)
 	}
 
 	args, os.Args, err = processAliases(dockerCli, cmd, args, os.Args)


### PR DESCRIPTION
**- What I did**
Detect the active context type, and if this one is not default (docker/moby) execv into a context specific binary

**- How I did it**
bake context-specific binary by appending context type to the current executable path.

**- How to verify it**
create an `ecs` context using docker/compose-cli
run `docker --context ECS foo` 
command will fail as you obviously have no `docker-ecs` binary to handle it.

**- Description for the changelog**
Add support for alternate context types CLI

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/101650431-35cce000-3a3c-11eb-9730-a62d086f15d5.png)

