### PR TITLE
Cobra completion v2 with CLI plugin support

### DIFF
--- a/cli-plugins/manager/cobra.go
+++ b/cli-plugins/manager/cobra.go
@@ -1,6 +1,9 @@
 package manager
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
@@ -31,12 +34,13 @@ const (
 // AddPluginCommandStubs adds a stub cobra.Commands for each valid and invalid
 // plugin. The command stubs will have several annotations added, see
 // `CommandAnnotationPlugin*`.
-func AddPluginCommandStubs(dockerCli command.Cli, cmd *cobra.Command) error {
-	plugins, err := ListPlugins(dockerCli, cmd)
+func AddPluginCommandStubs(dockerCli command.Cli, rootCmd *cobra.Command) error {
+	plugins, err := ListPlugins(dockerCli, rootCmd)
 	if err != nil {
 		return err
 	}
 	for _, p := range plugins {
+		p := p
 		vendor := p.Vendor
 		if vendor == "" {
 			vendor = "unknown"
@@ -49,11 +53,41 @@ func AddPluginCommandStubs(dockerCli command.Cli, cmd *cobra.Command) error {
 		if p.Err != nil {
 			annotations[CommandAnnotationPluginInvalid] = p.Err.Error()
 		}
-		cmd.AddCommand(&cobra.Command{
-			Use:         p.Name,
-			Short:       p.ShortDescription,
-			Run:         func(_ *cobra.Command, _ []string) {},
-			Annotations: annotations,
+		rootCmd.AddCommand(&cobra.Command{
+			Use:                p.Name,
+			Short:              p.ShortDescription,
+			Run:                func(_ *cobra.Command, _ []string) {},
+			Annotations:        annotations,
+			DisableFlagParsing: true,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				flags := rootCmd.PersistentFlags()
+				flags.SetOutput(nil)
+				err := flags.Parse(args)
+				if err != nil {
+					return err
+				}
+				if flags.Changed("help") {
+					cmd.HelpFunc()(rootCmd, args)
+					return nil
+				}
+				return fmt.Errorf("docker: '%s' is not a docker command.\nSee 'docker --help'", cmd.Name())
+			},
+			ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+				// Delegate completion to plugin
+				cargs := []string{p.Path, cobra.ShellCompRequestCmd, p.Name}
+				cargs = append(cargs, args...)
+				cargs = append(cargs, toComplete)
+				os.Args = cargs
+				runCommand, err := PluginRunCommand(dockerCli, p.Name, cmd)
+				if err != nil {
+					return nil, cobra.ShellCompDirectiveError
+				}
+				err = runCommand.Run()
+				if err == nil {
+					os.Exit(0) // plugin already rendered complete data
+				}
+				return nil, cobra.ShellCompDirectiveError
+			},
 		})
 	}
 	return nil

--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -125,6 +125,11 @@ func newPluginCommand(dockerCli *command.DockerCli, plugin *cobra.Command, meta 
 		},
 		TraverseChildren:      true,
 		DisableFlagsInUseLine: true,
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd:   false,
+			HiddenDefaultCmd:    true,
+			DisableDescriptions: true,
+		},
 	}
 	opts, flags := cli.SetupPluginRootCommand(cmd)
 

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	units "github.com/docker/go-units"
@@ -39,7 +40,8 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations: map[string]string{"version": "1.39"},
+		Annotations:       map[string]string{"version": "1.39"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/checkpoint/list.go
+++ b/cli/command/checkpoint/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, args[0], opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -1,0 +1,99 @@
+package completion
+
+import (
+	"os"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/formatter"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/spf13/cobra"
+)
+
+// ValidArgsFn a function to be used by cobra command as `ValidArgsFunction` to offer command line completion
+type ValidArgsFn func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+// ImageNames offers completion for images present within the local store
+func ImageNames(dockerCli command.Cli) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().ImageList(cmd.Context(), types.ImageListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, image := range list {
+			names = append(names, image.RepoTags...)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// ContainerNames offers completion for container names and IDs
+// By default, only names are returned.
+// Set DOCKER_COMPLETION_SHOW_CONTAINER_IDS=yes to also complete IDs.
+func ContainerNames(dockerCli command.Cli, all bool, filters ...func(types.Container) bool) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().ContainerList(cmd.Context(), types.ContainerListOptions{
+			All: all,
+		})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		showContainerIDs := os.Getenv("DOCKER_COMPLETION_SHOW_CONTAINER_IDS") == "yes"
+
+		var names []string
+		for _, container := range list {
+			skip := false
+			for _, fn := range filters {
+				if !fn(container) {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+			if showContainerIDs {
+				names = append(names, container.ID)
+			}
+			names = append(names, formatter.StripNamePrefix(container.Names)...)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// VolumeNames offers completion for volumes
+func VolumeNames(dockerCli command.Cli) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().VolumeList(cmd.Context(), filters.Args{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, volume := range list.Volumes {
+			names = append(names, volume.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// NetworkNames offers completion for networks
+func NetworkNames(dockerCli command.Cli) ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().NetworkList(cmd.Context(), types.NetworkListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, network := range list {
+			names = append(names, network.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// NoComplete is used for commands where there's no relevant completion
+func NoComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
 )
 
 // NewConfigCommand returns a cobra command for `config` subcommands
@@ -26,4 +27,19 @@ func NewConfigCommand(dockerCli command.Cli) *cobra.Command {
 		newConfigRemoveCommand(dockerCli),
 	)
 	return cmd
+}
+
+// completeNames offers completion for swarm configs
+func completeNames(dockerCli command.Cli) completion.ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().ConfigList(cmd.Context(), types.ConfigListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, config := range list {
+			names = append(names, config.ID)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -29,6 +29,9 @@ func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.Names = args
 			return RunConfigInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	cmd.Flags().StringVarP(&opts.Format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/config/ls.go
+++ b/cli/command/config/ls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -32,6 +33,7 @@ func newConfigListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunConfigList(dockerCli, listOpts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -28,6 +28,9 @@ func newConfigRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return RunConfigRemove(dockerCli, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 }
 

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -54,6 +55,7 @@ func NewAttachCommand(dockerCli command.Cli) *cobra.Command {
 			opts.container = args[0]
 			return runAttach(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
@@ -36,6 +37,7 @@ func NewCommitCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runCommit(dockerCli, &options)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/opts"
 	"github.com/docker/distribution/reference"
@@ -56,6 +57,7 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runCreate(dockerCli, cmd.Flags(), &opts, copts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func NewDiffCommand(dockerCli command.Cli) *cobra.Command {
 			opts.container = args[0]
 			return runDiff(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 }
 

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
@@ -52,6 +54,7 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 			options.Command = args[1:]
 			return RunExec(dockerCli, options)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 		Annotations: map[string]string{
 			"category-top": "2",
 		},
@@ -72,6 +75,19 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("env-file", "version", []string{"1.25"})
 	flags.StringVarP(&options.Workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.SetAnnotation("workdir", "version", []string{"1.35"})
+
+	cmd.RegisterFlagCompletionFunc(
+		"env",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return os.Environ(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	cmd.RegisterFlagCompletionFunc(
+		"env-file",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveDefault // _filedir
+		},
+	)
 
 	return cmd
 }

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func NewExportCommand(dockerCli command.Cli) *cobra.Command {
 			opts.container = args[0]
 			return runExport(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.refs = args
 			return runInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ func NewKillCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runKill(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -40,6 +41,7 @@ func NewPsCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "3",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
 			opts.container = args[0]
 			return runLogs(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +29,9 @@ func NewPauseCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runPause(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(container types.Container) bool {
+			return container.State != "paused"
+		}),
 	}
 }
 

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ func NewPortCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runPort(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 	return cmd
 }

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
@@ -35,7 +36,8 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:       map[string]string{"version": "1.25"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ func NewRenameCommand(dockerCli command.Cli) *cobra.Command {
 			opts.newName = args[1]
 			return runRename(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 	return cmd
 }

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func NewRestartCommand(dockerCli command.Cli) *cobra.Command {
 			opts.nSecondsChanged = cmd.Flags().Changed("time")
 			return runRestart(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
@@ -33,6 +34,7 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runRm(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"syscall"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -43,6 +45,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runRun(dockerCli, cmd.Flags(), &opts, copts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 		Annotations: map[string]string{
 			"category-top": "1",
 		},
@@ -67,6 +70,23 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	command.AddPlatformFlag(flags, &opts.platform)
 	command.AddTrustVerificationFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
 	copts = addFlags(flags)
+
+	cmd.RegisterFlagCompletionFunc(
+		"env",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return os.Environ(), cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	cmd.RegisterFlagCompletionFunc(
+		"env-file",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveDefault
+		},
+	)
+	cmd.RegisterFlagCompletionFunc(
+		"network",
+		completion.NetworkNames(dockerCli),
+	)
 	return cmd
 }
 

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/moby/sys/signal"
 	"github.com/moby/term"
@@ -43,6 +44,9 @@ func NewStartCommand(dockerCli command.Cli) *cobra.Command {
 			opts.Containers = args
 			return RunStart(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true, func(container types.Container) bool {
+			return container.State == "exited" || container.State == "created"
+		}),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
@@ -39,6 +40,7 @@ func NewStatsCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runStats(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func NewStopCommand(dockerCli command.Cli) *cobra.Command {
 			opts.timeChanged = cmd.Flags().Changed("time")
 			return runStop(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,7 @@ func NewTopCommand(dockerCli command.Cli) *cobra.Command {
 			opts.args = args[1:]
 			return runTop(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +29,9 @@ func NewUnpauseCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runUnpause(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(container types.Container) bool {
+			return container.State == "paused"
+		}),
 	}
 	return cmd
 }

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
@@ -48,6 +49,7 @@ func NewUpdateCommand(dockerCli command.Cli) *cobra.Command {
 			options.nFlag = cmd.Flags().NFlag()
 			return runUpdate(dockerCli, &options)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func NewWaitCommand(dockerCli command.Cli) *cobra.Command {
 			opts.containers = args
 			return runWait(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
 	}
 
 	return cmd

--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/context/docker"
 	flagsHelper "github.com/docker/cli/cli/flags"
@@ -30,6 +31,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/context/show.go
+++ b/cli/command/context/show.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ func newShowCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runShow(dockerCli)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	return cmd
 }

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -125,7 +125,7 @@ func (c *ContainerContext) ID() string {
 // slash (/) prefix stripped. Additional names for the container (related to the
 // legacy `--link` feature) are omitted.
 func (c *ContainerContext) Names() string {
-	names := stripNamePrefix(c.c.Names)
+	names := StripNamePrefix(c.c.Names)
 	if c.trunc {
 		for _, name := range names {
 			if len(strings.Split(name, "/")) == 1 {
@@ -135,6 +135,15 @@ func (c *ContainerContext) Names() string {
 		}
 	}
 	return strings.Join(names, ",")
+}
+
+// StripNamePrefix removes prefix from string, typically container names as returned by `ContainersList` API
+func StripNamePrefix(ss []string) []string {
+	sss := make([]string, len(ss))
+	for i, s := range ss {
+		sss[i] = s[1:]
+	}
+	return sss
 }
 
 // Image returns the container's image reference. If the trunc option is set,

--- a/cli/command/formatter/custom.go
+++ b/cli/command/formatter/custom.go
@@ -45,12 +45,3 @@ type HeaderContext struct {
 func (c *HeaderContext) FullHeader() interface{} {
 	return c.Header
 }
-
-func stripNamePrefix(ss []string) []string {
-	sss := make([]string, len(ss))
-	for i, s := range ss {
-		sss[i] = s[1:]
-	}
-
-	return sss
-}

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -108,6 +108,9 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "4",
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -1,10 +1,9 @@
 package image
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
 )
 
 // NewImageCommand returns a cobra command for `image` subcommands

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/system"
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ func NewLoadCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLoad(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
@@ -37,7 +38,8 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:       map[string]string{"version": "1.25"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -38,6 +39,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "6",
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -1,10 +1,9 @@
 package network
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
 )
 
 // NewNetworkCommand returns a cobra command for `network` subcommands

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/network"
 	"github.com/spf13/cobra"
@@ -36,6 +37,13 @@ func newConnectCommand(dockerCli command.Cli) *cobra.Command {
 			options.network = args[0]
 			options.container = args[1]
 			return runConnect(dockerCli, options)
+		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completion.NetworkNames(dockerCli)(cmd, args, toComplete)
+			}
+			network := args[0]
+			return completion.ContainerNames(dockerCli, true, not(isConnected(network)))(cmd, args, toComplete)
 		},
 	}
 

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
@@ -28,6 +29,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.names = args
 			return runInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.NetworkNames(dockerCli),
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -32,6 +33,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(dockerCli, args, &opts)
 		},
+		ValidArgsFunction: completion.NetworkNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -31,6 +32,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display IDs")

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/command/task"
 	"github.com/docker/cli/opts"
@@ -40,6 +41,7 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 
 			return runPs(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Do not truncate output")

--- a/cli/command/plugin/list.go
+++ b/cli/command/plugin/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -31,6 +32,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -1,10 +1,11 @@
 package secret
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
 )
 
 // NewSecretCommand returns a cobra command for `secret` subcommands
@@ -26,4 +27,19 @@ func NewSecretCommand(dockerCli command.Cli) *cobra.Command {
 		newSecretRemoveCommand(dockerCli),
 	)
 	return cmd
+}
+
+// completeNames offers completion for swarm secrets
+func completeNames(dockerCli command.Cli) completion.ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().SecretList(cmd.Context(), types.SecretListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, secret := range list {
+			names = append(names, secret.ID)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -28,6 +28,9 @@ func newSecretInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.names = args
 			return runSecretInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -31,6 +31,9 @@ func newSecretListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSecretList(dockerCli, options)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -27,6 +27,9 @@ func newSecretRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runSecretRemove(dockerCli, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 }
 

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -1,10 +1,11 @@
 package service
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
 )
 
 // NewServiceCommand returns a cobra command for `service` subcommands
@@ -31,4 +32,19 @@ func NewServiceCommand(dockerCli command.Cli) *cobra.Command {
 		newRollbackCommand(dockerCli),
 	)
 	return cmd
+}
+
+// CompletionFn offers completion for swarm services
+func CompletionFn(dockerCli command.Cli) completion.ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCli.Client().ServiceList(cmd.Context(), types.ServiceListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, service := range list {
+			names = append(names, service.ID)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -35,6 +35,9 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -32,6 +33,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -48,6 +48,9 @@ func newLogsCommand(dockerCli command.Cli) *cobra.Command {
 			return runLogs(dockerCli, &opts)
 		},
 		Annotations: map[string]string{"version": "1.29"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -37,6 +37,9 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 			options.services = args
 			return runPS(dockerCli, options)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display task IDs")

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -21,6 +21,9 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(dockerCli, args)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 	cmd.Flags()
 

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -22,6 +22,9 @@ func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
 			return runRollback(dockerCli, options, args[0])
 		},
 		Annotations: map[string]string{"version": "1.31"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -28,6 +28,9 @@ func newScaleCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runScale(dockerCli, options, args)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -33,6 +33,9 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(dockerCli, cmd.Flags(), options, args[0])
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return CompletionFn(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/command/stack/swarm"
 	"github.com/spf13/cobra"
 )
 
@@ -41,4 +43,19 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("orchestrator", "deprecated", nil)
 	flags.MarkDeprecated("orchestrator", "option will be ignored")
 	return cmd
+}
+
+// completeNames offers completion for swarm stacks
+func completeNames(dockerCli command.Cli) completion.ValidArgsFn {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := swarm.GetStacks(dockerCli)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var names []string
+		for _, stack := range list {
+			names = append(names, stack.Name)
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/stack/loader"
 	"github.com/docker/cli/cli/command/stack/options"
 	composeLoader "github.com/docker/cli/cli/compose/loader"
@@ -34,6 +35,7 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 			_, err = fmt.Fprintf(dockerCli.Out(), "%s", cfg)
 			return err
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -30,6 +30,9 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return RunDeploy(dockerCli, cmd.Flags(), config, opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/stack/formatter"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
@@ -24,6 +25,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunList(cmd, dockerCli, opts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -25,6 +25,9 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return RunPs(dockerCli, cmd.Flags(), opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.NoTrunc, "no-trunc", false, "Do not truncate output")

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -24,6 +24,9 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return RunRemove(dockerCli, cmd.Flags(), opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 	return cmd
 }

--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -32,6 +32,9 @@ func newServicesCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return RunServices(dockerCli, cmd.Flags(), opts)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return completeNames(dockerCli)(cmd, args, toComplete)
+		},
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display IDs")

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/swarm/progress"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -39,6 +40,7 @@ func newCACommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.30",
 			"swarm":   "manager",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -43,6 +44,7 @@ func newInitCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "", // swarm init does not require swarm to be active, and is always available on API 1.24 and up
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +28,7 @@ func newLeaveCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "active",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -28,6 +29,7 @@ func newUnlockCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	return cmd

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ func newUnlockKeyCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -32,6 +33,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	cmd.Flags().BoolVar(&opts.autolock, flagAutolock, false, "Change manager autolocking setting (true|false)")

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
@@ -27,7 +28,8 @@ func newDiskUsageCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDiskUsage(dockerCli, opts)
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:       map[string]string{"version": "1.25"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -22,6 +23,7 @@ func newDialStdioCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDialStdio(dockerCli)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	return cmd
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
@@ -36,6 +37,7 @@ func NewEventsCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEvents(dockerCli, &options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli"
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/debug"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
@@ -57,6 +58,7 @@ func NewInfoCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "12",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/builder"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/container"
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/command/network"
@@ -40,7 +41,8 @@ func newPruneCommand(dockerCli command.Cli) *cobra.Command {
 			options.pruneBuildCache = versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.31")
 			return runPrune(dockerCli, options)
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:       map[string]string{"version": "1.25"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/cli/templates"
@@ -97,6 +98,7 @@ func NewVersionCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "10",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.names = args
 			return runInspect(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.VolumeNames(dockerCli),
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -30,6 +31,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	units "github.com/docker/go-units"
 	"github.com/spf13/cobra"
@@ -35,7 +36,8 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:       map[string]string{"version": "1.25"},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/remove.go
+++ b/cli/command/volume/remove.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,7 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			opts.volumes = args
 			return runRemove(dockerCli, &opts)
 		},
+		ValidArgsFunction: completion.VolumeNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -118,6 +118,19 @@ func (s *store) List() ([]Metadata, error) {
 	return s.meta.list()
 }
 
+// Names return Metadata names for a Lister
+func Names(s Lister) ([]string, error) {
+	list, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, item := range list {
+		names = append(names, item.Name)
+	}
+	return names, nil
+}
+
 func (s *store) CreateOrUpdate(meta Metadata) error {
 	return s.meta.createOrUpdate(meta)
 }

--- a/cmd/docker/completions.go
+++ b/cmd/docker/completions.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/context/store"
+	"github.com/spf13/cobra"
+)
+
+func registerCompletionFuncForGlobalFlags(dockerCli *command.DockerCli, cmd *cobra.Command) {
+	cmd.RegisterFlagCompletionFunc(
+		"context",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			names, err := store.Names(dockerCli.ContextStore())
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveError
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+	cmd.RegisterFlagCompletionFunc(
+		"log-level",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			values := []string{"debug", "info", "warn", "error", "fatal"}
+			return values, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+}

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -42,6 +42,7 @@ func runCliCommand(t *testing.T, r io.ReadCloser, w io.Writer, args ...string) e
 	cli, err := command.NewDockerCli(command.WithInputStream(r), command.WithCombinedStreams(w))
 	assert.NilError(t, err)
 	tcmd := newDockerCommand(cli)
+
 	tcmd.SetArgs(args)
 	cmd, _, err := tcmd.HandleGlobalFlags()
 	assert.NilError(t, err)

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -83,7 +83,7 @@ func TestHelpBad(t *testing.T) {
 
 	res := icmd.RunCmd(run("help", "badmeta"))
 	res.Assert(t, icmd.Expected{
-		ExitCode: 1,
+		ExitCode: 0,
 		Out:      icmd.None,
 	})
 	golden.Assert(t, res.Stderr(), "docker-help-badmeta-err.golden")
@@ -105,13 +105,13 @@ func TestBadHelp(t *testing.T) {
 		Err: icmd.None,
 	})
 	// Short -h should be the same, modulo the deprecation message
-	exp := shortHFlagDeprecated + res.Stdout()
+	usage := res.Stdout()
 	res = icmd.RunCmd(run("badmeta", "-h"))
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		// This should be identical to the --help case above
-		Out: exp,
-		Err: icmd.None,
+		Out: usage,
+		Err: shortHFlagDeprecated,
 	})
 }
 

--- a/e2e/context/context_test.go
+++ b/e2e/context/context_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestContextList(t *testing.T) {
 	cmd := icmd.Command("docker", "context", "ls")
-	cmd.Env = append(cmd.Env, "DOCKER_CONFIG=./testdata/test-dockerconfig")
+	cmd.Env = append(cmd.Env, "DOCKER_CONFIG=testdata/test-dockerconfig")
 	result := icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		Err:      icmd.None,
 		ExitCode: 0,


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/1257

**- What I did**
Updated Cobra to 1.3.0 and started adopting [Completion v2 mechanism](https://github.com/spf13/cobra/blob/master/shell_completions.md) with dynamic flag completion

Longer terms plan is to be able to fully generate completion for all commands, and replace the hand-written completion script

**- How I did it**
Enabled completion command and introduced `registerCompletionFunc..`

I would prefer this is all set by `SetupRootCommand`, but  we need `dockerCli` to list available values, and passing this will change method signature. Or we need to set a global `util.*` variable like [kubernetes does](https://github.com/kubernetes/kubectl/blob/26ede5e6c7d31ab50b72e597370d523dd3d13952/pkg/util/completion.go#L32) 

Root Command gets a custom `ValidArgsFunction` set so that we can list available CLI plugins and include them in the completions. Note: they appear _after_ canonical commands, unsorted:
```
$ docker c [tab] [tab]
checkpoint  commit      compose     config      container   context     cp          create 
...
 ~ docker compose - [tab] [tab]
--ansi               (Control when to print ANSI control characters ("never"|"always"|"auto"))
--compatibility      (Run compose in backward compatibility mode)
--env-file           (Specify an alternate environment file.)
...
```

Note: support by plugin require docker/cli dependency to be updated and Metadata to explicitly declare `Completion` support (SchemaVersion 0.2.0)

**- How to verify it**
generate completion script by `docker completion bash > /usr/local/etc/bash_completion.d/docker.sh` and check completion within a new console

or directly invoke completion by: 
```
$ docker __complete --context "de"
desktop-linux
default
:0
Completion ended with directive: ShellCompDirectiveDefault
```

demo: https://asciinema.org/a/cThdD50ILb3G5Ugx9q25XlTGo

**- Description for the changelog**
Introduce generation of shell completion command `docker completion` with dynamic completion

**- A picture of a cute animal (not mandatory but encouraged)**

