### PR TITLE
Fix flaky TestContainerList tests

### DIFF
--- a/cli/command/container/testdata/container-list-without-format-no-trunc.golden
+++ b/cli/command/container/testdata/container-list-without-format-no-trunc.golden
@@ -1,3 +1,3 @@
-CONTAINER ID   IMAGE            COMMAND   CREATED                  STATUS        PORTS     NAMES
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c1
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c2,foo/bar
+CONTAINER ID   IMAGE            COMMAND   CREATED              STATUS        PORTS     NAMES
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute             c1
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute             c2,foo/bar

--- a/cli/command/container/testdata/container-list-without-format.golden
+++ b/cli/command/container/testdata/container-list-without-format.golden
@@ -1,6 +1,6 @@
-CONTAINER ID   IMAGE            COMMAND   CREATED                  STATUS        PORTS                NAMES
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second                        c1
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second                        c2
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   80-82/tcp            c3
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   81/udp               c4
-container_id   busybox:latest   "top"     Less than a second ago   Up 1 second   8.8.8.8:82->82/tcp   c5
+CONTAINER ID   IMAGE            COMMAND   CREATED              STATUS        PORTS                NAMES
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute                        c1
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute                        c2
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute   80-82/tcp            c3
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute   81/udp               c4
+container_id   busybox:latest   "top"     About a minute ago   Up 1 minute   8.8.8.8:82->82/tcp   c5

--- a/internal/test/builders/container.go
+++ b/internal/test/builders/container.go
@@ -16,8 +16,8 @@ func Container(name string, builders ...func(container *types.Container)) *types
 		Names:   []string{"/" + name},
 		Command: "top",
 		Image:   "busybox:latest",
-		Status:  "Up 1 second",
-		Created: time.Now().Unix(),
+		Status:  "Up 1 minute",
+		Created: time.Now().Add(-1 * time.Minute).Unix(),
 	}
 
 	for _, builder := range builders {


### PR DESCRIPTION
relates to https://github.com/docker/cli/pull/3471#issuecomment-1080989454

These tests were creating a stub container, using the current timestamp as
created date. However, if CI was slow to run the test, `Less than a second ago`
would change into `1 second ago`, causing the test to fail:

    --- FAIL: TestContainerListNoTrunc (0.00s)
        list_test.go:198: assertion failed:
            --- expected
            +++ actual
            @@ -1,4 +1,4 @@
            -CONTAINER ID   IMAGE            COMMAND   CREATED                  STATUS        PORTS     NAMES
            -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c1
            -container_id   busybox:latest   "top"     Less than a second ago   Up 1 second             c2,foo/bar
            +CONTAINER ID   IMAGE            COMMAND   CREATED        STATUS        PORTS     NAMES
            +container_id   busybox:latest   "top"     1 second ago   Up 1 second             c1
            +container_id   busybox:latest   "top"     1 second ago   Up 1 second             c2,foo/bar

This patch changes the "created" time of the container to be a minute ago. This
will result in `About a minute ago`, with a margin of 1 minute.


**- A picture of a cute animal (not mandatory but encouraged)**

