### PR TITLE
docs: Fix wrong bridge driver option

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -175,7 +175,7 @@ equivalent docker daemon flags used for docker0 bridge:
 | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
-| `com.docker.network.container_interface_prefix`  | -           | Set a custom prefix for container interfaces          |
+| `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to `docker daemon`.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a wrong bridge driver option for `docker network create`.

**- How I did it**

Fixed documentation.

**- How to verify it**

With the option in current documentation, the name of the interface in a container remains unchanged (eth0).

```
$ docker network create -d bridge --opt com.docker.network.container_interface_prefix=moby my-bridge
a6de36dff4b47db04bfd0ce72115d6a071401f82be653cfdd2ee4b805ba2c22a

$ docker run -it --network=my-bridge alpine ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
257425: eth0@if257426: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 02:42:c0:a8:30:02 brd ff:ff:ff:ff:ff:ff
```

With `com.docker.network.container_iface_prefix`, it works perfectly.

```
$ docker network create -d bridge --opt com.docker.network.container_iface_prefix=moby my-bridge
ca7448ba52d293a34ca1a1336c54f654c9cd5d5abe17b3d86c0de2f71291440f

$ docker run -it --network=my-bridge alpine ip link show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
257428: moby0@if257429: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 02:42:c0:a8:40:02 brd ff:ff:ff:ff:ff:ff
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
N/A

**- A picture of a cute animal (not mandatory but encouraged)**

This is Pui Pui Molcar, a stop-motion anime featuring Molmots, booming in Japan. ([@molcar_anime](https://twitter.com/molcar_anime/status/1351303376332419074))

![EsDKv6VVkAIPNqO](https://user-images.githubusercontent.com/7751680/109317887-8c55f780-7890-11eb-9f51-883053255b03.jpeg)
