### PR TITLE
cli/command: Add quiet option for create and run

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -56,6 +56,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
 	flags.StringVar(&opts.createOptions.pull, "pull", PullImageMissing,
 		`Pull image before running ("`+PullImageAlways+`"|"`+PullImageMissing+`"|"`+PullImageNever+`")`)
+	flags.BoolVarP(&opts.createOptions.quiet, "quiet", "q", false, "Suppress the pull output")
 
 	// Add an explicit help that doesn't have a `-h` to prevent the conflict
 	// with hostname

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1994,6 +1994,7 @@ _docker_container_run_and_create() {
 		--oom-kill-disable
 		--privileged
 		--publish-all -P
+		--quiet -q
 		--read-only
 		--tty -t
 	"

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -650,6 +650,7 @@ __docker_container_subcommand() {
         "($help)*"{-p=,--publish=}"[Expose a container's port to the host]:port:_ports"
         "($help)--pid=[PID namespace to use]:PID namespace:__docker_complete_pid"
         "($help)--privileged[Give extended privileges to this container]"
+        "($help -q --quiet)"{-q,--quiet}"[Suppress the pull output]"
         "($help)--read-only[Mount the container's root filesystem as read only]"
         "($help)*--security-opt=[Security options]:security option: "
         "($help)*--shm-size=[Size of '/dev/shm' (format is '<number><unit>')]:shm size: "

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -99,6 +99,7 @@ Options:
   -p, --publish value                 Publish a container's port(s) to the host (default [])
   -P, --publish-all                   Publish all exposed ports to random ports
       --pull string                   Pull image before creating ("always"|"missing"|"never") (default "missing")
+  -q, --quiet                         Suppress the pull output
       --read-only                     Mount the container's root filesystem as read only
       --restart string                Restart policy to apply when a container exits (default "no")
                                       Possible values are: no, on-failure[:max-retry], always, unless-stopped

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -109,6 +109,7 @@ Options:
   -p, --publish value                 Publish a container's port(s) to the host (default [])
   -P, --publish-all                   Publish all exposed ports to random ports
       --pull string                   Pull image before running ("always"|"missing"|"never") (default "missing")
+  -q, --quiet                         Suppress the pull output
       --read-only                     Mount the container's root filesystem as read only
       --restart string                Restart policy to apply when a container exits (default "no")
                                       Possible values are : no, on-failure[:max-retry], always, unless-stopped


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
fixes #3181 
The newly added `quiet` option for `docker run` and `docker create` will suppress `pull`'s output, other outputs remain.

**- How I did it**
The main changes are on `create.go`, `run.go` will make use of it when calling `createContainer`.


**- How to verify it**
```
# see the usage of --quiet
docker run --help
docker create --help

# run
docker rmi hello-world
docker run -ti --quiet hello-world

# create 
docker rmi hello-world
docker create --quiet hello-world
```

Below output shouldn't show unless without the `--quiet` option:
```
Unable to find image 'hello-world:latest' locally
latest: Pulling from library/hello-world
2db29710123e: Already exists
Digest: sha256:cc15c5b292d8525effc0f89cb299f1804f3a725c8d05e158653a563f15e4f685
Status: Downloaded newer image for hello-world:latest
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add `quiet` option for `create` and `run` commands to suppress `pull`'s output.

