### PR TITLE
Added Swarm Job support to Stack Deploy

### DIFF
--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -616,11 +616,21 @@ func convertDeployMode(mode string, replicas *uint64) (swarm.ServiceMode, error)
 	serviceMode := swarm.ServiceMode{}
 
 	switch mode {
+	case "global-job":
+		if replicas != nil {
+			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
+		}
+		serviceMode.GlobalJob = &swarm.GlobalJob{}
 	case "global":
 		if replicas != nil {
-			return serviceMode, errors.Errorf("replicas can only be used with replicated mode")
+			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
 		}
 		serviceMode.Global = &swarm.GlobalService{}
+	case "replicated-job":
+		serviceMode.ReplicatedJob = &swarm.ReplicatedJob{
+			MaxConcurrent:    replicas,
+			TotalCompletions: replicas,
+		}
 	case "replicated", "":
 		serviceMode.Replicated = &swarm.ReplicatedService{Replicas: replicas}
 	default:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the support for both `global-job` and `replicated-job` to Docker Stack deploy.

Follow up to https://github.com/docker/cli/pull/2262.

For `replicated-jobs`, the number of replicas adjusts the number of Concurrent Tasks as well as the required number of Completed Tasks. I have not added support for `max-concurrent` which allows the number of Concurrent Tasks and the number of Completed Tasks to be set independently. This is because `max-concurrent` is currently not defined in Compose, so I believe a follow up PR is required to add `max-concurrent` once support is in Compose.

**- How to verify it**
Locally verified with the following 3 Stack files.

```
$ cat global-job.yaml 
version: '3.9'

services:
  sleeper:
    deploy:
      mode: global-job
    image: ubuntu
    command:
      - sleep
      - "50"
```
```
$ cat replicated-job.yaml 
version: '3.9'

services:
  sleeper:
    deploy:
      mode: replicated-job
    image: ubuntu
    command:
      - sleep
      - "50"
```
```
$ cat max-replicas-per-node.yaml 
version: '3.9'

services:
  sleeper:
    deploy:
      mode: replicated-job
      replicas: 5
      placement: 
        max_replicas_per_node: 1
    image: ubuntu
    command:
      - sleep
      - "50"

```


**- Description for the changelog**
Swarm Job support in `docker stack deploy`