### PR TITLE
docs: rewrite reference docs for --stop-signal and --stop-timeout, and use "console" hints

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -589,9 +589,9 @@ Log tags are now generated in a standard way across different logging drivers.
 Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` and
 `fluentd-tag` have been deprecated in favor of the generic `tag` option.
 
-```bash
+```console
 {% raw %}
-docker --log-driver=syslog --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"
+$ docker --log-driver=syslog --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"
 {% endraw %}
 ```
 

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -55,7 +55,7 @@ enabled, and use it to create a volume.
 
 1.  Install the `sshfs` plugin.
 
-    ```bash
+    ```console
     $ docker plugin install vieux/sshfs
 
     Plugin "vieux/sshfs" is requesting the following privileges:
@@ -74,7 +74,7 @@ enabled, and use it to create a volume.
 
 2.  Check that the plugin is enabled in the output of `docker plugin ls`.
 
-    ```bash
+    ```console
     $ docker plugin ls
 
     ID                    NAME                  TAG                 DESCRIPTION                   ENABLED
@@ -87,7 +87,7 @@ enabled, and use it to create a volume.
 
     This volume can now be mounted into containers.
 
-    ```bash
+    ```console
     $ docker volume create \
       -d vieux/sshfs \
       --name sshvolume \
@@ -96,9 +96,10 @@ enabled, and use it to create a volume.
 
     sshvolume
     ```
+
 4.  Verify that the volume was created successfully.
 
-    ```bash
+    ```console
     $ docker volume ls
 
     DRIVER              NAME
@@ -107,18 +108,19 @@ enabled, and use it to create a volume.
 
 5.  Start a container that uses the volume `sshvolume`.
 
-    ```bash
+    ```console
     $ docker run --rm -v sshvolume:/data busybox ls /data
 
     <content of /remote on machine 1.2.3.4>
     ```
 
 6.  Remove the volume `sshvolume`
-    ```bash
-    docker volume rm sshvolume
+    ```console
+    $ docker volume rm sshvolume
 
     sshvolume
     ```
+
 To disable a plugin, use the `docker plugin disable` command. To completely
 remove it, use the `docker plugin remove` command. For other available
 commands and options, see the
@@ -134,7 +136,7 @@ example, it was created from a Dockerfile:
 >**Note:** The `/run/docker/plugins` directory is mandatory inside of the
 plugin's filesystem for docker to communicate with the plugin.
 
-```bash
+```console
 $ git clone https://github.com/vieux/docker-volume-sshfs
 $ cd docker-volume-sshfs
 $ docker build -t rootfsimage .
@@ -193,13 +195,13 @@ Stdout of a plugin is redirected to dockerd logs. Such entries have a
 `f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62` and their
 corresponding log entries in the docker daemon logs.
 
-```bash
+```console
 $ docker plugin install tiborvass/sample-volume-plugin
 
 INFO[0036] Starting...       Found 0 volumes on startup  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
 ```
 
-```bash
+```console
 $ docker volume create -d tiborvass/sample-volume-plugin samplevol
 
 INFO[0193] Create Called...  Ensuring directory /data/samplevol exists on host...  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
@@ -208,7 +210,7 @@ INFO[0193]                   Created volume samplevol with mountpoint /data/samp
 INFO[0193] Path Called...    Returned path /data/samplevol  plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
 ```
 
-```bash
+```console
 $ docker run -v samplevol:/tmp busybox sh
 
 INFO[0421] Get Called...     Found samplevol                plugin=f52a3df433b9aceee436eaada0752f5797aab1de47e5485f1690a073b860ff62
@@ -223,7 +225,7 @@ INFO[0421] Unmount Called... Unmounted samplevol            plugin=f52a3df433b9a
 plugins. This is specifically useful to collect plugin logs if they are
 redirected to a file.
 
-```bash
+```console
 $ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins list
 
 ID                                                                 PID         STATUS      BUNDLE                                                                                                                                       CREATED                          OWNER
@@ -232,13 +234,14 @@ ID                                                                 PID         S
 c5bb4b90941efcaccca999439ed06d6a6affdde7081bb34dc84126b57b3e793d   14984       running     /run/docker/containerd/daemon/io.containerd.runtime.v1.linux/moby-plugins/c5bb4b90941efcaccca999439ed06d6a6affdde7081bb34dc84126b57b3e793d   2018-02-08T21:35:12.321288966Z   root
 ```
 
-```bash
+```console
 $ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins exec 93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25 cat /var/log/plugin.log
 ```
 
 If the plugin has a built-in shell, then exec into the plugin can be done as
 follows:
-```bash
+
+```console
 $ sudo docker-runc --root /var/run/docker/plugins/runtime-root/moby-plugins exec -t 93f1e7dbfe11c938782c2993628c895cf28e2274072c4a346a6002446c949b25 sh
 ```
 
@@ -251,17 +254,18 @@ the plugin is listening on the said socket. For a well functioning plugin,
 these basic requests should work. Note that plugin sockets are available on the host under `/var/run/docker/plugins/<pluginID>`
 
 
-```bash
-curl -H "Content-Type: application/json" -XPOST -d '{}' --unix-socket /var/run/docker/plugins/e8a37ba56fc879c991f7d7921901723c64df6b42b87e6a0b055771ecf8477a6d/plugin.sock http:/VolumeDriver.List
+```console
+$ curl -H "Content-Type: application/json" -XPOST -d '{}' --unix-socket /var/run/docker/plugins/e8a37ba56fc879c991f7d7921901723c64df6b42b87e6a0b055771ecf8477a6d/plugin.sock http:/VolumeDriver.List
 
 {"Mountpoint":"","Err":"","Volumes":[{"Name":"myvol1","Mountpoint":"/data/myvol1"},{"Name":"myvol2","Mountpoint":"/data/myvol2"}],"Volume":null}
 ```
 
-```bash
-curl -H "Content-Type: application/json" -XPOST -d '{}' --unix-socket /var/run/docker/plugins/45e00a7ce6185d6e365904c8bcf62eb724b1fe307e0d4e7ecc9f6c1eb7bcdb70/plugin.sock http:/NetworkDriver.GetCapabilities
+```console
+$ curl -H "Content-Type: application/json" -XPOST -d '{}' --unix-socket /var/run/docker/plugins/45e00a7ce6185d6e365904c8bcf62eb724b1fe307e0d4e7ecc9f6c1eb7bcdb70/plugin.sock http:/NetworkDriver.GetCapabilities
 
 {"Scope":"local"}
 ```
+
 When using curl 7.5 and above, the URL should be of the form
 `http://hostname/APICall`, where `hostname` is the valid hostname where the
 plugin is installed and `APICall` is the call to the plugin API.

--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -114,7 +114,7 @@ a `service` file and a `socket` file.
 
 The `service` file (for example `/lib/systemd/system/your-plugin.service`):
 
-```
+```systemd
 [Unit]
 Description=Your plugin
 Before=docker.service
@@ -127,9 +127,10 @@ ExecStart=/usr/lib/docker/your-plugin
 [Install]
 WantedBy=multi-user.target
 ```
+
 The `socket` file (for example `/lib/systemd/system/your-plugin.socket`):
 
-```
+```systemd
 [Unit]
 Description=Your plugin
 
@@ -166,7 +167,8 @@ Plugins are activated via the following "handshake" API call.
 **Request:** empty body
 
 **Response:**
-```
+
+```json
 {
     "Implements": ["VolumeDriver"]
 }

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -116,7 +116,7 @@ value. This value can be the plugin’s socket or a path to a specification file
 Authorization plugins can be loaded without restarting the daemon. Refer
 to the [`dockerd` documentation](../reference/commandline/dockerd.md#configuration-reloading) for more information.
 
-```bash
+```console
 $ dockerd --authorization-plugin=plugin1 --authorization-plugin=plugin2,...
 ```
 
@@ -124,26 +124,26 @@ Docker's authorization subsystem supports multiple `--authorization-plugin` para
 
 ### Calling authorized command (allow)
 
-```bash
+```console
 $ docker pull centos
-...
+<...>
 f1b10cd84249: Pull complete
-...
+<...>
 ```
 
 ### Calling unauthorized command (deny)
 
-```bash
+```console
 $ docker pull centos
-...
+<...>
 docker: Error response from daemon: authorization denied by plugin PLUGIN_NAME: volumes are not allowed.
 ```
 
 ### Error from plugins
 
-```bash
+```console
 $ docker pull centos
-...
+<...>
 docker: Error response from daemon: plugin PLUGIN_NAME failed with error: AuthZPlugin.AuthZReq: Cannot connect to the Docker daemon. Is the docker daemon running on this host?.
 ```
 
@@ -180,6 +180,7 @@ should implement the following two methods:
     "Err":   "The error message if things go wrong"
 }
 ```
+
 #### /AuthZPlugin.AuthZRes
 
 **Request**:

--- a/docs/extend/plugins_graphdriver.md
+++ b/docs/extend/plugins_graphdriver.md
@@ -31,7 +31,7 @@ You need to install and enable the plugin and then restart the Docker daemon
 before using the plugin. See the following example for the correct ordering
 of steps.
 
-```
+```console
 $ docker plugin install cpuguy83/docker-overlay2-graphdriver-plugin # this command also enables the driver
 <output suppressed>
 $ pkill dockerd
@@ -309,6 +309,7 @@ Get an archive of the changes between the filesystem layers specified by the `ID
 and `Parent`. `Parent` may be an empty string, in which case there is no parent.
 
 **Response**:
+
 ```
 {% raw %}
 {{ TAR STREAM }}
@@ -354,6 +355,7 @@ Respond with a non-empty string error if an error occurred.
 ### /GraphDriver.ApplyDiff
 
 **Request**:
+
 ```
 {% raw %}
 {{ TAR STREAM }}

--- a/docs/extend/plugins_logging.md
+++ b/docs/extend/plugins_logging.md
@@ -211,6 +211,7 @@ as they come in once the existing logs have been read.
 to determine what set of logs to read.
 
 **Response**:
+
 ```
 {% raw %}{{ log stream }}{% endraw %}
 ```

--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -42,7 +42,7 @@ Once running however, network driver plugins are used just like the built-in
 network drivers: by being mentioned as a driver in network-oriented Docker
 commands. For example,
 
-```bash
+```console
 $ docker network create --driver weave mynet
 ```
 
@@ -51,7 +51,7 @@ Some network driver plugins are listed in [plugins](legacy_plugins.md)
 The `mynet` network is now owned by `weave`, so subsequent commands
 referring to that network will be sent to the plugin,
 
-```bash
+```console
 $ docker run --network=mynet busybox top
 ```
 

--- a/docs/extend/plugins_services.md
+++ b/docs/extend/plugins_services.md
@@ -29,20 +29,20 @@ node1 is the manager and node2 is the worker.
 
 1.  Prepare manager. In node 1:
 
-    ```bash
+    ```console
     $ docker swarm init
     Swarm initialized: current node (dxn1zf6l61qsb1josjja83ngz) is now a manager.
     ```
 
 2. Join swarm, install plugin and create volume on worker. In node 2:
 
-    ```bash
+    ```console
     $ docker swarm join \
-    --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
-    192.168.99.100:2377
+      --token SWMTKN-1-49nj1cmql0jkz5s954yi3oex3nedyz0fb0xx14ie39trti4wxv-8vxv8rssmk743ojnwacrr2e7c \
+      192.168.99.100:2377
     ```
 
-    ```bash
+    ```console
     $ docker plugin install tiborvass/sample-volume-plugin
     latest: Pulling from tiborvass/sample-volume-plugin
     eb9c16fbdc53: Download complete
@@ -51,23 +51,24 @@ node1 is the manager and node2 is the worker.
     Installed plugin tiborvass/sample-volume-plugin
     ```
 
-    ```bash
+    ```console
     $ docker volume create -d tiborvass/sample-volume-plugin --name pluginVol
     ```
 
 3. Create a service using the plugin and volume. In node1:
 
-    ```bash
+    ```console
     $ docker service create --name my-service --mount type=volume,volume-driver=tiborvass/sample-volume-plugin,source=pluginVol,destination=/tmp busybox top
 
     $ docker service ls
     z1sj8bb8jnfn  my-service   replicated  1/1       busybox:latest
     ```
-    docker service ls shows service 1 instance of service running.
+
+    `docker service ls` shows service 1 instance of service running.
 
 4. Observe the task getting scheduled in node 2:
 
-    ```bash
+    ```console
     {% raw %}
     $ docker ps --format '{{.ID}}\t {{.Status}} {{.Names}} {{.Command}}'
     83fc1e842599     Up 2 days my-service.1.9jn59qzn7nbc3m0zt1hij12xs "top"
@@ -87,7 +88,7 @@ Note that node1 is the manager and node2 is the worker.
 1. Install a global scoped network plugin on both manager and worker. On node1
    and node2:
 
-    ```bash
+    ```console
     $ docker plugin install bboreham/weave2
     Plugin "bboreham/weave2" is requesting the following privileges:
     - network: [host]
@@ -102,7 +103,7 @@ Note that node1 is the manager and node2 is the worker.
 
 2. Create a network using plugin on manager. On node1:
 
-    ```bash
+    ```console
     $ docker network create --driver=bboreham/weave2:latest globalnet
 
     $ docker network ls
@@ -115,12 +116,12 @@ containers get scheduled on both manager and worker.
 
     On node 1:
 
-    ```bash
+    ```console
     $ docker service create --network globalnet --name myservice --replicas=8 mrjana/simpleweb simpleweb
 w90drnfzw85nygbie9kb89vpa
     ```
 
-    ```bash
+    ```console
     $ docker ps
     CONTAINER ID        IMAGE                                                                                      COMMAND             CREATED             STATUS              PORTS               NAMES
     87520965206a        mrjana/simpleweb@sha256:317d7f221d68c86d503119b0ea12c29de42af0a22ca087d522646ad1069a47a4   "simpleweb"         5 seconds ago       Up 4 seconds                            myservice.4.ytdzpktmwor82zjxkh118uf1v
@@ -131,7 +132,7 @@ w90drnfzw85nygbie9kb89vpa
 
     On node 2:
 
-    ```bash
+    ```console
     $ docker ps
     CONTAINER ID        IMAGE                                                                                      COMMAND             CREATED             STATUS                  PORTS               NAMES
     53c0ae7c1dae        mrjana/simpleweb@sha256:317d7f221d68c86d503119b0ea12c29de42af0a22ca087d522646ad1069a47a4   "simpleweb"         2 seconds ago       Up Less than a second                       myservice.7.x44tvvdm3iwkt9kif35f7ykz1
@@ -142,14 +143,14 @@ w90drnfzw85nygbie9kb89vpa
 
 4. Scale down the number of instances. On node1:
 
-    ```bash
+    ```console
     $ docker service scale myservice=0
     myservice scaled to 0
     ```
 
 5. Disable and uninstall the plugin on the worker. On node2:
 
-    ```bash
+    ```console
     $ docker plugin rm -f bboreham/weave2
     bboreham/weave2
     ```
@@ -159,12 +160,12 @@ scheduled on the master and not on the worker, because the plugin is not availab
 
     On node 1:
 
-    ```bash
+    ```console
     $ docker service scale myservice=8
     myservice scaled to 8
     ```
 
-    ```bash
+    ```console
     $ docker ps
     CONTAINER ID        IMAGE                                                                                      COMMAND             CREATED             STATUS              PORTS               NAMES
     cf4b0ec2415e        mrjana/simpleweb@sha256:317d7f221d68c86d503119b0ea12c29de42af0a22ca087d522646ad1069a47a4   "simpleweb"         39 seconds ago      Up 36 seconds                           myservice.3.r7p5o208jmlzpcbm2ytl3q6n1
@@ -179,7 +180,7 @@ scheduled on the master and not on the worker, because the plugin is not availab
 
     On node 2:
 
-    ```bash
+    ```console
     $ docker ps
     CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
     ```

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -54,7 +54,7 @@ flags on the `docker container run` command.  The `--volume` (or `-v`) flag
 accepts a volume name and path on the host, and the `--volume-driver` flag
 accepts a driver type.
 
-```bash
+```console
 $ docker volume create --driver=flocker volumename
 
 $ docker container run -it --volume volumename:/data busybox sh

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -2173,9 +2173,14 @@ ONBUILD RUN /usr/local/bin/python-build --dir /app/src
 STOPSIGNAL signal
 ```
 
-The `STOPSIGNAL` instruction sets the system call signal that will be sent to the container to exit.
-This signal can be a valid unsigned number that matches a position in the kernel's syscall table, for instance 9,
-or a signal name in the format SIGNAME, for instance SIGKILL.
+The `STOPSIGNAL` instruction sets the system call signal that will be sent to the
+container to exit. This signal can be a signal name in the format `SIG<NAME>`,
+for instance `SIGKILL`, or an unsigned number that matches a position in the
+kernel's syscall table, for instance `9`. The default is `SIGTERM` if not
+defined.
+
+The image's default stopsignal can be overridden per container, using the
+`--stop-signal` flag on `docker run` and `docker create`.
 
 ## HEALTHCHECK
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -759,6 +759,7 @@ RUN instruction onto the next line. For example, consider these two lines:
 RUN /bin/bash -c 'source $HOME/.bashrc; \
 echo $HOME'
 ```
+
 Together they are equivalent to this single line:
 
 ```dockerfile
@@ -938,6 +939,7 @@ the `--format` option to show just the labels;
 ```console
 $ docker image inspect --format='{{json .Config.Labels}}' myimage
 ```
+
 ```json
 {
   "com.example.vendor": "ACME Incorporated",

--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -84,7 +84,7 @@ containers, see [**Configuration file** section](cli.md#configuration-files).
 
 ### Attach to and detach from a running container
 
-```bash
+```console
 $ docker run -d --name topdemo ubuntu /usr/bin/top -b
 
 $ docker attach topdemo
@@ -130,22 +130,19 @@ $ docker ps -a | grep topdemo
 And in this second example, you can see the exit code returned by the `bash`
 process is returned by the `docker attach` command to its caller too:
 
-```bash
-    $ docker run --name test -d -it debian
+```console
+$ docker run --name test -d -it debian
+275c44472aebd77c926d4527885bb09f2f6db21d878c75f0a1c212c03d3bcfab
 
-    275c44472aebd77c926d4527885bb09f2f6db21d878c75f0a1c212c03d3bcfab
+$ docker attach test
+root@f38c87f2a42d:/# exit 13
 
-    $ docker attach test
+exit
 
-    root@f38c87f2a42d:/# exit 13
+$ echo $?
+13
 
-    exit
+$ docker ps -a | grep test
 
-    $ echo $?
-
-    13
-
-    $ docker ps -a | grep test
-
-    275c44472aeb        debian:7            "/bin/bash"         26 seconds ago      Exited (13) 17 seconds ago                         test
+275c44472aeb        debian:7            "/bin/bash"         26 seconds ago      Exited (13) 17 seconds ago                         test
 ```

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -92,7 +92,7 @@ context.
 For example, run this command to use a directory called `docker` in the branch
 `container`:
 
-```bash
+```console
 $ docker build https://github.com/docker/rootfs.git#container:docker
 ```
 
@@ -120,7 +120,7 @@ Build Syntax Suffix             | Commit Used           | Build Context Used
 
 If you pass an URL to a remote tarball, the URL itself is sent to the daemon:
 
-```bash
+```console
 $ docker build http://server/context.tar.gz
 ```
 
@@ -136,7 +136,7 @@ build context. Tarball contexts must be tar archives conforming to the standard
 Instead of specifying a context, you can pass a single `Dockerfile` in the
 `URL` or pipe the file in via `STDIN`. To pipe a `Dockerfile` from `STDIN`:
 
-```bash
+```console
 $ docker build - < Dockerfile
 ```
 
@@ -176,7 +176,7 @@ build fails, a non-zero failure code will be returned.
 There should be informational output of the reason for failure output to
 `STDERR`:
 
-```bash
+```console
 $ docker build -t fail .
 
 Sending build context to Docker daemon 2.048 kB
@@ -198,7 +198,7 @@ See also:
 
 ### Build with PATH
 
-```bash
+```console
 $ docker build .
 
 Uploading context 10240 bytes
@@ -243,7 +243,7 @@ you must use `--rm=false`. This does not affect the build cache.
 
 ### Build with URL
 
-```bash
+```console
 $ docker build github.com/creack/docker-firefox
 ```
 
@@ -251,7 +251,7 @@ This will clone the GitHub repository and use the cloned repository as context.
 The Dockerfile at the root of the repository is used as Dockerfile. You can
 specify an arbitrary Git repository by using the `git://` or `git@` scheme.
 
-```bash
+```console
 $ docker build -f ctx/Dockerfile http://server/ctx.tar.gz
 
 Downloading context: http://server/ctx.tar.gz [===================>]    240 B/240 B
@@ -277,7 +277,7 @@ ctx/container.cfg /` operation works as expected.
 
 ### Build with -
 
-```bash
+```console
 $ docker build - < Dockerfile
 ```
 
@@ -286,7 +286,7 @@ context, no contents of any local directory will be sent to the Docker daemon.
 Since there is no context, a Dockerfile `ADD` only works if it refers to a
 remote URL.
 
-```bash
+```console
 $ docker build - < context.tar.gz
 ```
 
@@ -295,7 +295,7 @@ formats are: bzip2, gzip and xz.
 
 ### Use a .dockerignore file
 
-```bash
+```console
 $ docker build .
 
 Uploading context 18.829 MB
@@ -334,7 +334,7 @@ files.
 
 ### Tag an image (-t)
 
-```bash
+```console
 $ docker build -t vieux/apache:2.0 .
 ```
 
@@ -348,27 +348,27 @@ version.
 For example, to tag an image both as `whenry/fedora-jboss:latest` and
 `whenry/fedora-jboss:v2.1`, use the following:
 
-```bash
+```console
 $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
 ```
 
 ### Specify a Dockerfile (-f)
 
-```bash
+```console
 $ docker build -f Dockerfile.debug .
 ```
 
 This will use a file called `Dockerfile.debug` for the build instructions
 instead of `Dockerfile`.
 
-```bash
+```console
 $ curl example.com/remote/Dockerfile | docker build -f - .
 ```
 
 The above command will use the current directory as the build context and read
 a Dockerfile from stdin.
 
-```bash
+```console
 $ docker build -f dockerfiles/Dockerfile.debug -t myapp_debug .
 $ docker build -f dockerfiles/Dockerfile.prod  -t myapp_prod .
 ```
@@ -377,7 +377,7 @@ The above commands will build the current build context (as specified by the
 `.`) twice, once using a debug version of a `Dockerfile` and once using a
 production version.
 
-```bash
+```console
 $ cd /home/me/myapp/some/dir/really/deep
 $ docker build -f /home/me/myapp/dockerfiles/debug /home/me/myapp
 $ docker build -f ../../../../dockerfiles/debug /home/me/myapp
@@ -420,7 +420,7 @@ A good example is `http_proxy` or source versions for pulling intermediate
 files. The `ARG` instruction lets Dockerfile authors define values that users
 can set at build-time using the  `--build-arg` flag:
 
-```bash
+```console
 $ docker build --build-arg HTTP_PROXY=http://10.20.30.2:1234 --build-arg FTP_PROXY=http://40.50.60.5:4567 .
 ```
 
@@ -439,7 +439,7 @@ You may also use the `--build-arg` flag without a value, in which case the value
 from the local environment will be propagated into the Docker container being
 built:
 
-```bash
+```console
 $ export HTTP_PROXY=http://10.20.30.2:1234
 $ docker build --build-arg HTTP_PROXY .
 ```
@@ -491,7 +491,7 @@ FROM alpine AS production-env
 ...
 ```
 
-```bash
+```console
 $ docker build -t mybuildimage --target build-env .
 ```
 
@@ -516,7 +516,7 @@ The following example builds an image using the current directory (`.`) as build
 context, and exports the files to a directory named `out` in the current directory.
 If the directory does not exist, Docker creates the directory automatically:
 
-```bash
+```console
 $ docker build -o out .
 ```
 
@@ -525,13 +525,13 @@ thus uses the default (`local`) exporter. The example below shows the equivalent
 using the long-hand CSV syntax, specifying both `type` and `dest` (destination
 path):
 
-```bash
+```console
 $ docker build --output type=local,dest=out .
 ```
 
 Use the `tar` type to export the files as a `.tar` archive:
 
-```bash
+```console
 $ docker build --output type=tar,dest=out.tar .
 ```
 
@@ -540,8 +540,8 @@ case, `-` is specified as destination, which automatically selects the `tar` typ
 and writes the output tarball to standard output, which is then redirected to
 the `out.tar` file:
 
-```bash
-docker build -o - . > out.tar
+```console
+$ docker build -o - . > out.tar
 ```
 
 The `--output` option exports all files from the target stage. A common pattern
@@ -562,7 +562,7 @@ COPY --from=build-stage /go/bin/vndr /
 When building the Dockerfile with the `-o` option, only the files from the final
 stage are exported to the `out` directory, in this case, the `vndr` binary:
 
-```bash
+```console
 $ docker build -o out .
 
 [+] Building 2.3s (7/7) FINISHED
@@ -610,7 +610,7 @@ options) allow pulling layer data for intermediate stages in multi-stage builds.
 The following example builds an image with inline-cache metadata and pushes it
 to a registry, then uses the image as a cache source on another machine:
 
-```bash
+```console
 $ docker build -t myname/myapp --build-arg BUILDKIT_INLINE_CACHE=1 .
 $ docker push myname/myapp
 ```
@@ -618,8 +618,9 @@ $ docker push myname/myapp
 After pushing the image, the image is used as cache source on another machine.
 BuildKit automatically pulls the image from the registry if needed.
 
-```bash
-# on another machine
+On another machine:
+
+```console
 $ docker build --cache-from myname/myapp .
 ```
 
@@ -725,7 +726,7 @@ To enable experimental features, you need to start the Docker daemon with
 
 Then make sure the experimental flag is enabled:
 
-```bash
+```console
 $ docker version -f '{{.Server.Experimental}}'
 true
 ```
@@ -745,15 +746,15 @@ RUN rm /remove_me
 
 An image named `test` is built with `--squash` argument.
 
-```bash
+```console
 $ docker build --squash -t test .
 
-[...]
+<...>
 ```
 
 If everything is right, the history looks like this:
 
