### PR TITLE
Document option for daemon config validation

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2560,6 +2560,7 @@ _docker_daemon() {
 		--raw-logs
 		--selinux-enabled
 		--userland-proxy=false
+		--validate
 		--version -v
 	"
 	local options_with_args="

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2791,7 +2791,8 @@ __docker_subcommand() {
                 "($help)--tlsverify[Use TLS and verify the remote]" \
                 "($help)--userns-remap=[User/Group setting for user namespaces]:user\:group:->users-groups" \
                 "($help)--userland-proxy[Use userland proxy for loopback traffic]" \
-                "($help)--userland-proxy-path=[Path to the userland proxy binary]:binary:_files" && ret=0
+                "($help)--userland-proxy-path=[Path to the userland proxy binary]:binary:_files" \
+                "($help)--validate[Validate daemon configuration and exit]" && ret=0
 
             case $state in
                 (cluster-store)

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -104,6 +104,7 @@ Options:
       --userland-proxy                        Use userland proxy for loopback traffic (default true)
       --userland-proxy-path string            Path to the userland proxy binary
       --userns-remap string                   User/Group setting for user namespaces
+      --validate                              Validate daemon configuration and exit
   -v, --version                               Print version information and quit
 ```
 
@@ -1333,6 +1334,25 @@ silently ignore changes introduced in configuration reloads.
 For example, the daemon fails to start if you set daemon labels
 in the configuration file and also set daemon labels via the `--label` flag.
 Options that are not present in the file are ignored when the daemon starts.
+
+The `--validate` option allows to validate a configuration file without
+starting the Docker daemon. A non-zero exit code is returned for invalid
+configuration files.
+
+```console
+$ dockerd --validate --config-file=/tmp/valid-config.json
+configuration OK
+
+$ echo $?
+0
+
+$ dockerd --validate --config-file /tmp/invalid-config.json
+unable to configure the Docker daemon with file /tmp/invalid-config.json: the following directives don't match any configuration option: unknown-option
+
+$ echo $?
+1
+```
+
 
 ##### On Linux
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -75,6 +75,7 @@ dockerd - Enable daemon mode
 [**--userland-proxy**[=*true*]]
 [**--userland-proxy-path**[=*""*]]
 [**--userns-remap**[=*default*]]
+[**--validate**]
 
 # DESCRIPTION
 **dockerd** is used for starting the Docker daemon (i.e., to command the daemon
@@ -410,6 +411,9 @@ unix://[/path/to/socket] to use.
   Specifying a user (or uid) and optionally a group (or gid) will cause the
   daemon to lookup the user and group's subordinate ID ranges for use as the
   user namespace mappings for contained processes.
+
+**--validate**
+  Validate daemon configuration and exit.
 
 # STORAGE DRIVER OPTIONS
 


### PR DESCRIPTION
We are adding a `--validate` option to dockerd to check if the config file is valid without starting the daemon.

Related to https://github.com/moby/moby/pull/42393

**- What I did**
Added `--validate` option to the docker daemon options documentation.

**- Description for the changelog**
Update documentation and shell completion for the daemon validation option.
