### PR TITLE
[20.10 backport] Fix incorrect pointer inputs to `json.Unmarshal`

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -119,7 +119,7 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 // LoadFromReader reads the configuration data given and sets up the auth config
 // information with given directory and populates the receiver object
 func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
-	if err := json.NewDecoder(configData).Decode(&configFile); err != nil && !errors.Is(err, io.EOF) {
+	if err := json.NewDecoder(configData).Decode(configFile); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 	var err error


### PR DESCRIPTION
backport of https://github.com/docker/cli/pull/3434

See https://github.com/howardjohn/go-unmarshal-double-pointer for more
info on why this is not safe and how this is detected.

(cherry picked from commit ee97fe95bc7f3e1c10f508dc888ec26268d23d79)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

