### PR TITLE
[20.10 backport] assorted documentation fixes

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1632,7 +1632,7 @@ If you forget to add `exec` to the beginning of your `ENTRYPOINT`:
 ```dockerfile
 FROM ubuntu
 ENTRYPOINT top -b
-CMD --ignored-param1
+CMD -- --ignored-param1
 ```
 
 You can then run it (giving it a name for the next step):
@@ -1640,12 +1640,15 @@ You can then run it (giving it a name for the next step):
 ```console
 $ docker run -it --name test top --ignored-param2
 
-Mem: 1704184K used, 352484K free, 0K shrd, 0K buff, 140621524238337K cached
-CPU:   9% usr   2% sys   0% nic  88% idle   0% io   0% irq   0% sirq
-Load average: 0.01 0.02 0.05 2/101 7
-  PID  PPID USER     STAT   VSZ %VSZ %CPU COMMAND
-    1     0 root     S     3168   0%   0% /bin/sh -c top -b cmd cmd2
-    7     1 root     R     3164   0%   0% top -b
+top - 13:58:24 up 17 min,  0 users,  load average: 0.00, 0.00, 0.00
+Tasks:   2 total,   1 running,   1 sleeping,   0 stopped,   0 zombie
+%Cpu(s): 16.7 us, 33.3 sy,  0.0 ni, 50.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
+MiB Mem :   1990.8 total,   1354.6 free,    231.4 used,    404.7 buff/cache
+MiB Swap:   1024.0 total,   1024.0 free,      0.0 used.   1639.8 avail Mem
+
+  PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+    1 root      20   0    2612    604    536 S   0.0   0.0   0:00.02 sh
+    6 root      20   0    5956   3188   2768 R   0.0   0.2   0:00.00 top
 ```
 
 You can see from the output of `top` that the specified `ENTRYPOINT` is not `PID 1`.
@@ -1654,12 +1657,12 @@ If you then run `docker stop test`, the container will not exit cleanly - the
 `stop` command will be forced to send a `SIGKILL` after the timeout:
 
 ```console
-$ docker exec -it test ps aux
+$ docker exec -it test ps waux
 
-PID   USER     COMMAND
-    1 root     /bin/sh -c top -b cmd cmd2
-    7 root     top -b
-    8 root     ps aux
+USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root         1  0.4  0.0   2612   604 pts/0    Ss+  13:58   0:00 /bin/sh -c top -b --ignored-param2
+root         6  0.0  0.1   5956  3188 pts/0    S+   13:58   0:00 top -b
+root         7  0.0  0.1   5884  2816 pts/1    Rs+  13:58   0:00 ps waux
 
 $ /usr/bin/time docker stop test
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -99,16 +99,16 @@ $ docker build https://github.com/docker/rootfs.git#container:docker
 The following table represents all the valid suffixes with their build
 contexts:
 
-Build Syntax Suffix             | Commit Used           | Build Context Used
---------------------------------|-----------------------|-------------------
-`myrepo.git`                    | `refs/heads/master`   | `/`
-`myrepo.git#mytag`              | `refs/tags/mytag`     | `/`
-`myrepo.git#mybranch`           | `refs/heads/mybranch` | `/`
-`myrepo.git#pull/42/head`       | `refs/pull/42/head`   | `/`
-`myrepo.git#:myfolder`          | `refs/heads/master`   | `/myfolder`
-`myrepo.git#master:myfolder`    | `refs/heads/master`   | `/myfolder`
-`myrepo.git#mytag:myfolder`     | `refs/tags/mytag`     | `/myfolder`
-`myrepo.git#mybranch:myfolder`  | `refs/heads/mybranch` | `/myfolder`
+| Build Syntax Suffix            | Commit Used           | Build Context Used |
+|--------------------------------|-----------------------|--------------------|
+| `myrepo.git`                   | `refs/heads/master`   | `/`                |
+| `myrepo.git#mytag`             | `refs/tags/mytag`     | `/`                |
+| `myrepo.git#mybranch`          | `refs/heads/mybranch` | `/`                |
+| `myrepo.git#pull/42/head`      | `refs/pull/42/head`   | `/`                |
+| `myrepo.git#:myfolder`         | `refs/heads/master`   | `/myfolder`        |
+| `myrepo.git#master:myfolder`   | `refs/heads/master`   | `/myfolder`        |
+| `myrepo.git#mytag:myfolder`    | `refs/tags/mytag`     | `/myfolder`        |
+| `myrepo.git#mybranch:myfolder` | `refs/heads/mybranch` | `/myfolder`        |
 
 > **Note**
 >
@@ -461,11 +461,11 @@ technology. On Linux, the only supported is the `default` option which uses
 Linux namespaces. On Microsoft Windows, you can specify these values:
 
 
-| Value     | Description                                                                                                                                                   |
-|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value.  |
-| `process` | Namespace isolation only.                                                                                                                                     |
-| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                 |
+| Value     | Description                                                                                                                                                                    |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value. |
+| `process` | Namespace isolation only.                                                                                                                                                      |
+| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                                  |
 
 Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
 
