### PR TITLE
docs: hyphens are not dashes

### DIFF
--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -23,12 +23,12 @@ may not contain underscores. If a hostname is present, it may optionally be
 followed by a port number in the format `:8080`. If not present, the command
 uses Docker's public registry located at `registry-1.docker.io` by default. Name
 components may contain lowercase letters, digits and separators. A separator
-is defined as a period, one or two underscores, or one or more dashes. A name
+is defined as a period, one or two underscores, or one or more hyphens. A name
 component may not start or end with a separator.
 
 A tag name must be valid ASCII and may contain lowercase and uppercase letters,
-digits, underscores, periods and dashes. A tag name may not start with a
-period or a dash and may contain a maximum of 128 characters.
+digits, underscores, periods and hyphens. A tag name may not start with a
+period or a hyphen and may contain a maximum of 128 characters.
 
 You can group your images together using names and tags, and then upload them
 to [*Share images on Docker Hub*](https://docs.docker.com/get-started/part3/).


### PR DESCRIPTION
Hyphens are not dashes and dashes are not hyphens. Hyphens are an ASCII character, dashes are not. Docker allows hyphens in tag names, but it does not allow dashes.

While most people use these terms interchangeably, and the documentation is easy enough to understand, someone copying and pasting in a tag name, or having one programmatically entered through CI/CD software may not understand why they are getting the 'invalid reference format' error message and come looking to the docs to see what characters are allowed. For those who don't know or care what the difference is, they won't care whether the doc says 'hyphen' or 'dash'. For those who know the difference, it is important to be accurate to know what characters are and are not allowed.

Signed-off-by: fezzik1620 <fezzik1620@users.noreply.github.com>

