### PR TITLE
support for docker container prune --dry-run

### DIFF
--- a/vendor/github.com/docker/docker/client/container_prune.go
+++ b/vendor/github.com/docker/docker/client/container_prune.go
@@ -10,18 +10,21 @@ import (
 )
 
 // ContainersPrune requests the daemon to delete unused data
-func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
+func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args, dryRun bool) (types.ContainersPruneReport, error) {
 	var report types.ContainersPruneReport
 
 	if err := cli.NewVersionError("1.25", "container prune"); err != nil {
 		return report, err
 	}
 
-	query, err := getFiltersQuery(pruneFilters)
+	filtersQuery, err := getFiltersQuery(pruneFilters)
 	if err != nil {
 		return report, err
 	}
-
+	query, err := setPruneConfigQuery(dryRun, filtersQuery)
+	if err != nil {
+		return report, err
+	}
 	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -77,7 +77,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string, condition containertypes.WaitCondition) (<-chan containertypes.ContainerWaitOKBody, <-chan error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
+	ContainersPrune(ctx context.Context, pruneFilters filters.Args, dryRun bool) (types.ContainersPruneReport, error)
 }
 
 // DistributionAPIClient defines API client methods for the registry

--- a/vendor/github.com/docker/docker/client/utils.go
+++ b/vendor/github.com/docker/docker/client/utils.go
@@ -32,3 +32,12 @@ func getFiltersQuery(f filters.Args) (url.Values, error) {
 	}
 	return query, nil
 }
+
+// getFiltersQuery returns a url query with "filters" query term, based on the
+// filters provided.
+func setPruneConfigQuery(dryRun bool, query url.Values) (url.Values, error) {
+	if dryRun {
+		query.Set("dryRun", "true")
+	}
+	return query, nil
+}


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added support for docker container prune --dry-run. This feature currently works only for containers
The following commands work:
`docker container prune --dry-run`
`docker system prune --dry-run`

**- How I did it**
1. Added command for containers dry run prune
2. Added command at system level to enable dry run prune only for containers
3. Added comments

**- How to verify it**
I will need to add tests for this yet.

**- Description for the changelog**
[moby engine PR](https://github.com/moby/moby/pull/41449)
[Moby issue](https://github.com/moby/moby/issues/30623)


**- A picture of a cute animal (not mandatory but encouraged) look closely**
![dog-camo](https://user-images.githubusercontent.com/6545467/127583651-e376f753-5a68-4218-95cc-ed56374ce905.jpeg)