@@ -485,10 +485,10 @@ image. Commands after the target stage will be skipped.
 
 ```dockerfile
 FROM debian AS build-env
-...
+# ...
 
 FROM alpine AS production-env
-...
+# ...
 ```
 
 ```console

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -113,7 +113,7 @@ using a Go template.
 Valid placeholders for the Go template are listed below:
 
 | Placeholder  | Description                                                                          |
-| ------------ | ------------------------------------------------------------------------------------ |
+|--------------|--------------------------------------------------------------------------------------|
 | `.ID`        | Config ID                                                                            |
 | `.Name`      | Config name                                                                          |
 | `.CreatedAt` | Time when the config was created                                                     |

--- a/docs/reference/commandline/context.md
+++ b/docs/reference/commandline/context.md
@@ -1,0 +1,45 @@
+---
+title: "context"
+description: "The context command description and usage"
+keywords: "context"
+---
+
+# config
+
+```markdown
+Manage contexts
+
+Usage:
+docker context [command]
+
+Available Commands:
+create      Create new context
+export      Export a context to a tar or kubeconfig file
+import      Import a context from a tar or zip file
+inspect     Display detailed information on one or more contexts
+list        List available contexts
+rm          Remove one or more contexts
+show        Print the current context
+update      Update a context
+use         Set the default context
+
+Flags:
+-h, --help   Help for context
+
+Use "docker context [command] --help" for more information about a command.
+```
+
+## Description
+
+Manage contexts.
+
+## Related commands
+
+* [context create](context_create.md)
+* [context export](context_export.md)
+* [context import](context_import.md)
+* [context inspect](context_inspect.md)
+* [context list](context_ls.md)
+* [context rm](context_rm.md)
+* [context update](context_update.md)
+* [context use](context_use.md)

--- a/docs/reference/commandline/context_use.md
+++ b/docs/reference/commandline/context_use.md
@@ -13,6 +13,7 @@ Set the current docker context
 ```
 
 ## Description
+
 Set the default context to use, when `DOCKER_HOST`, `DOCKER_CONTEXT` environment
 variables and `--host`, `--context` global options are not set.
 To disable usage of contexts, you can use the special `default` context.

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -89,6 +89,28 @@ you must be explicit with a relative or absolute path, for example:
 
     `/path/to/file:name.txt` or `./file:name.txt`
 
+## Examples
+
+Copy a local file into container
+
+```console
+$ docker cp ./some_file CONTAINER:/work 
+```
+
+Copy files from container to local path
+
+```console
+$ docker cp CONTAINER:/var/logs/ /tmp/app_logs
+```
+
+Copy a file from container to stdout. Please note `cp` command produces a tar stream
+
+```console
+$ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"
+```
+
+### Corner cases
+
 It is not possible to copy certain system files such as resources under
 `/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
 the user in the container. However, you can still copy such files by manually

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -94,7 +94,7 @@ you must be explicit with a relative or absolute path, for example:
 Copy a local file into container
 
 ```console
-$ docker cp ./some_file CONTAINER:/work 
+$ docker cp ./some_file CONTAINER:/work
 ```
 
 Copy files from container to local path

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -98,6 +98,7 @@ Options:
       --privileged                    Give extended privileges to this container
   -p, --publish value                 Publish a container's port(s) to the host (default [])
   -P, --publish-all                   Publish all exposed ports to random ports
+      --pull string                   Pull image before creating ("always"|"missing"|"never") (default "missing")
       --read-only                     Mount the container's root filesystem as read only
       --restart string                Restart policy to apply when a container exits (default "no")
                                       Possible values are: no, on-failure[:max-retry], always, unless-stopped

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -135,35 +135,51 @@ Options:
 
 ## Description
 
-The `docker create` command creates a writeable container layer over the
-specified image and prepares it for running the specified command.  The
+The `docker container create` (or shorthand: `docker create`) command creates a
+new container from the specified image, without starting it.
+
+When creating a container, the docker daemon creates a writeable container layer
+over the specified image and prepares it for running the specified command.  The
 container ID is then printed to `STDOUT`.  This is similar to `docker run -d`
-except the container is never started.  You can then use the
-`docker start <container_id>` command to start the container at any point.
+except the container is never started. You can then use the `docker container start`
+(or shorthand: `docker start`) command to start the container at any point.
 
 This is useful when you want to set up a container configuration ahead of time
 so that it is ready to start when you need it. The initial status of the
 new container is `created`.
 
-Please see the [run command](run.md) section and the [Docker run reference](../run.md) for more details.
+The `docker create` command shares most of its options with the `docker run`
+command (which performs a `docker create` before starting it). Refer to the
+[`docker run` command](run.md) section and the [Docker run reference](../run.md)
+for details on the available flags and options.
 
 ## Examples
 
 ### Create and start a container
 
-```console
-$ docker create -t -i fedora bash
+The following example creates an interactive container with a pseudo-TTY attached,
+then starts the container and attaches to it:
 
+```console
+$ docker container create -i -t --name mycontainer alpine
 6d8af538ec541dd581ebc2a24153a28329acb5268abe5ef868c1f1a261221752
 
-$ docker start -a -i 6d8af538ec5
+$ docker container start --attach -i mycontainer
+/ # echo hello world
+hello world
+```
 
-bash-4.2#
+The above is the equivalent of a `docker run`:
+
+```console
+$ docker run -it --name mycontainer2 alpine
+/ # echo hello world
+hello world
 ```
 
 ### Initialize volumes
 
