### PR TITLE
fix containerd-plugins-namespace typos

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1375,7 +1375,7 @@ This is a full example of the allowed configuration options on Linux:
   "cluster-store-opts": {},
   "containerd": "/run/containerd/containerd.sock",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-address-pools": [
@@ -1502,7 +1502,7 @@ This is a full example of the allowed configuration options on Windows:
   "cluster-store": "",
   "containerd": "\\\\.\\pipe\\containerd-containerd",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-ulimits": {},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** add 's' to 'containerd-plugin-namespace' cli arg

**- How I did it** add 's' to the document

**- How to verify it** attempt to start docker engine service. verify that it does not fail because of 'container-plugin-namespace'

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix cli arg typo


**- A picture of a cute animal (not mandatory but encouraged)**

