### PR TITLE
Implement support for the command-line option --security-opt seccomp=without-user-namespaces

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -847,7 +847,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 				return securityOpts, errors.Errorf("Invalid --security-opt: %q", opt)
 			}
 		}
-		if con[0] == "seccomp" && con[1] != "unconfined" {
+		if con[0] == "seccomp" && con[1] != "unconfined" && con[1] != "without-user-namespaces" {
 			f, err := ioutil.ReadFile(con[1])
 			if err != nil {
 				return securityOpts, errors.Errorf("opening seccomp profile (%s) failed: %v", con[1], err)


### PR DESCRIPTION
Part of https://github.com/moby/moby/pull/42455