### PR TITLE
docs: dockerd: fix an unclickable and non-direct link in Markdown's blockquote area

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1386,7 +1386,7 @@ This is a full example of the allowed configuration options on Linux:
 > daemon startup as a flag.
 > On systems that use `systemd` to start the Docker daemon, `-H` is already set, so
 > you cannot use the `hosts` key in `daemon.json` to add listening addresses.
-> See https://docs.docker.com/engine/admin/systemd/#custom-docker-daemon-options for how
+> See ["custom Docker daemon options"](https://docs.docker.com/config/daemon/systemd/#custom-docker-daemon-options) for how
 > to accomplish this task with a systemd drop-in file.
 
 ##### On Windows


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Hello! In the docs:

1. I put the link behind a piece of text. The current webpage shows the URL in plaintext ([Wayback Machine archive](http://web.archive.org/web/20220313051005/https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file)). I think this may fix it.
2. I replaced the old link with non-redirect one.

**- How I did it**

Just editing Markdown.

**- How to verify it**

I have no environment to build the docs, but I guess this fix will work correctly.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

No changelog entity required.

**- A picture of a cute animal (not mandatory but encouraged)**

none.