### PR TITLE
docs: create.md: typo fix

### DIFF
--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -240,7 +240,7 @@ assigned devices will both be added to the cgroup.allow file and
 created into the container once it is run. This poses a problem when
 a new device needs to be added to running container.
 
-One of the solution is to add a more permissive rule to a container
+One of the solutions is to add a more permissive rule to a container
 allowing it access to a wider range of devices. For example, supposing
 our container needs access to a character device with major `42` and
 any number of minor number (added as new devices appear), the


### PR DESCRIPTION
Typo fi
![1](https://user-images.githubusercontent.com/29619660/135794765-3015607a-8919-4c64-b9b1-8d235e41377d.jpg)
x
