### PR TITLE
[20.10 backport] Update Go to 1.16.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.10
 ARG XX_VERSION=1.0.0-rc.2
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.16.9
+  GOVERSION: 1.16.10
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.10
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.10
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.10
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.16.10
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3357


go1.16.10 (released 2021-11-04) includes security fixes to the archive/zip and
debug/macho packages, as well as bug fixes to the compiler, linker, runtime, the
misc/wasm directory, and to the net/http package. See the Go 1.16.10 milestone
for details: https://github.com/golang/go/issues?q=milestone%3AGo1.16.10+label%3ACherryPickApproved

From the announcement e-mail:

[security] Go 1.17.3 and Go 1.16.10 are released

We have just released Go versions 1.17.3 and 1.16.10, minor point releases.
These minor releases include two security fixes following the security policy:

- archive/zip: don't panic on (*Reader).Open
  Reader.Open (the API implementing io/fs.FS introduced in Go 1.16) can be made
  to panic by an attacker providing either a crafted ZIP archive containing
  completely invalid names or an empty filename argument.
  Thank you to Colin Arnott, SiteHost and Noah Santschi-Cooney, Sourcegraph Code
  Intelligence Team for reporting this issue. This is CVE-2021-41772 and Go issue
  golang.org/issue/48085.
- debug/macho: invalid dynamic symbol table command can cause panic
  Malformed binaries parsed using Open or OpenFat can cause a panic when calling
  ImportedSymbols, due to an out-of-bounds slice operation.
  Thanks to Burak Çarıkçı - Yunus Yıldırım (CT-Zer0 Crypttech) for reporting this
  issue. This is CVE-2021-41771 and Go issue golang.org/issue/48990.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

