### PR TITLE
generate-man.sh: Only build md2man if it's not installed

### DIFF
--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -4,8 +4,10 @@ set -eu -o pipefail
 
 mkdir -p ./man/man1
 
-# yay, go install creates a binary named "v2" ¯\_(ツ)_/¯
-go build -o "/go/bin/md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
+if ! command -v md2man &> /dev/null; then
+	# yay, go install creates a binary named "v2" ¯\_(ツ)_/¯
+	go build -o "/go/bin/md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
+fi
 
 # Generate man pages from cobra commands
 go build -o /tmp/gen-manpages github.com/docker/cli/man


### PR DESCRIPTION
Distributions uses generate-man.sh to create man pages, however it only
assumes a container environment and attempts to build binaries towards
`/go` which might be an illegal path in `fakeroot`.

This patch ensures we only build `md2man` from the vendored sources if
the command is not present. This allows distributions to supply thier
packaged `md2man`.

Signed-off-by: Morten Linderud <morten@linderud.pw>