### PR TITLE
yamldocs: various improvements

### DIFF
--- a/docs/yaml/generate.go
+++ b/docs/yaml/generate.go
@@ -17,7 +17,7 @@ import (
 const descriptionSourcePath = "docs/reference/commandline/"
 
 func generateCliYaml(opts *options) error {
-	dockerCli, err := command.NewDockerCli()
+	dockerCLI, err := command.NewDockerCli()
 	if err != nil {
 		return err
 	}
@@ -25,11 +25,15 @@ func generateCliYaml(opts *options) error {
 		Use:   "docker [OPTIONS] COMMAND [ARG...]",
 		Short: "The base command for the Docker CLI.",
 	}
-	commands.AddCommands(cmd, dockerCli)
+	commands.AddCommands(cmd, dockerCLI)
 	disableFlagsInUseLine(cmd)
 	source := filepath.Join(opts.source, descriptionSourcePath)
 	fmt.Println("Markdown source:", source)
 	if err := loadLongDescription(cmd, source); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(opts.target, 0755); err != nil {
 		return err
 	}
 
@@ -80,9 +84,7 @@ func loadLongDescription(parentCmd *cobra.Command, path string) error {
 		if err != nil {
 			return err
 		}
-		description, examples := parseMDContent(string(content))
-		cmd.Long = description
-		cmd.Example = examples
+		applyDescriptionAndExamples(cmd, string(content))
 	}
 	return nil
 }

--- a/docs/yaml/markdown.go
+++ b/docs/yaml/markdown.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	// mdHeading matches MarkDown H1..h6 headings. Note that this regex may produce
+	// false positives for (e.g.) comments in code-blocks (# this is a comment),
+	// so should not be used as a generic regex for other purposes.
+	mdHeading = regexp.MustCompile(`^([#]{1,6})\s(.*)$`)
+	// htmlAnchor matches inline HTML anchors. This is intended to only match anchors
+	// for our use-case; DO NOT consider using this as a generic regex, or at least
+	// not before reading https://stackoverflow.com/a/1732454/1811501.
+	htmlAnchor = regexp.MustCompile(`<a\s+(?:name|id)="?([^"]+)"?\s*></a>\s*`)
+)
+
+// getSections returns all H2 sections by title (lowercase)
+func getSections(mdString string) map[string]string {
+	parsedContent := strings.Split("\n"+mdString, "\n## ")
+	sections := make(map[string]string, len(parsedContent))
+	for _, s := range parsedContent {
+		if strings.HasPrefix(s, "#") {
+			// not a H2 Section
+			continue
+		}
+		parts := strings.SplitN(s, "\n", 2)
+		if len(parts) == 2 {
+			sections[strings.ToLower(parts[0])] = parts[1]
+		}
+	}
+	return sections
+}
+
+// cleanupMarkDown cleans up the MarkDown passed in mdString for inclusion in
+// YAML. It removes trailing whitespace and substitutes tabs for four spaces
+// to prevent YAML switching to use "compact" form; ("line1  \nline\t2\n")
+// which, although equivalent, is hard to read.
+func cleanupMarkDown(mdString string) (md string, anchors []string) {
+	// remove leading/trailing whitespace, and replace tabs in the whole content
+	mdString = strings.TrimSpace(mdString)
+	mdString = strings.ReplaceAll(mdString, "\t", "    ")
+	mdString = strings.ReplaceAll(mdString, "https://docs.docker.com", "")
+
+	var id string
+	// replace trailing whitespace per line, and handle custom anchors
+	lines := strings.Split(mdString, "\n")
+	for i := 0; i < len(lines); i++ {
+		lines[i] = strings.TrimRightFunc(lines[i], unicode.IsSpace)
+		lines[i], id = convertHTMLAnchor(lines[i])
+		if id != "" {
+			anchors = append(anchors, id)
+		}
+	}
+	return strings.Join(lines, "\n"), anchors
+}
+
+// convertHTMLAnchor converts inline anchor-tags in headings (<a name=myanchor></a>)
+// to an extended-markdown property ({#myanchor}). Extended Markdown properties
+// are not supported in GitHub Flavored Markdown, but are supported by Jekyll,
+// and lead to cleaner HTML in our docs, and prevents duplicate anchors.
+// It returns the converted MarkDown heading and the custom ID (if present)
+func convertHTMLAnchor(mdLine string) (md string, customID string) {
+	if m := mdHeading.FindStringSubmatch(mdLine); len(m) > 0 {
+		if a := htmlAnchor.FindStringSubmatch(m[2]); len(a) > 0 {
+			customID = a[1]
+			mdLine = m[1] + " " + htmlAnchor.ReplaceAllString(m[2], "") + " {#" + customID + "}"
+		}
+	}
+	return mdLine, customID
+}

