### PR TITLE
Remove support for encrypted TLS private keys

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -67,17 +66,10 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 		keyBytes := c.TLSData.Key
 		pemBlock, _ := pem.Decode(keyBytes)
 		if pemBlock == nil {
-			return nil, fmt.Errorf("no valid private key found")
+			return nil, errors.New("no valid private key found")
 		}
-
-		var err error
-		// TODO should we follow Golang, and deprecate RFC 1423 encryption, and produce a warning (or just error)? see https://github.com/docker/cli/issues/3212
 		if x509.IsEncryptedPEMBlock(pemBlock) { //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
-			keyBytes, err = x509.DecryptPEMBlock(pemBlock, []byte(c.TLSPassword)) //nolint: staticcheck // SA1019: x509.IsEncryptedPEMBlock is deprecated, and insecure by design
-			if err != nil {
-				return nil, errors.Wrap(err, "private key is encrypted, but could not decrypt it")
-			}
-			keyBytes = pem.EncodeToMemory(&pem.Block{Type: pemBlock.Type, Bytes: keyBytes})
+			return nil, errors.New("private key is encrypted - support for encrypted private keys has been removed, see https://docs.docker.com/go/deprecated/")
 		}
 
 		x509cert, err := tls.X509KeyPair(c.TLSData.Cert, keyBytes)

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,7 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 Status     | Feature                                                                                                                            | Deprecated | Remove
 -----------|------------------------------------------------------------------------------------------------------------------------------------|------------|------------
-Deprecated | [Support for encrypted TLS private keys](#support-for-encrypted-tls-private-keys)                                                  | v20.10     | -
+Removed    | [Support for encrypted TLS private keys](#support-for-encrypted-tls-private-keys)                                                  | v20.10     | v21.xx
 Deprecated | [Kubernetes stack and context support](#kubernetes-stack-and-context-support)                                                      | v20.10     | -
 Deprecated | [Pulling images from non-compliant image registries](#pulling-images-from-non-compliant-image-registries)                          | v20.10     | -
 Removed    | [Linux containers on Windows (LCOW)](#linux-containers-on-windows-lcow-experimental)                                               | v20.10     | v21.xx
@@ -103,10 +103,17 @@ Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-
 
 **Deprecated in Release: v20.10**
 
-Use of encrypted TLS private keys has been deprecated, and will be removed in a
-future release. Golang has deprecated support for legacy PEM encryption (as
-specified in [RFC 1423](https://datatracker.ietf.org/doc/html/rfc1423)), as it
-is insecure by design (see [https://go-review.googlesource.com/c/go/+/264159](https://go-review.googlesource.com/c/go/+/264159)).
+**Removed in Release: v21.xx**
+
+Use of encrypted TLS private keys has been deprecated, and has been removed.
+Golang has deprecated support for legacy PEM encryption (as specified in
+[RFC 1423](https://datatracker.ietf.org/doc/html/rfc1423)), as it is insecure by
+design (see [https://go-review.googlesource.com/c/go/+/264159](https://go-review.googlesource.com/c/go/+/264159)).
+
+This feature allowed using an encrypted private key with a supplied password,
+but did not provide additional security as the encryption is known to be broken,
+and the key is sitting next to the password in the filesystem. Users are recommended
+to decrypt the private key, and store it un-encrypted to continue using it.
 
 ### Kubernetes stack and context support
 


### PR DESCRIPTION
relates to https://github.com/docker/cli/issues/3212
follow-up to https://github.com/docker/cli/pull/3218

> Legacy PEM encryption as specified in RFC 1423 is insecure by design. Since
> it does not authenticate the ciphertext, it is vulnerable to padding oracle
> attacks that can let an attacker recover the plaintext

From https://go-review.googlesource.com/c/go/+/264159

> It's unfortunate that we don't implement PKCS#8 encryption so we can't
> recommend an alternative but PEM encryption is so broken that it's worth
> deprecating outright.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

