### PR TITLE
[20.10] Update Go to 1.16.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.13
+ARG GO_VERSION=1.16.14
 ARG XX_VERSION=1.0.0-rc.2
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.12
+ARG GO_VERSION=1.16.13
 ARG XX_VERSION=1.0.0-rc.2
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.16.12
+  GOVERSION: 1.16.13
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.16.13
+  GOVERSION: 1.16.14
   DEPVERSION: v0.4.1
 
 install:

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.13
+ARG GO_VERSION=1.16.14
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.12
+ARG GO_VERSION=1.16.13
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.12
+ARG GO_VERSION=1.16.13
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.13
+ARG GO_VERSION=1.16.14
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build


### PR DESCRIPTION
### Update Go to 1.16.14

Includes security fixes for crypto/elliptic (CVE-2022-23806), math/big (CVE-2022-23772),
and cmd/go (CVE-2022-23773).

go1.16.14 (released 2022-02-10) includes security fixes to the crypto/elliptic,
math/big packages and to the go command, as well as bug fixes to the compiler,
linker, runtime, the go command, and the debug/macho, debug/pe, net/http/httptest,
and testing packages. See the Go 1.16.14 milestone on our issue tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.14+label%3ACherryPickApproved

full diff: https://github.com/golang/go/compare/go1.16.13...go1.16.14

### update Go to 1.16.13

go1.16.13 (released 2022-01-06) includes fixes to the compiler, linker, runtime,
and the net/http package. See the Go 1.16.13 milestone on our issue tracker for
details:

https://github.com/golang/go/issues?q=milestone%3AGo1.16.13+label%3ACherryPickApproved

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