-As of v1.4.0 container volumes are initialized during the `docker create` phase
+Container volumes are initialized during the `docker create` phase
 (i.e., `docker run` too). For example, this allows you to `create` the `data`
 volume container, and then use it from another container:
 
@@ -200,58 +216,3 @@ drwxr-sr-x  3 1000 staff   60 Dec  1 03:28 .local
 drwx--S---  2 1000 staff  460 Dec  5 00:51 .ssh
 drwxr-xr-x 32 1000 staff 1140 Dec  5 04:01 docker
 ```
-
-
-Set storage driver options per container.
-
-```console
-$ docker create -it --storage-opt size=120G fedora /bin/bash
-```
-
-This (size) will allow to set the container rootfs size to 120G at creation time.
-This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
-`windowsfilter` and `zfs` graph drivers.
-For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
-user cannot pass a size less than the Default BaseFS Size.
-For the `overlay2` storage driver, the size option is only available if the
-backing fs is `xfs` and mounted with the `pquota` mount option.
-Under these conditions, user can pass any size less than the backing fs size.
-
-### Specify isolation technology for container (--isolation)
-
-This option is useful in situations where you are running Docker containers on
-Windows. The `--isolation=<value>` option sets a container's isolation
-technology. On Linux, the only supported is the `default` option which uses
-Linux namespaces. On Microsoft Windows, you can specify these values:
-
-
-| Value     | Description                                                  |
-| --------- | ------------------------------------------------------------ |
-| `default` | Use the value specified by the Docker daemon's `--exec-opt` . If the `daemon` does not specify an isolation technology, Microsoft Windows uses `process` as its default value if the daemon is running on Windows server, or `hyperv` if running on Windows client. |
-| `process` | Namespace isolation only.                                    |
-| `hyperv`  | Hyper-V hypervisor partition-based isolation.                |
-
-Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
-
-### Dealing with dynamically created devices (--device-cgroup-rule)
-
-Devices available to a container are assigned at creation time. The
-assigned devices will both be added to the cgroup.allow file and
-created into the container once it is run. This poses a problem when
-a new device needs to be added to running container.
-
-One of the solutions is to add a more permissive rule to a container
-allowing it access to a wider range of devices. For example, supposing
-our container needs access to a character device with major `42` and
-any number of minor number (added as new devices appear), the
-following rule would be added:
-
-```console
-$ docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
-```
-
-Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
-the required device when it is added.
-
-NOTE: initially present devices still need to be explicitly added to
-the create/run command

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -1462,7 +1462,7 @@ This is a full example of the allowed configuration options on Linux:
 > daemon startup as a flag.
 > On systems that use `systemd` to start the Docker daemon, `-H` is already set, so
 > you cannot use the `hosts` key in `daemon.json` to add listening addresses.
-> See https://docs.docker.com/engine/admin/systemd/#custom-docker-daemon-options for how
+> See ["custom Docker daemon options"](https://docs.docker.com/config/daemon/systemd/#custom-docker-daemon-options) for how
 > to accomplish this task with a systemd drop-in file.
 
 ##### On Windows

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -773,7 +773,7 @@ time of writing, the following is the list of `libdm` log levels as well as
 their corresponding levels when output by `dockerd`.
 
 | `libdm` Level | Value | `--log-level` |
-| ------------- | -----:| ------------- |
+|---------------|------:|---------------|
 | `_LOG_FATAL`  |     2 | error         |
 | `_LOG_ERR`    |     3 | error         |
 | `_LOG_WARN`   |     4 | warn          |

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -54,14 +54,14 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder     | Description |
-| --------------- | ----------- |
-| `.ID`           | Image ID    |
+| Placeholder     | Description                                                                                               |
+|-----------------|-----------------------------------------------------------------------------------------------------------|
+| `.ID`           | Image ID                                                                                                  |
 | `.CreatedSince` | Elapsed time since the image was created if `--human=true`, otherwise timestamp of when image was created |
-| `.CreatedAt`    | Timestamp of when image was created |
-| `.CreatedBy`    | Command that was used to create the image |
-| `.Size`         | Image disk size |
-| `.Comment`      | Comment for image |
+| `.CreatedAt`    | Timestamp of when image was created                                                                       |
+| `.CreatedBy`    | Command that was used to create the image                                                                 |
+| `.Size`         | Image disk size                                                                                           |
+| `.Comment`      | Comment for image                                                                                         |
 
 When using the `--format` option, the `history` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -293,15 +293,15 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder | Description|
-| ---- | ---- |
-| `.ID` | Image ID |
-| `.Repository` | Image repository |
-| `.Tag` | Image tag |
-| `.Digest` | Image digest |
+| Placeholder     | Description                              |
+|-----------------|------------------------------------------|
+| `.ID`           | Image ID                                 |
+| `.Repository`   | Image repository                         |
+| `.Tag`          | Image tag                                |
+| `.Digest`       | Image digest                             |
 | `.CreatedSince` | Elapsed time since the image was created |
-| `.CreatedAt` | Time when the image was created |
-| `.Size` | Image disk size |
+| `.CreatedAt`    | Time when the image was created          |
+| `.Size`         | Image disk size                          |
 
 When using the `--format` option, the `image` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -28,16 +28,15 @@ specify an archive, Docker untars it in the container relative to the `/`
 the host. To import from a remote location, specify a `URI` that begins with the
 `http://` or `https://` protocol.
 
