### PR TITLE
feat(zsh): add context argument completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -3094,6 +3094,7 @@ _docker() {
     _arguments $(__docker_arguments) -C \
         "(: -)"{-h,--help}"[Print usage]" \
         "($help)--config[Location of client config files]:path:_directories" \
+        "($help -c --context)"{-c=,--context=}"[Execute the command in a docker context]:context:__docker_complete_contexts" \
         "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
         "($help -H --host)"{-H=,--host=}"[tcp://host:port to bind/connect to]:host: " \
         "($help -l --log-level)"{-l=,--log-level=}"[Logging level]:level:(debug info warn error fatal)" \
@@ -3109,7 +3110,8 @@ _docker() {
 
     local host=${opt_args[-H]}${opt_args[--host]}
     local config=${opt_args[--config]}
-    local docker_options="${host:+--host $host} ${config:+--config $config}"
+    local context=${opt_args[-c]}${opt_args[--context]}
+    local docker_options="${host:+--host $host} ${config:+--config $config} ${context:+--context $context} "
 
     case $state in
         (command)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add a `-c --context` docker option completion, resolves `-c` and `--context` with the description "Execute the command in a docker context". 
And resolves available contexts `docker -c=<tab>`
![image](https://user-images.githubusercontent.com/22034450/121491843-9da5b880-c9d6-11eb-84e0-360bcfcc93ed.png)

It also adds the context to the `docker_options` so the completion is depending on the given context.

**- How I did it**
This use the same function to list contexts previously added and use of docker_options variable

**- How to verify it**
Type `docker --<tab>` should add a `--context option`
Then type `docker --context <tab>` should give you the list of contexts available

Have a distant context and try to inspect a resource on it `docker -c my-context inspect <TAB>` should list you the resources of the given context.
**- Description for the changelog**
add docker --context argument completion

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/22034450/121491748-8797f800-c9d6-11eb-81dc-26bcdc2cb291.png)