-```bash
+```console
 $ docker history test
 
 IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -24,7 +24,7 @@ redirect_from:
 To list available commands, either run `docker` with no parameters
 or execute `docker help`:
 
-```bash
+```console
 $ docker
 Usage: docker [OPTIONS] COMMAND [ARG...]
        docker [ --help | -v | --version ]

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -43,7 +43,7 @@ created.  Supported `Dockerfile` instructions:
 
 ### Commit a container
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
@@ -62,7 +62,7 @@ svendowideit/testimage            version3            f5283438590d        16 sec
 
 ### Commit a container with new configurations
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
@@ -84,7 +84,7 @@ $ docker inspect -f "{{ .Config.Env }}" f5283438590d
 
 ### Commit a container with new `CMD` and `EXPOSE` instructions
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES

--- a/docs/reference/commandline/config_create.md
+++ b/docs/reference/commandline/config_create.md
@@ -33,7 +33,7 @@ For detailed information about using configs, refer to [store configuration data
 
 ### Create a config
 
-```bash
+```console
 $ printf <config> | docker config create my_config -
 
 onakdyv307se2tl7nl20anokv
@@ -46,7 +46,7 @@ onakdyv307se2tl7nl20anokv   my_config           6 seconds ago       6 seconds ag
 
 ### Create a config with a file
 
-```bash
+```console
 $ docker config create my_config ./config.json
 
 dg426haahpi5ezmkkj5kyl3sn
@@ -59,7 +59,7 @@ dg426haahpi5ezmkkj5kyl3sn   my_config           7 seconds ago       7 seconds ag
 
 ### Create a config with labels
 
-```bash
+```console
 $ docker config create \
     --label env=dev \
     --label rev=20170324 \
@@ -68,7 +68,7 @@ $ docker config create \
 eo7jnzguqgtpdah3cm5srfb97
 ```
 
-```bash
+```console
 $ docker config inspect my_config
 
 [

--- a/docs/reference/commandline/config_inspect.md
+++ b/docs/reference/commandline/config_inspect.md
@@ -43,14 +43,14 @@ You can inspect a config, either by its *name*, or *ID*
 
 For example, given the following config:
 
-```bash
+```console
 $ docker config ls
 
 ID                          NAME                CREATED             UPDATED
 eo7jnzguqgtpdah3cm5srfb97   my_config           3 minutes ago       3 minutes ago
 ```
 
-```bash
+```console
 $ docker config inspect config.json
 ```
 
@@ -83,7 +83,7 @@ You can use the --format option to obtain specific information about a
 config. The following example command outputs the creation time of the
 config.
 
-```bash
+```console
 $ docker config inspect --format='{{.CreatedAt}}' eo7jnzguqgtpdah3cm5srfb97
 
 2017-03-24 08:15:09.735271783 +0000 UTC

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -36,7 +36,7 @@ For detailed information about using configs, refer to [store configuration data
 
 ## Examples
 
-```bash
+```console
 $ docker config ls
 
 ID                          NAME                        CREATED             UPDATED
@@ -60,7 +60,7 @@ The currently supported filters are:
 
 The `id` filter matches all or prefix of a config's id.
 
-```bash
+```console
 $ docker config ls -f "id=6697bflskwj1998km1gnnjr38"
 
 ID                          NAME                        CREATED             UPDATED
@@ -75,7 +75,7 @@ a `label` and a value.
 The following filter matches all configs with a `project` label regardless of
 its value:
 
-```bash
+```console
 $ docker config ls --filter label=project
 
 ID                          NAME                        CREATED             UPDATED
@@ -85,7 +85,7 @@ mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   Abou
 The following filter matches only services with the `project` label with the
 `project-a` value.
 
-```bash
+```console
 $ docker service ls --filter label=project=test
 
 ID                          NAME                        CREATED             UPDATED
@@ -98,7 +98,7 @@ The `name` filter matches on all or prefix of a config's name.
 
 The following filter matches config with a name containing a prefix of `test`.
 
-```bash
+```console
 $ docker config ls --filter name=test_config
 
 ID                          NAME                        CREATED             UPDATED
@@ -128,7 +128,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Name` entries separated by a colon (`:`) for all images:
 
-```bash
+```console
 $ docker config ls --format "{{.ID}}: {{.Name}}"
 
 77af4d6b9913: config-1
@@ -139,7 +139,7 @@ b6fa739cedf5: config-2
 To list all configs with their name and created date in a table format you
 can use:
 
-```bash
+```console
 $ docker config ls --format "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}"
 
 ID                  NAME                      CREATED

--- a/docs/reference/commandline/config_rm.md
+++ b/docs/reference/commandline/config_rm.md
@@ -35,7 +35,7 @@ For detailed information about using configs, refer to [store configuration data
 
 This example removes a config:
 
-```bash
+```console
 $ docker config rm my_config
 sapth4csdo5b6wz2p5uimh5xg
 ```

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -26,7 +26,7 @@ Removes all stopped containers.
 
 ### Prune containers
 
-```bash
+```console
 $ docker container prune
 WARNING! This will remove all stopped containers.
 Are you sure you want to continue? [y/N] y
@@ -66,7 +66,7 @@ containers without the specified labels.
 
 The following removes containers created more than 5 minutes ago:
 
-```bash
+```console
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS
@@ -88,7 +88,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED AT          
 
 The following removes containers created before `2017-01-04T13:10:00`:
 
-```bash
+```console
 $ docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}'
 
 CONTAINER ID        IMAGE               COMMAND             CREATED AT                      STATUS

--- a/docs/reference/commandline/context_create.md
+++ b/docs/reference/commandline/context_create.md
@@ -62,7 +62,7 @@ kubernetes options. The example below creates the context `my-context`
 with a docker endpoint of `/var/run/docker.sock` and a kubernetes configuration
 sourced from the file `/home/me/my-kube-config`:
 
-```bash
+```console
 $ docker context create \
     --docker host=unix:///var/run/docker.sock \
     --kubernetes config-file=/home/me/my-kube-config \
@@ -75,19 +75,19 @@ Use the `--from=<context-name>` option to create a new context from
 an existing context. The example below creates a new context named `my-context`
 from the existing context `existing-context`:
 
-```bash
+```console
 $ docker context create --from existing-context my-context
 ```
 
 If the `--from` option is not set, the `context` is created from the current context:
 
-```bash
+```console
 $ docker context create my-context
 ```
 
 This can be used to create a context out of an existing `DOCKER_HOST` based script:
 
-```bash
+```console
 $ source my-setup-script.sh
 $ docker context create my-context
 ```
@@ -98,7 +98,7 @@ new context named `my-context` using the docker endpoint configuration from
 the existing context `existing-context` and a kubernetes configuration sourced
 from the file `/home/me/my-kube-config`:
 
-```bash
+```console
 $ docker context create \
     --docker from=existing-context \
     --kubernetes config-file=/home/me/my-kube-config \
@@ -110,7 +110,7 @@ To source only the `kubernetes` configuration from an existing context use the
 context named `my-context` using the kuberentes configuration from the existing
 context `existing-context` and a docker endpoint of `/var/run/docker.sock`:
 
-```bash
+```console
 $ docker context create \
     --docker host=unix:///var/run/docker.sock \
     --kubernetes from=existing-context \

--- a/docs/reference/commandline/context_inspect.md
+++ b/docs/reference/commandline/context_inspect.md
@@ -23,7 +23,7 @@ Inspects one or more contexts.
 
 ### Inspect a context by name
 
-```bash
+```console
 $ docker context inspect "local+aks"
 
 [

--- a/docs/reference/commandline/context_ls.md
+++ b/docs/reference/commandline/context_ls.md
@@ -25,7 +25,9 @@ Options:
 Use `docker context ls` to print all contexts. The currently active context is
 indicated with an `*`:
 
-```bash
+```console
+$ docker context ls
+
 NAME                DESCRIPTION                               DOCKER ENDPOINT                      KUBERNETES ENDPOINT   ORCHESTRATOR
 default *           Current DOCKER_HOST based configuration   unix:///var/run/docker.sock                                swarm
 production                                                    tcp:///prod.corp.example.com:2376

--- a/docs/reference/commandline/context_update.md
+++ b/docs/reference/commandline/context_update.md
@@ -54,7 +54,7 @@ See [context create](context_create.md).
 
 ### Update an existing context
 
-```bash
+```console
 $ docker context update \
     --description "some description" \
     --docker "host=tcp://myserver:2376,ca=~/ca-file,cert=~/cert-file,key=~/key-file" \

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -95,11 +95,11 @@ the user in the container. However, you can still copy such files by manually
 running `tar` in `docker exec`. Both of the following examples do the same thing
 in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):
 
-```bash
+```console
 $ docker exec CONTAINER tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) | tar Cxf DEST_PATH -
 ```
 
-```bash
+```console
 $ tar Ccf $(dirname SRC_PATH) - $(basename SRC_PATH) | docker exec -i CONTAINER tar Cxf DEST_PATH -
 ```
 

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -109,7 +109,7 @@ Options:
                                       Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes),
                                       or `g` (gigabytes). If you omit the unit, the system uses bytes.
       --stop-signal string            Signal to stop a container (default "SIGTERM")
-      --stop-timeout=10               Timeout (in seconds) to stop a container
+      --stop-timeout int              Timeout (in seconds) to stop a container
       --storage-opt value             Storage driver options for the container (default [])
       --sysctl value                  Sysctl options (default map[])
       --tmpfs value                   Mount a tmpfs directory (default [])

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -131,6 +131,7 @@ Options:
       --volumes-from value            Mount volumes from the specified container(s) (default [])
   -w, --workdir string                Working directory inside the container
 ```
+
 ## Description
 
 The `docker create` command creates a writeable container layer over the
@@ -149,7 +150,7 @@ Please see the [run command](run.md) section and the [Docker run reference](../r
 
 ### Create and start a container
 
-```bash
+```console
 $ docker create -t -i fedora bash
 
 6d8af538ec541dd581ebc2a24153a28329acb5268abe5ef868c1f1a261221752
@@ -165,7 +166,7 @@ As of v1.4.0 container volumes are initialized during the `docker create` phase
 (i.e., `docker run` too). For example, this allows you to `create` the `data`
 volume container, and then use it from another container:
 
-```bash
+```console
 $ docker create -v /data --name data ubuntu
 
 240633dfbb98128fa77473d3d9018f6123b99c454b3251427ae190a7d951ad57
@@ -180,7 +181,7 @@ drwxr-xr-x 48 root root 4096 Dec  5 04:11 ..
 Similarly, `create` a host directory bind mounted volume container, which can
 then be used from the subsequent container:
 
-```bash
+```console
 $ docker create -v /home/docker:/docker --name docker ubuntu
 
 9aa88c08f319cd1e4515c3c46b0de7cc9aa75e878357b1e96f91e2c773029f03
@@ -202,7 +203,7 @@ drwxr-xr-x 32 1000 staff 1140 Dec  5 04:01 docker
 
 Set storage driver options per container.
 
-```bash
+```console
 $ docker create -it --storage-opt size=120G fedora /bin/bash
 ```
 
@@ -245,8 +246,8 @@ our container needs access to a character device with major `42` and
 any number of minor number (added as new devices appear), the
 following rule would be added:
 
-```
-docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
+```console
+$ docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
 ```
 
 Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`

--- a/docs/reference/commandline/diff.md
+++ b/docs/reference/commandline/diff.md
@@ -33,7 +33,7 @@ You can use the full or shortened container ID or the container name set using
 
 Inspect the changes to an `nginx` container:
 
-```bash
+```console
 $ docker diff 1fdfd1f54c1b
 
 C /dev

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -175,20 +175,21 @@ find examples of using Systemd socket activation with Docker and Systemd in the
 You can configure the Docker daemon to listen to multiple sockets at the same
 time using multiple `-H` options:
 
-```bash
-# listen using the default unix socket, and on 2 specific IP addresses on this host.
+The example below runs the daemon listenin on the default unix socket, and
+on 2 specific IP addresses on this host:
 
+```console
 $ sudo dockerd -H unix:///var/run/docker.sock -H tcp://192.168.59.106 -H tcp://10.10.10.2
 ```
 
 The Docker client will honor the `DOCKER_HOST` environment variable to set the
 `-H` flag for the client. Use **one** of the following commands:
 
-```bash
+```console
 $ docker -H tcp://0.0.0.0:2375 ps
 ```
 
-```bash
+```console
 $ export DOCKER_HOST="tcp://0.0.0.0:2375"
 
 $ docker ps
@@ -198,7 +199,7 @@ Setting the `DOCKER_TLS_VERIFY` environment variable to any value other than
 the empty string is equivalent to setting the `--tlsverify` flag. The following
 are equivalent:
 
-```bash
+```console
 $ docker --tlsverify ps
 # or
 $ export DOCKER_TLS_VERIFY=1
@@ -211,7 +212,7 @@ precedence over `HTTP_PROXY`.
 
 The Docker client supports connecting to a remote daemon via SSH:
 
-```
+```console
 $ docker -H ssh://me@example.com:22 ps
 $ docker -H ssh://me@example.com ps
 $ docker -H ssh://example.com ps
@@ -268,22 +269,21 @@ when no `-H` was passed in.
 
 Run Docker in daemon mode:
 
-```bash
+```console
 $ sudo <path to>/dockerd -H 0.0.0.0:5555 &
 ```
 
 Download an `ubuntu` image:
 
-```bash
+```console
 $ docker -H :5555 pull ubuntu
 ```
 
 You can use multiple `-H`, for example, if you want to listen on both
 TCP and a Unix socket
 
-```bash
-# Run docker in daemon mode
-$ sudo <path to>/dockerd -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock &
+```console
+$ sudo dockerd -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock &
 # Download an ubuntu image, use default Unix socket
 $ docker pull ubuntu
 # OR use the TCP port
@@ -396,7 +396,7 @@ not use loopback in production. Ensure your Engine daemon has a
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.thinpooldev=/dev/mapper/thin-pool
 ```
 
@@ -407,7 +407,7 @@ device for you.
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.directlvm_device=/dev/xvdf
 ```
 
@@ -417,7 +417,7 @@ Sets the percentage of passed in block device to use for storage.
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.thinp_percent=95
 ```
 
@@ -427,7 +427,7 @@ Sets the percentage of the passed in block device to use for metadata storage.
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.thinp_metapercent=1
 ```
 
@@ -438,7 +438,7 @@ autoextend the available space [100 = disabled]
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.thinp_autoextend_threshold=80
 ```
 
@@ -449,7 +449,7 @@ attempts to autoextend the available space [100 = disabled]
 
 ###### Example:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.thinp_autoextend_percent=20
 ```
 
@@ -468,7 +468,7 @@ new base device size.
 
 ###### Examples
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.basesize=50G
 ```
 
@@ -480,7 +480,7 @@ This value affects the system-wide "base" empty filesystem
 that may already be initialized and inherited by pulled images. Typically,
 a change to this value requires additional steps to take effect:
 
- ```bash
+```console
 $ sudo service docker stop
 
 $ sudo rm -rf /var/lib/docker
@@ -503,7 +503,7 @@ much space.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.loopdatasize=200G
 ```
 
@@ -521,7 +521,7 @@ this much space.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.loopmetadatasize=4G
 ```
 
@@ -532,7 +532,7 @@ options are "ext4" and "xfs". The default is "xfs"
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.fs=ext4
 ```
 
@@ -542,7 +542,7 @@ Specifies extra mkfs arguments to be used when creating the base device.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt "dm.mkfsarg=-O ^has_journal"
 ```
 
@@ -552,7 +552,7 @@ Specifies extra mount options used when mounting the thin devices.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.mountopt=nodiscard
 ```
 
@@ -568,7 +568,7 @@ device.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd \
       --storage-opt dm.datadev=/dev/sdb1 \
       --storage-opt dm.metadatadev=/dev/sdc1
@@ -586,13 +586,13 @@ data, or even better on an SSD.
 If setting up a new metadata pool it is required to be valid. This can be
 achieved by zeroing the first 4k to indicate empty metadata, like this:
 
-```bash
+```console
 $ dd if=/dev/zero of=$metadata_dev bs=4096 count=1
 ```
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd \
       --storage-opt dm.datadev=/dev/sdb1 \
       --storage-opt dm.metadatadev=/dev/sdc1
@@ -605,7 +605,7 @@ blocksize is 64K.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.blocksize=512K
 ```
 
@@ -621,7 +621,7 @@ returned to the system for other use when containers are removed.
 
 ###### Examples
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.blkdiscard=false
 ```
 
@@ -633,11 +633,11 @@ Overrides the `udev` synchronization checks between `devicemapper` and `udev`.
 To view the `udev` sync support of a Docker daemon that is using the
 `devicemapper` driver, run:
 
-```bash
+```console
 $ docker info
-[...]
+<...>
 Udev Sync Supported: true
-[...]
+<...>
 ```
 
 When `udev` sync support is `true`, then `devicemapper` and udev can
@@ -651,7 +651,7 @@ results in errors and failures. (For information on these failures, see
 To allow the `docker` daemon to start, regardless of `udev` sync not being
 supported, set `dm.override_udev_sync_check` to true:
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.override_udev_sync_check=true
 ```
 
@@ -684,7 +684,7 @@ loop trying to remove a busy device.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.use_deferred_removal=true
 ```
 
@@ -702,7 +702,7 @@ Error deleting container: Error response from daemon: Cannot destroy container
 To avoid this failure, enable both deferred device deletion and deferred
 device removal on the daemon.
 
-```bash
+```console
 $ sudo dockerd \
       --storage-opt dm.use_deferred_deletion=true \
       --storage-opt dm.use_deferred_removal=true
@@ -742,7 +742,7 @@ the issue.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.min_free_space=10%
 ```
 
@@ -758,7 +758,7 @@ ENOSPC and will shutdown filesystem.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd --storage-opt dm.xfs_nospace_max_retries=0
 ```
 
@@ -784,7 +784,7 @@ their corresponding levels when output by `dockerd`.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd \
       --log-level debug \
       --storage-opt dm.libdm_log_level=7
@@ -800,7 +800,7 @@ By default docker will pick up the zfs filesystem where docker graph
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd -s zfs --storage-opt zfs.fsname=zroot/docker
 ```
 
@@ -815,7 +815,7 @@ a container with **--storage-opt size** option, docker should ensure the
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd -s btrfs --storage-opt btrfs.min_space=10G
 ```
 
@@ -838,7 +838,7 @@ conditions the user can pass any size less then the backing fs size.
 
 ###### Example
 
-```bash
+```console
 $ sudo dockerd -s overlay2 --storage-opt overlay2.size=1G
 ```
 
@@ -960,7 +960,7 @@ By default, the Docker daemon automatically starts `containerd`. If you want to
 control `containerd` startup, manually start `containerd` and pass the path to
 the `containerd` socket using the `--containerd` flag. For example:
 
-```bash
+```console
 $ sudo dockerd --containerd /var/run/dev/docker-containerd.sock
 ```
 
@@ -988,7 +988,7 @@ The following is an example adding 2 runtimes via the configuration:
 
 This is the same example via the command line:
 
-```bash
+```console
 $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-runc-replacement
 ```
 
@@ -1010,7 +1010,7 @@ is used on cgroup v2 hosts with systemd available.
 
 This example sets the `cgroupdriver` to `systemd`:
 
-```bash
+```console
 $ sudo dockerd --exec-opt native.cgroupdriver=systemd
 ```
 
@@ -1031,13 +1031,13 @@ value is specified on daemon start, on Windows client, the default is
 
 To set the DNS server for all Docker containers, use:
 
-```bash
+```console
 $ sudo dockerd --dns 8.8.8.8
 ```
 
 To set the DNS search domain for all Docker containers, use:
 
-```bash
+```console
 $ sudo dockerd --dns-search example.com
 ```
 
@@ -1163,7 +1163,7 @@ TLS. To configure the client TLS settings used by the daemon can be configured
 using the `--cluster-store-opt` flag, specifying the paths to PEM encoded
 files. For example:
 
-```bash
+```console
 $ sudo dockerd \
     --cluster-advertise 192.168.1.2:2376 \
     --cluster-store etcd://192.168.1.2:2379 \
@@ -1190,7 +1190,7 @@ organization can purchase or build themselves. You can install one or more
 authorization plugins when you start the Docker `daemon` using the
 `--authorization-plugin=PLUGIN_ID` option.
 
-```bash
+```console
 $ sudo dockerd --authorization-plugin=plugin1 --authorization-plugin=plugin2,...
 ```
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -208,13 +208,13 @@ You'll need two shells for this example.
 
 **Shell 1: Listening for events:**
 
-```bash
+```console
 $ docker events
 ```
 
 **Shell 2: Start and Stop containers:**
 
-```bash
+```console
 $ docker create --name test alpine:latest top
 $ docker start test
 $ docker stop test
@@ -239,7 +239,7 @@ To exit the `docker events` command, use `CTRL+C`.
 You can filter the output by an absolute timestamp or relative time on the host
 machine, using the following different time syntaxes:
 
-```bash
+```console
 $ docker events --since 1483283804
 2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
 2017-01-05T00:35:58.859401177+08:00 container create d9cd...4d70 (image=alpine:latest, name=test)
@@ -292,7 +292,7 @@ $ docker events --since '2017-01-05T00:35:30' --until '2017-01-05T00:36:05'
 The following commands show several different ways to filter the `docker event`
 output.
 
-```bash
+```console
 $ docker events --filter 'event=stop'
 
 2017-01-05T00:40:22.880175420+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
@@ -388,7 +388,7 @@ $ docker events --filter 'scope=swarm'
 
 ### Format the output
 
-```bash
+```console
 $ docker events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
 
 Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
@@ -401,7 +401,7 @@ Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299
 
 #### Format as JSON
 
-```bash
+```console
 $ docker events --format '{{json .}}'
 
 {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -46,7 +46,7 @@ not work, but `docker exec -ti my_container sh -c "echo a && echo b"` will.
 
 First, start a container.
 
-```bash
+```console
 $ docker run --name ubuntu_bash --rm -i -t ubuntu bash
 ```
 
@@ -54,7 +54,7 @@ This will create a container named `ubuntu_bash` and start a Bash session.
 
 Next, execute a command on the container.
 
-```bash
+```console
 $ docker exec -d ubuntu_bash touch /tmp/execWorks
 ```
 
@@ -63,7 +63,7 @@ This will create a new file `/tmp/execWorks` inside the running container
 
 Next, execute an interactive `bash` shell on the container.
 
-```bash
+```console
 $ docker exec -it ubuntu_bash bash
 ```
 
@@ -71,7 +71,7 @@ This will create a new Bash session in the container `ubuntu_bash`.
 
 Next, set an environment variable in the current bash session.
 
-```bash
+```console
 $ docker exec -it -e VAR=1 ubuntu_bash bash
 ```
 
@@ -81,14 +81,14 @@ on the current Bash session.
 
 By default `docker exec` command runs in the same working directory set when container was created.
 
-```bash
+```console
 $ docker exec -it ubuntu_bash pwd
 /
 ```
 
 You can select working directory for the command to execute into
 
-```bash
+```console
 $ docker exec -it -w /root ubuntu_bash pwd
 /root
 ```
@@ -98,7 +98,7 @@ $ docker exec -it -w /root ubuntu_bash pwd
 
 If the container is paused, then the `docker exec` command will fail with an error:
 
-```bash
+```console
 $ docker pause test
 
 test

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -30,10 +30,10 @@ in the user guide for examples on exporting data in a volume.
 
 Each of these commands has the same result.
 
-```bash
+```console
 $ docker export red_panda > latest.tar
 ```
 
-```bash
+```console
 $ docker export --output="latest.tar" red_panda
 ```

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -24,7 +24,7 @@ Options:
 
 To see how the `docker:latest` image was built:
 
-```bash
+```console
 $ docker history docker
 
 IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
@@ -38,7 +38,7 @@ be51b77efb42        8 days ago          /bin/sh -c apt-get update && apt-get ins
 
 To see how the `docker:apache` image was added to a container's base image:
 
-```bash
+```console
 $ docker history docker:scm
 IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
 2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
@@ -71,7 +71,7 @@ The following example uses a template without headers and outputs the
 `ID` and `CreatedSince` entries separated by a colon (`:`) for the `busybox`
 image:
 
-```bash
+```console
 $ docker history --format "{{.ID}}: {{.CreatedSince}}" busybox
 
 f6e427c148a7: 4 weeks ago

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -26,7 +26,7 @@ Remove all dangling images. If `-a` is specified, will also remove all images no
 
 Example output:
 
-```bash
+```console
 $ docker image prune -a
 
 WARNING! This will remove all images without at least one container associated to them.
@@ -101,7 +101,7 @@ images without the specified labels.
 
 The following removes images created before `2017-01-04T00:00:00`:
 
-```bash
+```console
 $ docker images --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedAt}}\t{{.Size}}'
 REPOSITORY          TAG                 IMAGE ID            CREATED AT                      SIZE
 foo                 latest              2f287ac753da        2017-01-04 13:42:23 -0800 PST   3.98 MB
@@ -128,7 +128,7 @@ foo                 latest              2f287ac753da        2017-01-04 13:42:23 
 
 The following removes images created more than 10 days (`240h`) ago:
 
-```bash
+```console
 $ docker images
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -168,25 +168,25 @@ busybox             latest              e02e811dd08f        2 months ago        
 
 The following example removes images with the label `deprecated`:
 
-```bash
+```console
 $ docker image prune --filter="label=deprecated"
 ```
 
 The following example removes images with the label `maintainer` set to `john`:
 
-```bash
+```console
 $ docker image prune --filter="label=maintainer=john"
 ```
 
 This example removes images which have no `maintainer` label:
 
-```bash
+```console
 $ docker image prune --filter="label!=maintainer"
 ```
 
 This example removes images which have a maintainer label not set to `john`:
 
-```bash
+```console
 $ docker image prune --filter="label!=maintainer=john"
 ```
 

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -48,7 +48,7 @@ uses up the `SIZE` listed only once.
 
 ### List the most recently created images
 
-```bash
+```console
 $ docker images
 
 REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
@@ -72,7 +72,7 @@ given repository.
 
 For example, to list all images in the "java" repository, run this command :
 
-```bash
+```console
 $ docker images java
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -88,7 +88,7 @@ If both `REPOSITORY` and `TAG` are provided, only images matching that
 repository and tag are listed.  To find all local images in the "java"
 repository with tag "8" you can use:
 
