### PR TITLE
[20.10 backport] Deprecate Kubernetes stack support

### DIFF
--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -62,8 +62,11 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		&opts.DefaultStackOrchestrator,
 		"default-stack-orchestrator", "",
 		"Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)")
+	flags.SetAnnotation("default-stack-orchestrator", "deprecated", nil)
 	flags.StringToStringVar(&opts.Docker, "docker", nil, "set the docker endpoint")
 	flags.StringToStringVar(&opts.Kubernetes, "kubernetes", nil, "set the kubernetes endpoint")
+	flags.SetAnnotation("kubernetes", "kubernetes", nil)
+	flags.SetAnnotation("kubernetes", "deprecated", nil)
 	flags.StringVar(&opts.From, "from", "", "create context from a named context")
 	return cmd
 }

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -46,6 +46,8 @@ func newExportCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.Kubeconfig, "kubeconfig", false, "Export as a kubeconfig file")
+	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
+	flags.SetAnnotation("kubeconfig", "deprecated", nil)
 	return cmd
 }
 

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -61,8 +61,11 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		&opts.DefaultStackOrchestrator,
 		"default-stack-orchestrator", "",
 		"Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)")
+	flags.SetAnnotation("default-stack-orchestrator", "deprecated", nil)
 	flags.StringToStringVar(&opts.Docker, "docker", nil, "set the docker endpoint")
 	flags.StringToStringVar(&opts.Kubernetes, "kubernetes", nil, "set the kubernetes endpoint")
+	flags.SetAnnotation("kubernetes", "kubernetes", nil)
+	flags.SetAnnotation("kubernetes", "deprecated", nil)
 	return cmd
 }
 

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -69,7 +69,9 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.PersistentFlags()
 	flags.String("kubeconfig", "", "Kubernetes config file")
 	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
+	flags.SetAnnotation("kubeconfig", "deprecated", nil)
 	flags.String("orchestrator", "", "Orchestrator to use (swarm|kubernetes|all)")
+	flags.SetAnnotation("orchestrator", "deprecated", nil)
 	return cmd
 }
 

--- a/cli/command/stack/kubernetes/cli.go
+++ b/cli/command/stack/kubernetes/cli.go
@@ -50,6 +50,7 @@ func NewOptions(flags *flag.FlagSet, orchestrator command.Orchestrator) Options 
 func AddNamespaceFlag(flags *flag.FlagSet) {
 	flags.String("namespace", "", "Kubernetes namespace to use")
 	flags.SetAnnotation("namespace", "kubernetes", nil)
+	flags.SetAnnotation("namespace", "deprecated", nil)
 }
 
 // WrapCli wraps command.Cli with kubernetes specifics

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -30,8 +30,10 @@ func newListCommand(dockerCli command.Cli, common *commonOptions) *cobra.Command
 	flags.StringVar(&opts.Format, "format", "", "Pretty-print stacks using a Go template")
 	flags.StringSliceVar(&opts.Namespaces, "namespace", []string{}, "Kubernetes namespaces to use")
 	flags.SetAnnotation("namespace", "kubernetes", nil)
+	flags.SetAnnotation("namespace", "deprecated", nil)
 	flags.BoolVarP(&opts.AllNamespaces, "all-namespaces", "", false, "List stacks from all Kubernetes namespaces")
 	flags.SetAnnotation("all-namespaces", "kubernetes", nil)
+	flags.SetAnnotation("all-namespaces", "deprecated", nil)
 	return cmd
 }
 

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -114,6 +114,7 @@ func NewVersionCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVarP(&opts.format, "format", "f", "", "Format the output using the given Go template")
 	flags.StringVar(&opts.kubeConfig, "kubeconfig", "", "Kubernetes config file")
 	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
+	flags.SetAnnotation("kubeconfig", "deprecated", nil)
 
 	return cmd
 }

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
+Deprecated | [Kubernetes stack support](#kubernetes-stack-support)                                                                              | v20.10     | -
 Deprecated | [Pulling images from non-compliant image registries](#pulling-images-from-non-compliant-image-registries)                          | v20.10     | -
 Deprecated | [Linux containers on Windows (LCOW)](#linux-containers-on-windows-lcow-experimental)                                               | v20.10     | -
 Deprecated | [BLKIO weight options with cgroups v1](#blkio-weight-options–with-cgroups-v1)                                                      | v20.10     | -
@@ -96,6 +97,13 @@ Removed    | [Old Command Line Options](#old-command-line-options)              
 Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09
 Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13
 Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12
+
+### Kubernetes stack support
+
+**Deprecated in Release: v20.10**
+
+Following the deprecation of [Compose on Kubernetes](https://github.com/docker/compose-on-kubernetes), support for
+Kubernetes in the `stack` command in the docker CLI is now marked as deprecated as well.
 
 ### Pulling images from non-compliant image registries
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,7 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
-Deprecated | [Kubernetes stack support](#kubernetes-stack-support)                                                                              | v20.10     | -
+Deprecated | [Kubernetes stack and context support](#kubernetes-stack-and-context-support)                                                      | v20.10     | -
 Deprecated | [Pulling images from non-compliant image registries](#pulling-images-from-non-compliant-image-registries)                          | v20.10     | -
 Deprecated | [Linux containers on Windows (LCOW)](#linux-containers-on-windows-lcow-experimental)                                               | v20.10     | -
 Deprecated | [BLKIO weight options with cgroups v1](#blkio-weight-options–with-cgroups-v1)                                                      | v20.10     | -
@@ -98,12 +98,12 @@ Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-
 Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13
 Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12
 
-### Kubernetes stack support
+### Kubernetes stack and context support
 
 **Deprecated in Release: v20.10**
 
 Following the deprecation of [Compose on Kubernetes](https://github.com/docker/compose-on-kubernetes), support for
-Kubernetes in the `stack` command in the docker CLI is now marked as deprecated as well.
+Kubernetes in the `stack` and `context` commands in the docker CLI is now marked as deprecated as well.
 
 ### Pulling images from non-compliant image registries
 

--- a/docs/yaml/yaml.go
+++ b/docs/yaml/yaml.go
@@ -199,6 +199,9 @@ func genFlagResult(flags *pflag.FlagSet) []cmdOption {
 		if _, ok := flag.Annotations["experimental"]; ok {
 			opt.Experimental = true
 		}
+		if _, ok := flag.Annotations["deprecated"]; ok {
+			opt.Deprecated = true
+		}
 		if v, ok := flag.Annotations["version"]; ok {
 			opt.MinAPIVersion = v[0]
 		}


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3166 and https://github.com/docker/cli/pull/3167