### PR TITLE
Add information on WORKDIR

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1822,6 +1822,11 @@ RUN pwd
 The output of the final `pwd` command in this `Dockerfile` would be
 `/path/$DIRNAME`
 
+If not specified, the default working directory is `/`. In practice, if you aren't building a Dockerfile from scratch (`FROM scratch`), 
+the `WORKDIR` may likely be set by the base image you're using.
+
+Therefore, to avoid unintended operations in unknown directories, it is best practice to set your `WORKDIR` explicitly.
+
 ## ARG
 
 ```dockerfile


### PR DESCRIPTION


**- What I did**
added information about default WORKDIR value
added information about base images passing down WORKDIR values
added best practice for WORKDIR

**- How I did it**
Updated README.md

**- How to verify it**
Use a base image that has WORKDIR set and see that WORKDIR in your image will automatically default to the base image's WORKDIR

**- Description for the changelog**
Add information about default WORKDIR value, inherited WORKDIR value, and best practice.

