### PR TITLE
Rename bin/md2man to bin/go-md2man

### DIFF
--- a/man/md2man-all.sh
+++ b/man/md2man-all.sh
@@ -18,5 +18,5 @@ for FILE in *.md; do
 		continue
 	fi
 	mkdir -p "./man${num}"
-	md2man -in "$FILE" -out "./man${num}/${name}"
+	go-md2man -in "$FILE" -out "./man${num}/${name}"
 done

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -4,9 +4,9 @@ set -eu -o pipefail
 
 mkdir -p ./man/man1
 
-if ! command -v md2man &> /dev/null; then
+if ! command -v go-md2man &> /dev/null; then
 	# yay, go install creates a binary named "v2" ¯\_(ツ)_/¯
-	go build -o "/go/bin/md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
+	go build -o "/go/bin/go-md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
 fi
 
 # Generate man pages from cobra commands


### PR DESCRIPTION
In the recent PR !2877, some code was added to check if md2man is
already installed in the build environment. This is to cater to the
needs of Linux distributions.

However it turns out that Linux distributions install md2man as
bin/go-md2man instead of bin/md2man, hence the PR !2877 doesn't help
much.

This commit fixes it by settling on using the binary name go-md2man.

For reference, here the file list of the package go-md2man in several
distributions:

- Debian: <https://packages.debian.org/sid/amd64/go-md2man/filelist>
- Ubuntu: <https://packages.ubuntu.com/hirsute/amd64/go-md2man/filelist>
- Fedora: <https://fedora.pkgs.org/31/fedora-x86_64/golang-github-cpuguy83-md2man-2.0.0-0.4.20190624gitf79a8a8.fc31.x86_64.rpm.html>
- ArchLinux: <https://www.archlinux.org/packages/community/x86_64/go-md2man/>

Signed-off-by: Arnaud Rebillout <elboulangero@gmail.com>