### PR TITLE
Add serve command (Follow up delegate to backend) 

### DIFF
--- a/backends/manager.go
+++ b/backends/manager.go
@@ -1,0 +1,94 @@
+package backends
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/theupdateframework/notary/tuf/utils"
+)
+
+// Backend info for available backends
+type Backend struct {
+	Name           string   `json:",omitempty"`
+	Path           string   `json:"-"`
+	Version        string   `json:",omitempty"`
+	SupportedTypes []string `json:"-"`
+	Err            error    `json:"-"`
+}
+
+type BackendMetadata struct {
+	Name    string
+	Version string
+}
+
+const (
+	backendPrefix = "docker-"
+	backendSuffix = "-backend"
+)
+
+// ListBackends produces a list of available backends on the system and their context types
+func ListBackends() ([]Backend, error) {
+	return listBackendsFrom(getDockerCliBackendDir(), fakeMetadata)
+}
+
+// GetBackend get backend for a given context type
+func GetBackend(contextType string) (*Backend, error) {
+	backends, err := ListBackends()
+	if err != nil {
+		return nil, err
+	}
+	for _, backend := range backends {
+		if utils.StrSliceContains(backend.SupportedTypes, contextType) {
+			return &backend, nil
+		}
+	}
+	return nil, fmt.Errorf("no available backend for context type %q", contextType)
+}
+
+type extractMetadataFunc func(binary string) (BackendMetadata, error)
+
+func fakeMetadata(binary string) (BackendMetadata, error) {
+	name := strings.TrimPrefix(filepath.Base(binary), backendPrefix)
+	return BackendMetadata{Name: strings.TrimSuffix(name, ".exe"), Version: "1.0"}, nil
+}
+
+func listBackendsFrom(backendDir string, extractVersion extractMetadataFunc) ([]Backend, error) {
+	if fi, err := os.Stat(backendDir); err != nil || !fi.IsDir() {
+		return nil, fmt.Errorf("%q is not a directory, unable to list backends", backendDir)
+	}
+	dentries, err := ioutil.ReadDir(backendDir)
+	if err != nil {
+		return nil, err
+	}
+	result := []Backend{}
+	for _, candidate := range dentries {
+		switch candidate.Mode() & os.ModeType {
+		case 0, os.ModeSymlink:
+			// Regular file or symlink, keep going
+		default:
+			// Something else, ignore.
+			continue
+		}
+		fileName := candidate.Name()
+		name := strings.TrimSuffix(fileName, ".exe")
+		if !strings.HasPrefix(name, backendPrefix) || !strings.HasSuffix(name, backendSuffix) {
+			continue
+		}
+		contextTypes := getContextTypes(name)
+		path := filepath.Join(backendDir, fileName)
+		metadata, err := extractVersion(path)
+		if err != nil {
+			continue
+		}
+		result = append(result, Backend{Name: metadata.Name, Path: path, Version: metadata.Version, SupportedTypes: contextTypes})
+	}
+	return result, nil
+}
+
+func getContextTypes(name string) []string {
+	name = strings.TrimPrefix(name, backendPrefix)
+	return strings.Split(strings.TrimSuffix(name, backendSuffix), "-")
+}

--- a/backends/manager_test.go
+++ b/backends/manager_test.go
@@ -23,12 +23,13 @@ func TestListBackend(t *testing.T) {
 	)
 	defer dir.Remove()
 
-	candidates := listBackendsFrom(dir.Path(), fakeMetadata, map[string][]string{"docker-aci-local-backend": {"aci", "local"}, "docker-ecs-backend": {"ecs"}})
+	candidates, err := listBackendsFrom(dir.Path(), fakeMetadata, map[string][]string{"docker-aci-local-backend": {"aci", "local"}, "docker-ecs-backend": {"ecs"}})
 	exp := []Backend{
 		{Name: "aci-local-backend", Path: filepath.Join(dir.Path(), "docker-aci-local-backend"), Version: "1.0", SupportedTypes: []string{"aci", "local"}},
 		{Name: "ecs-backend", Path: filepath.Join(dir.Path(), "docker-ecs-backend.exe"), Version: "1.0", SupportedTypes: []string{"ecs"}},
 	}
 
