### PR TITLE
[20.10 backport] Update Dockerfiles to latest syntax, remove "experimental"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-#syntax=docker/dockerfile:1.2
+# syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.13.15

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,5 @@
-# syntax=docker/dockerfile:1.1.7-experimental
+# syntax=docker/dockerfile:1.3
+
 ARG GO_VERSION=1.13.15
 
 FROM golang:${GO_VERSION}-alpine AS golang

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1.3-experimental
+# syntax=docker/dockerfile:1.3
 
 ARG GO_VERSION=1.13.15
 ARG GOLANGCI_LINTER_SHA="v1.21.0"


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3204

The experimental image is deprecated (now "labs"), and the features we use
are now included in the regular (stable) syntax.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

