### PR TITLE
docs: Fix broken jump link

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -587,7 +587,7 @@ $ docker inspect -f "{{ .State.StartedAt }}" my-container
 
 Combining `--restart` (restart policy) with the `--rm` (clean up) flag results
 in an error. On container restart, attached clients are disconnected. See the
-examples on using the [`--rm` (clean up)](#clean-up-rm) flag later in this page.
+examples on using the [`--rm` (clean up)](#clean-up---rm) flag later in this page.
 
 ### Examples
 


### PR DESCRIPTION
Fix a broken jump link under "Restart policies (--restart)" to the "Clean up (--rm)" heading
