### PR TITLE
[20.10 backport] Fix panic when failing to get DefaultAuthConfig

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -63,6 +63,9 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
 		indexServer := registry.GetAuthConfigKey(index)
 		isDefaultRegistry := indexServer == ElectAuthServer(context.Background(), cli)
 		authConfig, err := GetDefaultAuthConfig(cli, true, indexServer, isDefaultRegistry)
+		if authConfig == nil {
+			authConfig = &types.AuthConfig{}
+		}
 		if err != nil {
 			fmt.Fprintf(cli.Err(), "Unable to retrieve stored credentials for %s, error: %s.\n", indexServer, err)
 		}

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -111,11 +111,12 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint: gocycl
 		serverAddress = authServer
 	}
 
-	var err error
-	var authConfig *types.AuthConfig
 	var response registrytypes.AuthenticateOKBody
 	isDefaultRegistry := serverAddress == authServer
-	authConfig, err = command.GetDefaultAuthConfig(dockerCli, opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
+	authConfig, err := command.GetDefaultAuthConfig(dockerCli, opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
+	if authConfig == nil {
+		authConfig = &types.AuthConfig{}
+	}
 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {
 		response, err = loginWithCredStoreCreds(ctx, dockerCli, authConfig)
 	}


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2918

fixes https://github.com/docker/cli/issues/2890 Non-root user "docker login" results in panic SIGSEGV segmentation violation
fixes https://github.com/moby/moby/issues/41771 Command 'docker login' does not work

Commit f32731f9020f12ae2600a3f4c90e668565220cb6 (https://github.com/docker/cli/pull/2818) fixed a potential panic when an error was returned while trying to get existing credentials.

However, other code paths currently use the result of `GetDefaultAuthConfig()` even in an error condition; this resulted in a panic, because a `nil` was returned.

We should fix the other code paths to be more resilient, and to not use the result of `GetDefaultAuthConfig()` if an error occurs, but starting with a minimal patch to fix the immediate issue.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Fix a panic on `docker login` if no config file is present
```

