### PR TITLE
GitHub Actions cross

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,36 +2,6 @@ version: 2
 
 jobs:
 
-  cross:
-    working_directory: /work
-    docker: [{image: 'docker:20.10-git'}]
-    environment:
-      DOCKER_BUILDKIT: 1
-      BUILDX_VERSION: "v0.6.0"
-    parallelism: 3
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.6
-          reusable: true
-          exclusive: false
-      - run:
-          name: "Docker version"
-          command: docker version
-      - run:
-          name: "Docker info"
-          command: docker info
-      - run: apk add make curl
-      - run: mkdir -vp ~/.docker/cli-plugins/
-      - run: curl -fsSL --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-amd64
-      - run: chmod a+x ~/.docker/cli-plugins/docker-buildx
-      - run: docker buildx version
-      - run: docker context create buildctx
-      - run: docker buildx create --use buildctx && docker buildx inspect --bootstrap
-      - run: GROUP_INDEX=$CIRCLE_NODE_INDEX GROUP_TOTAL=$CIRCLE_NODE_TOTAL docker buildx bake cross --progress=plain
-      - store_artifacts:
-          path: /work/build
-
   test:
     working_directory: /work
     docker: [{image: 'docker:20.10-git'}]
@@ -112,6 +82,5 @@ workflows:
   version: 2
   ci:
     jobs:
-      - cross
       - test
       - validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: build
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+      - '[0-9]+.[0-9]{2}'
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - cross
+          - dynbinary-cross
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Run ${{ matrix.target }}
+        uses: docker/bake-action@v1
+        with:
+          targets: ${{ matrix.target }}
+      -
+        name: Flatten artifacts
+        working-directory: ./build
+        run: |
+          for dir in */; do
+            base=$(basename "$dir")
+            echo "Creating ${base}.tar.gz ..."
+            tar -cvzf "${base}.tar.gz" "$dir"
+            rm -rf "$dir"
+          done
+      -
+        name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}
+          path: ./build/*
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -1,64 +1,67 @@
-[![build status](https://circleci.com/gh/docker/cli.svg?style=shield)](https://circleci.com/gh/docker/cli/tree/master)
-[![Build Status](https://ci.docker.com/public/job/cli/job/master/badge/icon)](https://ci.docker.com/public/job/cli/job/master)
+# Docker CLI
 
-docker/cli
-==========
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/docker/cli)
+[![Build Status](https://img.shields.io/github/workflow/status/docker/cli/build?logo=github)](https://github.com/docker/cli/actions?query=workflow%3Abuild)
+[![CircleCI Status](https://img.shields.io/circleci/build/github/docker/cli/master?logo=circleci)](https://circleci.com/gh/docker/cli/tree/master)
+[![Jenkins Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.docker.com%2Fpublic%2Fjob%2Fcli%2Fjob%2Fmaster&logo=jenkins)](https://ci.docker.com/public/job/cli/job/master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/docker/cli)](https://goreportcard.com/report/github.com/docker/cli)
+[![Codecov](https://codecov.io/gh/docker/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/docker/cli)
+
+## About
 
 This repository is the home of the cli used in the Docker CE and
 Docker EE products.
 
-Development
-===========
+## Development
 
 `docker/cli` is developed using Docker.
 
 Build CLI from source:
 
-```
-$ docker buildx bake
+```shell
+docker buildx bake
 ```
 
 Build binaries for all supported platforms:
 
-```
-$ docker buildx bake cross
+```shell
+docker buildx bake cross
 ```
 
 Build for a specific platform:
 
-```
-$ docker buildx bake --set binary.platform=linux/arm64 
+```shell
+docker buildx bake --set binary.platform=linux/arm64 
 ```
 
 Build dynamic binary for glibc or musl:
 
+```shell
+USE_GLIBC=1 docker buildx bake dynbinary 
 ```
-$ USE_GLIBC=1 docker buildx bake dynbinary 
-```
-
 
 Run all linting:
 
-```
-$ make -f docker.Makefile lint
+```shell
+docker buildx bake lint shellcheck
 ```
 
 List all the available targets:
 
-```
-$ make help
+```shell
+make help
 ```
 
 ### In-container development environment
 
 Start an interactive development environment:
 
-```
-$ make -f docker.Makefile shell
+```shell
+make -f docker.Makefile shell
 ```
 
-Legal
-=====
+## Legal
+
 *Brought to you courtesy of our legal counsel. For more context,
 please see the [NOTICE](https://github.com/docker/cli/blob/master/NOTICE) document in this repo.*
 
@@ -70,8 +73,8 @@ violate applicable laws.
 
 For more information, please see https://www.bis.doc.gov
 
-Licensing
-=========
+## Licensing
+
 docker/cli is licensed under the Apache License, Version 2.0. See
 [LICENSE](https://github.com/docker/docker/blob/master/LICENSE) for the full
 license text.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -32,34 +32,16 @@ target "dynbinary" {
     }
 }
 
-variable "GROUP_TOTAL" {
-    default = "1"
-}
-
-variable "GROUP_INDEX" {
-    default = "0"
-}
-
-function "platforms" {
-    params = [USE_GLIBC]
-    result = concat(["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm", "windows/386"], USE_GLIBC!=""?[]:["windows/arm64"])
-}
-
-function "glen" {
-    params = [platforms, GROUP_TOTAL]
-    result = ceil(length(platforms)/GROUP_TOTAL)
-}
-
-target "_all_platforms" {
-    platforms = slice(platforms(USE_GLIBC), GROUP_INDEX*glen(platforms(USE_GLIBC), GROUP_TOTAL),min(length(platforms(USE_GLIBC)), (GROUP_INDEX+1)*glen(platforms(USE_GLIBC), GROUP_TOTAL)))
+target "platforms" {
+    platforms = concat(["linux/amd64", "linux/386", "linux/arm64", "linux/arm", "linux/ppc64le", "linux/s390x", "darwin/amd64", "darwin/arm64", "windows/amd64", "windows/arm", "windows/386"], USE_GLIBC!=""?[]:["windows/arm64"])
 }
 
 target "cross" {
-    inherits = ["binary", "_all_platforms"]
+    inherits = ["binary", "platforms"]
 }
 
 target "dynbinary-cross" {
-    inherits = ["dynbinary", "_all_platforms"]
+    inherits = ["dynbinary", "platforms"]
 }
 
 target "lint" {

--- a/dockerfiles/Dockerfile.cross
+++ b/dockerfiles/Dockerfile.cross
@@ -1,6 +1,0 @@
-ARG GO_VERSION=1.13.15
-
-FROM	dockercore/golang-cross:${GO_VERSION}
-ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1
-WORKDIR /go/src/github.com/docker/cli
-COPY    . .


### PR DESCRIPTION
* Switch To GitHub Actions for cross target
  * also store artifacts temporarly (90d by default in repo settings) in the workflow (can remove that if you want)
  * and build dynbinary cross
  * ~use GitHub Action cache backend~
* Cleanup bake definition that was specific to CircleCI
* Restore `binary` target in `Makefile` for non-sandboxed build
* Fix README with proper lint command using bake

Run: https://github.com/docker/cli/actions/runs/1103549570

![image](https://user-images.githubusercontent.com/1951866/128445130-b9e8d6e7-3bcd-4964-aef4-1d33c8652007.png)

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>