### PR TITLE
introduce plugin.RunningStandalone utility func

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -160,3 +160,11 @@ func newMetadataSubcommand(plugin *cobra.Command, meta manager.Metadata) *cobra.
 	}
 	return cmd
 }
+
+// RunningStandalone tells a CLI plugin it is run standalone by direct execution
+func RunningStandalone() bool {
+	if os.Getenv(manager.ReexecEnvvar) != "" {
+		return false
+	}
+	return len(os.Args) < 2 || os.Args[1] != manager.MetadataSubcommandName
+}


### PR DESCRIPTION
**- What I did**
introduced plugin.RunningStandalone

**- How I did it**
code from https://github.com/docker/buildx/blob/10debb577e0f2981ff5b4d09772be73a6267cebb/cmd/buildx/main.go#L46-L47

**- How to verify it**
This code is already in used, just made it reusable by other CLI plugins (typically, https://github.com/docker/compose/blob/740276f550ecb7da444b20dc21860ce2f2c547d6/cmd/main.go#L71)

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/155290950-eced49b1-ac92-476e-aae9-823c325f7efe.png)

