### PR TITLE
[20.10 backport] Fix reading context and dockerfile from stdin with BuildKit

### DIFF
--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -78,7 +78,7 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 		if options.dockerfileFromStdin() {
 			return errStdinConflict
 		}
-		rc, isArchive, err := build.DetectArchiveReader(os.Stdin)
+		rc, isArchive, err := build.DetectArchiveReader(dockerCli.In())
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 	case isLocalDir(options.context):
 		contextDir = options.context
 		if options.dockerfileFromStdin() {
-			dockerfileReader = os.Stdin
+			dockerfileReader = dockerCli.In()
 		} else if options.dockerfileName != "" {
 			dockerfileName = filepath.Base(options.dockerfileName)
 			dockerfileDir = filepath.Dir(options.dockerfileName)


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2885

fixes https://github.com/docker/cli/issues/2889

**- What I did**

I fixed the issue with reading context/dockerfile from docker client stdin (`os.Stdin != dockerCli.In()`). 
The issue affects users that work with the repository as a library.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![hippo](https://user-images.githubusercontent.com/17360817/102088197-7ea4e000-3e12-11eb-8b7a-cb7de3bb68bd.jpg)