### PR TITLE
fix --update-order and --rollback-order flags

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -165,7 +165,7 @@ func updateConfigFromDefaults(defaultUpdateConfig *api.UpdateConfig) *swarm.Upda
 }
 
 func (opts updateOptions) updateConfig(flags *pflag.FlagSet) *swarm.UpdateConfig {
-	if !anyChanged(flags, flagUpdateParallelism, flagUpdateDelay, flagUpdateMonitor, flagUpdateFailureAction, flagUpdateMaxFailureRatio) {
+	if !anyChanged(flags, flagUpdateParallelism, flagUpdateDelay, flagUpdateMonitor, flagUpdateFailureAction, flagUpdateMaxFailureRatio, flagUpdateOrder) {
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func (opts updateOptions) updateConfig(flags *pflag.FlagSet) *swarm.UpdateConfig
 }
 
 func (opts updateOptions) rollbackConfig(flags *pflag.FlagSet) *swarm.UpdateConfig {
-	if !anyChanged(flags, flagRollbackParallelism, flagRollbackDelay, flagRollbackMonitor, flagRollbackFailureAction, flagRollbackMaxFailureRatio) {
+	if !anyChanged(flags, flagRollbackParallelism, flagRollbackDelay, flagRollbackMonitor, flagRollbackFailureAction, flagRollbackMaxFailureRatio, flagRollbackOrder) {
 		return nil
 	}
 

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -289,6 +289,22 @@ func TestToServiceUpdateRollback(t *testing.T) {
 	assert.Check(t, is.DeepEqual(service.RollbackConfig, expected.RollbackConfig))
 }
 
+func TestToServiceUpdateRollbackOrder(t *testing.T) {
+	flags := newCreateCommand(nil).Flags()
+	flags.Set("update-order", "start-first")
+	flags.Set("rollback-order", "start-first")
+
+	o := newServiceOptions()
+	o.mode = "replicated"
+	o.update = updateOptions{order: "start-first"}
+	o.rollback = updateOptions{order: "start-first"}
+
+	service, err := o.ToService(context.Background(), &fakeClient{}, flags)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(service.UpdateConfig.Order, o.update.order))
+	assert.Check(t, is.Equal(service.RollbackConfig.Order, o.rollback.order))
+}
+
 func TestToServiceMaxReplicasGlobalModeConflict(t *testing.T) {
 	opt := serviceOptions{
 		mode:        "global",


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41581

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add missing flags in `anyChanged` function in two places, resolving <https://github.com/moby/moby/issues/41581>

**- How I did it**
Just add the missing flags.

**- How to verify it**
* `docker service create --update-order start-first --restart-condition none --no-healthcheck --name start-first-test alpine tail -f /dev/null`
* `docker inspect start-first-test`

(Before this commit)
```
...
            "UpdateConfig": {
                "Parallelism": 1,
                "FailureAction": "pause",
                "Monitor": 5000000000,
                "MaxFailureRatio": 0,
                "Order": "stop-first"
            },
            "RollbackConfig": {
                "Parallelism": 1,
                "FailureAction": "pause",
                "Monitor": 5000000000,
                "MaxFailureRatio": 0,
                "Order": "stop-first"
            },
            "EndpointSpec": {
                "Mode": "vip"
            }
        },
        "Endpoint": {
            "Spec": {}
        }
    }
]
```
(After this commit):
```
...
            "UpdateConfig": {
                "Parallelism": 1,
                "FailureAction": "pause",
                "Monitor": 5000000000,
                "MaxFailureRatio": 0,
                "Order": "start-first"
            },
            "RollbackConfig": {
                "Parallelism": 1,
                "FailureAction": "pause",
                "Monitor": 5000000000,
                "MaxFailureRatio": 0,
                "Order": "start-first"
            },
            "EndpointSpec": {
                "Mode": "vip"
            }
        },
        "Endpoint": {
            "Spec": {}
        }
    }
]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

fix `--update-order` and `--rollback-order` flags when only `--update-order` or `--rollback-order` is provided.


**- A picture of a cute animal (not mandatory but encouraged)**
🦁

