### PR TITLE
Describe privileged mode in terms of capabilities

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1249,12 +1249,12 @@ by default a container is not allowed to access any devices, but a
 "privileged" container is given access to all devices (see
 the documentation on [cgroups devices](https://www.kernel.org/doc/Documentation/cgroup-v1/devices.txt)).
 
-When the operator executes `docker run --privileged`, Docker will enable
-access to all devices on the host as well as set some configuration
-in AppArmor or SELinux to allow the container nearly all the same access to the
-host as processes running outside containers on the host. Additional
-information about running with `--privileged` is available on the
-[Docker Blog](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/).
+The --privileged flag gives all capabilities to the container. When the operator
+executes `docker run --privileged`, Docker will enable access to all devices on
+the host as well as set some configuration in AppArmor or SELinux to allow the
+container nearly all the same access to the host as processes running outside
+containers on the host. Additional information about running with `--privileged`
+is available on the [Docker Blog](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/).
 
 If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that


### PR DESCRIPTION
I didn't see where in the page that `--privileged` mode adds all capabilities.

I think this page once did contain that information. I got it from a Stack Overflow answer that seems to have copied from an earlier version of this same document.
 
> Full container capabilities (--privileged)
>
> The --privileged flag gives all capabilities to the container, and it also lifts all the limitations enforced by the device cgroup controller. In other words, the container can then do almost everything that the host can do. This flag exists to allow special use-cases, like running Docker within Docker.

https://stackoverflow.com/a/36441605/111424

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

