### PR TITLE
Various test cleanups

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -81,8 +81,8 @@ func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 }
 
 func TestNewAPIClientFromFlagsWithHttpProxyEnv(t *testing.T) {
-	defer env.Patch(t, "HTTP_PROXY", "http://proxy.acme.com:1234")()
-	defer env.Patch(t, "DOCKER_HOST", "tcp://docker.acme.com:2376")()
+	defer env.Patch(t, "HTTP_PROXY", "http://proxy.acme.example.com:1234")()
+	defer env.Patch(t, "DOCKER_HOST", "tcp://docker.acme.example.com:2376")()
 
 	opts := &flags.CommonOptions{}
 	configFile := &configfile.ConfigFile{}
@@ -91,11 +91,11 @@ func TestNewAPIClientFromFlagsWithHttpProxyEnv(t *testing.T) {
 	transport, ok := apiclient.HTTPClient().Transport.(*http.Transport)
 	assert.Assert(t, ok)
 	assert.Assert(t, transport.Proxy != nil)
-	request, err := http.NewRequest(http.MethodGet, "tcp://docker.acme.com:2376", nil)
+	request, err := http.NewRequest(http.MethodGet, "tcp://docker.acme.example.com:2376", nil)
 	assert.NilError(t, err)
 	url, err := transport.Proxy(request)
 	assert.NilError(t, err)
-	assert.Check(t, is.Equal("http://proxy.acme.com:1234", url.String()))
+	assert.Check(t, is.Equal("http://proxy.acme.example.com:1234", url.String()))
 }
 
 type fakeClient struct {

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -133,7 +133,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 				return ioutil.NopCloser(strings.NewReader("")), nil
 			},
 			infoFunc: func() (types.Info, error) {
-				return types.Info{IndexServerAddress: "http://indexserver"}, nil
+				return types.Info{IndexServerAddress: "https://indexserver.example.com"}, nil
 			},
 		}
 		cli := test.NewFakeCli(client)

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -169,7 +169,7 @@ func validateTestKubeEndpoint(t *testing.T, s store.Reader, name string) {
 	kubeMeta := ctxMetadata.Endpoints[kubernetes.KubernetesEndpoint].(kubernetes.EndpointMeta)
 	kubeEP, err := kubeMeta.WithTLSData(s, name)
 	assert.NilError(t, err)
-	assert.Equal(t, "https://someserver", kubeEP.Host)
+	assert.Equal(t, "https://someserver.example.com", kubeEP.Host)
 	assert.Equal(t, "the-ca", string(kubeEP.TLSData.CA))
 	assert.Equal(t, "the-cert", string(kubeEP.TLSData.Cert))
 	assert.Equal(t, "the-key", string(kubeEP.TLSData.Key))
@@ -287,7 +287,7 @@ func TestCreateFromContext(t *testing.T) {
 			assert.Equal(t, newContextTyped.Description, c.expectedDescription)
 			assert.Equal(t, newContextTyped.StackOrchestrator, c.expectedOrchestrator)
 			assert.Equal(t, dockerEndpoint.Host, "tcp://42.42.42.42:2375")
-			assert.Equal(t, kubeEndpoint.Host, "https://someserver")
+			assert.Equal(t, kubeEndpoint.Host, "https://someserver.example.com")
 		})
 	}
 }
@@ -361,7 +361,7 @@ func TestCreateFromCurrent(t *testing.T) {
 			assert.Equal(t, newContextTyped.Description, c.expectedDescription)
 			assert.Equal(t, newContextTyped.StackOrchestrator, c.expectedOrchestrator)
 			assert.Equal(t, dockerEndpoint.Host, "tcp://42.42.42.42:2375")
-			assert.Equal(t, kubeEndpoint.Host, "https://someserver")
+			assert.Equal(t, kubeEndpoint.Host, "https://someserver.example.com")
 		})
 	}
 }

--- a/cli/command/context/list_test.go
+++ b/cli/command/context/list_test.go
@@ -18,7 +18,7 @@ func createTestContextWithKubeAndSwarm(t *testing.T, cli command.Cli, name strin
 		DefaultStackOrchestrator: orchestrator,
 		Description:              "description of " + name,
 		Kubernetes:               map[string]string{keyFrom: "default"},
-		Docker:                   map[string]string{keyHost: "https://someswarmserver"},
+		Docker:                   map[string]string{keyHost: "https://someswarmserver.example.com"},
 	})
 	assert.NilError(t, err)
 }

