### PR TITLE
docs: document log-opts for "dual logging" cache

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1400,6 +1400,10 @@ This is a full example of the allowed configuration options on Linux:
   "log-driver": "json-file",
   "log-level": "",
   "log-opts": {
+    "cache-disabled": "false",
+    "cache-max-file": "5",
+    "cache-max-size": "20m",
+    "cache-compress": "true",
     "env": "os,customer",
     "labels": "somelabel",
     "max-file": "5",


### PR DESCRIPTION
These options are available in Docker 20.10 and up, but were
previously only available in Docker EE, and not documented.

relates to https://github.com/moby/moby/pull/40543#issuecomment-800961738
relates to https://github.com/docker/docker.github.io/pull/12696


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