+	assert.NilError(t, err)
 	assert.DeepEqual(t, candidates, exp)
 }
 

--- a/backends/manager_test.go
+++ b/backends/manager_test.go
@@ -1,0 +1,33 @@
+package backends
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+func TestListBackend(t *testing.T) {
+	// Populate a selection of directories with various shadowed and bogus/obscure plugin candidates.
+	// For the purposes of this test no contents is required and permissions are irrelevant.
+	dir := fs.NewDir(t, t.Name(),
+		fs.WithFile("docker-aci-ecs-local-backend", ""), // backend for aci, ecs, local types
+		fs.WithFile("docker-type1-backend", ""),         // backend for type1
+		fs.WithFile("docker-type2-backend.exe", ""),     // backend for type2
+		fs.WithFile("not-a-backend", ""),
+		fs.WithFile("docker-plugin", ""),
+		fs.WithDir("ignored1"),
+	)
+	defer dir.Remove()
+
+	candidates, err := listBackendsFrom(dir.Path(), fakeMetadata)
+	assert.NilError(t, err)
+	exp := []Backend{
+		{Name: "aci-ecs-local-backend", Path: filepath.Join(dir.Path(), "docker-aci-ecs-local-backend"), Version: "1.0", SupportedTypes: []string{"aci", "ecs", "local"}},
+		{Name: "type1-backend", Path: filepath.Join(dir.Path(), "docker-type1-backend"), Version: "1.0", SupportedTypes: []string{"type1"}},
+		{Name: "type2-backend", Path: filepath.Join(dir.Path(), "docker-type2-backend.exe"), Version: "1.0", SupportedTypes: []string{"type2"}},
+	}
+
+	assert.DeepEqual(t, candidates, exp)
+}

--- a/backends/manager_test.go
+++ b/backends/manager_test.go
@@ -2,6 +2,7 @@ package backends
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -12,22 +13,27 @@ func TestListBackend(t *testing.T) {
 	// Populate a selection of directories with various shadowed and bogus/obscure plugin candidates.
 	// For the purposes of this test no contents is required and permissions are irrelevant.
 	dir := fs.NewDir(t, t.Name(),
-		fs.WithFile("docker-aci-ecs-local-backend", ""), // backend for aci, ecs, local types
-		fs.WithFile("docker-type1-backend", ""),         // backend for type1
-		fs.WithFile("docker-type2-backend.exe", ""),     // backend for type2
+		fs.WithFile("docker-aci-local-backend", ""),      // backend for aci, local types
+		fs.WithFile("docker-ecs-backend.exe", ""),        // backend for ecs
+		fs.WithFile("docker-notallowed-backend.exe", ""), // type not allowed
+		fs.WithFile("docker-local-backend.exe", ""),      // binary not allowed
 		fs.WithFile("not-a-backend", ""),
 		fs.WithFile("docker-plugin", ""),
 		fs.WithDir("ignored1"),
 	)
 	defer dir.Remove()
 
-	candidates, err := listBackendsFrom(dir.Path(), fakeMetadata)
-	assert.NilError(t, err)
+	candidates := listBackendsFrom(dir.Path(), fakeMetadata, map[string][]string{"docker-aci-local-backend": {"aci", "local"}, "docker-ecs-backend": {"ecs"}})
 	exp := []Backend{
-		{Name: "aci-ecs-local-backend", Path: filepath.Join(dir.Path(), "docker-aci-ecs-local-backend"), Version: "1.0", SupportedTypes: []string{"aci", "ecs", "local"}},
-		{Name: "type1-backend", Path: filepath.Join(dir.Path(), "docker-type1-backend"), Version: "1.0", SupportedTypes: []string{"type1"}},
-		{Name: "type2-backend", Path: filepath.Join(dir.Path(), "docker-type2-backend.exe"), Version: "1.0", SupportedTypes: []string{"type2"}},
+		{Name: "aci-local-backend", Path: filepath.Join(dir.Path(), "docker-aci-local-backend"), Version: "1.0", SupportedTypes: []string{"aci", "local"}},
+		{Name: "ecs-backend", Path: filepath.Join(dir.Path(), "docker-ecs-backend.exe"), Version: "1.0", SupportedTypes: []string{"ecs"}},
 	}
 
 	assert.DeepEqual(t, candidates, exp)
+}
+
+func fakeMetadata(binary string) (BackendMetadata, error) {
+	name := strings.TrimPrefix(filepath.Base(binary), backendPrefix)
+	withoutExe := strings.TrimSuffix(name, ".exe")
+	return BackendMetadata{Name: withoutExe, Version: "1.0"}, nil
 }

