### PR TITLE
align wording of push --all-tags parameter description

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -38,7 +38,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tagged images in the repository")
+	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tags of an image to the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 	command.AddTrustSigningFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1083,7 +1083,7 @@ __docker_image_subcommand() {
         (push)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help -a --all-tags)"{-a,--all-tags}"[Push all tagged images in the repository]" \
+                "($help -a --all-tags)"{-a,--all-tags}"[Push all tags of an image to the repository]" \
                 "($help)--disable-content-trust[Skip image signing]" \
                 "($help -): :__docker_complete_images" && ret=0
             ;;

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -12,7 +12,7 @@ Usage:  docker push [OPTIONS] NAME[:TAG]
 Push an image or a repository to a registry
 
 Options:
-  -a, --all-tags                Push all tagged images in the repository
+  -a, --all-tags                Push all tags of an image to the repository
       --disable-content-trust   Skip image signing (default true)
       --help                    Print usage
   -q, --quiet                   Suppress verbose output

--- a/man/src/image/push.md
+++ b/man/src/image/push.md
@@ -35,7 +35,7 @@ listed.
 
 ### Push all tags of an image
 
-Use the `-a` (or `--all-tags`) option to push To push all tags of a local image.
+Use the `-a` (or `--all-tags`) option to push all tags of a local image.
 
 The following example creates multiple tags for an image, and pushes all those
 tags to Docker Hub.


### PR DESCRIPTION
Signed-off-by: Gleb Stsenov <gleb.stsenov@gmail.com>

Closes issue #3465 

- aligned description of `docker push --all-tags` command, see the issue #3465
- only documentation changed in markdown and CLI help output

**- Description for the changelog**
Improved `docker push --all-tags` parameter documentation

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/322967/157725623-b9424264-76e4-4dcd-a502-ee0a205e9b5c.png)
(image is taken from kawaiilife@pinterest)
