### PR TITLE
Fix `docker start` blocking on signal handling

### DIFF
--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -75,7 +75,7 @@ func runStart(dockerCli command.Cli, opts *startOptions) error {
 		// We always use c.ID instead of container to maintain consistency during `docker start`
 		if !c.Config.Tty {
 			sigc := notfiyAllSignals()
-			ForwardAllSignals(ctx, dockerCli, c.ID, sigc)
+			go ForwardAllSignals(ctx, dockerCli, c.ID, sigc)
 			defer signal.StopCatch(sigc)
 		}
 


### PR DESCRIPTION
We refactorted `ForwardAllSignals` so it blocks but did not update the
call in `start` to call it in a goroutine.

Closes (maybe) #2987