### PR TITLE
doc: Add `default-runtime` opt to daemon.json

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1505,6 +1505,7 @@ This is a full example of the allowed configuration options on Windows:
   "containerd-plugin-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
+  "default-runtime": "",
   "default-ulimits": {},
   "dns": [],
   "dns-opts": [],
@@ -1536,6 +1537,13 @@ This is a full example of the allowed configuration options on Windows:
   "tlsverify": true
 }
 ```
+
+The `default-runtime` option is by default unset, in which case dockerd will auto-detect the runtime. This detection is currently based on if the `containerd` flag is set.
+
+Accepted values:
+
+- `com.docker.hcsshim.v1` - This is the built-in runtime that Docker has used since Windows supported was first added and uses the v1 HCS API's in Windows.
+- `io.containerd.runhcs.v1` - This is uses the containerd `runhcs` shim to run the container and uses the v2 HCS API's in Windows.
 
 #### Feature options
 The optional field `features` in `daemon.json` allows users to enable or disable specific


### PR DESCRIPTION
This is a new flag for the Windows daemon.

Depends on moby/moby#42089