### PR TITLE
Clarify that docker secret manages Swarm secrets

### DIFF
--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -11,7 +11,7 @@ import (
 func NewSecretCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
-		Short: "Manage Docker secrets",
+		Short: "Manage Docker Swarm secrets",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -30,7 +30,7 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "create [OPTIONS] SECRET [file|-]",
-		Short: "Create a secret from a file or STDIN as content",
+		Short: "Create a Swarm secret from a file or STDIN as content",
 		Args:  cli.RequiresRangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.name = args[0]

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -21,7 +21,7 @@ func newSecretInspectCommand(dockerCli command.Cli) *cobra.Command {
 	opts := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] SECRET [SECRET...]",
-		Short: "Display detailed information on one or more secrets",
+		Short: "Display detailed information on one or more Swarm secrets",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.names = args

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -25,7 +25,7 @@ func newSecretListCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
 		Aliases: []string{"list"},
-		Short:   "List secrets",
+		Short:   "List Swarm secrets",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSecretList(dockerCli, options)

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -19,7 +19,7 @@ func newSecretRemoveCommand(dockerCli command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm SECRET [SECRET...]",
 		Aliases: []string{"remove"},
-		Short:   "Remove one or more secrets",
+		Short:   "Remove one or more Swarm secrets",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := removeOptions{

--- a/docs/reference/commandline/secret.md
+++ b/docs/reference/commandline/secret.md
@@ -9,16 +9,16 @@ keywords: "secret"
 ```markdown
 Usage:  docker secret COMMAND
 
-Manage Docker secrets
+Manage Docker Swarm secrets
 
 Options:
       --help   Print usage
 
 Commands:
-  create      Create a secret from a file or STDIN as content
-  inspect     Display detailed information on one or more secrets
-  ls          List secrets
-  rm          Remove one or more secrets
+  create      Create a Swarm secret from a file or STDIN as content
+  inspect     Display detailed information on one or more Swarm secrets
+  ls          List Swarm secrets
+  rm          Remove one or more Swarm secrets
 
 Run 'docker secret COMMAND --help' for more information on a command.
 
@@ -26,7 +26,7 @@ Run 'docker secret COMMAND --help' for more information on a command.
 
 ## Description
 
-Manage secrets.
+Manage Docker Swarm secrets.
 
 ## Related commands
 

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -9,7 +9,7 @@ keywords: ["secret, create"]
 ```Markdown
 Usage:  docker secret create [OPTIONS] SECRET [file|-]
 
-Create a secret from a file or STDIN as content
+Create a Swarm secret from a file or STDIN as content
 
 Options:
   -l, --label list               Secret labels

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -9,7 +9,7 @@ keywords: ["secret, inspect"]
 ```Markdown
 Usage:  docker secret inspect [OPTIONS] SECRET [SECRET...]
 
-Display detailed information on one or more secrets
+Display detailed information on one or more Swarm secrets
 
 Options:
   -f, --format string   Format the output using the given Go template

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -9,7 +9,7 @@ keywords: ["secret, ls"]
 ```Markdown
 Usage:  docker secret ls [OPTIONS]
 
-List secrets
+List Swarm secrets
 
 Aliases:
   ls, list

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -9,7 +9,7 @@ keywords: ["secret, rm"]
 ```Markdown
 Usage:  docker secret rm SECRET [SECRET...]
 
-Remove one or more secrets
+Remove one or more Swarm secrets
 
 Aliases:
   rm, remove


### PR DESCRIPTION
`docker secret` command is a swarm-specific secret implementation where secrets are stored in swarm managers and only made available to services via swarm worker agents. Unfortunately, the command was not put under `docker swarm`  subcommand and therefore leads to confusion when managing other types of secrets(eg. build secrets). Make it clear that these are Swarm secrets without requiring the user to read through the whole documentation.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>