### PR TITLE
Update stop.md to mention that other stop signals can be set

### DIFF
--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -19,7 +19,9 @@ Options:
 ## Description
 
 The main process inside the container will receive `SIGTERM`, and after a grace
-period, `SIGKILL`.
+period, `SIGKILL`. The first signal can be changed with the `STOPSIGNAL`
+instruction in the container's Dockerfile, or the `--stop-signal` option to
+`docker run`.
 
 ## Examples
 


### PR DESCRIPTION
**- What I did**

Updates the stop.md doc to mention that the stop signal can be changed, either with the Dockerfile or via `docker run --stop-signal`. This is a real gotcha if you're not familiar with this feature and build a container that extends a container that uses `STOPSIGNAL`.

**- How I did it**

Added an explanatory sentence.

**- How to verify it**

Read it, I guess?

**- Description for the changelog**

Updates `docker stop` documentation to mention stop signals other than SIGTERM can be set

**- A picture of a cute animal (not mandatory but encouraged)**

Here is a very cute bear I spotted in my neighborhood:

![Screen Shot 2016-11-01 at 9 52 03 AM](https://user-images.githubusercontent.com/1779442/113492616-9c23b580-94a6-11eb-947a-7806df449db8.png)
