### PR TITLE
Remove ClientInfo as it is not practically used.

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -52,7 +52,6 @@ type Cli interface {
 	Apply(ops ...DockerCliOption) error
 	ConfigFile() *configfile.ConfigFile
 	ServerInfo() ServerInfo
-	ClientInfo() ClientInfo
 	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
 	DefaultVersion() string
 	ManifestStore() manifeststore.Store
@@ -73,7 +72,6 @@ type DockerCli struct {
 	err                io.Writer
 	client             client.APIClient
 	serverInfo         ServerInfo
-	clientInfo         *ClientInfo
 	contentTrust       bool
 	contextStore       store.Store
 	currentContext     string
@@ -81,9 +79,9 @@ type DockerCli struct {
 	contextStoreConfig store.Config
 }
 
-// DefaultVersion returns api.defaultVersion or DOCKER_API_VERSION if specified.
+// DefaultVersion returns api.defaultVersion.
 func (cli *DockerCli) DefaultVersion() string {
-	return cli.ClientInfo().DefaultVersion
+	return api.DefaultVersion
 }
 
 // Client returns the APIClient
@@ -136,30 +134,6 @@ func (cli *DockerCli) loadConfigFile() {
 // connected to
 func (cli *DockerCli) ServerInfo() ServerInfo {
 	return cli.serverInfo
-}
-
-// ClientInfo returns the client details for the cli
-func (cli *DockerCli) ClientInfo() ClientInfo {
-	if cli.clientInfo == nil {
-		if err := cli.loadClientInfo(); err != nil {
-			panic(err)
-		}
-	}
-	return *cli.clientInfo
-}
-
-func (cli *DockerCli) loadClientInfo() error {
-	var v string
-	if cli.client != nil {
-		v = cli.client.ClientVersion()
-	} else {
-		v = api.DefaultVersion
-	}
-	cli.clientInfo = &ClientInfo{
-		DefaultVersion:  v,
-		HasExperimental: true,
-	}
-	return nil
 }
 
 // ContentTrustEnabled returns whether content trust has been enabled by an
@@ -260,11 +234,6 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		}
 	}
 	cli.initializeFromClient()
-
-	if err := cli.loadClientInfo(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -408,14 +377,6 @@ type ServerInfo struct {
 	HasExperimental bool
 	OSType          string
 	BuildkitVersion types.BuilderVersion
-}
-
-// ClientInfo stores details about the supported features of the client
-type ClientInfo struct {
-	// Deprecated: experimental CLI features always enabled. This field is kept
-	// for backward-compatibility, and is always "true".
-	HasExperimental bool
-	DefaultVersion  string
 }
 
 // NewDockerCli returns a DockerCli instance with all operators applied on it.

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -202,8 +202,6 @@ func TestExperimentalCLI(t *testing.T) {
 			cliconfig.SetDir(dir.Path())
 			err := cli.Initialize(flags.NewClientOptions())
 			assert.NilError(t, err)
-			// For backward-compatibility, HasExperimental will always be "true"
-			assert.Equal(t, cli.ClientInfo().HasExperimental, true)
 		})
 	}
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -278,7 +278,6 @@ func main() {
 
 type versionDetails interface {
 	Client() client.APIClient
-	ClientInfo() command.ClientInfo
 	ServerInfo() command.ServerInfo
 }
 

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -20,7 +20,6 @@ import (
 
 // NotaryClientFuncType defines a function that returns a fake notary client
 type NotaryClientFuncType func(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
-type clientInfoFuncType func() command.ClientInfo
 
 // FakeCli emulates the default DockerCli
 type FakeCli struct {
@@ -32,7 +31,6 @@ type FakeCli struct {
 	err              *bytes.Buffer
 	in               *streams.In
 	server           command.ServerInfo
-	clientInfoFunc   clientInfoFuncType
 	notaryClientFunc NotaryClientFuncType
 	manifestStore    manifeststore.Store
 	registryClient   registryclient.RegistryClient
@@ -141,19 +139,6 @@ func (c *FakeCli) DockerEndpoint() docker.Endpoint {
 // ServerInfo returns API server information for the server used by this client
 func (c *FakeCli) ServerInfo() command.ServerInfo {
 	return c.server
-}
-
-// ClientInfo returns client information
-func (c *FakeCli) ClientInfo() command.ClientInfo {
-	if c.clientInfoFunc != nil {
-		return c.clientInfoFunc()
-	}
-	return c.DockerCli.ClientInfo()
-}
-
-// SetClientInfo sets the internal getter for retrieving a ClientInfo
-func (c *FakeCli) SetClientInfo(clientInfoFunc clientInfoFuncType) {
-	c.clientInfoFunc = clientInfoFunc
 }
 
 // OutBuffer returns the stdout buffer


### PR DESCRIPTION
- relates to https://github.com/docker/for-linux/issues/1251#issuecomment-861380310

The information in this struct was basically fixed (there's
some discrepancy around the "DefaultVersion" which, probably,
should never vary, and always be set to the Default (maximum)
API version supported by the client.

Experimental is now always enabled, so this information did
not require any dynamic info as well.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

