### PR TITLE
[20.10] Update Go to 1.16.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.16.12
 ARG XX_VERSION=1.0.0-rc.2
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.16.11
+  GOVERSION: 1.16.12
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.16.12
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.11
+ARG GO_VERSION=1.16.12
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build


### PR DESCRIPTION
go1.16.12 (released 2021-12-09) includes security fixes to the syscall and net/http
packages. See the Go 1.16.12 milestone on the issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.12+label%3ACherryPickApproved


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