-The `--change` option will apply `Dockerfile` instructions to the image
-that is created.
-Supported `Dockerfile` instructions:
+The `--change` option applies `Dockerfile` instructions to the image that is
+created. Supported `Dockerfile` instructions:
 `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
 
 ## Examples
 
 ### Import from a remote location
 
-This will create a new untagged image.
+This creates a new untagged image.
 
 ```console
 $ docker import https://example.com/exampleimage.tgz

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -118,15 +118,15 @@ read the [`dockerd`](dockerd.md) reference page.
 
 ### Swarm management commands
 
-| Command | Description                                                        |
-|:--------|:-------------------------------------------------------------------|
-| [swarm init](swarm_init.md) | Initialize a swarm                             |
-| [swarm join](swarm_join.md) | Join a swarm as a manager node or worker node  |
-| [swarm leave](swarm_leave.md) | Remove the current node from the swarm       |
-| [swarm join-token](swarm_join_token.md) | Display or rotate join tokens      |
-| [swarm unlock](swarm_unlock.md) | Unlock swarm                               |
-| [swarm unlock-key](swarm_unlock_key.md) | Manage the unlock key              |
-| [swarm update](swarm_update.md) | Update attributes of a swarm               |
+| Command                                 | Description                                   |
+|:----------------------------------------|:----------------------------------------------|
+| [swarm init](swarm_init.md)             | Initialize a swarm                            |
+| [swarm join](swarm_join.md)             | Join a swarm as a manager node or worker node |
+| [swarm leave](swarm_leave.md)           | Remove the current node from the swarm        |
+| [swarm join-token](swarm_join-token.md) | Display or rotate join tokens                 |
+| [swarm unlock](swarm_unlock.md)         | Unlock swarm                                  |
+| [swarm unlock-key](swarm_unlock-key.md) | Manage the unlock key                         |
+| [swarm update](swarm_update.md)         | Update attributes of a swarm                  |
 
 ### Swarm service commands
 

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -36,7 +36,8 @@ $ docker network connect multi-host-network container1
 
 ### Connect a container to a network when it starts
 
-You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
+You can also use the `docker run --network=<network-name>` option to start a
+container and immediately connect it to a network.
 
 ```console
 $ docker run -itd --network=multi-host-network busybox
@@ -87,14 +88,17 @@ $ docker network create --subnet 172.20.0.0/16 --ip-range 172.20.240.0/20 multi-
 $ docker network connect --ip 172.20.128.2 multi-host-network container2
 ```
 
-To verify the container is connected, use the `docker network inspect` command. Use `docker network disconnect` to remove a container from the network.
+To verify the container is connected, use the `docker network inspect` command.
+Use `docker network disconnect` to remove a container from the network.
 
 Once connected in network, containers can communicate using only another
 container's IP address or name. For `overlay` networks or custom plugins that
 support multi-host connectivity, containers connected to the same multi-host
 network but launched from different Engines can also communicate in this way.
 
-You can connect a container to one or more networks. The networks need not be the same type. For example, you can connect a single container bridge and overlay networks.
+You can connect a container to one or more networks. The networks need not be
+the same type. For example, you can connect a single container bridge and overlay
+networks.
 
 ## Related commands
 

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -184,7 +184,7 @@ network driver, again with their approximate equivalents to `docker daemon`.
 |--------------|----------------|--------------------------------------------|
 | `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
 | `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
-| `--internal` | -              | Restrict external access to the network   |
+| `--internal` | -              | Restrict external access to the network    |
 | `--ipv6`     | `--ipv6`       | Enable IPv6 networking                     |
 | `--subnet`   | `--bip`        | Subnet for network                         |
 

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -204,17 +204,17 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder  | Description
--------------|------------------------------------------------------------------------------------------
-`.ID`        | Network ID
-`.Name`      | Network name
-`.Driver`    | Network driver
-`.Scope`     | Network scope (local, global)
-`.IPv6`      | Whether IPv6 is enabled on the network or not.
-`.Internal`  | Whether the network is internal or not.
-`.Labels`    | All labels assigned to the network.
-`.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}`
-`.CreatedAt` | Time when the network was created
+| Placeholder  | Description                                                                            |
+|--------------|----------------------------------------------------------------------------------------|
+| `.ID`        | Network ID                                                                             |
+| `.Name`      | Network name                                                                           |
+| `.Driver`    | Network driver                                                                         |
+| `.Scope`     | Network scope (local, global)                                                          |
+| `.IPv6`      | Whether IPv6 is enabled on the network or not.                                         |
+| `.Internal`  | Whether the network is internal or not.                                                |
+| `.Labels`    | All labels assigned to the network.                                                    |
+| `.Label`     | Value of a specific label for this network. For example `{{.Label "project.version"}}` |
+| `.CreatedAt` | Time when the network was created                                                      |
 
 When using the `--format` option, the `network ls` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -177,16 +177,16 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder      | Description
