### PR TITLE
Remove uses of deprecated io/ioutil, and use new t.TempDir() and t.Cleanup() in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ linters:
   enable:
     - bodyclose
     - deadcode
+    - depguard
     - dogsled
     - gocyclo
     - goimports
@@ -33,6 +34,13 @@ run:
     - .*generated.*
 
 linters-settings:
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      # The io/ioutil package has been deprecated.
+      # https://go.dev/doc/go1.16#ioutil
+      - io/ioutil
   gocyclo:
     min-complexity: 16
   govet:

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -57,12 +56,12 @@ func getPluginDirs(dockerCli command.Cli) ([]string, error) {
 }
 
 func addPluginCandidatesFromDir(res map[string][]string, d string) error {
-	dentries, err := ioutil.ReadDir(d)
+	dentries, err := os.ReadDir(d)
 	if err != nil {
 		return err
 	}
 	for _, dentry := range dentries {
-		switch dentry.Mode() & os.ModeType {
+		switch dentry.Type() & os.ModeType {
 		case 0, os.ModeSymlink:
 			// Regular file or symlink, keep going
 		default:

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestCheckpointCreateErrors(t *testing.T) {
 		})
 		cmd := newCreateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -41,7 +41,7 @@ func TestCheckpointListErrors(t *testing.T) {
 		})
 		cmd := newListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -40,7 +40,7 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 		})
 		cmd := newRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -275,7 +274,7 @@ func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.
 	store := &ContextStoreWithDefault{
 		Store: store.New(cliconfig.ContextStoreDir(), storeConfig),
 		Resolver: func() (*DefaultContext, error) {
-			return ResolveDefaultContext(opts, configFile, storeConfig, ioutil.Discard)
+			return ResolveDefaultContext(opts, configFile, storeConfig, io.Discard)
 		},
 	}
 	contextName, err := resolveContextName(opts, configFile, store)

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -225,23 +225,23 @@ func TestNewDockerCliAndOperators(t *testing.T) {
 	outbuf := bytes.NewBuffer(nil)
 	errbuf := bytes.NewBuffer(nil)
 	err = cli.Apply(
-		WithInputStream(ioutil.NopCloser(inbuf)),
+		WithInputStream(io.NopCloser(inbuf)),
 		WithOutputStream(outbuf),
 		WithErrorStream(errbuf),
 	)
 	assert.NilError(t, err)
 	// Check input stream
-	inputStream, err := ioutil.ReadAll(cli.In())
+	inputStream, err := io.ReadAll(cli.In())
 	assert.NilError(t, err)
 	assert.Equal(t, string(inputStream), "input")
 	// Check output stream
 	fmt.Fprintf(cli.Out(), "output")
-	outputStream, err := ioutil.ReadAll(outbuf)
+	outputStream, err := io.ReadAll(outbuf)
 	assert.NilError(t, err)
 	assert.Equal(t, string(outputStream), "output")
 	// Check error stream
 	fmt.Fprintf(cli.Err(), "error")
-	errStream, err := ioutil.ReadAll(errbuf)
+	errStream, err := io.ReadAll(errbuf)
 	assert.NilError(t, err)
 	assert.Equal(t, string(errStream), "error")
 }

--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -61,7 +60,7 @@ func RunConfigCreate(dockerCli command.Cli, options CreateOptions) error {
 		defer file.Close()
 	}
 
-	configData, err := ioutil.ReadAll(in)
+	configData, err := io.ReadAll(in)
 	if err != nil {
 		return errors.Errorf("Error reading content from %q: %v", options.File, err)
 	}

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -46,7 +47,7 @@ func TestConfigCreateErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -82,7 +83,7 @@ func TestConfigCreateWithLabels(t *testing.T) {
 	}
 	name := "foo"
 
-	data, err := ioutil.ReadFile(filepath.Join("testdata", configDataFile))
+	data, err := os.ReadFile(filepath.Join("testdata", configDataFile))
 	assert.NilError(t, err)
 
 	expected := swarm.ConfigSpec{

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func TestConfigInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -40,7 +40,7 @@ func TestConfigListErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestConfigRemoveErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -73,7 +73,7 @@ func TestConfigRemoveContinueAfterError(t *testing.T) {
 
 	cmd := newConfigRemoveCommand(cli)
 	cmd.SetArgs(names)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.Error(t, cmd.Execute(), "error removing config: foo")
 	assert.Check(t, is.DeepEqual(names, removedConfigs))
 }

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli"
@@ -71,7 +71,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -54,7 +53,7 @@ func TestRunCopyFromContainerToStdout(t *testing.T) {
 	fakeClient := &fakeClient{
 		containerCopyFromFunc: func(container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 			assert.Check(t, is.Equal("container", container))
-			return ioutil.NopCloser(strings.NewReader(tarContent)), types.ContainerPathStat{}, nil
+			return io.NopCloser(strings.NewReader(tarContent)), types.ContainerPathStat{}, nil
 		},
 	}
 	options := copyOptions{source: "container:/path", destination: "-"}
@@ -84,7 +83,7 @@ func TestRunCopyFromContainerToFilesystem(t *testing.T) {
 	assert.Check(t, is.Equal("", cli.OutBuffer().String()))
 	assert.Check(t, is.Equal("", cli.ErrBuffer().String()))
 
-	content, err := ioutil.ReadFile(destDir.Join("file1"))
+	content, err := os.ReadFile(destDir.Join("file1"))
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("content\n", string(content)))
 }

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sort"
@@ -67,7 +66,7 @@ func TestCIDFileCloseWithWrite(t *testing.T) {
 	content := "id"
 	assert.NilError(t, file.Write(content))
 
-	actual, err := ioutil.ReadFile(path)
+	actual, err := os.ReadFile(path)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(content, string(actual)))
 
@@ -130,7 +129,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 			},
 			imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
 				defer func() { pullCounter++ }()
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 			infoFunc: func() (types.Info, error) {
 				return types.Info{IndexServerAddress: "https://indexserver.example.com"}, nil
@@ -194,7 +193,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 		}, test.EnableContentTrust)
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewCreateCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)
@@ -254,7 +253,7 @@ func TestNewCreateCommandWithWarnings(t *testing.T) {
 				},
 			})
 			cmd := NewCreateCommand(cli)
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
 			assert.NilError(t, err)
@@ -306,7 +305,7 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 		},
 	})
 	cmd := NewCreateCommand(cli)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"image:tag"})
 	err := cmd.Execute()
 	assert.NilError(t, err)

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -267,7 +267,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc})
 		cmd := NewExecCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -17,11 +16,11 @@ func TestContainerExportOutputToFile(t *testing.T) {
 
 	cli := test.NewFakeCli(&fakeClient{
 		containerExportFunc: func(container string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("bar")), nil
+			return io.NopCloser(strings.NewReader("bar")), nil
 		},
 	})
 	cmd := NewExportCommand(cli)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"-o", dir.Join("foo"), "container"})
 	assert.NilError(t, cmd.Execute())
 
@@ -35,11 +34,11 @@ func TestContainerExportOutputToFile(t *testing.T) {
 func TestContainerExportOutputToIrregularFile(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerExportFunc: func(container string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader("foo")), nil
+			return io.NopCloser(strings.NewReader("foo")), nil
 		},
 	})
 	cmd := NewExportCommand(cli)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"-o", "/dev/random", "container"})
 
 	err := cmd.Execute()

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -89,7 +89,7 @@ func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, er
 
 		// This shouldn't error out but swallowing the error makes it harder
 		// to track down if preProcessor issues come up.
