### PR TITLE
docs: fix search results by filtered is-official

### DIFF
--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -128,9 +128,8 @@ This example displays images with a name containing 'busybox', at least
 ```console
 $ docker search --filter is-official=true --filter stars=3 busybox
 
-NAME                 DESCRIPTION                                     STARS     OFFICIAL   AUTOMATED
-progrium/busybox                                                     50                   [OK]
-radial/busyboxplus   Full-chain, Internet enabled, busybox made...   8                    [OK]
+NAME      DESCRIPTION           STARS     OFFICIAL   AUTOMATED
+busybox   Busybox base image.   325       [OK]
 ```
 
 ### Format the output


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix wrong `docker search --filter` results on`search.md`

**- How I did it**

**- How to verify it**
```
$ docker search --filter is-official=true --filter stars=3 busybox
NAME      DESCRIPTION           STARS     OFFICIAL   AUTOMATED
busybox   Busybox base image.   2359      [OK]
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
Piglets at the Piglet Cafe.

![image](https://user-images.githubusercontent.com/6612564/135385411-7648f7a7-6c86-4faf-9be8-f76253d8045f.png)
