### PR TITLE
docs: add missing redirect, and remove /go/experimental redirect

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -3,7 +3,7 @@ title: "Use the Docker command line"
 description: "Docker's CLI command description and usage"
 keywords: "Docker, Docker documentation, CLI, command line, config.json, CLI configuration file"
 redirect_from:
-  - /go/experimental/
+  - /reference/commandline/cli/
   - /engine/reference/commandline/engine/
   - /engine/reference/commandline/engine_activate/
   - /engine/reference/commandline/engine_check/
@@ -314,6 +314,9 @@ various fields:
 Experimental features provide early access to future product functionality.
 These features are intended for testing and feedback, and they may change
 between releases without warning or can be removed from a future release.
+
+Starting with Docker 20.10, experimental CLI features are enabled by default,
+and require no configuration to enable them.
 
 ### Notary
 


### PR DESCRIPTION
The /go/ redirects are now defined in the docs repository, so the one we defined here can be removed. Also adds a missing redirect for an old URL to the main CLI page.

Addresses https://github.com/docker/docker.github.io/issues/12177 (will be fixed after this is cherry-picked into 20.10)


**- A picture of a cute animal (not mandatory but encouraged)**

