### PR TITLE
use GO_LDFLAGS instead of LDFLAGS to prevent inheriting unrelated options

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -63,23 +63,23 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ]; then
 fi
 export GO_BUILDMODE
 
-LDFLAGS="${LDFLAGS:-} -w"
-LDFLAGS="$LDFLAGS -X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\""
-LDFLAGS="$LDFLAGS -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\""
-LDFLAGS="$LDFLAGS -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
+GO_LDFLAGS="${GO_LDFLAGS:-} -w"
+GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\""
+GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\""
+GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
 if test -n "${PLATFORM}"; then
-    LDFLAGS="$LDFLAGS -X \"github.com/docker/cli/cli/version.PlatformName=${PLATFORM}\""
+    GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.PlatformName=${PLATFORM}\""
 fi
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$(go env GOOS)" = "linux" ]; then
-    LDFLAGS="$LDFLAGS -extldflags -static"
+    GO_LDFLAGS="$GO_LDFLAGS -extldflags -static"
 fi
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     # compiling statically with CGO enabled requires osusergo to be set.
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo"
 fi
 if [ -n "$GO_STRIP" ]; then
-    LDFLAGS="$LDFLAGS -s"
+    GO_LDFLAGS="$GO_LDFLAGS -s"
 fi
-export LDFLAGS="$LDFLAGS" # https://github.com/koalaman/shellcheck/issues/2064
+export GO_LDFLAGS="$GO_LDFLAGS" # https://github.com/koalaman/shellcheck/issues/2064
 
 export SOURCE="github.com/docker/cli/cmd/docker"

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -24,6 +24,6 @@ if [ "$(go env GOOS)" = "windows" ]; then
   fi
 fi
 
-(set -x ; go build -o "${TARGET}" -tags "${GO_BUILDTAGS}" -ldflags "${LDFLAGS}" ${GO_BUILDMODE} "${SOURCE}")
+(set -x ; go build -o "${TARGET}" -tags "${GO_BUILDTAGS}" -ldflags "${GO_LDFLAGS}" ${GO_BUILDMODE} "${SOURCE}")
 
 ln -sf "$(basename "${TARGET}")" "$(dirname "${TARGET}")/docker"

--- a/scripts/build/plugins
+++ b/scripts/build/plugins
@@ -15,5 +15,5 @@ for p in cli-plugins/examples/* "$@" ; do
     mkdir -p "$(dirname "${TARGET_PLUGIN}")"
 
     echo "Building $GO_LINKMODE $(basename "${TARGET_PLUGIN}")"
-    (set -x ; CGO_ENABLED=0 GO111MODULE=auto go build -o "${TARGET_PLUGIN}" -tags "${GO_BUILDTAGS}" -ldflags "${LDFLAGS}" ${GO_BUILDMODE} "github.com/docker/cli/${p}")
+    (set -x ; CGO_ENABLED=0 GO111MODULE=auto go build -o "${TARGET_PLUGIN}" -tags "${GO_BUILDTAGS}" -ldflags "${GO_LDFLAGS}" ${GO_BUILDMODE} "github.com/docker/cli/${p}")
 done


### PR DESCRIPTION
relates to https://github.com/docker/docker-ce-packaging/pull/666

When building on Fedora 36, the build failed. I suspect this is because the
rpm tools also set LDFLAGS, but with options that cannot be used;

    GO_LINKMODE=dynamic
    + ./scripts/build/binary
      /go/src/github.com/docker/cli ~/rpmbuild/BUILD/src
      Building dynamic docker-linux-arm64
      + go build -o build/docker-linux-arm64 -tags ' pkcs11' -ldflags '-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -Wl,-dT,/root/rpmbuild/BUILD/src/.package_note-docker-ce-cli-0.0.0.20220330082637.68cad50-0.fc36.aarch64.ld -w -X "github.com/docker/cli/cli/version.GitCommit=68cad50" -X "github.com/docker/cli/cli/version.BuildTime=2022-03-30T20:05:36Z" -X "github.com/docker/cli/cli/version.Version=0.0.0-20220330082637-68cad50" -X "github.com/docker/cli/cli/version.PlatformName=Docker Engine - Community"' -buildmode=pie github.com/docker/cli/cmd/docker
    # github.com/docker/cli/cmd/docker
    flag provided but not defined: -Wl,-z,relro
    usage: link [options] main.o

This patch changes the variable we use to `GO_LDFLAGS`, taking a similar approach
as containerd, and various other projects using this name: https://grep.app/search?q=GO_LDFLAGS

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

