### PR TITLE
docs: Fix wrong variable name

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1740,7 +1740,7 @@ volume mounted on the host).
 
 The `container-dest` must always be an absolute path such as `/src/docs`.
 The `host-src` can either be an absolute path or a `name` value. If you
-supply an absolute path for the `host-dir`, Docker bind-mounts to the path
+supply an absolute path for the `host-src`, Docker bind-mounts to the path
 you specify. If you supply a `name`, Docker creates a named volume by that `name`.
 
 A `name` value must start with an alphanumeric character,


### PR DESCRIPTION
**- What I did**
  I think this is trivial mistake and fixed wrong variable name in run.md.
 
**- How I did it**
  `host-dir` -> `host-src`

**- How to verify it**
  😀
**- Description for the changelog**
  N/A

**- A picture of a cute animal (not mandatory but encouraged)**
![cat](https://cdn.pixabay.com/photo/2014/11/30/14/11/cat-551554_1280.jpg)
