### PR TITLE
CLI flag for running container as the current user

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"runtime"
 	"strings"
 	"testing"
@@ -967,5 +968,49 @@ func TestConvertToStandardNotation(t *testing.T) {
 		if _, err := convertToStandardNotation(ports); err == nil {
 			t.Fatalf("ConvertToStandardNotation(`%q`) should have failed conversion", ports)
 		}
+	}
+}
+
+func TestParseUser(t *testing.T) {
+	testUser := user.User{
+		Uid: "1234",
+		Gid: "1234",
+	}
+
+	testCases := []struct {
+		currentUser        *user.User
+		currentUserFlag    bool
+		userFlag           string
+		expectedParsedUser string
+	}{
+		{
+			currentUser:        &testUser,
+			currentUserFlag:    false,
+			userFlag:           "",
+			expectedParsedUser: "",
+		},
+		{
+			currentUser:        &testUser,
+			currentUserFlag:    false,
+			userFlag:           "1000",
+			expectedParsedUser: "1000",
+		},
+		{
+			currentUser:        &testUser,
+			currentUserFlag:    true,
+			userFlag:           "",
+			expectedParsedUser: "1234:1234",
+		},
+		{
+			currentUser:        &testUser,
+			currentUserFlag:    true,
+			userFlag:           "1000",
+			expectedParsedUser: "1000",
+		},
+	}
+
+	for _, tc := range testCases {
+		parsedUser := parseUser(tc.currentUser, tc.currentUserFlag, tc.userFlag)
+		assert.DeepEqual(t, parsedUser, tc.expectedParsedUser)
 	}
 }

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2007,6 +2007,7 @@ _docker_container_run_and_create() {
 			--detach -d
 			--rm
 			--sig-proxy=false
+			--current-user
 		"
 		__docker_complete_detach_keys && return
 	fi

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -659,6 +659,7 @@ __docker_container_subcommand() {
         "($help)*--sysctl=-[sysctl options]:sysctl: "
         "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]"
         "($help -u --user)"{-u=,--user=}"[Username or UID]:user:_users"
+        "($help)--current-user[Run as the user that called the CLI]"
         "($help)*--ulimit=[ulimit options]:ulimit: "
         "($help)--userns=[Container user namespace]:user namespace:(host)"
         "($help)--tmpfs[mount tmpfs]"

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -40,6 +40,7 @@ Options:
       --cpu-rt-runtime int            Limit the CPU real-time runtime in microseconds
       --cpuset-cpus string            CPUs in which to allow execution (0-3, 0,1)
       --cpuset-mems string            MEMs in which to allow execution (0-3, 0,1)
+      --current-user                  Run as the user that called the CLI
   -d, --detach                        Run container in background and print container ID
       --detach-keys string            Override the key sequence for detaching a container
       --device value                  Add a host device to the container (default [])


### PR DESCRIPTION
Signed-off-by: Konrad Ponichtera <konpon96@gmail.com>

Closes #3498

**- What I did**

I’ve added the `--current-user` boolean flag to the `docker run` command to avoid `docker run -u $(id -u):$(id -g)` construct which often appears in the scripts that use Docker containers for development.

**- How I did it**

The user parameter of the Docker API call is now built by the dedicated `parseUser` function in `opts.go` file. It checks if `--current-user` flag was set. In such case, it fetches current user UID and GID using [Go’s standard library](https://pkg.go.dev/os/user#Current), builds the string `UID:GID`, and passes it to the Docker API. The `--user` flag has precedence over `--current-user` - if both are specified, the `--user` one will be taken. 

There is also a unit test, which verifies the behavior of the function that builds the API call user field. I’ve also updated bash and zsh autocompletion files, as well as the Markdown reference document for the `run` command.

If there are some things that should be done and which I missed, please let me know and I will address them.

**- How to verify it**

1. Build repo with `docker buildx bake`
2. Run `./build/docker run -it --current-user ubuntu /bin/bash` - the Ubuntu container will run the process inside with the same UID and GID as the CLI caller’s process.
3. Run `./build/docker run -it --current-user -u 1234:1234 ubuntu /bin/bash` - the `-u` flag will take precedence

**- Description for the changelog**

Added `--current-user` flag to the `docker run` command.

**- A picture of a cute animal (not mandatory but encouraged)**

![cute_animal](https://user-images.githubusercontent.com/4958634/160261958-27406020-b171-4830-8405-b42dbea290eb.jpg)

