### PR TITLE
search: remove client-side default for --limit

### DIFF
--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -26,7 +26,7 @@ func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "search [OPTIONS] TERM",
-		Short: "Search the Docker Hub for images",
+		Short: "Search Docker Hub for images",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.term = args[0]

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -38,8 +38,7 @@ func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Don't truncate output")
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
-	// TODO(thaJeztah) remove default from client as the daemon already has a default
-	flags.IntVar(&options.limit, "limit", 25, "Max number of search results")
+	flags.IntVar(&options.limit, "limit", 0, "Max number of search results")
 	flags.StringVar(&options.format, "format", "", "Pretty-print search using a Go template")
 
 	return cmd

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -74,13 +74,13 @@ read the [`dockerd`](dockerd.md) reference page.
 
 ### Hub and registry commands
 
-| Command             | Description                                                            |
-|:--------------------|:-----------------------------------------------------------------------|
-| [login](login.md)   | Register or log in to a Docker registry                                |
-| [logout](logout.md) | Log out from a Docker registry                                         |
-| [pull](pull.md)     | Pull an image or a repository from a Docker registry                   |
-| [push](push.md)     | Push an image or a repository to a Docker registry                     |
-| [search](search.md) | Search the Docker Hub for images                                       |
+| Command             | Description                                                             |
+|:--------------------|:------------------------------------------------------------------------|
+| [login](login.md)   | Register or log in to a Docker registry                                 |
+| [logout](logout.md) | Log out from a Docker registry                                          |
+| [pull](pull.md)     | Pull an image or a repository from a Docker registry                    |
+| [push](push.md)     | Push an image or a repository to a Docker registry                      |
+| [search](search.md) | Search Docker Hub for images                                            |
 
 ### Network and connectivity commands
 

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -20,169 +20,170 @@ read the [`dockerd`](dockerd.md) reference page.
 
 ### Docker management commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
+| Command               | Description                                          |
+|:----------------------|:-----------------------------------------------------|
 | [dockerd](dockerd.md) | Launch the Docker daemon                             |
-| [info](info.md) | Display system-wide information                            |
-| [inspect](inspect.md)| Return low-level information on a container or image  |
+| [info](info.md)       | Display system-wide information                      |
+| [inspect](inspect.md) | Return low-level information on a container or image |
 | [version](version.md) | Show the Docker version information                  |
 
 
 ### Image commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [build](build.md) |  Build an image from a Dockerfile                        |
-| [commit](commit.md) | Create a new image from a container's changes          |
-| [history](history.md) | Show the history of an image                         |
-| [images](images.md) | List images                                            |
-| [import](import.md) | Import the contents from a tarball to create a filesystem image |
-| [load](load.md) | Load an image from a tar archive or STDIN                  |
-| [image prune](image_prune.md) | Remove unused images                         |
-| [rmi](rmi.md) | Remove one or more images                                    |
-| [save](save.md) | Save images to a tar archive                               |
-| [tag](tag.md) | Tag an image into a repository                               |
+| Command                       | Description                                                     |
+|:------------------------------|:----------------------------------------------------------------|
+| [build](build.md)             | Build an image from a Dockerfile                                |
+| [commit](commit.md)           | Create a new image from a container's changes                   |
+| [history](history.md)         | Show the history of an image                                    |
+| [images](images.md)           | List images                                                     |
+| [import](import.md)           | Import the contents from a tarball to create a filesystem image |
+| [load](load.md)               | Load an image from a tar archive or STDIN                       |
+| [image prune](image_prune.md) | Remove unused images                                            |
+| [rmi](rmi.md)                 | Remove one or more images                                       |
+| [save](save.md)               | Save images to a tar archive                                    |
+| [tag](tag.md)                 | Tag an image into a repository                                  |
 
 ### Container commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [attach](attach.md) | Attach to a running container                          |