--- a/backends/manager_unix.go
+++ b/backends/manager_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package backends
+
+func getDockerCliBackendDir() string {
+	// TODO check , "/usr/local/libexec/docker/cli-backends", if "/usr/local/lib/" does not exist
+	return "/usr/local/lib/docker/cli-backends"
+}

--- a/backends/manager_windows.go
+++ b/backends/manager_windows.go
@@ -1,0 +1,11 @@
+// +build windows
+package backends
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func getDockerCliBackendDir() string {
+	return filepath.Join(os.Getenv("ProgramData"), "Docker", "cli-backends")
+}

--- a/backends/shellout.go
+++ b/backends/shellout.go
@@ -1,0 +1,54 @@
+package backends
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+)
+
+func shellout(execBinary string, args ...string) ([]byte, error) {
+	cmd := exec.Command(execBinary, args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func delegate(execBinary string) {
+	cmd := exec.Command(execBinary, os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	signals := make(chan os.Signal, 1)
+	childExit := make(chan bool)
+	signal.Notify(signals) // catch all signals
+	go func() {
+		for {
+			select {
+			case sig := <-signals:
+				if cmd.Process == nil {
+					continue // can happen if receiving signal before the process is actually started
+				}
+				// nolint errcheck
+				cmd.Process.Signal(sig)
+			case <-childExit:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Run()
+	childExit <- true
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exiterr.ExitCode())
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/backends/types.go
+++ b/backends/types.go
@@ -3,8 +3,6 @@ package backends
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"os/signal"
 )
 
 const (
@@ -28,41 +26,4 @@ func RunBackendCLI(contextType string) error {
 	}
 	delegate(backend.Path) // will exit
 	return nil
-}
-
-func delegate(execBinary string) {
-	cmd := exec.Command(execBinary, os.Args[1:]...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = os.Environ()
-
-	signals := make(chan os.Signal, 1)
-	childExit := make(chan bool)
-	signal.Notify(signals) // catch all signals
-	go func() {
-		for {
-			select {
-			case sig := <-signals:
-				if cmd.Process == nil {
-					continue // can happen if receiving signal before the process is actually started
-				}
-				// nolint errcheck
-				cmd.Process.Signal(sig)
-			case <-childExit:
-				return
-			}
-		}
-	}()
-
-	err := cmd.Run()
-	childExit <- true
-	if err != nil {
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			os.Exit(exiterr.ExitCode())
-		}
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	os.Exit(0)
 }

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -161,6 +161,20 @@ func (tcmd *TopLevelCommand) Initialize(ops ...command.InitializeOpt) error {
 	return tcmd.dockerCli.Initialize(tcmd.opts, ops...)
 }
 
+// ContextType return the current context type, "" for default
+func (tcmd *TopLevelCommand) ContextType() (string, error) {
+	context := tcmd.dockerCli.CurrentContext()
+	metadata, err := tcmd.dockerCli.ContextStore().GetMetadata(context)
+	if err != nil {
+		return "", err
+	}
+	meta := metadata.Metadata.(command.DockerContext)
+	if s, ok := meta.AdditionalFields["Type"]; ok {
+		return s.(string), nil
+	}
+	return "", nil
+}
+
 // VisitAll will traverse all commands from the root.
 // This is different from the VisitAll of cobra.Command where only parents
 // are checked.

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/builder"
 	"github.com/docker/cli/cli/command/checkpoint"
+	"github.com/docker/cli/cli/command/compose"
 	"github.com/docker/cli/cli/command/config"
 	"github.com/docker/cli/cli/command/container"
 	"github.com/docker/cli/cli/command/context"
@@ -37,6 +38,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// container
 		container.NewContainerCommand(dockerCli),
 		container.NewRunCommand(dockerCli),
+
+		//compose
+		compose.NewComposeCommand(),
 
 		// image
 		image.NewImageCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cli/cli/command/plugin"
 	"github.com/docker/cli/cli/command/registry"
 	"github.com/docker/cli/cli/command/secret"
+	"github.com/docker/cli/cli/command/serve"
 	"github.com/docker/cli/cli/command/service"
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/swarm"
@@ -68,6 +69,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 
 		// secret
 		secret.NewSecretCommand(dockerCli),
+
+		// service
+		serve.NewServeCommand(),
 
 		// service
 		service.NewServiceCommand(dockerCli),

--- a/cli/command/compose/compose.go
+++ b/cli/command/compose/compose.go
@@ -1,0 +1,22 @@
+package compose
+
+import (
+	"github.com/docker/cli/backends"
+	"github.com/spf13/cobra"
+)
+
+// NewComposeCommand compose command delegated to backend
+func NewComposeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "compose",
+		Short:              "Manage compose projects",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return backends.RunBackendCLI(backends.ContextTypeLocal)
+		},
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use: "fake command so compose is a Management Command",
+	})
+	return cmd
+}

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"text/tabwriter"
 
+	"github.com/docker/cli/backends"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/kubernetes"
 	"github.com/docker/cli/cli/context/store"
@@ -78,7 +78,7 @@ func newAciCreateCommand() *cobra.Command {
 		Short:              "Create a context for Azure Container Instances",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return context.RunContextCLI(context.ContextTypeACI)
+			return backends.RunBackendCLI(backends.ContextTypeACI)
 		},
 	}
 	return cmd
@@ -90,7 +90,7 @@ func newEcsCreateCommand() *cobra.Command {
 		Short:              "Create a context for Amazon ECS",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return context.RunContextCLI(context.ContextTypeECS)
+			return backends.RunBackendCLI(backends.ContextTypeECS)
 		},
 	}
 	return cmd

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	configtypes "github.com/docker/cli/cli/config/types"
+	dockercontext "github.com/docker/cli/cli/context"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
@@ -52,7 +53,20 @@ func NewLoginCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&opts.password, "password", "p", "", "Password")
 	flags.BoolVarP(&opts.passwordStdin, "password-stdin", "", false, "Take the password from stdin")
 
