### PR TITLE
update go to 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.11
+          go-version: 1.17.8
       -
         name: Test
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,15 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.17.8
 ARG XX_VERSION=1.1.0
 ARG GOVERSIONINFO_VERSION=v1.3.0
 ARG GOTESTSUM_VERSION=v1.7.0
 ARG BUILDX_VERSION=0.7.1
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
-FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS golatest
-
-FROM gostable AS go-linux
-FROM gostable AS go-darwin
-FROM gostable AS go-windows-amd64
-FROM gostable AS go-windows-386
-FROM gostable AS go-windows-arm
-FROM golatest AS go-windows-arm64
-FROM go-windows-${TARGETARCH} AS go-windows
-
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM go-${TARGETOS} AS build-base-alpine
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS build-base-alpine
 COPY --from=xx / /
 RUN apk add --no-cache bash clang lld llvm file git
 WORKDIR /go/src/github.com/docker/cli
@@ -30,7 +19,7 @@ ARG TARGETPLATFORM
 # gcc is installed for libgcc only
 RUN xx-apk add --no-cache musl-dev gcc
 
-FROM go-${TARGETOS} AS build-base-buster
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-buster AS build-base-buster
 COPY --from=xx / /
 RUN apt-get update && apt-get install --no-install-recommends -y bash clang lld file
 WORKDIR /go/src/github.com/docker/cli

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.16.11"
+    default = "1.17.8"
 }
 variable "VERSION" {
     default = ""

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.17.8
 
 ARG BUILDX_VERSION=0.7.1
 FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.17.8
 ARG GOLANGCI_LINT_VERSION=v1.23.8
 
 FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.17.8
 ARG MODOUTDATED_VERSION=v0.8.0
 
 FROM golang:${GO_VERSION}-alpine AS base


### PR DESCRIPTION
carries / closes https://github.com/docker/cli/pull/3258

Removes the platform based switch between different versions.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

