### PR TITLE
dummy circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+# This is a dummy CircleCI config file to avoid GitHub status failures reported
+# on branches that don't use CircleCI. This file should be deleted when all
+# branches are no longer dependent on CircleCI.
+version: 2
+
+jobs:
+  dummy:
+    docker:
+      - image: busybox
+    steps:
+      - run:
+          name: "dummy"
+          command: echo "dummy job"
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - dummy


### PR DESCRIPTION
follow-up #3381 

adds a dummy CircleCI config file to avoid GitHub status failures reported on branches that don't use CircleCI. This file should be deleted when all branches are no longer dependent on CircleCI.

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>