### PR TITLE
remove duplicate imports, update or remove aliases on imports

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -7,7 +7,7 @@ import (
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/moby/term"
 	"github.com/morikuni/aec"
@@ -22,7 +22,7 @@ func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *p
 	opts := cliflags.NewClientOptions()
 	flags := rootCmd.Flags()
 
-	flags.StringVar(&opts.ConfigDir, "config", cliconfig.Dir(), "Location of client config files")
+	flags.StringVar(&opts.ConfigDir, "config", config.Dir(), "Location of client config files")
 	opts.Common.InstallFlags(flags)
 
 	cobra.AddTemplateFunc("add", func(a, b int) int { return a + b })

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/config"
-	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	dcontext "github.com/docker/cli/cli/context"
 	"github.com/docker/cli/cli/context/docker"
@@ -129,7 +128,7 @@ func (cli *DockerCli) ConfigFile() *configfile.ConfigFile {
 }
 
 func (cli *DockerCli) loadConfigFile() {
-	cli.configFile = cliconfig.LoadDefaultConfigFile(cli.err)
+	cli.configFile = config.LoadDefaultConfigFile(cli.err)
 }
 
 // ServerInfo returns the server version details for the host this client is
@@ -228,7 +227,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 	cliflags.SetLogLevel(opts.Common.LogLevel)
 
 	if opts.ConfigDir != "" {
-		cliconfig.SetDir(opts.ConfigDir)
+		config.SetDir(opts.ConfigDir)
 	}
 
 	if opts.Common.Debug {
@@ -237,7 +236,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 
 	cli.loadConfigFile()
 
-	baseContextStore := store.New(cliconfig.ContextStoreDir(), cli.contextStoreConfig)
+	baseContextStore := store.New(config.ContextStoreDir(), cli.contextStoreConfig)
 	cli.contextStore = &ContextStoreWithDefault{
 		Store: baseContextStore,
 		Resolver: func() (*DefaultContext, error) {
@@ -272,7 +271,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 func NewAPIClientFromFlags(opts *cliflags.CommonOptions, configFile *configfile.ConfigFile) (client.APIClient, error) {
 	storeConfig := DefaultContextStoreConfig()
 	contextStore := &ContextStoreWithDefault{
-		Store: store.New(cliconfig.ContextStoreDir(), storeConfig),
+		Store: store.New(config.ContextStoreDir(), storeConfig),
 		Resolver: func() (*DefaultContext, error) {
 			return ResolveDefaultContext(opts, configFile, storeConfig, io.Discard)
 		},

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api"
@@ -199,7 +199,7 @@ func TestExperimentalCLI(t *testing.T) {
 			}
 
 			cli := &DockerCli{client: apiclient, err: os.Stderr}
-			cliconfig.SetDir(dir.Path())
+			config.SetDir(dir.Path())
 			err := cli.Initialize(flags.NewClientOptions())
 			assert.NilError(t, err)
 			// For backward-compatibility, HasExperimental will always be "true"

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -16,7 +16,7 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary/client"

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"

--- a/cli/command/registry/formatter_search.go
+++ b/cli/command/registry/formatter_search.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command/formatter"
-	registry "github.com/docker/docker/api/types/registry"
+	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
 const (
@@ -28,7 +28,7 @@ func NewSearchFormat(source string) formatter.Format {
 }
 
 // SearchWrite writes the context
-func SearchWrite(ctx formatter.Context, results []registry.SearchResult) error {
+func SearchWrite(ctx formatter.Context, results []registrytypes.SearchResult) error {
 	render := func(format func(subContext formatter.SubContext) error) error {
 		for _, result := range results {
 			searchCtx := &searchContext{trunc: ctx.Trunc, s: result}
@@ -53,7 +53,7 @@ type searchContext struct {
 	formatter.HeaderContext
 	trunc bool
 	json  bool
-	s     registry.SearchResult
+	s     registrytypes.SearchResult
 }
 
 func (c *searchContext) MarshalJSON() ([]byte, error) {

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -9,7 +9,7 @@ import (
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/registry"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -69,16 +69,16 @@ var sampleInfoNoSwarm = types.Info{
 	OSType:             "linux",
 	Architecture:       "x86_64",
 	IndexServerAddress: "https://index.docker.io/v1/",
-	RegistryConfig: &registry.ServiceConfig{
+	RegistryConfig: &registrytypes.ServiceConfig{
 		AllowNondistributableArtifactsCIDRs:     nil,
 		AllowNondistributableArtifactsHostnames: nil,
-		InsecureRegistryCIDRs: []*registry.NetIPNet{
+		InsecureRegistryCIDRs: []*registrytypes.NetIPNet{
 			{
 				IP:   net.ParseIP("127.0.0.0"),
 				Mask: net.IPv4Mask(255, 0, 0, 0),
 			},
 		},
-		IndexConfigs: map[string]*registry.IndexInfo{
+		IndexConfigs: map[string]*registrytypes.IndexInfo{
 			"docker.io": {
 				Name:     "docker.io",
 				Mirrors:  nil,

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/errdefs"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 )
 

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
@@ -48,7 +48,7 @@ func NewCommonOptions() *CommonOptions {
 // InstallFlags adds flags for the common options on the FlagSet
 func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	if dockerCertPath == "" {
-		dockerCertPath = cliconfig.Dir()
+		dockerCertPath = config.Dir()
 	}
 
 	flags.BoolVarP(&commonOpts.Debug, "debug", "D", false, "Enable debug mode")

--- a/cli/flags/common_test.go
+++ b/cli/flags/common_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -27,7 +27,7 @@ func TestCommonOptionsInstallFlags(t *testing.T) {
 }
 
 func defaultPath(filename string) string {
-	return filepath.Join(cliconfig.Dir(), filename)
+	return filepath.Join(config.Dir(), filename)
 }
 
 func TestCommonOptionsInstallFlagsWithDefaults(t *testing.T) {

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/reference"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -14,7 +14,7 @@ import (
 	v2 "github.com/docker/distribution/registry/api/v2"
 	distclient "github.com/docker/distribution/registry/client"
 	"github.com/docker/docker/registry"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -21,7 +21,7 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/tlsconfig"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary"

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
-	cliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -47,7 +47,7 @@ var (
 
 // GetTrustDirectory returns the base trust directory name
 func GetTrustDirectory() string {
-	return filepath.Join(cliconfig.Dir(), "trust")
+	return filepath.Join(config.Dir(), "trust")
 }
 
 // certificateDirectory returns the directory containing
@@ -59,7 +59,7 @@ func certificateDirectory(server string) (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(cliconfig.Dir(), "tls", u.Host), nil
+	return filepath.Join(config.Dir(), "tls", u.Host), nil
 }
 
 // Server returns the base URL for the trust server.

--- a/cli/trust/trust_test.go
+++ b/cli/trust/trust_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/docker/distribution/reference"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/passphrase"
 	"github.com/theupdateframework/notary/trustpinning"


### PR DESCRIPTION
Had this on another branch, but let's get this in separately; some minor cleanup on `import` aliases.