--- a/cli/command/context/testdata/inspect.golden
+++ b/cli/command/context/testdata/inspect.golden
@@ -7,11 +7,11 @@
         },
         "Endpoints": {
             "docker": {
-                "Host": "https://someswarmserver",
+                "Host": "https://someswarmserver.example.com",
                 "SkipTLSVerify": false
             },
             "kubernetes": {
-                "Host": "https://someserver",
+                "Host": "https://someserver.example.com",
                 "SkipTLSVerify": false,
                 "DefaultNamespace": "default"
             }

--- a/cli/command/context/testdata/list.golden
+++ b/cli/command/context/testdata/list.golden
@@ -1,5 +1,5 @@
-NAME        DESCRIPTION                               DOCKER ENDPOINT               KUBERNETES ENDPOINT            ORCHESTRATOR
-current *   description of current                    https://someswarmserver       https://someserver (default)   all
-default     Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                  swarm
-other       description of other                      https://someswarmserver       https://someserver (default)   all
-unset       description of unset                      https://someswarmserver       https://someserver (default)   
+NAME        DESCRIPTION                               DOCKER ENDPOINT                       KUBERNETES ENDPOINT                        ORCHESTRATOR
+current *   description of current                    https://someswarmserver.example.com   https://someserver.example.com (default)   all
+default     Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                                      swarm
+other       description of other                      https://someswarmserver.example.com   https://someserver.example.com (default)   all
+unset       description of unset                      https://someswarmserver.example.com   https://someserver.example.com (default)   

--- a/cli/command/context/testdata/test-kubeconfig
+++ b/cli/command/context/testdata/test-kubeconfig
@@ -2,7 +2,7 @@ apiVersion: v1
 clusters:
 - cluster:
     certificate-authority-data: dGhlLWNh
-    server: https://someserver
+    server: https://someserver.example.com
   name: test-cluster
 contexts:
 - context:

--- a/cli/command/image/trust_test.go
+++ b/cli/command/image/trust_test.go
@@ -15,17 +15,17 @@ import (
 )
 
 func TestENVTrustServer(t *testing.T) {
-	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "https://notary-test.com:5000"})()
+	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "https://notary-test.example.com:5000"})()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
 	output, err := trust.Server(indexInfo)
-	expectedStr := "https://notary-test.com:5000"
+	expectedStr := "https://notary-test.example.com:5000"
 	if err != nil || output != expectedStr {
 		t.Fatalf("Expected server to be %s, got %s", expectedStr, output)
 	}
 }
 
 func TestHTTPENVTrustServer(t *testing.T) {
-	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "http://notary-test.com:5000"})()
+	defer env.PatchAll(t, map[string]string{"DOCKER_CONTENT_TRUST_SERVER": "http://notary-test.example.com:5000"})()
 	indexInfo := &registrytypes.IndexInfo{Name: "testserver"}
 	_, err := trust.Server(indexInfo)
 	if err == nil {

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -66,10 +66,10 @@ func TestElectAuthServer(t *testing.T) {
 			},
 		},
 		{
-			expectedAuthServer: "https://foo.bar",
+			expectedAuthServer: "https://foo.example.com",
 			expectedWarning:    "",
 			infoFunc: func() (types.Info, error) {
-				return types.Info{IndexServerAddress: "https://foo.bar"}, nil
+				return types.Info{IndexServerAddress: "https://foo.example.com"}, nil
 			},
 		},
 		{

--- a/cli/command/swarm/ca_test.go
+++ b/cli/command/swarm/ca_test.go
@@ -104,20 +104,20 @@ func TestDisplayTrustRootInvalidFlags(t *testing.T) {
 			errorMsg: "flag requires the `--rotate` flag to update the CA",
 		},
 		{
-			args:     []string{"--external-ca=protocol=cfssl,url=https://some.com/https/url"},
+			args:     []string{"--external-ca=protocol=cfssl,url=https://some.example.com/https/url"},
 			errorMsg: "flag requires the `--rotate` flag to update the CA",
 		},
 		{ // to make sure we're not erroring because we didn't provide a CA cert and external CA
 			args: []string{
 				"--ca-cert=" + tmpfile,
-				"--external-ca=protocol=cfssl,url=https://some.com/https/url",
+				"--external-ca=protocol=cfssl,url=https://some.example.com/https/url",
 			},
 			errorMsg: "flag requires the `--rotate` flag to update the CA",
 		},
 		{
 			args: []string{
 				"--rotate",
-				"--external-ca=protocol=cfssl,url=https://some.com/https/url",
+				"--external-ca=protocol=cfssl,url=https://some.example.com/https/url",
 			},
 			errorMsg: "rotating to an external CA requires the `--ca-cert` flag to specify the external CA's cert - " +
 				"to add an external CA with the current root CA certificate, use the `update` command instead",
@@ -243,7 +243,7 @@ func TestUpdateSwarmSpecCertAndExternalCA(t *testing.T) {
 		"--rotate",
 		"--detach",
 		"--ca-cert=" + certfile,
-		"--external-ca=protocol=cfssl,url=https://some.external.ca"})
+		"--external-ca=protocol=cfssl,url=https://some.external.ca.example.com"})
 	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
