### PR TITLE
Add bash completion for `dockerd --ip6tables`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2548,6 +2548,7 @@ _docker_daemon() {
 		--ip-forward=false
 		--ip-masq=false
 		--iptables=false
+		--ip6tables
 		--ipv6
 		--live-restore
 		--no-new-privileges


### PR DESCRIPTION
See https://github.com/moby/moby/pull/41622 and https://github.com/docker/cli/pull/2846 for the corresponding feature.