------------------|------------------------------------------------------------------------------------------
-`.ID`            | Node ID
-`.Self`          | Node of the daemon (`true/false`, `true`indicates that the node is the same as current docker daemon)
-`.Hostname`      | Node hostname
-`.Status`        | Node status
-`.Availability`  | Node availability ("active", "pause", or "drain")
-`.ManagerStatus` | Manager status of the node
-`.TLSStatus`     | TLS status of the node ("Ready", or "Needs Rotation" has TLS certificate signed by an old CA)
-`.EngineVersion` | Engine version
+| Placeholder      | Description                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------|
+| `.ID`            | Node ID                                                                                               |
+| `.Self`          | Node of the daemon (`true/false`, `true`indicates that the node is the same as current docker daemon) |
+| `.Hostname`      | Node hostname                                                                                         |
+| `.Status`        | Node status                                                                                           |
+| `.Availability`  | Node availability ("active", "pause", or "drain")                                                     |
+| `.ManagerStatus` | Manager status of the node                                                                            |
+| `.TLSStatus`     | TLS status of the node ("Ready", or "Needs Rotation" has TLS certificate signed by an old CA)         |
+| `.EngineVersion` | Engine version                                                                                        |
 
 When using the `--format` option, the `node ls` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -115,16 +115,16 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder     | Description
-----------------|------------------------------------------------------------------------------------------
-`.ID`           | Task ID
-`.Name`         | Task name
-`.Image`        | Task image
-`.Node`         | Node ID
-`.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-`.CurrentState` | Current state of the task
-`.Error`        | Error
-`.Ports`        | Task published ports
+| Placeholder     | Description                                                      |
+|-----------------|------------------------------------------------------------------|
+| `.ID`           | Task ID                                                          |
+| `.Name`         | Task name                                                        |
+| `.Image`        | Task image                                                       |
+| `.Node`         | Node ID                                                          |
+| `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+| `.CurrentState` | Current state of the task                                        |
+| `.Error`        | Error                                                            |
+| `.Ports`        | Task published ports                                             |
 
 When using the `--format` option, the `node ps` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -75,13 +75,13 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder        | Description
--------------------|------------------------------------------------------------
-`.ID`              | Plugin ID
-`.Name`            | Plugin name and tag
-`.Description`     | Plugin description
-`.Enabled`         | Whether plugin is enabled or not
-`.PluginReference` | The reference used to push/pull from a registry
+| Placeholder        | Description                                     |
+|--------------------|-------------------------------------------------|
+| `.ID`              | Plugin ID                                       |
+| `.Name`            | Plugin name and tag                             |
+| `.Description`     | Plugin description                              |
+| `.Enabled`         | Whether plugin is enabled or not                |
+| `.PluginReference` | The reference used to push/pull from a registry |
 
 When using the `--format` option, the `plugin ls` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -108,6 +108,7 @@ Options:
       --privileged                    Give extended privileges to this container
   -p, --publish value                 Publish a container's port(s) to the host (default [])
   -P, --publish-all                   Publish all exposed ports to random ports
+      --pull string                   Pull image before running ("always"|"missing"|"never") (default "missing")
       --read-only                     Mount the container's root filesystem as read only
       --restart string                Restart policy to apply when a container exits (default "no")
                                       Possible values are : no, on-failure[:max-retry], always, unless-stopped
@@ -357,6 +358,48 @@ $ docker run --expose 80 ubuntu bash
 
 This exposes port `80` of the container without publishing the port to the host
 system's interfaces.
+
+### <a name="pull"></a> Set the pull policy (--pull)
+
+Use the `--pull` flag to set the image pull policy when creating (and running)
+the container.
+
+The `--pull` flag can take one of these values:
+
+| Value               | Description                                                                                                       |
+|:--------------------|:------------------------------------------------------------------------------------------------------------------|
+| `missing` (default) | Pull the image if it was not found in the image cache, or use the cached image otherwise.                         |
+| `never`             | Do not pull the image, even if it's missing, and produce an error if the image does not exist in the image cache. |
+| `always`            | Always perform a pull before creating the container.                                                              |
+
+When creating (and running) a container from an image, the daemon checks if the
+image exists in the local image cache. If the image is missing, an error is
+returned to the cli, allowing it to initiate a pull.
+
+The default (`missing`) is to only pull the image if it is not present in the
+daemon's image cache. This default allows you to run images that only exist
+locally (for example, images you built from a Dockerfile, but that have not
+been pushed to a registry), and reduces networking.
+
+The `always` option always initiates a pull before creating the container. This
+option makes sure the image is up-to-date, and prevents you from using outdated
+images, but may not be suitable in situations where you want to test a locally
+built image before pushing (as pulling the image overwrites the existing image
+in the image cache).
+
+The `never` option disables (implicit) pulling images when creating containers,
+and only uses images that are available in the image cache. If the specified
+image is not found, an error is produced, and the container is not created.
+This option is useful in situations where networking is not available, or to
+prevent images from being pulled implicitly when creating containers.
+
+The following example shows `docker run` with the `--pull=never` option set,
+which produces en error as the image is missing in the image-cache:
+
+```console
+$ docker run --pull=never hello-world
+docker: Error response from daemon: No such image: hello-world:latest.
+```
 
 ### Set environment variables (-e, --env, --env-file)
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -653,9 +653,32 @@ PS C:\> docker run --device=class/86E0D1E0-8089-11D0-9CE4-08003E301F73 mcr.micro
 > This option fails if the container isolation is `hyperv` or when running Linux
 > Containers on Windows (LCOW).
 
