### PR TITLE
Makefile: allow overriding go command by environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 #
 # github.com/docker/cli
 #
+export GO ?= go
+
 all: binary
 
 
@@ -12,18 +14,18 @@ clean: ## remove build artifacts
 
 .PHONY: test-unit
 test-unit: ## run unit tests, to change the output format use: GOTESTSUM_FORMAT=(dots|short|standard-quiet|short-verbose|standard-verbose) make test-unit 
-	gotestsum $(TESTFLAGS) -- $${TESTDIRS:-$(shell go list ./... | grep -vE '/vendor/|/e2e/')}
+	gotestsum $(TESTFLAGS) -- $${TESTDIRS:-$(shell $(GO) list ./... | grep -vE '/vendor/|/e2e/')}
 
 .PHONY: test
 test: test-unit ## run tests
 
 .PHONY: test-coverage
 test-coverage: ## run test coverage
-	gotestsum -- -coverprofile=coverage.txt $(shell go list ./... | grep -vE '/vendor/|/e2e/')
+	gotestsum -- -coverprofile=coverage.txt $(shell $(GO) list ./... | grep -vE '/vendor/|/e2e/')
 
 .PHONY: fmt
 fmt:
-	go list -f {{.Dir}} ./... | xargs gofmt -w -s -d
+	$(GO) list -f {{.Dir}} ./... | xargs gofmt -w -s -d
 
 .PHONY: lint
 lint: ## run all the lint tools
@@ -81,7 +83,7 @@ help: ## print this help
 
 
 cli/compose/schema/bindata.go: cli/compose/schema/data/*.json
-	go generate github.com/docker/cli/cli/compose/schema
+	$(GO) generate github.com/docker/cli/cli/compose/schema
 
 compose-jsonschema: cli/compose/schema/bindata.go ## generate compose-file schemas
 	scripts/validate/check-git-diff cli/compose/schema/bindata.go

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -3,6 +3,7 @@ set -eu
 
 TARGET=${TARGET:-"build"}
 
+GO=${GO:-"go"}
 PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
@@ -22,10 +23,10 @@ export LDFLAGS="\
     ${LDFLAGS:-} \
 "
 
-GOOS="$(go env GOOS)"
-GOARCH="$(go env GOARCH)"
+GOOS="$($GO env GOOS)"
+GOARCH="$($GO env GOARCH)"
 if [ "${GOARCH}" = "arm" ]; then
-	GOARM="$(go env GOARM)"
+	GOARM="$($GO env GOARM)"
 fi
 
 TARGET="$TARGET/docker-${GOOS}-${GOARCH}"

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -14,9 +14,9 @@ set -eu
 . ./scripts/build/.variables
 
 if [ -z "$CGO_ENABLED" ]; then
-    case "$(go env GOOS)" in
+    case "$($GO env GOOS)" in
         linux)
-            case "$(go env GOARCH)" in
+            case "$($GO env GOARCH)" in
                 amd64|arm64|arm|s390x)
                     CGO_ENABLED=1
                 ;;
@@ -34,8 +34,8 @@ if [ -z "$CGO_ENABLED" ]; then
     esac
 fi
 export CGO_ENABLED
-if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ]; then
-    case "$(go env GOARCH)" in
+if [ "$CGO_ENABLED" = "1" ] && [ "$($GO env GOOS)" != "windows" ]; then
+    case "$($GO env GOARCH)" in
         mips*|ppc64)
             # pie build mode is not supported on mips architectures
             ;;
@@ -46,7 +46,7 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ]; then
     GO_BUILDTAGS="$GO_BUILDTAGS pkcs11"
 fi
 
-if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$(go env GOOS)" = "linux" ]; then
+if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$($GO env GOOS)" = "linux" ]; then
     LDFLAGS="$LDFLAGS -extldflags -static"
 fi
 
@@ -54,8 +54,8 @@ if [ -n "$GO_STRIP" ]; then
     LDFLAGS="$LDFLAGS -s -w"
 fi
 
-if [ "$(go env GOOS)" = "windows" ]; then
-    : "${WINDRES=$($(go env CC) --print-prog-name=windres)}"
+if [ "$($GO env GOOS)" = "windows" ]; then
+    : "${WINDRES=$($($GO env CC) --print-prog-name=windres)}"
     if [ -z "$WINDRES" ]; then
         >&2 echo "Empty WINDRES detected, skipping manifesting binary"
     else
@@ -67,7 +67,7 @@ if [ "$(go env GOOS)" = "windows" ]; then
         [ -n "$VERSION_QUAD" ] && set -- "$@" -D "DOCKER_VERSION_QUAD=$VERSION_QUAD"
         [ -n "$GITCOMMIT" ]    && set -- "$@" -D "DOCKER_COMMIT=\"$GITCOMMIT\""
 
-        target="$(dirname "$0")/../../cli/winresources/rsrc_$(go env GOARCH).syso"
+        target="$(dirname "$0")/../../cli/winresources/rsrc_$($GO env GOARCH).syso"
         mkdir -p "$(dirname "${target}")"
         "$WINDRES" -i "$(dirname "$0")/../winresources/docker.rc" -o "$target" --use-temp-file "$@"
         echo "package winresources" > "$(dirname "${target}")/stub_windows.go"
@@ -78,6 +78,6 @@ echo "Building $GO_LINKMODE $(basename "${TARGET}")"
 
 export GO111MODULE=auto
 
-go build -o "${TARGET}" -tags "${GO_BUILDTAGS}" --ldflags "${LDFLAGS}" ${GO_BUILDMODE} "${SOURCE}"
+$GO build -o "${TARGET}" -tags "${GO_BUILDTAGS}" --ldflags "${LDFLAGS}" ${GO_BUILDMODE} "${SOURCE}"
 
 ln -sf "$(basename "${TARGET}")" "$(dirname "${TARGET}")/docker"

--- a/scripts/build/plugins
+++ b/scripts/build/plugins
@@ -17,5 +17,5 @@ for p in cli-plugins/examples/* "$@" ; do
 
     echo "Building statically linked $TARGET"
     export CGO_ENABLED=0
-    go build -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
+    $GO build -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
 done

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -2,15 +2,17 @@
 # Generate man pages for docker/cli
 set -eu -o pipefail
 
+GO=${GO:-"go"}
+
 mkdir -p ./man/man1
 
 if ! command -v go-md2man &> /dev/null; then
 	# yay, go install creates a binary named "v2" ¯\_(ツ)_/¯
-	go build -o "/go/bin/go-md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
+	$GO build -o "/go/bin/go-md2man" ./vendor/github.com/cpuguy83/go-md2man/v2
 fi
 
 # Generate man pages from cobra commands
-go build -o /tmp/gen-manpages github.com/docker/cli/man
+$GO build -o /tmp/gen-manpages github.com/docker/cli/man
 /tmp/gen-manpages --root "$(pwd)" --target "$(pwd)/man/man1"
 
 # Generate legacy pages from markdown

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -2,7 +2,9 @@
 # Generate yaml for docker/cli reference docs
 set -eu -o pipefail
 
+GO=${GO:-"go"}
+
 mkdir -p docs/yaml/gen
 
-go build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
+$GO build -o build/yaml-docs-generator github.com/docker/cli/docs/yaml
 build/yaml-docs-generator --root "$(pwd)" --target "$(pwd)/docs/yaml/gen"


### PR DESCRIPTION
This is required for environments/build systems where a specific
go version / command needs to be used.

Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

