### PR TITLE
`--until` example should use negative interval

### DIFF
--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -65,13 +65,13 @@ fraction of a second no more than nine digits long. You can combine the
 
 ### Retrieve logs until a specific point in time
 
-In order to retrieve logs before a specific point in time, run:
+In order to retrieve logs before a specific point in time in the future, run:
 
 ```bash
 $ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
 $ date
 Tue 14 Nov 2017 16:40:00 CET
-$ docker logs -f --until=2s test
+$ docker logs -f --until=-2s test
 Tue 14 Nov 2017 16:40:00 CET
 Tue 14 Nov 2017 16:40:01 CET
 Tue 14 Nov 2017 16:40:02 CET


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Followed Example featuring `--until` within logs.md and could not replicate the shown functionality, however, it does work as expected if the sign of the interval is inverted. It is also in line with the sign meaning in case of the `--since` flag.

Therefore I replaced the example to use negative interval, to match the expected behavior.

**- How I did it**

Only doc change

**- How to verify it**

Just run the example pre and post commit.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

fixed logs example using --until to correctly print future log records


**- A picture of a cute animal (not mandatory but encouraged)**