-| [container prune](container_prune.md) | Remove all stopped containers        |
-| [cp](cp.md) | Copy files/folders from a container to a HOSTDIR or to STDOUT  |
-| [create](create.md) | Create a new container                                 |
-| [diff](diff.md) | Inspect changes on a container's filesystem                |
-| [events](events.md) | Get real time events from the server                   |
-| [exec](exec.md) | Run a command in a running container                       |
-| [export](export.md) | Export a container's filesystem as a tar archive       |
-| [kill](kill.md) | Kill a running container                                   |
-| [logs](logs.md) | Fetch the logs of a container                              |
-| [pause](pause.md) | Pause all processes within a container                   |
-| [port](port.md) | List port mappings or a specific mapping for the container |
-| [ps](ps.md) | List containers                                                |
-| [rename](rename.md) | Rename a container                                     |
-| [restart](restart.md) | Restart a running container                          |
-| [rm](rm.md) | Remove one or more containers                                  |
-| [run](run.md) | Run a command in a new container                             |
-| [start](start.md) | Start one or more stopped containers                     |
-| [stats](stats.md) | Display a live stream of container(s) resource usage  statistics |
-| [stop](stop.md) | Stop a running container                                   |
-| [top](top.md) | Display the running processes of a container                 |
-| [unpause](unpause.md) | Unpause all processes within a container             |
-| [update](update.md) | Update configuration of one or more containers         |
-| [wait](wait.md) | Block until a container stops, then print its exit code    |
+| Command                               | Description                                                      |
+|:--------------------------------------|:-----------------------------------------------------------------|
+| [attach](attach.md)                   | Attach to a running container                                    |
+| [container prune](container_prune.md) | Remove all stopped containers                                    |
+| [cp](cp.md)                           | Copy files/folders from a container to a HOSTDIR or to STDOUT    |
+| [create](create.md)                   | Create a new container                                           |
+| [diff](diff.md)                       | Inspect changes on a container's filesystem                      |
+| [events](events.md)                   | Get real time events from the server                             |
+| [exec](exec.md)                       | Run a command in a running container                             |
+| [export](export.md)                   | Export a container's filesystem as a tar archive                 |
+| [kill](kill.md)                       | Kill a running container                                         |
+| [logs](logs.md)                       | Fetch the logs of a container                                    |
+| [pause](pause.md)                     | Pause all processes within a container                           |
+| [port](port.md)                       | List port mappings or a specific mapping for the container       |
+| [ps](ps.md)                           | List containers                                                  |
+| [rename](rename.md)                   | Rename a container                                               |
+| [restart](restart.md)                 | Restart a running container                                      |
+| [rm](rm.md)                           | Remove one or more containers                                    |
+| [run](run.md)                         | Run a command in a new container                                 |
+| [start](start.md)                     | Start one or more stopped containers                             |
+| [stats](stats.md)                     | Display a live stream of container(s) resource usage  statistics |
+| [stop](stop.md)                       | Stop a running container                                         |
+| [top](top.md)                         | Display the running processes of a container                     |
+| [unpause](unpause.md)                 | Unpause all processes within a container                         |
+| [update](update.md)                   | Update configuration of one or more containers                   |
+| [wait](wait.md)                       | Block until a container stops, then print its exit code          |
 
 ### Hub and registry commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [login](login.md) | Register or log in to a Docker registry                  |
-| [logout](logout.md) | Log out from a Docker registry                         |
-| [pull](pull.md) | Pull an image or a repository from a Docker registry       |
-| [push](push.md) | Push an image or a repository to a Docker registry         |
-| [search](search.md) | Search the Docker Hub for images                       |
+| Command             | Description                                                            |
+|:--------------------|:-----------------------------------------------------------------------|
+| [login](login.md)   | Register or log in to a Docker registry                                |
+| [logout](logout.md) | Log out from a Docker registry                                         |
+| [pull](pull.md)     | Pull an image or a repository from a Docker registry                   |
+| [push](push.md)     | Push an image or a repository to a Docker registry                     |
+| [search](search.md) | Search the Docker Hub for images                                       |
 
 ### Network and connectivity commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [network connect](network_connect.md) | Connect a container to a network     |
