### PR TITLE
[20.10 backport] docs fixes

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -175,7 +175,7 @@ equivalent docker daemon flags used for docker0 bridge:
 | `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
-| `com.docker.network.container_interface_prefix`  | -           | Set a custom prefix for container interfaces          |
+| `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to `docker daemon`.

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -470,7 +470,7 @@ $ docker run -itd --network=my-net --ip=10.10.9.75 busybox
 If you want to add a running container to a network use the `docker network connect` subcommand.
 
 You can connect multiple containers to the same network. Once connected, the
-containers can communicate easily need only another container's IP address
+containers can communicate easily using only another container's IP address
 or name. For `overlay` networks or custom plugins that support multi-host
 connectivity, containers connected to the same multi-host network but launched
 from different Engines can also communicate in this way.


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/2984 and https://github.com/docker/cli/pull/3120