### PR TITLE
Change IO order in description

### DIFF
--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -71,8 +71,8 @@ following columns are shown.
 | `CONTAINER ID` and `Name` | the ID and name of the container                                                              |
 | `CPU %` and `MEM %`       | the percentage of the host's CPU and memory the container is using                            |
 | `MEM USAGE / LIMIT`       | the total memory the container is using, and the total amount of memory it is allowed to use  |
-| `NET I/O`                 | The amount of data the container has sent and received over its network interface             |
-| `BLOCK I/O`               | The amount of data the container has read to and written from block devices on the host       |
+| `NET I/O`                 | The amount of data the container has received and sent over its network interface             |
+| `BLOCK I/O`               | The amount of data the container has written to and read from block devices on the host       |
 | `PIDs`                    | the number of processes or threads the container has created                                  |
 
 Running `docker stats` on multiple containers by name and id against a Linux daemon.


### PR DESCRIPTION
Change the order of received/written and sent/read in NET I/O and BLOCK I/O description reflect the order in I/O (Input/Output).

From example above:
CONTAINER NAME: awesome_brattain
BLOCK I/O: 147kB / 0B

awesome_brattain has written 147kB and read 0B

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

