### PR TITLE
[20.10 backport] documentation fixes

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -963,7 +963,7 @@ easily, for example with `docker inspect`. To set a label corresponding to the
 `MAINTAINER` field you could use:
 
 ```dockerfile
-LABEL maintainer="SvenDowideit@home.org.au"
+LABEL org.opencontainers.image.authors="SvenDowideit@home.org.au"
 ```
 
 This will then be visible from `docker inspect` with the other labels.

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -160,7 +160,7 @@ Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
 FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-LABEL maintainer="some maintainer <maintainer@example.com>"
+LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 ```
 
 > **Note**

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -587,7 +587,7 @@ $ docker inspect -f "{{ .State.StartedAt }}" my-container
 
 Combining `--restart` (restart policy) with the `--rm` (clean up) flag results
 in an error. On container restart, attached clients are disconnected. See the
-examples on using the [`--rm` (clean up)](#clean-up-rm) flag later in this page.
+examples on using the [`--rm` (clean up)](#clean-up---rm) flag later in this page.
 
 ### Examples
 

--- a/man/src/image/pull.md
+++ b/man/src/image/pull.md
@@ -111,7 +111,7 @@ pull the above image by digest, run the following command:
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
     FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-    LABEL maintainer="some maintainer <maintainer@example.com>"
+    LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 
 > **Note**: Using this feature "pins" an image to a specific version in time.
 > Docker will therefore not pull updated versions of an image, which may include 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3082 and https://github.com/docker/cli/pull/3095