### PR TITLE
docker info: skip API connection if possible

### DIFF
--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -420,3 +420,55 @@ func TestFormatInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestNeedsServerInfo(t *testing.T) {
+	tests := []struct {
+		doc      string
+		template string
+		expected bool
+	}{
+		{
+			doc:      "no template",
+			template: "",
+			expected: true,
+		},
+		{
+			doc:      "JSON",
+			template: "json",
+			expected: true,
+		},
+		{
+			doc:      "JSON (all fields)",
+			template: "{{json .}}",
+			expected: true,
+		},
+		{
+			doc:      "JSON (Server ID)",
+			template: "{{json .ID}}",
+			expected: true,
+		},
+		{
+			doc:      "ClientInfo",
+			template: "{{json .ClientInfo}}",
+			expected: false,
+		},
+		{
+			doc:      "JSON ClientInfo",
+			template: "{{json .ClientInfo}}",
+			expected: false,
+		},
+		{
+			doc:      "JSON (Active context)",
+			template: "{{json .ClientInfo.Context}}",
+			expected: false,
+		},
+	}
+
+	inf := info{ClientInfo: &clientInfo{}}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.doc, func(t *testing.T) {
+			assert.Equal(t, needsServerInfo(tc.template, inf), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
The docker info output contains both "local" and "remote" (daemon-side) information.
The API endpoint to collect daemon information (`/info`) is known to be "heavy",
and (depending on what information is needed) not needed.

This patch checks if the template (`--format`) used requires information from the
daemon, and if not, omits making an API request.

This will improve performance if (for example), the current "context" is requested
from `docker info` or if only plugin information is requested.

Before:

    time docker info --format '{{range  .ClientInfo.Plugins}}Plugin: {{.Name}}, {{end}}'
    Plugin: buildx, Plugin: compose, Plugin: scan,

    ________________________________________________________
    Executed in  301.91 millis    fish           external
       usr time  168.64 millis   82.00 micros  168.56 millis
       sys time  113.72 millis  811.00 micros  112.91 millis

    time docker info --format '{{json .ClientInfo.Plugins}}'

    time docker info --format '{{.ClientInfo.Context}}'
    default

    ________________________________________________________
    Executed in  334.38 millis    fish           external
       usr time  177.23 millis   93.00 micros  177.13 millis
       sys time  124.90 millis  927.00 micros  123.97 millis

    docker context use remote-ssh-daemon
    time docker info --format '{{.ClientInfo.Context}}'
    remote-ssh-daemon

    ________________________________________________________
    Executed in    1.22 secs   fish           external
       usr time  116.93 millis  110.00 micros  116.82 millis
       sys time  144.36 millis  887.00 micros  143.47 millis

And daemon logs:

    Jul 06 12:42:12 remote-ssh-daemon dockerd[14377]: time="2021-07-06T12:42:12.139529947Z" level=debug msg="Calling HEAD /_ping"
    Jul 06 12:42:12 remote-ssh-daemon dockerd[14377]: time="2021-07-06T12:42:12.140772052Z" level=debug msg="Calling HEAD /_ping"
    Jul 06 12:42:12 remote-ssh-daemon dockerd[14377]: time="2021-07-06T12:42:12.163832016Z" level=debug msg="Calling GET /v1.41/info"

After:

    time ./build/docker info --format '{{range  .ClientInfo.Plugins}}Plugin: {{.Name}}, {{end}}'
    Plugin: buildx, Plugin: compose, Plugin: scan,

    ________________________________________________________
    Executed in  139.84 millis    fish           external
       usr time   76.53 millis   62.00 micros   76.46 millis
       sys time   69.25 millis  723.00 micros   68.53 millis

    time ./build/docker info --format '{{.ClientInfo.Context}}'
    default

    ________________________________________________________
    Executed in  136.94 millis    fish           external
       usr time   74.61 millis   74.00 micros   74.54 millis
       sys time   65.77 millis  858.00 micros   64.91 millis

    docker context use remote-ssh-daemon
    time ./build/docker info --format '{{.ClientInfo.Context}}'
    remote-ssh-daemon

    ________________________________________________________
    Executed in    1.02 secs   fish           external
       usr time   74.25 millis   76.00 micros   74.17 millis
       sys time   65.09 millis  643.00 micros   64.44 millis

And daemon logs:

    Jul 06 12:42:55 remote-ssh-daemon dockerd[14377]: time="2021-07-06T12:42:55.313654687Z" level=debug msg="Calling HEAD /_ping"
    Jul 06 12:42:55 remote-ssh-daemon dockerd[14377]: time="2021-07-06T12:42:55.314811624Z" level=debug msg="Calling HEAD /_ping"



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
Improve performance of `docker info` if a custom `--format` is used that only uses local information. Previously, the `docker info` command would unconditionally make an API call to request daemon system information. With this change, the CLI only uses the daemon API if it detects that information from the daemon is needed.
```


**- A picture of a cute animal (not mandatory but encouraged)**

