### PR TITLE
vendor: moby/term, Azure/go-ansiterm for golang.org/x/sys/windows compat

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -1,5 +1,5 @@
 cloud.google.com/go                                 ceeb313ad77b789a7fa5287b36a1d127b69b7093 # v0.44.3
-github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/Azure/go-ansiterm                        d185dfc1b5a126116ea5a19e148e29d16b4574c9
 github.com/beorn7/perks                             37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
 github.com/cespare/xxhash/v2                        d7df74196a9e781ede915320c11c378c1b2f3a1f # v2.1.1
 github.com/containerd/console                       5d7e1412f07b502a01029ea20e20e0d2be31fa7c # v1.0.1
@@ -49,7 +49,7 @@ github.com/miekg/pkcs11                             210dc1e16747c5ba98a03bcbcf72
 github.com/mitchellh/mapstructure                   d16e9488127408e67948eb43b6d3fbb9f222da10 # v1.3.2
 github.com/moby/buildkit                            8142d66b5ebde79846b869fba30d9d30633e74aa # v0.8.1
 github.com/moby/sys                                 1bc8673b57550ddf85262eb0fed0aac651a37dab # symlink/v0.1.0 (latest tag, either mount/vXXX, mountinfo/vXXX or symlink/vXXX)
-github.com/moby/term                                bea5bbe245bf407372d477f1361d2ff042d2f556
+github.com/moby/term                                3f7ff695adc6a35abc925370dd0a4dafb48ec64d
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
 github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b # v1.0.0

--- a/vendor/github.com/Azure/go-ansiterm/go.mod
+++ b/vendor/github.com/Azure/go-ansiterm/go.mod
@@ -1,0 +1,5 @@
+module github.com/Azure/go-ansiterm
+
+go 1.16
+
+require golang.org/x/sys v0.0.0-20210616094352-59db8d763f22

--- a/vendor/github.com/Azure/go-ansiterm/winterm/ansi.go
+++ b/vendor/github.com/Azure/go-ansiterm/winterm/ansi.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/Azure/go-ansiterm"
+	windows "golang.org/x/sys/windows"
 )
 
 // Windows keyboard constants
@@ -162,15 +163,28 @@ func ensureInRange(n int16, min int16, max int16) int16 {
 
 func GetStdFile(nFile int) (*os.File, uintptr) {
 	var file *os.File
-	switch nFile {
-	case syscall.STD_INPUT_HANDLE:
+
+	// syscall uses negative numbers
+	// windows package uses very big uint32
+	// Keep these switches split so we don't have to convert ints too much.
+	switch uint32(nFile) {
+	case windows.STD_INPUT_HANDLE:
 		file = os.Stdin
-	case syscall.STD_OUTPUT_HANDLE:
+	case windows.STD_OUTPUT_HANDLE:
 		file = os.Stdout
-	case syscall.STD_ERROR_HANDLE:
+	case windows.STD_ERROR_HANDLE:
 		file = os.Stderr
 	default:
-		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))
+		switch nFile {
+		case syscall.STD_INPUT_HANDLE:
+			file = os.Stdin
+		case syscall.STD_OUTPUT_HANDLE:
+			file = os.Stdout
+		case syscall.STD_ERROR_HANDLE:
+			file = os.Stderr
+		default:
+			panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))
+		}
 	}
 
 	fd, err := syscall.GetStdHandle(nFile)

--- a/vendor/github.com/moby/term/go.mod
+++ b/vendor/github.com/moby/term/go.mod
@@ -3,10 +3,10 @@ module github.com/moby/term
 go 1.13
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
 	gotest.tools/v3 v3.0.2
 )

--- a/vendor/github.com/moby/term/windows/console.go
+++ b/vendor/github.com/moby/term/windows/console.go
@@ -29,7 +29,7 @@ func GetHandleInfo(in interface{}) (uintptr, bool) {
 
 // IsConsole returns true if the given file descriptor is a Windows Console.
 // The code assumes that GetConsoleMode will return an error for file descriptors that are not a console.
-// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/crypto/ssh/terminal.IsTerminal()
+// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/term.IsTerminal()
 var IsConsole = isConsole
 
 func isConsole(fd uintptr) bool {


### PR DESCRIPTION
Relates to:

- https://github.com/moby/term/issues/26 Invalid Standard Handle Panic on Windows Server 2012
- addresses https://github.com/docker/for-win/issues/9770 "Invalid standard handle identifier" since 3.0.0 update
- fixes https://github.com/docker/cli/issues/2911 window 10 cmd run docker -v error

Changes:

- winterm: GetStdFile(): Added compatibility with "golang.org/x/sys/windows"
- winterm: fix GetStdFile() falltrough
- update deprecation message to refer to the correct replacement
- add go.mod
- Fix int overflow
- Convert int to string using rune()

full diff:

- https://github.com/moby/term/compare/bea5bbe245bf407372d477f1361d2ff042d2f556...3f7ff695adc6a35abc925370dd0a4dafb48ec64d
- https://github.com/Azure/go-ansiterm/compare/d6e3b3328b783f23731bc4d058875b0371ff8109...d185dfc1b5a126116ea5a19e148e29d16b4574c9

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Fix Invalid Standard Handle Panic on Windows
```


**- A picture of a cute animal (not mandatory but encouraged)**