-| [network create](network_create.md) | Create a new network                   |
-| [network disconnect](network_disconnect.md) | Disconnect a container from a network |
-| [network inspect](network_inspect.md) | Display information about a network  |
-| [network ls](network_ls.md) | Lists all the networks the Engine `daemon` knows about |
-| [network prune](network_prune.md) | Remove all unused networks               |
-| [network rm](network_rm.md) | Removes one or more networks                   |
+| Command                                     | Description                                            |
+|:--------------------------------------------|:-------------------------------------------------------|
+| [network connect](network_connect.md)       | Connect a container to a network                       |
+| [network create](network_create.md)         | Create a new network                                   |
+| [network disconnect](network_disconnect.md) | Disconnect a container from a network                  |
+| [network inspect](network_inspect.md)       | Display information about a network                    |
+| [network ls](network_ls.md)                 | Lists all the networks the Engine `daemon` knows about |
+| [network prune](network_prune.md)           | Remove all unused networks                             |
+| [network rm](network_rm.md)                 | Removes one or more networks                           |
 
 ### Shared data volume commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [volume create](volume_create.md) | Creates a new volume where containers can consume and store data |
-| [volume inspect](volume_inspect.md) | Display information about a volume     |
-| [volume ls](volume_ls.md) | Lists all the volumes Docker knows about         |
-| [volume prune](volume_prune.md) | Remove all unused local volumes            |
-| [volume rm](volume_rm.md) | Remove one or more volumes                       |
+| Command                             | Description                                                      |
+|:------------------------------------|:-----------------------------------------------------------------|
+| [volume create](volume_create.md)   | Creates a new volume where containers can consume and store data |
+| [volume inspect](volume_inspect.md) | Display information about a volume                               |
+| [volume ls](volume_ls.md)           | Lists all the volumes Docker knows about                         |
+| [volume prune](volume_prune.md)     | Remove all unused local volumes                                  |
+| [volume rm](volume_rm.md)           | Remove one or more volumes                                       |
 
 ### Swarm node commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [node demote](node_demote.md) | Demotes an existing manager so that it is no longer a manager |
-| [node inspect](node_inspect.md) | Inspect a node in the swarm                |
-| [node ls](node_ls.md) | List nodes in the swarm                              |
-| [node promote](node_promote.md) | Promote a node that is pending a promotion to manager |
-| [node ps](node_ps.md) | List tasks running on one or more nodes                         |
-| [node rm](node_rm.md) | Remove one or more nodes from the swarm                         |
-| [node update](node_update.md) | Update attributes for a node                 |
+| Command                         | Description                                                   |
+|:--------------------------------|:--------------------------------------------------------------|
+| [node demote](node_demote.md)   | Demotes an existing manager so that it is no longer a manager |
+| [node inspect](node_inspect.md) | Inspect a node in the swarm                                   |
+| [node ls](node_ls.md)           | List nodes in the swarm                                       |
+| [node promote](node_promote.md) | Promote a node that is pending a promotion to manager         |
+| [node ps](node_ps.md)           | List tasks running on one or more nodes                       |
+| [node rm](node_rm.md)           | Remove one or more nodes from the swarm                       |
+| [node update](node_update.md)   | Update attributes for a node                                  |
 
 ### Swarm management commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [swarm init](swarm_init.md) | Initialize a swarm                             |
