### PR TITLE
vendor: gotest.tools/v3 v3.1.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -45,7 +45,7 @@ require (
 	golang.org/x/text v0.3.4
 	google.golang.org/grpc v1.38.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
-	gotest.tools/v3 v3.0.3
+	gotest.tools/v3 v3.1.0
 )
 
 replace (

--- a/vendor.sum
+++ b/vendor.sum
@@ -935,6 +935,7 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1046,8 +1047,9 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
+gotest.tools/v3 v3.1.0 h1:rVV8Tcg/8jHUkPUorwjaMTtemIMVXfIPKiOqnhEhakk=
+gotest.tools/v3 v3.1.0/go.mod h1:fHy7eyTmJFO5bQbUsEGQ1v4m2J3Jz9eWL54TP2/ZuYQ=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/gotest.tools/v3/assert/assert_go113.go
+++ b/vendor/gotest.tools/v3/assert/assert_go113.go
@@ -1,0 +1,20 @@
+// +build go1.13
+
+package assert
+
+import (
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/internal/assert"
+)
+
+// ErrorIs fails the test if err is nil, or the error does not match expected
+// when compared using errors.Is. See https://golang.org/pkg/errors/#Is for
+// accepted argument values.
+func ErrorIs(t TestingT, err error, expected error, msgAndArgs ...interface{}) {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+	if !assert.Eval(t, assert.ArgsAfterT, cmp.ErrorIs(err, expected), msgAndArgs...) {
+		t.FailNow()
+	}
+}

--- a/vendor/gotest.tools/v3/assert/cmp/compare_go113.go
+++ b/vendor/gotest.tools/v3/assert/cmp/compare_go113.go
@@ -1,0 +1,29 @@
+// +build go1.13
+
+package cmp
+
+import (
+	"errors"
+)
+
+// ErrorIs succeeds if errors.Is(actual, expected) returns true. See
+// https://golang.org/pkg/errors/#Is for accepted argument values.
+func ErrorIs(actual error, expected error) Comparison {
+	return func() Result {
+		if errors.Is(actual, expected) {
+			return ResultSuccess
+		}
+
+		return ResultFailureTemplate(`error is
+			{{- if not .Data.a }} nil,{{ else }}
+			{{- printf " \"%v\"" .Data.a}} (
+				{{- with callArg 0 }}{{ formatNode . }} {{end -}}
+				{{- printf "%T" .Data.a -}}
+			),
+			{{- end }} not {{ printf "\"%v\"" .Data.x}} (
+				{{- with callArg 1 }}{{ formatNode . }} {{end -}}
+				{{- printf "%T" .Data.x -}}
+			)`,
+			map[string]interface{}{"a": actual, "x": expected})
+	}
+}

--- a/vendor/gotest.tools/v3/fs/file.go
+++ b/vendor/gotest.tools/v3/fs/file.go
@@ -113,3 +113,19 @@ func (d *Dir) Remove() {
 func (d *Dir) Join(parts ...string) string {
 	return filepath.Join(append([]string{d.Path()}, parts...)...)
 }
+
+// DirFromPath returns a Dir for a path that already exists. No directory is created.
+// Unlike NewDir the directory will not be removed automatically when the test exits,
+// it is the callers responsibly to remove the directory.
+// DirFromPath can be used with Apply to modify an existing directory.
+//
+// If the path does not already exist, use NewDir instead.
+func DirFromPath(t assert.TestingT, path string, ops ...PathOp) *Dir {
+	if ht, ok := t.(helperT); ok {
+		ht.Helper()
+	}
+
+	dir := &Dir{path: path}
+	assert.NilError(t, applyPathOps(dir, ops))
+	return dir
+}

--- a/vendor/gotest.tools/v3/fs/manifest_unix.go
+++ b/vendor/gotest.tools/v3/fs/manifest_unix.go
@@ -1,16 +1,24 @@
+//go:build !windows
 // +build !windows
 
 package fs
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 )
 
-const (
-	defaultRootDirMode = os.ModeDir | 0700
-	defaultSymlinkMode = os.ModeSymlink | 0777
-)
+const defaultRootDirMode = os.ModeDir | 0700
+
+var defaultSymlinkMode = os.ModeSymlink | 0777
+
+func init() {
+	switch runtime.GOOS {
+	case "darwin":
+		defaultSymlinkMode = os.ModeSymlink | 0755
+	}
+}
 
 func newResourceFromInfo(info os.FileInfo) resource {
 	statT := info.Sys().(*syscall.Stat_t)

--- a/vendor/gotest.tools/v3/golden/golden.go
+++ b/vendor/gotest.tools/v3/golden/golden.go
@@ -175,13 +175,13 @@ func compare(actual []byte, filename string) (cmp.Result, []byte) {
 }
 
 func update(filename string, actual []byte) error {
-	if dir := filepath.Dir(filename); dir != "." {
+	if !*flagUpdate {
+		return nil
+	}
+	if dir := filepath.Dir(Path(filename)); dir != "." {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
 	}
-	if *flagUpdate {
-		return ioutil.WriteFile(Path(filename), actual, 0644)
-	}
-	return nil
+	return ioutil.WriteFile(Path(filename), actual, 0644)
 }

--- a/vendor/gotest.tools/v3/icmd/command.go
+++ b/vendor/gotest.tools/v3/icmd/command.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
 
+	exec "golang.org/x/sys/execabs"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )

--- a/vendor/gotest.tools/v3/icmd/exitcode.go
+++ b/vendor/gotest.tools/v3/icmd/exitcode.go
@@ -1,10 +1,10 @@
 package icmd
 
 import (
-	"os/exec"
 	"syscall"
 
 	"github.com/pkg/errors"
+	exec "golang.org/x/sys/execabs"
 )
 
 // getExitCode returns the ExitStatus of a process from the error returned by

--- a/vendor/gotest.tools/v3/poll/check.go
+++ b/vendor/gotest.tools/v3/poll/check.go
@@ -11,16 +11,20 @@ type Check func(t LogT) Result
 // FileExists looks on filesystem and check that path exists.
 func FileExists(path string) Check {
 	return func(t LogT) Result {
-		_, err := os.Stat(path)
-		if os.IsNotExist(err) {
-			t.Logf("waiting on file %s to exist", path)
-			return Continue("file %s does not exist", path)
-		}
-		if err != nil {
-			return Error(err)
+		if h, ok := t.(helperT); ok {
+			h.Helper()
 		}
 
-		return Success()
+		_, err := os.Stat(path)
+		switch {
+		case os.IsNotExist(err):
+			t.Logf("waiting on file %s to exist", path)
+			return Continue("file %s does not exist", path)
+		case err != nil:
+			return Error(err)
+		default:
+			return Success()
+		}
 	}
 }
 
@@ -29,6 +33,10 @@ func FileExists(path string) Check {
 // address parameters.
 func Connection(network, address string) Check {
 	return func(t LogT) Result {
+		if h, ok := t.(helperT); ok {
+			h.Helper()
+		}
+
 		_, err := net.Dial(network, address)
 		if err != nil {
 			t.Logf("waiting on socket %s://%s to be available...", network, address)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -345,7 +345,7 @@ google.golang.org/protobuf/types/known/timestamppb
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit
 gopkg.in/yaml.v2
-# gotest.tools/v3 v3.0.3
+# gotest.tools/v3 v3.1.0
 ## explicit
 gotest.tools/v3/assert
 gotest.tools/v3/assert/cmp


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/3452 (I'll rebase once that's merged)

full diff: https://github.com/gotestyourself/gotest.tools/compare/v3.0.3...v3.1.0

noteworthy changes:

- ci: add go1.16
- ci: add go1.17, remove go1.13
- golden: only create dir if update flag is set
- icmd: replace all usages of os/exec with golang.org/x/sys/execabs
- assert: ErrorIs
- fs: add DirFromPath
- Stop creating directory outside of testdata
- fs: Fix comparing symlink permissions