+### <a name="device-cgroup-rule"></a> Using dynamically created devices (--device-cgroup-rule)
+
+Devices available to a container are assigned at creation time. The
+assigned devices will both be added to the cgroup.allow file and
+created into the container once it is run. This poses a problem when
+a new device needs to be added to running container.
+
+One of the solutions is to add a more permissive rule to a container
+allowing it access to a wider range of devices. For example, supposing
+our container needs access to a character device with major `42` and
+any number of minor number (added as new devices appear), the
+following rule would be added:
+
+```console
+$ docker run -d --device-cgroup-rule='c 42:* rmw' -name my-container my-image
+```
+
+Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
+the required device when it is added.
+
+> **Note**: initially present devices still need to be explicitly added to the
+> `docker run` / `docker create` command.
+
 ### Access an NVIDIA GPU
 
-The `--gpus­` flag allows you to access NVIDIA GPU resources. First you need to
+The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
 install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
 Visit [Specify a container's resources](https://docs.docker.com/config/containers/resource_constraints/)
 for more information.
@@ -818,9 +841,9 @@ and 30 seconds for Windows containers.
 ### Specify isolation technology for container (--isolation)
 
 This option is useful in situations where you are running Docker containers on
-Windows. The `--isolation <value>` option sets a container's isolation technology.
-On Linux, the only supported is the `default` option which uses
-Linux namespaces. These two commands are equivalent on Linux:
+Windows. The `--isolation=<value>` option sets a container's isolation technology.
+On Linux, the only supported is the `default` option which uses Linux namespaces.
+These two commands are equivalent on Linux:
 
 ```console
 $ docker run -d busybox top
@@ -829,16 +852,15 @@ $ docker run -d --isolation default busybox top
 
 On Windows, `--isolation` can take one of these values:
 
+| Value     | Description                                                                                |
+|:----------|:-------------------------------------------------------------------------------------------|
+| `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below). |
+| `process` | Shared-kernel namespace isolation.                                                         |
+| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
-| Value     | Description                                                                                                       |
-|:----------|:------------------------------------------------------------------------------------------------------------------|
-| `default` | Use the value specified by the Docker daemon's `--exec-opt` or system default (see below).                        |
-| `process` | Shared-kernel namespace isolation (not supported on Windows client operating systems older than Windows 10 1809). |
-| `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                     |
-
-The default isolation on Windows server operating systems is `process`. The default
-isolation on Windows client operating systems is `hyperv`. An attempt to start a container on a client
-operating system older than Windows 10 1809 with `--isolation process` will fail.
+The default isolation on Windows server operating systems is `process`, and `hyperv`
+on Windows client operating systems, such as Windows 10. Process isolation is more
+performant, but requires the image to
 
 On Windows server, assuming the default configuration, these commands are equivalent
 and result in `process` isolation:

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -140,7 +140,7 @@ using a Go template.
 Valid placeholders for the Go template are:
 
 | Placeholder    | Description                       |
-| -------------- | --------------------------------- |
+|----------------|-----------------------------------|
 | `.Name`        | Image Name                        |
 | `.Description` | Image description                 |
 | `.StarCount`   | Number of stars for the image     |

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -113,7 +113,7 @@ using a Go template.
 Valid placeholders for the Go template are listed below:
 
 | Placeholder  | Description                                                                          |
-| ------------ | ------------------------------------------------------------------------------------ |
+|--------------|--------------------------------------------------------------------------------------|
 | `.ID`        | Secret ID                                                                            |
 | `.Name`      | Secret name                                                                          |
 | `.CreatedAt` | Time when the secret was created                                                     |

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -670,16 +670,15 @@ or _exclude_ (`!=`) rule. Multiple constraints find nodes that satisfy every
 expression (AND match). Constraints can match node or Docker Engine labels as
 follows:
 
-node attribute       | matches                        | example
----------------------|--------------------------------|-----------------------------------------------
-`node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`
-`node.hostname`      | Node hostname                  | `node.hostname!=node-2`
-`node.role`          | Node role (`manager`/`worker`) | `node.role==manager`
-`node.platform.os`   | Node operating system          | `node.platform.os==windows`
-`node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`
-`node.labels`        | User-defined node labels       | `node.labels.security==high`
-`engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04`
-
+| node attribute       | matches                        | example                                       |
+|----------------------|--------------------------------|-----------------------------------------------|
+| `node.id`            | Node ID                        | `node.id==2ivku8v2gvtg4`                      |
+| `node.hostname`      | Node hostname                  | `node.hostname!=node-2`                       |
+| `node.role`          | Node role (`manager`/`worker`) | `node.role==manager`                          |
+| `node.platform.os`   | Node operating system          | `node.platform.os==windows`                   |
+| `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`                  |
+| `node.labels`        | User-defined node labels       | `node.labels.security==high`                  |
+| `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04` |
 
 `engine.labels` apply to Docker Engine labels like operating system, drivers,
 etc. Swarm administrators add `node.labels` for operational purposes by using

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -130,14 +130,14 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder | Description
-------------|------------------------------------------------------------------------------------------
-`.ID`       | Service ID
-`.Name`     | Service name
-`.Mode`     | Service mode (replicated, global)
-`.Replicas` | Service replicas
-`.Image`    | Service image
-`.Ports`    | Service ports published in ingress mode
+| Placeholder | Description                             |
+|-------------|-----------------------------------------|
+| `.ID`       | Service ID                              |
+| `.Name`     | Service name                            |
+| `.Mode`     | Service mode (replicated, global)       |
+| `.Replicas` | Service replicas                        |
+| `.Image`    | Service image                           |
+| `.Ports`    | Service ports published in ingress mode |
 
 When using the `--format` option, the `service ls` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -157,16 +157,16 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder     | Description
-----------------|------------------------------------------------------------------------------------------
-`.ID`           | Task ID
-`.Name`         | Task name
-`.Image`        | Task image
-`.Node`         | Node ID
-`.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-`.CurrentState` | Current state of the task
-`.Error`        | Error
-`.Ports`        | Task published ports
+| Placeholder     | Description                                                      |
+|-----------------|------------------------------------------------------------------|
+| `.ID`           | Task ID                                                          |
+| `.Name`         | Task name                                                        |
+| `.Image`        | Task image                                                       |
+| `.Node`         | Node ID                                                          |
+| `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+| `.CurrentState` | Current state of the task                                        |
+| `.Error`        | Error                                                            |
+| `.Ports`        | Task published ports                                             |
 
 When using the `--format` option, the `service ps` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -52,7 +52,7 @@ The formatting option (`--format`) pretty-prints stacks using a Go template.
 Valid placeholders for the Go template are listed below:
 
 | Placeholder     | Description        |
-| --------------- | ------------------ |
+|-----------------|--------------------|
 | `.Name`         | Stack name         |
 | `.Services`     | Number of services |
 | `.Orchestrator` | Orchestrator name  |

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -129,16 +129,16 @@ The formatting options (`--format`) pretty-prints tasks output using a Go templa
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder     | Description
-----------------|------------------------------------------------------------------------------------------
-`.ID`           | Task ID
-`.Name`         | Task name
-`.Image`        | Task image
-`.Node`         | Node ID
-`.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`)
-`.CurrentState` | Current state of the task
-`.Error`        | Error
-`.Ports`        | Task published ports
+| Placeholder     | Description                                                      |
+|-----------------|------------------------------------------------------------------|
+| `.ID`           | Task ID                                                          |
+| `.Name`         | Task name                                                        |
+| `.Image`        | Task image                                                       |
+| `.Node`         | Node ID                                                          |
+| `.DesiredState` | Desired state of the task (`running`, `shutdown`, or `accepted`) |
+| `.CurrentState` | Current state of the task                                        |
+| `.Error`        | Error                                                            |
+| `.Ports`        | Task published ports                                             |
 
 When using the `--format` option, the `stack ps` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -88,13 +88,13 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder | Description
-------------|-------------------------------------------------------------------
-`.ID`       | Service ID
-`.Name`     | Service name
-`.Mode`     | Service mode (replicated, global)
-`.Replicas` | Service replicas
-`.Image`    | Service image
+| Placeholder | Description                       |
+|-------------|-----------------------------------|
+| `.ID`       | Service ID                        |
+| `.Name`     | Service name                      |
+| `.Mode`     | Service mode (replicated, global) |
+| `.Replicas` | Service replicas                  |
+| `.Image`    | Service image                     |
 
 When using the `--format` option, the `stack services` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -138,18 +138,17 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder  | Description
------------- | --------------------------------------------
-`.Container` | Container name or ID (user input)
-`.Name`      | Container name
-`.ID`        | Container ID
-`.CPUPerc`   | CPU percentage
-`.MemUsage`  | Memory usage
-`.NetIO`     | Network IO
-`.BlockIO`   | Block IO
-`.MemPerc`   | Memory percentage (Not available on Windows)
-`.PIDs`      | Number of PIDs (Not available on Windows)
-
+| Placeholder  | Description                                  |
+|--------------|----------------------------------------------|
+| `.Container` | Container name or ID (user input)            |
+| `.Name`      | Container name                               |
+| `.ID`        | Container ID                                 |
+| `.CPUPerc`   | CPU percentage                               |
+| `.MemUsage`  | Memory usage                                 |
+| `.NetIO`     | Network IO                                   |
+| `.BlockIO`   | Block IO                                     |
+| `.MemPerc`   | Memory percentage (Not available on Windows) |
+| `.PIDs`      | Number of PIDs (Not available on Windows)    |
 
 When using the `--format` option, the `stats` command either
 outputs the data exactly as the template declares or, when using the

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -87,7 +87,7 @@ using a Go template.
 Valid placeholders for the Go template are listed below:
 
 | Placeholder    | Description                                |
-| -------------- | ------------------------------------------ |
+|----------------|--------------------------------------------|
 | `.Type`        | `Images`, `Containers` and `Local Volumes` |
 | `.TotalCount`  | Total number of items                      |
 | `.Active`      | Number of active items                     |
@@ -122,7 +122,7 @@ Local Volumes       150.3 MB            150.3 MB (100%)
 <Paste>
 ```
 
