### PR TITLE
scripts/build/binary: disable pkcs11 on static builds with CGO_ENABLED=1

### DIFF
--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -7,7 +7,10 @@ set -eu
 
 . ./scripts/build/.variables
 
-if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ]; then
+if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ] && [ "$GO_LINKMODE" != "static" ]; then
+  # pkcs11 cannot be compiled statically if CGO is enabled (and glibc is used)
+  # see https://github.com/docker/cli/blob/3897c3fa544f1239c2bc2c3af2adcebcb3650c4d/vendor/github.com/miekg/pkcs11/pkcs11.go#L75
+  # see https://github.com/docker/cli/pull/3490#issuecomment-1079711973
   GO_BUILDTAGS="$GO_BUILDTAGS pkcs11"
 fi
 


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3490
- static check is failing, similar to https://github.com/docker/docker-ce-packaging/pull/430
- possibly can be fixed through / similar to changes in https://github.com/docker/docker-credential-helpers/pull/209 


pkcs11 cannot be compiled statically if CGO is enabled (and glibc is used)
see https://github.com/docker/cli/blob/3897c3fa544f1239c2bc2c3af2adcebcb3650c4d/vendor/github.com/miekg/pkcs11/pkcs11.go#L75
see https://github.com/docker/cli/pull/3490#issuecomment-1079711973

When trying to do otherwise, warnings are printed (and shouldn't be ignored,
similar to the `osusergo` build-tag):

    #32 [linux/amd64->s390x build 2/2] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=from=dockercore/golang-cross:xx-sdk-extras,target=/xx-sdk,src=/xx-sdk     --mount=type=tmpfs,target=cli/winresources     xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     xx-verify $([ "static" = "static" ] && echo "--static") /out/docker
    #32 467.0 # github.com/docker/cli/cmd/docker
    #32 467.0 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-900380651/000018.o: in function `New':
    #32 467.0 /go/src/github.com/docker/cli/vendor/github.com/miekg/pkcs11/pkcs11.go:75: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
    #32 467.0 /usr/bin/s390x-linux-gnu-ld: /tmp/go-link-900380651/000004.o: in function `_cgo_26061493d47f_C2func_getaddrinfo':
    #32 467.0 /tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

