### PR TITLE
Fix incorrect pointer inputs to `json.Unmarshal`

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -120,7 +120,7 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 // LoadFromReader reads the configuration data given and sets up the auth config
 // information with given directory and populates the receiver object
 func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
-	if err := json.NewDecoder(configData).Decode(&configFile); err != nil && !errors.Is(err, io.EOF) {
+	if err := json.NewDecoder(configData).Decode(configFile); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 	var err error


### PR DESCRIPTION
See https://github.com/howardjohn/go-unmarshal-double-pointer for more
info on why this is not safe and how this is detected.

