### PR TITLE
create/run: remove default --stop-signal

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
-	"github.com/moby/sys/signal"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -183,7 +182,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.Var(&copts.labelsFile, "label-file", "Read in a line delimited file of labels")
 	flags.BoolVar(&copts.readonlyRootfs, "read-only", false, "Mount the container's root filesystem as read only")
 	flags.StringVar(&copts.restartPolicy, "restart", "no", "Restart policy to apply when a container exits")
-	flags.StringVar(&copts.stopSignal, "stop-signal", signal.DefaultStopSignal, "Signal to stop a container")
+	flags.StringVar(&copts.stopSignal, "stop-signal", "", "Signal to stop the container")
 	flags.IntVar(&copts.stopTimeout, "stop-timeout", 0, "Timeout (in seconds) to stop a container")
 	flags.SetAnnotation("stop-timeout", "version", []string{"1.25"})
 	flags.Var(copts.sysctls, "sysctl", "Sysctl options")
@@ -599,10 +598,8 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		Entrypoint:      entrypoint,
 		WorkingDir:      copts.workingDir,
 		Labels:          opts.ConvertKVStringsToMap(labels),
+		StopSignal:      copts.stopSignal,
 		Healthcheck:     healthConfig,
-	}
-	if flags.Changed("stop-signal") {
-		config.StopSignal = copts.stopSignal
 	}
 	if flags.Changed("stop-timeout") {
 		config.StopTimeout = &copts.stopTimeout

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -108,7 +108,7 @@ Options:
                                       The format is `<number><unit>`. `number` must be greater than `0`.
                                       Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                       or `g` (gigabytes). If you omit the unit, the system uses bytes.
-      --stop-signal string            Signal to stop a container (default "SIGTERM")
+      --stop-signal string            Signal to stop the container
       --stop-timeout int              Timeout (in seconds) to stop a container
       --storage-opt value             Storage driver options for the container (default [])
       --sysctl value                  Sysctl options (default map[])

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -23,10 +23,10 @@ inside the container is sent `SIGKILL` signal (default), or the signal that is
 specified with the `--signal` option. You can reference a container by its
 ID, ID-prefix, or name.
 
-The `--signal` (or `-s` shorthand) flag sets the system call signal that is sent
-to the container. This signal can be a signal name in the format `SIG<NAME>`, for
-instance `SIGINT`, or an unsigned number that matches a position in the kernel's
-syscall table, for instance `2`.
+The `--signal` flag sets the system call signal that is sent to the container.
+This signal can be a signal name in the format `SIG<NAME>`, for instance `SIGINT`,
+or an unsigned number that matches a position in the kernel's syscall table,
+for instance `2`.
 
 While the default (`SIGKILL`) signal will terminate the container, the signal
 set through `--signal` may be non-terminal, depending on the container's main

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -119,7 +119,7 @@ Options:
                                       Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                       or `g` (gigabytes). If you omit the unit, the system uses bytes.
       --sig-proxy                     Proxy received signals to the process (default true)
-      --stop-signal string            Signal to stop a container (default "SIGTERM")
+      --stop-signal string            Signal to stop the container
       --stop-timeout int              Timeout (in seconds) to stop a container
       --storage-opt value             Storage driver options for the container (default [])
       --sysctl value                  Sysctl options (default map[])
@@ -752,7 +752,8 @@ container to exit. This signal can be a signal name in the format `SIG<NAME>`,
 for instance `SIGKILL`, or an unsigned number that matches a position in the
 kernel's syscall table, for instance `9`.
 
-The default is `SIGTERM` if not specified.
+The default is defined by [`STOPSIGNAL`](https://docs.docker.com/engine/reference/builder/#stopsignal)
+in the image, or `SIGTERM` if the image has no `STOPSIGNAL` defined.
 
 ### Optional security options (--security-opt)
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -621,13 +621,16 @@ incompatible with any restart policy other than `none`.
    For the `overlay2` storage driver, the size option is only available if the backing fs is `xfs` and mounted with the `pquota` mount option.
    Under these conditions, user can pass any size less than the backing fs size.
 
-**--stop-signal**=*SIGTERM*
-   Signal to stop the container. Default is SIGTERM.
+**--stop-signal**=""
+   Signal to stop the container.
 
    The `--stop-signal` flag sets the system call signal that will be sent to the
    container to exit. This signal can be a signal name in the format `SIG<NAME>`,
    for instance `SIGKILL`, or an unsigned number that matches a position in the
    kernel's syscall table, for instance `9`.
+
+   The default is defined by `STOPSIGNAL` in the image, or `SIGTERM` if the image
+   has no `STOPSIGNAL` defined.
 
 **--stop-timeout**
   Timeout (in seconds) to stop a container, or **-1** to disable timeout.


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/42717

The DefaultStopSignal const has been deprecated, because the daemon already
handles a default value. The current code did not actually send the default
value unless the flag was set, which also made the flag description incorrect,
because in that case, the _daemon's_ default would be used, which could
potentially be different as was specified here.

This patch removes the default value from the flag, leaving it to the daemon
to set a default.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
Remove default value from `--stop-signal` flag, as it may not reflect the actual default used by the daemon.
```


**- A picture of a cute animal (not mandatory but encouraged)**

