### PR TITLE
Fix checkout behavior and FileVersion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,6 +23,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       -
         name: Run
         uses: docker/bake-action@v1

--- a/scripts/build/mkversioninfo
+++ b/scripts/build/mkversioninfo
@@ -33,7 +33,7 @@ cat > ./cli/winresources/versioninfo.json <<EOL
     "Comments": "",
     "CompanyName": "${COMPANY_NAME}",
     "FileDescription": "Docker Client",
-    "FileVersion": "${VERSION_QUAD}",
+    "FileVersion": "${VERSION}",
     "InternalName": "",
     "LegalCopyright": "Copyright © 2015-$(date +'%Y') Docker Inc.",
     "LegalTrademarks": "",


### PR DESCRIPTION
Looks like https://github.com/docker/cli/blob/6d2820b53025af2143fc6d244ae2a55c797cd3e3/scripts/build/.variables#L7 returns 0530566 which is the commit and not the actual tag.

![image](https://user-images.githubusercontent.com/1951866/136830906-8030817d-b3a9-417d-aede-bfabadeec4b4.png)

Seems related to GitHub Actions checkout behavior. We need to fetch all tags otherwise it fails:

![image](https://user-images.githubusercontent.com/1951866/136831231-0ecf2ae4-0b1b-4020-a176-4c9daa8c4876.png)

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>