### PR TITLE
zsh completion: Fix completion when using `docker run/exec -it` shortcut

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -665,6 +665,7 @@ __docker_container_subcommand() {
         "($help)--volume-driver=[Optional volume driver for the container]:volume driver:(local)"
         "($help)*--volumes-from=[Mount volumes from the specified container]:volume: "
         "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories"
+        "($help)-it[shortcut for --interactive and --tty]"
     )
     opts_create_run_update=(
         "($help)--blkio-weight=[Block IO (relative weight), between 10 and 1000]:Block IO weight:(10 100 500 1000)"
@@ -757,6 +758,7 @@ __docker_container_subcommand() {
                 "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \
                 "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users" \
                 "($help -w --workdir)"{-w=,--workdir=}"[Working directory inside the container]:directory:_directories" \
+                "($help)-it[shortcut for --interactive and --tty]" \
                 "($help -):containers:__docker_complete_running_containers" \
                 "($help -)*::command:->anycommand" && ret=0
             case $state in


### PR DESCRIPTION
This commit adds the -it support to any command that has both --interactive and --tty.
Before, the completions plugin did not recognize the -it option and thus the subcommands completion context break whenever -it is used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added the `-it` option in the relevant places in the zsh plugin
**- How I did it**

**- How to verify it**
on the master branch of a oh-my-zsh installation, run:
`docker run -it <TAB>` - the container list does not appear.

now replace with the plugin from this branch:
`docker run -it <TAB>` - the container name completor kicks in.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix completion for the -it option


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/2903914/116809948-92df4480-ab49-11eb-8c77-969125cf5e09.png)
