### PR TITLE
publish RunExec for use by docker/compose

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -16,62 +16,65 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type execOptions struct {
-	detachKeys  string
-	interactive bool
-	tty         bool
-	detach      bool
-	user        string
-	privileged  bool
-	env         opts.ListOpts
-	workdir     string
-	container   string
-	command     []string
-	envFile     opts.ListOpts
+// ExecOptions group options for `exec` command
+type ExecOptions struct {
+	DetachKeys  string
+	Interactive bool
+	TTY         bool
+	Detach      bool
+	User        string
+	Privileged  bool
+	Env         opts.ListOpts
+	Workdir     string
+	Container   string
+	Command     []string
+	EnvFile     opts.ListOpts
 }
 
-func newExecOptions() execOptions {
-	return execOptions{
-		env:     opts.NewListOpts(opts.ValidateEnv),
-		envFile: opts.NewListOpts(nil),
+// NewExecOptions creates a new ExecOptions
+func NewExecOptions() ExecOptions {
+	return ExecOptions{
+		Env:     opts.NewListOpts(opts.ValidateEnv),
+		EnvFile: opts.NewListOpts(nil),
 	}
 }
 
 // NewExecCommand creates a new cobra.Command for `docker exec`
 func NewExecCommand(dockerCli command.Cli) *cobra.Command {
-	options := newExecOptions()
+	options := NewExecOptions()
 
 	cmd := &cobra.Command{
 		Use:   "exec [OPTIONS] CONTAINER COMMAND [ARG...]",
 		Short: "Run a command in a running container",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			options.container = args[0]
-			options.command = args[1:]
-			return runExec(dockerCli, options)
+			options.Container = args[0]
+			options.Command = args[1:]
+			return RunExec(dockerCli, options)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.SetInterspersed(false)
 
-	flags.StringVarP(&options.detachKeys, "detach-keys", "", "", "Override the key sequence for detaching a container")
-	flags.BoolVarP(&options.interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
-	flags.BoolVarP(&options.tty, "tty", "t", false, "Allocate a pseudo-TTY")
-	flags.BoolVarP(&options.detach, "detach", "d", false, "Detached mode: run command in the background")
-	flags.StringVarP(&options.user, "user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
-	flags.BoolVarP(&options.privileged, "privileged", "", false, "Give extended privileges to the command")
-	flags.VarP(&options.env, "env", "e", "Set environment variables")
+	flags.StringVarP(&options.DetachKeys, "detach-keys", "", "", "Override the key sequence for detaching a container")
+	flags.BoolVarP(&options.Interactive, "interactive", "i", false, "Keep STDIN open even if not attached")
+	flags.BoolVarP(&options.TTY, "tty", "t", false, "Allocate a pseudo-TTY")
+	flags.BoolVarP(&options.Detach, "detach", "d", false, "Detached mode: run command in the background")
+	flags.StringVarP(&options.User, "user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	flags.BoolVarP(&options.Privileged, "privileged", "", false, "Give extended privileges to the command")
+	flags.VarP(&options.Env, "env", "e", "Set environment variables")
 	flags.SetAnnotation("env", "version", []string{"1.25"})
-	flags.Var(&options.envFile, "env-file", "Read in a file of environment variables")
+	flags.Var(&options.EnvFile, "env-file", "Read in a file of environment variables")
 	flags.SetAnnotation("env-file", "version", []string{"1.25"})
-	flags.StringVarP(&options.workdir, "workdir", "w", "", "Working directory inside the container")
+	flags.StringVarP(&options.Workdir, "workdir", "w", "", "Working directory inside the container")
 	flags.SetAnnotation("workdir", "version", []string{"1.35"})
 
 	return cmd
 }
 
-func runExec(dockerCli command.Cli, options execOptions) error {
+// RunExec executes an `exec` command
+func RunExec(dockerCli command.Cli, options ExecOptions) error {
 	execConfig, err := parseExec(options, dockerCli.ConfigFile())
 	if err != nil {
 		return err
@@ -84,7 +87,7 @@ func runExec(dockerCli command.Cli, options execOptions) error {
 	// otherwise if we error out we will leak execIDs on the server (and
 	// there's no easy way to clean those up). But also in order to make "not
 	// exist" errors take precedence we do a dummy inspect first.
-	if _, err := client.ContainerInspect(ctx, options.container); err != nil {
+	if _, err := client.ContainerInspect(ctx, options.Container); err != nil {
 		return err
 	}
 	if !execConfig.Detach {
@@ -93,7 +96,7 @@ func runExec(dockerCli command.Cli, options execOptions) error {
 		}
 	}
 
-	response, err := client.ContainerExecCreate(ctx, options.container, *execConfig)
+	response, err := client.ContainerExecCreate(ctx, options.Container, *execConfig)
 	if err != nil {
 		return err
 	}
@@ -195,33 +198,33 @@ func getExecExitStatus(ctx context.Context, client apiclient.ContainerAPIClient,
 
 // parseExec parses the specified args for the specified command and generates
 // an ExecConfig from it.
-func parseExec(execOpts execOptions, configFile *configfile.ConfigFile) (*types.ExecConfig, error) {
+func parseExec(execOpts ExecOptions, configFile *configfile.ConfigFile) (*types.ExecConfig, error) {
 	execConfig := &types.ExecConfig{
-		User:       execOpts.user,
-		Privileged: execOpts.privileged,
-		Tty:        execOpts.tty,
-		Cmd:        execOpts.command,
-		Detach:     execOpts.detach,
-		WorkingDir: execOpts.workdir,
+		User:       execOpts.User,
+		Privileged: execOpts.Privileged,
+		Tty:        execOpts.TTY,
+		Cmd:        execOpts.Command,
+		Detach:     execOpts.Detach,
+		WorkingDir: execOpts.Workdir,
 	}
 
 	// collect all the environment variables for the container
 	var err error
-	if execConfig.Env, err = opts.ReadKVEnvStrings(execOpts.envFile.GetAll(), execOpts.env.GetAll()); err != nil {
+	if execConfig.Env, err = opts.ReadKVEnvStrings(execOpts.EnvFile.GetAll(), execOpts.Env.GetAll()); err != nil {
 		return nil, err
 	}
 
 	// If -d is not set, attach to everything by default
-	if !execOpts.detach {
+	if !execOpts.Detach {
 		execConfig.AttachStdout = true
 		execConfig.AttachStderr = true
-		if execOpts.interactive {
+		if execOpts.Interactive {
 			execConfig.AttachStdin = true
 		}
 	}
 
-	if execOpts.detachKeys != "" {
-		execConfig.DetachKeys = execOpts.detachKeys
+	if execOpts.DetachKeys != "" {
+		execConfig.DetachKeys = execOpts.DetachKeys
 	} else {
 		execConfig.DetachKeys = configFile.DetachKeys
 	}


### PR DESCRIPTION
**- What I did**
make "exec" logic reusable by docker-compose without having to duplicate code

**- How I did it**
made `runExec` and `execOptions` public so this code can be reused in docker-compose

**- How to verify it**
see https://github.com/docker/compose/pull/9197

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/155283452-a64a79b6-7aa7-4b7e-980d-36b5bb11d857.png)

