### PR TITLE
[20.10 backport] docs: improve example for "remove all stopped containers"

### DIFF
--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -58,13 +58,33 @@ The main process inside the container referenced under the link `redis` will rec
 
 ### Remove all stopped containers
 
-```bash
-$ docker rm $(docker ps -a -q)
+Use the [`docker container prune`](container_prune.md) command to remove all
+stopped containers, or refer to the [`docker system prune`](system_prune.md)
+command to remove unused containers in addition to other Docker resources, such
+as (unused) images and networks.
+
+Alternatively, you can use the `docker ps` with the `-q` / `--quiet` option to
+generate a list of container IDs to remove, and use that list as argument for
+the `docker rm` command. 
+
+Combining commands can be more flexible, but is less portable as it depends
+on features provided by the shell, and the exact syntax may differ depending on
+what shell is used. To use this approach on Windows, consider using PowerShell
+or Bash.
+
+The example below uses `docker ps -q` to print the IDs of all containers that
+have exited (`--filter status=exited`), and removes those containers with
+the `docker rm` command:
+
+```console
+$ docker rm $(docker ps --filter status=exited -q)
 ```
 
-This command deletes all stopped containers. The command
-`docker ps -a -q` above returns all existing container IDs and passes them to
-the `rm` command which deletes them. Running containers are not deleted.
+Or, using the `xargs` Linux utility;
+
+```console
+$ docker ps --filter status=exited -q | xargs docker rm
+```
 
 ### Remove a container and its volumes
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3001

recommend using `docker container prune`, but show an example on
how to combine commands with a bit more context and warnings
about portability/compatibility.

Thanks to Charlie Arehart to do the initial work on this.

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit d051df9943d79f59ba190d209b35ee038537aedb)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