-```bash
+```console
 $ docker images java:8
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -97,7 +97,7 @@ java                8                   308e519aac60        6 days ago          
 
 If nothing matches `REPOSITORY[:TAG]`, the list is empty.
 
-```bash
+```console
 $ docker images java:0
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -105,7 +105,7 @@ REPOSITORY          TAG                 IMAGE ID            CREATED             
 
 ### List the full length image IDs
 
-```bash
+```console
 $ docker images --no-trunc
 
 REPOSITORY                    TAG                 IMAGE ID                                                                  CREATED             SIZE
@@ -127,7 +127,7 @@ called a `digest`. As long as the input used to generate the image is
 unchanged, the digest value is predictable. To list image digest values, use
 the `--digests` flag:
 
-```bash
+```console
 $ docker images --digests
 REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
 localhost:5000/test/busybox        <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536        9 weeks ago         2.43 MB
@@ -153,7 +153,7 @@ The currently supported filters are:
 
 #### Show untagged images (dangling)
 
-```bash
+```console
 $ docker images --filter "dangling=true"
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -173,7 +173,7 @@ using it. By having this flag it allows for batch cleanup.
 
 You can use this in conjunction with `docker rmi ...`:
 
-```bash
+```console
 $ docker rmi $(docker images -f "dangling=true" -q)
 
 8abc22fbb042
@@ -194,7 +194,7 @@ value.
 
 The following filter matches images with the `com.example.version` label regardless of its value.
 
-```bash
+```console
 $ docker images --filter "label=com.example.version"
 
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
@@ -204,7 +204,7 @@ match-me-2          latest              dea752e4e117        About a minute ago  
 
 The following filter matches images with the `com.example.version` label with the `1.0` value.
 
-```bash
+```console
 $ docker images --filter "label=com.example.version=1.0"
 
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
@@ -213,7 +213,7 @@ match-me            latest              511136ea3c5a        About a minute ago  
 
 In this example, with the `0.1` value, it returns an empty set because no matches were found.
 
-```bash
+```console
 $ docker images --filter "label=com.example.version=0.1"
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
 ```
@@ -223,7 +223,7 @@ REPOSITORY          TAG                 IMAGE ID            CREATED             
 The `before` filter shows only images created before the image with
 given id or reference. For example, having these images:
 
-```bash
+```console
 $ docker images
 
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
@@ -234,7 +234,7 @@ image3              latest              511136ea3c5a        25 minutes ago      
 
 Filtering with `before` would give:
 
-```bash
+```console
 $ docker images --filter "before=image1"
 
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
@@ -244,7 +244,7 @@ image3              latest              511136ea3c5a        25 minutes ago      
 
 Filtering with `since` would give:
 
-```bash
+```console
 $ docker images --filter "since=image3"
 REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
 image1              latest              eeae25ada2aa        4 minutes ago        188.3 MB
@@ -256,7 +256,7 @@ image2              latest              dea752e4e117        9 minutes ago       
 The `reference` filter shows only images whose reference matches
 the specified pattern.
 
-```bash
+```console
 $ docker images
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -268,7 +268,7 @@ busybox             glibc               21c16b6787c6        5 weeks ago         
 
 Filtering with `reference` would give:
 
-```bash
+```console
 $ docker images --filter=reference='busy*:*libc'
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -278,7 +278,7 @@ busybox             glibc               21c16b6787c6        5 weeks ago         
 
 Filtering with multiple `reference` would give, either match A or B:
 
-```bash
+```console
 $ docker images --filter=reference='busy*:uclibc' --filter=reference='busy*:glibc'
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -310,7 +310,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Repository` entries separated by a colon (`:`) for all images:
 
-```bash
+```console
 $ docker images --format "{{.ID}}: {{.Repository}}"
 
 77af4d6b9913: <none>
@@ -327,7 +327,7 @@ b6fa739cedf5: committ
 To list all images with their repository and tag in a table format you
 can use:
 
-```bash
+```console
 $ docker images --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
 
 IMAGE ID            REPOSITORY                TAG

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -39,39 +39,39 @@ Supported `Dockerfile` instructions:
 
 This will create a new untagged image.
 
-```bash
-$ docker import http://example.com/exampleimage.tgz
+```console
+$ docker import https://example.com/exampleimage.tgz
 ```
 
 ### Import from a local file
 
-- Import to docker via pipe and `STDIN`.
+Import to docker via pipe and `STDIN`.
 
-  ```bash
-  $ cat exampleimage.tgz | docker import - exampleimagelocal:new
-  ```
+```console
+$ cat exampleimage.tgz | docker import - exampleimagelocal:new
+```
 
-- Import with a commit message.
+Import with a commit message.
 
-  ```bash
-  $ cat exampleimage.tgz | docker import --message "New image imported from tarball" - exampleimagelocal:new
-  ```
+```console
+$ cat exampleimage.tgz | docker import --message "New image imported from tarball" - exampleimagelocal:new
+```
 
-- Import to docker from a local archive.
+Import to docker from a local archive.
 
-  ```bash
-  $ docker import /path/to/exampleimage.tgz
-  ```
+```console
+$ docker import /path/to/exampleimage.tgz
+```
 
 ### Import from a local directory
 
-```bash
+```console
 $ sudo tar -c . | docker import - exampleimagedir
 ```
 
 ### Import from a local directory with new configurations
 
-```bash
+```console
 $ sudo tar -c . | docker import --change "ENV DEBUG=true" - exampleimagedir
 ```
 
@@ -87,6 +87,6 @@ does not match the default operating system, it may be necessary to add
 `--platform`. This would be necessary when importing a Linux image into a Windows
 daemon.
 
-```bash
+```console
 $ docker import --platform=linux .\linuximage.tar
 ```

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -44,8 +44,9 @@ The example below shows the output for a daemon running on Red Hat Enterprise Li
 using the `devicemapper` storage driver. As can be seen in the output, additional
 information about the `devicemapper` storage driver is shown:
 
-```bash
+```console
 $ docker info
+
 Client:
  Context:    default
  Debug Mode: false
@@ -104,8 +105,9 @@ Server:
 Here is a sample output for a daemon running on Ubuntu, using the overlay2
 storage driver and a node that is part of a 2-node swarm:
 
-```bash
-$ docker -D info
+```console
+$ docker --debug info
+
 Client:
  Context:    default
  Debug Mode: true
@@ -194,7 +196,7 @@ The global `-D` option causes all `docker` commands to output debug information.
 
 You can also specify the output format:
 
-```bash
+```console
 $ docker info --format '{{json .}}'
 
 {"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -45,7 +45,7 @@ option.
 
 The following example inspects a _volume_ named "myvolume"
 
-```bash
+```console
 $ docker inspect --type=volume myvolume
 ```
 
@@ -56,25 +56,25 @@ $ docker inspect --type=volume myvolume
 For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
-```bash
+```console
 $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $INSTANCE_ID
 ```
 
 ### Get an instance's MAC address
 
-```bash
+```console
 $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.MacAddress}}{{end}}' $INSTANCE_ID
 ```
 
 ### Get an instance's log path
 
-```bash
+```console
 $ docker inspect --format='{{.LogPath}}' $INSTANCE_ID
 ```
 
 ### Get an instance's image name
 
-```bash
+```console
 $ docker inspect --format='{{.Config.Image}}' $INSTANCE_ID
 ```
 
@@ -83,7 +83,7 @@ $ docker inspect --format='{{.Config.Image}}' $INSTANCE_ID
 You can loop over arrays and maps in the results to produce simple text
 output:
 
-```bash
+```console
 $ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
 ```
 
@@ -97,7 +97,7 @@ numeric public port, you use `index` to find the specific port map, and
 then `index` 0 contains the first object inside of that. Then we ask for
 the `HostPort` field to get the public address.
 
-```bash
+```console
 $ docker inspect --format='{{(index (index .NetworkSettings.Ports "8787/tcp") 0).HostPort}}' $INSTANCE_ID
 ```
 
@@ -108,6 +108,6 @@ fields, by default you get a Go-style dump of the inner values.
 Docker adds a template function, `json`, which can be applied to get
 results in JSON format.
 
-```bash
+```console
 $ docker inspect --format='{{json .Config}}' $INSTANCE_ID
 ```

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -20,8 +20,18 @@ Options:
 
 The `docker kill` subcommand kills one or more containers. The main process
 inside the container is sent `SIGKILL` signal (default), or the signal that is
-specified with the `--signal` option. You can kill a container using the
-container's ID, ID-prefix, or name.
+specified with the `--signal` option. You can reference a container by its
+ID, ID-prefix, or name.
+
+The `--signal` (or `-s` shorthand) flag sets the system call signal that is sent
+to the container. This signal can be a signal name in the format `SIG<NAME>`, for
+instance `SIGINT`, or an unsigned number that matches a position in the kernel's
+syscall table, for instance `2`.
+
+While the default (`SIGKILL`) signal will terminate the container, the signal
+set through `--signal` may be non-terminal, depending on the container's main
+process. For example, the `SIGHUP` signal in most cases will be non-terminal,
+and the container will continue running after receiving the signal.
 
 > **Note**
 >
@@ -32,16 +42,16 @@ container's ID, ID-prefix, or name.
 ## Examples
 
 
-### Send a KILL signal  to a container
+### Send a KILL signal to a container
 
-The following example sends the default `KILL` signal to the container named
+The following example sends the default `SIGKILL` signal to the container named
 `my_container`:
 
 ```bash
 $ docker kill my_container
 ```
 
-### Send a custom signal  to a container
+### Send a custom signal to a container
 
 The following example sends a `SIGHUP` signal to the container named
 `my_container`:

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -47,7 +47,7 @@ and the container will continue running after receiving the signal.
 The following example sends the default `SIGKILL` signal to the container named
 `my_container`:
 
-```bash
+```console
 $ docker kill my_container
 ```
 
@@ -56,7 +56,7 @@ $ docker kill my_container
 The following example sends a `SIGHUP` signal to the container named
 `my_container`:
 
-```bash
+```console
 $ docker kill --signal=SIGHUP  my_container
 ```
 
@@ -64,7 +64,7 @@ $ docker kill --signal=SIGHUP  my_container
 You can specify a custom signal either by _name_, or _number_. The `SIG` prefix
 is optional, so the following examples are equivalent:
 
-```bash
+```console
 $ docker kill --signal=SIGHUP my_container
 $ docker kill --signal=HUP my_container
 $ docker kill --signal=1 my_container

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -18,6 +18,7 @@ Options:
                        The tarball may be compressed with gzip, bzip, or xz
   -q, --quiet          Suppress the load output but still outputs the imported images
 ```
+
 ## Description
 
 Load an image or repository from a tar archive (even if compressed with gzip,
@@ -25,7 +26,7 @@ bzip2, or xz) from a file or STDIN. It restores both images and tags.
 
 ## Examples
 
-```bash
+```console
 $ docker image ls
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -30,7 +30,7 @@ Login to a registry.
 If you want to login to a self-hosted registry you can specify this by
 adding the server name.
 
-```bash
+```console
 $ docker login localhost:8080
 ```
 
@@ -44,7 +44,7 @@ or log-files.
 The following example reads a password from a file, and passes it to the
 `docker login` command using `STDIN`:
 
-```bash
+```console
 $ cat ~/my_password.txt | docker login --username foo --password-stdin
 ```
 

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -18,7 +18,7 @@ Options:
 
 ## Examples
 
-```bash
+```console
 $ docker logout localhost:8080
 ```
 

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -67,7 +67,7 @@ fraction of a second no more than nine digits long. You can combine the
 
 In order to retrieve logs before a specific point in time, run:
 
-```bash
+```console
 $ docker run --name test -d busybox sh -c "while true; do $(echo date); sleep 1; done"
 $ date
 Tue 14 Nov 2017 16:40:00 CET

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -40,8 +40,8 @@ to two images -- one for windows on amd64, and one for darwin on amd64.
 
 ### manifest inspect
 
-```bash
-manifest inspect --help
+```console
+$ docker manifest inspect --help
 
 Usage:  docker manifest inspect [OPTIONS] [MANIFEST_LIST] MANIFEST
 
@@ -55,7 +55,7 @@ Options:
 
 ### manifest create
 
-```bash
+```console
 Usage:  docker manifest create MANIFEST_LIST MANIFEST [MANIFEST...]
 
 Create a local manifest list for annotating and pushing to a registry
@@ -68,7 +68,7 @@ Options:
 
 ### manifest annotate
 
-```bash
+```console
 Usage:  docker manifest annotate [OPTIONS] MANIFEST_LIST MANIFEST
 
 Add additional information to a local image manifest
@@ -85,7 +85,7 @@ Options:
 
 ### manifest push
 
-```bash
+```console
 Usage:  docker manifest push [OPTIONS] MANIFEST_LIST
 
 Push a manifest list to a repository
@@ -113,7 +113,7 @@ default requirements.
 
 ### Inspect an image's manifest object
 
