### PR TITLE
cli/config: prevent warning if HOME is not set

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -26,7 +26,21 @@ const (
 var (
 	initConfigDir sync.Once
 	configDir     string
+	homeDir       string
 )
+
+// resetHomeDir is used in testing to resets the "homeDir" package variable to
+// force re-lookup of the home directory between tests.
+func resetHomeDir() {
+	homeDir = ""
+}
+
+func getHomeDir() string {
+	if homeDir == "" {
+		homeDir = homedir.Get()
+	}
+	return homeDir
+}
 
 func setConfigDir() {
 	if configDir != "" {
@@ -34,7 +48,7 @@ func setConfigDir() {
 	}
 	configDir = os.Getenv("DOCKER_CONFIG")
 	if configDir == "" {
-		configDir = filepath.Join(homedir.Get(), configFileDir)
+		configDir = filepath.Join(getHomeDir(), configFileDir)
 	}
 }
 
@@ -109,11 +123,7 @@ func Load(configDir string) (*configfile.ConfigFile, error) {
 	}
 
 	// Can't find latest config file so check for the old one
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return configFile, errors.Wrap(err, oldConfigfile)
-	}
-	filename = filepath.Join(home, oldConfigfile)
+	filename = filepath.Join(getHomeDir(), oldConfigfile)
 	if file, err := os.Open(filename); err == nil {
 		defer file.Close()
 		if err := configFile.LegacyLoadFromReader(file); err != nil {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -115,6 +115,7 @@ password`: "Invalid Auth config file",
 email`: "Invalid auth configuration file",
 	}
 
+	resetHomeDir()
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
@@ -131,6 +132,7 @@ email`: "Invalid auth configuration file",
 }
 
 func TestOldValidAuth(t *testing.T) {
+	resetHomeDir()
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
@@ -165,6 +167,7 @@ func TestOldValidAuth(t *testing.T) {
 }
 
 func TestOldJSONInvalid(t *testing.T) {
+	resetHomeDir()
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
@@ -184,6 +187,7 @@ func TestOldJSONInvalid(t *testing.T) {
 }
 
 func TestOldJSON(t *testing.T) {
+	resetHomeDir()
 	tmpHome, err := ioutil.TempDir("", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/41890 WARNING: Error loading config file: .dockercfg: $HOME is not defined

commit c2626a8270924d0cec54477fc506174cd31dc560 (https://github.com/docker/cli/pull/2101) replaced the use of github.com/docker/docker/pkg/homedir with Golang's `os.UserHomeDir()`.

This change was partially reverted in 7a279af43de6650d2f36c41f9d926db7be3b3567 (https://github.com/docker/cli/pull/2111) to account for situations where `$HOME` is not set.

In  situations where no configuration file is present in `~/.config/`, the CLI falls back to looking for the (deprecated) `~/.dockercfg` configuration file, which was still using `os.UserHomeDir()`, which produces an error/warning if `$HOME` is not set.

This patch introduces a helper function and a global variable to get the user's home-directory. The global variable is used to prevent repeatedly looking up the user's information (which, depending on the setup can be a costly operation).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
- Fix "`WARNING: Error loading config file: .dockercfg: $HOME is not defined`"
```


**- A picture of a cute animal (not mandatory but encouraged)**

