### PR TITLE
docs: fix description of restart-delay to mention max (1 minute)

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -554,17 +554,17 @@ Docker supports the following restart policies:
   </tbody>
 </table>
 
-An ever increasing delay (double the previous delay, starting at 100
-milliseconds) is added before each restart to prevent flooding the server.
+An increasing delay (double the previous delay, starting at 100 milliseconds)
+is added before each restart to prevent flooding the server.
 This means the daemon will wait for 100 ms, then 200 ms, 400, 800, 1600,
-and so on until either the `on-failure` limit is hit, or when you `docker stop`
-or `docker rm -f` the container.
+and so on until either the `on-failure` limit, the maximum delay of 1 minute is
+hit, or when you `docker stop` or `docker rm -f` the container.
 
 If a container is successfully restarted (the container is started and runs
 for at least 10 seconds), the delay is reset to its default value of 100 ms.
 
 You can specify the maximum amount of times Docker will try to restart the
-container when using the **on-failure** policy.  The default is that Docker
+container when using the **on-failure** policy. The default is that Docker
 will try forever to restart the container. The number of (attempted) restarts
 for a container can be obtained via [`docker inspect`](commandline/inspect.md). For example, to get the number of restarts
 for container "my-container";


### PR DESCRIPTION
fixes https://github.com/moby/moby/issues/42873

Commit https://github.com/docker/docker/commit/9bd3a7c0297fdb93deb846070c85ac23da0a20e8 (https://github.com/moby/moby/pull/30683) (docker 17.04 and up) added a maximum timeout of 1 minute to the restart timeout.

This patch updates the documentation to match the current behavior.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

