### PR TITLE
Fix Typos

### DIFF
--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -215,7 +215,7 @@ func execCreateWithID(_ string, _ types.ExecConfig) (types.IDResponse, error) {
 
 func TestGetExecExitStatus(t *testing.T) {
 	execID := "the exec id"
-	expecatedErr := errors.New("unexpected error")
+	expectedErr := errors.New("unexpected error")
 
 	testcases := []struct {
 		inspectError  error
@@ -227,8 +227,8 @@ func TestGetExecExitStatus(t *testing.T) {
 			exitCode:     0,
 		},
 		{
-			inspectError:  expecatedErr,
-			expectedError: expecatedErr,
+			inspectError:  expectedErr,
+			expectedError: expectedErr,
 		},
 		{
 			exitCode:      15,

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1278,7 +1278,7 @@ func TestUpdateCredSpec(t *testing.T) {
 			spec:     &swarm.ContainerSpec{},
 			expected: nil,
 		}, {
-			name:    "add a config credenital spec",
+			name:    "add a config credential spec",
 			flagVal: "config://someConfigName",
 			spec: &swarm.ContainerSpec{
 				Configs: []*swarm.ConfigReference{

--- a/cli/command/stack/kubernetes/watcher.go
+++ b/cli/command/stack/kubernetes/watcher.go
@@ -27,13 +27,13 @@ type podListWatch interface {
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
 }
 
-// DeployWatcher watches a stack deployement
+// DeployWatcher watches a stack deployment
 type deployWatcher struct {
 	pods   podListWatch
 	stacks stackListWatch
 }
 
-// Watch watches a stuck deployement and return a chan that will holds the state of the stack
+// Watch watches a stuck deployment and return a chan that will holds the state of the stack
 func (w *deployWatcher) Watch(name string, serviceNames []string, statusUpdates chan serviceStatus) error {
 	errC := make(chan error, 1)
 	defer close(errC)


### PR DESCRIPTION
This commit fixes spelling mistakes (typos) at a few places in the codebase.