-| [swarm join](swarm_join.md) | Join a swarm as a manager node or worker node  |
-| [swarm leave](swarm_leave.md) | Remove the current node from the swarm       |
-| [swarm join-token](swarm_join_token.md) | Display or rotate join tokens      |
-| [swarm unlock](swarm_unlock.md) | Unlock swarm                               |
-| [swarm unlock-key](swarm_unlock_key.md) | Manage the unlock key              |
-| [swarm update](swarm_update.md) | Update attributes of a swarm               |
+| Command                                 | Description                                   |
+|:----------------------------------------|:----------------------------------------------|
+| [swarm init](swarm_init.md)             | Initialize a swarm                            |
+| [swarm join](swarm_join.md)             | Join a swarm as a manager node or worker node |
+| [swarm leave](swarm_leave.md)           | Remove the current node from the swarm        |
+| [swarm join-token](swarm_join_token.md) | Display or rotate join tokens                 |
+| [swarm unlock](swarm_unlock.md)         | Unlock swarm                                  |
+| [swarm unlock-key](swarm_unlock_key.md) | Manage the unlock key                         |
+| [swarm update](swarm_update.md)         | Update attributes of a swarm                  |
 
 ### Swarm service commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [service create](service_create.md) | Create a new service                   |
-| [service inspect](service_inspect.md) | Inspect a service                    |
-| [service logs](service_logs.md)  | Fetch the logs of a service or task       |
-| [service ls](service_ls.md) | List services in the swarm                     |
-| [service ps](service_ps.md) | List the tasks of a service              |
-| [service rm](service_rm.md) | Remove a service from the swarm                |
-| [service scale](service_scale.md) | Set the number of replicas for the desired state of the service |
-| [service update](service_update.md)  | Update the attributes of a service    |
+| Command                               | Description                                                     |
+|:--------------------------------------|:----------------------------------------------------------------|
+| [service create](service_create.md)   | Create a new service                                            |
+| [service inspect](service_inspect.md) | Inspect a service                                               |
+| [service logs](service_logs.md)       | Fetch the logs of a service or task                             |
+| [service ls](service_ls.md)           | List services in the swarm                                      |
+| [service ps](service_ps.md)           | List the tasks of a service                                     |
+| [service rm](service_rm.md)           | Remove a service from the swarm                                 |
+| [service scale](service_scale.md)     | Set the number of replicas for the desired state of the service |
+| [service update](service_update.md)   | Update the attributes of a service                              |
 
 ### Swarm secret commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [secret create](secret_create.md) | Create a secret from a file or STDIN as content |
-| [secret inspect](service_inspect.md) | Inspect the specified secret          |
-| [secret ls](secret_ls.md) | List secrets in the swarm                        |
-| [secret rm](secret_rm.md) | Remove the specified secrets from the swarm      |
+| Command                              | Description                                     |
+|:-------------------------------------|:------------------------------------------------|
+| [secret create](secret_create.md)    | Create a secret from a file or STDIN as content |
+| [secret inspect](service_inspect.md) | Inspect the specified secret                    |
+| [secret ls](secret_ls.md)            | List secrets in the swarm                       |
+| [secret rm](secret_rm.md)            | Remove the specified secrets from the swarm     |
 
 ### Swarm stack commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [stack deploy](stack_deploy.md) | Deploy a new stack or update an existing stack |
-| [stack ls](stack_ls.md) | List stacks in the swarm                           |
-| [stack ps](stack_ps.md) | List the tasks in the stack                        |
-| [stack rm](stack_rm.md) | Remove the stack from the swarm                    |
-| [stack services](stack_services.md) | List the services in the stack         |
+| Command                             | Description                                    |
+|:------------------------------------|:-----------------------------------------------|
+| [stack deploy](stack_deploy.md)     | Deploy a new stack or update an existing stack |
+| [stack ls](stack_ls.md)             | List stacks in the swarm                       |
+| [stack ps](stack_ps.md)             | List the tasks in the stack                    |
+| [stack rm](stack_rm.md)             | Remove the stack from the swarm                |
+| [stack services](stack_services.md) | List the services in the stack                 |
 
 ### Plugin commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [plugin create](plugin_create.md) | Create a plugin from a rootfs and configuration |
