### PR TITLE
Check to see if the repo is really dirty

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -5,6 +5,38 @@ TARGET=${TARGET:-"build"}
 
 PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
+case "$VERSION" in
+  *.m) if git status -s | awk 'BEGIN {
+a[".circleci/config.yml"] = 0
+a[".dockerignore"] = 0
+a[".github/CODEOWNERS"] = 0
+a[".github/ISSUE_TEMPLATE.md"] = 0
+a[".github/PULL_REQUEST_TEMPLATE.md"] = 0
+a[".github/workflows/build.yml"] = 0
+a[".github/workflows/codeql-analysis.yml"] = 0
+a[".github/workflows/validate.yml"] = 0
+a[".gitignore"] = 0
+a["appveyor.yml"] = 0
+a["cli/winresources/winresources.go"] = 0
+expectedLen = length(a);
+}
+$1 == "D" || $1 == "M" || $1 == "??" { a[$2] = 1 }
+END {
+  foundLen = length(a);
+  if (expectedLen != foundLen) {
+    exit(1);
+  }
+  for (key in a) {
+    if (a[key] == 0) {
+      exit(1);
+    }
+  }
+}' ; then
+  VERSION=${VERSION%.m}
+fi
+  ;;
+esac
+
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 BUILDTIME=${BUILDTIME:-$(date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
 


### PR DESCRIPTION
fixes #3347 

**- What I did**

For whatever reason, some files are `git removed` according to the container. If a particular set of files has been removed, and there aren't any other git changes, ignore the `.m` suffix on the version.

**- How I did it**

I wrote a clunky awk script to make that check. I wanted to do something like `if diff -sw <(git status -s | sort) <(sort <<'EOT'
list of files
EOT
); then ...`
but the script is written to use the bourne shell, which doesn't support process substitution.

I didn't bother understanding why those 11 files are deleted, but not deleting them would obviously be a better fix, and presumably not require awk code.

**- How to verify it**
Apply a tag to the codebase. I used `git tag 20.10.10`.
Running `docker buildx bake && build/docker -v` should output `20.10.10`, not `20.10.10.m`

**- Description for the changelog**
Avoid adding a .m suffix to the version field when there are no actual changes to the codebase.

**- A picture of a cute animal (not mandatory but encouraged)**

![yodie](https://farm3.static.flickr.com/2726/4143758149_59a7788776.jpg)

