### PR TITLE
Dockerfile: use syntax=docker/dockerfile:1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.16.11

--- a/dockerfiles/Dockerfile.authors
+++ b/dockerfiles/Dockerfile.authors
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1
 
 FROM alpine:3.14 AS gen
 RUN apk add --no-cache bash git

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.16.11
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.16.11
 ARG GOLANGCI_LINT_VERSION=v1.23.8

--- a/dockerfiles/Dockerfile.shellcheck
+++ b/dockerfiles/Dockerfile.shellcheck
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 FROM koalaman/shellcheck-alpine:v0.7.1 AS shellcheck
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3-labs
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.16.11
 ARG MODOUTDATED_VERSION=v0.8.0


### PR DESCRIPTION
Now that HEREDOC is included in the stable Dockerfile syntax, we can use the latest stable syntax for all Dockerfiles.

The recommendation for the stable syntax is to use `:1` (which is equivalent to "latest" stable syntax.

**- A picture of a cute animal (not mandatory but encouraged)**