-**Note** the format option is meaningless when verbose is true.
+The format option has no effect when the `--verbose` option is used.
 
 ## Related commands
 * [system prune](system_prune.md)

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -158,14 +158,14 @@ using a Go template.
 
 Valid placeholders for the Go template are listed below:
 
-Placeholder   | Description
---------------|------------------------------------------------------------------------------------------
-`.Name`       | Volume name
-`.Driver`     | Volume driver
-`.Scope`      | Volume scope (local, global)
-`.Mountpoint` | The mount point of the volume on the host
-`.Labels`     | All labels assigned to the volume
-`.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}`
+| Placeholder   | Description                                                                           |
+|---------------|---------------------------------------------------------------------------------------|
+| `.Name`       | Volume name                                                                           |
+| `.Driver`     | Volume driver                                                                         |
+| `.Scope`      | Volume scope (local, global)                                                          |
+| `.Mountpoint` | The mount point of the volume on the host                                             |
+| `.Labels`     | All labels assigned to the volume                                                     |
+| `.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}` |
 
 When using the `--format` option, the `volume ls` command will either
 output the data exactly as the template declares or, when using the

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1407,16 +1407,20 @@ The container can have a different logging driver than the Docker daemon. Use
 the `--log-driver=VALUE` with the `docker run` command to configure the
 container's logging driver. The following options are supported:
 
