### PR TITLE
ForwardAllSignals: check if channel is closed, and remove warning

### DIFF
--- a/cli/command/container/signals.go
+++ b/cli/command/container/signals.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"context"
-	"fmt"
 	"os"
 	gosignal "os/signal"
 
@@ -15,10 +14,16 @@ import (
 //
 // The channel you pass in must already be setup to receive any signals you want to forward.
 func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string, sigc <-chan os.Signal) {
-	var s os.Signal
+	var (
+		s  os.Signal
+		ok bool
+	)
 	for {
 		select {
-		case s = <-sigc:
+		case s, ok = <-sigc:
+			if !ok {
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -40,7 +45,6 @@ func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string, sigc <-
 			}
 		}
 		if sig == "" {
-			fmt.Fprintf(cli.Err(), "Unsupported signal: %v. Discarding.\n", s)
 			continue
 		}
 


### PR DESCRIPTION
Commit fff164c22e8dc904291fecb62307312fd4ca153e (https://github.com/docker/cli/pull/2929) modified `ForwardAllSignals` to take `SIGURG` signals into account, which can be generated by the Go runtime on Go 1.14 and up as an interrupt to support pre-emptable system calls on Linux.

With the updated code, the signal (`s`) would sometimes be `nil` (when the channel was closed), causing spurious (but otherwise harmless) warnings to be printed;

    Unsupported signal: <nil>. Discarding.

To debug this issue, I patched v20.10.4 to handle `nil`, and added a debug line to print the signal in all cases;

```patch
diff --git a/cli/command/container/signals.go b/cli/command/container/signals.go
index 06e4d9eb6..0cb53ef06 100644
--- a/cli/command/container/signals.go
+++ b/cli/command/container/signals.go
@@ -22,8 +22,9 @@ func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string, sigc <-
                case <-ctx.Done():
                        return
                }
+               fmt.Fprintf(cli.Err(), "Signal: %v\n", s)

                if s == signal.SIGCHLD || s == signal.SIGPIPE {
```

When running a cross-compiled macOS binary with Go 1.13 (`make -f docker.Makefile binary-osx`):

    # regular "docker run" (note that the `<nil>` signal only happens "sometimes"):
    ./build/docker run --rm alpine/git clone https://github.com/docker/getting-started.git
    Cloning into 'getting-started'...
    Signal: <nil>

    # when cancelling with CTRL-C:
    ./build/docker run --rm alpine/git clone https://github.com/docker/getting-started.git
    ^CSignal: interrupt
    Cloning into 'getting-started'...
    error: could not lock config file /git/getting-started/.git/config: No such file or directory
    fatal: could not set 'core.repositoryformatversion' to '0'
    Signal: <nil>
    Signal: <nil>

When running a macOS binary built with Go 1.15 (`DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary`):

    # regular "docker run" (note that the `<nil>` signal only happens "sometimes"):
    # this is the same as on Go 1.13
    ./build/docker run --rm alpine/git clone https://github.com/docker/getting-started.git
    Cloning into 'getting-started'...
    Signal: <nil>

    # when cancelling with CTRL-C:
    ./build/docker run --rm alpine/git clone https://github.com/docker/getting-started.git
    Cloning into 'getting-started'...
    ^CSignal: interrupt
    Signal: urgent I/O condition
    Signal: urgent I/O condition
    fatal: --stdin requires a git repository
    fatal: index-pack failed
    Signal: <nil>
    Signal: <nil>

This patch checks if the channel is closed, and removes the warning (to prevent warnings if new
signals are added that are not in our known list of signals)

~As a follow-up, we should consider removing the "validation" step altogether, as it looks like the code performs client-side validation based on signals known by the client platform, which may not match the server platform~

~For example, there are various signals not defined on darwin (macOS); https://github.com/moby/moby/blob/v20.10.4/pkg/signal/signal_darwin.go#L7-L41 That are supported on Linux: https://github.com/moby/moby/blob/v20.10.4/pkg/signal/signal_linux.go#L17-L83~

~Given that for this particular use, translation from signal names to numbers is handled daemon-side, so no validation should be needed.~

We should also consider updating `notfiyAllSignals()`, which currently forwards _all_ signals (`signal.Notify(sigc)` without passing a list of signals), and instead pass it "all signals _minus_ the signals we don't want forwarded":
https://github.com/docker/cli/blob/35f023a7c22a51867fb099d29006ef27379bc7fe/cli/command/container/signals.go#L55

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix spurious `Unsupported signal: <nil>. Discarding.` messages when running containers.
```

**- A picture of a cute animal (not mandatory but encouraged)**

