### PR TITLE
Dockerfile: use xx-apt-get instead of xx-apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ WORKDIR /go/src/github.com/docker/cli
 
 FROM build-base-buster AS build-buster
 ARG TARGETPLATFORM
-RUN xx-apt install --no-install-recommends -y libc6-dev libgcc-8-dev
+RUN xx-apt-get install --no-install-recommends -y libc6-dev libgcc-8-dev
 
 FROM build-base-${BASE_VARIANT} AS goversioninfo
 ARG GOVERSIONINFO_VERSION


### PR DESCRIPTION
The `apt` command is meant to provide a user-friendly interface, but does not
have a stable interface, and not recommended for scripting, see:

    #54 [linux/amd64 build-buster 1/1] RUN xx-apt install --no-install-recommends -y libc6-dev libgcc-8-dev
    #54 0.706 Hit:1 http://security.debian.org/debian-security buster/updates InRelease
    #54 0.707 Hit:2 http://deb.debian.org/debian buster InRelease
    #54 0.708 Hit:3 http://deb.debian.org/debian buster-updates InRelease
    #54 2.149 Reading package lists...
    #54 4.917 + apt  install --no-install-recommends -y libc6-dev libgcc-8-dev
    #54 4.934
    #54 4.934 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

This changes the command to use `apt-get` instead


**- A picture of a cute animal (not mandatory but encouraged)**

