### PR TITLE
flag clean to clear the log

### DIFF
--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -78,6 +78,7 @@ type ContainerLogsOptions struct {
 	Follow     bool
 	Tail       string
 	Details    bool
+	Clean      bool
 }
 
 // ContainerRemoveOptions holds parameters to remove containers.


### PR DESCRIPTION
I had disk space issues, where the problem was the log size of one of the docker instances.
it would be very easy to just delete the log, but I would have to know where it was, so I wasted some time researching where it might be.

Therefore, I propose the --clean flag, this can be the immediate solution for those who have a large volume of instances or something in production that needs to be resolved immediately.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What did I do**
A flag to clear the container log.
docker logs --clean <container>

**- How I did**
Truncate the log file

**- How to check**
Looking at the $DOCKERDIR/container/<-instanceID->/*-json.log directory

**- Changelog description**
flag clean to clear the log