--- a/docs/yaml/markdown_test.go
+++ b/docs/yaml/markdown_test.go
@@ -1,0 +1,132 @@
+package main
+
+import "testing"
+
+func TestCleanupMarkDown(t *testing.T) {
+	tests := []struct {
+		doc, in, expected string
+	}{
+		{
+			doc: "whitespace around sections",
+			in: `
+
+	## Section start
+
+Some lines.
+And more lines.
+
+`,
+			expected: `## Section start
+
+Some lines.
+And more lines.`,
+		},
+		{
+			doc: "lines with inline tabs",
+			in: `## Some	Heading
+
+A line with tabs		in it.
+Tabs	should be replaced by spaces`,
+			expected: `## Some    Heading
+
+A line with tabs        in it.
+Tabs    should be replaced by spaces`,
+		},
+		{
+			doc: "lines with trailing spaces",
+			in: `## Some Heading with spaces                  
+       
+This is a line.              
+    This is an indented line        
+
+### Some other heading         
+
+Last line.`,
+			expected: `## Some Heading with spaces
+
+This is a line.
+    This is an indented line
+
+### Some other heading
+
+Last line.`,
+		},
+		{
+			doc: "lines with trailing tabs",
+			in: `## Some Heading with tabs				
+		
+This is a line.		
+	This is an indented line		
+
+### Some other heading 	
+
+Last line.`,
+			expected: `## Some Heading with tabs
+
+This is a line.
+    This is an indented line
+
+### Some other heading
+
+Last line.`,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			out, _ := cleanupMarkDown(tc.in)
+			if out != tc.expected {
+				t.Fatalf("\nexpected:\n%q\nactual:\n%q\n", tc.expected, out)
+			}
+		})
+	}
+}
+
+func TestConvertHTMLAnchor(t *testing.T) {
+	tests := []struct {
+		in, id, expected string
+	}{
+		{
+			in:       `# <a name=heading1></a> Heading 1`,
+			id:       "heading1",
+			expected: `# Heading 1 {#heading1}`,
+		},
+		{
+			in:       `## Heading 2<a name=heading2></a> `,
+			id:       "heading2",
+			expected: `## Heading 2 {#heading2}`,
+		},
+		{
+			in:       `### <a id=heading3></a>Heading 3`,
+			id:       "heading3",
+			expected: `### Heading 3 {#heading3}`,
+		},
+		{
+			in:       `#### <a id="heading4"></a> Heading 4`,
+			id:       "heading4",
+			expected: `#### Heading 4 {#heading4}`,
+		},
+		{
+			in:       `##### <a   id="heading5"  ></a>  Heading 5`,
+			id:       "heading5",
+			expected: `##### Heading 5 {#heading5}`,
+		},
+		{
+			in:       `###### <a id=hello href=foo>hello!</a>Heading 6`,
+			id:       "",
+			expected: `###### <a id=hello href=foo>hello!</a>Heading 6`,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			out, id := convertHTMLAnchor(tc.in)
+			if id != tc.id {
+				t.Fatalf("expected: %s, actual:   %s\n", tc.id, id)
+			}
+			if out != tc.expected {
+				t.Fatalf("\nexpected: %s\nactual:   %s\n", tc.expected, out)
+			}
+		})
+	}
+}

--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -73,9 +73,23 @@ func GenYamlTreeCustom(cmd *cobra.Command, dir string, filePrepender func(string
 			return err
 		}
 	}
-	if !cmd.HasParent() {
-		return nil
-	}
+
+	// TODO: conditionally skip the root command (for plugins)
+	//
+	// The "root" command used in the generator is just a "stub", and only has a
+	// list of subcommands, but not (e.g.) global options/flags. We should fix
+	// that, so that the YAML file for the docker "root" command contains the
+	// global flags.
+	//
+	// If we're using this code to generate YAML docs for a plugin, the root-
+	// command is even less useful; in that case, the root command represents
+	// the "docker" command, and is a "dummy" with no flags, and only a single
+	// subcommand (the plugin's top command). For plugins, we should skip the
+	// root command altogether, to prevent generating a useless YAML file.
+	// if !cmd.HasParent() {
+	// 	return nil
+	// }
+
 	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".yaml"
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -4,5 +4,5 @@ set -eu -o pipefail
 
 mkdir -p docs/yaml/gen
 
-go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
+GO111MODULE=off go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
 build/yaml-docs-generator --root "$(pwd)" --target "$(pwd)/docs/yaml/gen"


### PR DESCRIPTION
Changes I made when working on https://github.com/docker/buildx/pull/91. Still lots of things to clean up, but thought it didn't hurt to at least take some of them

- make sure the target directory is created if missing
- add support for custom ID's in headings through `<a>` tags (e.g.
  `<a name=heading2></a>`). This allows use of custom anchors that
  work both on GitHub (GFM doesn't support extended MarkDown), and
  in Jekyll (which does).
- add code to cleanup markdown for use in our docs:
    - remove absolute URLs to https://docs.docker.com
    - remove tabs in MarkDown, and convert them to 4 spaces. This
      prevents the YAML conversion from switching between "short"
      and "long" syntax. Tabs in code examples also don't always
      work well, so using spaces doesn't hurt for that.
- refactor some code for readability, and to be less "hacky" (still
  lots to be improved though)