### PR TITLE
Change "COMPANY_NAME" to "PACKAGER_NAME"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ ARG GO_STRIP
 ARG CGO_ENABLED
 # VERSION sets the version for the produced binary
 ARG VERSION
-# COMPANY_NAME sets the company that produced the windows binary
-ARG COMPANY_NAME
+# PACKAGER_NAME sets the company that produced the windows binary
+ARG PACKAGER_NAME
 COPY --from=goversioninfo /out/goversioninfo /usr/bin/goversioninfo
 RUN --mount=type=bind,target=.,ro \
     --mount=type=cache,target=/root/.cache \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 
 # Sets the name of the company that produced the windows binary.
-COMPANY_NAME ?=
+PACKAGER_NAME ?=
 
 all: binary
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,7 +15,7 @@ variable "IMAGE_NAME" {
 }
 
 # Sets the name of the company that produced the windows binary.
-variable "COMPANY_NAME" {
+variable "PACKAGER_NAME" {
     default = ""
 }
 
@@ -38,7 +38,7 @@ target "binary" {
     args = {
         BASE_VARIANT = USE_GLIBC != "" ? "buster" : "alpine"
         VERSION = VERSION
-        COMPANY_NAME = COMPANY_NAME
+        PACKAGER_NAME = PACKAGER_NAME
         GO_STRIP = STRIP_TARGET
     }
 }

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -10,7 +10,7 @@ DOCKER_CLI_CONTAINER_NAME ?=
 DOCKER_CLI_GO_BUILD_CACHE ?= y
 
 # Sets the name of the company that produced the windows binary.
-COMPANY_NAME ?=
+PACKAGER_NAME ?=
 
 DEV_DOCKER_IMAGE_NAME = docker-cli-dev$(IMAGE_TAG)
 E2E_IMAGE_NAME = docker-cli-e2e
@@ -36,7 +36,7 @@ DOCKER_RUN := docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(DOCKER_RUN_NAME_
 
 .PHONY: binary
 binary:
-	COMPANY_NAME=$(COMPANY_NAME) docker buildx bake binary
+	PACKAGER_NAME=$(PACKAGER_NAME) docker buildx bake binary
 
 build: binary ## alias for binary
 
@@ -53,11 +53,11 @@ clean: build_docker_image ## clean build artifacts
 
 .PHONY: cross
 cross:
-	COMPANY_NAME=$(COMPANY_NAME) docker buildx bake cross
+	PACKAGER_NAME=$(PACKAGER_NAME) docker buildx bake cross
 
 .PHONY: dynbinary
 dynbinary: ## build dynamically linked binary
-	USE_GLIBC=1 COMPANY_NAME=$(COMPANY_NAME)  docker buildx bake dynbinary
+	USE_GLIBC=1 PACKAGER_NAME=$(PACKAGER_NAME)  docker buildx bake dynbinary
 
 .PHONY: dev
 dev: build_docker_image ## start a build container in interactive mode for in-container development

--- a/scripts/build/mkversioninfo
+++ b/scripts/build/mkversioninfo
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-: "${COMPANY_NAME=}"
+: "${PACKAGER_NAME=}"
 
 . ./scripts/build/.variables
 
@@ -31,7 +31,7 @@ cat > ./cli/winresources/versioninfo.json <<EOL
   "StringFileInfo":
   {
     "Comments": "",
-    "CompanyName": "${COMPANY_NAME}",
+    "CompanyName": "${PACKAGER_NAME}",
     "FileDescription": "Docker Client",
     "FileVersion": "${VERSION}",
     "InternalName": "",


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/3310

The COMPANY_NAME currently sets the "CompanyName" field in the metadata
of Windows binaries. Our intent of this field is this field to contain
information about the company/party that produced the binary.

Also from [FileVersionInfo.CompanyName][FileVersionInfo.CompanyName]:

> Gets the name of the company that produced the file

Based on the above, "PACKAGER_NAME" is a bit more generic, and clearer
on intent, and we may at some point re-use this same information to
propagate equivalent fields on other platforms (rpms, debs)

[FileVersionInfo.CompanyName]: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.fileversioninfo.companyname

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

