### PR TITLE
docs: add redirect for old reference URL

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,6 +1,8 @@
 ---
 description: "Configure containers at runtime"
 keywords: "docker, run, configure, runtime"
+redirect_from:
+- /reference/run/
 ---
 
 <!-- This file is maintained within the docker/cli GitHub


### PR DESCRIPTION
fixes https://github.com/docker/docker.github.io/issues/12151
fixes https://github.com/docker/docker.github.io/issues/12149