### PR TITLE
Attach: do not disable sig-proxy when using a TTY

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -96,7 +96,7 @@ func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 		in = dockerCli.In()
 	}
 
-	if opts.proxy && !c.Config.Tty {
+	if opts.proxy {
 		sigc := notfiyAllSignals()
 		go ForwardAllSignals(ctx, dockerCli, opts.container, sigc)
 		defer signal.StopCatch(sigc)

--- a/cli/command/container/signals.go
+++ b/cli/command/container/signals.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"context"
-	"fmt"
 	"os"
 	gosignal "os/signal"
 
@@ -15,10 +14,16 @@ import (
 //
 // The channel you pass in must already be setup to receive any signals you want to forward.
 func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string, sigc <-chan os.Signal) {
-	var s os.Signal
+	var (
+		s  os.Signal
+		ok bool
+	)
 	for {
 		select {
-		case s = <-sigc:
+		case s, ok = <-sigc:
+			if !ok {
+				return
+			}
 		case <-ctx.Done():
 			return
 		}
@@ -40,7 +45,6 @@ func ForwardAllSignals(ctx context.Context, cli command.Cli, cid string, sigc <-
 			}
 		}
 		if sig == "" {
-			fmt.Fprintf(cli.Err(), "Unsupported signal: %v. Discarding.\n", s)
 			continue
 		}
 


### PR DESCRIPTION
Trying to fix the regression introduced in https://github.com/docker/cli/pull/2929
This appears to fix https://github.com/moby/moby/issues/42093

Similar to https://github.com/docker/cli/pull/1841