### PR TITLE
Some fixes for "make vendor"

### DIFF
--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -8,6 +8,7 @@ RUN apk add --no-cache bash git rsync
 WORKDIR /src
 
 FROM base AS vendored
+ENV GOPROXY=direct
 RUN --mount=target=/context \
     --mount=target=.,type=tmpfs  \
     --mount=target=/go/pkg/mod,type=cache <<EOT

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -21,11 +21,10 @@ go 1.16
 EOL
 
 update() {
-  (set -x ; go mod vendor -modfile=vendor.mod)
+  (set -x ; go mod tidy -modfile=vendor.mod; go mod vendor -modfile=vendor.mod)
 }
 
 validate() {
-  (set -x ; go mod tidy -modfile=vendor.mod)
   diff=$(git status --porcelain -- vendor.mod vendor.sum vendor)
   if [ -n "$diff" ]; then
     echo >&2 'ERROR: Vendor result differs. Please vendor your package with "make -f docker.Makefile vendor"'


### PR DESCRIPTION
### scripts/vendor: run go mod tidy when vendoring

There was some debate about this, and wether or not tidy should be run
when vendoring, but without this, validation failed after running
`make vendor`, and manually doing a `go mod tidy` is complicated
(due to the `vendor.mod`, and because the cache is not inside the
build-cache, not on the host).


### Dockerfile.vendor: use GOPROXY=direct

While the module proxy can speed up vendoring, it may cause issues when
(temporarily) vendoring from a fork, because the proxy may not have the
module yet on first try, which causes vendoring to fail:

    vendor.mod:95:2: replace github.com/thaJeztah/compose-on-kubernetes:
    version "0b59cf047b3b0199048fe13fdcd21b0cb46549f2" invalid:
    Get "https://proxy.golang.org/github.com/tha%21jeztah/compose-on-kubernetes/@v/0b59cf047b3b0199048fe13fdcd21b0cb46549f2.info": read tcp 172.17.0.2:60290->172.217.168.209:443: read: connection reset by peer

Using `GOPROXY=direct` to fetch sources directly from upstream (GitHub) instead.