### PR TITLE
GitHub Actions for lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,41 +2,6 @@ version: 2
 
 jobs:
 
-  lint:
-    working_directory: /work
-    docker: [{image: 'docker:20.10-git'}]
-    environment:
-      DOCKER_BUILDKIT: 1
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.6
-          reusable: true
-          exclusive: false
-      - run:
-          name: "Docker version"
-          command: docker version
-      - run:
-          name: "Docker info"
-          command: docker info
-      - run:
-          name: "Shellcheck - build image"
-          command: |
-            docker build --progress=plain -f dockerfiles/Dockerfile.shellcheck --tag cli-validator:$CIRCLE_BUILD_NUM .
-      - run:
-          name: "Shellcheck"
-          command: |
-            docker run --rm cli-validator:$CIRCLE_BUILD_NUM \
-                make shellcheck
-      - run:
-          name: "Lint - build image"
-          command: |
-            docker build --progress=plain -f dockerfiles/Dockerfile.lint --tag cli-linter:$CIRCLE_BUILD_NUM .
-      - run:
-          name: "Lint"
-          command: |
-            docker run --rm cli-linter:$CIRCLE_BUILD_NUM
-
   cross:
     working_directory: /work
     docker: [{image: 'docker:20.10-git'}]
@@ -147,7 +112,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - lint
       - cross
       - test
       - validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: validate
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]{2}'
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - lint
+          - shellcheck
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Run
+        uses: docker/bake-action@v1
+        with:
+          targets: ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,6 @@ test-coverage: ## run test coverage
 fmt:
 	go list -f {{.Dir}} ./... | xargs gofmt -w -s -d
 
-.PHONY: lint
-lint: ## run all the lint tools
-	gometalinter --config gometalinter.json ./...
-
 .PHONY: binary
 binary:
 	docker buildx bake binary
@@ -70,10 +66,6 @@ manpages: ## generate man pages from go source and markdown
 .PHONY: yamldocs
 yamldocs: ## generate documentation YAML files consumed by docs repo
 	scripts/docs/generate-yaml.sh
-
-.PHONY: shellcheck
-shellcheck: ## run shellcheck validation
-	scripts/validate/shellcheck
 
 .PHONY: help
 help: ## print this help

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,3 +61,15 @@ target "cross" {
 target "dynbinary-cross" {
     inherits = ["dynbinary", "_all_platforms"]
 }
+
+target "lint" {
+    dockerfile = "./dockerfiles/Dockerfile.lint"
+    target = "lint"
+    output = ["type=cacheonly"]
+}
+
+target "shellcheck" {
+    dockerfile = "./dockerfiles/Dockerfile.shellcheck"
+    target = "shellcheck"
+    output = ["type=cacheonly"]
+}

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,24 +1,16 @@
 # syntax=docker/dockerfile:1.3
 
 ARG GO_VERSION=1.16.6
-ARG GOLANGCI_LINTER_SHA="v1.21.0"
+ARG GOLANGCI_LINT_VERSION=v1.23.8
 
-FROM    golang:${GO_VERSION}-alpine AS build
-ENV     CGO_ENABLED=0
-RUN     apk add --no-cache git
-ARG     GOLANGCI_LINTER_SHA
-ARG     GO111MODULE=on
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-        go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINTER_SHA}
+FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 
-FROM    golang:${GO_VERSION}-alpine AS lint
-ENV     GO111MODULE=off
-ENV     CGO_ENABLED=0
-ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-COPY --from=build /go/bin/golangci-lint /usr/local/bin
+FROM golang:${GO_VERSION}-alpine AS lint
+ENV GO111MODULE=off
+ENV CGO_ENABLED=0
+ENV GOGC=75
 WORKDIR /go/src/github.com/docker/cli
-ENV     GOGC=75
-ENTRYPOINT ["/usr/local/bin/golangci-lint"]
-CMD     ["run", "--config=.golangci.yml"]
-COPY    . .
+COPY --from=golangci-lint /usr/bin/golangci-lint /usr/bin/golangci-lint
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/root/.cache \
+        golangci-lint run

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,5 +1,7 @@
-FROM    koalaman/shellcheck-alpine:v0.7.1
-RUN     apk add --no-cache bash make
+# syntax=docker/dockerfile:1.3
+
+FROM koalaman/shellcheck-alpine:v0.7.1 AS shellcheck
 WORKDIR /go/src/github.com/docker/cli
-ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-COPY    . .
+RUN --mount=type=bind,target=. \
+  set -eo pipefail; \
+  find scripts/ contrib/completion/bash -type f | grep -v scripts/winresources | grep -v '.*.ps1' | xargs shellcheck

--- a/scripts/validate/shellcheck
+++ b/scripts/validate/shellcheck
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -eo pipefail
-
-shellcheck contrib/completion/bash/docker
-find scripts/ -type f | grep -v scripts/winresources | grep -v '.*.ps1' | xargs shellcheck


### PR DESCRIPTION
First step to switch from CircleCI to GitHub Actions for lint.

`shellcheck` and `lint` Dockerfiles have also been simplified and don't need to be built and run.

Have also added new bake targets for that:

* `docker buildx bake lint` or `make -f docker.Makefile lint`
* `docker buildx bake shellcheck` or `make -f docker.Makefile shellcheck`

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>