### PR TITLE
[20.10 backport] context: deprecate support for encrypted TLS private keys

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -255,7 +255,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		if tlsconfig.IsErrEncryptedKey(err) {
 			passRetriever := passphrase.PromptRetrieverWithInOut(cli.In(), cli.Out(), nil)
 			newClient := func(password string) (client.APIClient, error) {
-				cli.dockerEndpoint.TLSPassword = password
+				cli.dockerEndpoint.TLSPassword = password //nolint: staticcheck // SA1019: cli.dockerEndpoint.TLSPassword is deprecated
 				return newAPIClientFromEndpoint(cli.dockerEndpoint, cli.configFile)
 			}
 			cli.client, err = getClientWithPassword(passRetriever, newClient)

--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -66,8 +66,9 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 		}
 
 		var err error
-		if x509.IsEncryptedPEMBlock(pemBlock) {
-			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword))
+		// TODO should we follow Golang, and deprecate RFC 1423 encryption, and produce a warning (or just error)? see https://github.com/docker/cli/issues/3212
+		if x509.IsEncryptedPEMBlock(pemBlock) { //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
+			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword)) //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
 			if err != nil {
 				return nil, errors.Wrap(err, "private key is encrypted, but could not decrypt it")
 			}

--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -26,7 +26,12 @@ type EndpointMeta = context.EndpointMetaBase
 // a Docker Engine endpoint, with its tls data
 type Endpoint struct {
 	EndpointMeta
-	TLSData     *context.TLSData
+	TLSData *context.TLSData
+
+	// Deprecated: Use of encrypted TLS private keys has been deprecated, and
+	// will be removed in a future release. Golang has deprecated support for
+	// legacy PEM encryption (as specified in RFC 1423), as it is insecure by
+	// design (see https://go-review.googlesource.com/c/go/+/264159).
 	TLSPassword string
 }
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
+Deprecated | [Support for encrypted TLS private keys](#support-for-encrypted-tls-private-keys)                                                  | v20.10     | -
 Deprecated | [Kubernetes stack and context support](#kubernetes-stack-and-context-support)                                                      | v20.10     | -
 Deprecated | [Pulling images from non-compliant image registries](#pulling-images-from-non-compliant-image-registries)                          | v20.10     | -
 Deprecated | [Linux containers on Windows (LCOW)](#linux-containers-on-windows-lcow-experimental)                                               | v20.10     | -
@@ -97,6 +98,15 @@ Removed    | [Old Command Line Options](#old-command-line-options)              
 Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09
 Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13
 Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12
+
+### Support for encrypted TLS private keys
+
+**Deprecated in Release: v20.10**
+
+Use of encrypted TLS private keys has been deprecated, and will be removed in a
+future release. Golang has deprecated support for legacy PEM encryption (as
+specified in [RFC 1423](https://datatracker.ietf.org/doc/html/rfc1423)), as it
+is insecure by design (see [https://go-review.googlesource.com/c/go/+/264159](https://go-review.googlesource.com/c/go/+/264159)).
 
 ### Kubernetes stack and context support
 


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3218 and https://github.com/docker/cli/pull/3213

relates to https://github.com/docker/cli/issues/3212


> Legacy PEM encryption as specified in RFC 1423 is insecure by design. Since
> it does not authenticate the ciphertext, it is vulnerable to padding oracle
> attacks that can let an attacker recover the plaintext

From https://go-review.googlesource.com/c/go/+/264159

> It's unfortunate that we don't implement PKCS#8 encryption so we can't
> recommend an alternative but PEM encryption is so broken that it's worth
> deprecating outright.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

