### PR TITLE
cli/context: ignore linting warnings about RFC 1423 encryption

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -66,8 +66,9 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 		}
 
 		var err error
-		if x509.IsEncryptedPEMBlock(pemBlock) {
-			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword))
+		// TODO should we follow Golang, and deprecate RFC 1423 encryption, and produce a warning (or just error)? see https://github.com/docker/cli/issues/3212
+		if x509.IsEncryptedPEMBlock(pemBlock) { //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
+			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword)) //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
 			if err != nil {
 				return nil, errors.Wrap(err, "private key is encrypted, but could not decrypt it")
 			}


### PR DESCRIPTION
relates to https://github.com/docker/cli/issues/3212

From https://go-review.googlesource.com/c/go/+/264159

> It's unfortunate that we don't implement PKCS#8 encryption so we can't
> recommend an alternative but PEM encryption is so broken that it's worth
> deprecating outright.

When linting on Go 1.16:

    cli/context/docker/load.go:69:6: SA1019: x509.IsEncryptedPEMBlock is deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design. Since it does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.  (staticcheck)
            if x509.IsEncryptedPEMBlock(pemBlock) {
               ^
    cli/context/docker/load.go:70:20: SA1019: x509.DecryptPEMBlock is deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design. Since it does not authenticate the ciphertext, it is vulnerable to padding oracle attacks that can let an attacker recover the plaintext.  (staticcheck)
                keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword))
                                ^


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

