### PR TITLE
Fixing output in commandline RUN example

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -406,7 +406,6 @@ USER
 $ docker run --env-file env.list ubuntu env | grep VAR
 VAR1=value1
 VAR2=value2
-USER=denis
 ```
 
 ### Set metadata on container (-l, --label, --label-file)


### PR DESCRIPTION
Even if `USER` is defined, it should not be outputted because of the grep. 
