### PR TITLE
vendor: github.com/theupdateframework/notary v0.7.0-21-gbf96a202

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -67,7 +67,7 @@ github.com/shurcooL/sanitized_anchor_name           7bfe4c7ecddb3666a94b053b422c
 github.com/sirupsen/logrus                          6699a89a232f3db797f2e280639854bbc4b89725 # v1.7.0
 github.com/spf13/cobra                              86f8bfd7fef868a174e1b606783bd7f5c82ddf8f # v1.1.1
 github.com/spf13/pflag                              2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab # v1.0.5
-github.com/theupdateframework/notary                5f1f4a34f4cfa3066e44f652e895f4b24b96248e
+github.com/theupdateframework/notary                bf96a202a09a312ae005cd312fc06ff4d2c166ce # v0.7.0-21-gbf96a202
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/go-rosetta                    f79598599c5d34ea253b56a1d7c89bc6a96de7db
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2

--- a/vendor/github.com/theupdateframework/notary/go.mod
+++ b/vendor/github.com/theupdateframework/notary/go.mod
@@ -5,12 +5,12 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Shopify/logrus-bugsnag v0.0.0-20170309145241-6dbc35f2c30d
-	github.com/beorn7/perks v0.0.0-20150223135152-b965b613227f // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bitly/go-simplejson v0.5.0 // indirect
-	github.com/bugsnag/bugsnag-go v1.0.5-0.20150529004307-13fd6b8acda0
+	github.com/bugsnag/bugsnag-go v1.0.5
 	github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b // indirect
 	github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 // indirect
-	github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004
+	github.com/cloudflare/cfssl v0.0.0-20180223231731-4e2dcbde5004 // 1.3.1
 	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73 // indirect
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c
@@ -29,21 +29,20 @@ require (
 	github.com/jinzhu/inflection v0.0.0-20170102125226-1c35d901db3d // indirect
 	github.com/jinzhu/now v1.1.1 // indirect
 	github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/lib/pq v1.9.0
 	github.com/magiconair/properties v1.5.3 // indirect
 	github.com/mattn/go-sqlite3 v1.6.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/miekg/pkcs11 v1.0.2
-	github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366 // indirect
-	github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420 // indirect
+	github.com/miekg/pkcs11 v1.0.3
+	github.com/mitchellh/mapstructure v1.0.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06
 	github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5 // indirect
 	github.com/prometheus/common v0.0.0-20180110214958-89604d197083 // indirect
 	github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7 // indirect
-	github.com/sirupsen/logrus v1.4.1
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94 // indirect
 	github.com/spf13/cobra v0.0.1
 	github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 // indirect


### PR DESCRIPTION
no change in local code, but updates some dependencies to more recent
versions, which may help users that consume docker/cli to get a better
selection (when using go modules).

full diff: https://github.com/theupdateframework/notary/compare/5f1f4a34f4cfa3066e44f652e895f4b24b96248e...bf96a202a09a312ae005cd312fc06ff4d2c166ce


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

