### PR TITLE
docs: reference: remove trailing space to fix yaml formatting

### DIFF
--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -94,7 +94,7 @@ you must be explicit with a relative or absolute path, for example:
 Copy a local file into container
 
 ```console
-$ docker cp ./some_file CONTAINER:/work 
+$ docker cp ./some_file CONTAINER:/work
 ```
 
 Copy files from container to local path


### PR DESCRIPTION
This was introduced in 41a5e0e4dfb650688ca71a819669611be4159b5e (https://github.com/docker/cli/pull/3463), and
having the trailing whitespace causes the yamldocs generator to
switch to "compact" formatting, which makes that yaml hard to read.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

