### PR TITLE
[completion/zsh] add volume completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -661,7 +661,7 @@ __docker_container_subcommand() {
         "($help)*--ulimit=[ulimit options]:ulimit: "
         "($help)--userns=[Container user namespace]:user namespace:(host)"
         "($help)--tmpfs[mount tmpfs]"
-        "($help)*-v[Bind mount a volume]:volume: "
+        "($help)*-v[Bind mount a volume]:volume:_directories -W / -P '/' -S '\:' -r '/ '"
         "($help)--volume-driver=[Optional volume driver for the container]:volume driver:(local)"
         "($help)*--volumes-from=[Mount volumes from the specified container]:volume: "
         "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories"


### PR DESCRIPTION
This provides completion for `docker run ... -v <TAB>`.
This closes part of #1997.

 - the completion of `docker run -it` is discussed in the issue and does not require a fix (maybe a different default, but that's out of scope here)
 - the completion of `docker run ... -v ` is addressed in this PR

As outlined [here](contrib/completion/zsh/_docker) there are multiple options passed to `_directories`. The behaviour is that:

 - `docker run -v <TAB>` inserts a `/` immediately and will suggest directories relative to `/`. On my system that means `docker run -v <TAB>` turns into `docker run -v /` and the completion list contains elements such as `usr`,`home`
 - a `:` is inserted at the end of every suggestion. depending how the user configured their completion this means they can cycle through insertions of `docker run -v /usr:` `docker run -v /home:`and so on (for me the colon is bold face).
 - the `:` does not need to be removed by the user if they want to go one level higher. hitting space or `/` will remove the `:`. I.e. hitting `/` after the completion inserted `docker run -v /usr:` turns the command line into `docker run -v /usr/`. Continued hitting of TAB continues the game and suggests `docker run -v /usr/bin:`, again with a self-removing `:`
 - the `:` persists if the user types `:`
 - after `:` in the same word there is no more completion suggestions, the user needs to type the volume mount on their own.
 - after a ` ` (such as `docker run -v /home ` or `docker run -v /home:/hosthome `) the completion continues to complete arguments to docker run just like it did before this PR.
 
Verification was trying around on the command line with `docker run -it --rm -v <stuff here> debian:testing`. I think the suggestions should be absolute paths (the original draft suggested relative paths to the cwd, but docker didn't mount them).

One can probably argue if the treatment of the trailing `:` is optimal (self removal on space and slash. i caught myself a few times that after having `docker run -it --rm -v /home:` i tried to continue with `/hosthome` and wanting to type`-v /home:/hosthome` but typed `/home/hosthome` as the `/` overwrote the visual `:`).

not an animal, but a cake:
![cake](https://user-images.githubusercontent.com/5124749/110035892-85216480-7d3c-11eb-8df4-989b23d0881f.jpg)