-| [plugin disable](plugin_disable.md) | Disable a plugin                       |
-| [plugin enable](plugin_enable.md)  | Enable a plugin                         |
-| [plugin inspect](plugin_inspect.md) | Display detailed information on a plugin |
-| [plugin install](plugin_install.md) | Install a plugin                       |
-| [plugin ls](plugin_ls.md) | List plugins                                     |
-| [plugin push](plugin_push.md) | Push a plugin to a registry                  |
-| [plugin rm](plugin_rm.md) | Remove a plugin                                  |
-| [plugin set](plugin_set.md)  | Change settings for a plugin                  |
+| Command                             | Description                                     |
+|:------------------------------------|:------------------------------------------------|
+| [plugin create](plugin_create.md)   | Create a plugin from a rootfs and configuration |
+| [plugin disable](plugin_disable.md) | Disable a plugin                                |
+| [plugin enable](plugin_enable.md)   | Enable a plugin                                 |
+| [plugin inspect](plugin_inspect.md) | Display detailed information on a plugin        |
+| [plugin install](plugin_install.md) | Install a plugin                                |
+| [plugin ls](plugin_ls.md)           | List plugins                                    |
+| [plugin push](plugin_push.md)       | Push a plugin to a registry                     |
+| [plugin rm](plugin_rm.md)           | Remove a plugin                                 |
+| [plugin set](plugin_set.md)         | Change settings for a plugin                    |
 
 ### Context commands
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [context create](context_create.md) | Create a context |
-| [context export](context_export.md) | Export a context |
-| [context import](context_import.md) | Import a context |
-| [context ls](context_ls.md) | List contexts |
-| [context rm](context_rm.md) | Remove one or more contexts |
-| [context update](context_update.md) | Update a context |
-| [context use](context_use.md) | Set the current docker context |
-| [context inspect](context_inspect.md) | Inspect one or more contexts |
+
+| Command                               | Description                    |
+|:--------------------------------------|:-------------------------------|
+| [context create](context_create.md)   | Create a context               |
+| [context export](context_export.md)   | Export a context               |
+| [context import](context_import.md)   | Import a context               |
+| [context ls](context_ls.md)           | List contexts                  |
+| [context rm](context_rm.md)           | Remove one or more contexts    |
+| [context update](context_update.md)   | Update a context               |
+| [context use](context_use.md)         | Set the current docker context |
+| [context inspect](context_inspect.md) | Inspect one or more contexts   |
 

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -9,7 +9,7 @@ keywords: "search, hub, images"
 ```markdown
 Usage:  docker search [OPTIONS] TERM
 
-Search the Docker Hub for images
+Search Docker Hub for images
 
 Options:
   -f, --filter value   Filter output based on conditions provided (default [])

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -18,7 +18,7 @@ Options:
                        - stars=<number> - image has at least 'number' stars
       --format string  Pretty-print images using a Go template
       --help           Print usage
-      --limit int      Max number of search results (default 25)
+      --limit int      Max number of search results
       --no-trunc       Don't truncate output
 ```
 
@@ -79,8 +79,8 @@ radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Co
 
 ### Limit search results (--limit)
 
-The flag `--limit` is the maximum number of results returned by a search. This value could
-be in the range between 1 and 100. The default value of `--limit` is 25.
+The flag `--limit` is the maximum number of results returned by a search. If no
+value is set, the default is set by the daemon.
 
 ### Filtering
 

--- a/man/src/search.md
+++ b/man/src/search.md
@@ -2,8 +2,6 @@ Search Docker Hub for images that match the specified `TERM`. The table
 of images returned displays the name, description (truncated by default), number
 of stars awarded, whether the image is official, and whether it is automated.
 
-*Note* - Search queries will only return up to 25 results
-
 ## Filter
 
    Filter output based on these conditions:


### PR DESCRIPTION

- [x] depends on https://github.com/moby/moby/pull/43380
- [x] depends on https://github.com/docker/cli/pull/3486

The daemon (and registry) already have a default limit. This patch
removes the default from the client side, to not duplicate setting
these defaults.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

