### PR TITLE
Ignore SIGURG on Unix (including Darwin)

### DIFF
--- a/cli/command/container/signals_unix.go
+++ b/cli/command/container/signals_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package container
 
 import (

--- a/cli/command/container/signals_unix_test.go
+++ b/cli/command/container/signals_unix_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package container
 
 import (

--- a/cli/command/container/signals_windows.go
+++ b/cli/command/container/signals_windows.go
@@ -1,5 +1,3 @@
-// +build !linux
-
 package container
 
 import "os"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Ignored spurious `SIGURG` signals generated by the Go 1.14+ runtime on Darwin.

Running the example in https://github.com/golang/go/issues/37942
I see lots of these signals:
```
dave@m1 sigurg % uname -ms
Darwin arm64

dave@m1 sigurg % go run main.go
received urgent I/O condition: 2021-05-21 16:03:03.482211 +0100 BST m=+0.014553751
received urgent I/O condition: 2021-05-21 16:03:03.507171 +0100 BST m=+0.039514459
```

Previously I would also see a spurious error when closing a connection:
```
dave@m1 cli % ./build/docker run -it --init ubuntu
root@7f9fc6aee300:/# exit
Unsupported signal: <nil>. Discarding.
```

**- How I did it**

#2929 already covered `SIGURG` on Linux. I extended it to cover all Unix versions via `_unix.go`.

I added an `ok` to detect the signals channel being closed and return from the forwarding function.

**- How to verify it**

The unit test for Linux should also cover Mac. On Docker Desktop if you run an interactive container:
```
dave@m1 cli % ./build/docker run -it --init ubuntu
```
and then watch the Docker API proxy log:
```
tail -f ~/Library/Containers/com.docker.docker/Data/log/host/com.docker.driver.amd64-linux.log
```
and observe no
```
2021-05-21 18:01:39.972896+0900  localhost com.docker.driver.amd64-linux[87081]: proxy >> POST /v1.41/containers/b6e4ab5bb7d4271bae2ad14dfce139f9b0e84f315ae6e9fdac8224cd93c0b780/kill?signal=URG
```
as seen on docker/for-mac#5712

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Don't inject `SIGURG` signals generated by the Go runtime into containers

**- A picture of a cute animal (not mandatory but encouraged)**

![darwinfrog](https://user-images.githubusercontent.com/198586/119164664-908b4e80-ba54-11eb-94cd-812e069cea3d.jpg)
