### PR TITLE
build: do not alias to buildx for wcow

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -235,10 +235,13 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 	}
 
 	if v, ok := aliasMap["builder"]; ok {
-		aliases = append(aliases,
-			[2][]string{{"build"}, {v, "build"}},
-			[2][]string{{"image", "build"}, {v, "build"}},
-		)
+		// wcow build command is not compatible with buildx
+		if v != "buildx" || dockerCli.ServerInfo().OSType != "windows" {
+			aliases = append(aliases,
+				[2][]string{{"build"}, {v, "build"}},
+				[2][]string{{"image", "build"}, {v, "build"}},
+			)
+		}
 	}
 	for _, al := range aliases {
 		var didChange bool


### PR DESCRIPTION
Build command must not use the buildx alias for windows containers reported from server-side.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>