### PR TITLE
vendor: github.com/docker/docker-credential-helpers v0.6.4

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff7826
 github.com/docker/compose-on-kubernetes             78e6a00beda64ac8ccb9fec787e601fe2ce0d5bb # v0.5.0-alpha1
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
 github.com/docker/docker                            b0f5bc36fea9dfb9672e1e9b1278ebab797b9ee0 # v20.10.7
-github.com/docker/docker-credential-helpers         38bea2ce277ad0c9d2a6230692b0606ca5286526
+github.com/docker/docker-credential-helpers         fc9290adbcf1594e78910e2f0334090eaee0e1ee # v0.6.4
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
@@ -1,4 +1,4 @@
 package credentials
 
 // Version holds a string describing the current version
-const Version = "0.6.3"
+const Version = "0.6.4"


### PR DESCRIPTION
The last update has now been tagged as v0.6.4, so updating the vendor version

full diff: https://github.com/docker/docker-credential-helpers/compare/38bea2ce277ad0c9d2a6230692b0606ca5286526...v0.6.4

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