@@ -253,7 +253,7 @@ func TestUpdateSwarmSpecCertAndExternalCA(t *testing.T) {
 	expected.CAConfig.ExternalCAs = []*swarm.ExternalCA{
 		{
 			Protocol: swarm.ExternalCAProtocolCFSSL,
-			URL:      "https://some.external.ca",
+			URL:      "https://some.external.ca.example.com",
 			CACert:   cert,
 			Options:  make(map[string]string),
 		},
@@ -281,7 +281,7 @@ func TestUpdateSwarmSpecCertAndKeyAndExternalCA(t *testing.T) {
 		"--detach",
 		"--ca-cert=" + certfile,
 		"--ca-key=" + keyfile,
-		"--external-ca=protocol=cfssl,url=https://some.external.ca"})
+		"--external-ca=protocol=cfssl,url=https://some.external.ca.example.com"})
 	cmd.SetOut(cli.OutBuffer())
 	assert.NilError(t, cmd.Execute())
 
@@ -291,7 +291,7 @@ func TestUpdateSwarmSpecCertAndKeyAndExternalCA(t *testing.T) {
 	expected.CAConfig.ExternalCAs = []*swarm.ExternalCA{
 		{
 			Protocol: swarm.ExternalCAProtocolCFSSL,
-			URL:      "https://some.external.ca",
+			URL:      "https://some.external.ca.example.com",
 			CACert:   cert,
 			Options:  make(map[string]string),
 		},

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -27,16 +27,19 @@ func TestEncodeAuth(t *testing.T) {
 }
 
 func TestProxyConfig(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.example.com:3128"
-	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
-	noProxy := "*.intra.mycorp.example.com"
-	defaultProxyConfig := ProxyConfig{
-		HTTPProxy:  httpProxy,
-		HTTPSProxy: httpsProxy,
-		FTPProxy:   ftpProxy,
-		NoProxy:    noProxy,
-	}
+	var (
+		httpProxy  = "http://proxy.mycorp.example.com:3128"
+		httpsProxy = "https://user:password@proxy.mycorp.example.com:3129"
+		ftpProxy   = "http://ftpproxy.mycorp.example.com:21"
+		noProxy    = "*.intra.mycorp.example.com"
+
+		defaultProxyConfig = ProxyConfig{
+			HTTPProxy:  httpProxy,
+			HTTPSProxy: httpsProxy,
+			FTPProxy:   ftpProxy,
+			NoProxy:    noProxy,
+		}
+	)
 
 	cfg := ConfigFile{
 		Proxies: map[string]ProxyConfig{
@@ -59,18 +62,21 @@ func TestProxyConfig(t *testing.T) {
 }
 
 func TestProxyConfigOverride(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.example.com:3128"
-	overrideHTTPProxy := "http://proxy.example.com:3128"
-	overrideNoProxy := ""
-	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
-	noProxy := "*.intra.mycorp.example.com"
-	defaultProxyConfig := ProxyConfig{
-		HTTPProxy:  httpProxy,
-		HTTPSProxy: httpsProxy,
-		FTPProxy:   ftpProxy,
-		NoProxy:    noProxy,
-	}
+	var (
+		httpProxy         = "http://proxy.mycorp.example.com:3128"
+		httpProxyOverride = "http://proxy.example.com:3128"
+		httpsProxy        = "https://user:password@proxy.mycorp.example.com:3129"
+		ftpProxy          = "http://ftpproxy.mycorp.example.com:21"
+		noProxy           = "*.intra.mycorp.example.com"
+		noProxyOverride   = ""
+
+		defaultProxyConfig = ProxyConfig{
+			HTTPProxy:  httpProxy,
+			HTTPSProxy: httpsProxy,
+			FTPProxy:   ftpProxy,
+			NoProxy:    noProxy,
+		}
+	)
 
 	cfg := ConfigFile{
 		Proxies: map[string]ProxyConfig{
@@ -84,46 +90,49 @@ func TestProxyConfigOverride(t *testing.T) {
 	}
 
 	ropts := map[string]*string{
-		"HTTP_PROXY": clone(overrideHTTPProxy),
-		"NO_PROXY":   clone(overrideNoProxy),
+		"HTTP_PROXY": clone(httpProxyOverride),
+		"NO_PROXY":   clone(noProxyOverride),
 	}
 	proxyConfig := cfg.ParseProxyConfig("/var/run/docker.sock", ropts)
 	expected := map[string]*string{
-		"HTTP_PROXY":  &overrideHTTPProxy,
+		"HTTP_PROXY":  &httpProxyOverride,
 		"http_proxy":  &httpProxy,
 		"HTTPS_PROXY": &httpsProxy,
 		"https_proxy": &httpsProxy,
 		"FTP_PROXY":   &ftpProxy,
 		"ftp_proxy":   &ftpProxy,
-		"NO_PROXY":    &overrideNoProxy,
+		"NO_PROXY":    &noProxyOverride,
 		"no_proxy":    &noProxy,
 	}
 	assert.Check(t, is.DeepEqual(expected, proxyConfig))
 }
 
 func TestProxyConfigPerHost(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.example.com:3128"
-	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
-	noProxy := "*.intra.mycorp.example.com"
+	var (
+		httpProxy  = "http://proxy.mycorp.example.com:3128"
+		httpsProxy = "https://user:password@proxy.mycorp.example.com:3129"
+		ftpProxy   = "http://ftpproxy.mycorp.example.com:21"
+		noProxy    = "*.intra.mycorp.example.com"
 
-	extHTTPProxy := "http://proxy.example.com:3128"
-	extHTTPSProxy := "https://user:password@proxy.example.com:3129"
-	extFTPProxy := "http://ftpproxy.example.com:21"
-	extNoProxy := "*.intra.example.com"
+		extHTTPProxy  = "http://proxy.example.com:3128"
+		extHTTPSProxy = "https://user:password@proxy.example.com:3129"
+		extFTPProxy   = "http://ftpproxy.example.com:21"
+		extNoProxy    = "*.intra.example.com"
 
-	defaultProxyConfig := ProxyConfig{
-		HTTPProxy:  httpProxy,
-		HTTPSProxy: httpsProxy,
-		FTPProxy:   ftpProxy,
-		NoProxy:    noProxy,
-	}
-	externalProxyConfig := ProxyConfig{
-		HTTPProxy:  extHTTPProxy,
-		HTTPSProxy: extHTTPSProxy,
-		FTPProxy:   extFTPProxy,
-		NoProxy:    extNoProxy,
-	}
+		defaultProxyConfig = ProxyConfig{
+			HTTPProxy:  httpProxy,
+			HTTPSProxy: httpsProxy,
+			FTPProxy:   ftpProxy,
+			NoProxy:    noProxy,
+		}
+
+		externalProxyConfig = ProxyConfig{
+			HTTPProxy:  extHTTPProxy,
+			HTTPSProxy: extHTTPSProxy,
+			FTPProxy:   extFTPProxy,
+			NoProxy:    extNoProxy,
+		}
+	)
 
 	cfg := ConfigFile{
 		Proxies: map[string]ProxyConfig{
@@ -226,9 +235,11 @@ func TestGetAllCredentialsCredsStore(t *testing.T) {
 }
 
 func TestGetAllCredentialsCredHelper(t *testing.T) {
-	testCredHelperSuffix := "test_cred_helper"
-	testCredHelperRegistryHostname := "credhelper.com"
-	testExtraCredHelperRegistryHostname := "somethingweird.com"
+	const (
+		testCredHelperSuffix                = "test_cred_helper"
+		testCredHelperRegistryHostname      = "credhelper.com"
+		testExtraCredHelperRegistryHostname = "somethingweird.com"
+	)
 
 	unexpectedCredHelperAuth := types.AuthConfig{
 		Username: "file_store_user",
@@ -265,9 +276,11 @@ func TestGetAllCredentialsCredHelper(t *testing.T) {
 }
 
 func TestGetAllCredentialsFileStoreAndCredHelper(t *testing.T) {
-	testFileStoreRegistryHostname := "example.com"
-	testCredHelperSuffix := "test_cred_helper"
-	testCredHelperRegistryHostname := "credhelper.com"
+	const (
+		testFileStoreRegistryHostname  = "example.com"
+		testCredHelperSuffix           = "test_cred_helper"
+		testCredHelperRegistryHostname = "credhelper.com"
+	)
 
 	expectedFileStoreAuth := types.AuthConfig{
 		Username: "file_store_user",
@@ -301,10 +314,12 @@ func TestGetAllCredentialsFileStoreAndCredHelper(t *testing.T) {
 }
 
 func TestGetAllCredentialsCredStoreAndCredHelper(t *testing.T) {
-	testCredStoreSuffix := "test_creds_store"
-	testCredStoreRegistryHostname := "credstore.com"
-	testCredHelperSuffix := "test_cred_helper"
-	testCredHelperRegistryHostname := "credhelper.com"
+	const (
+		testCredStoreSuffix            = "test_creds_store"
+		testCredStoreRegistryHostname  = "credstore.com"
+		testCredHelperSuffix           = "test_cred_helper"
+		testCredHelperRegistryHostname = "credhelper.com"
+	)
 
 	configFile := New("filename")
 	configFile.CredentialsStore = testCredStoreSuffix
@@ -343,9 +358,11 @@ func TestGetAllCredentialsCredStoreAndCredHelper(t *testing.T) {
 }
 
 func TestGetAllCredentialsCredHelperOverridesDefaultStore(t *testing.T) {
-	testCredStoreSuffix := "test_creds_store"
-	testCredHelperSuffix := "test_cred_helper"
-	testRegistryHostname := "example.com"
+	const (
+		testCredStoreSuffix  = "test_creds_store"
+		testCredHelperSuffix = "test_cred_helper"
+		testRegistryHostname = "example.com"
+	)
 
 	configFile := New("filename")
 	configFile.CredentialsStore = testCredStoreSuffix
@@ -424,38 +441,36 @@ func TestCheckKubernetesConfigurationRaiseAnErrorOnInvalidValue(t *testing.T) {
 		expectError bool
 	}{
 		{
-			"no kubernetes config is valid",
-			nil,
-			false,
+			name: "no kubernetes config is valid",
 		},
 		{
-			"enabled is valid",
-			&KubernetesConfig{AllNamespaces: "enabled"},
-			false,
+			name:   "enabled is valid",
+			config: &KubernetesConfig{AllNamespaces: "enabled"},
 		},
 		{
-			"disabled is valid",
-			&KubernetesConfig{AllNamespaces: "disabled"},
-			false,
+			name:   "disabled is valid",
+			config: &KubernetesConfig{AllNamespaces: "disabled"},
 		},
 		{
-			"empty string is valid",
-			&KubernetesConfig{AllNamespaces: ""},
-			false,
+			name:   "empty string is valid",
+			config: &KubernetesConfig{AllNamespaces: ""},
 		},
 		{
-			"other value is invalid",
-			&KubernetesConfig{AllNamespaces: "unknown"},
-			true,
+			name:        "other value is invalid",
+			config:      &KubernetesConfig{AllNamespaces: "unknown"},
+			expectError: true,
 		},
 	}
-	for _, test := range testCases {
-		err := checkKubernetesConfiguration(test.config)
-		if test.expectError {
-			assert.Assert(t, err != nil, test.name)
-		} else {
-			assert.NilError(t, err, test.name)
-		}
+	for _, tc := range testCases {
+		test := tc
+		t.Run(test.name, func(t *testing.T) {
+			err := checkKubernetesConfiguration(test.config)
+			if test.expectError {
+				assert.Assert(t, err != nil, test.name)
+			} else {
+				assert.NilError(t, err, test.name)
+			}
+		})
 	}
 }
 

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -27,10 +27,10 @@ func TestEncodeAuth(t *testing.T) {
 }
 
 func TestProxyConfig(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.com:3128"
-	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.com:21"
-	noProxy := "*.intra.mycorp.com"
+	httpProxy := "http://proxy.mycorp.example.com:3128"
+	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
+	noProxy := "*.intra.mycorp.example.com"
 	defaultProxyConfig := ProxyConfig{
 		HTTPProxy:  httpProxy,
 		HTTPSProxy: httpsProxy,
@@ -59,12 +59,12 @@ func TestProxyConfig(t *testing.T) {
 }
 
 func TestProxyConfigOverride(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.com:3128"
+	httpProxy := "http://proxy.mycorp.example.com:3128"
 	overrideHTTPProxy := "http://proxy.example.com:3128"
 	overrideNoProxy := ""
-	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.com:21"
-	noProxy := "*.intra.mycorp.com"
+	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
+	noProxy := "*.intra.mycorp.example.com"
 	defaultProxyConfig := ProxyConfig{
 		HTTPProxy:  httpProxy,
 		HTTPSProxy: httpsProxy,
@@ -102,10 +102,10 @@ func TestProxyConfigOverride(t *testing.T) {
 }
 
 func TestProxyConfigPerHost(t *testing.T) {
-	httpProxy := "http://proxy.mycorp.com:3128"
-	httpsProxy := "https://user:password@proxy.mycorp.com:3129"
-	ftpProxy := "http://ftpproxy.mycorp.com:21"
-	noProxy := "*.intra.mycorp.com"
+	httpProxy := "http://proxy.mycorp.example.com:3128"
+	httpsProxy := "https://user:password@proxy.mycorp.example.com:3129"
+	ftpProxy := "http://ftpproxy.mycorp.example.com:21"
+	noProxy := "*.intra.mycorp.example.com"
 
 	extHTTPProxy := "http://proxy.example.com:3128"
 	extHTTPSProxy := "https://user:password@proxy.example.com:3129"

--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -70,7 +70,7 @@ func TestFileStoreGet(t *testing.T) {
 
 func TestFileStoreGetAll(t *testing.T) {
 	s1 := "https://example.com"
-	s2 := "https://example2.com"
+	s2 := "https://example2.example.com"
 	f := newStore(map[string]types.AuthConfig{
 		s1: {
 			Auth:          "super_secret_token",
@@ -80,7 +80,7 @@ func TestFileStoreGetAll(t *testing.T) {
 		s2: {
 			Auth:          "super_secret_token2",
 			Email:         "foo@example2.com",
-			ServerAddress: "https://example2.com",
+			ServerAddress: "https://example2.example.com",
 		},
 	})
 

--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -49,7 +49,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args("docker", "system", "dial-stdio")...)...)
 			},
-			Host: "http://docker",
+			Host: "http://docker.example.com",
 		}, nil
 	}
 	// Future version may support plugins via ~/.docker/config.json. e.g. "dind"
@@ -63,6 +63,6 @@ func GetCommandConnectionHelper(cmd string, flags ...string) (*ConnectionHelper,
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return commandconn.New(ctx, cmd, flags...)
 		},
-		Host: "http://docker",
+		Host: "http://docker.example.com",
 	}, nil
 }


### PR DESCRIPTION
### Use designated test domains (RFC2606) in tests

Some tests were using domain names that were intended to be "fake", but are
actually registered domain names (such as mycorp.com).

Even though we were not actually making connections to these domains, it's
better to use domains that are designated for testing/examples in RFC2606:
https://tools.ietf.org/html/rfc2606

### cli/config/configfile: various test cleanups

- use var/const blocks when declaring a list of variables
- use const where possible

TestCheckKubernetesConfigurationRaiseAnErrorOnInvalidValue:

- use keys when assigning values
- make sure test is dereferenced in the loop
- use subtests
