### PR TITLE
docs: remove note about buildkit not supporting git subdirectories

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -110,12 +110,6 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 `myrepo.git#mytag:myfolder`     | `refs/tags/mytag`     | `/myfolder`
 `myrepo.git#mybranch:myfolder`  | `refs/heads/mybranch` | `/myfolder`
 
-> **Note**
->
-> You cannot specify the build-context directory (`myfolder` in the examples above)
-> when using BuildKit as builder (`DOCKER_BUILDKIT=1`). Support for this feature
-> is tracked in [buildkit#1684](https://github.com/moby/buildkit/issues/1684).
-
 ### Tarball contexts
 
 If you pass an URL to a remote tarball, the URL itself is sent to the daemon:


### PR DESCRIPTION

- supersedes / closes https://github.com/docker/cli/pull/3194
- supersedes / closes https://github.com/docker/cli/pull/3342

depends on:

- [x] https://github.com/moby/buildkit/issues/1684 Add support for subdirectories when building from git source
- [x] https://github.com/moby/buildkit/pull/2116 git: support subdir component
- [x] Moby vendor update https://github.com/moby/moby/pull/42473


This has now been implemented in buildkit#2116, so this note can be removed (once integrated into Docker).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

