### PR TITLE
scripts/build: make sure osusergo is set for static with CGO enabled

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -73,6 +73,10 @@ fi
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$(go env GOOS)" = "linux" ]; then
     LDFLAGS="$LDFLAGS -extldflags -static"
 fi
+if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
+    # compiling statically with CGO enabled requires osusergo to be set.
+    GO_BUILDTAGS="$GO_BUILDTAGS osusergo"
+fi
 if [ -n "$GO_STRIP" ]; then
     LDFLAGS="$LDFLAGS -s"
 fi


### PR DESCRIPTION
Our previous CI probably did not cross-compile for s390x and ppc64le,
and therefore did not get these errors; the scripts/build/.variables
file sets CGO_ENABLED=1 for amd64|arm64|arm|s390x architectures if
it's not set;
https://github.com/docker/cli/blob/87b8e57868adba9e189e9fb74e5bd5d189a024c8/scripts/build/.variables#L34-L46

When compiling statically with CGO enabled, we must have osusergo
enabled as well, so set it accordingly, to prevent;

    #53 [linux/amd64 build 2/2] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=from=dockercore/golang-cross:xx-sdk-extras,target=/xx-sdk,src=/xx-sdk     --mount=type=tmpfs,target=cli/winresources     xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     xx-verify $([ "static" = "static" ] && echo "--static") /out/docker
    #53 953.6 # github.com/docker/cli/cmd/docker
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000022.o: in function `New':
    #53 953.6 /go/src/github.com/docker/cli/vendor/github.com/miekg/pkcs11/pkcs11.go:75: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000018.o: in function `mygetgrouplist':
    #53 953.6 /usr/local/go/src/os/user/getgrouplist_unix.go:18: warning: Using 'getgrouplist' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000017.o: in function `mygetgrgid_r':
    #53 953.6 /usr/local/go/src/os/user/cgo_lookup_unix.go:40: warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000017.o: in function `mygetgrnam_r':
    #53 953.6 /usr/local/go/src/os/user/cgo_lookup_unix.go:45: warning: Using 'getgrnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000017.o: in function `mygetpwnam_r':
    #53 953.6 /usr/local/go/src/os/user/cgo_lookup_unix.go:35: warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000017.o: in function `mygetpwuid_r':
    #53 953.6 /usr/local/go/src/os/user/cgo_lookup_unix.go:30: warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #53 953.6 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-2402600021/000004.o: in function `_cgo_3c1cec0c9a4e_C2func_getaddrinfo':
    #53 953.6 /tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