-		if err := tmpl.Execute(ioutil.Discard, optionsProcessor); err != nil {
+		if err := tmpl.Execute(io.Discard, optionsProcessor); err != nil {
 			return nil, errors.Wrap(err, "failed to execute template")
 		}
 

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -161,7 +161,7 @@ func TestContainerListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/container/logs_test.go
+++ b/cli/command/container/logs_test.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -15,7 +14,7 @@ import (
 
 var logFn = func(expectedOut string) func(string, types.ContainerLogsOptions) (io.ReadCloser, error) {
 	return func(container string, opts types.ContainerLogsOptions) (io.ReadCloser, error) {
-		return ioutil.NopCloser(strings.NewReader(expectedOut)), nil
+		return io.NopCloser(strings.NewReader(expectedOut)), nil
 	}
 }
 

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"reflect"
 	"regexp"
@@ -845,7 +845,7 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 			}
 		}
 		if con[0] == "seccomp" && con[1] != "unconfined" {
-			f, err := ioutil.ReadFile(con[1])
+			f, err := os.ReadFile(con[1])
 			if err != nil {
 				return securityOpts, errors.Errorf("opening seccomp profile (%s) failed: %v", con[1], err)
 			}

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -58,7 +58,7 @@ func parseRun(args []string) (*container.Config, *container.HostConfig, *network
 
 func setupRunFlags() (*pflag.FlagSet, *containerOptions) {
 	flags := pflag.NewFlagSet("run", pflag.ContinueOnError)
-	flags.SetOutput(ioutil.Discard)
+	flags.SetOutput(io.Discard)
 	flags.Usage = nil
 	copts := addFlags(flags)
 	return flags, copts

--- a/cli/command/container/port_test.go
+++ b/cli/command/container/port_test.go
@@ -1,7 +1,7 @@
 package container
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -47,7 +47,7 @@ func TestNewPortCommandOutput(t *testing.T) {
 				},
 			}, test.EnableContentTrust)
 			cmd := NewPortCommand(cli)
-			cmd.SetErr(ioutil.Discard)
+			cmd.SetErr(io.Discard)
 			cmd.SetArgs([]string{"some_container", "80"})
 			err := cmd.Execute()
 			assert.NilError(t, err)

--- a/cli/command/container/rm_test.go
+++ b/cli/command/container/rm_test.go
@@ -3,7 +3,7 @@ package container
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestRemoveForce(t *testing.T) {
 		Version: "1.36",
 	})
 	cmd := NewRmCommand(cli)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 
 	t.Run("without force", func(t *testing.T) {
 		cmd.SetArgs([]string{"nosuchcontainer", "mycontainer"})

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -68,7 +68,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewRunCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		err := cmd.Execute()
 		assert.Assert(t, err != nil)
 		assert.Assert(t, is.Contains(cli.ErrBuffer().String(), tc.expectedError))

--- a/cli/command/context/export-import_test.go
+++ b/cli/command/context/export-import_test.go
@@ -3,7 +3,7 @@ package context
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,12 +13,8 @@ import (
 )
 
 func TestExportImportWithFile(t *testing.T) {
-	contextDir, err := ioutil.TempDir("", t.Name()+"context")
-	assert.NilError(t, err)
-	defer os.RemoveAll(contextDir)
-	contextFile := filepath.Join(contextDir, "exported")
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	contextFile := filepath.Join(t.TempDir(), "exported")
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "test")
 	cli.ErrBuffer().Reset()
 	assert.NilError(t, RunExport(cli, &ExportOptions{
@@ -43,8 +39,7 @@ func TestExportImportWithFile(t *testing.T) {
 }
 
 func TestExportImportPipe(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "test")
 	cli.ErrBuffer().Reset()
 	cli.OutBuffer().Reset()
@@ -53,7 +48,7 @@ func TestExportImportPipe(t *testing.T) {
 		Dest:        "-",
 	}))
 	assert.Equal(t, cli.ErrBuffer().String(), "")
-	cli.SetIn(streams.NewIn(ioutil.NopCloser(bytes.NewBuffer(cli.OutBuffer().Bytes()))))
+	cli.SetIn(streams.NewIn(io.NopCloser(bytes.NewBuffer(cli.OutBuffer().Bytes()))))
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
 	assert.NilError(t, RunImport(cli, "test2", "-"))
@@ -71,14 +66,10 @@ func TestExportImportPipe(t *testing.T) {
 }
 
 func TestExportExistingFile(t *testing.T) {
-	contextDir, err := ioutil.TempDir("", t.Name()+"context")
-	assert.NilError(t, err)
-	defer os.RemoveAll(contextDir)
-	contextFile := filepath.Join(contextDir, "exported")
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	contextFile := filepath.Join(t.TempDir(), "exported")
+	cli := makeFakeCli(t)
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, ioutil.WriteFile(contextFile, []byte{}, 0644))
-	err = RunExport(cli, &ExportOptions{ContextName: "test", Dest: contextFile})
+	assert.NilError(t, os.WriteFile(contextFile, []byte{}, 0644))
+	err := RunExport(cli, &ExportOptions{ContextName: "test", Dest: contextFile})
 	assert.Assert(t, os.IsExist(err))
 }

--- a/cli/command/context/inspect_test.go
+++ b/cli/command/context/inspect_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestInspect(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	cli.OutBuffer().Reset()
 	assert.NilError(t, runInspect(cli, inspectOptions{

--- a/cli/command/context/list_test.go
+++ b/cli/command/context/list_test.go
@@ -20,8 +20,7 @@ func createTestContext(t *testing.T, cli command.Cli, name string) {
 }
 
 func TestList(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	createTestContext(t, cli, "unset")
@@ -32,8 +31,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListQuiet(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	cli.SetCurrentContext("current")

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -1,8 +1,6 @@
 package context
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,8 +11,7 @@ import (
 )
 
 func TestRemove(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	assert.NilError(t, RunRemove(cli, RemoveOptions{}, []string{"other"}))
@@ -25,8 +22,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveNotAContext(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	err := RunRemove(cli, RemoveOptions{}, []string{"not-a-context"})
@@ -34,8 +30,7 @@ func TestRemoveNotAContext(t *testing.T) {
 }
 
 func TestRemoveCurrent(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	cli.SetCurrentContext("current")
@@ -44,16 +39,13 @@ func TestRemoveCurrent(t *testing.T) {
 }
 
 func TestRemoveCurrentForce(t *testing.T) {
-	configDir, err := ioutil.TempDir("", t.Name()+"config")
-	assert.NilError(t, err)
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
 	testCfg.CurrentContext = "current"
 	assert.NilError(t, testCfg.Save())
 
-	cli, cleanup := makeFakeCli(t, withCliConfig(testCfg))
-	defer cleanup()
+	cli := makeFakeCli(t, withCliConfig(testCfg))
 	createTestContext(t, cli, "current")
 	createTestContext(t, cli, "other")
 	cli.SetCurrentContext("current")
@@ -64,8 +56,7 @@ func TestRemoveCurrentForce(t *testing.T) {
 }
 
 func TestRemoveDefault(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "other")
 	cli.SetCurrentContext("current")
 	err := RunRemove(cli, RemoveOptions{}, []string{"default"})

--- a/cli/command/context/update_test.go
+++ b/cli/command/context/update_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestUpdateDescriptionOnly(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	err := RunCreate(cli, &CreateOptions{
 		Name:   "test",
 		Docker: map[string]string{},
@@ -34,8 +33,7 @@ func TestUpdateDescriptionOnly(t *testing.T) {
 }
 
 func TestUpdateDockerOnly(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	createTestContext(t, cli, "test")
 	assert.NilError(t, RunUpdate(cli, &UpdateOptions{
 		Name: "test",
@@ -53,8 +51,7 @@ func TestUpdateDockerOnly(t *testing.T) {
 }
 
 func TestUpdateInvalidDockerHost(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	err := RunCreate(cli, &CreateOptions{
 		Name:   "test",
 		Docker: map[string]string{},

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -1,8 +1,6 @@
 package context
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,14 +11,11 @@ import (
 )
 
 func TestUse(t *testing.T) {
-	configDir, err := ioutil.TempDir("", t.Name()+"config")
-	assert.NilError(t, err)
-	defer os.RemoveAll(configDir)
+	configDir := t.TempDir()
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
-	cli, cleanup := makeFakeCli(t, withCliConfig(testCfg))
-	defer cleanup()
-	err = RunCreate(cli, &CreateOptions{
+	cli := makeFakeCli(t, withCliConfig(testCfg))
+	err := RunCreate(cli, &CreateOptions{
 		Name:   "test",
 		Docker: map[string]string{},
 	})
@@ -42,8 +37,7 @@ func TestUse(t *testing.T) {
 }
 
 func TestUseNoExist(t *testing.T) {
-	cli, cleanup := makeFakeCli(t)
-	defer cleanup()
+	cli := makeFakeCli(t)
 	err := newUseCommand(cli).RunE(nil, []string{"test"})
 	assert.Check(t, store.IsErrContextDoesNotExist(err))
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -298,7 +297,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 			if err != nil {
 				return err
 			}
-			dockerfileCtx = ioutil.NopCloser(bytes.NewBuffer(newDockerfile))
+			dockerfileCtx = io.NopCloser(bytes.NewBuffer(newDockerfile))
 		}
 	}
 
@@ -394,7 +393,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		if imageID == "" {
 			return errors.Errorf("Server did not provide an image ID. Cannot write %s", options.imageIDFile)
 		}
-		if err := ioutil.WriteFile(options.imageIDFile, []byte(imageID), 0666); err != nil {
+		if err := os.WriteFile(options.imageIDFile, []byte(imageID), 0666); err != nil {
 			return err
 		}
 	}

--- a/cli/command/image/client_test.go
+++ b/cli/command/image/client_test.go
@@ -3,7 +3,6 @@ package image
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -41,7 +40,7 @@ func (cli *fakeClient) ImageSave(_ context.Context, images []string) (io.ReadClo
 	if cli.imageSaveFunc != nil {
 		return cli.imageSaveFunc(images)
 	}
-	return ioutil.NopCloser(strings.NewReader("")), nil
+	return io.NopCloser(strings.NewReader("")), nil
 }
 
 func (cli *fakeClient) ImageRemove(_ context.Context, image string,
@@ -56,7 +55,7 @@ func (cli *fakeClient) ImagePush(_ context.Context, ref string, options types.Im
 	if cli.imagePushFunc != nil {
 		return cli.imagePushFunc(ref, options)
 	}
-	return ioutil.NopCloser(strings.NewReader("")), nil
+	return io.NopCloser(strings.NewReader("")), nil
 }
 
 func (cli *fakeClient) Info(_ context.Context) (types.Info, error) {
@@ -70,7 +69,7 @@ func (cli *fakeClient) ImagePull(_ context.Context, ref string, options types.Im
 	if cli.imagePullFunc != nil {
 		cli.imagePullFunc(ref, options)
 	}
-	return ioutil.NopCloser(strings.NewReader("")), nil
+	return io.NopCloser(strings.NewReader("")), nil
 }
 
 func (cli *fakeClient) ImagesPrune(_ context.Context, pruneFilter filters.Args) (types.ImagesPruneReport, error) {
@@ -106,7 +105,7 @@ func (cli *fakeClient) ImageImport(_ context.Context, source types.ImageImportSo
 	if cli.imageImportFunc != nil {
 		return cli.imageImportFunc(source, ref, options)
 	}
-	return ioutil.NopCloser(strings.NewReader("")), nil
+	return io.NopCloser(strings.NewReader("")), nil
 }
 
 func (cli *fakeClient) ImageHistory(_ context.Context, img string) ([]image.HistoryResponseItem, error) {
@@ -120,5 +119,5 @@ func (cli *fakeClient) ImageBuild(ctx context.Context, context io.Reader, option
 	if cli.imageBuildFunc != nil {
 		return cli.imageBuildFunc(ctx, context, options)
 	}
-	return types.ImageBuildResponse{Body: ioutil.NopCloser(strings.NewReader(""))}, nil
+	return types.ImageBuildResponse{Body: io.NopCloser(strings.NewReader(""))}, nil
 }

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -37,7 +37,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -95,7 +95,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
 		cmd := NewHistoryCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -44,7 +43,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
 	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}))
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
 	assert.ErrorContains(t, cmd.Execute(), "testdata/import-command-success.unexistent-file")
 }
@@ -68,7 +67,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			args: []string{"-", "image:local"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
 				assert.Check(t, is.Equal("image:local", ref))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 		{
@@ -76,7 +75,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			args: []string{"--message", "test message", "-"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
 				assert.Check(t, is.Equal("test message", options.Message))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 		{
@@ -84,7 +83,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			args: []string{"--change", "ENV DEBUG=true", "-"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
 				assert.Check(t, is.Equal("ENV DEBUG=true", options.Changes[0]))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 		{
@@ -92,13 +91,13 @@ func TestNewImportCommandSuccess(t *testing.T) {
 			args: []string{"--change", "ENV DEBUG true", "-"},
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
 				assert.Check(t, is.Equal("ENV DEBUG true", options.Changes[0]))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 	}
 	for _, tc := range testCases {
 		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NilError(t, cmd.Execute())
 	}

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -26,7 +26,7 @@ func TestNewInspectCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := newInspectCommand(test.NewFakeCli(&fakeClient{}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -78,7 +78,7 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 		imageInspectInvocationCount = 0
 		cli := test.NewFakeCli(&fakeClient{imageInspectFunc: tc.imageInspectFunc})
 		cmd := newInspectCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -82,7 +82,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc})
 		cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
 		cmd := NewImagesCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -3,7 +3,6 @@ package image
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 		cli.In().SetIsTerminal(tc.isTerminalIn)
 		cmd := NewLoadCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -53,7 +52,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
 	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}))
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
 	err := cmd.Execute()
 	assert.ErrorContains(t, err, expectedError)
@@ -68,7 +67,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 		{
 			name: "simple",
 			imageLoadFunc: func(input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
-				return types.ImageLoadResponse{Body: ioutil.NopCloser(strings.NewReader("Success"))}, nil
+				return types.ImageLoadResponse{Body: io.NopCloser(strings.NewReader("Success"))}, nil
 			},
 		},
 		{
@@ -76,7 +75,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 			imageLoadFunc: func(input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
 				json := "{\"ID\": \"1\"}"
 				return types.ImageLoadResponse{
-					Body: ioutil.NopCloser(strings.NewReader(json)),
+					Body: io.NopCloser(strings.NewReader(json)),
 					JSON: true,
 				}, nil
 			},
@@ -85,14 +84,14 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 			name: "input-file",
 			args: []string{"--input", "testdata/load-command-success.input.txt"},
 			imageLoadFunc: func(input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
-				return types.ImageLoadResponse{Body: ioutil.NopCloser(strings.NewReader("Success"))}, nil
+				return types.ImageLoadResponse{Body: io.NopCloser(strings.NewReader("Success"))}, nil
 			},
 		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 		cmd := NewLoadCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -39,7 +39,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 		cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
 			imagesPruneFunc: tc.imagesPruneFunc,
 		}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -93,7 +93,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imagesPruneFunc: tc.imagesPruneFunc})
 		cmd := NewPruneCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -3,7 +3,6 @@ package image
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -40,7 +39,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := NewPullCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -72,11 +71,11 @@ func TestNewPullCommandSuccess(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{
 			imagePullFunc: func(ref string, options types.ImagePullOptions) (io.ReadCloser, error) {
 				assert.Check(t, is.Equal(tc.expectedTag, ref), tc.name)
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		})
 		cmd := NewPullCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.NilError(t, err)
@@ -113,12 +112,12 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{
 			imagePullFunc: func(ref string, options types.ImagePullOptions) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), fmt.Errorf("shouldn't try to pull image")
+				return io.NopCloser(strings.NewReader("")), fmt.Errorf("shouldn't try to pull image")
 			},
 		}, test.EnableContentTrust)
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := NewPullCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -3,7 +3,7 @@ package image
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -93,7 +93,7 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 	}
 
 	if opts.quiet {
-		err = jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(ioutil.Discard), nil)
+		err = jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(io.Discard), nil)
 		if err == nil {
 			fmt.Fprintln(dockerCli.Out(), ref.String())
 		}

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -34,14 +33,14 @@ func TestNewPushCommandErrors(t *testing.T) {
 			args:          []string{"image:repo"},
 			expectedError: "Failed to push",
 			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), errors.Errorf("Failed to push")
+				return io.NopCloser(strings.NewReader("")), errors.Errorf("Failed to push")
 			},
 		},
 	}
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
 		cmd := NewPushCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -69,7 +68,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
-					return ioutil.NopCloser(strings.NewReader("")), nil
+					return io.NopCloser(strings.NewReader("")), nil
 				},
 			})
 			cmd := NewPushCommand(cli)

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -68,7 +68,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 			cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
 				imageRemoveFunc: tc.imageRemoveFunc,
 			}))
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
@@ -124,7 +124,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc})
 			cmd := NewRemoveCommand(cli)
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			assert.NilError(t, cmd.Execute())
 			assert.Check(t, is.Equal(tc.expectedStderr, cli.ErrBuffer().String()))

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +37,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 			isTerminal:    false,
 			expectedError: "error saving image",
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), errors.Errorf("error saving image")
+				return io.NopCloser(strings.NewReader("")), errors.Errorf("error saving image")
 			},
 		},
 		{
@@ -56,7 +55,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 		cli.Out().SetIsTerminal(tc.isTerminal)
 		cmd := NewSaveCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -75,7 +74,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
 				assert.Assert(t, is.Len(images, 1))
 				assert.Check(t, is.Equal("arg1", images[0]))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 			deferredFunc: func() {
 				os.Remove("save_tmp_file")
@@ -88,17 +87,17 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 				assert.Assert(t, is.Len(images, 2))
 				assert.Check(t, is.Equal("arg1", images[0]))
 				assert.Check(t, is.Equal("arg2", images[1]))
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 	}
 	for _, tc := range testCases {
 		cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		}))
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.NilError(t, cmd.Execute())
 		if tc.deferredFunc != nil {

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -19,7 +19,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 	for _, args := range testCases {
 		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), expectedError)
 	}
 }
@@ -34,7 +34,7 @@ func TestCliNewTagCommand(t *testing.T) {
 			},
 		}))
 	cmd.SetArgs([]string{"image1", "image2"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	value, _ := cmd.Flags().GetBool("interspersed")
 	assert.Check(t, !value)

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 
 	"github.com/docker/cli/cli/command"
@@ -283,7 +282,7 @@ func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth tru
 
 	out := cli.Out()
 	if opts.quiet {
-		out = streams.NewOut(ioutil.Discard)
+		out = streams.NewOut(io.Discard)
 	}
 	return jsonmessage.DisplayJSONMessagesToStream(responseBody, out, nil)
 }

--- a/cli/command/image/trust_test.go
+++ b/cli/command/image/trust_test.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/docker/cli/cli/trust"
@@ -51,11 +49,7 @@ func TestNonOfficialTrustServer(t *testing.T) {
 }
 
 func TestAddTargetToAllSignableRolesError(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	notaryRepo, err := client.NewFileCachedRepository(t.TempDir(), "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
 	assert.NilError(t, err)
 	target := client.Target{}
 	err = AddTargetToAllSignableRoles(notaryRepo, &target)

--- a/cli/command/manifest/annotate_test.go
+++ b/cli/command/manifest/annotate_test.go
@@ -1,9 +1,10 @@
 package manifest
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
+	"github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/cli/internal/test"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -33,14 +34,13 @@ func TestManifestAnnotateError(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newAnnotateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 func TestManifestAnnotate(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -51,7 +51,7 @@ func TestManifestAnnotate(t *testing.T) {
 
 	cmd := newAnnotateCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/fake:0.0"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	expectedError := "manifest for image example.com/fake:0.0 does not exist"
 	assert.ErrorContains(t, cmd.Execute(), expectedError)
 

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -2,9 +2,10 @@ package manifest
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
+	"github.com/docker/cli/cli/manifest/store"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/distribution/reference"
@@ -33,15 +34,14 @@ func TestManifestCreateErrors(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newCreateListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 // create a manifest list, then overwrite it, and inspect to see if the old one is still there
 func TestManifestCreateAmend(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -58,7 +58,7 @@ func TestManifestCreateAmend(t *testing.T) {
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.1"})
 	cmd.Flags().Set("amend", "true")
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	err = cmd.Execute()
 	assert.NilError(t, err)
 
@@ -75,8 +75,7 @@ func TestManifestCreateAmend(t *testing.T) {
 
 // attempt to overwrite a saved manifest and get refused
 func TestManifestCreateRefuseAmend(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -87,15 +86,14 @@ func TestManifestCreateRefuseAmend(t *testing.T) {
 
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	err = cmd.Execute()
 	assert.Error(t, err, "refusing to amend an existing manifest list with no --amend flag")
 }
 
 // attempt to make a manifest list without valid images
 func TestManifestCreateNoManifest(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -110,7 +108,7 @@ func TestManifestCreateNoManifest(t *testing.T) {
 
 	cmd := newCreateListCommand(cli)
 	cmd.SetArgs([]string{"example.com/list:v1", "example.com/alpine:3.0"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	err := cmd.Execute()
 	assert.Error(t, err, "No such image: example.com/alpine:3.0")
 }

--- a/cli/command/manifest/push_test.go
+++ b/cli/command/manifest/push_test.go
@@ -2,9 +2,10 @@ package manifest
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
+	"github.com/docker/cli/cli/manifest/store"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/distribution/reference"
@@ -42,14 +43,13 @@ func TestManifestPushErrors(t *testing.T) {
 		cli := test.NewFakeCli(nil)
 		cmd := newPushListCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 func TestManifestPush(t *testing.T) {
-	store, sCleanup := newTempManifestStore(t)
-	defer sCleanup()
+	store := store.NewStore(t.TempDir())
 
 	registry := newFakeRegistryClient()
 

--- a/cli/command/manifest/rm_test.go
+++ b/cli/command/manifest/rm_test.go
@@ -1,17 +1,17 @@
 package manifest
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
+	"github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/cli/internal/test"
 	"gotest.tools/v3/assert"
 )
 
 // create two manifest lists and remove them both
 func TestRmSeveralManifests(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -31,7 +31,7 @@ func TestRmSeveralManifests(t *testing.T) {
 
 	cmd := newRmManifestListCommand(cli)
 	cmd.SetArgs([]string{"example.com/first:1", "example.com/second:2"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	err = cmd.Execute()
 	assert.NilError(t, err)
 
@@ -43,8 +43,7 @@ func TestRmSeveralManifests(t *testing.T) {
 
 // attempt to remove a manifest list which was never created
 func TestRmManifestNotCreated(t *testing.T) {
-	store, cleanup := newTempManifestStore(t)
-	defer cleanup()
+	store := store.NewStore(t.TempDir())
 
 	cli := test.NewFakeCli(nil)
 	cli.SetManifestStore(store)
@@ -56,7 +55,7 @@ func TestRmManifestNotCreated(t *testing.T) {
 
 	cmd := newRmManifestListCommand(cli)
 	cmd.SetArgs([]string{"example.com/first:1", "example.com/second:2"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	err = cmd.Execute()
 	assert.Error(t, err, "No such manifest: example.com/first:1")
 

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -37,7 +37,7 @@ func TestNetworkConnectErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 
 	}

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -137,7 +137,7 @@ func TestNetworkCreateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			assert.NilError(t, cmd.Flags().Set(key, value))
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 
 	}

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -35,7 +35,7 @@ func TestNetworkDisconnectErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -35,7 +35,7 @@ func TestNetworkListErrors(t *testing.T) {
 				networkListFunc: tc.networkListFunc,
 			}),
 		)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -43,7 +43,7 @@ func TestNodeDemoteErrors(t *testing.T) {
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -73,7 +73,7 @@ func TestNodeInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -47,7 +47,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 			infoFunc:     tc.infoFunc,
 		})
 		cmd := newListCommand(cli)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -43,7 +43,7 @@ func TestNodePromoteErrors(t *testing.T) {
 				nodeUpdateFunc:  tc.nodeUpdateFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -3,7 +3,7 @@ package node
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func TestNodePsErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/remove_test.go
+++ b/cli/command/node/remove_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -32,7 +32,7 @@ func TestNodeRemoveErrors(t *testing.T) {
 				nodeRemoveFunc: tc.nodeRemoveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -63,7 +63,7 @@ func TestNodeUpdateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/create_test.go
+++ b/cli/command/plugin/create_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"testing"
 
@@ -41,7 +40,7 @@ func TestCreateErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := newCreateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -53,7 +52,7 @@ func TestCreateErrorOnFileAsContextDir(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpFile.Path()})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "context must be a directory")
 }
 
@@ -64,7 +63,7 @@ func TestCreateErrorOnContextDirWithoutConfig(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 
 	expectedErr := "config.json: no such file or directory"
 	if runtime.GOOS == "windows" {
@@ -82,7 +81,7 @@ func TestCreateErrorOnInvalidConfig(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "invalid")
 }
 
@@ -100,7 +99,7 @@ func TestCreateErrorFromDaemon(t *testing.T) {
 
 	cmd := newCreateCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo", tmpDir.Path()})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "Error creating plugin")
 }
 

--- a/cli/command/plugin/disable_test.go
+++ b/cli/command/plugin/disable_test.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -40,7 +40,7 @@ func TestPluginDisableErrors(t *testing.T) {
 				pluginDisableFunc: tc.pluginDisableFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/enable_test.go
+++ b/cli/command/plugin/enable_test.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -51,7 +51,7 @@ func TestPluginEnableErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/inspect_test.go
+++ b/cli/command/plugin/inspect_test.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -73,7 +73,7 @@ func TestInspectErrors(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
 	}

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -58,7 +57,7 @@ func TestInstallErrors(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{pluginInstallFunc: tc.installFunc})
 		cmd := newInstallCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -100,7 +99,7 @@ func TestInstallContentTrustErrors(t *testing.T) {
 		cli.SetNotaryClient(tc.notaryFunc)
 		cmd := newInstallCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -117,7 +116,7 @@ func TestInstall(t *testing.T) {
 			args:           []string{"foo"},
 			expectedOutput: "Installed plugin foo\n",
 			installFunc: func(name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 		{
@@ -126,7 +125,7 @@ func TestInstall(t *testing.T) {
 			expectedOutput: "Installed plugin foo\n",
 			installFunc: func(name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
 				assert.Check(t, options.Disabled)
-				return ioutil.NopCloser(strings.NewReader("")), nil
+				return io.NopCloser(strings.NewReader("")), nil
 			},
 		},
 	}

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -52,7 +52,7 @@ func TestListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/plugin/remove_test.go
+++ b/cli/command/plugin/remove_test.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -37,7 +37,7 @@ func TestRemoveErrors(t *testing.T) {
 		})
 		cmd := newRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -84,7 +84,7 @@ func verifyloginOptions(dockerCli command.Cli, opts *loginOptions) error {
 			return errors.New("Must provide --username with --password-stdin")
 		}
 
-		contents, err := ioutil.ReadAll(dockerCli.In())
+		contents, err := io.ReadAll(dockerCli.In())
 		if err != nil {
 			return err
 		}

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -101,7 +100,7 @@ func readSecretData(in io.ReadCloser, file string) ([]byte, error) {
 		}
 		defer in.Close()
 	}
-	data, err := ioutil.ReadAll(in)
+	data, err := io.ReadAll(in)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -1,7 +1,8 @@
 package secret
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -44,14 +45,14 @@ func TestSecretCreateErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 func TestSecretCreateWithName(t *testing.T) {
 	name := "foo"
-	data, err := ioutil.ReadFile(filepath.Join("testdata", secretDataFile))
+	data, err := os.ReadFile(filepath.Join("testdata", secretDataFile))
 	assert.NilError(t, err)
 
 	expected := swarm.SecretSpec{

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func TestSecretInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -1,7 +1,7 @@
 package secret
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -40,7 +40,7 @@ func TestSecretListErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -1,7 +1,7 @@
 package secret
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestSecretRemoveErrors(t *testing.T) {
 			}),
 		)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -72,7 +72,7 @@ func TestSecretRemoveContinueAfterError(t *testing.T) {
 	})
 
 	cmd := newSecretRemoveCommand(cli)
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs(names)
 	assert.Error(t, cmd.Execute(), "error removing secret: foo")
 	assert.Check(t, is.DeepEqual(names, removedSecrets))

--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"io"
-	"io/ioutil"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service/progress"
@@ -21,7 +20,7 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string,
 	}()
 
 	if quiet {
-		go io.Copy(ioutil.Discard, pipeReader)
+		go io.Copy(io.Discard, pipeReader)
 		return <-errChan
 	}
 

--- a/cli/command/service/rollback_test.go
+++ b/cli/command/service/rollback_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -49,7 +49,7 @@ func TestRollback(t *testing.T) {
 		cmd := newRollbackCommand(cli)
 		cmd.SetArgs(tc.args)
 		cmd.Flags().Set("quiet", "true")
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.NilError(t, cmd.Execute())
 		assert.Check(t, is.Equal(strings.TrimSpace(cli.ErrBuffer().String()), tc.expectedDockerCliErr))
 	}
@@ -98,7 +98,7 @@ func TestRollbackWithErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		cmd.Flags().Set("quiet", "true")
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/stack/deploy_test.go
+++ b/cli/command/stack/deploy_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -11,7 +11,7 @@ import (
 func TestDeployWithEmptyName(t *testing.T) {
 	cmd := newDeployCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetArgs([]string{"'   '"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -49,7 +49,7 @@ func TestListErrors(t *testing.T) {
 			serviceListFunc: tc.serviceListFunc,
 		}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -3,7 +3,6 @@ package loader
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -132,9 +131,9 @@ func loadConfigFile(filename string, stdin io.Reader) (*composetypes.ConfigFile,
 	var err error
 
 	if filename == "-" {
-		bytes, err = ioutil.ReadAll(stdin)
+		bytes, err = io.ReadAll(stdin)
 	} else {
-		bytes, err = ioutil.ReadFile(filename)
+		bytes, err = os.ReadFile(filename)
 	}
 	if err != nil {
 		return nil, err

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -45,7 +45,7 @@ func TestStackPsErrors(t *testing.T) {
 			taskListFunc: tc.taskListFunc,
 		}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -169,7 +169,7 @@ func TestStackPs(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 
 			if tc.expectedErr != "" {
 				assert.Error(t, cmd.Execute(), tc.expectedErr)

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -2,7 +2,7 @@ package stack
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -44,7 +44,7 @@ func fakeClientForRemoveStackTest(version string) *fakeClient {
 func TestRemoveWithEmptyName(t *testing.T) {
 	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetArgs([]string{"good", "'   '", "alsogood"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }
@@ -155,7 +155,7 @@ func TestRemoveContinueAfterError(t *testing.T) {
 		},
 	}
 	cmd := newRemoveCommand(test.NewFakeCli(cli))
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.Error(t, cmd.Execute(), "Failed to remove some resources from stack: foo")

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -79,7 +79,7 @@ func TestStackServicesErrors(t *testing.T) {
 			for key, value := range tc.flags {
 				cmd.Flags().Set(key, value)
 			}
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 		})
 	}
@@ -88,7 +88,7 @@ func TestStackServicesErrors(t *testing.T) {
 func TestRunServicesWithEmptyName(t *testing.T) {
 	cmd := newServicesCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetArgs([]string{"'   '"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 
 	assert.ErrorContains(t, cmd.Execute(), `invalid stack name: "'   '"`)
 }

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -113,7 +112,7 @@ func attach(ctx context.Context, dockerCli command.Cli, opts caOptions) error {
 	}()
 
 	if opts.quiet {
-		go io.Copy(ioutil.Discard, pipeReader)
+		go io.Copy(io.Discard, pipeReader)
 		return <-errChan
 	}
 

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -2,7 +2,7 @@ package swarm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -73,7 +73,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -54,7 +54,7 @@ func TestSwarmJoinErrors(t *testing.T) {
 				infoFunc:      tc.infoFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -2,7 +2,7 @@ package swarm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -98,7 +98,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 				swarmLeaveFunc: tc.swarmLeaveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -4,7 +4,7 @@ import (
 	"encoding/csv"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -140,7 +140,7 @@ func (p *PEMFile) String() string {
 
 // Set parses a root rotation option
 func (p *PEMFile) Set(value string) error {
-	contents, err := ioutil.ReadFile(value)
+	contents, err := os.ReadFile(value)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 			hasURL = true
 			externalCA.URL = value
 		case "cacert":
-			cacontents, err := ioutil.ReadFile(value)
+			cacontents, err := os.ReadFile(value)
 			if err != nil {
 				return nil, errors.Wrap(err, "unable to read CA cert for external CA")
 			}

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -2,7 +2,7 @@ package swarm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -90,7 +90,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -70,7 +70,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 				swarmUnlockFunc: tc.swarmUnlockFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -92,7 +92,7 @@ func TestSwarmUnlock(t *testing.T) {
 			return nil
 		},
 	})
-	dockerCli.SetIn(streams.NewIn(ioutil.NopCloser(strings.NewReader(input))))
+	dockerCli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
 	cmd := newUnlockCommand(dockerCli)
 	assert.NilError(t, cmd.Execute())
 }

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -2,7 +2,7 @@ package swarm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -75,7 +75,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"text/template"
@@ -100,7 +99,7 @@ func makeTemplate(format string) (*template.Template, error) {
 	}
 	// we execute the template for an empty message, so as to validate
 	// a bad template like "{{.badFieldString}}"
-	return tmpl, tmpl.Execute(ioutil.Discard, &eventtypes.Message{})
+	return tmpl, tmpl.Execute(io.Discard, &eventtypes.Message{})
 }
 
 // rfc3339NanoFixed is similar to time.RFC3339Nano, except it pads nanoseconds

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"sort"
 	"strings"
@@ -121,7 +120,7 @@ func needsServerInfo(template string, info info) bool {
 	}
 
 	// This constructs an "info" object that only has the client-side fields.
-	err = tmpl.Execute(ioutil.Discard, sparseInfo{
+	err = tmpl.Execute(io.Discard, sparseInfo{
 		ClientInfo:   info.ClientInfo,
 		ClientErrors: info.ClientErrors,
 	})

--- a/cli/command/trust/helpers_test.go
+++ b/cli/command/trust/helpers_test.go
@@ -1,8 +1,6 @@
 package trust
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/theupdateframework/notary/client"
@@ -12,11 +10,7 @@ import (
 )
 
 func TestGetOrGenerateNotaryKeyAndInitRepo(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
+	notaryRepo, err := client.NewFileCachedRepository(t.TempDir(), "gun", "https://localhost", nil, passphrase.ConstantRetriever(passwd), trustpinning.TrustPinConfig{})
 	assert.NilError(t, err)
 
 	err = getOrGenerateRootKeyAndInitRepo(notaryRepo)

--- a/cli/command/trust/inspect_pretty_test.go
+++ b/cli/command/trust/inspect_pretty_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/docker/cli/cli/trust"
@@ -65,7 +64,7 @@ func TestTrustInspectPrettyCommandErrors(t *testing.T) {
 		cmd := newInspectCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.Flags().Set("pretty", "true")
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -77,7 +76,7 @@ func TestTrustInspectPrettyCommandOfflineErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"nonexistent-reg-name.io/image"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access nonexistent-reg-name.io/image")
 
 	cli = test.NewFakeCli(&fakeClient{})
@@ -85,7 +84,7 @@ func TestTrustInspectPrettyCommandOfflineErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"nonexistent-reg-name.io/image:tag"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access nonexistent-reg-name.io/image")
 }
 
@@ -95,7 +94,7 @@ func TestTrustInspectPrettyCommandUninitializedErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/unsigned-img"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access reg/unsigned-img")
 
 	cli = test.NewFakeCli(&fakeClient{})
@@ -103,7 +102,7 @@ func TestTrustInspectPrettyCommandUninitializedErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/unsigned-img:tag"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.ErrorContains(t, cmd.Execute(), "No signatures or cannot access reg/unsigned-img:tag")
 }
 
@@ -113,7 +112,7 @@ func TestTrustInspectPrettyCommandEmptyNotaryRepoErrors(t *testing.T) {
 	cmd := newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/img:unsigned-tag"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "No signatures for reg/img:unsigned-tag"))
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "Administrative keys for reg/img"))
@@ -123,7 +122,7 @@ func TestTrustInspectPrettyCommandEmptyNotaryRepoErrors(t *testing.T) {
 	cmd = newInspectCommand(cli)
 	cmd.Flags().Set("pretty", "true")
 	cmd.SetArgs([]string{"reg/img"})
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "No signatures for reg/img"))
 	assert.Check(t, is.Contains(cli.OutBuffer().String(), "Administrative keys for reg/img"))

--- a/cli/command/trust/inspect_test.go
+++ b/cli/command/trust/inspect_test.go
@@ -1,7 +1,7 @@
 package trust
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/trust"
@@ -38,7 +38,7 @@ func TestTrustInspectCommandErrors(t *testing.T) {
 			test.NewFakeCli(&fakeClient{}))
 		cmd.Flags().Set("pretty", "true")
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -85,7 +85,7 @@ func TestTrustInspectCommandRepositoryErrors(t *testing.T) {
 			cli.SetNotaryClient(tc.notaryRepository)
 			cmd := newInspectCommand(cli)
 			cmd.SetArgs(tc.args)
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			assert.ErrorContains(t, cmd.Execute(), tc.err)
 			if tc.golden != "" {
 				golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -3,7 +3,6 @@ package trust
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -126,7 +125,7 @@ func writePubKeyPEMToDir(pubPEM pem.Block, keyName, workingDir string) (string, 
 	// Output the public key to a file in the CWD or specified dir
 	pubFileName := strings.Join([]string{keyName, "pub"}, ".")
 	pubFilePath := filepath.Join(workingDir, pubFileName)
-	if err := ioutil.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms); err != nil {
+	if err := os.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms); err != nil {
 		return "", errors.Wrapf(err, "failed to write public key to %s", pubFilePath)
 	}
 	return pubFilePath, nil

--- a/cli/command/trust/key_generate_test.go
+++ b/cli/command/trust/key_generate_test.go
@@ -3,7 +3,7 @@ package trust
 import (
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,28 +35,20 @@ func TestTrustKeyGenerateErrors(t *testing.T) {
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "docker-key-generate-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-	config.SetDir(tmpDir)
+	config.SetDir(t.TempDir())
 
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})
 		cmd := newKeyGenerateCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 func TestGenerateKeySuccess(t *testing.T) {
-	pubKeyCWD, err := ioutil.TempDir("", "pub-keys-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(pubKeyCWD)
-
-	privKeyStorageDir, err := ioutil.TempDir("", "priv-keys-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(privKeyStorageDir)
+	pubKeyCWD := t.TempDir()
+	privKeyStorageDir := t.TempDir()
 
 	passwd := "password"
 	cannedPasswordRetriever := passphrase.ConstantRetriever(passwd)
@@ -79,7 +71,7 @@ func TestGenerateKeySuccess(t *testing.T) {
 	_, err = os.Stat(expectedPrivKeyDir)
 	assert.NilError(t, err)
 
-	keyFiles, err := ioutil.ReadDir(expectedPrivKeyDir)
+	keyFiles, err := os.ReadDir(expectedPrivKeyDir)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(keyFiles, 1))
 	privKeyFilePath := filepath.Join(expectedPrivKeyDir, keyFiles[0].Name())
@@ -87,7 +79,7 @@ func TestGenerateKeySuccess(t *testing.T) {
 	// verify the key content
 	privFrom, _ := os.OpenFile(privKeyFilePath, os.O_RDONLY, notary.PrivExecPerms)
 	defer privFrom.Close()
-	fromBytes, _ := ioutil.ReadAll(privFrom)
+	fromBytes, _ := io.ReadAll(privFrom)
 	privKeyPEM, _ := pem.Decode(fromBytes)
 	assert.Check(t, is.Equal(keyName, privKeyPEM.Headers["role"]))
 	// the default GUN is empty
@@ -106,17 +98,15 @@ func TestGenerateKeySuccess(t *testing.T) {
 	_, err = os.Stat(expectedPubKeyPath)
 	assert.NilError(t, err)
 	// check that the public key is the only file output in CWD
-	cwdKeyFiles, err := ioutil.ReadDir(pubKeyCWD)
+	cwdKeyFiles, err := os.ReadDir(pubKeyCWD)
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(cwdKeyFiles, 1))
 }
 
 func TestValidateKeyArgs(t *testing.T) {
-	pubKeyCWD, err := ioutil.TempDir("", "pub-keys-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(pubKeyCWD)
+	pubKeyCWD := t.TempDir()
 
-	err = validateKeyArgs("a", pubKeyCWD)
+	err := validateKeyArgs("a", pubKeyCWD)
 	assert.NilError(t, err)
 
 	err = validateKeyArgs("a/b", pubKeyCWD)
@@ -125,7 +115,7 @@ func TestValidateKeyArgs(t *testing.T) {
 	err = validateKeyArgs("-", pubKeyCWD)
 	assert.Error(t, err, "key name \"-\" must start with lowercase alphanumeric characters and can include \"-\" or \"_\" after the first character")
 
-	assert.NilError(t, ioutil.WriteFile(filepath.Join(pubKeyCWD, "a.pub"), []byte("abc"), notary.PrivExecPerms))
+	assert.NilError(t, os.WriteFile(filepath.Join(pubKeyCWD, "a.pub"), []byte("abc"), notary.PrivExecPerms))
 	err = validateKeyArgs("a", pubKeyCWD)
 	assert.Error(t, err, fmt.Sprintf("public key file already exists: \"%s\"", filepath.Join(pubKeyCWD, "a.pub")))
 

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 
@@ -86,7 +86,7 @@ func getPrivKeyBytesFromPath(keyPath string) ([]byte, error) {
 	}
 	defer from.Close()
 
-	return ioutil.ReadAll(from)
+	return io.ReadAll(from)
 }
 
 func loadPrivKeyBytesToStore(privKeyBytes []byte, privKeyImporters []trustmanager.Importer, keyPath, keyName string, passRet notary.PassRetriever) error {

--- a/cli/command/trust/revoke_test.go
+++ b/cli/command/trust/revoke_test.go
@@ -1,8 +1,7 @@
 package trust
 
 import (
-	"io/ioutil"
-	"os"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/trust"
@@ -50,7 +49,7 @@ func TestTrustRevokeCommandErrors(t *testing.T) {
 		cmd := newRevokeCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -131,7 +130,7 @@ func TestTrustRevokeCommand(t *testing.T) {
 			cli.SetNotaryClient(tc.notaryRepository)
 			cmd := newRevokeCommand(cli)
 			cmd.SetArgs(tc.args)
-			cmd.SetOut(ioutil.Discard)
+			cmd.SetOut(io.Discard)
 			if tc.expectedErr != "" {
 				assert.ErrorContains(t, cmd.Execute(), tc.expectedErr)
 				return
@@ -144,11 +143,7 @@ func TestTrustRevokeCommand(t *testing.T) {
 }
 
 func TestGetSignableRolesForTargetAndRemoveError(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	notaryRepo, err := client.NewFileCachedRepository(t.TempDir(), "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
 	assert.NilError(t, err)
 	target := client.Target{}
 	err = getSignableRolesForTargetAndRemove(target, notaryRepo)

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -125,7 +124,7 @@ func ingestPublicKeys(pubKeyPaths []string) ([]data.PublicKey, error) {
 		defer pubKeyFile.Close()
 		// limit to
 		l := io.LimitReader(pubKeyFile, 1<<20)
-		pubKeyBytes, err := ioutil.ReadAll(l)
+		pubKeyBytes, err := io.ReadAll(l)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read public key from file")
 		}

--- a/cli/command/trust/signer_add_test.go
+++ b/cli/command/trust/signer_add_test.go
@@ -2,7 +2,7 @@ package trust
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,29 +52,24 @@ func TestTrustSignerAddErrors(t *testing.T) {
 			expectedError: "signer name \"_alice\" must start with lowercase alphanumeric characters and can include \"-\" or \"_\" after the first character",
 		},
 	}
-	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-	config.SetDir(tmpDir)
+	config.SetDir(t.TempDir())
 
 	for _, tc := range testCases {
 		cli := test.NewFakeCli(&fakeClient{})
 		cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)
 		cmd := newSignerAddCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
 
 func TestSignerAddCommandNoTargetsKey(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-	config.SetDir(tmpDir)
+	config.SetDir(t.TempDir())
 
-	tmpfile, err := ioutil.TempFile("", "pemfile")
+	tmpfile, err := os.CreateTemp("", "pemfile")
 	assert.NilError(t, err)
+	tmpfile.Close()
 	defer os.Remove(tmpfile.Name())
 
 	cli := test.NewFakeCli(&fakeClient{})
@@ -82,22 +77,19 @@ func TestSignerAddCommandNoTargetsKey(t *testing.T) {
 	cmd := newSignerAddCommand(cli)
 	cmd.SetArgs([]string{"--key", tmpfile.Name(), "alice", "alpine", "linuxkit/alpine"})
 
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.Error(t, cmd.Execute(), fmt.Sprintf("could not parse public key from file: %s: no valid public key found", tmpfile.Name()))
 }
 
 func TestSignerAddCommandBadKeyPath(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-	config.SetDir(tmpDir)
+	config.SetDir(t.TempDir())
 
 	cli := test.NewFakeCli(&fakeClient{})
 	cli.SetNotaryClient(notaryfake.GetEmptyTargetsNotaryRepository)
 	cmd := newSignerAddCommand(cli)
 	cmd.SetArgs([]string{"--key", "/path/to/key.pem", "alice", "alpine"})
 
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	expectedError := "unable to read public key from file: open /path/to/key.pem: no such file or directory"
 	if runtime.GOOS == "windows" {
 		expectedError = "unable to read public key from file: open /path/to/key.pem: The system cannot find the path specified."
@@ -106,16 +98,11 @@ func TestSignerAddCommandBadKeyPath(t *testing.T) {
 }
 
 func TestSignerAddCommandInvalidRepoName(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "docker-sign-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-	config.SetDir(tmpDir)
+	config.SetDir(t.TempDir())
 
-	pubKeyDir, err := ioutil.TempDir("", "key-load-test-pubkey-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(pubKeyDir)
+	pubKeyDir := t.TempDir()
 	pubKeyFilepath := filepath.Join(pubKeyDir, "pubkey.pem")
-	assert.NilError(t, ioutil.WriteFile(pubKeyFilepath, pubKeyFixture, notary.PrivNoExecPerms))
+	assert.NilError(t, os.WriteFile(pubKeyFilepath, pubKeyFixture, notary.PrivNoExecPerms))
 
 	cli := test.NewFakeCli(&fakeClient{})
 	cli.SetNotaryClient(notaryfake.GetUninitializedNotaryRepository)
@@ -123,7 +110,7 @@ func TestSignerAddCommandInvalidRepoName(t *testing.T) {
 	imageName := "870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd"
 	cmd.SetArgs([]string{"--key", pubKeyFilepath, "alice", imageName})
 
-	cmd.SetOut(ioutil.Discard)
+	cmd.SetOut(io.Discard)
 	assert.Error(t, cmd.Execute(), "Failed to add signer to: 870d292919d01a0af7e7f056271dc78792c05f55f49b9b9012b6d89725bd9abd")
 	expectedErr := fmt.Sprintf("invalid repository name (%s), cannot specify 64-byte hexadecimal strings\n\n", imageName)
 
@@ -139,8 +126,9 @@ func TestIngestPublicKeys(t *testing.T) {
 	}
 	assert.Error(t, err, expectedError)
 	// Call with real file path
-	tmpfile, err := ioutil.TempFile("", "pemfile")
+	tmpfile, err := os.CreateTemp("", "pemfile")
 	assert.NilError(t, err)
+	tmpfile.Close()
 	defer os.Remove(tmpfile.Name())
 	_, err = ingestPublicKeys([]string{tmpfile.Name()})
 	assert.Error(t, err, fmt.Sprintf("could not parse public key from file: %s: no valid public key found", tmpfile.Name()))

--- a/cli/command/trust/signer_remove_test.go
+++ b/cli/command/trust/signer_remove_test.go
@@ -1,7 +1,7 @@
 package trust
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -32,7 +32,7 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		cmd := newSignerRemoveCommand(
 			test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 	testCasesWithOutput := []struct {
@@ -61,7 +61,7 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)
 		cmd := newSignerRemoveCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		cmd.Execute()
 		assert.Check(t, is.Contains(cli.ErrBuffer().String(), tc.expectedError))
 	}

--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,15 +36,13 @@ func TestStringSliceReplaceAt(t *testing.T) {
 }
 
 func TestValidateOutputPath(t *testing.T) {
-	basedir, err := ioutil.TempDir("", "TestValidateOutputPath")
-	assert.NilError(t, err)
-	defer os.RemoveAll(basedir)
+	basedir := t.TempDir()
 	dir := filepath.Join(basedir, "dir")
 	notexist := filepath.Join(basedir, "notexist")
-	err = os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0755)
 	assert.NilError(t, err)
 	file := filepath.Join(dir, "file")
-	err = ioutil.WriteFile(file, []byte("hi"), 0644)
+	err = os.WriteFile(file, []byte("hi"), 0644)
 	assert.NilError(t, err)
 	var testcases = []struct {
 		path string

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -1,7 +1,7 @@
 package volume
 
 import (
-	"io/ioutil"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -49,7 +49,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -2,7 +2,7 @@ package volume
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -60,7 +60,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -1,7 +1,7 @@
 package volume
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -43,7 +43,7 @@ func TestVolumeListErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -2,7 +2,7 @@ package volume
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"runtime"
 	"strings"
 	"testing"
@@ -48,7 +48,7 @@ func TestVolumePruneErrors(t *testing.T) {
 		for key, value := range tc.flags {
 			cmd.Flags().Set(key, value)
 		}
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }
@@ -86,7 +86,7 @@ func TestVolumePrunePromptYes(t *testing.T) {
 			volumePruneFunc: simplePruneFunc,
 		})
 
-		cli.SetIn(streams.NewIn(ioutil.NopCloser(strings.NewReader(input))))
+		cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
 		cmd := NewPruneCommand(cli)
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "volume-prune-yes.golden")
@@ -102,7 +102,7 @@ func TestVolumePrunePromptNo(t *testing.T) {
 			volumePruneFunc: simplePruneFunc,
 		})
 
-		cli.SetIn(streams.NewIn(ioutil.NopCloser(strings.NewReader(input))))
+		cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
 		cmd := NewPruneCommand(cli)
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "volume-prune-no.golden")

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -1,7 +1,7 @@
 package volume
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
@@ -32,7 +32,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 				volumeRemoveFunc: tc.volumeRemoveFunc,
 			}))
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -1,7 +1,7 @@
 package convert
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	composetypes "github.com/docker/cli/cli/compose/types"
@@ -178,7 +178,7 @@ func driverObjectConfig(namespace Namespace, name string, obj composetypes.FileO
 }
 
 func fileObjectConfig(namespace Namespace, name string, obj composetypes.FileObjectConfig) (swarmFileObject, error) {
-	data, err := ioutil.ReadFile(obj.File)
+	data, err := os.ReadFile(obj.File)
 	if err != nil {
 		return swarmFileObject{}, err
 	}

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -2,7 +2,6 @@ package loader
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -946,7 +945,7 @@ func uint32Ptr(value uint32) *uint32 {
 }
 
 func TestFullExample(t *testing.T) {
-	bytes, err := ioutil.ReadFile("full-example.yml")
+	bytes, err := os.ReadFile("full-example.yml")
 	assert.NilError(t, err)
 
 	homeDir := "/home/foo"

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +74,7 @@ func New(fn string) *ConfigFile {
 // LegacyLoadFromReader reads the non-nested configuration data given and sets up the
 // auth config information with given directory and populates the receiver object
 func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
-	b, err := ioutil.ReadAll(configData)
+	b, err := io.ReadAll(configData)
 	if err != nil {
 		return err
 	}
@@ -188,7 +187,7 @@ func (configFile *ConfigFile) Save() (retErr error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
-	temp, err := ioutil.TempFile(dir, filepath.Base(configFile.Filename))
+	temp, err := os.CreateTemp(dir, filepath.Base(configFile.Filename))
 	if err != nil {
 		return err
 	}

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -3,7 +3,6 @@ package configfile
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -443,7 +442,7 @@ func TestSave(t *testing.T) {
 	defer os.Remove("test-save")
 	err := configFile.Save()
 	assert.NilError(t, err)
-	cfg, err := ioutil.ReadFile("test-save")
+	cfg, err := os.ReadFile("test-save")
 	assert.NilError(t, err)
 	assert.Equal(t, string(cfg), `{
 	"auths": {}
@@ -458,7 +457,7 @@ func TestSaveCustomHTTPHeaders(t *testing.T) {
 	configFile.HTTPHeaders["user-agent"] = "user-agent 2"
 	err := configFile.Save()
 	assert.NilError(t, err)
-	cfg, err := ioutil.ReadFile(t.Name())
+	cfg, err := os.ReadFile(t.Name())
 	assert.NilError(t, err)
 	assert.Equal(t, string(cfg), `{
 	"auths": {},
@@ -486,11 +485,11 @@ func TestSaveWithSymlink(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "expected %s to be a symlink", symLink)
 
-	cfg, err := ioutil.ReadFile(symLink)
+	cfg, err := os.ReadFile(symLink)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
 
-	cfg, err = ioutil.ReadFile(realFile)
+	cfg, err = os.ReadFile(realFile)
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
 }
@@ -509,7 +508,7 @@ func TestPluginConfig(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Read it back and check it has the expected content
-	cfg, err := ioutil.ReadFile("test-plugin")
+	cfg, err := os.ReadFile("test-plugin")
 	assert.NilError(t, err)
 	golden.Assert(t, string(cfg), "plugin-config.golden")
 
@@ -520,7 +519,7 @@ func TestPluginConfig(t *testing.T) {
 	assert.NilError(t, configFile.LoadFromReader(bytes.NewReader(cfg)))
 	err = configFile.Save()
 	assert.NilError(t, err)
-	cfg, err = ioutil.ReadFile("test-plugin2")
+	cfg, err = os.ReadFile("test-plugin2")
 	assert.NilError(t, err)
 	golden.Assert(t, string(cfg), "plugin-config.golden")
 
@@ -555,7 +554,7 @@ func TestPluginConfig(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Read it back and check it has the expected content again
-	cfg, err = ioutil.ReadFile("test-plugin2")
+	cfg, err = os.ReadFile("test-plugin2")
 	assert.NilError(t, err)
 	golden.Assert(t, string(cfg), "plugin-config-2.golden")
 }

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -36,7 +35,7 @@ type mockCommand struct {
 // Output returns responses from the remote credentials helper.
 // It mocks those responses based in the input in the mock.
 func (m *mockCommand) Output() ([]byte, error) {
-	in, err := ioutil.ReadAll(m.input)
+	in, err := io.ReadAll(m.input)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/context/store/io_utils_test.go
+++ b/cli/context/store/io_utils_test.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -11,14 +11,14 @@ import (
 func TestLimitReaderReadAll(t *testing.T) {
 	r := strings.NewReader("Reader")
 
-	_, err := ioutil.ReadAll(r)
+	_, err := io.ReadAll(r)
 	assert.NilError(t, err)
 
 	r = strings.NewReader("Test")
-	_, err = ioutil.ReadAll(&LimitedReader{R: r, N: 4})
+	_, err = io.ReadAll(&LimitedReader{R: r, N: 4})
 	assert.NilError(t, err)
 
 	r = strings.NewReader("Test")
-	_, err = ioutil.ReadAll(&LimitedReader{R: r, N: 2})
+	_, err = io.ReadAll(&LimitedReader{R: r, N: 2})
 	assert.Error(t, err, "read exceeds the defined limit")
 }

--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -35,7 +34,7 @@ func (s *metadataStore) createOrUpdate(meta Metadata) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0644)
+	return os.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0644)
 }
 
 func parseTypedOrMap(payload []byte, getter TypeGetter) (interface{}, error) {
@@ -58,7 +57,7 @@ func parseTypedOrMap(payload []byte, getter TypeGetter) (interface{}, error) {
 
 func (s *metadataStore) get(id contextdir) (Metadata, error) {
 	contextDir := s.contextDir(id)
-	bytes, err := ioutil.ReadFile(filepath.Join(contextDir, metaFile))
+	bytes, err := os.ReadFile(filepath.Join(contextDir, metaFile))
 	if err != nil {
 		return Metadata{}, convertContextDoesNotExist(err)
 	}
@@ -117,7 +116,7 @@ func isContextDir(path string) bool {
 }
 
 func listRecursivelyMetadataDirs(root string) ([]string, error) {
-	fis, err := ioutil.ReadDir(root)
+	fis, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -349,7 +348,7 @@ func importTar(name string, s Writer, reader io.Reader) error {
 			return errors.Wrap(err, hdr.Name)
 		}
 		if hdr.Name == metaFile {
-			data, err := ioutil.ReadAll(tr)
+			data, err := io.ReadAll(tr)
 			if err != nil {
 				return err
 			}
@@ -362,7 +361,7 @@ func importTar(name string, s Writer, reader io.Reader) error {
 			}
 			importedMetaFile = true
 		} else if strings.HasPrefix(hdr.Name, "tls/") {
-			data, err := ioutil.ReadAll(tr)
+			data, err := io.ReadAll(tr)
 			if err != nil {
 				return err
 			}
@@ -378,7 +377,7 @@ func importTar(name string, s Writer, reader io.Reader) error {
 }
 
 func importZip(name string, s Writer, reader io.Reader) error {
-	body, err := ioutil.ReadAll(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
+	body, err := io.ReadAll(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
 	if err != nil {
 		return err
 	}
@@ -406,7 +405,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 				return err
 			}
 
-			data, err := ioutil.ReadAll(&LimitedReader{R: f, N: maxAllowedFileSizeToImport})
+			data, err := io.ReadAll(&LimitedReader{R: f, N: maxAllowedFileSizeToImport})
 			defer f.Close()
 			if err != nil {
 				return err
@@ -424,7 +423,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 			if err != nil {
 				return err
 			}
-			data, err := ioutil.ReadAll(f)
+			data, err := io.ReadAll(f)
 			defer f.Close()
 			if err != nil {
 				return err

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -30,11 +29,8 @@ var testCfg = NewConfig(func() interface{} { return &context{} },
 )
 
 func TestExportImport(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	s := New(testDir, testCfg)
-	err = s.CreateOrUpdate(
+	s := New(t.TempDir(), testCfg)
+	err := s.CreateOrUpdate(
 		Metadata{
 			Endpoints: map[string]interface{}{
 				"ep1": endpoint{Foo: "bar"},
@@ -87,11 +83,8 @@ func TestExportImport(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	s := New(testDir, testCfg)
-	err = s.CreateOrUpdate(
+	s := New(t.TempDir(), testCfg)
+	err := s.CreateOrUpdate(
 		Metadata{
 			Endpoints: map[string]interface{}{
 				"ep1": endpoint{Foo: "bar"},
@@ -114,30 +107,18 @@ func TestRemove(t *testing.T) {
 }
 
 func TestListEmptyStore(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	store := New(testDir, testCfg)
-	result, err := store.List()
+	result, err := New(t.TempDir(), testCfg).List()
 	assert.NilError(t, err)
 	assert.Check(t, len(result) == 0)
 }
 
 func TestErrHasCorrectContext(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	store := New(testDir, testCfg)
-	_, err = store.GetMetadata("no-exists")
+	_, err := New(t.TempDir(), testCfg).GetMetadata("no-exists")
 	assert.ErrorContains(t, err, "no-exists")
 	assert.Check(t, IsErrContextDoesNotExist(err))
 }
 
 func TestDetectImportContentType(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-
 	buf := new(bytes.Buffer)
 	r := bufio.NewReader(buf)
 	ct, err := getImportContentType(r)
@@ -146,10 +127,7 @@ func TestDetectImportContentType(t *testing.T) {
 }
 
 func TestImportTarInvalid(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-
+	testDir := t.TempDir()
 	tf := path.Join(testDir, "test.context")
 
 	f, err := os.Create(tf)
@@ -179,10 +157,7 @@ func TestImportTarInvalid(t *testing.T) {
 }
 
 func TestImportZip(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-
+	testDir := t.TempDir()
 	zf := path.Join(testDir, "test.zip")
 
 	f, err := os.Create(zf)
@@ -230,10 +205,7 @@ func TestImportZip(t *testing.T) {
 }
 
 func TestImportZipInvalid(t *testing.T) {
-	testDir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-
+	testDir := t.TempDir()
 	zf := path.Join(testDir, "test.zip")
 
 	f, err := os.Create(zf)

--- a/cli/context/store/tlsstore.go
+++ b/cli/context/store/tlsstore.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -33,11 +32,11 @@ func (s *tlsStore) createOrUpdate(contextID contextdir, endpointName, filename s
 	if err := os.MkdirAll(epdir, 0700); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(s.filePath(contextID, endpointName, filename), data, 0600)
+	return os.WriteFile(s.filePath(contextID, endpointName, filename), data, 0600)
 }
 
 func (s *tlsStore) getData(contextID contextdir, endpointName, filename string) ([]byte, error) {
-	data, err := ioutil.ReadFile(s.filePath(contextID, endpointName, filename))
+	data, err := os.ReadFile(s.filePath(contextID, endpointName, filename))
 	if err != nil {
 		return nil, convertTLSDataDoesNotExist(endpointName, filename, err)
 	}
@@ -61,7 +60,7 @@ func (s *tlsStore) removeAllContextData(contextID contextdir) error {
 }
 
 func (s *tlsStore) listContextData(contextID contextdir) (map[string]EndpointFiles, error) {
-	epFSs, err := ioutil.ReadDir(s.contextDir(contextID))
+	epFSs, err := os.ReadDir(s.contextDir(contextID))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return map[string]EndpointFiles{}, nil
@@ -72,7 +71,7 @@ func (s *tlsStore) listContextData(contextID contextdir) (map[string]EndpointFil
 	for _, epFS := range epFSs {
 		if epFS.IsDir() {
 			epDir := s.endpointDir(contextID, epFS.Name())
-			fss, err := ioutil.ReadDir(epDir)
+			fss, err := os.ReadDir(epDir)
 			if err != nil {
 				return nil, err
 			}

--- a/cli/context/store/tlsstore_test.go
+++ b/cli/context/store/tlsstore_test.go
@@ -1,19 +1,14 @@
 package store
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"gotest.tools/v3/assert"
 )
 
 func TestTlsCreateUpdateGetRemove(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestTlsCreateUpdateGetRemove")
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	testee := tlsStore{root: testDir}
-	_, err = testee.getData("test-ctx", "test-ep", "test-data")
+	testee := tlsStore{root: t.TempDir()}
+	_, err := testee.getData("test-ctx", "test-ep", "test-data")
 	assert.Equal(t, true, IsErrTLSDataDoesNotExist(err))
 
 	err = testee.createOrUpdate("test-ctx", "test-ep", "test-data", []byte("data"))
@@ -37,10 +32,7 @@ func TestTlsCreateUpdateGetRemove(t *testing.T) {
 }
 
 func TestTlsListAndBatchRemove(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "TestTlsListAndBatchRemove")
-	assert.NilError(t, err)
-	defer os.RemoveAll(testDir)
-	testee := tlsStore{root: testDir}
+	testee := tlsStore{root: t.TempDir()}
 
 	all := map[string]EndpointFiles{
 		"ep1": {"f1", "f2", "f3"},
@@ -55,7 +47,7 @@ func TestTlsListAndBatchRemove(t *testing.T) {
 
 	for name, files := range all {
 		for _, file := range files {
-			err = testee.createOrUpdate("test-ctx", name, file, []byte("data"))
+			err := testee.createOrUpdate("test-ctx", name, file, []byte("data"))
 			assert.NilError(t, err)
 		}
 	}

--- a/cli/context/tlsdata.go
+++ b/cli/context/tlsdata.go
@@ -1,7 +1,7 @@
 package context
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/docker/cli/cli/context/store"
 	"github.com/pkg/errors"
@@ -77,17 +77,17 @@ func TLSDataFromFiles(caPath, certPath, keyPath string) (*TLSData, error) {
 		err           error
 	)
 	if caPath != "" {
-		if ca, err = ioutil.ReadFile(caPath); err != nil {
+		if ca, err = os.ReadFile(caPath); err != nil {
 			return nil, err
 		}
 	}
 	if certPath != "" {
-		if cert, err = ioutil.ReadFile(certPath); err != nil {
+		if cert, err = os.ReadFile(certPath); err != nil {
 			return nil, err
 		}
 	}
 	if keyPath != "" {
-		if key, err = ioutil.ReadFile(keyPath); err != nil {
+		if key, err = os.ReadFile(keyPath); err != nil {
 			return nil, err
 		}
 	}

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,7 +46,7 @@ func (s *fsStore) Get(listRef reference.Reference, manifest reference.Reference)
 }
 
 func (s *fsStore) getFromFilename(ref reference.Reference, filename string) (types.ImageManifest, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	switch {
 	case os.IsNotExist(err):
 		return types.ImageManifest{}, newNotFoundError(ref.String())
@@ -112,7 +111,7 @@ func (s *fsStore) GetList(listRef reference.Reference) ([]types.ImageManifest, e
 // listManifests stored in a transaction
 func (s *fsStore) listManifests(transaction string) ([]string, error) {
 	transactionDir := filepath.Join(s.root, makeFilesafeName(transaction))
-	fileInfos, err := ioutil.ReadDir(transactionDir)
+	fileInfos, err := os.ReadDir(transactionDir)
 	switch {
 	case os.IsNotExist(err):
 		return nil, nil
@@ -120,7 +119,7 @@ func (s *fsStore) listManifests(transaction string) ([]string, error) {
 		return nil, err
 	}
 
-	filenames := []string{}
+	filenames := make([]string, 0, len(fileInfos))
 	for _, info := range fileInfos {
 		filenames = append(filenames, info.Name())
 	}
@@ -137,7 +136,7 @@ func (s *fsStore) Save(listRef reference.Reference, manifest reference.Reference
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, bytes, 0644)
+	return os.WriteFile(filename, bytes, 0644)
 }
 
 func (s *fsStore) createManifestListDirectory(transaction string) error {

--- a/cli/required_test.go
+++ b/cli/required_test.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -119,7 +119,7 @@ func runTestCases(t *testing.T, testCases []testCase) {
 	for _, tc := range testCases {
 		cmd := newDummyCommand(tc.validateFunc)
 		cmd.SetArgs(tc.args)
-		cmd.SetOut(ioutil.Discard)
+		cmd.SetOut(io.Discard)
 
 		err := cmd.Execute()
 		assert.ErrorContains(t, err, tc.expectedError)

--- a/cli/trust/trust_test.go
+++ b/cli/trust/trust_test.go
@@ -1,8 +1,6 @@
 package trust
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/docker/distribution/reference"
@@ -49,11 +47,7 @@ func TestGetDigest(t *testing.T) {
 }
 
 func TestGetSignableRolesError(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "notary-test-")
-	assert.NilError(t, err)
-	defer os.RemoveAll(tmpDir)
-
-	notaryRepo, err := client.NewFileCachedRepository(tmpDir, "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
+	notaryRepo, err := client.NewFileCachedRepository(t.TempDir(), "gun", "https://localhost", nil, passphrase.ConstantRetriever("password"), trustpinning.TrustPinConfig{})
 	assert.NilError(t, err)
 	target := client.Target{}
 	_, err = GetSignableRoles(notaryRepo, &target)

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestClientDebugEnabled(t *testing.T) {
 	assert.Check(t, is.Equal(logrus.DebugLevel, logrus.GetLevel()))
 }
 
-var discard = ioutil.NopCloser(bytes.NewBuffer(nil))
+var discard = io.NopCloser(bytes.NewBuffer(nil))
 
 func runCliCommand(t *testing.T, r io.ReadCloser, w io.Writer, args ...string) error {
 	t.Helper()
@@ -38,7 +37,7 @@ func runCliCommand(t *testing.T, r io.ReadCloser, w io.Writer, args ...string) e
 		r = discard
 	}
 	if w == nil {
-		w = ioutil.Discard
+		w = io.Discard
 	}
 	cli, err := command.NewDockerCli(command.WithInputStream(r), command.WithCombinedStreams(w))
 	assert.NilError(t, err)

--- a/docs/yaml/generate.go
+++ b/docs/yaml/generate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -76,7 +75,7 @@ func loadLongDescription(parentCmd *cobra.Command, path string) error {
 		}
 		mdFile := strings.ReplaceAll(name, " ", "_") + ".md"
 		fullPath := filepath.Join(path, mdFile)
-		content, err := ioutil.ReadFile(fullPath)
+		content, err := os.ReadFile(fullPath)
 		if os.IsNotExist(err) {
 			log.Printf("WARN: %s does not exist, skipping\n", mdFile)
 			continue

--- a/e2e/context/context_test.go
+++ b/e2e/context/context_test.go
@@ -1,7 +1,6 @@
 package context
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -21,10 +20,7 @@ func TestContextList(t *testing.T) {
 }
 
 func TestContextImportNoTLS(t *testing.T) {
-	d, _ := ioutil.TempDir("", "")
-	defer func() {
-		os.RemoveAll(d)
-	}()
+	d := t.TempDir()
 	cmd := icmd.Command("docker", "context", "import", "remote", "./testdata/test-dockerconfig.tar")
 	cmd.Env = append(cmd.Env,
 		"DOCKER_CONFIG="+d,
@@ -38,10 +34,7 @@ func TestContextImportNoTLS(t *testing.T) {
 }
 
 func TestContextImportTLS(t *testing.T) {
-	d, _ := ioutil.TempDir("", "")
-	defer func() {
-		os.RemoveAll(d)
-	}()
+	d := t.TempDir()
 	cmd := icmd.Command("docker", "context", "import", "test", "./testdata/test-dockerconfig-tls.tar")
 	cmd.Env = append(cmd.Env,
 		"DOCKER_CONFIG="+d,
@@ -55,7 +48,7 @@ func TestContextImportTLS(t *testing.T) {
 	result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 	golden.Assert(t, result.Stdout(), "context-ls-tls.golden")
 
-	b, err := ioutil.ReadFile(d + "/contexts/tls/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08/kubernetes/key.pem")
+	b, err := os.ReadFile(d + "/contexts/tls/9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08/kubernetes/key.pem")
 	assert.NilError(t, err)
 	assert.Equal(t, string(b), `-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEArQk77K5sgrQYY6HiQ1y7AC+67HrRB36oEvR+Fq60RsFcc3cZ

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -2,7 +2,7 @@ package image
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -141,7 +141,7 @@ func TestBuildIidFileSquash(t *testing.T) {
 		withWorkingDir(buildDir),
 	)
 	result.Assert(t, icmd.Success)
-	id, err := ioutil.ReadFile(iidfile)
+	id, err := os.ReadFile(iidfile)
 	assert.NilError(t, err)
 	result = icmd.RunCommand("docker", "image", "inspect", "-f", "{{.Id}}", imageTag)
 	result.Assert(t, icmd.Success)

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/docker/cli/cli/command"
@@ -52,7 +51,7 @@ func NewFakeCli(client client.APIClient, opts ...func(*FakeCli)) *FakeCli {
 		out:       streams.NewOut(outBuffer),
 		outBuffer: outBuffer,
 		err:       errBuffer,
-		in:        streams.NewIn(ioutil.NopCloser(strings.NewReader(""))),
+		in:        streams.NewIn(io.NopCloser(strings.NewReader(""))),
 		// Use an empty string for filename so that tests don't create configfiles
 		// Set cli.ConfigFile().Filename to a tempfile to support Save.
 		configfile:     configfile.New(""),

--- a/man/generate.go
+++ b/man/generate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -74,7 +73,7 @@ func loadLongDescription(cmd *cobra.Command, path string) error {
 			continue
 		}
 
-		content, err := ioutil.ReadFile(fullpath)
+		content, err := os.ReadFile(fullpath)
 		if err != nil {
 			return err
 		}
@@ -85,7 +84,7 @@ func loadLongDescription(cmd *cobra.Command, path string) error {
 			continue
 		}
 
-		content, err = ioutil.ReadFile(fullpath)
+		content, err = os.ReadFile(fullpath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I had a "WIP" branch for this locally, and decided to finish the work; there's quite some uses of this package, so I split this up into commits per-package for easier reviewing.

Current versions of Go also added `t.TempDIr()` and `t.Cleanup()` for tests, so while at it, I updated tests to use those (which simplified the tests).

Finally, I updated the `golangci-lint` configuration to prevent the package from accidentally being added again.