### PR TITLE
Add top-level --completion flag, and integrate completion for plugins

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5486,11 +5486,8 @@ _docker_wait() {
 	_docker_container_wait
 }
 
-COMPOSE_PLUGIN_PATH=$(docker info --format '{{json .ClientInfo.Plugins}}' | sed -n 's/.*"Path":"\([^"]\+docker-compose\)".*/\1/p')
-
-_docker_compose() {
-	local completionCommand="__completeNoDesc"
-	local resultArray=($COMPOSE_PLUGIN_PATH $completionCommand compose)
+__completeNoDesc() {
+	local resultArray=(docker __completeNoDesc $1)
 	for value in "${words[@]:2}"; do
 		if [ -z "$value" ]; then
 			resultArray+=( "''" )
@@ -5501,6 +5498,18 @@ _docker_compose() {
 	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
 
 	COMPREPLY=( $(compgen -W "${result}" -- "$current") )
+}
+
+_docker_buildx() {
+	__completeNoDesc buildx
+}
+
+_docker_compose() {
+	__completeNoDesc compose
+}
+
+_docker_scan() {
+	__completeNoDesc scan
 }
 
 _docker() {
@@ -5572,11 +5581,8 @@ _docker() {
 		wait
 	)
 
-	local known_plugin_commands=()
-
-	if [ -f "$COMPOSE_PLUGIN_PATH" ] ; then
-		known_plugin_commands+=("compose")
-	fi
+	PLUGINS_INSTALLED=$(docker info --format '{{range .ClientInfo.Plugins}}{{ .Name }} {{end}}')
+	local known_plugin_commands=($PLUGINS_INSTALLED)
 
 	local experimental_server_commands=(
 		checkpoint

--- a/contrib/completion/completion.go
+++ b/contrib/completion/completion.go
@@ -1,0 +1,32 @@
+package completion
+
+import (
+	_ "embed" // needed to make embed work
+	"errors"
+)
+
+var (
+	//go:embed bash/docker
+	completionBash string
+
+	//go:embed fish/docker.fish
+	completionFish string
+
+	//go:embed zsh/_docker
+	completionZsh string
+
+	completions = map[string]string{
+		"bash": completionBash,
+		"fish": completionFish,
+		"zsh":  completionZsh,
+	}
+)
+
+// Get returns the completion script for the given shell (bash, fish, or zsh).
+func Get(shell string) (string, error) {
+	cs, ok := completions[shell]
+	if !ok {
+		return "", errors.New("no completion available for: " + shell)
+	}
+	return cs, nil
+}

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -32,6 +32,7 @@ Usage: docker [OPTIONS] COMMAND [ARG...]
 A self-sufficient runtime for containers.
 
 Options:
+      --completion string  Print the shell completion script for the specified shell (bash, fish, powershell, or zsh) and quit
       --config string      Location of client config files (default "/root/.docker")
   -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with "docker context use")
   -D, --debug              Enable debug mode

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -20,6 +20,10 @@ To see the man page for a command run **man docker <command>**.
 **--help**
   Print usage statement
 
+**--completion**=""
+  Print the shell completion script for the specified shell (bash, fish,
+  powershell, or zsh) and quit.
+
 **--config**=""
   Specifies the location of the Docker client configuration files. The default is '~/.docker'.
 


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/1257

This patch adds a new top-level `--completion` flag, which allows the user to
print the completion script for their shell of choice.

We currently maintain hand-written completion scripts for bash, fish, and zsh,
of which the bash script is in a good state, but the fish and zsh scripts are
less well maintained.

We should review the quality of the fish and zsh scripts, and decide wether or
not we want to use the hand-written versions for those, or to replace them with
the auto-generated completion provided by Cobra.

This patch embeds the hand-written completion scripts using Go 1.16's "embed"
functionality, but also adds options to try/test/compare the Cobra completion
scripts. Currently, this patch allows for the following:

    docker --completion=bash        outputs the hand-written bash completion script
    docker --completion=bash-cobra  outputs cobra's generated completion script
    docker --completion=fish        outputs the hand-written fish completion script
    docker --completion=fish-cobra  outputs cobra's generated completion script
    docker --completion=powershell  outputs cobra's generated completion script
    docker --completion=zsh         outputs the hand-written bash completion script
    docker --completion=zsh-cobra   outputs cobra's generated completion script

While the hand-written bash completion script has definitions for commands and
options provided by the main CLI, it does not provide completions for commands
and options provided by plug-ins. Commits 1148163c3ec90fc78b8f385e065984989b018e8b
and 5a8d7d506cbbe7cd0df3ed3903cb27a90a51e142 (https://github.com/docker/cli/pull/3158) added support for completions for
the compose cli plug-in, but do so by directly calling the plug-in binary.

Cobra's completion scripts use two hidden subcommands that provide dynamic
generating of completion scripts: `__complete` and `__completeNoDesc`. This
patch adds support for both these subcommands, and implements code to extend
these commands to be plug-in aware: if either of those commands request completion
for an unknown command, the cli will look if a plug-in is install that provides
the command, and will call the `__complete` or `__completeNoDesc` command on the
plug-in.

With that, we are able to automatically provide completion scripts for all plug-
ins. For example:

    docker __complete compose r
    restart	Restart containers
    rm	Removes stopped service containers
    run	Run a one-off command on a service.
    :4
    Completion ended with directive: ShellCompDirectiveNoFileComp

    docker __complete scan --
    --accept-license	Accept using a third party scanning provider
    --dependency-tree	Show dependency tree with scan results
    --exclude-base	Exclude base image from vulnerability scanning (requires --file)
    --file	Dockerfile associated with image, provides more detailed results
    --file=	Dockerfile associated with image, provides more detailed results
    --group-issues	Aggregate duplicated vulnerabilities and group them to a single one (requires --json)
    --json	Output results in JSON format
    --login	Authenticate to the scan provider using an optional token (with --token), or web base token if empty
    --reject-license	Reject using a third party scanning provider
    --severity	Only report vulnerabilities of provided level or higher (low|medium|high)
    --severity=	Only report vulnerabilities of provided level or higher (low|medium|high)
    --token	Authentication token to login to the third party scanning provider
    --token=	Authentication token to login to the third party scanning provider
    --version	Display version of the scan plugin
    :0
    Completion ended with directive: ShellCompDirectiveDefault

    docker __completeNoDesc scan --
    --accept-license
    --dependency-tree
    --exclude-base
    --file
    --file=
    --group-issues
    --json
    --login
    --reject-license
    --severity
    --severity=
    --token
    --token=
    --version
    :0
    Completion ended with directive: ShellCompDirectiveDefault


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

