### PR TITLE
[20.10 backport] docs updates

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1400,6 +1400,10 @@ This is a full example of the allowed configuration options on Linux:
   "log-driver": "json-file",
   "log-level": "",
   "log-opts": {
+    "cache-disabled": "false",
+    "cache-max-file": "5",
+    "cache-max-size": "20m",
+    "cache-compress": "true",
     "env": "os,customer",
     "labels": "somelabel",
     "max-file": "5",

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -19,7 +19,9 @@ Options:
 ## Description
 
 The main process inside the container will receive `SIGTERM`, and after a grace
-period, `SIGKILL`.
+period, `SIGKILL`. The first signal can be changed with the `STOPSIGNAL`
+instruction in the container's Dockerfile, or the `--stop-signal` option to
+`docker run`.
 
 ## Examples
 


### PR DESCRIPTION
backports:

- https://github.com/docker/cli/pull/3039 Update stop.md to mention that other stop signals can be set
- https://github.com/docker/cli/pull/3052 docs: document log-opts for "dual logging" cache