-```bash
+```console
 $ docker manifest inspect hello-world
 {
         "schemaVersion": 2,
@@ -143,7 +143,7 @@ without a tag, or by digest (e.g. `hello-world@sha256:f3b3b28a45160805bb16542c95
 
 Here is an example of inspecting an image's manifest with the `--verbose` flag:
 
-```bash
+```console
 $ docker manifest inspect --verbose hello-world
 {
         "Ref": "docker.io/library/hello-world:latest",
@@ -187,7 +187,7 @@ After you have created your local copy of the manifest list, you may optionally
 Finally, you need to `push` your manifest list to the desired registry. Below are
 descriptions of these three commands, and an example putting them all together.
 
-```bash
+```console
 $ docker manifest create 45.55.81.106:5000/coolapp:v1 \
     45.55.81.106:5000/coolapp-ppc64le-linux:v1 \
     45.55.81.106:5000/coolapp-arm-linux:v1 \
@@ -197,11 +197,11 @@ $ docker manifest create 45.55.81.106:5000/coolapp:v1 \
 Created manifest list 45.55.81.106:5000/coolapp:v1
 ```
 
-```bash
+```console
 $ docker manifest annotate 45.55.81.106:5000/coolapp:v1 45.55.81.106:5000/coolapp-arm-linux --arch arm
 ```
 
-```bash
+```console
 $ docker manifest push 45.55.81.106:5000/coolapp:v1
 Pushed manifest 45.55.81.106:5000/coolapp@sha256:9701edc932223a66e49dd6c894a11db8c2cf4eccd1414f1ec105a623bf16b426 with digest: sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b
 Pushed manifest 45.55.81.106:5000/coolapp@sha256:f3b3b28a45160805bb16542c9531888519430e9e6d6ffc09d72261b0d26ff74f with digest: sha256:b64ca0b60356a30971f098c92200b1271257f100a55b351e6bbe985638352f3a
@@ -213,7 +213,7 @@ sha256:050b213d49d7673ba35014f21454c573dcbec75254a08f4a7c34f66a47c06aba
 
 ### Inspect a manifest list
 
-```bash
+```console
 $ docker manifest inspect coolapp:v1
 {
    "schemaVersion": 2,
@@ -264,7 +264,7 @@ $ docker manifest inspect coolapp:v1
 Here is an example of creating and pushing a manifest list using a known
 insecure registry.
 
-```bash
+```console
 $ docker manifest create --insecure myprivateregistry.mycompany.com/repo/image:1.0 \
     myprivateregistry.mycompany.com/repo/image-linux-ppc64le:1.0 \
     myprivateregistry.mycompany.com/repo/image-linux-s390x:1.0 \

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -30,7 +30,7 @@ the same network.
 
 ### Connect a running container to a network
 
-```bash
+```console
 $ docker network connect multi-host-network container1
 ```
 
@@ -38,7 +38,7 @@ $ docker network connect multi-host-network container1
 
 You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
 
-```bash
+```console
 $ docker run -itd --network=multi-host-network busybox
 ```
 
@@ -46,7 +46,7 @@ $ docker run -itd --network=multi-host-network busybox
 
 You can specify the IP address you want to be assigned to the container's interface.
 
-```bash
+```console
 $ docker network connect --ip 10.10.36.122 multi-host-network container2
 ```
 
@@ -54,7 +54,7 @@ $ docker network connect --ip 10.10.36.122 multi-host-network container2
 
 You can use `--link` option to link another container with a preferred alias
 
-```bash
+```console
 $ docker network connect --link container1:c1 multi-host-network container2
 ```
 
@@ -63,7 +63,7 @@ $ docker network connect --link container1:c1 multi-host-network container2
 `--alias` option can be used to resolve the container by another name in the network
 being connected to.
 
-```bash
+```console
 $ docker network connect --alias db --alias mysql multi-host-network container2
 ```
 
@@ -79,11 +79,11 @@ to specify an `--ip-range` when creating the network, and choose the static IP
 address(es) from outside that range. This ensures that the IP address is not
 given to another container while this container is not on the network.
 
-```bash
+```console
 $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-host-network
 ```
 
-```bash
+```console
 $ docker network connect --ip 172.20.128.2 multi-host-network container2
 ```
 

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -45,7 +45,7 @@ on. When you launch a new container with  `docker run` it automatically connects
 this bridge network. You cannot remove this default bridge network, but you can
 create new ones using the `network create` command.
 
-```bash
+```console
 $ docker network create -d bridge my-bridge-network
 ```
 
@@ -75,7 +75,7 @@ discovery and server management tools that can assist your implementation.
 Once you have prepared the `overlay` network prerequisites you simply choose a
 Docker host in the cluster and issue the following to create the network:
 
-```bash
+```console
 $ docker network create -d overlay my-multihost-network
 ```
 
@@ -102,7 +102,7 @@ for more information about different endpoint modes.
 When you start a container, use the `--network` flag to connect it to a network.
 This example adds the `busybox` container to the `mynet` network:
 
-```bash
+```console
 $ docker run -itd --network=mynet busybox
 ```
 
@@ -126,14 +126,14 @@ network. It is purely for ip-addressing purposes. You can override this default
 and specify subnetwork values directly using the `--subnet` option. On a
 `bridge` network you can only create a single subnet:
 
-```bash
+```console
 $ docker network create --driver=bridge --subnet=192.168.0.0/16 br0
 ```
 
 Additionally, you also specify the `--gateway` `--ip-range` and `--aux-address`
 options.
 
-```bash
+```console
 $ docker network create \
   --driver=bridge \
   --subnet=172.28.0.0/16 \
@@ -148,7 +148,7 @@ support it you can create multiple subnetworks. This example uses two `/25`
 subnet mask to adhere to the current guidance of not having more than 256 IPs in
 a single overlay network. Each of the subnetworks has 126 usable addresses.
 
-```bash
+```console
 $ docker network create -d overlay \
   --subnet=192.168.10.0/25 \
   --subnet=192.168.20.0/25 \
@@ -191,7 +191,7 @@ network driver, again with their approximate equivalents to `docker daemon`.
 For example, let's use `-o` or `--opt` options to specify an IP address binding
 when publishing ports:
 
-```bash
+```console
 $ docker network create \
     -o "com.docker.network.bridge.host_binding_ipv4"="172.19.0.1" \
     simple-network
@@ -212,7 +212,7 @@ one ingress network can be created at the time. The network can be removed only
 if no services depend on it. Any option available when creating an overlay network
 is also available when creating the ingress network, besides the `--attachable` option.
 
-```bash
+```console
 $ docker network create -d overlay \
   --subnet=10.11.0.0/16 \
   --ingress \

--- a/docs/reference/commandline/network_disconnect.md
+++ b/docs/reference/commandline/network_disconnect.md
@@ -23,7 +23,7 @@ disconnect it from the network.
 
 ## Examples
 
-```bash
+```console
 $ docker network disconnect multi-host-network container1
 ```
 

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -27,7 +27,7 @@ all results in a JSON object.
 
 Connect two containers to the default `bridge` network:
 
-```bash
+```console
 $ sudo docker run -itd --name=container1 busybox
 f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27
 
@@ -47,7 +47,7 @@ template for each result. Go's
 [text/template](http://golang.org/pkg/text/template/) package describes all the
 details of the format.
 
-```bash
+```console
 $ sudo docker network inspect bridge
 ```
 
@@ -104,13 +104,13 @@ The output is in JSON format, for example:
 
 Create and inspect a user-defined network:
 
-```bash
+```console
 $ docker network create simple-network
 
 69568e6336d8c96bbf57869030919f7c69524f71183b44d80948bd3927c87f6a
 ```
 
-```bash
+```console
 $ docker network inspect simple-network
 ```
 
@@ -146,7 +146,7 @@ For swarm mode overlay networks `network inspect` also shows the IP address and 
 of the peers. Peers are the nodes in the swarm cluster which have at least one task attached
 to the network. Node name is of the format `<hostname>-<unique ID>`.
 
-```bash
+```console
 $ docker network inspect ingress
 ```
 
@@ -213,7 +213,7 @@ and the IPs of the nodes where the tasks are running.
 Following is an example output for an overlay network `ov1` that has one service `s1`
 attached to. service `s1` in this case has three replicas.
 
-```bash
+```console
 $ docker network inspect --verbose ov1
 ```
 

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -31,8 +31,8 @@ networks that span across multiple hosts in a cluster.
 
 ### List all networks
 
-```bash
-$ sudo docker network ls
+```console
+$ docker network ls
 NETWORK ID          NAME                DRIVER          SCOPE
 7fca4eb8c647        bridge              bridge          local
 9f904ee27bf5        none                null            local
@@ -42,7 +42,7 @@ cf03ee007fb4        host                host            local
 
 Use the `--no-trunc` option to display the full network id:
 
-```bash
+```console
 $ docker network ls --no-trunc
 NETWORK ID                                                         NAME                DRIVER           SCOPE
 18a2866682b85619a026c81b98a5e375bd33e1b0936a26cc497c283d27bae9b3   none                null             local
@@ -74,7 +74,7 @@ The `driver` filter matches networks based on their driver.
 
 The following example matches networks with the `bridge` driver:
 
-```bash
+```console
 $ docker network ls --filter driver=bridge
 NETWORK ID          NAME                DRIVER            SCOPE
 db9db329f835        test1               bridge            local
@@ -88,7 +88,7 @@ The `id` filter matches on all or part of a network's ID.
 The following filter matches all networks with an ID containing the
 `63d1ff1f77b0...` string.
 
-```bash
+```console
 $ docker network ls --filter id=63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161
 NETWORK ID          NAME                DRIVER           SCOPE
 63d1ff1f77b0        dev                 bridge           local
@@ -96,7 +96,7 @@ NETWORK ID          NAME                DRIVER           SCOPE
 
 You can also filter for a substring in an ID as this shows:
 
-```bash
+```console
 $ docker network ls --filter id=95e74588f40d
 NETWORK ID          NAME                DRIVER          SCOPE
 95e74588f40d        foo                 bridge          local
@@ -113,7 +113,7 @@ value.
 
 The following filter matches networks with the `usage` label regardless of its value.
 
-```bash
+```console
 $ docker network ls -f "label=usage"
 NETWORK ID          NAME                DRIVER         SCOPE
 db9db329f835        test1               bridge         local
@@ -122,7 +122,7 @@ f6e212da9dfd        test2               bridge         local
 
 The following filter matches networks with the `usage` label with the `prod` value.
 
-```bash
+```console
 $ docker network ls -f "label=usage=prod"
 NETWORK ID          NAME                DRIVER        SCOPE
 f6e212da9dfd        test2               bridge        local
@@ -134,7 +134,7 @@ The `name` filter matches on all or part of a network's name.
 
 The following filter matches all networks with a name containing the `foobar` string.
 
-```bash
+```console
 $ docker network ls --filter name=foobar
 NETWORK ID          NAME                DRIVER       SCOPE
 06e7eef0a170        foobar              bridge       local
@@ -142,7 +142,7 @@ NETWORK ID          NAME                DRIVER       SCOPE
 
 You can also filter for a substring in a name as this shows:
 
-```bash
+```console
 $ docker network ls --filter name=foo
 NETWORK ID          NAME                DRIVER       SCOPE
 95e74588f40d        foo                 bridge       local
@@ -155,7 +155,7 @@ The `scope` filter matches networks based on their scope.
 
 The following example matches networks with the `swarm` scope:
 
-```bash
+```console
 $ docker network ls --filter scope=swarm
 NETWORK ID          NAME                DRIVER              SCOPE
 xbtm0v4f1lfh        ingress             overlay             swarm
@@ -164,7 +164,7 @@ ic6r88twuu92        swarmnet            overlay             swarm
 
 The following example matches networks with the `local` scope:
 
-```bash
+```console
 $ docker network ls --filter scope=local
 NETWORK ID          NAME                DRIVER              SCOPE
 e85227439ac7        bridge              bridge              local
@@ -180,7 +180,7 @@ The `type` filter supports two values; `builtin` displays predefined networks
 
 The following filter matches all user defined networks:
 
-```bash
+```console
 $ docker network ls --filter type=custom
 NETWORK ID          NAME                DRIVER       SCOPE
 95e74588f40d        foo                 bridge       local
@@ -190,7 +190,7 @@ NETWORK ID          NAME                DRIVER       SCOPE
 By having this flag it allows for batch cleanup. For example, use this filter
 to delete all user defined networks:
 
-```bash
+```console
 $ docker network rm `docker network ls --filter type=custom -q`
 ```
 
@@ -223,7 +223,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Driver` entries separated by a colon (`:`) for all networks:
 
-```bash
+```console
 $ docker network ls --format "{{.ID}}: {{.Driver}}"
 afaaab448eb2: bridge
 d1584f8dc718: host

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -24,7 +24,7 @@ by any containers.
 
 ## Examples
 
-```bash
+```console
 $ docker network prune
 
 WARNING! This will remove all custom networks not used by at least one container.
@@ -64,7 +64,7 @@ networks without the specified labels.
 The following removes networks created more than 5 minutes ago. Note that
 system networks such as `bridge`, `host`, and `none` will never be pruned:
 
-```bash
+```console
 $ docker network ls
 
 NETWORK ID          NAME                DRIVER              SCOPE

--- a/docs/reference/commandline/network_rm.md
+++ b/docs/reference/commandline/network_rm.md
@@ -29,8 +29,8 @@ you must first disconnect any containers connected to it.
 
 To remove the network named 'my-network':
 
-```bash
-  $ docker network rm my-network
+```console
+$ docker network rm my-network
 ```
 
 ### Remove multiple networks
@@ -39,8 +39,8 @@ To delete multiple networks in a single `docker network rm` command, provide
 multiple network names or ids. The following example deletes a network with id
 `3695c422697f` and a network named `my-network`:
 
-```bash
-  $ docker network rm 3695c422697f my-network
+```console
+$ docker network rm 3695c422697f my-network
 ```
 
 When you specify multiple networks, the command attempts to delete each in turn.

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -28,7 +28,7 @@ Demotes an existing manager so that it is no longer a manager.
 
 ## Examples
 
-```bash
+```console
 $ docker node demote <node name>
 ```
 

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -36,7 +36,7 @@ details of the format.
 
 ### Inspect a node
 
-```bash
+```console
 $ docker node inspect swarm-manager
 ```
 
@@ -113,7 +113,7 @@ $ docker node inspect swarm-manager
 
 ### Specify an output format
 
-```bash
+```console
 $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self
 
 false
@@ -121,7 +121,7 @@ false
 
 Use `--format=pretty` or the `--pretty` shorthand to pretty-print the output:
 
-```bash
+```console
 $ docker node inspect --format=pretty self
 
 ID:                     e216jshn25ckzbvmwlnh5jr3g

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -36,7 +36,7 @@ for more information about available filter options.
 
 ## Examples
 
-```bash
+```console
 $ docker node ls
 
 ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
@@ -44,6 +44,7 @@ ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATU
 38ciaotwjuritcdtn9npbnkuz    swarm-worker1   Ready   Active
 e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 ```
+
 > **Note**
 >
 > In the above example output, there is a hidden column of `.Self` that indicates
@@ -69,7 +70,7 @@ The currently supported filters are:
 
 The `id` filter matches all or part of a node's id.
 
-```bash
+```console
 $ docker node ls -f id=1
 
 ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
@@ -85,7 +86,7 @@ Swarm `node` labels, use [`node.label` instead](#nodelabel).
 
 The following filter matches nodes with the `foo` label regardless of its value.
 
-```bash
+```console
 $ docker node ls -f "label=foo"
 
 ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
@@ -135,7 +136,7 @@ The `membership` filter matches nodes based on the presence of a `membership` an
 
 The following filter matches nodes with the `membership` of `accepted`.
 
-```bash
+```console
 $ docker node ls -f "membership=accepted"
 
 ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
@@ -149,7 +150,7 @@ The `name` filter matches on all or part of a node hostname.
 
 The following filter matches the nodes with a name equal to `swarm-master` string.
 
-```bash
+```console
 $ docker node ls -f name=swarm-manager1
 
 ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
@@ -162,7 +163,7 @@ The `role` filter matches nodes based on the presence of a `role` and a value `w
 
 The following filter matches nodes with the `manager` role.
 
-```bash
+```console
 $ docker node ls -f "role=manager"
 
 ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATUS
@@ -195,8 +196,9 @@ The following example uses a template without headers and outputs the
 `ID`, `Hostname`, and `TLS Status` entries separated by a colon (`:`) for all
 nodes:
 
-```bash
+```console
 $ docker node ls --format "{{.ID}}: {{.Hostname}} {{.TLSStatus}}"
+
 e216jshn25ckzbvmwlnh5jr3g: swarm-manager1 Ready
 35o6tiywb700jesrt3dmllaza: swarm-worker1 Needs Rotation
 ```

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -28,7 +28,7 @@ Promotes a node to manager. This command can only be executed on a manager node.
 
 ## Examples
 
-```bash
+```console
 $ docker node promote <node name>
 ```
 

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -36,8 +36,9 @@ information about available filter options.
 
 ## Examples
 
-```bash
+```console
 $ docker node ps swarm-manager1
+
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
 redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:3.0.6  swarm-manager1  Running        Running 5 hours
 redis.6.b465edgho06e318egmgjbqo4o   redis:3.0.6  swarm-manager1  Running        Running 29 seconds
@@ -64,7 +65,7 @@ The `name` filter matches on all or part of a task's name.
 
 The following filter matches all tasks with a name containing the `redis` string.
 
-```bash
+```console
 $ docker node ps -f name=redis swarm-manager1
 
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
@@ -79,7 +80,7 @@ redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        
 
 The `id` filter matches a task's id.
 
-```bash
+```console
 $ docker node ps -f id=bg8c07zzg87di2mufeq51a2qp swarm-manager1
 
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
@@ -93,7 +94,7 @@ value.
 
 The following filter matches tasks with the `usage` label regardless of its value.
 
-```bash
+```console
 $ docker node ps -f "label=usage"
 
 NAME                               IMAGE        NODE            DESIRED STATE  CURRENT STATE
@@ -132,8 +133,9 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
-```bash
+```console
 $ docker node ps --format "{{.Name}}: {{.Image}}"
+
 top.1: busybox
 top.2: busybox
 top.3: busybox

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -34,11 +34,12 @@ Removes the specified nodes from a swarm.
 
 ### Remove a stopped node from the swarm
 
-```bash
+```console
 $ docker node rm swarm-node-02
 
 Node swarm-node-02 removed from swarm
 ```
+
 ### Attempt to remove a running node from a swarm
 
 Removes the specified nodes from the swarm, but only if the nodes are in the
@@ -58,7 +59,7 @@ compromised or is not behaving as expected, you can use the `--force` option.
 This may cause transient errors or interruptions, depending on the type of task
 being run on the node.
 
-```bash
+```console
 $ docker node rm --force swarm-node-03
 
 Node swarm-node-03 removed from swarm

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -43,7 +43,7 @@ $ docker node update --label-add foo worker1
 
 To add multiple labels to a node, pass the `--label-add` flag for each label:
 
-```bash
+```console
 $ docker node update --label-add foo --label-add bar worker1
 ```
 

--- a/docs/reference/commandline/pause.md
+++ b/docs/reference/commandline/pause.md
@@ -30,7 +30,7 @@ for further details.
 
 ## Examples
 
-```bash
+```console
 $ docker pause my_container
 ```
 

--- a/docs/reference/commandline/plugin_create.md
+++ b/docs/reference/commandline/plugin_create.md
@@ -25,7 +25,7 @@ Creates a plugin. Before creating the plugin, prepare the plugin's root filesyst
 
 The following example shows how to create a sample `plugin`.
 
-```bash
+```console
 $ ls -ls /home/pluginDir
 
 total 4

--- a/docs/reference/commandline/plugin_disable.md
+++ b/docs/reference/commandline/plugin_disable.md
@@ -27,7 +27,7 @@ a plugin that has references (e.g., volumes, networks) cannot be disabled.
 The following example shows that the `sample-volume-plugin` plugin is installed
 and enabled:
 
-```bash
+```console
 $ docker plugin ls
 
 ID            NAME                                    DESCRIPTION                ENABLED
@@ -36,7 +36,7 @@ ID            NAME                                    DESCRIPTION               
 
 To disable the plugin, use the following command:
 
-```bash
+```console
 $ docker plugin disable tiborvass/sample-volume-plugin
 
 tiborvass/sample-volume-plugin

--- a/docs/reference/commandline/plugin_enable.md
+++ b/docs/reference/commandline/plugin_enable.md
@@ -26,7 +26,7 @@ see [`docker plugin install`](plugin_install.md).
 The following example shows that the `sample-volume-plugin` plugin is installed,
 but disabled:
 
-```bash
+```console
 $ docker plugin ls
 
 ID            NAME                                    DESCRIPTION                ENABLED
@@ -35,7 +35,7 @@ ID            NAME                                    DESCRIPTION               
 
 To enable the plugin, use the following command:
 
-```bash
+```console
 $ docker plugin enable tiborvass/sample-volume-plugin
 
 tiborvass/sample-volume-plugin

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -27,7 +27,7 @@ in a JSON array.
 
 The following example example inspects the `tiborvass/sample-volume-plugin` plugin:
 
-```bash
+```console
 $ docker plugin inspect tiborvass/sample-volume-plugin:latest
 ```
 
@@ -144,7 +144,7 @@ Output is in JSON format (output below is formatted for readability):
 
 ### Formatting the output
 
-```bash
+```console
 $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest
 
 8c74c978c434745c3ade82f1bc0acf38d04990eaf494fa507c16d9f1daa99c21

--- a/docs/reference/commandline/plugin_install.md
+++ b/docs/reference/commandline/plugin_install.md
@@ -33,7 +33,7 @@ The following example installs `vieus/sshfs` plugin and [sets](plugin_set.md) it
 Hub and prompt the user to accept the list of privileges that the plugin needs,
 set the plugin's parameters and enable the plugin.
 
-```bash
+```console
 $ docker plugin install vieux/sshfs DEBUG=1
 
 Plugin "vieux/sshfs" is requesting the following privileges:
@@ -46,7 +46,7 @@ vieux/sshfs
 
 After the plugin is installed, it appears in the list of plugins:
 
-```bash
+```console
 $ docker plugin ls
 
 ID             NAME                  DESCRIPTION                ENABLED

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -31,7 +31,7 @@ Refer to the [filtering](#filtering) section for more information about availabl
 
 ## Examples
 
-```bash
+```console
 $ docker plugin ls
 
 ID            NAME                                    DESCRIPTION                ENABLED
@@ -58,7 +58,7 @@ The `capability` filter matches on plugin capabilities. One plugin
 might have multiple capabilities. Currently `volumedriver`, `networkdriver`,
 `ipamdriver`, `logdriver`, `metricscollector`, and `authz` are supported capabilities.
 
-```bash
+```console
 $ docker plugin install --disable vieux/sshfs
 
 Installed plugin vieux/sshfs
@@ -90,7 +90,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Name` entries separated by a colon (`:`) for all plugins:
 
-```bash
+```console
 $ docker plugin ls --format "{{.ID}}: {{.Name}}"
 
 4be01827a72e: vieux/sshfs:latest

--- a/docs/reference/commandline/plugin_push.md
+++ b/docs/reference/commandline/plugin_push.md
@@ -26,7 +26,7 @@ Registry credentials are managed by [docker login](login.md).
 
 The following example shows how to push a sample `user/plugin`.
 
-```bash
+```console
 $ docker plugin ls
 
 ID             NAME                    DESCRIPTION                  ENABLED

--- a/docs/reference/commandline/plugin_rm.md
+++ b/docs/reference/commandline/plugin_rm.md
@@ -31,7 +31,7 @@ functioning of running containers using the plugin).
 The following example disables and removes the `sample-volume-plugin:latest`
 plugin:
 
-```bash
+```console
 $ docker plugin disable tiborvass/sample-volume-plugin
 
 tiborvass/sample-volume-plugin

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -84,7 +84,7 @@ On the contrary, the `LOGGING` environment variable doesn't have any settable fi
 The following example change the env variable `DEBUG` on the
 `sample-volume-plugin` plugin.
 
-```bash
+```console
 $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 [DEBUG=0]
 
@@ -99,7 +99,7 @@ $ docker plugin inspect -f {{.Settings.Env}} tiborvass/sample-volume-plugin
 The following example change the source of the `mymount` mount on
 the `myplugin` plugin.
 
-```bash
+```console
 $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.Source}}{{end}}' myplugin
 /foo
 
@@ -119,7 +119,7 @@ $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.
 The following example change the path of the `mydevice` device on
 the `myplugin` plugin.
 
-```bash
+```console
 $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$device.Path}}{{end}}' myplugin
 
 /dev/foo
@@ -139,7 +139,7 @@ $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$devi
 
 The following example change the value of the args on the `myplugin` plugin.
 
-```bash
+```console
 $ docker plugin inspect -f '{{.Settings.Args}}' myplugin
 
 ["foo", "bar"]

--- a/docs/reference/commandline/plugin_upgrade.md
+++ b/docs/reference/commandline/plugin_upgrade.md
@@ -30,7 +30,7 @@ The plugin must be disabled before running the upgrade.
 The following example installs `vieus/sshfs` plugin, uses it to create and use
 a volume, then upgrades the plugin.
 
-```bash
+```console
 $ docker plugin install vieux/sshfs DEBUG=1
 
 Plugin "vieux/sshfs:next" is requesting the following privileges:

--- a/docs/reference/commandline/port.md
+++ b/docs/reference/commandline/port.md
@@ -22,7 +22,7 @@ Options:
 You can find out all the ports mapped by not specifying a `PRIVATE_PORT`, or
 just a specific mapping:
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -45,7 +45,7 @@ Options:
 
 Running `docker ps --no-trunc` showing 2 linked containers.
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
@@ -58,7 +58,7 @@ d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minut
 The `docker ps` command only shows running containers by default. To see all
 containers, use the `-a` (or `--all`) flag:
 
-```bash
+```console
 $ docker ps -a
 ```
 
@@ -70,7 +70,7 @@ the `PORTS` column.
 
 The `docker ps -s` command displays two different on-disk-sizes for each container:
 
-```bash
+```console
 $ docker ps -s
 
 CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
@@ -114,7 +114,7 @@ value.
 
 The following filter matches containers with the `color` label regardless of its value.
 
-```bash
+```console
 $ docker ps --filter "label=color"
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -124,7 +124,7 @@ d85756f57265        busybox             "top"               52 seconds ago      
 
 The following filter matches containers with the `color` label with the `blue` value.
 
-```bash
+```console
 $ docker ps --filter "label=color=blue"
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
@@ -137,7 +137,7 @@ The `name` filter matches on all or part of a container's name.
 
 The following filter matches all containers with a name containing the `nostalgic_stallman` string.
 
-```bash
+```console
 $ docker ps --filter "name=nostalgic_stallman"
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -146,7 +146,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 You can also filter for a substring in a name as this shows:
 
-```bash
+```console
 $ docker ps --filter "name=nostalgic"
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -160,7 +160,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 The `exited` filter matches containers by exist status code. For example, to
 filter for containers that have exited successfully:
 
-```bash
+```console
 $ docker ps -a --filter 'exited=0'
 
 CONTAINER ID        IMAGE             COMMAND                CREATED             STATUS                   PORTS                      NAMES
@@ -174,7 +174,7 @@ ea09c3c82f6e        registry:latest   /srv/run.sh            2 weeks ago        
 You can use a filter to locate containers that exited with status of `137`
 meaning a `SIGKILL(9)` killed them.
 
-```bash
+```console
 $ docker ps -a --filter 'exited=137'
 
 CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
@@ -194,7 +194,7 @@ The `status` filter matches containers by status. You can filter using
 `created`, `restarting`, `running`, `removing`, `paused`, `exited` and `dead`. For example,
 to filter for `running` containers:
 
-```bash
+```console
 $ docker ps --filter status=running
 
 CONTAINER ID        IMAGE                  COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -205,7 +205,7 @@ d5c976d3c462        busybox                "top"               23 minutes ago   
 
 To filter for `paused` containers:
 
-```bash
+```console
 $ docker ps --filter status=paused
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                      PORTS               NAMES
@@ -226,7 +226,7 @@ it. The filter supports the following image representation:
 If you don't specify a `tag`, the `latest` tag is used. For example, to filter
 for containers that use the latest `ubuntu` image:
 
-```bash
+```console
 $ docker ps --filter ancestor=ubuntu
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
@@ -239,7 +239,7 @@ bab2a34ba363        ubuntu              "top"               3 minutes ago       
 Match containers based on the `ubuntu-c1` image which, in this case, is a child
 of `ubuntu`:
 
-```bash
+```console
 $ docker ps --filter ancestor=ubuntu-c1
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
@@ -248,7 +248,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 Match containers based on the `ubuntu` version `12.04.5` image:
 
-```bash
+```console
 $ docker ps --filter ancestor=ubuntu:12.04.5
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
@@ -258,7 +258,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 The following matches containers based on the layer `d0e008c6cf02` or an image
 that have this layer in its layer stack.
 
-```bash
+```console
 $ docker ps --filter ancestor=d0e008c6cf02
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
@@ -272,7 +272,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 The `before` filter shows only containers created before the container with
 given id or name. For example, having these containers created:
 
-```bash
+```console
 $ docker ps
 
 CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
@@ -283,7 +283,7 @@ CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS       
 
 Filtering with `before` would give:
 
-```bash
+```console
 $ docker ps -f before=9c3527ed70ce
 
 CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS              PORTS              NAMES
@@ -296,7 +296,7 @@ CONTAINER ID        IMAGE       COMMAND       CREATED              STATUS       
 The `since` filter shows only containers created since the container with given
 id or name. For example, with the same containers as in `before` filter:
 
-```bash
+```console
 $ docker ps -f since=6e63f6ff38b0
 
 CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS              PORTS               NAMES
@@ -309,7 +309,7 @@ CONTAINER ID        IMAGE       COMMAND       CREATED             STATUS        
 The `volume` filter shows only containers that mount a specific volume or have
 a volume mounted in a specific path:
 
-```bash
+```console
 $ docker ps --filter volume=remote-volume --format "table {{.ID}}\t{{.Mounts}}"
 
 CONTAINER ID        MOUNTS
@@ -329,7 +329,7 @@ a given name or id.
 The following filter matches all containers that are connected to a network
 with a name containing `net1`.
 
-```bash
+```console
 $ docker run -d --net=net1 --name=test1 ubuntu top
 $ docker run -d --net=net2 --name=test2 ubuntu top
 
@@ -343,7 +343,7 @@ The network filter matches on both the network's name and id. The following
 example shows all containers that are attached to the `net1` network, using
 the network id as a filter;
 
-```bash
+```console
 $ docker network inspect --format "{{.ID}}" net1
 
 8c0b4110ae930dbe26b258de9bc34a03f98056ed6f27f991d32919bfe401d7c5
@@ -361,7 +361,7 @@ number, port range, and/or protocol. The default protocol is `tcp` when not spec
 
 The following filter matches all containers that have published port of 80:
 
-```bash
+```console
 $ docker run -d --publish=80 busybox top
 $ docker run -d --expose=8080 busybox top
 
@@ -378,7 +378,8 @@ fc7e477723b7        busybox             "top"               About a minute ago  
 ```
 
 The following filter matches all containers that have exposed TCP port in the range of `8000-8080`:
-```bash
+
+```console
 $ docker ps --filter expose=8000-8080/tcp
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -386,7 +387,8 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 ```
 
 The following filter matches all containers that have exposed UDP port `80`:
-```bash
+
+```console
 $ docker ps --filter publish=80/udp
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
@@ -423,7 +425,7 @@ column headers as well.
 The following example uses a template without headers and outputs the `ID` and
 `Command` entries separated by a colon (`:`) for all running containers:
 
-```bash
+```console
 $ docker ps --format "{{.ID}}: {{.Command}}"
 
 a87ecb4f327c: /bin/sh -c #(nop) MA
@@ -434,7 +436,7 @@ c1d3b0166030: /bin/sh -c yum -y up
 
 To list all running containers with their labels in a table format you can use:
 
-```bash
+```console
 $ docker ps --format "table {{.ID}}\t{{.Labels}}"
 
 CONTAINER ID        LABELS

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -53,7 +53,7 @@ To download a particular image, or set of images (i.e., a repository), use
 `docker pull`. If no tag is provided, Docker Engine uses the `:latest` tag as a
 default. This command pulls the `debian:latest` image:
 
-```bash
+```console
 $ docker pull debian
 
 Using default tag: latest
@@ -72,7 +72,7 @@ both layers with `debian:latest`. Pulling the `debian:jessie` image therefore
 only pulls its metadata, but not its layers, because all layers are already
 present locally:
 
-```bash
+```console
 $ docker pull debian:jessie
 
 jessie: Pulling from library/debian
@@ -85,7 +85,7 @@ Status: Downloaded newer image for debian:jessie
 To see which images are present locally, use the [`docker images`](images.md)
 command:
 
-```bash
+```console
 $ docker images
 
 REPOSITORY   TAG      IMAGE ID        CREATED      SIZE
@@ -121,22 +121,22 @@ and guarantee that the image you're using is always the same.
 To know the digest of an image, pull the image first. Let's pull the latest
 `ubuntu:14.04` image from Docker Hub:
 
-```bash
-$ docker pull ubuntu:14.04
+```console
+$ docker pull ubuntu:20.04
 
-14.04: Pulling from library/ubuntu
-5a132a7e7af1: Pull complete
-fd2731e4c50c: Pull complete
-28a2f68d1120: Pull complete
-a3ed95caeb02: Pull complete
-Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-Status: Downloaded newer image for ubuntu:14.04
+20.04: Pulling from library/ubuntu
+16ec32c2132b: Pull complete
+Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+Status: Downloaded newer image for ubuntu:20.04
+docker.io/library/ubuntu:20.04
 ```
 
 Docker prints the digest of the image after the pull has finished. In the example
 above, the digest of the image is:
 
-    sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+```console
+sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+```
 
 Docker also prints the digest of an image when *pushing* to a registry. This
 may be useful if you want to pin to a version of the image you just pushed.
@@ -144,22 +144,19 @@ may be useful if you want to pin to a version of the image you just pushed.
 A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
-```bash
-$ docker pull ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+```console
+$ docker pull ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
 
-sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2: Pulling from library/ubuntu
-5a132a7e7af1: Already exists
-fd2731e4c50c: Already exists
-28a2f68d1120: Already exists
-a3ed95caeb02: Already exists
-Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-Status: Downloaded newer image for ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3: Pulling from library/ubuntu
+Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+Status: Image is up to date for ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
 ```
 
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
-FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+FROM ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
 LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 ```
 
@@ -181,7 +178,7 @@ path is similar to a URL, but does not contain a protocol specifier (`https://`)
 The following command pulls the `testing/test-image` image from a local registry
 listening on port 5000 (`myregistry.local:5000`):
 
-```bash
+```console
 $ docker pull myregistry.local:5000/testing/test-image
 ```
 
@@ -200,7 +197,7 @@ can contain multiple images. To pull all images from a repository, provide the
 
 This command pulls all images from the `fedora` repository:
 
-```bash
+```console
 $ docker pull --all-tags fedora
 
 Pulling repository fedora
@@ -217,7 +214,7 @@ After the pull has completed use the `docker images` command to see the
 images that were pulled. The example below shows all the `fedora` images
 that are present locally:
 
-```bash
+```console
 $ docker images fedora
 
 REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
@@ -232,7 +229,7 @@ fedora       latest      105182bb5e8b    5 days ago   372.7 MB
 Killing the `docker pull` process, for example by pressing `CTRL-c` while it is
 running in a terminal, will terminate the pull operation.
 
-```bash
+```console
 $ docker pull fedora
 
 Using default tag: latest

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -50,7 +50,7 @@ First save the new image by finding the container ID (using [`docker container l
 and then committing it to a new image name.  Note that only `a-z0-9-_.` are
 allowed when naming images:
 
-```bash
+```console
 $ docker container commit c16378f943fe rhel-httpd:latest
 ```
 
@@ -59,7 +59,7 @@ registry is on host named `registry-host` and listening on port `5000`. To do
 this, tag the image with the host name or IP address, and the port of the
 registry:
 
-```bash
+```console
 $ docker image tag rhel-httpd:latest registry-host:5000/myadmin/rhel-httpd:latest
 
 $ docker image push registry-host:5000/myadmin/rhel-httpd:latest
@@ -67,7 +67,7 @@ $ docker image push registry-host:5000/myadmin/rhel-httpd:latest
 
 Check that this worked by running:
 
-```bash
+```console
 $ docker image ls
 ```
 
@@ -82,7 +82,7 @@ The following example creates multiple tags for an image, and pushes all those
 tags to Docker Hub.
 
 
-```bash
+```console
 $ docker image tag myimage registry-host:5000/myname/myimage:latest
 $ docker image tag myimage registry-host:5000/myname/myimage:v1.0.1
 $ docker image tag myimage registry-host:5000/myname/myimage:v1.0
@@ -91,7 +91,7 @@ $ docker image tag myimage registry-host:5000/myname/myimage:v1
 
 The image is now tagged under multiple names:
 
-```bash
+```console
 $ docker image ls
 
 REPOSITORY                          TAG        IMAGE ID       CREATED      SIZE
@@ -106,7 +106,7 @@ When pushing with the `--all-tags` option, all tags of the `registry-host:5000/m
 image are pushed:
 
 
-```bash
+```console
 $ docker image push --all-tags registry-host:5000/myname/myimage
 
 The push refers to repository [registry-host:5000/myname/myimage]

--- a/docs/reference/commandline/rename.md
+++ b/docs/reference/commandline/rename.md
@@ -21,6 +21,6 @@ The `docker rename` command renames a container.
 
 ## Examples
 
-```bash
+```console
 $ docker rename my_container my_new_container
 ```

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -18,6 +18,6 @@ Options:
 
 ## Examples
 
-```bash
+```console
 $ docker restart my_container
 ```

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -24,7 +24,7 @@ Options:
 
 This removes the container referenced under the link `/redis`.
 
-```bash
+```console
 $ docker rm /redis
 
 /redis
@@ -37,7 +37,7 @@ containers on the default bridge network, removing all network communication
 between the two containers. This does not apply when `--link` is used with
 user-specified networks.
 
-```bash
+```console
 $ docker rm --link /webapp/redis
 
 /webapp/redis
@@ -47,7 +47,7 @@ $ docker rm --link /webapp/redis
 
 This command force-removes a running container.
 
-```bash
+```console
 $ docker rm --force redis
 
 redis
@@ -88,7 +88,7 @@ $ docker ps --filter status=exited -q | xargs docker rm
 
 ### Remove a container and its volumes
 
-```bash
+```console
 $ docker rm -v redis
 redis
 ```
@@ -98,7 +98,7 @@ Note that if a volume was specified with a name, it will not be removed.
 
 ### Remove a container and selectively remove volumes
 
-```bash
+```console
 $ docker create -v awesome:/foo -v /bar --name hello redis
 hello
 

--- a/docs/reference/commandline/rmi.md
+++ b/docs/reference/commandline/rmi.md
@@ -35,7 +35,7 @@ an image has one or more tags referencing it, you must remove all of them before
 the image is removed. Digest references are removed automatically when an image
 is removed by tag.
 
-```bash
+```console
 $ docker images
 
 REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
@@ -71,7 +71,7 @@ Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
 If you use the `-f` flag and specify the image's short or long ID, then this
 command untags and removes all images that match the specified ID.
 
-```bash
+```console
 $ docker images
 
 REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
@@ -89,7 +89,7 @@ Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
 
 An image pulled by digest has no tag associated with it:
 
-```bash
+```console
 $ docker images --digests
 
 REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         SIZE
@@ -98,7 +98,7 @@ localhost:5000/test/busybox    <none>    sha256:cbbf2f9a99b47fc460d422812b6a5adf
 
 To remove an image using its digest:
 
-```bash
+```console
 $ docker rmi localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
 Untagged: localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
 Deleted: 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -161,7 +161,7 @@ For information on connecting a container to a network, see the ["*Docker networ
 
 ### Assign name and allocate pseudo-TTY (--name, -it)
 
-```bash
+```console
 $ docker run --name test -it debian
 
 root@d6c0fe130dba:/# exit 13
@@ -180,7 +180,7 @@ In the example, the `bash` shell is quit by entering
 
 ### Capture container ID (--cidfile)
 
-```bash
+```console
 $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
 ```
 
@@ -191,7 +191,7 @@ file when `docker run` exits.
 
 ### Full container capabilities (--privileged)
 
-```bash
+```console
 $ docker run -t -i --rm ubuntu bash
 root@bc338942ef20:/# mount -t tmpfs none /mnt
 mount: permission denied
@@ -201,7 +201,7 @@ This will *not* work, because by default, most potentially dangerous kernel
 capabilities are dropped; including `cap_sys_admin` (which is required to mount
 filesystems). However, the `--privileged` flag will allow it to run:
 
-```bash
+```console
 $ docker run -t -i --privileged ubuntu bash
 root@50e3f57e16e6:/# mount -t tmpfs none /mnt
 root@50e3f57e16e6:/# df -h
@@ -216,7 +216,7 @@ flag exists to allow special use-cases, like running Docker within Docker.
 
 ### Set working directory (-w)
 
-```bash
+```console
 $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
 ```
 
@@ -225,7 +225,7 @@ The `-w` lets the command being executed inside directory given, here
 
 ### Set storage driver options per container
 
-```bash
+```console
 $ docker run -it --storage-opt size=120G fedora /bin/bash
 ```
 
@@ -240,7 +240,7 @@ Under these conditions, user can pass any size less than the backing fs size.
 
 ### Mount tmpfs (--tmpfs)
 
-```bash
+```console
 $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 ```
 
@@ -249,7 +249,7 @@ The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
 
 ### Mount volume (-v, --read-only)
 
-```bash
+```console
 $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
 ```
 
@@ -259,7 +259,7 @@ changing into the directory to the value returned by `pwd`. So this
 combination executes the command using the container, but inside the
 current working directory.
 
-```bash
+```console
 $ docker run -v /doesnt/exist:/foo -w /foo -i -t ubuntu bash
 ```
 
@@ -268,7 +268,7 @@ will automatically create this directory on the host for you. In the
 example above, Docker will create the `/doesnt/exist`
 folder before starting your container.
 
-```bash
+```console
 $ docker run --read-only -v /icanwrite busybox touch /icanwrite/here
 ```
 
@@ -277,7 +277,7 @@ a container writes files. The `--read-only` flag mounts the container's root
 filesystem as read only prohibiting writes to locations other than the
 specified volumes for the container.
 
-```bash
+```console
 $ docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/static-docker-binary:/usr/bin/docker busybox sh
 ```
 
@@ -327,17 +327,17 @@ Even though there is no plan to deprecate `--volume`, usage of `--mount` is reco
 
 Examples:
 
-```bash
+```console
 $ docker run --read-only --mount type=volume,target=/icanwrite busybox touch /icanwrite/here
 ```
 
-```bash
+```console
 $ docker run -t -i --mount type=bind,src=/data,dst=/data busybox sh
 ```
 
 ### Publish or expose port (-p, --expose)
 
-```bash
+```console
 $ docker run -p 127.0.0.1:80:8080/tcp ubuntu bash
 ```
 
@@ -351,7 +351,7 @@ Note that ports which are not bound to the host (i.e., `-p 80:80` instead of
 you configured UFW to block this specific port, as Docker manages his
 own iptables rules. [Read more](https://docs.docker.com/network/iptables/)
 
-```bash
+```console
 $ docker run --expose 80 ubuntu bash
 ```
 
@@ -360,7 +360,7 @@ system's interfaces.
 
 ### Set environment variables (-e, --env, --env-file)
 
-```bash
+```console
 $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
 ```
 
@@ -370,7 +370,7 @@ that are defined in the Dockerfile of the image you're running.
 
 You can define the variable and its value when running the container:
 
-```bash
+```console
 $ docker run --env VAR1=value1 --env VAR2=value2 ubuntu env | grep VAR
 VAR1=value1
 VAR2=value2
@@ -378,7 +378,7 @@ VAR2=value2
 
 You can also use variables that you've exported to your local environment:
 
-```bash
+```console
 export VAR1=value1
 export VAR2=value2
 
@@ -396,7 +396,7 @@ You can also load the environment variables from a file. This file should use
 the syntax `<variable>=value` (which sets the variable to the given value) or
 `<variable>` (which takes the value from the local environment), and `#` for comments.
 
-```bash
+```console
 $ cat env.list
 # This is a comment
 VAR1=value1
@@ -413,7 +413,7 @@ USER=denis
 
 A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
-```bash
+```console
 $ docker run -l my-label --label com.example.foo=bar ubuntu bash
 ```
 
@@ -428,7 +428,7 @@ Use the `--label-file` flag to load multiple labels from a file. Delimit each
 label in the file with an EOL mark. The example below loads labels from a
 labels file in the current directory:
 
-```bash
+```console
 $ docker run --label-file ./labels ubuntu bash
 ```
 
@@ -456,14 +456,14 @@ the Docker User Guide.
 When you start a container use the `--network` flag to connect it to a network.
 This adds the `busybox` container to the `my-net` network.
 
-```bash
+```console
 $ docker run -itd --network=my-net busybox
 ```
 
 You can also choose the IP addresses for the container with `--ip` and `--ip6`
 flags when you start the container on a user-defined network.
 
-```bash
+```console
 $ docker run -itd --network=my-net --ip=10.10.9.75 busybox
 ```
 
@@ -486,7 +486,7 @@ disconnect` command.
 
 ### Mount volumes from container (--volumes-from)
 
-```bash
+```console
 $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
 ```
 
@@ -516,14 +516,14 @@ The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT`
 or `STDERR`. This makes it possible to manipulate the output and input as
 needed.
 
-```bash
+```console
 $ echo "test" | docker run -i -a stdin ubuntu cat -
 ```
 
 This pipes data into a container and prints the container's ID by attaching
 only to the container's `STDIN`.
 
-```bash
+```console
 $ docker run -a stderr ubuntu echo test
 ```
 
@@ -531,7 +531,7 @@ This isn't going to print anything unless there's an error because we've
 only attached to the `STDERR` of the container. The container's logs
 still store what's been written to `STDERR` and `STDOUT`.
 
-```bash
+```console
 $ cat somefile | docker run -i -a stdin mybuilder dobuild
 ```
 
@@ -543,7 +543,7 @@ retrieve the container's ID once the container has finished running.
 
 ### Add host device to container (--device)
 
-```bash
+```console
 $ docker run --device=/dev/sdc:/dev/xvdc \
              --device=/dev/sdd --device=/dev/zero:/dev/nulo \
              -i -t \
@@ -564,7 +564,7 @@ This can be overridden using a third `:rwm` set of options to each `--device`
 flag. If the container is running in privileged mode, then the permissions specified
 will be ignored.
 
-```bash
+```console
 $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
 Command (m for help): q
@@ -620,20 +620,20 @@ for more information.
 To use `--gpus`, specify which GPUs (or all) to use. If no value is provied, all
 available GPUs are used. The example below exposes all available GPUs.
 
-```bash
+```console
 $ docker run -it --rm --gpus all ubuntu nvidia-smi
 ```
 
 Use the `device` option to specify GPUs. The example below exposes a specific
 GPU.
 
-```bash
+```console
 $ docker run -it --rm --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a ubuntu nvidia-smi
 ```
 
 The example below exposes the first and third GPUs.
 
-```bash
+```console
 $ docker run -it --rm --gpus device=0,2 nvidia-smi
 ```
 
@@ -650,7 +650,7 @@ Docker supports the following restart policies:
 | `unless-stopped`           | Restart the container unless it is explicitly stopped or Docker itself is stopped or restarted.                                                                                                                                                                  |
 | `always`                   | Always restart the container regardless of the exit status. When you specify always, the Docker daemon will try to restart the container indefinitely. The container will also always start on daemon startup, regardless of the current state of the container. |
 
-```bash
+```console
 $ docker run --restart=always redis
 ```
 
@@ -667,16 +667,18 @@ You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
 `docker`:
 
-```bash
-$ docker run --add-host=docker:10.180.0.1 --rm -it debian
+```console
+$ docker run --add-host=docker:93.184.216.34 --rm -it alpine
 
-root@f38c87f2a42d:/# ping docker
-PING docker (10.180.0.1): 48 data bytes
-56 bytes from 10.180.0.1: icmp_seq=0 ttl=254 time=7.600 ms
-56 bytes from 10.180.0.1: icmp_seq=1 ttl=254 time=30.705 ms
-^C--- docker ping statistics ---
-2 packets transmitted, 2 packets received, 0% packet loss
-round-trip min/avg/max/stddev = 7.600/19.152/30.705/11.553 ms
+/ # ping docker
+PING docker (93.184.216.34): 56 data bytes
+64 bytes from 93.184.216.34: seq=0 ttl=37 time=93.052 ms
+64 bytes from 93.184.216.34: seq=1 ttl=37 time=92.467 ms
+64 bytes from 93.184.216.34: seq=2 ttl=37 time=92.252 ms
+^C
+--- docker ping statistics ---
+4 packets transmitted, 4 packets received, 0% packet loss
+round-trip min/avg/max = 92.209/92.495/93.052 ms
 ```
 
 Sometimes you need to connect to the Docker host from within your
@@ -688,7 +690,7 @@ The flags you pass to `ip addr show` depend on whether you are
 using IPv4 or IPv6 networking in your containers. Use the following
 flags for IPv4 address retrieval for a network device named `eth0`:
 
-```bash
+```console
 $ HOSTIP=`ip -4 addr show scope global dev eth0 | grep inet | awk '{print $2}' | cut -d / -f 1 | sed -n 1p`
 $ docker run  --add-host=docker:${HOSTIP} --rm -it debian
 ```
@@ -704,7 +706,7 @@ available in the default container, you can set these using the `--ulimit` flag.
 `--ulimit` is specified with a soft and hard limit as such:
 `<type>=<soft limit>[:<hard limit>]`, for example:
 
-```bash
+```console
 $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
 1024
 ```
@@ -716,7 +718,7 @@ $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
 > the default `ulimits` set on the daemon. The `as` option is disabled now.
 > In other words, the following script is not supported:
 >
-> ```bash
+> ```console
 > $ docker run -it --ulimit as=1024 fedora /bin/bash`
 > ```
 
@@ -729,7 +731,7 @@ Be careful setting `nproc` with the `ulimit` flag as `nproc` is designed by Linu
 maximum number of processes available to a user, not to a container.  For example, start four
 containers with `daemon` user:
 
-```bash
+```console
 $ docker run -d -u daemon --ulimit nproc=3 busybox top
 
 $ docker run -d -u daemon --ulimit nproc=3 busybox top
@@ -777,7 +779,7 @@ Windows. The `--isolation <value>` option sets a container's isolation technolog
 On Linux, the only supported is the `default` option which uses
 Linux namespaces. These two commands are equivalent on Linux:
 
-```bash
+```console
 $ docker run -d busybox top
 $ docker run -d --isolation default busybox top
 ```
@@ -858,7 +860,7 @@ The `--sysctl` sets namespaced kernel parameters (sysctls) in the
 container. For example, to turn on IP forwarding in the containers
 network namespace, run this command:
 
-```bash
+```console
 $ docker run --sysctl net.ipv4.ip_forward=1 someimage
 ```
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -120,7 +120,7 @@ Options:
                                       or `g` (gigabytes). If you omit the unit, the system uses bytes.
       --sig-proxy                     Proxy received signals to the process (default true)
       --stop-signal string            Signal to stop a container (default "SIGTERM")
-      --stop-timeout=10               Timeout (in seconds) to stop a container
+      --stop-timeout int              Timeout (in seconds) to stop a container
       --storage-opt value             Storage driver options for the container (default [])
       --sysctl value                  Sysctl options (default map[])
       --tmpfs value                   Mount a tmpfs directory (default [])
@@ -745,9 +745,12 @@ the three processes quota set for the `daemon` user.
 
 ### Stop container with signal (--stop-signal)
 
-The `--stop-signal` flag sets the system call signal that will be sent to the container to exit.
-This signal can be a valid unsigned number that matches a position in the kernel's syscall table, for instance 9,
-or a signal name in the format SIGNAME, for instance SIGKILL.
+The `--stop-signal` flag sets the system call signal that will be sent to the
+container to exit. This signal can be a signal name in the format `SIG<NAME>`,
+for instance `SIGKILL`, or an unsigned number that matches a position in the
+kernel's syscall table, for instance `9`.
+
+The default is `SIGTERM` if not specified.
 
 ### Optional security options (--security-opt)
 
@@ -756,8 +759,16 @@ The `credentialspec` must be in the format `file://spec.txt` or `registry://keyn
 
 ### Stop container with timeout (--stop-timeout)
 
-The `--stop-timeout` flag sets the timeout (in seconds) that a pre-defined (see `--stop-signal`) system call
-signal that will be sent to the container to exit. After timeout elapses the container will be killed with SIGKILL.
+The `--stop-timeout` flag sets the number of seconds to wait for the container
+to stop after sending the pre-defined (see `--stop-signal`) system call signal.
+If the container does not exit after the timeout elapses, it is forcibly killed
+with a `SIGKILL` signal.
+
+If `--stop-timeout` is set to `-1`, no timeout is applied, and the daemon will
+wait indefinitely for the container to exit.
+
+The default is determined by the daemon, and is 10 seconds for Linux containers,
+and 30 seconds for Windows containers.
 
 ### Specify isolation technology for container (--isolation)
 

--- a/docs/reference/commandline/save.md
+++ b/docs/reference/commandline/save.md
@@ -26,7 +26,7 @@ each argument provided.
 
 ### Create a backup that can then be used with `docker load`.
 
-```bash
+```console
 $ docker save busybox > busybox.tar
 
 $ ls -sh busybox.tar
@@ -48,14 +48,14 @@ $ docker save -o fedora-latest.tar fedora:latest
 
 You can use gzip to save the image file and make the backup smaller.
 
-```bash
-docker save myimage:latest | gzip > myimage_latest.tar.gz
+```console
+$ docker save myimage:latest | gzip > myimage_latest.tar.gz
 ```
 
 ### Cherry-pick particular tags
 
 You can even cherry-pick particular tags of an image repository.
 
-```bash
+```console
 $ docker save -o ubuntu.tar ubuntu:lucid ubuntu:saucy
 ```

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -32,7 +32,7 @@ Search [Docker Hub](https://hub.docker.com) for images
 
 This example displays images with a name containing 'busybox':
 
-```bash
+```console
 $ docker search busybox
 
 NAME                             DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
@@ -68,8 +68,9 @@ marclop/busybox-solr
 This example displays images with a name containing 'busybox',
 at least 3 stars and the description isn't truncated in the output:
 
-```bash
+```console
 $ docker search --filter=stars=3 --no-trunc busybox
+
 NAME                 DESCRIPTION                                                                               STARS     OFFICIAL   AUTOMATED
 busybox              Busybox base image.                                                                       325       [OK]
 progrium/busybox                                                                                               50                   [OK]
@@ -97,7 +98,7 @@ The currently supported filters are:
 This example displays images with a name containing 'busybox' and at
 least 3 stars:
 
-```bash
+```console
 $ docker search --filter stars=3 busybox
 
 NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
@@ -111,7 +112,7 @@ radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8          
 This example displays images with a name containing 'busybox'
 and are automated builds:
 
-```bash
+```console
 $ docker search --filter is-automated=true busybox
 
 NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
@@ -124,7 +125,7 @@ radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8          
 This example displays images with a name containing 'busybox', at least
 3 stars and are official builds:
 
-```bash
+```console
 $ docker search --filter is-official=true --filter stars=3 busybox
 
 NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
@@ -154,7 +155,7 @@ output the data exactly as the template declares. If you use the
 The following example uses a template without headers and outputs the
 `Name` and `StarCount` entries separated by a colon (`:`) for all images:
 
-```bash
+```console
 $ docker search --format "{{.Name}}: {{.StarCount}}" nginx
 
 nginx: 5441
@@ -171,7 +172,7 @@ maxexcloo/nginx: 7
 
 This example outputs a table format:
 
-```bash
+```console
 $ docker search --format "table {{.Name}}\t{{.IsAutomated}}\t{{.IsOfficial}}" nginx
 
 NAME                                     AUTOMATED           OFFICIAL

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -33,8 +33,8 @@ For detailed information about using secrets, refer to [manage sensitive data wi
 
 ### Create a secret
 
-```bash
-$ printf <secret> | docker secret create my_secret -
+```console
+$ printf "my super secret password" | docker secret create my_secret -
 
 onakdyv307se2tl7nl20anokv
 
@@ -46,7 +46,7 @@ onakdyv307se2tl7nl20anokv   my_secret           6 seconds ago       6 seconds ag
 
 ### Create a secret with a file
 
-```bash
+```console
 $ docker secret create my_secret ./secret.json
 
 dg426haahpi5ezmkkj5kyl3sn
@@ -59,15 +59,16 @@ dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ag
 
 ### Create a secret with labels
 
-```bash
-$ docker secret create --label env=dev \
-                       --label rev=20170324 \
-                       my_secret ./secret.json
+```console
+$ docker secret create \
+  --label env=dev \
+  --label rev=20170324 \
+  my_secret ./secret.json
 
 eo7jnzguqgtpdah3cm5srfb97
 ```
 
-```bash
+```console
 $ docker secret inspect my_secret
 
 [

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -43,14 +43,14 @@ You can inspect a secret, either by its *name*, or *ID*
 
 For example, given the following secret:
 
-```bash
+```console
 $ docker secret ls
 
 ID                          NAME                CREATED             UPDATED
 eo7jnzguqgtpdah3cm5srfb97   my_secret           3 minutes ago       3 minutes ago
 ```
 
-```bash
+```console
 $ docker secret inspect secret.json
 ```
 
@@ -82,7 +82,7 @@ You can use the --format option to obtain specific information about a
 secret. The following example command outputs the creation time of the
 secret.
 
-```bash
+```console
 $ docker secret inspect --format='{{.CreatedAt}}' eo7jnzguqgtpdah3cm5srfb97
 
 2017-03-24 08:15:09.735271783 +0000 UTC

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -36,7 +36,7 @@ For detailed information about using secrets, refer to [manage sensitive data wi
 
 ## Examples
 
-```bash
+```console
 $ docker secret ls
 
 ID                          NAME                        CREATED             UPDATED
@@ -60,7 +60,7 @@ The currently supported filters are:
 
 The `id` filter matches all or prefix of a secret's id.
 
-```bash
+```console
 $ docker secret ls -f "id=6697bflskwj1998km1gnnjr38"
 
 ID                          NAME                        CREATED             UPDATED
@@ -75,7 +75,7 @@ a `label` and a value.
 The following filter matches all secrets with a `project` label regardless of
 its value:
 
-```bash
+```console
 $ docker secret ls --filter label=project
 
 ID                          NAME                        CREATED             UPDATED
@@ -85,7 +85,7 @@ mem02h8n73mybpgqjf0kfi1n0   test_secret                 About an hour ago   Abou
 The following filter matches only services with the `project` label with the
 `project-a` value.
 
-```bash
+```console
 $ docker service ls --filter label=project=test
 
 ID                          NAME                        CREATED             UPDATED
@@ -98,7 +98,7 @@ The `name` filter matches on all or prefix of a secret's name.
 
 The following filter matches secret with a name containing a prefix of `test`.
 
-```bash
+```console
 $ docker secret ls --filter name=test_secret
 
 ID                          NAME                        CREATED             UPDATED
@@ -128,7 +128,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID` and `Name` entries separated by a colon (`:`) for all images:
 
-```bash
+```console
 $ docker secret ls --format "{{.ID}}: {{.Name}}"
 
 77af4d6b9913: secret-1
@@ -139,7 +139,7 @@ b6fa739cedf5: secret-2
 To list all secrets with their name and created date in a table format you
 can use:
 
-```bash
+```console
 $ docker secret ls --format "table {{.ID}}\t{{.Name}}\t{{.CreatedAt}}"
 
 ID                  NAME                      CREATED

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -35,7 +35,7 @@ For detailed information about using secrets, refer to [manage sensitive data wi
 
 This example removes a secret:
 
-```bash
+```console
 $ docker secret rm secret.json
 sapth4csdo5b6wz2p5uimh5xg
 ```

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -101,7 +101,7 @@ Creates a service as described by the specified parameters.
 
 ### Create a service
 
-```bash
+```console
 $ docker service create --name redis redis:3.0.6
 
 dmu1ept4cxcfe8k8lhtux3ro3
@@ -124,7 +124,7 @@ If your image is available on a private registry which requires login, use the
 your image is stored on `registry.example.com`, which is a private registry, use
 a command like the following:
 
-```bash
+```console
 $ docker login registry.example.com
 
 $ docker service  create \
@@ -142,7 +142,7 @@ nodes are able to log into the registry and pull the image.
 Use the `--replicas` flag to set the number of replica tasks for a replicated
 service. The following command creates a `redis` service with `5` replica tasks:
 
-```bash
+```console
 $ docker service create --name redis --replicas=5 redis:3.0.6
 
 4cdgfyky7ozwh3htjfw0d12qv
@@ -156,7 +156,7 @@ of replica tasks for the service.
 In the following example the desired state is  `5` replicas, but the current
 number of `RUNNING` tasks is `3`:
 
-```bash
+```console
 $ docker service ls
 
 ID            NAME   MODE        REPLICAS  IMAGE
@@ -166,7 +166,7 @@ ID            NAME   MODE        REPLICAS  IMAGE
 Once all the tasks are created and `RUNNING`, the actual number of tasks is
 equal to the desired number:
 
-```bash
+```console
 $ docker service ls
 
 ID            NAME   MODE        REPLICAS  IMAGE
@@ -180,7 +180,7 @@ Use the `--secret` flag to give a container access to a
 
 Create a service specifying a secret:
 
-```bash
+```console
 $ docker service create --name redis --secret secret.json redis:3.0.6
 
 4cdgfyky7ozwh3htjfw0d12qv
@@ -188,7 +188,7 @@ $ docker service create --name redis --secret secret.json redis:3.0.6
 
 Create a service specifying the secret, target, user/group ID, and mode:
 
-```bash
+```console
 $ docker service create --name redis \
     --secret source=ssh-key,target=ssh \
     --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
@@ -217,13 +217,13 @@ as numerical IDs or names. When using names, the provided group/user names must
 pre-exist in the container. The `mode` is specified as a 4-number sequence such
 as `0755`.
 
-```bash
+```console
 $ docker service create --name=redis --config redis-conf redis:3.0.6
 ```
 
 Create a service with a config and specify the target location and file mode:
 
-```bash
+```console
 $ docker service create --name redis \
   --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400 redis:3.0.6
 ```
@@ -236,7 +236,7 @@ the container. If a target is specified, that is used as the filename.
 
 ### Create a service with a rolling update policy
 
-```bash
+```console
 $ docker service create \
   --replicas 10 \
   --name redis \
@@ -254,7 +254,7 @@ tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
 This sets an environment variable for all tasks in a service. For example:
 
-```bash
+```console
 $ docker service create \
   --name redis_2 \
   --replicas 5 \
@@ -265,7 +265,7 @@ $ docker service create \
 To specify multiple environment variables, specify multiple `--env` flags, each
 with a separate key-value pair.
 
-```bash
+```console
 $ docker service create \
   --name redis_2 \
   --replicas 5 \
@@ -279,7 +279,7 @@ $ docker service create \
 This option sets the docker service containers hostname to a specific string.
 For example:
 
-```bash
+```console
 $ docker service create --name redis --hostname myredis redis:3.0.6
 ```
 
@@ -288,7 +288,7 @@ $ docker service create --name redis --hostname myredis redis:3.0.6
 A label is a `key=value` pair that applies metadata to a service. To label a
 service with two labels:
 
-```bash
+```console
 $ docker service create \
   --name redis_2 \
   --label com.example.foo="bar"
@@ -592,7 +592,7 @@ or `--volume` flag for `docker run`, with some important exceptions:
 
 The following example creates a service that uses a named volume:
 
-```bash
+```console
 $ docker service create \
   --name my-service \
   --replicas 3 \
@@ -622,7 +622,7 @@ be deployed on a different node.
 The following command creates a service with three replicas with an anonymous
 volume on `/path/in/container`:
 
-```bash
+```console
 $ docker service create \
   --name my-service \
   --replicas 3 \
@@ -640,7 +640,7 @@ the task using them is complete.
 The following example bind-mounts a host directory at `/path/in/container` in
 the containers backing the service:
 
-```bash
+```console
 $ docker service create \
   --name my-service \
   --mount type=bind,source=/path/on/host,destination=/path/in/container \
@@ -655,7 +655,7 @@ service runs on each active node in the swarm.
 
 The following command creates a global service:
 
-```bash
+```console
 $ docker service create \
  --name redis_2 \
  --mode global \
@@ -688,7 +688,7 @@ the [`docker node update`](node_update.md) command.
 For example, the following limits tasks for the redis service to nodes where the
 node type label equals queue:
 
-```bash
+```console
 $ docker service create \
   --name redis_2 \
   --constraint node.platform.os==linux \
@@ -703,7 +703,7 @@ loop and deploy the service once a suitable node becomes available.
 In the example below, no node satisfying the constraint was found, causing the
 service to not reconcile with the desired state:
 
-```bash
+```console
 $ docker service create \
   --name web \
   --constraint node.labels.region==east \
@@ -721,7 +721,7 @@ b6lww17hrr4e        web      replicated   0/1        nginx:alpine
 After adding the `region=east` label to a node in the cluster, the service
 reconciles, and the desired number of replicas are deployed:
 
-```bash
+```console
 $ docker node update --label-add region=east yswe2dm4c5fdgtsrli1e8ya5l
 yswe2dm4c5fdgtsrli1e8ya5l
 
@@ -736,7 +736,7 @@ You can set up the service to divide tasks evenly over different categories of
 nodes. One example of where this can be useful is to balance tasks over a set
 of datacenters or availability zones. The example below illustrates this:
 
-```bash
+```console
 $ docker service create \
   --replicas 9 \
   --name redis_2 \
@@ -787,7 +787,7 @@ The following example sets up a service with multiple placement preferences.
 Tasks are spread first over the various datacenters, and then over racks
 (as indicated by the respective labels):
 
-```bash
+```console
 $ docker service create \
   --replicas 9 \
   --name redis_2 \
@@ -812,7 +812,7 @@ pending state.
 The following example requires that 4GB of memory be available and reservable
 on a given node before scheduling the service to run on that node.
 
-```bash
+```console
 $ docker service create --reserve-memory=4GB --name=too-big nginx:alpine
 ```
 
@@ -825,7 +825,7 @@ given amount of memory on a node. This example limits the amount of memory used
 by the task to 4GB. The task will be scheduled even if each of your nodes has
 only 2GB of memory, because `--limit-memory` is an upper limit.
 
-```bash
+```console
 $ docker service create --limit-memory=4GB --name=too-big nginx:alpine
 ```
 
@@ -880,7 +880,7 @@ maintenance or datacenter failure.
 
 The example below illustrates this:
 
-```bash
+```console
 $ docker service create \
   --name nginx \
   --replicas 2 \
@@ -896,7 +896,7 @@ You can use overlay networks to connect one or more services within the swarm.
 First, create an overlay network on a manager node the docker network create
 command:
 
-```bash
+```console
 $ docker network create --driver overlay my-network
 
 etjpu59cykrptrgw0z0hk5snf
@@ -908,7 +908,7 @@ access to the network.
 When you create a service and pass the `--network` flag to attach the service to
 the overlay network:
 
-```bash
+```console
 $ docker service create \
   --replicas 3 \
   --network my-network \
@@ -933,7 +933,7 @@ using the `--publish` flag. The `--publish` flag can take two different styles
 of arguments. The short version is positional, and allows you to specify the
 published port and target port separated by a colon (`:`).
 
-```bash
+```console
 $ docker service create --name my_web --replicas 3 --publish 8080:80 nginx
 ```
 
@@ -942,7 +942,7 @@ more options. The long format is preferred. You cannot specify the service's
 mode when using the short format. Here is an example of using the long format
 for the same service as above:
 
-```bash
+```console
 $ docker service create --name my_web --replicas 3 --publish published=8080,target=80 nginx
 ```
 
@@ -1074,7 +1074,7 @@ Valid placeholders for the Go template are listed below:
 In this example, we are going to set the template of the created containers based on the
 service's name, the node's ID and hostname where it sits.
 
-```bash
+```console
 $ docker service create \
     --name hosttempl \
     --hostname="{{.Node.Hostname}}-{{.Node.ID}}-{{.Service.Name}}"\
@@ -1098,7 +1098,7 @@ By default, tasks scheduled on Windows nodes are run using the default isolation
 configured for this particular node. To force a specific isolation mode, you can use
 the `--isolation` flag:
 
-```bash
+```console
 $ docker service create --name myservice --isolation=process microsoft/nanoserver
 ```
 
@@ -1112,7 +1112,7 @@ Supported isolation modes on Windows are:
 You can narrow the kind of nodes your task can land on through the using the
 `--generic-resource` flag (if the nodes advertise these resources):
 
-```bash
+```console
 $ docker service create \
     --name cuda \
     --generic-resource "NVIDIA-GPU=2" \
@@ -1129,7 +1129,7 @@ belonging to a job exits successfully (return value 0), the Task is marked as
 
 Jobs are started by using one of two modes, `replicated-job` or `global-job`
 
-```bash
+```console
 $ docker service create --name myjob \
                         --mode replicated-job \
                         bash "true"
@@ -1159,12 +1159,13 @@ By default, all replicas of a replicated job will launch at once. To control
 the total number of replicas that are executing simultaneously at any one time,
 the `--max-concurrent` flag can be used:
 
-```bash
-$ docker service create --name mythrottledjob \
-                        --mode replicated-job \
-                        --replicas 10 \
-                        --max-concurrent 2 \
-                        bash "true"
+```console
+$ docker service create \
+    --name mythrottledjob \
+    --mode replicated-job \
+    --replicas 10 \
+    --max-concurrent 2 \
+    bash "true"
 ```
 
 The above command will execute 10 Tasks in total, but only 2 of them will be

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -42,7 +42,7 @@ You can inspect a service, either by its *name*, or *ID*
 
 For example, given the following service;
 
-```bash
+```console
 $ docker service ls
 ID            NAME   MODE        REPLICAS  IMAGE
 dmu1ept4cxcf  redis  replicated  3/3       redis:3.0.6
@@ -51,7 +51,7 @@ dmu1ept4cxcf  redis  replicated  3/3       redis:3.0.6
 Both `docker service inspect redis`, and `docker service inspect dmu1ept4cxcf`
 produce the same result:
 
-```bash
+```console
 $ docker service inspect redis
 ```
 
@@ -99,7 +99,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-```bash
+```console
 $ docker service inspect dmu1ept4cxcf
 
 [
@@ -118,7 +118,7 @@ $ docker service inspect dmu1ept4cxcf
 You can print the inspect output in a human-readable format instead of the default
 JSON output, by using the `--pretty` option:
 
-```bash
+```console
 $ docker service inspect --pretty frontend
 
 ID:     c8wgl7q4ndfd52ni6qftkvnnp
@@ -153,7 +153,7 @@ The `--format` option can be used to obtain specific information about a
 service. For example, the following command outputs the number of replicas
 of the "redis" service.
 
-```bash
+```console
 $ docker service inspect --format='{{.Spec.Mode.Replicated.Replicas}}' redis
 
 10

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -36,7 +36,7 @@ This command lists services are running in the swarm.
 
 On a manager node:
 
-```bash
+```console
 $ docker service ls
 
 ID            NAME      MODE            REPLICAS             IMAGE
@@ -67,7 +67,7 @@ The currently supported filters are:
 
 The `id` filter matches all or part of a service's id.
 
-```bash
+```console
 $ docker service ls -f "id=0bcjw"
 ID            NAME   MODE        REPLICAS  IMAGE
 0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
@@ -81,7 +81,7 @@ a `label` and a value.
 The following filter matches all services with a `project` label regardless of
 its value:
 
-```bash
+```console
 $ docker service ls --filter label=project
 ID            NAME       MODE        REPLICAS  IMAGE
 01sl1rp6nj5u  frontend2  replicated  1/1       nginx:alpine
@@ -92,7 +92,7 @@ ID            NAME       MODE        REPLICAS  IMAGE
 The following filter matches only services with the `project` label with the
 `project-a` value.
 
-```bash
+```console
 $ docker service ls --filter label=project=project-a
 ID            NAME      MODE        REPLICAS  IMAGE
 36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
@@ -105,7 +105,7 @@ The `mode` filter matches on the mode (either `replicated` or `global`) of a ser
 
 The following filter matches only `global` services.
 
-```bash
+```console
 $ docker service ls --filter mode=global
 ID                  NAME                MODE                REPLICAS            IMAGE
 w7y0v2yrn620        top                 global              1/1                 busybox
@@ -117,7 +117,7 @@ The `name` filter matches on all or part of a service's name.
 
 The following filter matches services with a name containing `redis`.
 
-```bash
+```console
 $ docker service ls --filter name=redis
 ID            NAME   MODE        REPLICAS  IMAGE
 0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
@@ -146,7 +146,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon (`:`) for all services:
 
-```bash
+```console
 $ docker service ls --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -38,7 +38,7 @@ Lists the tasks that are running as part of the specified services.
 
 The following command shows all the tasks that are part of the `redis` service:
 
-```bash
+```console
 $ docker service ps redis
 
 ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE          ERROR  PORTS
@@ -58,7 +58,7 @@ In addition to _running_ tasks, the output also shows the task history. For
 example, after updating the service to use the `redis:3.0.6` image, the output
 may look like this:
 
-```bash
+```console
 $ docker service ps redis
 
 ID            NAME         IMAGE        NODE      DESIRED STATE  CURRENT STATE                   ERROR  PORTS
@@ -83,7 +83,7 @@ image, and pins the service to that digest. The digest is not shown by
 default, but is printed if `--no-trunc` is used. The `--no-trunc` option
 also shows the non-truncated task ID, and error-messages, as can be seen below;
 
-```bash
+```console
 $ docker service ps --no-trunc redis
 
 ID                          NAME         IMAGE                                                                                NODE      DESIRED STATE  CURRENT STATE            ERROR                                                                                           PORTS
@@ -112,7 +112,7 @@ The currently supported filters are:
 
 The `id` filter matches on all or a prefix of a task's ID.
 
-```bash
+```console
 $ docker service ps -f "id=8" redis
 
 ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
@@ -124,8 +124,9 @@ ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE    
 
 The `name` filter matches on task names.
 
-```bash
+```console
 $ docker service ps -f "name=redis.1" redis
+
 ID            NAME     IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
 qihejybwf1x5  redis.1  redis:3.0.6  manager1  Running        Running 8 seconds
 ```
@@ -135,8 +136,9 @@ qihejybwf1x5  redis.1  redis:3.0.6  manager1  Running        Running 8 seconds
 
 The `node` filter matches on a node name or a node ID.
 
-```bash
+```console
 $ docker service ps -f "node=manager1" redis
+
 ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
 0qihejybwf1x  redis.1   redis:3.0.6  manager1  Running        Running 8 seconds
 1x0v8yomsncd  redis.5   redis:3.0.6  manager1  Running        Running 8 seconds
@@ -173,8 +175,9 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
-```bash
+```console
 $ docker service ps --format "{{.Name}}: {{.Image}}" top
+
 top.1: busybox
 top.2: busybox
 top.3: busybox

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -33,7 +33,7 @@ Removes the specified services from the swarm.
 
 Remove the `redis` service:
 
-```bash
+```console
 $ docker service rm redis
 
 redis

--- a/docs/reference/commandline/service_rollback.md
+++ b/docs/reference/commandline/service_rollback.md
@@ -43,13 +43,13 @@ previous version, having one replica.
 
 Create a service with a single replica:
 
-```bash
+```console
 $ docker service create --name my-service -p 8080:80 nginx:alpine
 ```
 
 Confirm that the service is running with a single replica:
 
-```bash
+```console
 $ docker service ls
 
 ID                  NAME                MODE                REPLICAS            IMAGE               PORTS
@@ -58,7 +58,7 @@ xbw728mf6q0d        my-service          replicated          1/1                 
 
 Update the service to use three replicas:
 
-```bash
+```console
 $ docker service update --replicas=3 my-service
 
 $ docker service ls
@@ -70,7 +70,7 @@ xbw728mf6q0d        my-service          replicated          3/3                 
 Now roll back the service to its previous version, and confirm it is
 running a single replica again:
 
-```bash
+```console
 $ docker service rollback my-service
 
 $ docker service ls

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -37,7 +37,7 @@ service while keeping the service active in the swarm you can set the scale to 0
 
 The following command scales the "frontend" service to 50 tasks.
 
-```bash
+```console
 $ docker service scale frontend=50
 
 frontend scaled to 50
@@ -45,7 +45,7 @@ frontend scaled to 50
 
 The following command tries to scale a global service to 10 tasks and returns an error.
 
-```bash
+```console
 $ docker service create --mode global --name backend backend:latest
 
 b4g08uwuairexjub6ome6usqh
@@ -58,7 +58,7 @@ backend: scale can only be used with replicated or replicated-job mode
 Directly afterwards, run `docker service ls`, to see the actual number of
 replicas.
 
-```bash
+```console
 $ docker service ls --filter name=frontend
 
 ID            NAME      MODE        REPLICAS  IMAGE
@@ -68,7 +68,7 @@ ID            NAME      MODE        REPLICAS  IMAGE
 You can also scale a service using the [`docker service update`](service_update.md)
 command. The following commands are equivalent:
 
-```bash
+```console
 $ docker service scale frontend=50
 $ docker service update --replicas=50 frontend
 ```
@@ -79,7 +79,7 @@ The `docker service scale` command allows you to set the desired number of
 tasks for multiple services at once. The following example scales both the
 backend and frontend services:
 
-```bash
+```console
 $ docker service scale backend=3 frontend=5
 
 backend scaled to 3

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -127,13 +127,13 @@ rolling restart without any changes to the service parameters.
 
 ### Update a service
 
-```bash
+```console
 $ docker service update --limit-cpu 2 redis
 ```
 
 ### Perform a rolling restart with no parameter changes
 
-```bash
+```console
 $ docker service update --force --update-parallelism 1 --update-delay 30s redis
 ```
 
@@ -161,7 +161,7 @@ service name.
 
 - The `--mount-rm` flag takes the `target` path of the mount.
 
-```bash
+```console
 $ docker service create \
     --name=myservice \
     --mount type=volume,source=test-data,target=/somewhere \
@@ -189,7 +189,7 @@ reference.
 
 The following example adds a published service port to an existing service.
 
-```bash
+```console
 $ docker service update \
   --publish-add published=8080,target=80 \
   myservice
@@ -204,7 +204,7 @@ reference.
 
 The following example adds a new alias name to an existing service already connected to network my-network:
 
-```bash
+```console
 $ docker service update \
   --network-rm my-network \
   --network-add name=my-network,alias=web1 \
@@ -219,7 +219,7 @@ This will revert the service to the configuration that was in place before the m
 
 The following example updates the number of replicas for the service from 4 to 5, and then rolls back to the previous configuration.
 
-```bash
+```console
 $ docker service update --replicas=5 web
 
 web
@@ -230,9 +230,10 @@ ID            NAME  MODE        REPLICAS  IMAGE
 80bvrzp6vxf3  web   replicated  0/5       nginx:alpine
 
 ```
+
 Roll back the `web` service...
 
-```bash
+```console
 $ docker service update --rollback web
 
 web
@@ -246,7 +247,7 @@ ID            NAME  MODE        REPLICAS  IMAGE
 
 Other options can be combined with `--rollback` as well, for example, `--update-delay 0s` to execute the rollback without a delay between tasks:
 
-```bash
+```console
 $ docker service update \
   --rollback \
   --update-delay 0s
@@ -283,7 +284,7 @@ secrets.
 
 The following example adds a secret named `ssh-2` and removes `ssh-1`:
 
-```bash
+```console
 $ docker service update \
     --secret-add source=ssh-2,target=ssh-2 \
     --secret-rm ssh-1 \

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -43,7 +43,7 @@ Create and update a stack from a `compose` file on the swarm.
 
 The `deploy` command supports compose file version `3.0` and above.
 
-```bash
+```console
 $ docker stack deploy --compose-file docker-compose.yml vossibility
 
 Ignoring unsupported options: links
@@ -60,7 +60,7 @@ Creating service vossibility_lookupd
 
 The Compose file can also be provided as standard input with `--compose-file -`:
 
-```bash
+```console
 $ cat docker-compose.yml | docker stack deploy --compose-file - vossibility
 
 Ignoring unsupported options: links
@@ -79,7 +79,7 @@ If your configuration is split between multiple Compose files, e.g. a base
 configuration and environment-specific overrides, you can provide multiple
 `--compose-file` flags.
 
-```bash
+```console
 $ docker stack deploy --compose-file docker-compose.yml -c docker-compose.prod.yml vossibility
 
 Ignoring unsupported options: links
@@ -96,7 +96,7 @@ Creating service vossibility_lookupd
 
 You can verify that the services were correctly created:
 
-```bash
+```console
 $ docker service ls
 
 ID            NAME                               MODE        REPLICAS  IMAGE

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -37,7 +37,7 @@ Lists the stacks.
 
 The following command shows all stacks and some additional information:
 
-```bash
+```console
 $ docker stack ls
 
 ID                 SERVICES            ORCHESTRATOR
@@ -65,7 +65,7 @@ the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Name` and `Services` entries separated by a colon (`:`) for all stacks:
 
-```bash
+```console
 $ docker stack ls --format "{{.Name}}: {{.Services}}"
 web-server: 1
 web-cache: 4

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -40,8 +40,9 @@ Lists the tasks that are running as part of the specified stack.
 
 The following command shows all the tasks that are part of the `voting` stack:
 
-```bash
+```console
 $ docker stack ps voting
+
 ID                  NAME                  IMAGE                                          NODE   DESIRED STATE  CURRENT STATE          ERROR  PORTS
 xim5bcqtgk1b        voting_worker.1       dockersamples/examplevotingapp_worker:latest   node2  Running        Running 2 minutes ago
 q7yik0ks1in6        voting_result.1       dockersamples/examplevotingapp_result:before   node1  Running        Running 2 minutes ago
@@ -71,8 +72,9 @@ The currently supported filters are:
 
 The `id` filter matches on all or a prefix of a task's ID.
 
-```bash
+```console
 $ docker stack ps -f "id=t" voting
+
 ID                  NAME                IMAGE               NODE         DESIRED STATE       CURRENTSTATE            ERROR  PORTS
 tz6j82jnwrx7        voting_db.1         postgres:9.4        node1        Running             Running 14 minutes ago
 t72q3z038jeh        voting_redis.2      redis:alpine        node3        Running             Running 14 minutes ago
@@ -82,8 +84,9 @@ t72q3z038jeh        voting_redis.2      redis:alpine        node3        Running
 
 The `name` filter matches on task names.
 
-```bash
+```console
 $ docker stack ps -f "name=voting_redis" voting
+
 ID                  NAME                IMAGE               NODE         DESIRED STATE       CURRENTSTATE            ERROR  PORTS
 w48spazhbmxc        voting_redis.1      redis:alpine        node2        Running             Running 17 minutes ago
 t72q3z038jeh        voting_redis.2      redis:alpine        node3        Running             Running 17 minutes ago
@@ -93,8 +96,9 @@ t72q3z038jeh        voting_redis.2      redis:alpine        node3        Running
 
 The `node` filter matches on a node name or a node ID.
 
-```bash
+```console
 $ docker stack ps -f "node=node1" voting
+
 ID                  NAME                  IMAGE                                          NODE   DESIRED STATE  CURRENT STATE          ERROR  PORTS
 q7yik0ks1in6        voting_result.1       dockersamples/examplevotingapp_result:before   node1  Running        Running 18 minutes ago
 tz6j82jnwrx7        voting_db.1           postgres:9.4                                   node1  Running        Running 18 minutes ago
@@ -105,8 +109,9 @@ tz6j82jnwrx7        voting_db.1           postgres:9.4                          
 
 The `desired-state` filter can take the values `running`, `shutdown`, `ready` or `accepted`.
 
-```bash
+```console
 $ docker stack ps -f "desired-state=running" voting
+
 ID                  NAME                  IMAGE                                          NODE   DESIRED STATE  CURRENT STATE           ERROR  PORTS
 xim5bcqtgk1b        voting_worker.1       dockersamples/examplevotingapp_worker:latest   node2  Running        Running 21 minutes ago
 q7yik0ks1in6        voting_result.1       dockersamples/examplevotingapp_result:before   node1  Running        Running 21 minutes ago
@@ -142,8 +147,9 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Name` and `Image` entries separated by a colon (`:`) for all tasks:
 
-```bash
+```console
 $ docker stack ps --format "{{.Name}}: {{.Image}}" voting
+
 voting_worker.1: dockersamples/examplevotingapp_worker:latest
 voting_result.1: dockersamples/examplevotingapp_result:before
 voting_vote.1: dockersamples/examplevotingapp_vote:before
@@ -158,8 +164,9 @@ voting_redis.2: redis:alpine
 
 The `--no-resolve` option shows IDs for task name, without mapping IDs to Names.
 
-```bash
+```console
 $ docker stack ps --no-resolve voting
+
 ID                  NAME                          IMAGE                                          NODE                        DESIRED STATE  CURRENT STATE            ERROR  PORTS
 xim5bcqtgk1b        10z9fjfqzsxnezo4hb81p8mqg.1   dockersamples/examplevotingapp_worker:latest   qaqt4nrzo775jrx6detglho01   Running        Running 30 minutes ago
 q7yik0ks1in6        hbxltua1na7mgqjnidldv5m65.1   dockersamples/examplevotingapp_result:before   mxpaef1tlh23s052erw88a4w5   Running        Running 30 minutes ago
@@ -178,8 +185,9 @@ image, and pins the service to that digest. The digest is not shown by
 default, but is printed if `--no-trunc` is used. The `--no-trunc` option
 also shows the non-truncated task IDs, and error-messages, as can be seen below:
 
-```bash
+```console
 $ docker stack ps --no-trunc voting
+
 ID                          NAME                  IMAGE                                                                                                                 NODE   DESIRED STATE  CURREN STATE           ERROR  PORTS
 xim5bcqtgk1bxqz91jzo4a1s5   voting_worker.1       dockersamples/examplevotingapp_worker:latest@sha256:3e4ddf59c15f432280a2c0679c4fc5a2ee5a797023c8ef0d3baf7b1385e9fed   node2  Running        Runnin 32 minutes ago
 q7yik0ks1in6kv32gg6y6yjf7   voting_result.1       dockersamples/examplevotingapp_result:before@sha256:83b56996e930c292a6ae5187fda84dd6568a19d97cdb933720be15c757b7463   node1  Running        Runnin 32 minutes ago
@@ -196,7 +204,7 @@ t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1e
 The `-q ` or `--quiet` option only shows IDs of the tasks in the stack.
 This example outputs all task IDs of the "voting" stack;
 
-```bash
+```console
 $ docker stack ps -q voting
 xim5bcqtgk1b
 q7yik0ks1in6
@@ -212,14 +220,14 @@ This option can be used to perform batch operations. For example, you can use
 the task IDs as input for other commands, such as `docker inspect`. The
 following example inspects all tasks of the "voting" stack;
 
-```bash
+```console
 $ docker inspect $(docker stack ps -q voting)
 
 [
     {
         "ID": "xim5bcqtgk1b1gk0krq1",
         "Version": {
-(...)
+<...>
 ```
 
 ## Related commands

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -38,7 +38,7 @@ Remove the stack from the swarm.
 
 This will remove the stack with the name `myapp`. Services, networks, and secrets associated with the stack will be removed.
 
-```bash
+```console
 $ docker stack rm myapp
 
 Removing service myapp_redis
@@ -52,7 +52,7 @@ Removing network myapp_frontend
 
 This will remove all the specified stacks, `myapp` and `vossibility`. Services, networks, and secrets associated with all the specified stacks will be removed.
 
-```bash
+```console
 $ docker stack rm myapp vossibility
 
 Removing service myapp_redis

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -36,7 +36,7 @@ Lists the services that are running as part of the specified stack.
 
 The following command shows all services in the `myapp` stack:
 
-```bash
+```console
 $ docker stack services myapp
 
 ID            NAME            REPLICAS  IMAGE                                                                          COMMAND
@@ -52,7 +52,7 @@ Multiple filter flags are combined as an `OR` filter.
 
 The following command shows both the `web` and `db` services:
 
-```bash
+```console
 $ docker stack services --filter name=myapp_web --filter name=myapp_db myapp
 
 ID            NAME            REPLICAS  IMAGE                                                                          COMMAND
@@ -103,7 +103,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `ID`, `Mode`, and `Replicas` entries separated by a colon (`:`) for all services:
 
-```bash
+```console
 $ docker stack services --format "{{.ID}}: {{.Mode}} {{.Replicas}}"
 
 0zmvwuiu3vue: replicated 10/10

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -20,6 +20,6 @@ Options:
 
 ## Examples
 
-```bash
+```console
 $ docker start my_container
 ```

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -53,7 +53,7 @@ the `/containers/(id)/stats` API endpoint.
 
 Running `docker stats` on all running containers against a Linux daemon.
 
-```bash
+```console
 $ docker stats
 
 CONTAINER ID        NAME                                    CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
@@ -77,7 +77,7 @@ following columns are shown.
 
 Running `docker stats` on multiple containers by name and id against a Linux daemon.
 
-```bash
+```console
 $ docker stats awesome_brattain 67b2525d8ad1
 
 CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
@@ -87,7 +87,7 @@ b95a83497c91        awesome_brattain    0.28%               5.629MiB / 1.952GiB 
 
 Running `docker stats` with customized format on all (Running and Stopped) containers.
 
-```bash
+```console
 $ docker stats --all --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" fervent_panini 5acfcb1b4fd1 drunk_visvesvaraya big_heisenberg
 
 CONTAINER                CPU %               MEM USAGE / LIMIT
@@ -151,7 +151,7 @@ outputs the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Container` and `CPUPerc` entries separated by a colon (`:`) for all images:
 
-```bash
+```console
 $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
 
 09d3bb5b1604: 6.61%
@@ -162,7 +162,7 @@ $ docker stats --format "{{.Container}}: {{.CPUPerc}}"
 To list all containers statistics with their name, CPU percentage and memory
 usage in a table format you can use:
 
-```bash
+```console
 $ docker stats --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}"
 
 CONTAINER           CPU %               PRIV WORKING SET

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -25,6 +25,6 @@ instruction in the container's Dockerfile, or the `--stop-signal` option to
 
 ## Examples
 
-```bash
+```console
 $ docker stop my_container
 ```

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -38,8 +38,9 @@ View or rotate the current swarm CA certificate.
 Run the `docker swarm ca` command without any options to view the current root CA certificate
 in PEM format.
 
-```bash
+```console
 $ docker swarm ca
+
 -----BEGIN CERTIFICATE-----
 MIIBazCCARCgAwIBAgIUJPzo67QC7g8Ebg2ansjkZ8CbmaswCgYIKoZIzj0EAwIw
 EzERMA8GA1UEAxMIc3dhcm0tY2EwHhcNMTcwNTAzMTcxMDAwWhcNMzcwNDI4MTcx
@@ -55,7 +56,7 @@ lIwQqLkJ48SQqCjG1DBTSBsHmMSRT+6mE2My+Z3GKA==
 Pass the `--rotate` flag (and optionally a `--ca-cert`, along with a `--ca-key` or
 `--external-ca` parameter flag), in order to rotate the current swarm root CA.
 
-```
+```console
 $ docker swarm ca --rotate
 desired root digest: sha256:05da740cf2577a25224c53019e2cce99bcc5ba09664ad6bb2a9425d9ebd1b53e
   rotated TLS certificates:  [=========================>                         ] 1/2 nodes
@@ -65,7 +66,7 @@ desired root digest: sha256:05da740cf2577a25224c53019e2cce99bcc5ba09664ad6bb2a94
 Once the rotation os finished (all the progress bars have completed) the now-current
 CA certificate will be printed:
 
-```
+```console
 $ docker swarm ca --rotate
 desired root digest: sha256:05da740cf2577a25224c53019e2cce99bcc5ba09664ad6bb2a9425d9ebd1b53e
   rotated TLS certificates:  [==================================================>] 2/2 nodes

--- a/docs/reference/commandline/swarm_init.md
+++ b/docs/reference/commandline/swarm_init.md
@@ -37,8 +37,9 @@ in the newly created single-node swarm.
 
 ## Examples
 
-```bash
+```console
 $ docker swarm init --advertise-addr 192.168.99.121
+
 Swarm initialized: current node (bvz81updecsj6wjz393c09vti) is now a manager.
 
 To add a worker to this swarm, run the following command:
@@ -132,20 +133,21 @@ applies to all nodes that join the swarm.
 The following example initializes a new Swarm, and configures the data path
 port to UDP port 7777;
 
-```bash
-docker swarm init --data-path-port=7777
+```console
+$ docker swarm init --data-path-port=7777
 ```
+
 After the swarm is initialized, use the `docker info` command to verify that
 the port is configured:
 
-```bash
-docker info
-...
+```console
+$ docker info
+<...>
 ClusterID: 9vs5ygs0gguyyec4iqf2314c0
 Managers: 1
 Nodes: 1
 Data Path Port: 7777
-...
+<...>
 ```
 
 ### `--default-addr-pool`

--- a/docs/reference/commandline/swarm_join-token.md
+++ b/docs/reference/commandline/swarm_join-token.md
@@ -40,7 +40,7 @@ As a convenience, you can pass `worker` or `manager` as an argument to
 `join-token` to print the full `docker swarm join` command to join a new node to
 the swarm:
 
-```bash
+```console
 $ docker swarm join-token worker
 
 To add a worker to this swarm, run the following command:
@@ -60,7 +60,7 @@ To add a manager to this swarm, run the following command:
 
 Use the `--rotate` flag to generate a new join token for the specified role:
 
-```bash
+```console
 $ docker swarm join-token --rotate worker
 
 Successfully rotated worker join token.
@@ -76,7 +76,7 @@ After using `--rotate`, only the new token will be valid for joining with the sp
 
 The `-q` (or `--quiet`) flag only prints the token:
 
-```bash
+```console
 $ docker swarm join-token -q worker
 
 SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-b30ljddcqhef9b9v4rs7mel7t

--- a/docs/reference/commandline/swarm_join.md
+++ b/docs/reference/commandline/swarm_join.md
@@ -32,9 +32,10 @@ pass a worker token, the node joins as a worker.
 
 The example below demonstrates joining a manager node using a manager token.
 
-```bash
+```console
 $ docker swarm join --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-7p73s1dx5in4tatdymyhg9hu2 192.168.99.121:2377
 This node joined a swarm as a manager.
+
 $ docker node ls
 ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
 dkp8vy1dq1kxleu9g4u78tlag *  manager2  Ready   Active        Reachable
@@ -49,9 +50,10 @@ should join as workers instead. Managers should be stable hosts that have static
 
 The example below demonstrates joining a worker node using a worker token.
 
-```bash
+```console
 $ docker swarm join --token SWMTKN-1-3pu6hszjas19xyp7ghgosyx9k8atbfcr8p2is99znpy26u2lkl-1awxwuwd3z9j1z3puu7rcgdbx 192.168.99.121:2377
 This node joined a swarm as a worker.
+
 $ docker node ls
 ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
 7ln70fl22uw2dvjn2ft53m3q5    worker2   Ready   Active

--- a/docs/reference/commandline/swarm_leave.md
+++ b/docs/reference/commandline/swarm_leave.md
@@ -31,7 +31,7 @@ no longer be used after the manager leaves, such as in a single-node swarm.
 
 Consider the following swarm, as seen from the manager:
 
-```bash
+```console
 $ docker node ls
 
 ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
@@ -42,7 +42,7 @@ dvfxp4zseq4s0rih1selh0d20 *  manager1  Ready   Active        Leader
 
 To remove `worker2`, issue the following command from `worker2` itself:
 
-```bash
+```console
 $ docker swarm leave
 
 Node left the default swarm.

--- a/docs/reference/commandline/swarm_unlock-key.md
+++ b/docs/reference/commandline/swarm_unlock-key.md
@@ -35,7 +35,7 @@ run the `docker swarm unlock-key` command without any arguments:
 
 ## Examples
 
-```bash
+```console
 $ docker swarm unlock-key
 
 To unlock a swarm manager after it restarts, run the `docker swarm unlock`
@@ -50,7 +50,7 @@ will not be able to restart the manager.
 Use the `--rotate` flag to rotate the unlock key to a new, randomly-generated
 key:
 
-```bash
+```console
 $ docker swarm unlock-key --rotate
 
 Successfully rotated manager unlock key.
@@ -66,7 +66,7 @@ will not be able to restart the manager.
 
 The `-q` (or `--quiet`) flag only prints the key:
 
-```bash
+```console
 $ docker swarm unlock-key -q
 
 SWMKEY-1-7c37Cc8654o6p38HnroywCi19pllOnGtbdZEgtKxZu8

--- a/docs/reference/commandline/swarm_unlock.md
+++ b/docs/reference/commandline/swarm_unlock.md
@@ -31,7 +31,7 @@ enabled, and is also available from the `docker swarm unlock-key` command.
 
 ## Examples
 
-```bash
+```console
 $ docker swarm unlock
 Please enter unlock key:
 ```

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -35,7 +35,7 @@ Updates a swarm with new parameter values.
 
 ## Examples
 
-```bash
+```console
 $ docker swarm update --cert-expiry 720h
 ```
 

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -26,7 +26,7 @@ amount of disk space used by the docker daemon.
 
 By default the command will just show a summary of the data used:
 
-```bash
+```console
 $ docker system df
 
 TYPE                TOTAL               ACTIVE              SIZE                RECLAIMABLE
@@ -37,7 +37,7 @@ Local Volumes       2                   1                   36 B                
 
 A more detailed view can be requested using the `-v, --verbose` flag:
 
-```bash
+```console
 $ docker system df -v
 
 Images space usage:
@@ -101,7 +101,7 @@ the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Type` and `TotalCount` entries separated by a colon (`:`):
 
-```bash
+```console
 $ docker system df --format "{{.Type}}: {{.TotalCount}}"
 
 Images: 2
@@ -112,7 +112,7 @@ Local Volumes: 1
 To list the disk usage with size and reclaimable size in a table format you
 can use:
 
-```bash
+```console
 $ docker system df --format "table {{.Type}}\t{{.Size}}\t{{.Reclaimable}}"
 
 TYPE                SIZE                RECLAIMABLE

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -161,13 +161,13 @@ You'll need two shells for this example.
 
 **Shell 1: Listening for events:**
 
-```bash
+```console
 $ docker system events
 ```
 
 **Shell 2: Start and Stop containers:**
 
-```bash
+```console
 $ docker create --name test alpine:latest top
 $ docker start test
 $ docker stop test
@@ -192,7 +192,7 @@ To exit the `docker system events` command, use `CTRL+C`.
 You can filter the output by an absolute timestamp or relative time on the host
 machine, using the following different time syntaxes:
 
-```bash
+```console
 $ docker system events --since 1483283804
 
 2017-01-05T00:35:41.241772953+08:00 volume create testVol (driver=local)
@@ -243,7 +243,7 @@ $ docker system events --since '10m'
 The following commands show several different ways to filter the `docker event`
 output.
 
-```bash
+```console
 $ docker system events --filter 'event=stop'
 
 2017-01-05T00:40:22.880175420+08:00 container stop 0fdb...ff37 (image=alpine:latest, name=test)
@@ -316,7 +316,7 @@ $ docker system events --filter 'type=plugin'
 
 ### Format the output
 
-```bash
+```console
 $ docker system events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
 
 Type=container  Status=create  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299c126a87812311951e26
@@ -329,7 +329,7 @@ Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299
 
 #### Format as JSON
 
-```bash
+```console
 $ docker system events --format '{{json .}}'
 
 {"status":"create","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f4..

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -26,7 +26,7 @@ and optionally, volumes.
 
 ## Examples
 
-```bash
+```console
 $ docker system prune
 
 WARNING! This will remove:
@@ -56,7 +56,7 @@ By default, volumes are not removed to prevent important data from being
 deleted if there is currently no container using the volume. Use the `--volumes`
 flag when running the command to prune volumes as well:
 
-```bash
+```console
 $ docker system prune -a --volumes
 
 WARNING! This will remove:

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -40,7 +40,7 @@ to [*Share images on Docker Hub*](https://docs.docker.com/get-started/part3/).
 To tag a local image with ID "0e5574283393" into the "fedora" repository with
 "version1.0":
 
-```bash
+```console
 $ docker tag 0e5574283393 fedora/httpd:version1.0
 ```
 
@@ -49,7 +49,7 @@ $ docker tag 0e5574283393 fedora/httpd:version1.0
 To tag a local image with name "httpd" into the "fedora" repository with
 "version1.0":
 
-```bash
+```console
 $ docker tag httpd fedora/httpd:version1.0
 ```
 
@@ -61,7 +61,7 @@ existing local version `httpd:latest`.
 To tag a local image with name "httpd" and tag "test" into the "fedora"
 repository with "version1.0.test":
 
-```bash
+```console
 $ docker tag httpd:test fedora/httpd:version1.0.test
 ```
 
@@ -70,6 +70,6 @@ $ docker tag httpd:test fedora/httpd:version1.0.test
 To push an image to a private registry and not the central Docker
 registry you must tag it with the registry hostname and port (if needed).
 
-```bash
+```console
 $ docker tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0
 ```

--- a/docs/reference/commandline/trust_inspect.md
+++ b/docs/reference/commandline/trust_inspect.md
@@ -29,7 +29,7 @@ new tags.
 Use the `docker trust inspect` to get trust information about an image. The
 following example prints trust information for the `alpine:latest` image:
 
-```bash
+```console
 $ docker trust inspect alpine:latest
 ```
 
@@ -79,7 +79,7 @@ and the `Signers` responsible for the signature.
 If signers are set up for the repository via other `docker trust`
 commands, `docker trust inspect` includes a `Signers` key:
 
-```bash
+```console
 $ docker trust inspect my-image:purple
 ```
 
@@ -157,7 +157,7 @@ The output is in JSON format, for example:
 If the image tag is unsigned or unavailable, `docker trust inspect` does not
 display any signed tags.
 
-```bash
+```console
 $ docker trust inspect unsigned-img
 
 No signatures or cannot access unsigned-img
@@ -166,7 +166,7 @@ No signatures or cannot access unsigned-img
 However, if other tags are signed in the same image repository,
 `docker trust inspect` reports relevant key information:
 
-```bash
+```console
 $ docker trust inspect alpine:unsigned
 ```
 
@@ -204,7 +204,7 @@ The output is in JSON format, for example:
 If no tag is specified, `docker trust inspect` will report details for all
 signed tags in the repository:
 
-```bash
+```console
 $ docker trust inspect alpine
 ```
 
@@ -273,7 +273,7 @@ The output is in JSON format, for example:
 `docker trust inspect` can take multiple repositories and images as arguments,
 and reports the results in an ordered list:
 
-```bash
+```console
 $ docker trust inspect alpine notary
 ```
 
@@ -388,7 +388,7 @@ JSON output, by using the `--pretty` option:
 
 ### Get details about signatures for a single image tag
 
-```bash
+```console
 $ docker trust inspect --pretty alpine:latest
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -410,7 +410,7 @@ If signers are set up for the repository via other `docker trust` commands,
 `docker trust inspect --pretty` displays them appropriately as a `SIGNER`
 and specify their `KEYS`:
 
-```bash
+```console
 $ docker trust inspect --pretty my-image:purple
 
 SIGNED TAG          DIGEST                                                              SIGNERS
@@ -431,7 +431,7 @@ Root Key:       40b66ccc8b176be8c7d365a17f3e046d1c3494e053dd57cfeacfe2e19c4f8e8f
 However, if other tags are signed in the same image repository,
 `docker trust inspect` reports relevant key information.
 
-```bash
+```console
 $ docker trust inspect --pretty alpine:unsigned
 
 No signatures for alpine:unsigned
@@ -444,7 +444,7 @@ Root Key:       a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
 
 ### Get details about signatures for all image tags in a repository
 
-```bash
+```console
 $ docker trust inspect --pretty alpine
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -466,7 +466,7 @@ Root Key:       a2489bcac7a79aa67b19b96c4a3bf0c675ffdf00c6d2fabe1a5df1115e80adce
 
 Here's an example with signers that are set up by `docker trust` commands:
 
-```bash
+```console
 $ docker trust inspect --pretty my-image
 
 SIGNED TAG          DIGEST                                                              SIGNERS

--- a/docs/reference/commandline/trust_key_generate.md
+++ b/docs/reference/commandline/trust_key_generate.md
@@ -25,7 +25,7 @@ Options:
 
 ### Generate a key-pair
 
-```bash
+```console
 $ docker trust key generate alice
 
 Generating key for alice...
@@ -44,7 +44,7 @@ be used directly by `docker trust signer add`.
 
 Provide the `--dir` argument to specify a directory to generate the key in:
 
-```bash
+```console
 $ docker trust key generate alice --dir /foo
 
 Generating key for alice...

--- a/docs/reference/commandline/trust_key_load.md
+++ b/docs/reference/commandline/trust_key_load.md
@@ -28,7 +28,7 @@ To add a signer to a repository use `docker trust signer add`.
 
 For a private key `alice.pem` with permissions `-rw-------`
 
-```bash
+```console
 $ docker trust key load alice.pem
 
 Loading key from "alice.pem"...
@@ -39,7 +39,7 @@ Successfully imported key from alice.pem
 
 To specify a name use the `--name` flag:
 
-```bash
+```console
 $ docker trust key load --name alice-key alice.pem
 
 Loading key from "alice.pem"...

--- a/docs/reference/commandline/trust_revoke.md
+++ b/docs/reference/commandline/trust_revoke.md
@@ -27,7 +27,7 @@ Options:
 Here's an example of a repo with two signed tags:
 
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 SIGNED TAG          DIGEST                                                              SIGNERS
 red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
@@ -46,7 +46,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 When `alice`, one of the signers, runs `docker trust revoke`:
 
-```bash
+```console
 $ docker trust revoke example/trust-demo:red
 Enter passphrase for delegation key with ID 27d42a8:
 Successfully deleted signature for example/trust-demo:red
@@ -54,7 +54,7 @@ Successfully deleted signature for example/trust-demo:red
 
 After revocation, the tag is removed from the list of released tags:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 SIGNED TAG          DIGEST                                                              SIGNERS
 blue                f1c38dbaeeb473c36716f6494d803fbfbe9d8a76916f7c0093f227821e378197    alice, bob
@@ -74,7 +74,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 When no tag is specified, `docker trust` revokes all signatures that you have a signing key for.
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 SIGNED TAG          DIGEST                                                              SIGNERS
 red                 852cc04935f930a857b630edc4ed6131e91b22073bcc216698842e44f64d2943    alice
@@ -93,7 +93,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 When `alice`, one of the signers, runs `docker trust revoke`:
 
-```bash
+```console
 $ docker trust revoke example/trust-demo
 Please confirm you would like to delete all signature data for example/trust-demo? [y/N] y
 Enter passphrase for delegation key with ID 27d42a8:
@@ -102,7 +102,7 @@ Successfully deleted signature for example/trust-demo
 
 All tags that have `alice`'s signature on them are removed from the list of released tags:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo

--- a/docs/reference/commandline/trust_sign.md
+++ b/docs/reference/commandline/trust_sign.md
@@ -27,7 +27,7 @@ Options:
 
 Given an image:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -40,7 +40,7 @@ Root Key:       246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b
 
 Sign a new tag with `docker trust sign`:
 
-```bash
+```console
 $ docker trust sign example/trust-demo:v2
 
 Signing and pushing trust metadata for example/trust-demo:v2
@@ -60,7 +60,7 @@ Successfully signed docker.io/example/trust-demo:v2
 
 Use `docker trust inspect --pretty` to list the new signature:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -76,7 +76,7 @@ Root Key:       246d360f7c53a9021ee7d4259e3c5692f3f1f7ad4737b1ea8c7b8da741ad980b
 
 Given an image:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -95,7 +95,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 Sign a new tag with `docker trust sign`:
 
-```bash
+```console
 $ docker trust sign example/trust-demo:v1
 
 Signing and pushing trust metadata for example/trust-demo:v1
@@ -113,7 +113,7 @@ Successfully signed docker.io/example/trust-demo:v1
 
 `docker trust inspect --pretty` lists the new signature:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -134,13 +134,13 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 When signing an image on a repo for the first time, `docker trust sign` sets up new keys before signing the image.
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures or cannot access example/trust-demo
 ```
 
-```bash
+```console
 $ docker trust sign example/trust-demo:v1
 
 Signing and pushing trust metadata for example/trust-demo:v1
@@ -165,7 +165,7 @@ Enter passphrase for alice key with ID 6d52b29:
 Successfully signed docker.io/example/trust-demo:v1
 ```
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS

--- a/docs/reference/commandline/trust_signer_add.md
+++ b/docs/reference/commandline/trust_signer_add.md
@@ -26,7 +26,7 @@ Options:
 
 To add a new signer, `alice`, to this repository:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -44,7 +44,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 Add `alice` with `docker trust signer add`:
 
-```bash
+```console
 $ docker trust signer add alice example/trust-demo --key alice.crt
   Adding signer "alice" to example/trust-demo...
   Enter passphrase for repository key with ID 642692c:
@@ -53,7 +53,7 @@ Successfully added signer: alice to example/trust-demo
 
 `docker trust inspect --pretty` now lists `alice` as a valid signer:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -74,13 +74,13 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 When adding a signer on a repo for the first time, `docker trust signer add` sets up a new repo if it doesn't exist.
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures or cannot access example/trust-demo
 ```
 
-```bash
+```console
 $ docker trust signer add alice example/trust-demo --key alice.crt
 
 Initializing signed repository for example/trust-demo...
@@ -93,7 +93,7 @@ Adding signer "alice" to example/trust-demo...
 Successfully added signer: alice to example/trust-demo
 ```
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -113,7 +113,7 @@ Root Key:       748121c14bd1461f6c58cb3ef39087c8fdc7633bb11a98af844fd9a04e208103
 
 ## Add a signer to multiple repos
 To add a signer, `alice`, to multiple repositories:
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -128,7 +128,8 @@ Administrative keys for example/trust-demo:
 Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 ```
-```bash
+
+```console
 $ docker trust inspect --pretty example/trust-demo2
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -143,9 +144,10 @@ Administrative keys for example/trust-demo2:
 Repository Key: ece554f14c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4553d2ab20a8d9268
 Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 ```
+
 Add `alice` to both repositories with a single `docker trust signer add` command:
 
-```bash
+```console
 $ docker trust signer add alice example/trust-demo example/trust-demo2 --key alice.crt
 
 Adding signer "alice" to example/trust-demo...
@@ -160,7 +162,7 @@ Successfully added signer: alice to example/trust-demo2
 `docker trust inspect --pretty` now lists `alice` as a valid signer of both `example/trust-demo` and `example/trust-demo2`:
 
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -177,7 +179,7 @@ Repository Key: 95b9e5514c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 ```
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo2
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -197,7 +199,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 `docker trust signer add` adds signers to repositories on a best effort basis, so it will continue to add the signer to subsequent repositories if one attempt fails:
 
-```bash
+```console
 $ docker trust signer add alice example/unauthorized example/authorized --key alice.crt
 
 Adding signer "alice" to example/unauthorized...

--- a/docs/reference/commandline/trust_signer_remove.md
+++ b/docs/reference/commandline/trust_signer_remove.md
@@ -25,7 +25,8 @@ Options:
 ### Remove a signer from a repo
 
 To remove an existing signer, `alice`, from this repository:
-```bash
+
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -44,7 +45,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 Remove `alice` with `docker trust signer remove`:
 
-```bash
+```console
 $ docker trust signer remove alice example/trust-demo
 
 Removing signer "alice" from image example/trust-demo...
@@ -54,7 +55,7 @@ Successfully removed alice from example/trust-demo
 
 `docker trust inspect --pretty` now does not list `alice` as a valid signer:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 No signatures for example/trust-demo
@@ -74,7 +75,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 To remove an existing signer, `alice`, from multiple repositories:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -91,7 +92,7 @@ Repository Key: 95b9e5514c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 ```
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo2
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -110,7 +111,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 
 Remove `alice` from both images with a single `docker trust signer remove` command:
 
-```bash
+```console
 $ docker trust signer remove alice example/trust-demo example/trust-demo2
 
 Removing signer "alice" from image example/trust-demo...
@@ -125,7 +126,7 @@ Successfully removed alice from example/trust-demo2
 Run `docker trust inspect --pretty` to confirm that `alice` is no longer listed as a valid
 signer of either `example/trust-demo` or `example/trust-demo2`:
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -141,7 +142,7 @@ Repository Key: ecc457614c9fc399da523a5f4e24fe306a0a6ee1cc79a10e4555b3c6ab02f71e
 Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 ```
 
-```bash
+```console
 $ docker trust inspect --pretty example/trust-demo2
 
 SIGNED TAG          DIGEST                                                             SIGNERS
@@ -161,7 +162,7 @@ Root Key:       3cb2228f6561e58f46dbc4cda4fcaff9d5ef22e865a94636f82450d1d2234949
 basis, so it will continue to remove the signer from subsequent repositories if
 one attempt fails:
 
-```bash
+```console
 $ docker trust signer remove alice example/unauthorized example/authorized
 
 Removing signer "alice" from image example/unauthorized...

--- a/docs/reference/commandline/unpause.md
+++ b/docs/reference/commandline/unpause.md
@@ -26,7 +26,7 @@ for further details.
 
 ## Examples
 
-```bash
+```console
 $ docker unpause my_container
 my_container
 ```

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -59,7 +59,7 @@ To limit a container's cpu-shares to 512, first identify the container
 name or ID. You can use `docker ps` to find these values. You can also
 use the ID returned from the `docker run` command.  Then, do the following:
 
-```bash
+```console
 $ docker update --cpu-shares 512 abebf7571666
 ```
 
@@ -67,7 +67,7 @@ $ docker update --cpu-shares 512 abebf7571666
 
 To update multiple resource configurations for multiple containers:
 
-```bash
+```console
 $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ```
 
@@ -85,19 +85,19 @@ the container before updating kernel memory.
 
 For example, if you started a container with this command:
 
-```bash
+```console
 $ docker run -dit --name test --kernel-memory 50M ubuntu bash
 ```
 
 You can update kernel memory while the container is running:
 
-```bash
+```console
 $ docker update --kernel-memory 80M test
 ```
 
 If you started a container *without* kernel memory initialized:
 
-```bash
+```console
 $ docker run -dit --name test2 --memory 300M ubuntu bash
 ```
 
@@ -116,7 +116,7 @@ container.
 
 To update restart policy for one or more containers:
 
-```bash
+```console
 $ docker update --restart=on-failure:3 abebf7571666 hopeful_morse
 ```
 

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -29,7 +29,7 @@ describes all the details of the format.
 
 ### Default output
 
-```bash
+```console
 $ docker version
 
 Client:
@@ -64,7 +64,7 @@ Server:
 
 ### Get the server version
 
-```bash
+```console
 $ docker version --format '{{.Server.Version}}'
 
 19.03.8
@@ -72,7 +72,7 @@ $ docker version --format '{{.Server.Version}}'
 
 ### Dump raw JSON data
 
-```bash
+```console
 $ docker version --format '{{json .}}'
 
 {"Client":{"Platform":{"Name":"Docker Engine - Community"},"Version":"19.03.8","ApiVersion":"1.40","DefaultAPIVersion":"1.40","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"darwin","Arch":"amd64","BuildTime":"Wed Mar 11 01:21:11 2020","Experimental":true},"Server":{"Platform":{"Name":"Docker Engine - Community"},"Components":[{"Name":"Engine","Version":"19.03.8","Details":{"ApiVersion":"1.40","Arch":"amd64","BuildTime":"Wed Mar 11 01:29:16 2020","Experimental":"true","GitCommit":"afacb8b","GoVersion":"go1.12.17","KernelVersion":"4.19.76-linuxkit","MinAPIVersion":"1.12","Os":"linux"}},{"Name":"containerd","Version":"v1.2.13","Details":{"GitCommit":"7ad184331fa3e55e52b890ea95e65ba581ae3429"}},{"Name":"runc","Version":"1.0.0-rc10","Details":{"GitCommit":"dc9208a3303feef5b3839f4323d9beb36df0a9dd"}},{"Name":"docker-init","Version":"0.18.0","Details":{"GitCommit":"fec3683"}}],"Version":"19.03.8","ApiVersion":"1.40","MinAPIVersion":"1.12","GitCommit":"afacb8b","GoVersion":"go1.12.17","Os":"linux","Arch":"amd64","KernelVersion":"4.19.76-linuxkit","Experimental":true,"BuildTime":"2020-03-11T01:29:16.000000000+00:00"}}
@@ -82,7 +82,7 @@ $ docker version --format '{{json .}}'
 
 The following example prints the currently used [`docker context`](context.md):
 
-```bash
+```console
 $ docker version --format='{{.Client.Context}}'
 default
 ```
@@ -94,7 +94,7 @@ could be used when using Bash as your shell.
 Declare a function to obtain the current context in your `~/.bashrc`, and set
 this command as your `PROMPT_COMMAND`
 
-```bash
+```console
 function docker_context_prompt() {
         PS1="context: $(docker version --format='{{.Client.Context}}')> "
 }
@@ -105,7 +105,7 @@ PROMPT_COMMAND=docker_context_prompt
 After reloading the `~/.bashrc`, the prompt now shows the currently selected
 `docker context`:
 
-```bash
+```console
 $ source ~/.bashrc
 context: default> docker context create --docker host=unix:///var/run/docker.sock my-context
 my-context

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -27,7 +27,7 @@ not specified, Docker generates a random name.
 
 Create a volume and then configure the container to use it:
 
-```bash
+```console
 $ docker volume create hello
 
 hello
@@ -58,7 +58,7 @@ assumes you want to re-use the existing volume and does not return an error.
 Some volume drivers may take options to customize the volume creation. Use the
 `-o` or `--opt` flags to pass driver options:
 
-```bash
+```console
 $ docker volume create --driver fake \
     --opt tardis=blue \
     --opt timey=wimey \
@@ -79,7 +79,7 @@ found [here](http://man7.org/linux/man-pages/man8/mount.8.html).
 For example, the following creates a `tmpfs` volume called `foo` with a size of
 100 megabyte and `uid` of 1000.
 
-```bash
+```console
 $ docker volume create --driver local \
     --opt type=tmpfs \
     --opt device=tmpfs \
@@ -89,7 +89,7 @@ $ docker volume create --driver local \
 
 Another example that uses `btrfs`:
 
-```bash
+```console
 $ docker volume create --driver local \
     --opt type=btrfs \
     --opt device=/dev/sda2 \
@@ -99,7 +99,7 @@ $ docker volume create --driver local \
 Another example that uses `nfs` to mount the `/path/to/dir` in `rw` mode from
 `192.168.1.1`:
 
-```bash
+```console
 $ docker volume create --driver local \
     --opt type=nfs \
     --opt o=addr=192.168.1.1,rw \

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -26,7 +26,7 @@ details of the format.
 
 ## Examples
 
-```bash
+```console
 $ docker volume create myvolume
 
 myvolume
@@ -34,7 +34,7 @@ myvolume
 
 Use the `docker volume inspect` comment to inspect the configuration of the volume:
 
-```bash
+```console
 $ docker volume inspect myvolume
 ```
 
@@ -53,10 +53,11 @@ The output is in JSON format, for example:
   }
 ]
 ```
+
 Use the `--format` flag to format the output using a Go template, for example,
 to print the `Mountpoint` property:
 
-```bash
+```console
 $ docker volume inspect --format '{{ .Mountpoint }}' myvolume
 
 /var/lib/docker/volumes/myvolume/_data

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -34,7 +34,8 @@ information about available filter options.
 ## Examples
 
 ### Create a volume
-```bash
+
+```console
 $ docker volume create rosemary
 
 rosemary
@@ -66,7 +67,7 @@ The currently supported filters are:
 
 The `dangling` filter matches on all volumes not referenced by any containers
 
-```bash
+```console
 $ docker run -d  -v tyler:/tmpwork  busybox
 
 f86a7dd02898067079c99ceacd810149060a70528eff3754d0b0f1a93bd0af18
@@ -81,7 +82,7 @@ The `driver` filter matches volumes based on their driver.
 
 The following example matches volumes that are created with the `local` driver:
 
-```bash
+```console
 $ docker volume ls -f driver=local
 
 DRIVER              VOLUME NAME
@@ -96,7 +97,7 @@ a `label` and a value.
 
 First, let's create some volumes to illustrate this;
 
-```bash
+```console
 $ docker volume create the-doctor --label is-timelord=yes
 
 the-doctor
@@ -108,7 +109,7 @@ daleks
 The following example filter matches volumes with the `is-timelord` label
 regardless of its value.
 
-```bash
+```console
 $ docker volume ls --filter label=is-timelord
 
 DRIVER              VOLUME NAME
@@ -121,7 +122,7 @@ As the above example demonstrates, both volumes with `is-timelord=yes`, and
 
 Filtering on both `key` *and* `value` of the label, produces the expected result:
 
-```bash
+```console
 $ docker volume ls --filter label=is-timelord=yes
 
 DRIVER              VOLUME NAME
@@ -131,7 +132,7 @@ local               the-doctor
 Specifying multiple label filter produces an "and" search; all conditions
 should be met;
 
-```bash
+```console
 $ docker volume ls --filter label=is-timelord=yes --filter label=is-timelord=no
 
 DRIVER              VOLUME NAME
@@ -143,7 +144,7 @@ The `name` filter matches on all or part of a volume's name.
 
 The following filter matches all volumes with a name containing the `rose` string.
 
-```bash
+```console
 $ docker volume ls -f name=rose
 
 DRIVER              VOLUME NAME
@@ -173,7 +174,7 @@ output the data exactly as the template declares or, when using the
 The following example uses a template without headers and outputs the
 `Name` and `Driver` entries separated by a colon (`:`) for all volumes:
 
-```bash
+```console
 $ docker volume ls --format "{{.Name}}: {{.Driver}}"
 
 vol1: local

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -23,7 +23,7 @@ Remove all unused local volumes. Unused local volumes are those which are not re
 
 ## Examples
 
-```bash
+```console
 $ docker volume prune
 
 WARNING! This will remove all local volumes not used by at least one container.

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -25,7 +25,7 @@ Remove one or more volumes. You cannot remove a volume that is in use by a conta
 
 ## Examples
 
-```bash
+```console
 $ docker volume rm hello
 
 hello

--- a/docs/reference/commandline/wait.md
+++ b/docs/reference/commandline/wait.md
@@ -24,27 +24,27 @@ Options:
 
 Start a container in the background.
 
-```bash
+```console
 $ docker run -dit --name=my_container ubuntu bash
 ```
 
 Run `docker wait`, which should block until the container exits.
 
-```bash
+```console
 $ docker wait my_container
 ```
 
 In another terminal, stop the first container. The `docker wait` command above
 returns the exit code.
 
-```bash
+```console
 $ docker stop my_container
 ```
 
 This is the same `docker wait` command from above, but it now exits, returning
 `0`.
 
-```bash
+```console
 $ docker wait my_container
 
 0

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -132,7 +132,7 @@ If you do not specify `-a` then Docker will [attach to both stdout and stderr
 You can specify to which of the three standard streams (`STDIN`, `STDOUT`,
 `STDERR`) you'd like to connect instead, as in:
 
-```bash
+```console
 $ docker run -a stdin -a stdout -i -t ubuntu /bin/bash
 ```
 
@@ -141,7 +141,7 @@ order to allocate a tty for the container process. `-i -t` is often written `-it
 as you'll see in later examples.  Specifying `-t` is forbidden when the client
 is receiving its standard input from a pipe, as in:
 
-```bash
+```console
 $ echo test | docker run -i busybox cat
 ```
 
@@ -198,7 +198,7 @@ the digest value is predictable and referenceable.
 The following example runs a container from the `alpine` image with the
 `sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0` digest:
 
-```bash
+```console
 $ docker run alpine@sha256:9cacb71397b640eca97488cf08582ae4e4068513101088e9f96c9814bfda95e0 date
 ```
 
@@ -232,13 +232,13 @@ CMD ["htop"]
 
 Build the Dockerfile and tag the image as `myhtop`:
 
-```bash
+```console
 $ docker build -t myhtop .
 ```
 
 Use the following command to run `htop` inside a container:
 
-```bash
+```console
 $ docker run -it --rm --pid=host myhtop
 ```
 
@@ -248,13 +248,13 @@ Joining another container's pid namespace can be used for debugging that contain
 
 Start a container running a redis server:
 
-```bash
+```console
 $ docker run --name my-redis -d redis
 ```
 
 Debug the redis container by running another container that has strace in it:
 
-```bash
+```console
 $ docker run -it --pid=container:my-redis my_strace_docker_image bash
 $ strace -p 1
 ```
@@ -440,7 +440,7 @@ Example running a Redis container with Redis binding to `localhost` then
 running the `redis-cli` command and connecting to the Redis server over the
 `localhost` interface.
 
-```bash
+```console
 $ docker run -d --name redis example/redis --bind 127.0.0.1
 $ # use the redis container's network stack to access localhost
 $ docker run --rm -it --network container:redis example/redis-cli -h 127.0.0.1
@@ -460,7 +460,7 @@ Engines can also communicate in this way.
 The following example creates a network using the built-in `bridge` network
 driver and running a container in the created network
 
-```bash
+```console
 $ docker network create -d bridge my-net
 $ docker run --network=my-net -itd --name=container3 busybox
 ```
@@ -471,7 +471,7 @@ Your container will have lines in `/etc/hosts` which define the hostname of the
 container itself as well as `localhost` and a few other common things. The
 `--add-host` flag can be used to add additional lines to `/etc/hosts`.
 
-```bash
+```console
 $ docker run -it --add-host db-static:86.75.30.9 ubuntu cat /etc/hosts
 
 172.17.0.22     09d03f76bf2c
@@ -569,7 +569,7 @@ will try forever to restart the container. The number of (attempted) restarts
 for a container can be obtained via [`docker inspect`](commandline/inspect.md). For example, to get the number of restarts
 for container "my-container";
 
-```bash
+```console
 {% raw %}
 $ docker inspect -f "{{ .RestartCount }}" my-container
 # 2
@@ -578,7 +578,7 @@ $ docker inspect -f "{{ .RestartCount }}" my-container
 
 Or, to get the last time the container was (re)started;
 
-```bash
+```console
 {% raw %}
 $ docker inspect -f "{{ .State.StartedAt }}" my-container
 # 2015-03-04T23:47:07.691840179Z
@@ -591,14 +591,14 @@ examples on using the [`--rm` (clean up)](#clean-up---rm) flag later in this pag
 
 ### Examples
 
-```bash
+```console
 $ docker run --restart=always redis
 ```
 
 This will run the `redis` container with a restart policy of **always**
 so that if the container exits, Docker will restart it.
 
-```bash
+```console
 $ docker run --restart=on-failure:10 redis
 ```
 
@@ -616,7 +616,7 @@ the exit codes follow the `chroot` standard, see below:
 
 **_125_** if the error is with Docker daemon **_itself_**
 
-```bash
+```console
 $ docker run --foo busybox; echo $?
 
 flag provided but not defined: --foo
@@ -626,7 +626,7 @@ See 'docker run --help'.
 
 **_126_** if the **_contained command_** cannot be invoked
 
-```bash
+```console
 $ docker run busybox /etc; echo $?
 
 docker: Error response from daemon: Container command '/etc' could not be invoked.
@@ -635,7 +635,7 @@ docker: Error response from daemon: Container command '/etc' could not be invoke
 
 **_127_** if the **_contained command_** cannot be found
 
-```bash
+```console
 $ docker run busybox foo; echo $?
 
 docker: Error response from daemon: Container command 'foo' not found or does not exist.
@@ -644,9 +644,9 @@ docker: Error response from daemon: Container command 'foo' not found or does no
 
 **_Exit code_** of **_contained command_** otherwise
 
-```bash
-$ docker run busybox /bin/sh -c 'exit 3'; echo $?
-
+```console
+$ docker run busybox /bin/sh -c 'exit 3'
+$ echo $?
 3
 ```
 
@@ -669,8 +669,8 @@ the container exits**, you can add the `--rm` flag:
 > to running `docker rm -v my-container`. Only volumes that are specified without
 > a name are removed. For example, when running:
 >
-> ```bash
-> docker run --rm -v /foo -v awesome:/bar busybox top
+> ```console
+> $ docker run --rm -v /foo -v awesome:/bar busybox top
 > ```
 > 
 > the volume for `/foo` will be removed, but the volume for `/bar` will not.
@@ -696,7 +696,7 @@ You can override the default labeling scheme for each container by specifying
 the `--security-opt` flag. Specifying the level in the following command
 allows you to share the same content between containers.
 
-```bash
+```console
 $ docker run --security-opt label=level:s0:c100,c200 -it fedora bash
 ```
 
@@ -707,7 +707,7 @@ $ docker run --security-opt label=level:s0:c100,c200 -it fedora bash
 To disable the security labeling for this container versus running with the
 `--privileged` flag, use the following command:
 
-```bash
+```console
 $ docker run --security-opt label=disable -it fedora bash
 ```
 
@@ -716,7 +716,7 @@ you can specify an alternate type for the container. You could run a container
 that is only allowed to listen on Apache ports by executing the following
 command:
 
-```bash
+```console
 $ docker run --security-opt label=type:svirt_apache_t -it centos bash
 ```
 
@@ -727,7 +727,7 @@ $ docker run --security-opt label=type:svirt_apache_t -it centos bash
 If you want to prevent your container processes from gaining additional
 privileges, you can execute the following command:
 
-```bash
+```console
 $ docker run --security-opt no-new-privileges -it centos bash
 ```
 
@@ -836,14 +836,14 @@ We have four ways to set user memory usage:
 
 Examples:
 
-```bash
+```console
 $ docker run -it ubuntu:14.04 /bin/bash
 ```
 
 We set nothing about memory, this means the processes in the container can use
 as much memory and swap memory as they need.
 
-```bash
+```console
 $ docker run -it -m 300M --memory-swap -1 ubuntu:14.04 /bin/bash
 ```
 
@@ -851,7 +851,7 @@ We set memory limit and disabled swap memory limit, this means the processes in
 the container can use 300M memory and as much swap memory as they need (if the
 host supports swap memory).
 
-```bash
+```console
 $ docker run -it -m 300M ubuntu:14.04 /bin/bash
 ```
 
@@ -860,7 +860,7 @@ We set memory limit only, this means the processes in the container can use
 (--memory-swap) will be set as double of memory, in this case, memory + swap
 would be 2*300M, so processes can use 300M swap memory as well.
 
-```bash
+```console
 $ docker run -it -m 300M --memory-swap 1G ubuntu:14.04 /bin/bash
 ```
 
@@ -886,7 +886,7 @@ heavily contended for, memory is allocated based on the reservation hints/setup.
 The following example limits the memory (`-m`) to 500M and sets the memory
 reservation to 200M.
 
-```bash
+```console
 $ docker run -it -m 500M --memory-reservation 200M ubuntu:14.04 /bin/bash
 ```
 
@@ -896,7 +896,7 @@ memory below 200M.
 
 The following example set memory reservation to 1G without a hard memory limit.
 
-```bash
+```console
 $ docker run -it --memory-reservation 1G ubuntu:14.04 /bin/bash
 ```
 
@@ -914,13 +914,13 @@ memory.
 The following example limits the memory to 100M and disables the OOM killer for
 this container:
 
-```bash
+```console
 $ docker run -it -m 100M --oom-kill-disable ubuntu:14.04 /bin/bash
 ```
 
 The following example, illustrates a dangerous way to use the flag:
 
-```bash
+```console
 $ docker run -it --oom-kill-disable ubuntu:14.04 /bin/bash
 ```
 
@@ -990,14 +990,14 @@ limit and "K" the kernel limit. There are three possible ways to set limits:
 
 Examples:
 
-```bash
+```console
 $ docker run -it -m 500M --kernel-memory 50M ubuntu:14.04 /bin/bash
 ```
 
 We set memory and kernel memory, so the processes in the container can use
 500M memory in total, in this 500M memory, it can be 50M kernel memory tops.
 
-```bash
+```console
 $ docker run -it --kernel-memory 50M ubuntu:14.04 /bin/bash
 ```
 
@@ -1014,7 +1014,7 @@ between 0 and 100. A value of 0 turns off anonymous page swapping. A value of
 
 For example, you can set:
 
-```bash
+```console
 $ docker run -it --memory-swappiness=0 ubuntu:14.04 /bin/bash
 ```
 
@@ -1065,7 +1065,7 @@ And usually `--cpu-period` should work with `--cpu-quota`.
 
 Examples:
 
-```bash
+```console
 $ docker run -it --cpu-period=50000 --cpu-quota=25000 ubuntu:14.04 /bin/bash
 ```
 
@@ -1086,13 +1086,13 @@ We can set cpus in which to allow execution for containers.
 
 Examples:
 
-```bash
+```console
 $ docker run -it --cpuset-cpus="1,3" ubuntu:14.04 /bin/bash
 ```
 
 This means processes in container can be executed on cpu 1 and cpu 3.
 
-```bash
+```console
 $ docker run -it --cpuset-cpus="0-2" ubuntu:14.04 /bin/bash
 ```
 
@@ -1103,14 +1103,14 @@ on NUMA systems.
 
 Examples:
 
-```bash
+```console
 $ docker run -it --cpuset-mems="1,3" ubuntu:14.04 /bin/bash
 ```
 
 This example restricts the processes in the container to only use memory from
 memory nodes 1 and 3.
 
-```bash
+```console
 $ docker run -it --cpuset-mems="0-2" ubuntu:14.04 /bin/bash
 ```
 
@@ -1142,14 +1142,14 @@ The `--blkio-weight` flag can set the weighting to a value between 10 to 1000.
 For example, the commands below create two containers with different blkio
 weight:
 
-```bash
+```console
 $ docker run -it --name c1 --blkio-weight 300 ubuntu:14.04 /bin/bash
 $ docker run -it --name c2 --blkio-weight 600 ubuntu:14.04 /bin/bash
 ```
 
 If you do block IO in the two containers at the same time, by, for example:
 
-```bash
+```console
 $ time dd if=/mnt/zerofile of=test.out bs=1M count=1024 oflag=direct
 ```
 
@@ -1160,7 +1160,7 @@ The `--blkio-weight-device="DEVICE_NAME:WEIGHT"` flag sets a specific device wei
 The `DEVICE_NAME:WEIGHT` is a string containing a colon-separated device name and weight.
 For example, to set `/dev/sda` device weight to `200`:
 
-```bash
+```console
 $ docker run -it \
     --blkio-weight-device "/dev/sda:200" \
     ubuntu
@@ -1172,7 +1172,7 @@ to override this default with a new value on a specific device.
 The following example uses a default weight of `300` and overrides this default
 on `/dev/sda` setting that weight to `200`:
 
-```bash
+```console
 $ docker run -it \
     --blkio-weight 300 \
     --blkio-weight-device "/dev/sda:200" \
@@ -1183,7 +1183,7 @@ The `--device-read-bps` flag limits the read rate (bytes per second) from a devi
 For example, this command creates a container and limits the read rate to `1mb`
 per second from `/dev/sda`:
 
-```bash
+```console
 $ docker run -it --device-read-bps /dev/sda:1mb ubuntu
 ```
 
@@ -1191,7 +1191,7 @@ The `--device-write-bps` flag limits the write rate (bytes per second) to a devi
 For example, this command creates a container and limits the write rate to `1mb`
 per second for `/dev/sda`:
 
-```bash
+```console
 $ docker run -it --device-write-bps /dev/sda:1mb ubuntu
 ```
 
@@ -1203,7 +1203,7 @@ The `--device-read-iops` flag limits read rate (IO per second) from a device.
 For example, this command creates a container and limits the read rate to
 `1000` IO per second from `/dev/sda`:
 
-```bash
+```console
 $ docker run -ti --device-read-iops /dev/sda:1000 ubuntu
 ```
 
@@ -1211,7 +1211,7 @@ The `--device-write-iops` flag limits write rate (IO per second) to a device.
 For example, this command creates a container and limits the write rate to
 `1000` IO per second to `/dev/sda`:
 
-```bash
+```console
 $ docker run -ti --device-write-iops /dev/sda:1000 ubuntu
 ```
 
@@ -1220,7 +1220,7 @@ write rates must be a positive integer.
 
 ## Additional groups
 
-```bash
+```console
 --group-add: Add additional groups to run as
 ```
 
@@ -1228,11 +1228,12 @@ By default, the docker container process runs with the supplementary groups look
 up for the specified user. If one wants to add more to that list of groups, then
 one can use this flag:
 
-```bash
+```console
 $ docker run --rm --group-add audio --group-add nogroup --group-add 777 busybox id
 
 uid=0(root) gid=0(root) groups=10(wheel),29(audio),99(nogroup),777
 ```
+
 ## Runtime privilege and Linux capabilities
 
 | Option         | Description                                                                   |
@@ -1259,14 +1260,14 @@ If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that
 will be accessible within the container.
 
-```bash
+```console
 $ docker run --device=/dev/snd:/dev/snd ...
 ```
 
 By default, the container will be able to `read`, `write`, and `mknod` these devices.
 This can be overridden using a third `:rwm` set of options to each `--device` flag:
 
-```bash
+```console
 $ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
 Command (m for help): q
@@ -1342,14 +1343,14 @@ and in the [Linux kernel source code](https://github.com/torvalds/linux/blob/124
 Both flags support the value `ALL`, so to allow a container to use all capabilities
 except for `MKNOD`:
 
-```bash
+```console
 $ docker run --cap-add=ALL --cap-drop=MKNOD ...
 ```
 
 The `--cap-add` and `--cap-drop` flags accept capabilities to be specified with
 a `CAP_` prefix. The following examples are therefore equivalent:
 
-```bash
+```console
 $ docker run --cap-add=SYS_ADMIN ...
 $ docker run --cap-add=CAP_SYS_ADMIN ...
 ```
@@ -1357,7 +1358,7 @@ $ docker run --cap-add=CAP_SYS_ADMIN ...
 For interacting with the network stack, instead of using `--privileged` they
 should use `--cap-add=NET_ADMIN` to modify the network interfaces.
 
-```bash
+```console
 $ docker run -it --rm  ubuntu:14.04 ip link add dummy0 type dummy
 
 RTNETLINK answers: Operation not permitted
@@ -1368,7 +1369,7 @@ $ docker run -it --rm --cap-add=NET_ADMIN ubuntu:14.04 ip link add dummy0 type d
 To mount a FUSE based filesystem, you need to combine both `--cap-add` and
 `--device`:
 
-```bash
+```console
 $ docker run --rm -it --cap-add SYS_ADMIN sshfs sshfs sven@10.10.10.20:/home/sven /mnt
 
 fuse: failed to open /dev/fuse: Operation not permitted
@@ -1448,7 +1449,7 @@ Dockerfile instruction and how the operator can override that setting.
 Recall the optional `COMMAND` in the Docker
 commandline:
 
-```bash
+```console
 $ docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]
 ```
 
@@ -1463,7 +1464,7 @@ get appended as arguments to the `ENTRYPOINT`.
 
 ### ENTRYPOINT (default command to execute at runtime)
 
-```bash
+```console
     --entrypoint="": Overwrite the default entrypoint set by the image
 ```
 
@@ -1479,20 +1480,20 @@ runtime by using a string to specify the new `ENTRYPOINT`. Here is an
 example of how to run a shell in a container that has been set up to
 automatically run something else (like `/usr/bin/redis-server`):
 
-```bash
+```console
 $ docker run -it --entrypoint /bin/bash example/redis
 ```
 
 or two examples of how to pass more parameters to that ENTRYPOINT:
 
-```bash
+```console
 $ docker run -it --entrypoint /bin/bash example/redis -c ls -l
 $ docker run -it --entrypoint /usr/bin/redis-cli example/redis --help
 ```
 
 You can reset a containers entrypoint by passing an empty string, for example:
 
-```bash
+```console
 $ docker run -it --entrypoint="" mysql bash
 ```
 
@@ -1579,7 +1580,7 @@ above, or already defined by the developer with a Dockerfile `ENV`. If the
 operator names an environment variable without specifying a value, then the
 current value of the named variable is propagated into the container's environment:
 
-```bash
+```console
 $ export today=Wednesday
 $ docker run -e "deep=purple" -e today --rm alpine env
 
@@ -1640,7 +1641,7 @@ Similarly the operator can set the **HOSTNAME** (Linux) or **COMPUTERNAME** (Win
 
 Example:
 
-```bash
+```console
 {% raw %}
 $ docker run --name=test -d \
     --health-cmd='stat /etc/passwd || exit 1' \
@@ -1693,7 +1694,7 @@ The health status is also displayed in the `docker ps` output.
 
 ### TMPFS (mount tmpfs filesystems)
 
-```bash
+```console
 --tmpfs=[]: Create a tmpfs mount with: container-dir[:<options>],
             where the options are identical to the Linux
             'mount -t tmpfs -o' command.
@@ -1702,7 +1703,7 @@ The health status is also displayed in the `docker ps` output.
 The example below mounts an empty tmpfs into the container with the `rw`,
 `noexec`, `nosuid`, and `size=65536k` options.
 
-```bash
+```console
 $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 ```
 

--- a/man/Dockerfile.5.md
+++ b/man/Dockerfile.5.md
@@ -183,6 +183,18 @@ A Dockerfile is similar to a Makefile.
 
   To display an image's labels, use the `docker inspect` command.
 
+**STOPSIGNAL**
+
+  -- `STOPSIGNAL <signal>`
+  The **STOPSIGNAL** instruction sets the system call signal that will be sent
+  to the container to exit. This signal can be a signal name in the format
+  **SIG<NAME>**, for instance **SIGKILL**, or an unsigned number that matches a
+  position in the kernel's syscall table, for instance **9**. The default is
+  **SIGTERM** if not defined.
+
+  The image's default stopsignal can be overridden per container, using the
+  **--stop-signal** flag on **docker-run(1)** and **docker-create(1)**.
+
 **EXPOSE**
   -- `EXPOSE <port> [<port>...]`
   The **EXPOSE** instruction informs Docker that the container listens on the

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -622,10 +622,26 @@ incompatible with any restart policy other than `none`.
    Under these conditions, user can pass any size less than the backing fs size.
 
 **--stop-signal**=*SIGTERM*
-  Signal to stop a container. Default is SIGTERM.
+   Signal to stop the container. Default is SIGTERM.
 
-**--stop-timeout**=*10*
-  Timeout (in seconds) to stop a container. Default is 10.
+   The `--stop-signal` flag sets the system call signal that will be sent to the
+   container to exit. This signal can be a signal name in the format `SIG<NAME>`,
+   for instance `SIGKILL`, or an unsigned number that matches a position in the
+   kernel's syscall table, for instance `9`.
+
+**--stop-timeout**
+  Timeout (in seconds) to stop a container, or **-1** to disable timeout.
+
+  The `--stop-timeout` flag sets the number of seconds to wait for the container
+  to stop after sending the pre-defined (see `--stop-signal`) system call signal.
+  If the container does not exit after the timeout elapses, it is forcibly killed
+  with a `SIGKILL` signal.
+
+  If `--stop-timeout` is set to **-1**, no timeout is applied, and the daemon will
+  wait indefinitely for the container to exit.
+
+  The default is determined by the daemon, and 10 seconds for Linux containers,
+  and 30 seconds for Windows containers.
 
 **--shm-size**=""
    Size of `/dev/shm`. The format is `<number><unit>`.


### PR DESCRIPTION
rewrite reference docs for `--stop-signal` and `--stop-timeout`, and use "console" code-hint for shell examples. This replaces the use of bash where suitable, to allow easier copy/pasting of shell examples without copying the prompt or process output.

(see https://github.com/docker/docker.github.io/pull/13299)

**- A picture of a cute animal (not mandatory but encouraged)**

