### PR TITLE
docs: remove trailing spaces to prevent yamldocs using "compact" notation

### DIFF
--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -65,7 +65,7 @@ as (unused) images and networks.
 
 Alternatively, you can use the `docker ps` with the `-q` / `--quiet` option to
 generate a list of container IDs to remove, and use that list as argument for
-the `docker rm` command. 
+the `docker rm` command.
 
 Combining commands can be more flexible, but is less portable as it depends
 on features provided by the shell, and the exact syntax may differ depending on

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -43,7 +43,7 @@ ID            NAME      MODE            REPLICAS             IMAGE
 c8wgl7q4ndfd  frontend  replicated      5/5                  nginx:alpine
 dmu1ept4cxcf  redis     replicated      3/3                  redis:3.0.6
 iwe3278osahj  mongo     global          7/7                  mongo:3.3
-hh08h9uu8uwr  job       replicated-job  1/1 (3/5 completed)  nginx:latest        
+hh08h9uu8uwr  job       replicated-job  1/1 (3/5 completed)  nginx:latest
 ```
 
 The `REPLICAS` column shows both the *actual* and *desired* number of tasks for


### PR DESCRIPTION
see the output format in https://github.com/docker/docker.github.io/commit/3ed725064445f19e836620432ba7522865002da5#diff-8d3cb70b451e3ca1da126da3460e34abc1c45211fc24b83832bb58ccb29674e9R44-R57
