### PR TITLE
trim leading 0 for minor in the version quad

### DIFF
--- a/scripts/build/mkversioninfo
+++ b/scripts/build/mkversioninfo
@@ -7,6 +7,10 @@ set -eu
 
 # Create version quad for Windows of the form major.minor.patch.build
 VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | sed -re 's/\.$//' | sed -re 's/^[0-9]+$/\0\.0/' | sed -re 's/^[0-9]+\.[0-9]+$/\0\.0/' | sed -re 's/^[0-9]+\.[0-9]+\.[0-9]+$/\0\.0/')
+VERSION_MAJOR=$(echo "${VERSION_QUAD:-0}" | cut -d. -f1)
+VERSION_MINOR=$(echo "${VERSION_QUAD:-0}" | cut -d. -f2)
+VERSION_PATCH=$(echo "${VERSION_QUAD:-0}" | cut -d. -f3)
+VERSION_BUILD=$(echo "${VERSION_QUAD:-0}" | cut -d. -f4)
 
 # Generate versioninfo.json to be able to create a syso file which contains
 # Microsoft Windows Version Information and an icon using goversioninfo.
@@ -17,10 +21,10 @@ cat > ./cli/winresources/versioninfo.json <<EOL
   "FixedFileInfo":
   {
     "FileVersion": {
-      "Major": $(echo "${VERSION_QUAD:-0}" | cut -d. -f1),
-      "Minor": $(echo "${VERSION_QUAD:-0}" | cut -d. -f2),
-      "Patch": $(echo "${VERSION_QUAD:-0}" | cut -d. -f3),
-      "Build": $(echo "${VERSION_QUAD:-0}" | cut -d. -f4)
+      "Major": ${VERSION_MAJOR},
+      "Minor": ${VERSION_MINOR#0},
+      "Patch": ${VERSION_PATCH},
+      "Build": ${VERSION_BUILD}
     },
     "FileFlagsMask": "3f",
     "FileFlags ": "00",


### PR DESCRIPTION
```
+ cat ./cli/winresources/versioninfo.json
{
  "FixedFileInfo":
  {
    "FileVersion": {
      "Major": 22,
      "Minor": 04,
      "Patch": 0,
      "Build": 0
    },
    "FileFlagsMask": "3f",
    "FileFlags ": "00",
    "FileOS": "040004",
    "FileType": "01",
    "FileSubType": "00"
  },
  "StringFileInfo":
  {
    "Comments": "",
    "CompanyName": "",
    "FileDescription": "Docker Client",
    "FileVersion": "22.04.0-beta.0",
    "InternalName": "",
    "LegalCopyright": "Copyright © 2015-2022 Docker Inc.",
    "LegalTrademarks": "",
    "OriginalFilename": "docker-windows-amd64.exe",
    "PrivateBuild": "",
    "ProductName": "Docker Client",
    "ProductVersion": "22.04.0-beta.0",
    "SpecialBuild": "58d425d"
  },
  "VarFileInfo":
  {
    "Translation": {
      "LangID": "0409",
      "CharsetID": "04B0"
    }
  }
}
```

```
2022/03/31 13:16:40 Could not parse the .json file: invalid character '4' after object key:value pair
cmd/docker/docker_windows_amd64.go:4: running "goversioninfo": exit status 2
ERROR: executor failed running [/bin/sh -c xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     xx-verify $([ "$GO_LINKMODE" = "static" ] && echo "--static") /out/docker]: exit code: 1
------
 > [build 3/3] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=from=dockercore/golang-cross:xx-sdk-extras,target=/xx-sdk,src=/xx-sdk     --mount=type=tmpfs,target=cli/winresources     xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     xx-verify $([ "static" = "static" ] && echo "--static") /out/docker:
}
```

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>