### PR TITLE
[20.10 backport] Dockerfile: update xx to 1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.16.15
-ARG XX_VERSION=1.0.0-rc.2
+ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
 FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS golatest
@@ -55,7 +55,7 @@ RUN --mount=ro --mount=type=cache,target=/root/.cache \
     TARGET=/out ./scripts/build/binary && \
     xx-verify $([ "$GO_LINKMODE" = "static" ] && echo "--static") /out/docker
 
-FROM build-base-${BASE_VARIANT} AS dev 
+FROM build-base-${BASE_VARIANT} AS dev
 COPY . .
 
 FROM scratch AS binary


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3489
(cherry picked from commit 40d8016627cc78988fc03f45d6540bf65a39b4f9)


**- A picture of a cute animal (not mandatory but encouraged)**

