### PR TITLE
Handle relative source mounts

### DIFF
--- a/opts/mount.go
+++ b/opts/mount.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -92,6 +93,11 @@ func (m *MountOpt) Set(value string) error {
 			mount.Type = mounttypes.Type(strings.ToLower(value))
 		case "source", "src":
 			mount.Source = value
+			if strings.HasPrefix(value, "."+string(filepath.Separator)) || value == "." {
+				if abs, err := filepath.Abs(value); err == nil {
+					mount.Source = abs
+				}
+			}
 		case "target", "dst", "destination":
 			mount.Target = value
 		case "readonly", "ro":


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

With this change it is now possible to give a relative path to the --volume and
--mount flags.

```console
$ docker run --mount type=bind,source=./,target=/test ...
```

```console
$ docker run -v .:/test ...
```

Fixes #1203

**- How I did it**

Updated opts parsing for volumes and mounts

**- How to verify it**

Run `docker run --rm -v .:/test busybox ls -l /test` and you should see the listing of your current working dir

**- Description for the changelog**
The run command accepts relative source paths in `-v/--volume` and `-m/--mount` flags

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/158160394-874d08f2-80b1-40a3-b785-fbf88decc82b.png)

