### PR TITLE
Allow `--format=json` as an alias of `--format={{json .}}`

### DIFF
--- a/templates/templates.go
+++ b/templates/templates.go
@@ -61,6 +61,11 @@ var HeaderFunctions = template.FuncMap{
 	},
 }
 
+// aliases for convenience
+var aliases = map[string]string{
+	"json": "{{json .}}",
+}
+
 // Parse creates a new anonymous template with the basic functions
 // and parses the given format.
 func Parse(format string) (*template.Template, error) {
@@ -76,6 +81,9 @@ func New(tag string) *template.Template {
 // NewParse creates a new tagged template with the basic functions
 // and parses the given format.
 func NewParse(tag, format string) (*template.Template, error) {
+	if alias, ok := aliases[format]; ok {
+		format = alias
+	}
 	return New(tag).Parse(format)
 }
 

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -39,6 +39,26 @@ func TestNewParse(t *testing.T) {
 	assert.Check(t, is.Equal(want, b.String()))
 }
 
+func TestParseJSON(t *testing.T) {
+	f := func(t testing.TB, format string) {
+		tm, err := Parse(format)
+		assert.NilError(t, err)
+		var b bytes.Buffer
+		m := map[string]int{
+			"foo": 42,
+		}
+		assert.NilError(t, tm.Execute(&b, m))
+		want := `{"foo":42}`
+		assert.Check(t, is.Equal(want, b.String()))
+	}
+	t.Run("CanonicalForm", func(t *testing.T) {
+		f(t, "{{json .}}")
+	})
+	t.Run("ConvenienceForm", func(t *testing.T) {
+		f(t, "json")
+	})
+}
+
 func TestParseTruncateFunction(t *testing.T) {
 	source := "tupx5xzf6hvsrhnruz5cr8gwp"
 


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Allow `--format=json` as an alias of `--format={{json .}}` for convenience.

**- How I did it**

Updated `templates.NewParse`

**- How to verify it**

Before:
```console
$ docker image inspect alpine --format=json
json
```

After:
```console
$ docker image inspect alpine --format=json
{"Id":"sha256:14119a10abf4669e8cdbdff324a9f9605d99697215a0d21c360fe8dfa8471bab","RepoTags":["alpine:latest"],"RepoDigests":["alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"],"Parent":"","Comment":"","Created":"2021-08-27T17:19:45.758611523Z","Container":"330289c649db86f5fb1ae5bfef18501012b550adb0638b9193d4a3a4b65a2f9b","ContainerConfig":{"Hostname":"330289c649db","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["/bin/sh","-c","#(nop) ","CMD [\"/bin/sh\"]"],"Image":"sha256:d3e0b6258ec2f725c19668f11ae5323c3b0245e197ec478424ec6a87935690eb","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":{}},"DockerVersion":"20.10.7","Author":"","Config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],"Cmd":["/bin/sh"],"Image":"sha256:d3e0b6258ec2f725c19668f11ae5323c3b0245e197ec478424ec6a87935690eb","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"Architecture":"amd64","Os":"linux","Size":5595292,"VirtualSize":5595292,"GraphDriver":{"Data":{"MergedDir":"/var/lib/docker/overlay2/f2ce81000bfa11a765bf1774978ec5f257aa66c250024fd50e9f5e2ee33043a0/merged","UpperDir":"/var/lib/docker/overlay2/f2ce81000bfa11a765bf1774978ec5f257aa66c250024fd50e9f5e2ee33043a0/diff","WorkDir":"/var/lib/docker/overlay2/f2ce81000bfa11a765bf1774978ec5f257aa66c250024fd50e9f5e2ee33043a0/work"},"Name":"overlay2"},"RootFS":{"Type":"layers","Layers":["sha256:e2eb06d8af8218cfec8210147357a68b7e13f7c485b991c288c2d01dc228bb68"]},"Metadata":{"LastTagTime":"0001-01-01T00:00:00Z"}}
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow `--format=json` as an alias of `--format={{json .}}`

**- A picture of a cute animal (not mandatory but encouraged)**
:penguin:

---

Podman seems already implemented the same syntax
https://github.com/containers/common/blob/850904b0be9c4960a83acf077e34acc7857312bf/pkg/report/validate.go#L5