### PR TITLE
Try pull missing image while tagging

### DIFF
--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -2,15 +2,22 @@ package image
 
 import (
 	"context"
+	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/api/types"
+	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
 )
 
 type tagOptions struct {
-	image string
-	name  string
+	image    string
+	name     string
+	platform string
 }
 
 // NewTagCommand creates a new `docker tag` command
@@ -31,11 +38,61 @@ func NewTagCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)
 
+	command.AddPlatformFlag(flags, &opts.platform)
+
 	return cmd
 }
 
 func runTag(dockerCli command.Cli, opts tagOptions) error {
 	ctx := context.Background()
 
+	err := dockerCli.Client().ImageTag(ctx, opts.image, opts.name)
+	if err == nil || !apiclient.IsErrNotFound(err) {
+		return err
+	}
+
+	// pull the missing image and retry tagging
+	err = pullImage(ctx, dockerCli, opts.image, opts.platform, dockerCli.Err())
+	if err != nil {
+		return err
+	}
+
 	return dockerCli.Client().ImageTag(ctx, opts.image, opts.name)
+}
+
+func pullImage(ctx context.Context, dockerCli command.Cli, image string, platform string, out io.Writer) error {
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return err
+	}
+
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	if err != nil {
+		return err
+	}
+
+	options := types.ImageCreateOptions{
+		RegistryAuth: encodedAuth,
+		Platform:     platform,
+	}
+
+	responseBody, err := dockerCli.Client().ImageCreate(ctx, image, options)
+	if err != nil {
+		return err
+	}
+	defer responseBody.Close()
+
+	return jsonmessage.DisplayJSONMessagesStream(
+		responseBody,
+		out,
+		dockerCli.Out().FD(),
+		dockerCli.Out().IsTerminal(),
+		nil)
 }


### PR DESCRIPTION
closes #3370 

**- What I did**
Make the tag command work even for images that are not present locally.

**- How I did it**
Detect the NotFound error on the tag command, pull the missing image and re-try the tag operation.

**- How to verify it**
1. Make sure don't have the `hello-world` image locally
2. Run `docker tag hello-world hey`
3. The `hello-world` image should appear locally and so is the new `hey` tag.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Support auto-pull while tagging images that are not present locally.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/1474089/147285129-2f2ce28b-3b3d-49a7-b5a4-b7ac122ceb35.png)

