### PR TITLE
Bump go 1.16.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.16.6
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
-FROM --platform=$BUILDPLATFORM golang:1.16-${BASE_VARIANT} AS golatest	
+FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS golatest
 
-FROM gostable AS go-linux	
-FROM golatest AS go-darwin
-FROM golatest AS go-windows-amd64
-FROM golatest AS go-windows-386
-FROM golatest AS go-windows-arm
-FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS go-windows-arm64
+FROM gostable AS go-linux
+FROM gostable AS go-darwin
+FROM gostable AS go-windows-amd64
+FROM gostable AS go-windows-386
+FROM gostable AS go-windows-arm
+FROM golatest AS go-windows-arm64
 FROM go-windows-${TARGETARCH} AS go-windows
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:620d36a9d7f1e3b102a5c7e8eff12081ac363828b3a44390f24fa8da2d49383d AS xx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.13.15
+  GOVERSION: 1.16.6
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.16.6
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.16.6
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0
@@ -10,21 +10,21 @@ ARG ESC_VERSION=v0.2.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \
-    GO111MODULE=on go get github.com/mjibson/esc@${ESC_VERSION}
+    GO111MODULE=on go install github.com/mjibson/esc@${ESC_VERSION}
 
 FROM golang AS gotestsum
 ARG GOTESTSUM_VERSION=v0.4.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \
-    GO111MODULE=on go get gotest.tools/gotestsum@${GOTESTSUM_VERSION}
+    GO111MODULE=on go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
 FROM golang AS vndr
 ARG VNDR_VERSION=v0.1.2
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \
-    GO111MODULE=on go get github.com/LK4D4/vndr@${VNDR_VERSION}
+    GO111MODULE=on go install github.com/LK4D4/vndr@${VNDR_VERSION}
 
 FROM golang AS dev
 RUN  apk add --no-cache \
@@ -44,4 +44,5 @@ COPY --from=vndr      /go/bin/* /go/bin/
 COPY --from=gotestsum /go/bin/* /go/bin/
 
 WORKDIR /go/src/github.com/docker/cli
+ENV GO111MODULE=auto
 COPY . .

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.16.6
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.13.15
+ARG GO_VERSION=1.16.6
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build
@@ -13,6 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
         go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINTER_SHA}
 
 FROM    golang:${GO_VERSION}-alpine AS lint
+ENV     GO111MODULE=off
 ENV     CGO_ENABLED=0
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
 COPY --from=build /go/bin/golangci-lint /usr/local/bin

--- a/scripts/build/plugins
+++ b/scripts/build/plugins
@@ -17,5 +17,5 @@ for p in cli-plugins/examples/* "$@" ; do
 
     echo "Building statically linked $TARGET"
     export CGO_ENABLED=0
-    go build -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
+    GO111MODULE=auto go build -o "${TARGET}" --ldflags "${LDFLAGS}" "github.com/docker/cli/${p}"
 done

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -71,6 +71,7 @@ runtests() {
         PATH="$PWD/build/:/usr/bin:/usr/local/bin:/usr/local/go/bin" \
         HOME="$HOME" \
         DOCKER_CLI_E2E_PLUGINS_EXTRA_DIRS="$PWD/build/plugins-linux-amd64" \
+        GO111MODULE=auto \
         "$(command -v gotestsum)" -- ${TESTDIRS:-./e2e/...} ${TESTFLAGS-}
 }
 


### PR DESCRIPTION
Keeping the dockerfiles/Dockerfile.cross image at 1.13, as we don't
have more current versions of that image. However, I don't think it's
still used, so we should remove it.
