### PR TITLE
[20.10 backport] docs: fix link to command-line reference

### DIFF
--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -122,7 +122,7 @@ enabled, and use it to create a volume.
 To disable a plugin, use the `docker plugin disable` command. To completely
 remove it, use the `docker plugin remove` command. For other available
 commands and options, see the
-[command line reference](../reference/commandline/index.md).
+[command line reference](https://docs.docker.com/engine/reference/commandline/cli/).
 
 
 ## Developing a plugin


### PR DESCRIPTION
backport of https://github.com/docker/cli/issues/3109

fixes https://github.com/docker/cli/issues/3109
fixes https://github.com/docker/docker.github.io/issues/12235

This link worked on GitHub, but was broken on docs.docker.com, so replacing with a regular link directly to the docs instead.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