+	cmd.AddCommand(newLoginAzureCommand())
+
 	return cmd
+}
+
+func newLoginAzureCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:                "azure [OPTIONS]",
+		Short:              "Log in to Azure",
+		DisableFlagParsing: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return dockercontext.RunContextCLI(dockercontext.ContextTypeACI)
+		},
+	}
 }
 
 // displayUnencryptedWarning warns the user when using an insecure credential storage.

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -6,10 +6,10 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/docker/cli/backends"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	configtypes "github.com/docker/cli/cli/config/types"
-	dockercontext "github.com/docker/cli/cli/context"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
@@ -64,7 +64,7 @@ func newLoginAzureCommand() *cobra.Command {
 		Short:              "Log in to Azure",
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return dockercontext.RunContextCLI(dockercontext.ContextTypeACI)
+			return backends.RunBackendCLI(backends.ContextTypeACI)
 		},
 	}
 }

--- a/cli/command/serve/serve.go
+++ b/cli/command/serve/serve.go
@@ -1,0 +1,20 @@
+package serve
+
+import (
+	"github.com/docker/cli/backends"
+	"github.com/spf13/cobra"
+)
+
+// NewServeCommand command to serve gRPC API for backend commands (ACI/ECS for now) delegated to backend
+func NewServeCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "serve",
+		Short:              "Start a Docker client api server",
+		DisableFlagParsing: true,
+		Hidden:             true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return backends.RunBackendCLI(backends.ContextTypeLocal)
+		},
+	}
+	return cmd
+}

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -11,7 +11,7 @@ type NamedTypeGetter struct {
 	typeGetter TypeGetter
 }
 