-| Driver      | Description                                                                                                                   |
-|:------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `none`      | Disables any logging for the container. `docker logs` won't be available with this driver.                                    |
-| `json-file` | Default logging driver for Docker. Writes JSON messages to file.  No logging options are supported for this driver.           |
-| `syslog`    | Syslog logging driver for Docker. Writes log messages to syslog.                                                              |
-| `journald`  | Journald logging driver for Docker. Writes log messages to `journald`.                                                        |
-| `gelf`      | Graylog Extended Log Format (GELF) logging driver for Docker. Writes log messages to a GELF endpoint likeGraylog or Logstash. |
-| `fluentd`   | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                          |
-| `awslogs`   | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs                               |
-| `splunk`    | Splunk logging driver for Docker. Writes log messages to `splunk` using Event Http Collector.                                 |
+| Driver       | Description                                                                                                                    |
+|:-------------|:-------------------------------------------------------------------------------------------------------------------------------|
+| `none`       | Disables any logging for the container. `docker logs` won't be available with this driver.                                     |
+| `local`      | Logs are stored in a custom format designed for minimal overhead.                                                              |
+| `json-file`  | Default logging driver for Docker. Writes JSON messages to file.  No logging options are supported for this driver.            |
+| `syslog`     | Syslog logging driver for Docker. Writes log messages to syslog.                                                               |
+| `journald`   | Journald logging driver for Docker. Writes log messages to `journald`.                                                         |
+| `gelf`       | Graylog Extended Log Format (GELF) logging driver for Docker. Writes log messages to a GELF endpoint likeGraylog or Logstash.  |
+| `fluentd`    | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                           |
+| `awslogs`    | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs.                               |
+| `splunk`     | Splunk logging driver for Docker. Writes log messages to `splunk` using Event Http Collector.                                  |
+| `etwlogs`    | Event Tracing for Windows (ETW) events. Writes log messages as Event Tracing for Windows (ETW) events. Only Windows platforms. |                                                  
+| `gcplogs`    | Google Cloud Platform (GCP) Logging. Writes log messages to Google Cloud Platform (GCP) Logging.                               |
+| `logentries` | Rapid7 Logentries. Writes log messages to Rapid7 Logentries.                                                                   |
 
 The `docker logs` command is available only for the `json-file` and `journald`
 logging drivers.  For detailed information on working with logging drivers, see

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1249,12 +1249,12 @@ by default a container is not allowed to access any devices, but a
 "privileged" container is given access to all devices (see
 the documentation on [cgroups devices](https://www.kernel.org/doc/Documentation/cgroup-v1/devices.txt)).
 
-When the operator executes `docker run --privileged`, Docker will enable
-access to all devices on the host as well as set some configuration
-in AppArmor or SELinux to allow the container nearly all the same access to the
-host as processes running outside containers on the host. Additional
-information about running with `--privileged` is available on the
-[Docker Blog](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/).
+The --privileged flag gives all capabilities to the container. When the operator
+executes `docker run --privileged`, Docker will enable access to all devices on
+the host as well as set some configuration in AppArmor or SELinux to allow the
+container nearly all the same access to the host as processes running outside
+containers on the host. Additional information about running with `--privileged`
+is available on the [Docker Blog](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/).
 
 If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that


### PR DESCRIPTION
closes https://github.com/docker/cli/issues/3431

- addresses https://github.com/docker/docker.github.io/issues/14135
- addresses https://github.com/docker/docker.github.io/issues/11319


backport of:

- https://github.com/docker/cli/pull/3449
- https://github.com/docker/cli/pull/3450
- https://github.com/docker/cli/pull/3463
- https://github.com/docker/cli/pull/3467
- https://github.com/docker/cli/pull/2704
- https://github.com/docker/cli/pull/2953
- partial backport of https://github.com/docker/cli/pull/3509
- https://github.com/docker/cli/pull/3524
- https://github.com/docker/cli/pull/3419



**- A picture of a cute animal (not mandatory but encouraged)**

