### PR TITLE
Fix typo for configuring dockerd Containerd plugins namespace.

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -119,7 +119,7 @@ To run the daemon with debug output, use `dockerd -D` or add `"debug": true` to
 the `daemon.json` file.
 
 > **Enabling experimental features**
-> 
+>
 > Enable experimental features by starting `dockerd` with the `--experimental`
 > flag or adding `"experimental": true` to the `daemon.json` file.
 
@@ -1349,7 +1349,7 @@ This is a full example of the allowed configuration options on Linux:
   "cluster-store-opts": {},
   "containerd": "/run/containerd/containerd.sock",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-address-pools": [
@@ -1472,7 +1472,7 @@ This is a full example of the allowed configuration options on Windows:
   "cluster-store": "",
   "containerd": "\\\\.\\pipe\\containerd-containerd",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-ulimits": {},


### PR DESCRIPTION

**- What I did**

When I ried to configure the containerd namespace for plugins via JSON, I found an error that was caused by an incorrect spelling

**- How I did it**

Updated the JSON

**- How to verify it**

I ran the daemon using the new configuration suggested in this PR and then it worked.

**- Description for the changelog**

Fix typo for configuring dockerd Containerd plugins namespace.

