### PR TITLE
Fixes to windows scripts

### DIFF
--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -63,11 +63,10 @@ if [ "$(go env GOOS)" = "windows" ]; then
     [ -n "$VERSION_QUAD" ] && set -- "$@" -D "DOCKER_VERSION_QUAD=$VERSION_QUAD"
     [ -n "$GITCOMMIT" ]    && set -- "$@" -D "DOCKER_COMMIT=\"$GITCOMMIT\""
 
-    windres=$($(go env CC) --print-prog-name=windres)
-
     target="$(dirname "$0")/../../cli/winresources/rsrc_$(go env GOARCH).syso"
     mkdir -p "$(dirname "${target}")"
-    "$windres" -i "$(dirname "$0")/../winresources/docker.rc" -o "$target" "$@"
+    : ${WINDRES:="$($(go env CC) --print-prog-name=windres)"}
+    "$WINDRES" -i "$(dirname "$0")/../winresources/docker.rc" -o "$target" --use-temp-file "$@"
     echo "package winresources" > "$(dirname "${target}")/stub_windows.go"
 fi
 

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -55,19 +55,23 @@ if [ -n "$GO_STRIP" ]; then
 fi
 
 if [ "$(go env GOOS)" = "windows" ]; then
-    # Generate a Windows file version of the form major,minor,patch,build
-    VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . , | sed -re 's/,$//' | sed -re 's/^[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+,[0-9]+$/\0,0/')
+    : "${WINDRES=$($(go env CC) --print-prog-name=windres)}"
+    if [ -z "$WINDRES" ]; then
+        >&2 echo "Empty WINDRES detected, skipping manifesting binary"
+    else
+        # Generate a Windows file version of the form major,minor,patch,build
+        VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . , | sed -re 's/,$//' | sed -re 's/^[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+,[0-9]+$/\0,0/')
 
-    set --
-    [ -n "$VERSION" ]      && set -- "$@" -D "DOCKER_VERSION=\"$VERSION\""
-    [ -n "$VERSION_QUAD" ] && set -- "$@" -D "DOCKER_VERSION_QUAD=$VERSION_QUAD"
-    [ -n "$GITCOMMIT" ]    && set -- "$@" -D "DOCKER_COMMIT=\"$GITCOMMIT\""
+        set --
+        [ -n "$VERSION" ]      && set -- "$@" -D "DOCKER_VERSION=\"$VERSION\""
+        [ -n "$VERSION_QUAD" ] && set -- "$@" -D "DOCKER_VERSION_QUAD=$VERSION_QUAD"
+        [ -n "$GITCOMMIT" ]    && set -- "$@" -D "DOCKER_COMMIT=\"$GITCOMMIT\""
 
-    target="$(dirname "$0")/../../cli/winresources/rsrc_$(go env GOARCH).syso"
-    mkdir -p "$(dirname "${target}")"
-    : ${WINDRES:="$($(go env CC) --print-prog-name=windres)"}
-    "$WINDRES" -i "$(dirname "$0")/../winresources/docker.rc" -o "$target" --use-temp-file "$@"
-    echo "package winresources" > "$(dirname "${target}")/stub_windows.go"
+        target="$(dirname "$0")/../../cli/winresources/rsrc_$(go env GOARCH).syso"
+        mkdir -p "$(dirname "${target}")"
+        "$WINDRES" -i "$(dirname "$0")/../winresources/docker.rc" -o "$target" --use-temp-file "$@"
+        echo "package winresources" > "$(dirname "${target}")/stub_windows.go"
+    fi
 fi
 
 echo "Building $GO_LINKMODE $(basename "${TARGET}")"

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -56,7 +56,7 @@ fi
 
 if [ "$(go env GOOS)" = "windows" ]; then
     # Generate a Windows file version of the form major,minor,patch,build
-    VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . , | sed -re 's/^[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+,[0-9]+$/\0,0/')
+    VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | tr . , | sed -re 's/,$//' | sed -re 's/^[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+$/\0,0/' | sed -re 's/^[0-9]+,[0-9]+,[0-9]+$/\0,0/')
 
     set --
     [ -n "$VERSION" ]      && set -- "$@" -D "DOCKER_VERSION=\"$VERSION\""


### PR DESCRIPTION
- scripts: fix VERSION_QUAD corner case in windows resource

> When the git checkout is dirty on top of a git tag (i.e., v20.10.6.m),
the VERSION_QUAD was keeping a trailing comma.
> Now the trailing comma is stripped.


- scripts: use WINDRES env var if set

> This allows setting WINDRES to mingw's windres.
>
> For the record, mingw's windres needs --use-temp-file for a weird reason:
in that case, it keeps preprocessor arguments intact (including quotes),
without it, mingw's windres calls popen, which happens to pass the entire
command to sh -c, stripping quotes after evaluation and causing a syntax
error in mingw's windres.
>
> To use mingw's windres, set WINDRES to:
> - `x86_64-w64-mingw32-windres` on 64 bit
> - `i686-w64-mingw32-windres` on 32 bit

- scripts: Allow skipping windres when WINDRES= (empty string)