### PR TITLE
make compose plugin detection in bash completion work on Mac OS

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5486,7 +5486,7 @@ _docker_wait() {
 	_docker_container_wait
 }
 
-COMPOSE_PLUGIN_PATH=$(docker info --format '{{json .ClientInfo.Plugins}}' | sed -n 's/.*"Path":"\([^"]\+docker-compose\)".*/\1/p')
+COMPOSE_PLUGIN_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{if eq .Name "compose"}}{{.Path}}{{end}}{{end}}')
 
 _docker_compose() {
 	local completionCommand="__completeNoDesc"


### PR DESCRIPTION


Signed-off-by: Vardan Pogosian <vardan.pogosyan@gmail.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Made sed invocation compatible with OS X (POSIX 1003.2 Regular expressions)

**- How I did it**
Changed the regular expression used in sed [invocation]((https://github.com/varp/cli/blob/make_compose_plugin_detection_compatible_with_posix_bre/contrib/completion/bash/docker#L5489))

**- How to verify it**
Install docker-compose 2.2.2 as a plugin for docker CLI on Mac OS X and try to auto-complete `docker comp<tab>`. It will auto-complete to `docker compose` 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Made sed invocation, used at COMPOSER_PLUGIN_PATH detection (for BASH completion) compatible with POSIX 1003.2 RE to properly work on OS X. 


**- A picture of a cute animal (not mandatory but encouraged)**

