### PR TITLE
Allow sharing UTS namespace of another container

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -623,7 +623,10 @@ func TestParseModes(t *testing.T) {
 	}
 
 	// uts ko
-	_, _, _, err = parseRun([]string{"--uts=container:", "img", "cmd"}) //nolint:dogsled
+	flags, copts = setupRunFlags()
+	args = []string{"--uts=container:", "img", "cmd"}
+	assert.NilError(t, flags.Parse(args))
+	_, err = parse(flags, copts, runtime.GOOS)
 	assert.ErrorContains(t, err, "--uts: invalid UTS mode")
 
 	// uts ok

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2155,6 +2155,20 @@ _docker_container_run_and_create() {
 			esac
 			return
 			;;
+		--uts)
+			case "$cur" in
+				*:*)
+					__docker_complete_containers_running --cur "${cur#*:}"
+					;;
+				*)
+					COMPREPLY=( $( compgen -W 'host container:' -- "$cur" ) )
+					if [ "${COMPREPLY[*]}" = "container:" ]; then
+						__docker_nospace
+					fi
+					;;
+			esac
+			return
+			;;
 		--pull)
 		  COMPREPLY=( $( compgen -W 'always missing never' -- "$cur" ) )
 		  return

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -486,6 +486,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l net -d 'Set the
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s P -l publish-all -d 'Publish all exposed ports to random ports on the host interfaces'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s p -l publish -d "Publish a container's port to the host"
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l pid -d 'Default is to create a private PID namespace for the container'
+complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l uts -d 'Default is to create a private UTS namespace for the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l privileged -d 'Give extended privileges to this container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l read-only -d "Mount the container's root filesystem as read only"
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l restart -d 'Restart policy to apply when a container exits (no, on-failure[:max-retry], always)'

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -262,13 +262,14 @@ $ strace -p 1
 ## UTS settings (--uts)
 
     --uts=""  : Set the UTS namespace mode for the container,
+           'container:<name|id>': joins another container's UTS namespace
            'host': use the host's UTS namespace inside the container
 
 The UTS namespace is for setting the hostname and the domain that is visible
 to running processes in that namespace.  By default, all containers, including
 those with `--network=host`, have their own UTS namespace.  The `host` setting will
 result in the container using the same UTS namespace as the host.  Note that
-`--hostname` and `--domainname` are invalid in `host` UTS mode.
+`--hostname` and `--domainname` are invalid in `host` and `container` UTS modes.
 
 You may wish to share the UTS namespace with the host if you would like the
 hostname of the container to change as the hostname of the host changes.  A

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -87,7 +87,7 @@ docker-run - Run a command in a new container
 [**--tmpfs**[=*[CONTAINER-DIR[:OPTIONS]*]]
 [**-u**|**--user**[=*USER*]]
 [**--ulimit**[=*[]*]]
-[**--uts**[=*[]*]]
+[**--uts**[=*[UTS]*]]
 [**-v**|**--volume**[=*[[HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]]
 [**--volume-driver**[=*DRIVER*]]
 [**--volumes-from**[=*[]*]]
@@ -557,10 +557,11 @@ Use `docker port`(1) to see the actual mapping, e.g. `docker port CONTAINER $CON
 **--pids-limit**=""
    Tune the container's pids (process IDs) limit. Set to `-1` to have unlimited pids for the container.
 
-**--uts**=*type*
-   Set the UTS mode for the container. The only possible *type* is **host**, meaning to
-use the host's UTS namespace inside the container.
-     Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
+**--uts**=""
+   Set the UTS mode for the container. 
+   Default is to create a private UTS namespace for the container
+                               'container:<name|id>': join another container's UTS namespace
+                               'host': use the host's UTS namespace for the container. Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
 
 **--privileged** [**true**|**false**]
    Give extended privileges to this container. A "privileged" container is given access to all devices.


### PR DESCRIPTION
Signed-off-by: Grant Millar <rid@cylo.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow sharing of the UTS namespace of another container using `--uts container:<name|id>`

**- How I did it**
- Updated tests
- Updated bash/fish shell completion 
- Updated readme

**- How to verify it**
See https://github.com/moby/moby/pull/43349

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Allow sharing UTS namespace of another container

**- A picture of a cute animal (not mandatory but encouraged)**
🐤

This first requires vendoring of https://github.com/moby/moby/pull/43349 due to changes in `host_config` interfaces.