### PR TITLE
Add bash completion for jobs

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -3601,7 +3601,7 @@ _docker_service_ls() {
 			return
 			;;
 		mode)
-			COMPREPLY=( $( compgen -W "global replicated" -- "${cur##*=}" ) )
+			COMPREPLY=( $( compgen -W "global global-job replicated replicated-job" -- "${cur##*=}" ) )
 			return
 			;;
 		name)
@@ -3731,6 +3731,7 @@ _docker_service_update_and_create() {
 		--limit-pids
 		--log-driver
 		--log-opt
+		--max-replicas
 		--replicas
 		--replicas-max-per-node
 		--reserve-cpu
@@ -3804,7 +3805,7 @@ _docker_service_update_and_create() {
 				return
 				;;
 			--mode)
-				COMPREPLY=( $( compgen -W "global replicated" -- "$cur" ) )
+				COMPREPLY=( $( compgen -W "global global-job replicated replicated-job" -- "$cur" ) )
 				return
 				;;
 		esac


### PR DESCRIPTION
ref: #2262

This adds bash completion for
- `docker service create --mode global-job|replicated-job`
- `docker service create|update --max-replicas`
- `docker service ls --filter mode=global-job|replicated-job`

The filter for `service ls` currently does not work (jobs will be ignored). This will be fixed by https://github.com/moby/moby/pull/41806/
edit: https://github.com/moby/moby/pull/41806 was merged.