### PR TITLE
Use private network address for default-address-pools setting in daem…

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1380,11 +1380,11 @@ This is a full example of the allowed configuration options on Linux:
   "debug": true,
   "default-address-pools": [
     {
-      "base": "172.80.0.0/16",
+      "base": "172.30.0.0/16",
       "size": 24
     },
     {
-      "base": "172.90.0.0/16",
+      "base": "172.31.0.0/16",
       "size": 24
     }
   ],


### PR DESCRIPTION
172.80.0.0/16 is a publicly routable internet address. It shouldn't be used as a private network.
Example in docker documentation encourages users to follow this bad practice.

This pull request changes network address used in example daemon.json file to correct private network.