### PR TITLE
Fix the (dead) link for docs for Dockerfile syntax reference

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -159,8 +159,8 @@ implementation. For example, BuildKit can:
 To use the BuildKit backend, you need to set an environment variable
 `DOCKER_BUILDKIT=1` on the CLI before invoking `docker build`.
 
-To learn about the experimental Dockerfile syntax available to BuildKit-based
-builds [refer to the documentation in the BuildKit repository](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md).
+To learn about the Dockerfile syntax available to BuildKit-based
+builds [refer to the documentation in the BuildKit repository](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md).
 
 ## Format
 


### PR DESCRIPTION
This change will update the docs at https://docs.docker.com/engine/reference/builder/#buildkit

https://github.com/moby/buildkit/pull/1884 requires this change on the docs.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

**- What I did**

This change a sentence with a valid URL for the link in https://docs.docker.com/engine/reference/builder/#buildkit

**- How I did it**

Follows the link

**- How to verify it**

https://github.com/moby/buildkit/pull/1884 showed us Dockerfile got GA'ed.

**- Description for the changelog**

Fix the docs for Dockerfile syntax reference

**- A picture of a cute animal (not mandatory but encouraged)**

🐱 