### PR TITLE
Fix container creation time in test/builders

### DIFF
--- a/internal/test/builders/container.go
+++ b/internal/test/builders/container.go
@@ -17,7 +17,7 @@ func Container(name string, builders ...func(container *types.Container)) *types
 		Command: "top",
 		Image:   "busybox:latest",
 		Status:  "Up 1 second",
-		Created: time.Now().UnixNano(),
+		Created: time.Now().Unix(),
 	}
 
 	for _, builder := range builders {


### PR DESCRIPTION
The created time of the containerd is initialized with nanoseconds,
it seems to be a mistake.

In other places of the code, this field is initialized with seconds:

    $ grep -rh 'time\.Now()\.Unix()' | grep Created
    Created: time.Now().Unix(),
    Created: time.Now().Unix(),
    return []image.HistoryResponseItem{{ID: img, Created: time.Now().Unix()}}, nil

We can also see the the formatter assumes it to be seconds:

    cli/command/formatter/container.go
    ----
    func (c *ContainerContext) CreatedAt() string {
        return time.Unix(c.c.Created, 0).String()
    }

Interestingly, initializing the field with nanoseconds seems to work,
except on mips architecture, where it causes some kind of overflow.

~~~~
=== Failed
=== FAIL: cli/command/container TestContainerListWithoutFormat (0.00s)
    list_test.go:183: assertion failed:
        --- expected
        +++ actual
        @@ -1,7 +1,7 @@
         CONTAINER ID   IMAGE            COMMAND   CREATED                  STATUS        PORTS                NAMES
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second                        c1
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second                        c2
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   80-82/tcp            c3
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   81/udp               c4
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   8.8.8.8:82->82/tcp   c5
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second                        c1
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second                        c2
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second   80-82/tcp            c3
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second   81/udp               c4
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second   8.8.8.8:82->82/tcp   c5

=== FAIL: cli/command/container TestContainerListNoTrunc (0.00s)
    list_test.go:198: assertion failed:
        --- expected
        +++ actual
        @@ -1,4 +1,4 @@
         CONTAINER ID   IMAGE            COMMAND   CREATED                  STATUS        PORTS     NAMES
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c1
        -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c2,foo/bar
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second             c1
        +container_id   busybox:latest   "top"     -153722867 minutes ago   Up 1 second             c2,foo/bar
~~~~

Logs above taken from:
https://buildd.debian.org/status/fetch.php?pkg=docker.io&arch=mipsel&ver=20.10.0%7Erc1%2Bdfsg3-1&stamp=1606895899

~~~~
=== RUN   TestChtimesLinux
    chtimes_linux_test.go:87: Expected: 2262-04-11 23:47:16 +0000 UTC, got: 1990-01-27 10:50:44 +0000 UTC
--- FAIL: TestChtimesLinux (0.00s)
=== RUN   TestChtimes
    chtimes_test.go:92: Expected: 2262-04-11 23:47:16 +0000 UTC, got: 1990-01-27 10:50:44 +0000 UTC
--- FAIL: TestChtimes (0.00s)
~~~~

Logs above taken from:
https://buildd.debian.org/status/fetch.php?pkg=docker.io&arch=mips64el&ver=20.10.0%7Erc1%2Bdfsg3-1&stamp=1606895622

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

