### PR TITLE
docker build description: notes on how `git` is called amended.

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -72,16 +72,16 @@ pre-packaged tarball contexts and plain text files.
 
 When the `URL` parameter points to the location of a Git repository, the
 repository acts as the build context. The system recursively fetches the
-repository and its submodules. The commit history is not preserved. A
-repository is first pulled into a temporary directory on your local host. After
-that succeeds, the directory is sent to the Docker daemon as the context.
-Local copy gives you the ability to access private repositories using local
-user credentials, VPN's, and so forth.
+repository and its submodules. The commit history is not preserved (i.e.
+using `git clone --depth 1`). A repository is first pulled into a temporary
+directory on your local host. After that succeeds, the directory is sent to
+the Docker daemon as the context. Local copy gives you the ability to access
+private repositories using local user credentials, VPN's, and so forth.
 
 > **Note**
 >
 > If the `URL` parameter contains a fragment the system will recursively clone
-> the repository and its submodules using a `git clone --recursive` command.
+> the repository and its submodules using a `git clone --recurse-submodules` command.
 
 Git URLs accept context configuration in their fragment section, separated by a
 colon (`:`).  The first part represents the reference that Git will check out,


### PR DESCRIPTION
The current notes in `docs/reference/build.md` on how `git` is used to retrieve a git repository ...

1. lack an explanation of what's done
1. provide an invalid `git` option

I updated both sections.
<br/>

**A picture of a cute animal (not mandatory but encouraged)**

![](https://i.pinimg.com/736x/20/f7/c8/20f7c84d8ffc10066f7994c09840fd9c.jpg)