### PR TITLE
Fix mistake with env var example in docker run docs

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -403,10 +403,10 @@ VAR1=value1
 VAR2=value2
 USER
 
-$ docker run --env-file env.list ubuntu env | grep VAR
+$ docker run --env-file env.list ubuntu env | grep -E 'VAR|USER'
 VAR1=value1
 VAR2=value2
-USER=denis
+USER=jonzeolla
 ```
 
 ### Set metadata on container (-l, --label, --label-file)


### PR DESCRIPTION
supersedes / closes https://github.com/docker/cli/pull/3273

**- What I did**
Fixed a typo in the docs that was introduced in d24201d734fd0ed73e62c820e0e1bfe101c40207

**- How I did it**
`vi` 😆 

**- How to verify it**
Run the example command `docker run --env-file env.list ubuntu env | grep -E 'VAR|USER'` and confirm the output is expected.

**- Description for the changelog**
Fix mistake with env var example in docker run docs

**- A picture of a cute animal (not mandatory but encouraged)**
![jonas-von-werne-9sXMFrCYxhw-unsplash](https://user-images.githubusercontent.com/1385510/108770083-e456cc00-7527-11eb-8f4e-f11f47ee6093.jpg)