### PR TITLE
docs: improve example for "remove all stopped containers"

### DIFF
--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -58,13 +58,33 @@ The main process inside the container referenced under the link `redis` will rec
 
 ### Remove all stopped containers
 
-```bash
-$ docker rm $(docker ps -a -q)
+Use the [`docker container prune`](container_prune.md) command to remove all
+stopped containers, or refer to the [`docker system prune`](system_prune.md)
+command to remove unused containers in addition to other Docker resources, such
+as (unused) images and networks.
+
+Alternatively, you can use the `docker ps` with the `-q` / `--quiet` option to
+generate a list of container IDs to remove, and use that list as argument for
+the `docker rm` command. 
+
+Combining commands can be more flexible, but is less portable as it depends
+on features provided by the shell, and the exact syntax may differ depending on
+what shell is used. To use this approach on Windows, consider using PowerShell
+or Bash.
+
+The example below uses `docker ps -q` to print the IDs of all containers that
+have exited (`--filter status=exited`), and removes those containers with
+the `docker rm` command:
+
+```console
+$ docker rm $(docker ps --filter status=exited -q)
 ```
 
-This command deletes all stopped containers. The command
-`docker ps -a -q` above returns all existing container IDs and passes them to
-the `rm` command which deletes them. Running containers are not deleted.
+Or, using the `xargs` Linux utility;
+
+```console
+$ docker ps --filter status=exited -q | xargs docker rm
+```
 
 ### Remove a container and its volumes
 


### PR DESCRIPTION
recommend using `docker container prune`, but show an example on how to combine commands with a bit more context and warnings about portability/compatibility.

Thanks to Charlie Arehart to do the initial work on this.


replaces https://github.com/docker/cli/pull/2983
closes https://github.com/docker/cli/pull/2983

relates to https://stackoverflow.com/questions/66544341/delete-all-the-stopped-containers-on-windows
