### PR TITLE
fix version quad logic that trims 0 digit so returns an empty one

### DIFF
--- a/scripts/build/mkversioninfo
+++ b/scripts/build/mkversioninfo
@@ -3,14 +3,19 @@ set -eu
 
 : "${PACKAGER_NAME=}"
 
+quadVersionNum() {
+  num=$(echo "${1:-0}" | cut -d. -f"$2")
+  if [ "$num" != "0" ]; then
+    echo "${num#0}"
+  else
+    echo "$num"
+  fi
+}
+
 . ./scripts/build/.variables
 
 # Create version quad for Windows of the form major.minor.patch.build
 VERSION_QUAD=$(printf "%s" "$VERSION" | sed -re 's/^([0-9.]*).*$/\1/' | sed -re 's/\.$//' | sed -re 's/^[0-9]+$/\0\.0/' | sed -re 's/^[0-9]+\.[0-9]+$/\0\.0/' | sed -re 's/^[0-9]+\.[0-9]+\.[0-9]+$/\0\.0/')
-VERSION_MAJOR=$(echo "${VERSION_QUAD:-0}" | cut -d. -f1)
-VERSION_MINOR=$(echo "${VERSION_QUAD:-0}" | cut -d. -f2)
-VERSION_PATCH=$(echo "${VERSION_QUAD:-0}" | cut -d. -f3)
-VERSION_BUILD=$(echo "${VERSION_QUAD:-0}" | cut -d. -f4)
 
 # Generate versioninfo.json to be able to create a syso file which contains
 # Microsoft Windows Version Information and an icon using goversioninfo.
@@ -21,10 +26,10 @@ cat > ./cli/winresources/versioninfo.json <<EOL
   "FixedFileInfo":
   {
     "FileVersion": {
-      "Major": ${VERSION_MAJOR},
-      "Minor": ${VERSION_MINOR#0},
-      "Patch": ${VERSION_PATCH},
-      "Build": ${VERSION_BUILD}
+      "Major": $(quadVersionNum "$VERSION_QUAD" 1),
+      "Minor": $(quadVersionNum "$VERSION_QUAD" 2),
+      "Patch": $(quadVersionNum "$VERSION_QUAD" 3),
+      "Build": $(quadVersionNum "$VERSION_QUAD" 4)
     },
     "FileFlagsMask": "3f",
     "FileFlags ": "00",


### PR DESCRIPTION
follow-up https://github.com/docker/cli/pull/3517

```
#25 0.448 Building static docker-windows-amd64.exe
#25 0.468 + cat ./cli/winresources/versioninfo.json
#25 0.469 {
#25 0.469   "FixedFileInfo":
#25 0.469   {
#25 0.469     "FileVersion": {
#25 0.469       "Major": 0,
#25 0.469       "Minor": ,
#25 0.469       "Patch": 0,
#25 0.469       "Build": 0
#25 0.469     },
#25 0.469     "FileFlagsMask": "3f",
#25 0.469     "FileFlags ": "00",
#25 0.469     "FileOS": "040004",
#25 0.469     "FileType": "01",
#25 0.469     "FileSubType": "00"
#25 0.469   },
#25 0.469   "StringFileInfo":
#25 0.469   {
#25 0.469     "Comments": "",
#25 0.469     "CompanyName": "",
#25 0.469     "FileDescription": "Docker Client",
#25 0.469     "FileVersion": "0.0.0-20220331141022-b1ce915",
#25 0.469     "InternalName": "",
#25 0.469     "LegalCopyright": "Copyright © 2015-2022 Docker Inc.",
#25 0.469     "LegalTrademarks": "",
#25 0.469     "OriginalFilename": "docker-windows-amd64.exe",
#25 0.469     "PrivateBuild": "",
#25 0.469     "ProductName": "Docker Client",
#25 0.469     "ProductVersion": "0.0.0-20220331141022-b1ce915",
#25 0.469     "SpecialBuild": "b1ce915"
#25 0.469   },
#25 0.469   "VarFileInfo":
#25 0.469   {
#25 0.469     "Translation": {
#25 0.469       "LangID": "0409",
#25 0.469       "CharsetID": "04B0"
#25 0.469     }
#25 0.469   }
#25 0.469 }
```

cc @thaJeztah 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>