-// EndpointTypeGetter returns a NamedTypeGetter with the spcecified name and getter
+// EndpointTypeGetter returns a NamedTypeGetter with the specified name and getter
 func EndpointTypeGetter(name string, getter TypeGetter) NamedTypeGetter {
 	return NamedTypeGetter{
 		name:       name,

--- a/cli/context/types.go
+++ b/cli/context/types.go
@@ -3,27 +3,68 @@ package context
 import (
 	"fmt"
 	"os"
-	"syscall"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
 )
 
 const (
 	// ContextTypeECS is Amazon ECS context type
 	ContextTypeECS = "ecs"
-
 	// ContextTypeACI is MS Azure Container Instances context type
 	ContextTypeACI = "aci"
+
+	//TODO move in a separate file and have a windows version
+	backendFolder = "/usr/local/lib/docker/cli-backends"
 )
 
 // RunContextCLI replace the current process with dedicated CLI for this context type
 func RunContextCLI(context string) error {
-	executable, err := os.Executable()
-	if err != nil {
-		return err
+	if context != ContextTypeACI && context != ContextTypeECS {
+		return fmt.Errorf("unsupported context type: %q", context)
 	}
-	x := executable + "-" + context
+	x := filepath.Join(backendFolder, "compose-cli")
 	if _, err := os.Stat(x); os.IsNotExist(err) {
 		// TODO we could be more restrictive about supported types to prevent abuses using ContextType enum values
 		return fmt.Errorf("unsupported context type %q", context)
 	}
-	return syscall.Exec(x, os.Args[1:], os.Environ())
+	delegate(x) // will exit
+	return nil
+}
+
+func delegate(execBinary string) {
+	cmd := exec.Command(execBinary, os.Args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	signals := make(chan os.Signal, 1)
+	childExit := make(chan bool)
+	signal.Notify(signals) // catch all signals
+	go func() {
+		for {
+			select {
+			case sig := <-signals:
+				if cmd.Process == nil {
+					continue // can happen if receiving signal before the process is actually started
+				}
+				// nolint errcheck
+				cmd.Process.Signal(sig)
+			case <-childExit:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Run()
+	childExit <- true
+	if err != nil {
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exiterr.ExitCode())
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/cli/context/types.go
+++ b/cli/context/types.go
@@ -1,0 +1,29 @@
+package context
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const (
+	// ContextTypeECS is Amazon ECS context type
+	ContextTypeECS = "ecs"
+
+	// ContextTypeACI is MS Azure Container Instances context type
+	ContextTypeACI = "aci"
+)
+
+// RunContextCLI replace the current process with dedicated CLI for this context type
+func RunContextCLI(context string) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	x := executable + "-" + context
+	if _, err := os.Stat(x); os.IsNotExist(err) {
+		// TODO we could be more restrictive about supported types to prevent abuses using ContextType enum values
+		return fmt.Errorf("unsupported context type %q", context)
+	}
+	return syscall.Exec(x, os.Args[1:], os.Environ())
+}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/docker/cli/backends"
 	"github.com/docker/cli/cli"
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
-	"github.com/docker/cli/cli/context"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/docker/api/types/versions"
@@ -270,7 +270,7 @@ func runDocker(dockerCli *command.DockerCli) error {
 		return err
 	}
 	if ctx != "" {
-		return context.RunContextCLI(ctx)
+		return backends.RunBackendCLI(ctx)
 	}
 
 	args, os.Args, err = processAliases(dockerCli, cmd, args, os.Args)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
+	"github.com/docker/cli/cli/context"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/docker/api/types/versions"
@@ -262,6 +263,14 @@ func runDocker(dockerCli *command.DockerCli) error {
 
 	if err := tcmd.Initialize(); err != nil {
 		return err
+	}
+
+	ctx, err := tcmd.ContextType()
+	if err != nil {
+		return err
+	}
+	if ctx != "" {
+		return context.RunContextCLI(ctx)
 	}
 
 	args, os.Args, err = processAliases(dockerCli, cmd, args, os.Args)


### PR DESCRIPTION
**- What I did**
* Add serve command delegating to backend the startup of gRPC API for context backend commands (ACI/ECS), today provided by docker/compose-cli, and started in Docker Desktop

This is based on #2922 , only the last commit is really part of this PR. (other commits will potentially get rebased from #2922 )

Fixes https://github.com/docker/dev-tooling-team/issues/253

**- How I did it**

**- How to verify it**
* place compose-cli v1.0.6 binary in /usr/local/lib/docker/cli-backends/
* `docker serve --help` displays help for serve command

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

