### PR TITLE
bring back and expose BuildKitEnabled func

### DIFF
--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -41,8 +41,7 @@ func newBuilderError(warn bool, err error) error {
 }
 
 func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []string) ([]string, []string, error) {
-	var useLegacy bool
-	var useBuilder bool
+	var useLegacy, useBuilder bool
 
 	// check DOCKER_BUILDKIT env var is present and
 	// if not assume we want to use the builder component
@@ -70,6 +69,12 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	// is this a build that should be forwarded to the builder?
 	fwargs, fwosargs, forwarded := forwardBuilder(builderAlias, args, osargs)
 	if !forwarded {
+		return args, osargs, nil
+	}
+
+	// wcow build command must use the legacy builder
+	// if not opt-in through a builder component
+	if !useBuilder && dockerCli.ServerInfo().OSType == "windows" {
 		return args, osargs, nil
 	}
 

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -215,3 +215,8 @@ func (c *FakeCli) ContentTrustEnabled() bool {
 func EnableContentTrust(c *FakeCli) {
 	c.contentTrust = true
 }
+
+// BuildKitEnabled on the fake cli
+func (c *FakeCli) BuildKitEnabled() (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
Bring back `BuildKitEnabled` that is used by compose: https://github.com/docker/compose/blob/598b59f8bf0a86f3ba2a135c0489b63bb4285973/pkg/compose/build.go#L216-L219. @ndeloof Signature has changed, let me know if it sounds good to you.

Second commit fixes an issue where legacy builder was not used if wcow was reported server-side (see #3314).