### PR TITLE
[20.10 backport] Dockerfile: update tonistiigi/xx to 1.0.0-rc.2, add XX_VERSION arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.16.8
+ARG XX_VERSION=1.0.0-rc.2
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
 FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS golatest
@@ -14,7 +15,7 @@ FROM gostable AS go-windows-arm
 FROM golatest AS go-windows-arm64
 FROM go-windows-${TARGETARCH} AS go-windows
 
-FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:620d36a9d7f1e3b102a5c7e8eff12081ac363828b3a44390f24fa8da2d49383d AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 FROM go-${TARGETOS} AS build-base-alpine
 COPY --from=xx / /


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3298, as this addresses some issues we ran into in our release-pipeline.
