### PR TITLE
CI: update engine versions and Jenkins labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ jobs:
 
   lint:
     working_directory: /work
-    docker: [{image: 'docker:19.03-git'}]
+    docker: [{image: 'docker:20.10-git'}]
     environment:
       DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.6
           reusable: true
           exclusive: false
       - run:
@@ -39,7 +39,7 @@ jobs:
 
   cross:
     working_directory: /work
-    docker: [{image: 'docker:19.03-git'}]
+    docker: [{image: 'docker:20.10-git'}]
     environment:
       DOCKER_BUILDKIT: 1
       BUILDX_VERSION: "v0.5.1"
@@ -47,7 +47,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.6
           reusable: true
           exclusive: false
       - run:
@@ -69,13 +69,13 @@ jobs:
 
   test:
     working_directory: /work
-    docker: [{image: 'docker:19.03-git'}]
+    docker: [{image: 'docker:20.10-git'}]
     environment:
       DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.6
           reusable: true
           exclusive: false
       - run:
@@ -116,13 +116,13 @@ jobs:
 
   validate:
     working_directory: /work
-    docker: [{image: 'docker:19.03-git'}]
+    docker: [{image: 'docker:20.10-git'}]
     environment:
       DOCKER_BUILDKIT: 1
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.12
+          version: 20.10.6
           reusable: true
           exclusive: false
       - run:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,9 @@ pipeline {
                     make -f docker.Makefile test-e2e-non-experimental"
             }
         }
-        stage("e2e (non-experimental) - 18.09 engine") {
+        stage("e2e (non-experimental) - 19.03 engine") {
             steps {
-                sh "E2E_ENGINE_VERSION=18.09-dind \
+                sh "E2E_ENGINE_VERSION=19.03-dind \
                   E2E_UNIQUE_ID=clie2e${BUILD_NUMBER} \
                   IMAGE_TAG=clie2e${BUILD_NUMBER} \
                   make -f docker.Makefile test-e2e-non-experimental"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label "linux && x86_64"
+        label "amd64 && ubuntu-1804 && overlay2"
     }
 
     options {


### PR DESCRIPTION
Splitting this from https://github.com/docker/cli/pull/3128, as the "e2e" docker-in-docker version needs a bit more work.

This update makes sure that Jenkins doesn't fail when trying to run on machines with cgroups v2 enabled (which docker 19.03 doesn't work on)