### PR TITLE
Modify a 'docker build' command with no context specified to infer "." as the context.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-FROM ubuntu
-
-RUN echo test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu
+
+RUN echo test

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -112,13 +112,13 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 			} else {
 				currentDir, err := os.Getwd()
 				if err != nil {
-					_, _ = fmt.Fprint(dockerCli.Err(), "No build context was specified, and we were" +
-					    "unable to get the local directory's path in order to use it as a" +
-					    "build context. Consider passing the build context path as an argument.")
+					_, _ = fmt.Fprint(dockerCli.Err(), "No build context was specified, and we were"+
+						"unable to get the local directory's path in order to use it as a"+
+						"build context. Consider passing the build context path as an argument.")
 					return errors.Errorf("unable to prepare context: %s", err)
 				}
-				_, _ = fmt.Fprintln(dockerCli.Out(), "No build context was specified. Using the current " +
-				    fmt.Sprintf("working directory '%s' as our build context.", currentDir))
+				_, _ = fmt.Fprintln(dockerCli.Out(), "No build context was specified. Using the current "+
+					fmt.Sprintf("working directory '%s' as our build context.", currentDir))
 				options.context = currentDir
 			}
 			return runBuild(dockerCli, options)

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -112,12 +112,13 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 			} else {
 				currentDir, err := os.Getwd()
 				if err != nil {
-					_, _ = fmt.Fprint(dockerCli.Err(), `No build context was specified, and we were
-				    unable to get the local directory's path in order to use it as a
-				    build context. Consider passing the build context path as an argument.
-`)
+					_, _ = fmt.Fprint(dockerCli.Err(), "No build context was specified, and we were" +
+					    "unable to get the local directory's path in order to use it as a" +
+					    "build context. Consider passing the build context path as an argument.")
 					return errors.Errorf("unable to prepare context: %s", err)
 				}
+				_, _ = fmt.Fprintln(dockerCli.Out(), "No build context was specified. Using the current " +
+				    fmt.Sprintf("working directory '%s' as our build context.", currentDir))
 				options.context = currentDir
 			}
 			return runBuild(dockerCli, options)

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -241,8 +241,8 @@ The transfer of context from the local machine to the Docker daemon is what the
 If you wish to keep the intermediate containers after the build is complete,
 you must use `--rm=false`. This does not affect the build cache.
 
-If no filepath is specified, docker infers the context is the local directory.
-This means `docker build` is equivalent to "`docker build .`".
+If no context is specified, docker infers the context to be the local
+directory. This means `docker build` is equivalent to "`docker build .`".
 
 ### Build with URL
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -7,7 +7,7 @@ keywords: "build, docker, image"
 # build
 
 ```markdown
-Usage:  docker build [OPTIONS] PATH | URL | -
+Usage:  docker build [OPTIONS] [PATH | URL | -]
 
 Build an image from a Dockerfile
 
@@ -240,6 +240,9 @@ The transfer of context from the local machine to the Docker daemon is what the
 
 If you wish to keep the intermediate containers after the build is complete,
 you must use `--rm=false`. This does not affect the build cache.
+
+If no filepath is specified, docker infers the context is the local directory.
+This means `docker build` is equivalent to "`docker build .`".
 
 ### Build with URL
 


### PR DESCRIPTION
Also update documentation to match.

Signed-off-by: Marshall Conover <marzhall.o+docker@gmail.com>

**- What I did**
Removed the requirement to specify a context when running docker build.
**- How I did it**
Modified the options parsing for `docker build` to use the current working directory as the context when no context is specified.
**- How to verify it**
In a directory with a Dockerfile, and with an updated binary, run:
```
    docker build
```
You will see a line to stdout with the message
```
    No build context was specified. Using the current working directory '<current working directory>' as our build context.
```
followed by the docker build command executing as if you had run `docker build .`.

This is in contrast to the previous behavior, in which case running `docker build` would return:
```
    "docker build" requires exactly 1 argument.
```
followed by the client exiting.

**- Description for the changelog**

Infer the local directory as the context to use if no context is specified. `docker build` is now the same as `docker build .`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/973107/105611184-bf810480-5d81-11eb-85a0-71ac62687abf.png)

# Important Notes

- I was not able to figure out how to run the unit tests from within the docker container development environment; I'm cracking at it, but wanted to note that the current documentation (at least that I saw) didn't have a straightforward "just run these commands" in it. I'm happy to update the doc once I have it working.
- I'm unsure of how to test the error case in the code, as it requires os.GetCWD to fail. Pointers on how to do so would be helpful, though (like the above issue) I can continue digging.

Thanks!

(PR for #2946 )