### PR TITLE
Add support for ALL_PROXY

### DIFF
--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -277,6 +277,8 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 		"no_proxy=noProxy",
 		"FTP_PROXY=ftpProxy",
 		"ftp_proxy=ftpProxy",
+		"ALL_PROXY=allProxy",
+		"all_proxy=allProxy",
 	}
 	sort.Strings(expected)
 
@@ -299,6 +301,7 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 				HTTPSProxy: "httpsProxy",
 				NoProxy:    "noProxy",
 				FTPProxy:   "ftpProxy",
+				AllProxy:   "allProxy",
 			},
 		},
 	})

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -60,6 +60,7 @@ type ProxyConfig struct {
 	HTTPSProxy string `json:"httpsProxy,omitempty"`
 	NoProxy    string `json:"noProxy,omitempty"`
 	FTPProxy   string `json:"ftpProxy,omitempty"`
+	AllProxy   string `json:"allProxy,omitempty"`
 }
 
 // KubernetesConfig contains Kubernetes orchestrator settings
@@ -244,6 +245,7 @@ func (configFile *ConfigFile) ParseProxyConfig(host string, runOpts map[string]*
 		"HTTPS_PROXY": &config.HTTPSProxy,
 		"NO_PROXY":    &config.NoProxy,
 		"FTP_PROXY":   &config.FTPProxy,
+		"ALL_PROXY":   &config.AllProxy,
 	}
 	m := runOpts
 	if m == nil {

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -32,12 +32,14 @@ func TestProxyConfig(t *testing.T) {
 		httpsProxy = "https://user:password@proxy.mycorp.example.com:3129"
 		ftpProxy   = "http://ftpproxy.mycorp.example.com:21"
 		noProxy    = "*.intra.mycorp.example.com"
+		allProxy   = "socks://example.com:1234"
 
 		defaultProxyConfig = ProxyConfig{
 			HTTPProxy:  httpProxy,
 			HTTPSProxy: httpsProxy,
 			FTPProxy:   ftpProxy,
 			NoProxy:    noProxy,
+			AllProxy:   allProxy,
 		}
 	)
 
@@ -57,6 +59,8 @@ func TestProxyConfig(t *testing.T) {
 		"ftp_proxy":   &ftpProxy,
 		"NO_PROXY":    &noProxy,
 		"no_proxy":    &noProxy,
+		"ALL_PROXY":   &allProxy,
+		"all_proxy":   &allProxy,
 	}
 	assert.Check(t, is.DeepEqual(expected, proxyConfig))
 }

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1973,6 +1973,8 @@ corresponding `ARG` instruction in the Dockerfile.
 - `ftp_proxy`
 - `NO_PROXY`
 - `no_proxy`
+- `ALL_PROXY`
+- `all_proxy`
 
 To use these, pass them on the command line using the `--build-arg` flag, for
 example:

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -214,6 +214,7 @@ be set for each environment:
 | `httpsProxy`   | Default value of `HTTPS_PROXY` and `https_proxy` for containers, and as `--build-arg` on `docker build` |
 | `ftpProxy`     | Default value of `FTP_PROXY` and `ftp_proxy` for containers, and as `--build-arg` on `docker build`     |
 | `noProxy`      | Default value of `NO_PROXY` and `no_proxy` for containers, and as `--build-arg` on `docker build`       |
+| `allProxy`     | Default value of `ALL_PROXY` and `all_proxy` for containers, and as `--build-arg` on `docker build`     |
 
 These settings are used to configure proxy settings for containers only, and not
 used as proxy settings for the `docker` CLI or the `dockerd` daemon. Refer to the
@@ -295,7 +296,8 @@ various fields:
       "httpProxy":  "http://user:pass@example.com:3128",
       "httpsProxy": "https://my-proxy.example.com:3129",
       "noProxy":    "intra.mycorp.example.com",
-      "ftpProxy":   "http://user:pass@example.com:3128"
+      "ftpProxy":   "http://user:pass@example.com:3128",
+      "allProxy":   "socks://example.com:1234"
     },
     "https://manager1.mycorp.example.com:2377": {
       "httpProxy":  "http://user:pass@example.com:3128",

--- a/man/Dockerfile.5.md
+++ b/man/Dockerfile.5.md
@@ -437,6 +437,8 @@ A Dockerfile is similar to a Makefile.
   * `ftp_proxy`
   * `NO_PROXY`
   * `no_proxy`
+  * `ALL_PROXY`
+  * `all_proxy`
 
   To use these, pass them on the command line using `--build-arg` flag, for
   example:


### PR DESCRIPTION
Depends on / relates to:

- [x] https://github.com/docker/cli/pull/3072 docs: various changes, and touch-up main CLI page
- [x] https://github.com/moby/buildkit/pull/2086 Add "ALL_PROXY" to list of default args / proxy env-vars
- [x] https://github.com/moby/moby/pull/42318 builder/dockerfile: add "ALL_PROXY" to list of default build args
- [x] revendor buildkit in moby and cli https://github.com/docker/cli/pull/3153

(changes are needed in https://github.com/docker/docker.github.io as well)


Support for ALL_PROXY as default build-arg was added recently in
buildkit and the classic builder.

This patch adds the `ALL_PROXY` environment variable to the list of
configurable proxy variables, and updates the documentation.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

