### PR TITLE
update command to remove stopped containers, for Windows

### DIFF
--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -62,8 +62,13 @@ The main process inside the container referenced under the link `redis` will rec
 $ docker rm $(docker ps -a -q)
 ```
 
-This command deletes all stopped containers. The command
-`docker ps -a -q` above returns all existing container IDs and passes them to
+This command deletes all stopped containers, in Linux or Windows PowerShell. To run this at the Windows command line, pass it via PowerShell, with:
+
+```
+powershell "docker rm $(docker ps -a -q)"
+```
+
+The command `docker ps -a -q` above returns all existing container IDs and passes them to
 the `rm` command which deletes them. Running containers are not deleted.
 
 ### Remove a container and its volumes


### PR DESCRIPTION
The command line that was offered works only in Linux. Only a modest change was needed to explain how it could work on Windows, either in PowerShell or on the command line.