### PR TITLE
registry: ensure default auth config has address

### DIFF
--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -145,7 +145,21 @@ func TestGetDefaultAuthConfig(t *testing.T) {
 			assert.Check(t, is.Equal(tc.expectedErr, err.Error()))
 		} else {
 			assert.NilError(t, err)
-			assert.Check(t, is.DeepEqual(tc.expectedAuthConfig, *authconfig))
+			assert.Check(t, is.DeepEqual(tc.expectedAuthConfig, authconfig))
 		}
 	}
+}
+
+func TestGetDefaultAuthConfig_HelperError(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{})
+	errBuf := new(bytes.Buffer)
+	cli.SetErr(errBuf)
+	cli.ConfigFile().CredentialsStore = "fake-does-not-exist"
+	serverAddress := "test-server-address"
+	expectedAuthConfig := types.AuthConfig{
+		ServerAddress: serverAddress,
+	}
+	authconfig, err := GetDefaultAuthConfig(cli, true, serverAddress, serverAddress == "https://index.docker.io/v1/")
+	assert.Check(t, is.DeepEqual(expectedAuthConfig, authconfig))
+	assert.Check(t, is.ErrorContains(err, "docker-credential-fake-does-not-exist"))
 }


### PR DESCRIPTION
(cherry picked from commit 42d1c02750b3631402da3973e5f36b76c8c934f4)

**- What I did**
Ensure the default auth config retains its address.  See https://github.com/docker/cli/security/advisories/GHSA-99pg-grm5-qq3v.

**- How I did it**
`GetDefaultAuthConfig` returns a `types.AuthConfig` instead of a `*types.AuthConfig`.  When an error occurs, the returned `types.AuthConfig` has a correctly-set `ServerAddress`.

**- How to verify it**

**- Description for the changelog**
Ensure default auth config has address field set to prevent credentials being
sent to the default registry. (https://github.com/docker/cli/security/advisories/GHSA-99pg-grm5-qq3v)
