### PR TITLE
[20.10 backport] docs: add anchor tags for command-line flags

### DIFF
--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -1,5 +1,5 @@
 ---
-description: "How develop and use a plugin with the managed plugin system"
+description: "How to develop and use a plugin with the managed plugin system"
 keywords: "API, Usage, plugins, documentation, developer"
 ---
 
@@ -15,17 +15,14 @@ keywords: "API, Usage, plugins, documentation, developer"
 
 # Plugin Config Version 1 of Plugin V2
 
-This document outlines the format of the V0 plugin configuration. The plugin
-config described herein was introduced in the Docker daemon in the [v1.12.0
-release](https://github.com/docker/docker/commit/f37117045c5398fd3dca8016ea8ca0cb47e7312b).
+This document outlines the format of the V0 plugin configuration.
 
 Plugin configs describe the various constituents of a docker plugin. Plugin
 configs can be serialized to JSON format with the following media types:
 
-Config Type  | Media Type
-------------- | -------------
-config  | "application/vnd.docker.plugin.v1+json"
-
+| Config Type | Media Type                              |
+|-------------|-----------------------------------------|
+| config      | "application/vnd.docker.plugin.v1+json" |
 
 ## *Config* Field Descriptions
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -497,6 +497,13 @@ $ docker build -t mybuildimage --target build-env .
 
 ### <a name=output></a> Custom build outputs (--output)
 
+> **Note**
+>
+> This feature requires the BuildKit backend. You can either
+> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
+> use the [buildx](https://github.com/docker/buildx) plugin which provides more
+> output type options.
+
 By default, a local container image is created from the build result. The
 `--output` (or `-o`) flag allows you to override this behavior, and a specify a
 custom exporter. For example, custom exporters allow you to export the build
@@ -582,14 +589,14 @@ $ ls ./out
 vndr
 ```
 
+### <a name=cache-from></a> Specifying external cache sources (--cache-from)
+
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
 > [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
-> use the [buildx](https://github.com/docker/buildx) plugin which provides more
-> output type options.
-
-### <a name=cache-from></a> Specifying external cache sources (--cache-from)
+> use the [buildx](https://github.com/docker/buildx) plugin. The previous
+> builder has limited support for reusing cache from pre-pulled images.
 
 In addition to local build cache, the builder can reuse the cache generated from
 previous builds with the `--cache-from` flag pointing to an image in the registry.
@@ -624,13 +631,6 @@ On another machine:
 ```console
 $ docker build --cache-from myname/myapp .
 ```
-
-> **Note**
->
-> This feature requires the BuildKit backend. You can either
-> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
-> use the [buildx](https://github.com/docker/buildx) plugin. The previous
-> builder has limited support for reusing cache from pre-pulled images.
 
 ### <a name=squash></a> Squash an image's layers (--squash) (experimental)
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -332,7 +332,7 @@ found, the `.dockerignore` file is used if present. Using a Dockerfile based
 expect to ignore different sets of files.
 
 
-### Tag an image (-t)
+### <a name=tag></a> Tag an image (-t, --tag)
 
 ```console
 $ docker build -t vieux/apache:2.0 .
@@ -352,7 +352,7 @@ For example, to tag an image both as `whenry/fedora-jboss:latest` and
 $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
 ```
 
-### Specify a Dockerfile (-f)
+### <a name=file></a> Specify a Dockerfile (-f, --file)
 
 ```console
 $ docker build -f Dockerfile.debug .
@@ -399,17 +399,17 @@ the command line.
 > repeatable builds on remote Docker hosts. This is also the reason why
 > `ADD ../file` does not work.
 
-### Use a custom parent cgroup (--cgroup-parent)
+### <a name=cgroup-parent></a> Use a custom parent cgroup (--cgroup-parent)
 
 When `docker build` is run with the `--cgroup-parent` option the containers
 used in the build will be run with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
 
-### Set ulimits in container (--ulimit)
+### <a name=ulimit></a> Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` will cause each build step's
 container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
 
-### Set build-time variables (--build-arg)
+### <a name=build-arg></a> Set build-time variables (--build-arg)
 
 You can use `ENV` instructions in a Dockerfile to define variable
 values. These values persist in the built image. However, often
@@ -447,13 +447,13 @@ $ docker build --build-arg HTTP_PROXY .
 This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
 for more information.
 
-### Optional security options (--security-opt)
+### <a name=security-opt></a> Optional security options (--security-opt)
 
 This flag is only supported on a daemon running on Windows, and only supports
 the `credentialspec` option. The `credentialspec` must be in the format
 `file://spec.txt` or `registry://keyname`.
 
-### Specify isolation technology for container (--isolation)
+### <a name=isolation></a> Specify isolation technology for container (--isolation)
 
 This option is useful in situations where you are running Docker containers on
 Windows. The `--isolation=<value>` option sets a container's isolation
@@ -469,7 +469,7 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 
 Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
 
-### Add entries to container hosts file (--add-host)
+### <a name=add-host></a> Add entries to container hosts file (--add-host)
 
 You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
@@ -477,7 +477,7 @@ more `--add-host` flags. This example adds a static address for a host named
 
     $ docker build --add-host=docker:10.180.0.1 .
 
-### Specifying target build stage (--target)
+### <a name=target></a> Specifying target build stage (--target)
 
 When building a Dockerfile with multiple build stages, `--target` can be used to
 specify an intermediate build stage by name as a final stage for the resulting
@@ -495,7 +495,7 @@ FROM alpine AS production-env
 $ docker build -t mybuildimage --target build-env .
 ```
 
-### Custom build outputs
+### <a name=output></a> Custom build outputs (--output)
 
 By default, a local container image is created from the build result. The
 `--output` (or `-o`) flag allows you to override this behavior, and a specify a
@@ -589,7 +589,7 @@ vndr
 > use the [buildx](https://github.com/docker/buildx) plugin which provides more
 > output type options.
 
-### Specifying external cache sources
+### <a name=cache-from></a> Specifying external cache sources (--cache-from)
 
 In addition to local build cache, the builder can reuse the cache generated from
 previous builds with the `--cache-from` flag pointing to an image in the registry.
@@ -632,7 +632,7 @@ $ docker build --cache-from myname/myapp .
 > use the [buildx](https://github.com/docker/buildx) plugin. The previous
 > builder has limited support for reusing cache from pre-pulled images.
 
-### Squash an image's layers (--squash) (experimental)
+### <a name=squash></a> Squash an image's layers (--squash) (experimental)
 
 #### Overview
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -332,7 +332,7 @@ found, the `.dockerignore` file is used if present. Using a Dockerfile based
 expect to ignore different sets of files.
 
 
-### <a name=tag></a> Tag an image (-t, --tag)
+### <a name="tag"></a> Tag an image (-t, --tag)
 
 ```console
 $ docker build -t vieux/apache:2.0 .
@@ -352,7 +352,7 @@ For example, to tag an image both as `whenry/fedora-jboss:latest` and
 $ docker build -t whenry/fedora-jboss:latest -t whenry/fedora-jboss:v2.1 .
 ```
 
-### <a name=file></a> Specify a Dockerfile (-f, --file)
+### <a name="file"></a> Specify a Dockerfile (-f, --file)
 
 ```console
 $ docker build -f Dockerfile.debug .
@@ -399,17 +399,17 @@ the command line.
 > repeatable builds on remote Docker hosts. This is also the reason why
 > `ADD ../file` does not work.
 
-### <a name=cgroup-parent></a> Use a custom parent cgroup (--cgroup-parent)
+### <a name="cgroup-parent"></a> Use a custom parent cgroup (--cgroup-parent)
 
 When `docker build` is run with the `--cgroup-parent` option the containers
 used in the build will be run with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
 
-### <a name=ulimit></a> Set ulimits in container (--ulimit)
+### <a name="ulimit"></a> Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` will cause each build step's
 container to be started using those [`--ulimit` flag values](run.md#ulimit).
 
-### <a name=build-arg></a> Set build-time variables (--build-arg)
+### <a name="build-arg"></a> Set build-time variables (--build-arg)
 
 You can use `ENV` instructions in a Dockerfile to define variable
 values. These values persist in the built image. However, often
@@ -447,13 +447,13 @@ $ docker build --build-arg HTTP_PROXY .
 This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](run.md#env)
 for more information.
 
-### <a name=security-opt></a> Optional security options (--security-opt)
+### <a name="security-opt"></a> Optional security options (--security-opt)
 
 This flag is only supported on a daemon running on Windows, and only supports
 the `credentialspec` option. The `credentialspec` must be in the format
 `file://spec.txt` or `registry://keyname`.
 
-### <a name=isolation></a> Specify isolation technology for container (--isolation)
+### <a name="isolation"></a> Specify isolation technology for container (--isolation)
 
 This option is useful in situations where you are running Docker containers on
 Windows. The `--isolation=<value>` option sets a container's isolation
@@ -469,7 +469,7 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 
 Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
 
-### <a name=add-host></a> Add entries to container hosts file (--add-host)
+### <a name="add-host"></a> Add entries to container hosts file (--add-host)
 
 You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
@@ -477,7 +477,7 @@ more `--add-host` flags. This example adds a static address for a host named
 
     $ docker build --add-host=docker:10.180.0.1 .
 
-### <a name=target></a> Specifying target build stage (--target)
+### <a name="target"></a> Specifying target build stage (--target)
 
 When building a Dockerfile with multiple build stages, `--target` can be used to
 specify an intermediate build stage by name as a final stage for the resulting
@@ -495,7 +495,7 @@ FROM alpine AS production-env
 $ docker build -t mybuildimage --target build-env .
 ```
 
-### <a name=output></a> Custom build outputs (--output)
+### <a name="output"></a> Custom build outputs (--output)
 
 > **Note**
 >
@@ -589,7 +589,7 @@ $ ls ./out
 vndr
 ```
 
-### <a name=cache-from></a> Specifying external cache sources (--cache-from)
+### <a name="cache-from"></a> Specifying external cache sources (--cache-from)
 
 > **Note**
 >
@@ -632,7 +632,7 @@ On another machine:
 $ docker build --cache-from myname/myapp .
 ```
 
-### <a name=squash></a> Squash an image's layers (--squash) (experimental)
+### <a name="squash"></a> Squash an image's layers (--squash) (experimental)
 
 #### Overview
 

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -407,7 +407,7 @@ used in the build will be run with the [corresponding `docker run` flag](../run.
 ### <a name=ulimit></a> Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` will cause each build step's
-container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
+container to be started using those [`--ulimit` flag values](run.md#ulimit).
 
 ### <a name=build-arg></a> Set build-time variables (--build-arg)
 
@@ -444,7 +444,7 @@ $ export HTTP_PROXY=http://10.20.30.2:1234
 $ docker build --build-arg HTTP_PROXY .
 ```
 
-This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](run.md#env)
 for more information.
 
 ### <a name=security-opt></a> Optional security options (--security-opt)

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -154,17 +154,17 @@ different location.
 These fields allow you to customize the default output format for some commands
 if no `--format` flag is provided.
 
-| Property               | Description                                                                                                                                                                                                                         |
-|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `configFormat`         | Custom default format for `docker config ls` output. Refer to the [**format the output** section in the `docker config ls` documentation](config_ls.md#format-the-output) for a list of supported formatting directives.            |
-| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. Refer to the [**format the output** section in the `docker images` documentation](images.md#format-the-output) for a list of supported formatting directives. |
-| `nodesFormat`          | Custom default format for `docker node ls` output. Refer to the [**formatting** section in the `docker node ls` documentation](node_ls.md#formatting) for a list of supported formatting directives.                                |
-| `pluginsFormat`        | Custom default format for `docker plugin ls` output. Refer to the [**formatting** section in the `docker plugin ls` documentation](plugin_ls.md#formatting) for a list of supported formatting directives.                          |
-| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. Refer to the [**formatting** section in the `docker ps` documentation](ps.md#formatting) for a list of supported formatting directives.                       |
-| `secretFormat`         | Custom default format for `docker secret ls` output. Refer to the [**format the output** section in the `docker secret ls` documentation](secret_ls.md#format-the-output) for a list of supported formatting directives.            |
-| `serviceInspectFormat` | Custom default format for `docker service inspect` output. Refer to the [**formatting** section in the `docker service inspect` documentation](service_inspect.md#formatting) for a list of supported formatting directives.        |
-| `servicesFormat`       | Custom default format for `docker service ls` output. Refer to the [**formatting** section in the `docker service ls` documentation](service_ls.md#formatting) for a list of supported formatting directives.                       |
-| `statsFormat`          | Custom default format for `docker stats` output. Refer to the [**formatting** section in the `docker stats` documentation](stats.md#formatting) for a list of supported formatting directives.                                      |
+| Property               | Description                                                                                                                                                                                                              |
+|:-----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `configFormat`         | Custom default format for `docker config ls` output. Refer to the [**format the output** section in the `docker config ls` documentation](config_ls.md#format) for a list of supported formatting directives.            |
+| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. Refer to the [**format the output** section in the `docker images` documentation](images.md#format) for a list of supported formatting directives. |
+| `nodesFormat`          | Custom default format for `docker node ls` output. Refer to the [**formatting** section in the `docker node ls` documentation](node_ls.md#format) for a list of supported formatting directives.                         |
+| `pluginsFormat`        | Custom default format for `docker plugin ls` output. Refer to the [**formatting** section in the `docker plugin ls` documentation](plugin_ls.md#format) for a list of supported formatting directives.                   |
+| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. Refer to the [**formatting** section in the `docker ps` documentation](ps.md#format) for a list of supported formatting directives.                |
+| `secretFormat`         | Custom default format for `docker secret ls` output. Refer to the [**format the output** section in the `docker secret ls` documentation](secret_ls.md#format) for a list of supported formatting directives.            |
+| `serviceInspectFormat` | Custom default format for `docker service inspect` output. Refer to the [**formatting** section in the `docker service inspect` documentation](service_inspect.md#format) for a list of supported formatting directives. |
+| `servicesFormat`       | Custom default format for `docker service ls` output. Refer to the [**formatting** section in the `docker service ls` documentation](service_ls.md#format) for a list of supported formatting directives.                |
+| `statsFormat`          | Custom default format for `docker stats` output. Refer to the [**formatting** section in the `docker stats` documentation](stats.md#format) for a list of supported formatting directives.                               |
 
 
 ### Custom HTTP headers

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -60,7 +60,7 @@ REPOSITORY                        TAG                 ID                  CREATE
 svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
 ```
 
-### Commit a container with new configurations
+### <a name=change></a> Commit a container with new configurations (--change)
 
 ```console
 $ docker ps

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -60,7 +60,7 @@ REPOSITORY                        TAG                 ID                  CREATE
 svendowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
 ```
 
-### <a name=change></a> Commit a container with new configurations (--change)
+### <a name="change"></a> Commit a container with new configurations (--change)
 
 ```console
 $ docker ps

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -47,8 +47,8 @@ created.  Supported `Dockerfile` instructions:
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker commit c3f279d17e0a  svendowideit/testimage:version3
 
@@ -66,8 +66,8 @@ svendowideit/testimage            version3            f5283438590d        16 sec
 $ docker ps
 
 CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker inspect -f "{{ .Config.Env }}" c3f279d17e0a
 
@@ -88,8 +88,8 @@ $ docker inspect -f "{{ .Config.Env }}" f5283438590d
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  svendowideit/testimage:version4
 
@@ -103,6 +103,6 @@ $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND                 CREATED             STATUS              PORTS              NAMES
 89373736e2e7        testimage:version4  "apachectl -DFOREGROU"  3 seconds ago       Up 2 seconds        80/tcp             distracted_fermat
-c3f279d17e0a        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:12.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
 ```

--- a/docs/reference/commandline/config_create.md
+++ b/docs/reference/commandline/config_create.md
@@ -57,7 +57,7 @@ ID                          NAME                CREATED             UPDATED
 dg426haahpi5ezmkkj5kyl3sn   my_config           7 seconds ago       7 seconds ago
 ```
 
-### Create a config with labels
+### <a name=label></a> Create a config with labels (-l, --label)
 
 ```console
 $ docker config create \

--- a/docs/reference/commandline/config_create.md
+++ b/docs/reference/commandline/config_create.md
@@ -57,7 +57,7 @@ ID                          NAME                CREATED             UPDATED
 dg426haahpi5ezmkkj5kyl3sn   my_config           7 seconds ago       7 seconds ago
 ```
 
-### <a name=label></a> Create a config with labels (-l, --label)
+### <a name="label"></a> Create a config with labels (-l, --label)
 
 ```console
 $ docker config create \

--- a/docs/reference/commandline/config_inspect.md
+++ b/docs/reference/commandline/config_inspect.md
@@ -77,7 +77,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 You can use the --format option to obtain specific information about a
 config. The following example command outputs the creation time of the

--- a/docs/reference/commandline/config_inspect.md
+++ b/docs/reference/commandline/config_inspect.md
@@ -77,7 +77,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 You can use the --format option to obtain specific information about a
 config. The following example command outputs the creation time of the

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -45,7 +45,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_config                 3 seconds ago       3 seconds ago
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (-f, --filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -105,7 +105,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints configs output
 using a Go template.

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -45,7 +45,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_config                 3 seconds ago       3 seconds ago
 ```
 
-### <a name=filter></a> Filtering (-f, --filter)
+### <a name="filter"></a> Filtering (-f, --filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -105,7 +105,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints configs output
 using a Go template.

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -37,7 +37,7 @@ f98f9c2aa1eaf727e4ec9c0283bc7d4aa4762fbdba7f26191f26c97f64090360
 Total reclaimed space: 212 B
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -37,7 +37,7 @@ f98f9c2aa1eaf727e4ec9c0283bc7d4aa4762fbdba7f26191f26c97f64090360
 Total reclaimed space: 212 B
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/context_create.md
+++ b/docs/reference/commandline/context_create.md
@@ -69,7 +69,7 @@ $ docker context create \
     my-context
 ```
 
-### Create a context based on an existing context
+### <a name=from></a> Create a context based on an existing context (--from)
 
 Use the `--from=<context-name>` option to create a new context from
 an existing context. The example below creates a new context named `my-context`

--- a/docs/reference/commandline/context_create.md
+++ b/docs/reference/commandline/context_create.md
@@ -69,7 +69,7 @@ $ docker context create \
     my-context
 ```
 
-### <a name=from></a> Create a context based on an existing context (--from)
+### <a name="from"></a> Create a context based on an existing context (--from)
 
 Use the `--from=<context-name>` option to create a new context from
 an existing context. The example below creates a new context named `my-context`

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -112,7 +112,7 @@ $ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"
 ### Corner cases
 
 It is not possible to copy certain system files such as resources under
-`/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
+`/proc`, `/sys`, `/dev`, [tmpfs](run.md#tmpfs), and mounts created by
 the user in the container. However, you can still copy such files by manually
 running `tar` in `docker exec`. Both of the following examples do the same thing
 in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -141,7 +141,7 @@ Docker configs report the following events:
 
 ### Limiting, filtering, and formatting the output
 
-#### Limit events by time
+#### <a name=since></a> Limit events by time (--since, --until)
 
 The `--since` and `--until` parameters can be Unix timestamps, date formatted
 timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
@@ -159,7 +159,7 @@ fraction of a second no more than nine digits long.
 Only the last 1000 log events are returned. You can use filters to further limit
 the number of events returned.
 
-#### Filtering
+#### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
 like to use multiple filters, pass multiple flags (e.g.,
@@ -190,7 +190,7 @@ The currently supported filters are:
 * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
 * volume (`volume=<name>`)
 
-#### Format
+#### <a name=format></a> Format the output (--format)
 
 If a format (`--format`) is specified, the given template will be executed
 instead of the default

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -340,8 +340,8 @@ $ docker events --filter 'type=network'
 
 $ docker events --filter 'container=container_1' --filter 'container=container_2'
 
-2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
+2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
 2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
 2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 

--- a/docs/reference/commandline/events.md
+++ b/docs/reference/commandline/events.md
@@ -141,7 +141,7 @@ Docker configs report the following events:
 
 ### Limiting, filtering, and formatting the output
 
-#### <a name=since></a> Limit events by time (--since, --until)
+#### <a name="since"></a> Limit events by time (--since, --until)
 
 The `--since` and `--until` parameters can be Unix timestamps, date formatted
 timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed
@@ -159,7 +159,7 @@ fraction of a second no more than nine digits long.
 Only the last 1000 log events are returned. You can use filters to further limit
 the number of events returned.
 
-#### <a name=filter></a> Filtering (--filter)
+#### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
 like to use multiple filters, pass multiple flags (e.g.,
@@ -190,7 +190,7 @@ The currently supported filters are:
 * type (`type=<container or image or volume or network or daemon or plugin or service or node or secret or config>`)
 * volume (`volume=<name>`)
 
-#### <a name=format></a> Format the output (--format)
+#### <a name="format"></a> Format the output (--format)
 
 If a format (`--format`) is specified, the given template will be executed
 instead of the default

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -32,13 +32,13 @@ The command started using `docker exec` only runs while the container's primary
 process (`PID 1`) is running, and it is not restarted if the container is
 restarted.
 
-COMMAND will run in the default directory of the container. If the
-underlying image has a custom directory specified with the WORKDIR directive
-in its Dockerfile, this will be used instead.
+COMMAND runs in the default directory of the container. If the underlying image
+has a custom directory specified with the WORKDIR directive in its Dockerfile,
+this directory is used instead.
 
-COMMAND should be an executable, a chained or a quoted command
-will not work. Example: `docker exec -ti my_container "echo a && echo b"` will
-not work, but `docker exec -ti my_container sh -c "echo a && echo b"` will.
+COMMAND must be an executable. A chained or a quoted command does not work.
+For example, `docker exec -it my_container sh -c "echo a && echo b"` works,
+work, but `docker exec -it my_container "echo a && echo b"` does not.
 
 ## Examples
 
@@ -47,70 +47,91 @@ not work, but `docker exec -ti my_container sh -c "echo a && echo b"` will.
 First, start a container.
 
 ```console
-$ docker run --name ubuntu_bash --rm -i -t ubuntu bash
+$ docker run --name mycontainer -d -i -t alpine /bin/sh
 ```
 
-This will create a container named `ubuntu_bash` and start a Bash session.
+This creates and starts a container named `mycontainer` from an `alpine` image
+with an `sh` shell as its main process. The `-d` option (shorthand for `--detach`)
+sets the container to run in the background, in detached mode, with a pseudo-TTY
+attached (`-t`). The `-i` option is set to keep `STDIN` attached (`-i`), which
+prevents the `sh` process from exiting immediately.
 
 Next, execute a command on the container.
 
 ```console
-$ docker exec -d ubuntu_bash touch /tmp/execWorks
+$ docker exec -d mycontainer touch /tmp/execWorks
 ```
 
-This will create a new file `/tmp/execWorks` inside the running container
-`ubuntu_bash`, in the background.
+This creates a new file `/tmp/execWorks` inside the running container
+`mycontainer`, in the background.
 
-Next, execute an interactive `bash` shell on the container.
+Next, execute an interactive `sh` shell on the container.
 
 ```console
-$ docker exec -it ubuntu_bash bash
+$ docker exec -it mycontainer sh
 ```
 
-This will create a new Bash session in the container `ubuntu_bash`.
+This starts a new shell session in the container `mycontainer`.
+
+### <a name=env></a> Set environment variables for the exec process (--env, -e)
 
 Next, set environment variables in the current bash session.
 
+By default, the `docker exec` command, inherits the environment variables that
+are set at the time the container is created. Use the `--env` (or the `-e` shorthand)
+to override global environment variables, or to set additional environment variables
+for the process started by `docker exec`.
+
+The example below creates a new shell session in the container `mycontainer` with
+environment variables `$VAR_A` and `$VAR_B` set to "1" and "2" respectively.
+These environment variables are only valid for the `sh` process started by that
+`docker exec` command, and are not available to other processes running inside
+the container.
+
 ```console
-$ docker exec -it -e VAR_A=1 -e VAR_B=2 ubuntu_bash bash
+$ docker exec -e VAR_A=1 -e VAR_B=2 mycontainer env
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=f64a4851eb71
+VAR_A=1
+VAR_B=2
+HOME=/root
 ```
 
-This will create a new Bash session in the container `ubuntu_bash` with environment
-variables `$VAR_A` and `$VAR_B` set to "1" and "2" respectively. Note that these
-environment variables will only be valid on the current Bash session.
+### <a name=workdir></a> Set the working directory for the exec process (--workdir, -w)
 
-By default `docker exec` command runs in the same working directory set when container was created.
+By default `docker exec` command runs in the same working directory set when 
+the container was created.
 
 ```console
-$ docker exec -it ubuntu_bash pwd
+$ docker exec -it mycontainer pwd
 /
 ```
 
-You can select working directory for the command to execute into
+You can specify an alternative working directory for the command to execute 
+using the `--workdir` option (or the `-w` shorthand):
 
 ```console
-$ docker exec -it -w /root ubuntu_bash pwd
+$ docker exec -it -w /root mycontainer pwd
 /root
 ```
 
 
 ### Try to run `docker exec` on a paused container
 
-If the container is paused, then the `docker exec` command will fail with an error:
+If the container is paused, then the `docker exec` command fails with an error:
 
 ```console
-$ docker pause test
-
-test
+$ docker pause mycontainer
+mycontainer
 
 $ docker ps
 
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                   PORTS               NAMES
-1ae3b36715d2        ubuntu:latest       "bash"              17 seconds ago      Up 16 seconds (Paused)                       test
+CONTAINER ID   IMAGE     COMMAND     CREATED          STATUS                   PORTS     NAMES
+482efdf39fac   alpine    "/bin/sh"   17 seconds ago   Up 16 seconds (Paused)             mycontainer
 
-$ docker exec test ls
+$ docker exec mycontainer sh
 
-FATA[0000] Error response from daemon: Container test is paused, unpause the container before exec
+Error response from daemon: Container mycontainer is paused, unpause the container before exec
 
 $ echo $?
 1

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -73,7 +73,7 @@ $ docker exec -it mycontainer sh
 
 This starts a new shell session in the container `mycontainer`.
 
-### <a name=env></a> Set environment variables for the exec process (--env, -e)
+### <a name="env"></a> Set environment variables for the exec process (--env, -e)
 
 Next, set environment variables in the current bash session.
 
@@ -97,7 +97,7 @@ VAR_B=2
 HOME=/root
 ```
 
-### <a name=workdir></a> Set the working directory for the exec process (--workdir, -w)
+### <a name="workdir"></a> Set the working directory for the exec process (--workdir, -w)
 
 By default `docker exec` command runs in the same working directory set when 
 the container was created.

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -23,7 +23,7 @@ with the container. If a volume is mounted on top of an existing directory in
 the container, `docker export` will export the contents of the *underlying*
 directory, not the contents of the volume.
 
-Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes)
+Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes)
 in the user guide for examples on exporting data in a volume.
 
 ## Examples

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -47,7 +47,7 @@ c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mand
 511136ea3c5a        19 months ago                                                       0 B                 Imported from -
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) will pretty-prints history output
 using a Go template.

--- a/docs/reference/commandline/history.md
+++ b/docs/reference/commandline/history.md
@@ -47,7 +47,7 @@ c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mand
 511136ea3c5a        19 months ago                                                       0 B                 Imported from -
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) will pretty-prints history output
 using a Go template.

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -59,7 +59,7 @@ deleted: sha256:2c675ee9ed53425e31a13e3390bf3f539bf8637000e4bcfbb85ee03ef4d910a1
 Total reclaimed space: 16.43 MB
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -59,7 +59,7 @@ deleted: sha256:2c675ee9ed53425e31a13e3390bf3f539bf8637000e4bcfbb85ee03ef4d910a1
 Total reclaimed space: 16.43 MB
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -103,7 +103,7 @@ $ docker images java:0
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 ```
 
-### <a name=no-trunc></a> List the full length image IDs (--no-trunc)
+### <a name="no-trunc"></a> List the full length image IDs (--no-trunc)
 
 ```console
 $ docker images --no-trunc
@@ -120,7 +120,7 @@ tryout                        latest              sha256:2629d1fa0b81b222fca6337
 <none>                        <none>              sha256:5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
 ```
 
-### <a name=digests></a> List image digests (--digests)
+### <a name="digests"></a> List image digests (--digests)
 
 Images that use the v2 or later format have a content-addressable identifier
 called a `digest`. As long as the input used to generate the image is
@@ -138,7 +138,7 @@ output includes the image digest. You can `pull` using a digest value. You can
 also reference by digest in `create`, `run`, and `rmi` commands, as well as the
 `FROM` image reference in a Dockerfile.
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -286,7 +286,7 @@ busybox             uclibc              e02e811dd08f        5 weeks ago         
 busybox             glibc               21c16b6787c6        5 weeks ago         4.19 MB
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) will pretty print container output
 using a Go template.

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -286,7 +286,7 @@ busybox             uclibc              e02e811dd08f        5 weeks ago         
 busybox             glibc               21c16b6787c6        5 weeks ago         4.19 MB
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) will pretty print container output
 using a Go template.

--- a/docs/reference/commandline/images.md
+++ b/docs/reference/commandline/images.md
@@ -103,7 +103,7 @@ $ docker images java:0
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 ```
 
-### List the full length image IDs
+### <a name=no-trunc></a> List the full length image IDs (--no-trunc)
 
 ```console
 $ docker images --no-trunc
@@ -120,7 +120,7 @@ tryout                        latest              sha256:2629d1fa0b81b222fca6337
 <none>                        <none>              sha256:5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
 ```
 
-### List image digests
+### <a name=digests></a> List image digests (--digests)
 
 Images that use the v2 or later format have a content-addressable identifier
 called a `digest`. As long as the input used to generate the image is
@@ -138,7 +138,7 @@ output includes the image digest. You can `pull` using a digest value. You can
 also reference by digest in `create`, `run`, and `rmi` commands, as well as the
 `FROM` image reference in a Dockerfile.
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -100,7 +100,7 @@ Server:
   127.0.0.0/8
 ```
 
-### Show debugging output
+### <a name=debug></a> Show debugging output (--debug)
 
 Here is a sample output for a daemon running on Ubuntu, using the overlay2
 storage driver and a node that is part of a 2-node swarm:
@@ -192,7 +192,7 @@ Server:
 
 The global `-D` option causes all `docker` commands to output debug information.
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 You can also specify the output format:
 

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -40,9 +40,9 @@ available on the volume where `/var/lib/docker` is mounted.
 
 ### Show output
 
-The example below shows the output for a daemon running on Red Hat Enterprise Linux,
-using the `devicemapper` storage driver. As can be seen in the output, additional
-information about the `devicemapper` storage driver is shown:
+The example below shows the output for a daemon running on Ubuntu Linux,
+using the `overlay2` storage driver. As can be seen in the output, additional
+information about the `overlay2` storage driver is shown:
 
 ```console
 $ docker info
@@ -50,6 +50,16 @@ $ docker info
 Client:
  Context:    default
  Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc.)
+    Version:  v0.8.2
+    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+  compose: Docker Compose (Docker Inc.)
+    Version:  v2.6.0
+    Path:     /usr/libexec/docker/cli-plugins/docker-compose
+  scan: Docker Scan (Docker Inc.)
+    Version:  v0.17.0
+    Path:     /usr/libexec/docker/cli-plugins/docker-scan
 
 Server:
  Containers: 14
@@ -57,140 +67,50 @@ Server:
   Paused: 1
   Stopped: 10
  Images: 52
- Server Version: 1.10.3
- Storage Driver: devicemapper
-  Pool Name: docker-202:2-25583803-pool
-  Pool Blocksize: 65.54 kB
-  Base Device Size: 10.74 GB
-  Backing Filesystem: xfs
-  Data file: /dev/loop0
-  Metadata file: /dev/loop1
-  Data Space Used: 1.68 GB
-  Data Space Total: 107.4 GB
-  Data Space Available: 7.548 GB
-  Metadata Space Used: 2.322 MB
-  Metadata Space Total: 2.147 GB
-  Metadata Space Available: 2.145 GB
-  Udev Sync Supported: true
-  Deferred Removal Enabled: false
-  Deferred Deletion Enabled: false
-  Deferred Deleted Device Count: 0
-  Data loop file: /var/lib/docker/devicemapper/devicemapper/data
-  Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
-  Library Version: 1.02.107-RHEL7 (2015-12-01)
- Execution Driver: native-0.2
+ Server Version: 22.06.0
+ Storage Driver: overlay2
+  Backing Filesystem: extfs
+  Supports d_type: true
+  Using metacopy: false
+  Native Overlay Diff: true
+  userxattr: false
  Logging Driver: json-file
+ Cgroup Driver: systemd
+ Cgroup Version: 2
  Plugins:
   Volume: local
-  Network: null host bridge
- Kernel Version: 3.10.0-327.el7.x86_64
- Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
+  Network: bridge host ipvlan macvlan null overlay
+  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
+ Swarm: inactive
+ Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
+ Default Runtime: runc
+ Init Binary: docker-init
+ containerd version: 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
+ runc version: v1.1.1-0-g52de29d
+ init version: de40ad0
+ Security Options:
+  apparmor
+  seccomp
+   Profile: builtin
+  cgroupns
+ Kernel Version: 5.15.0-25-generic
+ Operating System: Ubuntu 22.04 LTS
  OSType: linux
  Architecture: x86_64
  CPUs: 1
  Total Memory: 991.7 MiB
  Name: ip-172-30-0-91.ec2.internal
- ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
+ ID: 4cee4408-10d2-4e17-891c-a41736ac4536
  Docker Root Dir: /var/lib/docker
  Debug Mode: false
  Username: gordontheturtle
  Registry: https://index.docker.io/v1/
+ Experimental: false
  Insecure registries:
   myinsecurehost:5000
   127.0.0.0/8
-```
-
-### <a name=debug></a> Show debugging output (--debug)
-
-Here is a sample output for a daemon running on Ubuntu, using the overlay2
-storage driver and a node that is part of a 2-node swarm:
-
-```console
-$ docker --debug info
-
-Client:
- Context:    default
- Debug Mode: true
-
-Server:
- Containers: 14
-  Running: 3
-  Paused: 1
-  Stopped: 10
- Images: 52
- Server Version: 1.13.0
- Storage Driver: overlay2
-  Backing Filesystem: extfs
-  Supports d_type: true
-  Native Overlay Diff: false
- Logging Driver: json-file
- Cgroup Driver: cgroupfs
- Plugins:
-  Volume: local
-  Network: bridge host macvlan null overlay
- Swarm: active
-  NodeID: rdjq45w1op418waxlairloqbm
-  Is Manager: true
-  ClusterID: te8kdyw33n36fqiz74bfjeixd
-  Managers: 1
-  Nodes: 2
-  Orchestration:
-   Task History Retention Limit: 5
-  Raft:
-   Snapshot Interval: 10000
-   Number of Old Snapshots to Retain: 0
-   Heartbeat Tick: 1
-   Election Tick: 3
-  Dispatcher:
-   Heartbeat Period: 5 seconds
-  CA Configuration:
-   Expiry Duration: 3 months
-  Root Rotation In Progress: false
-  Node Address: 172.16.66.128 172.16.66.129
-  Manager Addresses:
-   172.16.66.128:2477
- Runtimes: runc
- Default Runtime: runc
- Init Binary: docker-init
- containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
- runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
- init version: N/A (expected: v0.13.0)
- Security Options:
-  apparmor
-  seccomp
-   Profile: default
- Kernel Version: 4.4.0-31-generic
- Operating System: Ubuntu 16.04.1 LTS
- OSType: linux
- Architecture: x86_64
- CPUs: 2
- Total Memory: 1.937 GiB
- Name: ubuntu
- ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
- Docker Root Dir: /var/lib/docker
- Debug Mode: true
-  File Descriptors: 30
-  Goroutines: 123
-  System Time: 2016-11-12T17:24:37.955404361-08:00
-  EventsListeners: 0
- Http Proxy: http://test:test@proxy.example.com:8080
- Https Proxy: https://test:test@proxy.example.com:8080
- No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
- Registry: https://index.docker.io/v1/
- WARNING: No swap limit support
- Labels:
-  storage=ssd
-  staging=true
- Experimental: false
- Insecure Registries:
-  127.0.0.0/8
- Registry Mirrors:
-   http://192.168.1.2/
-   http://registry-mirror.example.com:5000/
  Live Restore Enabled: false
 ```
-
-The global `-D` option causes all `docker` commands to output debug information.
 
 ### <a name=format></a> Format the output (--format)
 
@@ -204,13 +124,18 @@ $ docker info --format '{{json .}}'
 
 ### Run `docker info` on Windows
 
-Here is a sample output for a daemon running on Windows Server 2016:
+Here is a sample output for a daemon running on Windows Server:
 
 ```console
-E:\docker>docker info
+C:\> docker info
+
 Client:
  Context:    default
  Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc., v0.8.2-docker)
+  compose: Docker Compose (Docker Inc., v2.6.0)
+  scan: Docker Scan (Docker Inc., v0.17.0)
 
 Server:
  Containers: 1
@@ -218,27 +143,29 @@ Server:
   Paused: 0
   Stopped: 1
  Images: 17
- Server Version: 1.13.0
+ Server Version: 20.10.16
  Storage Driver: windowsfilter
-  Windows:
  Logging Driver: json-file
  Plugins:
   Volume: local
-  Network: nat null overlay
+  Network: ics internal l2bridge l2tunnel nat null overlay private transparent
+  Log: awslogs etwlogs fluentd gcplogs gelf json-file local logentries splunk syslog
  Swarm: inactive
  Default Isolation: process
- Kernel Version: 10.0 14393 (14393.206.amd64fre.rs1_release.160912-1937)
- Operating System: Windows Server 2016 Datacenter
+ Kernel Version: 10.0 20348 (20348.1.amd64fre.fe_release.210507-1500)
+ Operating System: Microsoft Windows Server Version 21H2 (OS Build 20348.707)
  OSType: windows
  Architecture: x86_64
  CPUs: 8
  Total Memory: 3.999 GiB
  Name: WIN-V0V70C0LU5P
- ID: NYMS:B5VK:UMSL:FVDZ:EWB5:FKVK:LPFL:FJMQ:H6FT:BZJ6:L2TD:XH62
- Docker Root Dir: C:\control
+ ID: 2880d38d-464e-4d01-91bd-c76f33ba3981
+ Docker Root Dir: C:\ProgramData\docker
  Debug Mode: false
  Registry: https://index.docker.io/v1/
+ Experimental: true
  Insecure Registries:
+  myregistry:5000
   127.0.0.0/8
  Registry Mirrors:
    http://192.168.1.2/

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -112,7 +112,7 @@ Server:
  Live Restore Enabled: false
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 You can also specify the output format:
 

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -25,14 +25,14 @@ Docker inspect provides detailed information on constructs controlled by Docker.
 
 By default, `docker inspect` will render results in a JSON array.
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 If a format is specified, the given template will be executed for each result.
 
 Go's [text/template](https://golang.org/pkg/text/template/) package describes
 all the details of the format.
 
-### <a name=type></a>Specify target type (--type)
+### <a name="type"></a> Specify target type (--type)
 
 `--type container|image|node|network|secret|service|volume|task|plugin`
 
@@ -49,7 +49,7 @@ The following example inspects a _volume_ named "myvolume"
 $ docker inspect --type=volume myvolume
 ```
 
-### <a name=size></a> Inspect the size of a container (-s, --size)
+### <a name="size"></a> Inspect the size of a container (-s, --size)
 
 The `--size`, or short-form `-s`, option adds two additional fields to the
 `docker inspect` output. This option only works for containers. The container

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -25,14 +25,14 @@ Docker inspect provides detailed information on constructs controlled by Docker.
 
 By default, `docker inspect` will render results in a JSON array.
 
-## Request a custom response format (--format)
+### <a name=format></a> Format the output (--format)
 
 If a format is specified, the given template will be executed for each result.
 
 Go's [text/template](https://golang.org/pkg/text/template/) package describes
 all the details of the format.
 
-## Specify target type (--type)
+### <a name=type></a>Specify target type (--type)
 
 `--type container|image|node|network|secret|service|volume|task|plugin`
 

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -51,7 +51,7 @@ The following example sends the default `SIGKILL` signal to the container named
 $ docker kill my_container
 ```
 
-### Send a custom signal to a container
+### <a name=signal></a>Send a custom signal to a container (--signal)
 
 The following example sends a `SIGHUP` signal to the container named
 `my_container`:

--- a/docs/reference/commandline/kill.md
+++ b/docs/reference/commandline/kill.md
@@ -51,7 +51,7 @@ The following example sends the default `SIGKILL` signal to the container named
 $ docker kill my_container
 ```
 
-### <a name=signal></a>Send a custom signal to a container (--signal)
+### <a name="signal"></a> Send a custom signal to a container (--signal)
 
 The following example sends a `SIGHUP` signal to the container named
 `my_container`:

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -30,18 +30,25 @@ bzip2, or xz) from a file or STDIN. It restores both images and tags.
 $ docker image ls
 
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+```
 
+### Load images from STDIN
+
+```console
 $ docker load < busybox.tar.gz
 
 Loaded image: busybox:latest
 $ docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+```
 
+### <a name=input></a> Load images from a file (--input)
+
+```console
 $ docker load --input fedora.tar
 
 Loaded image: fedora:rawhide
-
 Loaded image: fedora:20
 
 $ docker images

--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -43,7 +43,7 @@ REPOSITORY          TAG                 IMAGE ID            CREATED             
 busybox             latest              769b9341d937        7 weeks ago         2.489 MB
 ```
 
-### <a name=input></a> Load images from a file (--input)
+### <a name="input"></a> Load images from a file (--input)
 
 ```console
 $ docker load --input fedora.tar

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -34,7 +34,7 @@ adding the server name.
 $ docker login localhost:8080
 ```
 
-### Provide a password using STDIN
+### <a name=password-stdin></a> Provide a password using STDIN (--password-stdin)
 
 To run the `docker login` command non-interactively, you can set the
 `--password-stdin` flag to provide a password through `STDIN`. Using

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -34,7 +34,7 @@ adding the server name.
 $ docker login localhost:8080
 ```
 
-### <a name=password-stdin></a> Provide a password using STDIN (--password-stdin)
+### <a name="password-stdin"></a> Provide a password using STDIN (--password-stdin)
 
 To run the `docker login` command non-interactively, you can set the
 `--password-stdin` flag to provide a password through `STDIN`. Using

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -58,7 +58,7 @@ fraction of a second no more than nine digits long. You can combine the
 
 ## Examples
 
-### <a name=until></a> Retrieve logs until a specific point in time (--until)
+### <a name="until"></a> Retrieve logs until a specific point in time (--until)
 
 In order to retrieve logs before a specific point in time, run:
 

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -58,7 +58,7 @@ fraction of a second no more than nine digits long. You can combine the
 
 ## Examples
 
-### Retrieve logs until a specific point in time
+### <a name=until></a> Retrieve logs until a specific point in time (--until)
 
 In order to retrieve logs before a specific point in time, run:
 

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -43,7 +43,7 @@ container and immediately connect it to a network.
 $ docker run -itd --network=multi-host-network busybox
 ```
 
-### Specify the IP address a container will use on a given network
+### <a name=ip></a> Specify the IP address a container will use on a given network (--ip)
 
 You can specify the IP address you want to be assigned to the container's interface.
 
@@ -51,7 +51,7 @@ You can specify the IP address you want to be assigned to the container's interf
 $ docker network connect --ip 10.10.36.122 multi-host-network container2
 ```
 
-### Use the legacy `--link` option
+### <a name=link></a> Use the legacy `--link` option (--link)
 
 You can use `--link` option to link another container with a preferred alias
 
@@ -59,7 +59,7 @@ You can use `--link` option to link another container with a preferred alias
 $ docker network connect --link container1:c1 multi-host-network container2
 ```
 
-### Create a network alias for a container
+### <a name=alias></a> Create a network alias for a container (--alias)
 
 `--alias` option can be used to resolve the container by another name in the network
 being connected to.

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -43,7 +43,7 @@ container and immediately connect it to a network.
 $ docker run -itd --network=multi-host-network busybox
 ```
 
-### <a name=ip></a> Specify the IP address a container will use on a given network (--ip)
+### <a name="ip"></a> Specify the IP address a container will use on a given network (--ip)
 
 You can specify the IP address you want to be assigned to the container's interface.
 
@@ -51,7 +51,7 @@ You can specify the IP address you want to be assigned to the container's interf
 $ docker network connect --ip 10.10.36.122 multi-host-network container2
 ```
 
-### <a name=link></a> Use the legacy `--link` option (--link)
+### <a name="link"></a> Use the legacy `--link` option (--link)
 
 You can use `--link` option to link another container with a preferred alias
 
@@ -59,7 +59,7 @@ You can use `--link` option to link another container with a preferred alias
 $ docker network connect --link container1:c1 multi-host-network container2
 ```
 
-### <a name=alias></a> Create a network alias for a container (--alias)
+### <a name="alias"></a> Create a network alias for a container (--alias)
 
 `--alias` option can be used to resolve the container by another name in the network
 being connected to.

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -197,14 +197,14 @@ $ docker network create \
     simple-network
 ```
 
-### Network internal mode
+### <a name=internal></a> Network internal mode (--internal)
 
 By default, when you connect a container to an `overlay` network, Docker also
 connects a bridge network to it to provide external connectivity. If you want
 to create an externally isolated `overlay` network, you can specify the
 `--internal` option.
 
-### Network ingress mode
+### <a name=ingress></a> Network ingress mode (--ingress)
 
 You can create the network which will be used to provide the routing-mesh in the
 swarm cluster. You do so by specifying `--ingress` when creating the network. Only

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -197,14 +197,14 @@ $ docker network create \
     simple-network
 ```
 
-### <a name=internal></a> Network internal mode (--internal)
+### <a name="internal"></a> Network internal mode (--internal)
 
 By default, when you connect a container to an `overlay` network, Docker also
 connects a bridge network to it to provide external connectivity. If you want
 to create an externally isolated `overlay` network, you can specify the
 `--internal` option.
 
-### <a name=ingress></a> Network ingress mode (--ingress)
+### <a name="ingress"></a> Network ingress mode (--ingress)
 
 You can create the network which will be used to provide the routing-mesh in the
 swarm cluster. You do so by specifying `--ingress` when creating the network. Only

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -204,7 +204,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### <a name=verbose></a> View detailed information of a network (--verbose)
+### <a name="verbose"></a> View detailed information of a network (--verbose)
 
 `docker network inspect --verbose` for swarm mode overlay networks shows service-specific
 details such as the service's VIP and port mappings. It also shows IPs of service tasks,

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -204,7 +204,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### Using `verbose` option for `network inspect`
+### <a name=verbose></a> View detailed information of a network (--verbose)
 
 `docker network inspect --verbose` for swarm mode overlay networks shows service-specific
 details such as the service's VIP and port mappings. It also shows IPs of service tasks,

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -52,7 +52,7 @@ c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host         
 63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -197,7 +197,7 @@ $ docker network rm `docker network ls --filter type=custom -q`
 A warning will be issued when trying to remove a network that has containers
 attached.
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints networks output
 using a Go template.

--- a/docs/reference/commandline/network_ls.md
+++ b/docs/reference/commandline/network_ls.md
@@ -52,7 +52,7 @@ c288470c46f6c8949c5f7e5099b5b7947b07eabe8d9a27d79a9cbf111adcbf47   host         
 63d1ff1f77b07ca51070a8c227e962238358bd310bde1529cf62e6c307ade161   dev                 bridge           local
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -197,7 +197,7 @@ $ docker network rm `docker network ls --filter type=custom -q`
 A warning will be issued when trying to remove a network that has containers
 attached.
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints networks output
 using a Go template.

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -34,7 +34,7 @@ n1
 n2
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -34,7 +34,7 @@ n1
 n2
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -111,7 +111,7 @@ $ docker node inspect swarm-manager
 ]
 ```
 
-### Specify an output format
+### <a name=format></a> Format the output (--format)
 
 ```console
 $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -111,7 +111,7 @@ $ docker node inspect swarm-manager
 ]
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 ```console
 $ docker node inspect --format '{{ .ManagerStatus.Leader }}' self

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -24,7 +24,7 @@ Options:
 ## Description
 
 Lists all the nodes that the Docker Swarm manager knows about. You can filter
-using the `-f` or `--filter` flag. Refer to the [filtering](#filtering) section
+using the `-f` or `--filter` flag. Refer to the [filtering](#filter) section
 for more information about available filter options.
 
 > **Note**

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -52,7 +52,7 @@ e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.
 
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -170,7 +170,7 @@ ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATU
 e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints nodes output
 using a Go template.

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -52,7 +52,7 @@ e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.
 
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -170,7 +170,7 @@ ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATU
 e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints nodes output
 using a Go template.

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -47,7 +47,7 @@ redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        
 redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -108,7 +108,7 @@ redis.7.bg8c07zzg87di2mufeq51a2qp  redis:3.0.6  swarm-manager1  Running        R
 The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output
 using a Go template.

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -47,7 +47,7 @@ redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        
 redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -108,7 +108,7 @@ redis.7.bg8c07zzg87di2mufeq51a2qp  redis:3.0.6  swarm-manager1  Running        R
 The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output
 using a Go template.

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -24,7 +24,7 @@ Options:
 ## Description
 
 Lists all the tasks on a Node that Docker knows about. You can filter using the
-`-f` or `--filter` flag. Refer to the [filtering](#filtering) section for more
+`-f` or `--filter` flag. Refer to the [filtering](#filter) section for more
 information about available filter options.
 
 > **Note**

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -52,7 +52,7 @@ Error response from daemon: rpc error: code = 9 desc = node swarm-node-03 is not
 down and can't be removed
 ```
 
-### Forcibly remove an inaccessible node from a swarm
+### <a name=force></a> Forcibly remove an inaccessible node from a swarm (--force)
 
 If you lose access to a worker node or need to shut it down because it has been
 compromised or is not behaving as expected, you can use the `--force` option.

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -52,7 +52,7 @@ Error response from daemon: rpc error: code = 9 desc = node swarm-node-03 is not
 down and can't be removed
 ```
 
-### <a name=force></a> Forcibly remove an inaccessible node from a swarm (--force)
+### <a name="force"></a> Forcibly remove an inaccessible node from a swarm (--force)
 
 If you lose access to a worker node or need to shut it down because it has been
 compromised or is not behaving as expected, you can use the `--force` option.

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -32,7 +32,7 @@ Update metadata about a node, such as its availability, labels, or roles.
 
 ## Examples
 
-### Add label metadata to a node
+### <a name=label-add></a> Add label metadata to a node (--label-add)
 
 Add metadata to a swarm node using node labels. You can specify a node label as
 a key with an empty value:

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -32,7 +32,7 @@ Update metadata about a node, such as its availability, labels, or roles.
 
 ## Examples
 
-### <a name=label-add></a> Add label metadata to a node (--label-add)
+### <a name="label-add"></a> Add label metadata to a node (--label-add)
 
 Add metadata to a swarm node using node labels. You can specify a node label as
 a key with an empty value:

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -142,7 +142,7 @@ Output is in JSON format (output below is formatted for readability):
 ```
 
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 ```console
 $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -142,7 +142,7 @@ Output is in JSON format (output below is formatted for readability):
 ```
 
 
-### Formatting the output
+### <a name=format></a> Format the output (--format)
 
 ```console
 $ docker plugin inspect -f '{{.Id}}' tiborvass/sample-volume-plugin:latest

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -38,7 +38,7 @@ ID            NAME                                    DESCRIPTION               
 69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
-### <a name=format></a> Filtering (--filter)
+### <a name="format"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -68,7 +68,7 @@ $ docker plugin ls --filter enabled=true
 ID                  NAME                DESCRIPTION         ENABLED
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints plugins output
 using a Go template.

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -27,7 +27,7 @@ Options:
 Lists all the plugins that are currently installed. You can install plugins
 using the [`docker plugin install`](plugin_install.md) command.
 You can also filter using the `-f` or `--filter` flag.
-Refer to the [filtering](#filtering) section for more information about available filter options.
+Refer to the [filtering](#filter) section for more information about available filter options.
 
 ## Examples
 

--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -38,7 +38,7 @@ ID            NAME                                    DESCRIPTION               
 69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
-### Filtering
+### <a name=format></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -68,7 +68,7 @@ $ docker plugin ls --filter enabled=true
 ID                  NAME                DESCRIPTION         ENABLED
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints plugins output
 using a Go template.

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -41,7 +41,7 @@ Options:
 
 ## Examples
 
-### Prevent truncating output
+### <a name=no-trunc></a> Do not truncate output (--no-trunc)
 
 Running `docker ps --no-trunc` showing 2 linked containers.
 
@@ -53,10 +53,10 @@ CONTAINER ID        IMAGE                        COMMAND                CREATED 
 d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
 ```
 
-### Show both running and stopped containers
+### <a name=all></a> Show both running and stopped containers (-a, --all)
 
 The `docker ps` command only shows running containers by default. To see all
-containers, use the `-a` (or `--all`) flag:
+containers, use the `--all` (or `-a`) flag:
 
 ```console
 $ docker ps -a
@@ -66,12 +66,12 @@ $ docker ps -a
 container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
 the `PORTS` column.
 
-### Show disk usage by container
+### <a name=size></a> Show disk usage by container (--size)
 
-The `docker ps -s` command displays two different on-disk-sizes for each container:
+The `docker ps --size` (or `-s`) command displays two different on-disk-sizes for each container:
 
 ```console
-$ docker ps -s
+$ docker ps --size
 
 CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
 e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
@@ -83,9 +83,9 @@ e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours
 For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
 
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
-The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
+The `--filter` (or `-f`) flag format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
 
 The currently supported filters are:
@@ -394,7 +394,7 @@ $ docker ps --filter publish=80/udp
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints container output using a Go
 template.

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -41,7 +41,7 @@ Options:
 
 ## Examples
 
-### <a name=no-trunc></a> Do not truncate output (--no-trunc)
+### <a name="no-trunc"></a> Do not truncate output (--no-trunc)
 
 Running `docker ps --no-trunc` showing 2 linked containers.
 
@@ -53,7 +53,7 @@ CONTAINER ID        IMAGE                        COMMAND                CREATED 
 d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
 ```
 
-### <a name=all></a> Show both running and stopped containers (-a, --all)
+### <a name="all"></a> Show both running and stopped containers (-a, --all)
 
 The `docker ps` command only shows running containers by default. To see all
 containers, use the `--all` (or `-a`) flag:
@@ -66,7 +66,7 @@ $ docker ps -a
 container that exposes TCP ports `100, 101, 102` displays `100-102/tcp` in
 the `PORTS` column.
 
-### <a name=size></a> Show disk usage by container (--size)
+### <a name="size"></a> Show disk usage by container (--size)
 
 The `docker ps --size` (or `-s`) command displays two different on-disk-sizes for each container:
 
@@ -83,7 +83,7 @@ e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours
 For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
 
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The `--filter` (or `-f`) flag format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`)
@@ -394,7 +394,7 @@ $ docker ps --filter publish=80/udp
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints container output using a Go
 template.

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -49,7 +49,7 @@ Running `docker ps --no-trunc` showing 2 linked containers.
 $ docker ps
 
 CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
-4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
+4c01db0b339c        ubuntu:22.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
 d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
 ```
 
@@ -246,13 +246,13 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
 ```
 
-Match containers based on the `ubuntu` version `12.04.5` image:
+Match containers based on the `ubuntu` version `22.04` image:
 
 ```console
-$ docker ps --filter ancestor=ubuntu:12.04.5
+$ docker ps --filter ancestor=ubuntu:22.04
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
 ```
 
 The following matches containers based on the layer `d0e008c6cf02` or an image
@@ -262,7 +262,7 @@ that have this layer in its layer stack.
 $ docker ps --filter ancestor=d0e008c6cf02
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-82a598284012        ubuntu:12.04.5      "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
 ```
 
 #### Create time

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -189,7 +189,7 @@ registry is allowed to be accessed over an insecure connection. Refer to the
 [insecure registries](dockerd.md#insecure-registries) section for more information.
 
 
-### Pull a repository with multiple images
+### <a name=all-tags></a> Pull a repository with multiple images (-a, --all-tags)
 
 By default, `docker pull` pulls a *single* image from the registry. A repository
 can contain multiple images. To pull all images from a repository, provide the

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -188,7 +188,7 @@ registry is allowed to be accessed over an insecure connection. Refer to the
 [insecure registries](dockerd.md#insecure-registries) section for more information.
 
 
-### <a name=all-tags></a> Pull a repository with multiple images (-a, --all-tags)
+### <a name="all-tags"></a> Pull a repository with multiple images (-a, --all-tags)
 
 By default, `docker pull` pulls a *single* image from the registry. A repository
 can contain multiple images. To pull all images from a repository, provide the

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -50,36 +50,36 @@ this via the `--max-concurrent-downloads` daemon option. See the
 ### Pull an image from Docker Hub
 
 To download a particular image, or set of images (i.e., a repository), use
-`docker pull`. If no tag is provided, Docker Engine uses the `:latest` tag as a
-default. This command pulls the `debian:latest` image:
+`docker image pull` (or the `docker pull` shorthand). If no tag is provided,
+Docker Engine uses the `:latest` tag as a default. This example pulls the
+`debian:latest` image:
 
 ```console
-$ docker pull debian
+$ docker image pull debian
 
 Using default tag: latest
 latest: Pulling from library/debian
-fdd5d7827f33: Pull complete
-a3ed95caeb02: Pull complete
-Digest: sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa
+e756f3fdd6a3: Pull complete
+Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
 Status: Downloaded newer image for debian:latest
+docker.io/library/debian:latest
 ```
 
 Docker images can consist of multiple layers. In the example above, the image
-consists of two layers; `fdd5d7827f33` and `a3ed95caeb02`.
+consists of a single layer; `e756f3fdd6a3`.
 
-Layers can be reused by images. For example, the `debian:jessie` image shares
-both layers with `debian:latest`. Pulling the `debian:jessie` image therefore
-only pulls its metadata, but not its layers, because all layers are already
-present locally:
+Layers can be reused by images. For example, the `debian:bullseye` image shares
+its layer with the `debian:latest`. Pulling the `debian:bullseye` image therefore
+only pulls its metadata, but not its layers, because the layer is already present
+locally:
 
 ```console
-$ docker pull debian:jessie
+$ docker image pull debian:bullseye
 
-jessie: Pulling from library/debian
-fdd5d7827f33: Already exists
-a3ed95caeb02: Already exists
-Digest: sha256:a9c958be96d7d40df920e7041608f2f017af81800ca5ad23e327bc402626b58e
-Status: Downloaded newer image for debian:jessie
+bullseye: Pulling from library/debian
+Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
+Status: Downloaded newer image for debian:bullseye
+docker.io/library/debian:bullseye
 ```
 
 To see which images are present locally, use the [`docker images`](images.md)
@@ -88,17 +88,16 @@ command:
 ```console
 $ docker images
 
-REPOSITORY   TAG      IMAGE ID        CREATED      SIZE
-debian       jessie   f50f9524513f    5 days ago   125.1 MB
-debian       latest   f50f9524513f    5 days ago   125.1 MB
+REPOSITORY   TAG        IMAGE ID       CREATED        SIZE
+debian       bullseye   4eacea30377a   8 days ago     124MB
+debian       latest     4eacea30377a   8 days ago     124MB
 ```
 
 Docker uses a content-addressable image store, and the image ID is a SHA256
 digest covering the image's configuration and layers. In the example above,
-`debian:jessie` and `debian:latest` have the same image ID because they are
-actually the *same* image tagged with different names. Because they are the
-same image, their layers are stored only once and do not consume extra disk
-space.
+`debian:bullseye` and `debian:latest` have the same image ID because they are
+the *same* image tagged with different names. Because they are the same image,
+their layers are stored only once and do not consume extra disk space.
 
 For more information about images, layers, and the content-addressable store,
 refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/).
@@ -109,8 +108,8 @@ refer to [understand images, containers, and storage drivers](https://docs.docke
 So far, you've pulled images by their name (and "tag"). Using names and tags is
 a convenient way to work with images. When using tags, you can `docker pull` an
 image again to make sure you have the most up-to-date version of that image.
-For example, `docker pull ubuntu:20.04` pulls the latest version of the Ubuntu
-20.04 image.
+For example, `docker pull ubuntu:22.04` pulls the latest version of the Ubuntu
+22.04 image.
 
 In some cases you don't want images to be updated to newer versions, but prefer
 to use a fixed version of an image. Docker enables you to pull an image by its
@@ -119,23 +118,23 @@ of an image to pull. Doing so, allows you to "pin" an image to that version,
 and guarantee that the image you're using is always the same.
 
 To know the digest of an image, pull the image first. Let's pull the latest
-`ubuntu:20.04` image from Docker Hub:
+`ubuntu:22.04` image from Docker Hub:
 
 ```console
-$ docker pull ubuntu:20.04
+$ docker pull ubuntu:22.04
 
-20.04: Pulling from library/ubuntu
-16ec32c2132b: Pull complete
-Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-Status: Downloaded newer image for ubuntu:20.04
-docker.io/library/ubuntu:20.04
+22.04: Pulling from library/ubuntu
+125a6e411906: Pull complete
+Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+Status: Downloaded newer image for ubuntu:22.04
+docker.io/library/ubuntu:22.04
 ```
 
 Docker prints the digest of the image after the pull has finished. In the example
 above, the digest of the image is:
 
 ```console
-sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ```
 
 Docker also prints the digest of an image when *pushing* to a registry. This
@@ -145,25 +144,25 @@ A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
 ```console
-$ docker pull ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+$ docker pull ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 
-docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3: Pulling from library/ubuntu
-Digest: sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-Status: Image is up to date for ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
-docker.io/library/ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d: Pulling from library/ubuntu
+Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+Status: Image is up to date for ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 ```
 
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
-FROM ubuntu@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
+FROM ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 ```
 
 > **Note**
 >
 > Using this feature "pins" an image to a specific version in time.
-> Docker will therefore not pull updated versions of an image, which may include
+> Docker does therefore not pull updated versions of an image, which may include
 > security updates. If you want to pull an updated image, you need to change the
 > digest accordingly.
 
@@ -179,7 +178,7 @@ The following command pulls the `testing/test-image` image from a local registry
 listening on port 5000 (`myregistry.local:5000`):
 
 ```console
-$ docker pull myregistry.local:5000/testing/test-image
+$ docker image pull myregistry.local:5000/testing/test-image
 ```
 
 Registry credentials are managed by [docker login](login.md).
@@ -195,33 +194,35 @@ By default, `docker pull` pulls a *single* image from the registry. A repository
 can contain multiple images. To pull all images from a repository, provide the
 `-a` (or `--all-tags`) option when using `docker pull`.
 
-This command pulls all images from the `fedora` repository:
+This command pulls all images from the `ubuntu` repository:
 
 ```console
-$ docker pull --all-tags fedora
+$ docker image pull --all-tags ubuntu
 
-Pulling repository fedora
+Pulling repository ubuntu
 ad57ef8d78d7: Download complete
 105182bb5e8b: Download complete
 511136ea3c5a: Download complete
 73bd853d2ea5: Download complete
 ....
 
-Status: Downloaded newer image for fedora
+Status: Downloaded newer image for ubuntu
 ```
 
-After the pull has completed use the `docker images` command to see the
-images that were pulled. The example below shows all the `fedora` images
-that are present locally:
+After the pull has completed use the `docker image ls` command (or the `docker images`
+shorthand) to see the images that were pulled. The example below shows all the
+`ubuntu` images that are present locally:
 
 ```console
-$ docker images fedora
-
-REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
-fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB
-fedora       20          105182bb5e8b    5 days ago   372.7 MB
-fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
-fedora       latest      105182bb5e8b    5 days ago   372.7 MB
+$ docker image ls --filter reference=ubuntu
+REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
+ubuntu       18.04     c6ad7e71ba7d   5 weeks ago    63.2MB
+ubuntu       bionic    c6ad7e71ba7d   5 weeks ago    63.2MB
+ubuntu       22.04     5ccefbfc0416   2 months ago   78MB
+ubuntu       focal     ff0fea8310f3   2 months ago   72.8MB
+ubuntu       latest    ff0fea8310f3   2 months ago   72.8MB
+ubuntu       jammy     41ba606c8ab9   3 months ago   79MB
+ubuntu       20.04     ba6acccedd29   7 months ago   72.8MB
 ```
 
 ### Cancel a pull
@@ -230,18 +231,15 @@ Killing the `docker pull` process, for example by pressing `CTRL-c` while it is
 running in a terminal, will terminate the pull operation.
 
 ```console
-$ docker pull fedora
+$ docker pull ubuntu
 
 Using default tag: latest
-latest: Pulling from library/fedora
+latest: Pulling from library/ubuntu
 a3ed95caeb02: Pulling fs layer
 236608c7b546: Pulling fs layer
 ^C
 ```
 
-> **Note**
->
-> The Engine terminates a pull operation when the connection between the Docker
-> Engine daemon and the Docker Engine client initiating the pull is lost. If the
-> connection with the Engine daemon is lost for other reasons than a manual
-> interaction, the pull is also aborted.
+The Engine terminates a pull operation when the connection between the daemon
+and the client (initiating the pull) is cut or lost for any reason or the
+command is manually terminated.

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -74,7 +74,7 @@ $ docker image ls
 You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
 listed.
 
-### Push all tags of an image
+### <a name=all-tags></a> Push all tags of an image (-a, --all-tags)
 
 Use the `-a` (or `--all-tags`) option to push all tags of a local image.
 

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -74,7 +74,7 @@ $ docker image ls
 You should see both `rhel-httpd` and `registry-host:5000/myadmin/rhel-httpd`
 listed.
 
-### <a name=all-tags></a> Push all tags of an image (-a, --all-tags)
+### <a name="all-tags"></a> Push all tags of an image (-a, --all-tags)
 
 Use the `-a` (or `--all-tags`) option to push all tags of a local image.
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -30,7 +30,7 @@ $ docker rm /redis
 /redis
 ```
 
-### Remove a link specified with `--link` on the default bridge network
+### <a name=link></a> Remove a link specified with `--link` on the default bridge network (--link)
 
 This removes the underlying link between `/webapp` and the `/redis`
 containers on the default bridge network, removing all network communication
@@ -43,7 +43,7 @@ $ docker rm --link /webapp/redis
 /webapp/redis
 ```
 
-### Force-remove a running container
+### <a name=force></a> Force-remove a running container (--force)
 
 This command force-removes a running container.
 
@@ -86,10 +86,10 @@ Or, using the `xargs` Linux utility;
 $ docker ps --filter status=exited -q | xargs docker rm
 ```
 
-### Remove a container and its volumes
+### <a name=volumes></a> Remove a container and its volumes (-v, --volumes)
 
 ```console
-$ docker rm -v redis
+$ docker rm --volumes redis
 redis
 ```
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -30,7 +30,7 @@ $ docker rm /redis
 /redis
 ```
 
-### <a name=link></a> Remove a link specified with `--link` on the default bridge network (--link)
+### <a name="link"></a> Remove a link specified with `--link` on the default bridge network (--link)
 
 This removes the underlying link between `/webapp` and the `/redis`
 containers on the default bridge network, removing all network communication
@@ -43,7 +43,7 @@ $ docker rm --link /webapp/redis
 /webapp/redis
 ```
 
-### <a name=force></a> Force-remove a running container (--force)
+### <a name="force"></a> Force-remove a running container (--force)
 
 This command force-removes a running container.
 
@@ -86,7 +86,7 @@ Or, using the `xargs` Linux utility;
 $ docker ps --filter status=exited -q | xargs docker rm
 ```
 
-### <a name=volumes></a> Remove a container and its volumes (-v, --volumes)
+### <a name="volumes"></a> Remove a container and its volumes (-v, --volumes)
 
 ```console
 $ docker rm --volumes redis

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -583,7 +583,7 @@ logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
-See also [the `docker cp` command](/engine/reference/commandline/cp/).
+See also [the `docker cp` command](cp.md).
 
 ### <a name=device></a> Add host device to container (--device)
 

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -153,9 +153,6 @@ specified image, and then `starts` it using the specified command. That is,
 previous changes intact using `docker start`. See `docker ps -a` to view a list
 of all containers.
 
-The `docker run` command can be used in combination with `docker commit` to
-[*change the command that a container runs*](commit.md). There is additional detailed information about `docker run` in the [Docker run reference](../run.md).
-
 For information on connecting a container to a network, see the ["*Docker network overview*"](https://docs.docker.com/network/).
 
 ## Examples
@@ -230,14 +227,14 @@ The `-w` lets the command being executed inside directory given, here
 $ docker run -it --storage-opt size=120G fedora /bin/bash
 ```
 
-This (size) will allow to set the container rootfs size to 120G at creation time.
+This (size) will allow to set the container filesystem size to 120G at creation time.
 This option is only available for the `devicemapper`, `btrfs`, `overlay2`,
 `windowsfilter` and `zfs` graph drivers.
 For the `devicemapper`, `btrfs`, `windowsfilter` and `zfs` graph drivers,
 user cannot pass a size less than the Default BaseFS Size.
 For the `overlay2` storage driver, the size option is only available if the
-backing fs is `xfs` and mounted with the `pquota` mount option.
-Under these conditions, user can pass any size less than the backing fs size.
+backing filesystem is `xfs` and mounted with the `pquota` mount option.
+Under these conditions, user can pass any size less than the backing filesystem size.
 
 ### <a name=tmpfs></a> Mount tmpfs (--tmpfs)
 
@@ -282,8 +279,8 @@ specified volumes for the container.
 $ docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/static-docker-binary:/usr/bin/docker busybox sh
 ```
 
-By bind-mounting the docker unix socket and statically linked docker
-binary (refer to [get the linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
+By bind-mounting the Docker Unix socket and statically linked Docker
+binary (refer to [get the Linux binary](https://docs.docker.com/engine/install/binaries/#install-static-binaries)),
 you give the container the full access to create and manipulate the host's
 Docker daemon.
 
@@ -322,7 +319,7 @@ mounts in a container.
 The `--mount` flag supports most options that are supported by the `-v` or the
 `--volume` flag, but uses a different syntax. For in-depth information on the
 `--mount` flag, and a comparison between `--volume` and `--mount`, refer to
-the [service create command reference](service_create.md#add-bind-mounts-volumes-or-memory-filesystems).
+[Bind mounts](https://docs.docker.com/storage/bind-mounts/).
 
 Even though there is no plan to deprecate `--volume`, usage of `--mount` is recommended.
 
@@ -374,7 +371,7 @@ The `--pull` flag can take one of these values:
 
 When creating (and running) a container from an image, the daemon checks if the
 image exists in the local image cache. If the image is missing, an error is
-returned to the cli, allowing it to initiate a pull.
+returned to the CLI, allowing it to initiate a pull.
 
 The default (`missing`) is to only pull the image if it is not present in the
 daemon's image cache. This default allows you to run images that only exist
@@ -497,9 +494,11 @@ the Docker User Guide.
 ### <a name=network></a> Connect a container to a network (--network)
 
 When you start a container use the `--network` flag to connect it to a network.
-This adds the `busybox` container to the `my-net` network.
+The following commands create a network named `my-net`, and adds a `busybox` container
+to the `my-net` network.
 
 ```console
+$ docker network create my-net
 $ docker run -itd --network=my-net busybox
 ```
 
@@ -520,9 +519,9 @@ from different Engines can also communicate in this way.
 
 > **Note**
 >
-> Service discovery is unavailable on the default bridge network. Containers can
-> communicate via their IP addresses by default. To communicate by name, they
-> must be linked.
+> The default bridge network only allow containers to communicate with each other using
+> internal IP addresses. User-created bridge networks provide DNS resolution between
+> containers using container names.
 
 You can disconnect a container from a network using the `docker network
 disconnect` command.
@@ -578,11 +577,13 @@ still store what's been written to `STDERR` and `STDOUT`.
 $ cat somefile | docker run -i -a stdin mybuilder dobuild
 ```
 
-This is how piping a file into a container could be done for a build.
+This is a way of using `--attach` to pipe a build file into a container.
 The container's ID will be printed after the build is done and the build
 logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
+
+See also [the `docker cp` command](/engine/reference/commandline/cp/).
 
 ### <a name=device></a> Add host device to container (--device)
 
@@ -684,7 +685,7 @@ install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-run
 Visit [Specify a container's resources](https://docs.docker.com/config/containers/resource_constraints/)
 for more information.
 
-To use `--gpus`, specify which GPUs (or all) to use. If no value is provied, all
+To use `--gpus`, specify which GPUs (or all) to use. If no value is provided, all
 available GPUs are used. The example below exposes all available GPUs.
 
 ```console
@@ -795,7 +796,7 @@ Docker doesn't perform any byte conversion. Take this into account when setting 
 #### For `nproc` usage
 
 Be careful setting `nproc` with the `ulimit` flag as `nproc` is designed by Linux to set the
-maximum number of processes available to a user, not to a container.  For example, start four
+maximum number of processes available to a user, not to a container. For example, start four
 containers with `daemon` user:
 
 ```console
@@ -860,8 +861,8 @@ On Windows, `--isolation` can take one of these values:
 | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                              |
 
 The default isolation on Windows server operating systems is `process`, and `hyperv`
-on Windows client operating systems, such as Windows 10. Process isolation is more
-performant, but requires the image to
+on Windows client operating systems, such as Windows 10. Process isolation has better
+performance, but requires that the image and host use the same kernel version.
 
 On Windows server, assuming the default configuration, these commands are equivalent
 and result in `process` isolation:

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -157,7 +157,7 @@ For information on connecting a container to a network, see the ["*Docker networ
 
 ## Examples
 
-### <a name=name></a> Assign name and allocate pseudo-TTY (--name, -it)
+### <a name="name"></a> Assign name and allocate pseudo-TTY (--name, -it)
 
 ```console
 $ docker run --name test -it debian
@@ -176,7 +176,7 @@ In the example, the `bash` shell is quit by entering
 `exit 13`. This exit code is passed on to the caller of
 `docker run`, and is recorded in the `test` container's metadata.
 
-### <a name=cidfile></a> Capture container ID (--cidfile)
+### <a name="cidfile"></a> Capture container ID (--cidfile)
 
 ```console
 $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
@@ -187,7 +187,7 @@ flag makes Docker attempt to create a new file and write the container ID to it.
 If the file exists already, Docker will return an error. Docker will close this
 file when `docker run` exits.
 
-### <a name=privileged></a> Full container capabilities (--privileged)
+### <a name="privileged"></a> Full container capabilities (--privileged)
 
 ```console
 $ docker run -t -i --rm ubuntu bash
@@ -212,7 +212,7 @@ lifts all the limitations enforced by the `device` cgroup controller. In other
 words, the container can then do almost everything that the host can do. This
 flag exists to allow special use-cases, like running Docker within Docker.
 
-### <a name=workdir></a> Set working directory (-w, --workdir)
+### <a name="workdir"></a> Set working directory (-w, --workdir)
 
 ```console
 $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
@@ -221,7 +221,7 @@ $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
 The `-w` lets the command being executed inside directory given, here
 `/path/to/dir/`. If the path does not exist it is created inside the container.
 
-### <a name=storage-opt></a> Set storage driver options per container (--storage-opt)
+### <a name="storage-opt"></a> Set storage driver options per container (--storage-opt)
 
 ```console
 $ docker run -it --storage-opt size=120G fedora /bin/bash
@@ -236,7 +236,7 @@ For the `overlay2` storage driver, the size option is only available if the
 backing filesystem is `xfs` and mounted with the `pquota` mount option.
 Under these conditions, user can pass any size less than the backing filesystem size.
 
-### <a name=tmpfs></a> Mount tmpfs (--tmpfs)
+### <a name="tmpfs"></a> Mount tmpfs (--tmpfs)
 
 ```console
 $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
@@ -245,7 +245,7 @@ $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
 `noexec`, `nosuid`, `size=65536k` options.
 
-### <a name=volume></a> Mount volume (-v, --read-only)
+### <a name="volume"></a> Mount volume (-v, --read-only)
 
 ```console
 $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
@@ -311,7 +311,7 @@ docker run -v c:\foo:c:\existing-directory-with-contents ...
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/storage/volumes/)
 
 
-### <a name=mount></a> Add bind mounts or volumes using the --mount flag
+### <a name="mount"></a> Add bind mounts or volumes using the --mount flag
 
 The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
 mounts in a container.
@@ -333,7 +333,7 @@ $ docker run --read-only --mount type=volume,target=/icanwrite busybox touch /ic
 $ docker run -t -i --mount type=bind,src=/data,dst=/data busybox sh
 ```
 
-### <a name=publish></a> Publish or expose port (-p, --expose)
+### <a name="publish"></a> Publish or expose port (-p, --expose)
 
 ```console
 $ docker run -p 127.0.0.1:80:8080/tcp ubuntu bash
@@ -398,7 +398,7 @@ $ docker run --pull=never hello-world
 docker: Error response from daemon: No such image: hello-world:latest.
 ```
 
-### <a name=env></a> Set environment variables (-e, --env, --env-file)
+### <a name="env"></a> Set environment variables (-e, --env, --env-file)
 
 ```console
 $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
@@ -449,7 +449,7 @@ VAR2=value2
 USER=jonzeolla
 ```
 
-### <a name=label></a> Set metadata on container (-l, --label, --label-file)
+### <a name="label"></a> Set metadata on container (-l, --label, --label-file)
 
 A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
@@ -491,7 +491,7 @@ For additional information on working with labels, see [*Labels - custom
 metadata in Docker*](https://docs.docker.com/config/labels-custom-metadata/) in
 the Docker User Guide.
 
-### <a name=network></a> Connect a container to a network (--network)
+### <a name="network"></a> Connect a container to a network (--network)
 
 When you start a container use the `--network` flag to connect it to a network.
 The following commands create a network named `my-net`, and adds a `busybox` container
@@ -526,7 +526,7 @@ from different Engines can also communicate in this way.
 You can disconnect a container from a network using the `docker network
 disconnect` command.
 
-### <a name=volumes-from></a> Mount volumes from container (--volumes-from)
+### <a name="volumes-from"></a> Mount volumes from container (--volumes-from)
 
 ```console
 $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
@@ -552,7 +552,7 @@ content label. Shared volume labels allow all containers to read/write content.
 The `Z` option tells Docker to label the content with a private unshared label.
 Only the current container can use a private volume.
 
-### <a name=attach></a> Attach to STDIN/STDOUT/STDERR (-a, --attach)
+### <a name="attach"></a> Attach to STDIN/STDOUT/STDERR (-a, --attach)
 
 The `--attach` (or `-a`) flag tells `docker run` to bind to the container's
 `STDIN`, `STDOUT` or `STDERR`. This makes it possible to manipulate the output
@@ -585,7 +585,7 @@ retrieve the container's ID once the container has finished running.
 
 See also [the `docker cp` command](cp.md).
 
-### <a name=device></a> Add host device to container (--device)
+### <a name="device"></a> Add host device to container (--device)
 
 ```console
 $ docker run -it --rm \
@@ -678,7 +678,7 @@ the required device when it is added.
 > **Note**: initially present devices still need to be explicitly added to the
 > `docker run` / `docker create` command.
 
-### <a name=gpus></a> Access an NVIDIA GPU
+### <a name="gpus"></a> Access an NVIDIA GPU
 
 The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
 install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
@@ -705,7 +705,7 @@ The example below exposes the first and third GPUs.
 $ docker run -it --rm --gpus '"device=0,2"' nvidia-smi
 ```
 
-### <a name=restart></a> Restart policies (--restart)
+### <a name="restart"></a> Restart policies (--restart)
 
 Use Docker's `--restart` to specify a container's *restart policy*. A restart
 policy controls whether the Docker daemon restarts a container after exit.
@@ -729,7 +729,7 @@ More detailed information on restart policies can be found in the
 [Restart Policies (--restart)](../run.md#restart-policies---restart)
 section of the Docker run reference page.
 
-### <a name=add-host></a> Add entries to container hosts file (--add-host)
+### <a name="add-host"></a> Add entries to container hosts file (--add-host)
 
 You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
@@ -767,7 +767,7 @@ For IPv6 use the `-6` flag instead of the `-4` flag. For other network
 devices, replace `eth0` with the correct device name (for example `docker0`
 for the bridge device).
 
-### <a name=ulimit></a> Set ulimits in container (--ulimit)
+### <a name="ulimit"></a> Set ulimits in container (--ulimit)
 
 Since setting `ulimit` settings in a container requires extra privileges not
 available in the default container, you can set these using the `--ulimit` flag.
@@ -813,7 +813,7 @@ The 4th container fails and reports "[8] System error: resource temporarily unav
 This fails because the caller set `nproc=3` resulting in the first three containers using up
 the three processes quota set for the `daemon` user.
 
-### <a name=stop-signal></a> Stop container with signal (--stop-signal)
+### <a name="stop-signal"></a> Stop container with signal (--stop-signal)
 
 The `--stop-signal` flag sets the system call signal that will be sent to the
 container to exit. This signal can be a signal name in the format `SIG<NAME>`,
@@ -822,12 +822,12 @@ kernel's syscall table, for instance `9`.
 
 The default is `SIGTERM` if not specified.
 
-### <a name=security-opt></a> Optional security options (--security-opt)
+### <a name="security-opt"></a> Optional security options (--security-opt)
 
 On Windows, this flag can be used to specify the `credentialspec` option.
 The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
 
-### <a name=stop-timeout></a> Stop container with timeout (--stop-timeout)
+### <a name="stop-timeout"></a> Stop container with timeout (--stop-timeout)
 
 The `--stop-timeout` flag sets the number of seconds to wait for the container
 to stop after sending the pre-defined (see `--stop-signal`) system call signal.
@@ -840,7 +840,7 @@ wait indefinitely for the container to exit.
 The default is determined by the daemon, and is 10 seconds for Linux containers,
 and 30 seconds for Windows containers.
 
-### <a name=isolation></a> Specify isolation technology for container (--isolation)
+### <a name="isolation"></a> Specify isolation technology for container (--isolation)
 
 This option is useful in situations where you are running Docker containers on
 Windows. The `--isolation=<value>` option sets a container's isolation technology.
@@ -883,7 +883,7 @@ PS C:\> docker run -d --isolation default microsoft/nanoserver powershell echo h
 PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv
 ```
 
-### <a name=memory></a> Specify hard limits on memory available to containers (-m, --memory)
+### <a name="memory"></a> Specify hard limits on memory available to containers (-m, --memory)
 
 These parameters always set an upper limit on the memory available to the container. On Linux, this
 is set on the cgroup and applications in a container can query it at `/sys/fs/cgroup/memory/memory.limit_in_bytes`.
@@ -921,7 +921,7 @@ On Windows, this will affect containers differently depending on what type of is
     ```
 
 
-### <a name=sysctl></a> Configure namespaced kernel parameters (sysctls) at runtime (--sysctl)
+### <a name="sysctl"></a> Configure namespaced kernel parameters (sysctls) at runtime (--sysctl)
 
 The `--sysctl` sets namespaced kernel parameters (sysctls) in the
 container. For example, to turn on IP forwarding in the containers

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -160,7 +160,7 @@ For information on connecting a container to a network, see the ["*Docker networ
 
 ## Examples
 
-### Assign name and allocate pseudo-TTY (--name, -it)
+### <a name=name></a> Assign name and allocate pseudo-TTY (--name, -it)
 
 ```console
 $ docker run --name test -it debian
@@ -179,7 +179,7 @@ In the example, the `bash` shell is quit by entering
 `exit 13`. This exit code is passed on to the caller of
 `docker run`, and is recorded in the `test` container's metadata.
 
-### Capture container ID (--cidfile)
+### <a name=cidfile></a> Capture container ID (--cidfile)
 
 ```console
 $ docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
@@ -190,7 +190,7 @@ flag makes Docker attempt to create a new file and write the container ID to it.
 If the file exists already, Docker will return an error. Docker will close this
 file when `docker run` exits.
 
-### Full container capabilities (--privileged)
+### <a name=privileged></a> Full container capabilities (--privileged)
 
 ```console
 $ docker run -t -i --rm ubuntu bash
@@ -215,7 +215,7 @@ lifts all the limitations enforced by the `device` cgroup controller. In other
 words, the container can then do almost everything that the host can do. This
 flag exists to allow special use-cases, like running Docker within Docker.
 
-### Set working directory (-w)
+### <a name=workdir></a> Set working directory (-w, --workdir)
 
 ```console
 $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
@@ -224,7 +224,7 @@ $ docker  run -w /path/to/dir/ -i -t  ubuntu pwd
 The `-w` lets the command being executed inside directory given, here
 `/path/to/dir/`. If the path does not exist it is created inside the container.
 
-### Set storage driver options per container
+### <a name=storage-opt></a> Set storage driver options per container (--storage-opt)
 
 ```console
 $ docker run -it --storage-opt size=120G fedora /bin/bash
@@ -239,7 +239,7 @@ For the `overlay2` storage driver, the size option is only available if the
 backing fs is `xfs` and mounted with the `pquota` mount option.
 Under these conditions, user can pass any size less than the backing fs size.
 
-### Mount tmpfs (--tmpfs)
+### <a name=tmpfs></a> Mount tmpfs (--tmpfs)
 
 ```console
 $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
@@ -248,7 +248,7 @@ $ docker run -d --tmpfs /run:rw,noexec,nosuid,size=65536k my_image
 The `--tmpfs` flag mounts an empty tmpfs into the container with the `rw`,
 `noexec`, `nosuid`, `size=65536k` options.
 
-### Mount volume (-v, --read-only)
+### <a name=volume></a> Mount volume (-v, --read-only)
 
 ```console
 $ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
@@ -314,7 +314,7 @@ docker run -v c:\foo:c:\existing-directory-with-contents ...
 For in-depth information about volumes, refer to [manage data in containers](https://docs.docker.com/storage/volumes/)
 
 
-### Add bind mounts or volumes using the --mount flag
+### <a name=mount></a> Add bind mounts or volumes using the --mount flag
 
 The `--mount` flag allows you to mount volumes, host-directories and `tmpfs`
 mounts in a container.
@@ -336,7 +336,7 @@ $ docker run --read-only --mount type=volume,target=/icanwrite busybox touch /ic
 $ docker run -t -i --mount type=bind,src=/data,dst=/data busybox sh
 ```
 
-### Publish or expose port (-p, --expose)
+### <a name=publish></a> Publish or expose port (-p, --expose)
 
 ```console
 $ docker run -p 127.0.0.1:80:8080/tcp ubuntu bash
@@ -401,7 +401,7 @@ $ docker run --pull=never hello-world
 docker: Error response from daemon: No such image: hello-world:latest.
 ```
 
-### Set environment variables (-e, --env, --env-file)
+### <a name=env></a> Set environment variables (-e, --env, --env-file)
 
 ```console
 $ docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
@@ -452,7 +452,7 @@ VAR2=value2
 USER=jonzeolla
 ```
 
-### Set metadata on container (-l, --label, --label-file)
+### <a name=label></a> Set metadata on container (-l, --label, --label-file)
 
 A label is a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
@@ -494,7 +494,7 @@ For additional information on working with labels, see [*Labels - custom
 metadata in Docker*](https://docs.docker.com/config/labels-custom-metadata/) in
 the Docker User Guide.
 
-### Connect a container to a network (--network)
+### <a name=network></a> Connect a container to a network (--network)
 
 When you start a container use the `--network` flag to connect it to a network.
 This adds the `busybox` container to the `my-net` network.
@@ -527,7 +527,7 @@ from different Engines can also communicate in this way.
 You can disconnect a container from a network using the `docker network
 disconnect` command.
 
-### Mount volumes from container (--volumes-from)
+### <a name=volumes-from></a> Mount volumes from container (--volumes-from)
 
 ```console
 $ docker run --volumes-from 777f7dc92da7 --volumes-from ba8c0c54f0f2:ro -i -t ubuntu pwd
@@ -553,11 +553,11 @@ content label. Shared volume labels allow all containers to read/write content.
 The `Z` option tells Docker to label the content with a private unshared label.
 Only the current container can use a private volume.
 
-### Attach to STDIN/STDOUT/STDERR (-a)
+### <a name=attach></a> Attach to STDIN/STDOUT/STDERR (-a, --attach)
 
-The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT`
-or `STDERR`. This makes it possible to manipulate the output and input as
-needed.
+The `--attach` (or `-a`) flag tells `docker run` to bind to the container's
+`STDIN`, `STDOUT` or `STDERR`. This makes it possible to manipulate the output
+and input as needed.
 
 ```console
 $ echo "test" | docker run -i -a stdin ubuntu cat -
@@ -584,7 +584,7 @@ logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
-### Add host device to container (--device)
+### <a name=device></a> Add host device to container (--device)
 
 ```console
 $ docker run -it --rm \
@@ -677,7 +677,7 @@ the required device when it is added.
 > **Note**: initially present devices still need to be explicitly added to the
 > `docker run` / `docker create` command.
 
-### Access an NVIDIA GPU
+### <a name=gpus></a> Access an NVIDIA GPU
 
 The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
 install [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
@@ -704,7 +704,7 @@ The example below exposes the first and third GPUs.
 $ docker run -it --rm --gpus '"device=0,2"' nvidia-smi
 ```
 
-### Restart policies (--restart)
+### <a name=restart></a> Restart policies (--restart)
 
 Use Docker's `--restart` to specify a container's *restart policy*. A restart
 policy controls whether the Docker daemon restarts a container after exit.
@@ -728,7 +728,7 @@ More detailed information on restart policies can be found in the
 [Restart Policies (--restart)](../run.md#restart-policies---restart)
 section of the Docker run reference page.
 
-### Add entries to container hosts file (--add-host)
+### <a name=add-host></a> Add entries to container hosts file (--add-host)
 
 You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
@@ -766,7 +766,7 @@ For IPv6 use the `-6` flag instead of the `-4` flag. For other network
 devices, replace `eth0` with the correct device name (for example `docker0`
 for the bridge device).
 
-### Set ulimits in container (--ulimit)
+### <a name=ulimit></a> Set ulimits in container (--ulimit)
 
 Since setting `ulimit` settings in a container requires extra privileges not
 available in the default container, you can set these using the `--ulimit` flag.
@@ -812,7 +812,7 @@ The 4th container fails and reports "[8] System error: resource temporarily unav
 This fails because the caller set `nproc=3` resulting in the first three containers using up
 the three processes quota set for the `daemon` user.
 
-### Stop container with signal (--stop-signal)
+### <a name=stop-signal></a> Stop container with signal (--stop-signal)
 
 The `--stop-signal` flag sets the system call signal that will be sent to the
 container to exit. This signal can be a signal name in the format `SIG<NAME>`,
@@ -821,12 +821,12 @@ kernel's syscall table, for instance `9`.
 
 The default is `SIGTERM` if not specified.
 
-### Optional security options (--security-opt)
+### <a name=security-opt></a> Optional security options (--security-opt)
 
 On Windows, this flag can be used to specify the `credentialspec` option.
 The `credentialspec` must be in the format `file://spec.txt` or `registry://keyname`.
 
-### Stop container with timeout (--stop-timeout)
+### <a name=stop-timeout></a> Stop container with timeout (--stop-timeout)
 
 The `--stop-timeout` flag sets the number of seconds to wait for the container
 to stop after sending the pre-defined (see `--stop-signal`) system call signal.
@@ -839,7 +839,7 @@ wait indefinitely for the container to exit.
 The default is determined by the daemon, and is 10 seconds for Linux containers,
 and 30 seconds for Windows containers.
 
-### Specify isolation technology for container (--isolation)
+### <a name=isolation></a> Specify isolation technology for container (--isolation)
 
 This option is useful in situations where you are running Docker containers on
 Windows. The `--isolation=<value>` option sets a container's isolation technology.
@@ -882,7 +882,7 @@ PS C:\> docker run -d --isolation default microsoft/nanoserver powershell echo h
 PS C:\> docker run -d --isolation hyperv microsoft/nanoserver powershell echo hyperv
 ```
 
-### Specify hard limits on memory available to containers (-m, --memory)
+### <a name=memory></a> Specify hard limits on memory available to containers (-m, --memory)
 
 These parameters always set an upper limit on the memory available to the container. On Linux, this
 is set on the cgroup and applications in a container can query it at `/sys/fs/cgroup/memory/memory.limit_in_bytes`.
@@ -920,7 +920,7 @@ On Windows, this will affect containers differently depending on what type of is
     ```
 
 
-### Configure namespaced kernel parameters (sysctls) at runtime
+### <a name=sysctl></a> Configure namespaced kernel parameters (sysctls) at runtime (--sysctl)
 
 The `--sysctl` sets namespaced kernel parameters (sysctls) in the
 container. For example, to turn on IP forwarding in the containers

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -63,7 +63,7 @@ scottabernethy/busybox                                                          
 marclop/busybox-solr
 ```
 
-### <a name=no-trunc></a> Display non-truncated description (--no-trunc)
+### <a name="no-trunc"></a> Display non-truncated description (--no-trunc)
 
 This example displays images with a name containing 'busybox',
 at least 3 stars and the description isn't truncated in the output:
@@ -77,12 +77,12 @@ progrium/busybox                                                                
 radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
 ```
 
-### <a name=limit></a> Limit search results (--limit)
+### <a name="limit"></a> Limit search results (--limit)
 
 The flag `--limit` is the maximum number of results returned by a search. This value could
 be in the range between 1 and 100. The default value of `--limit` is 25.
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g. `--filter is-automated=true --filter stars=3`)
@@ -132,7 +132,7 @@ NAME      DESCRIPTION           STARS     OFFICIAL   AUTOMATED
 busybox   Busybox base image.   325       [OK]
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints search output
 using a Go template.

--- a/docs/reference/commandline/search.md
+++ b/docs/reference/commandline/search.md
@@ -63,7 +63,7 @@ scottabernethy/busybox                                                          
 marclop/busybox-solr
 ```
 
-### Display non-truncated description (--no-trunc)
+### <a name=no-trunc></a> Display non-truncated description (--no-trunc)
 
 This example displays images with a name containing 'busybox',
 at least 3 stars and the description isn't truncated in the output:
@@ -77,12 +77,12 @@ progrium/busybox                                                                
 radial/busyboxplus   Full-chain, Internet enabled, busybox made from scratch. Comes in git and cURL flavors.   8                    [OK]
 ```
 
-### Limit search results (--limit)
+### <a name=limit></a> Limit search results (--limit)
 
 The flag `--limit` is the maximum number of results returned by a search. This value could
 be in the range between 1 and 100. The default value of `--limit` is 25.
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g. `--filter is-automated=true --filter stars=3`)
@@ -132,7 +132,7 @@ NAME      DESCRIPTION           STARS     OFFICIAL   AUTOMATED
 busybox   Busybox base image.   325       [OK]
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints search output
 using a Go template.

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -57,7 +57,7 @@ ID                          NAME                CREATED             UPDATED
 dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ago
 ```
 
-### Create a secret with labels
+### <a name=label></a> Create a secret with labels (--label)
 
 ```console
 $ docker secret create \

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -57,7 +57,7 @@ ID                          NAME                CREATED             UPDATED
 dg426haahpi5ezmkkj5kyl3sn   my_secret           7 seconds ago       7 seconds ago
 ```
 
-### <a name=label></a> Create a secret with labels (--label)
+### <a name="label"></a> Create a secret with labels (--label)
 
 ```console
 $ docker secret create \

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -76,7 +76,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 You can use the --format option to obtain specific information about a
 secret. The following example command outputs the creation time of the

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -76,7 +76,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 You can use the --format option to obtain specific information about a
 secret. The following example command outputs the creation time of the

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -45,7 +45,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_secret                 3 seconds ago       3 seconds ago
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -105,7 +105,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_secret                 About an hour ago   About an hour ago
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints secrets output
 using a Go template.

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -45,7 +45,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_secret                 3 seconds ago       3 seconds ago
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -105,7 +105,7 @@ ID                          NAME                        CREATED             UPDA
 mem02h8n73mybpgqjf0kfi1n0   test_secret                 About an hour ago   About an hour ago
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints secrets output
 using a Go template.

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -117,7 +117,7 @@ dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
 a8q9dasaafud  redis2  global      1/1       redis:3.0.6
 ```
 
-#### Create a service using an image on a private registry
+#### <a name=with-registry-auth></a>Create a service using an image on a private registry (--with-registry-auth)
 
 If your image is available on a private registry which requires login, use the
 `--with-registry-auth` flag with `docker service create`, after logging in. If
@@ -137,7 +137,7 @@ This passes the login token from your local client to the swarm nodes where the
 service is deployed, using the encrypted WAL logs. With this information, the
 nodes are able to log into the registry and pull the image.
 
-### Create a service with 5 replica tasks (--replicas)
+### <a name=replicas></a>Create a service with 5 replica tasks (--replicas)
 
 Use the `--replicas` flag to set the number of replica tasks for a replicated
 service. The following command creates a `redis` service with `5` replica tasks:
@@ -173,7 +173,7 @@ ID            NAME   MODE        REPLICAS  IMAGE
 4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
 ```
 
-### Create a service with secrets
+### <a name=secret></a>Create a service with secrets (--secret)
 
 Use the `--secret` flag to give a container access to a
 [secret](secret_create.md).
@@ -205,7 +205,7 @@ in the container. If a target is specified, that is used as the filename. In the
 example above, two files are created: `/run/secrets/ssh` and
 `/run/secrets/app` for each of the secret targets specified.
 
-### Create a service with configs
+### <a name=config></a>Create a service with configs (--config)
 
 Use the `--config` flag to give a container access to a
 [config](config_create.md).
@@ -234,7 +234,7 @@ Configs are located in `/` in the container if no target is specified. If no
 target is specified, the name of the config is used as the name of the file in
 the container. If a target is specified, that is used as the filename.
 
-### Create a service with a rolling update policy
+### <a name=update-delay></a>Create a service with a rolling update policy
 
 ```console
 $ docker service create \
@@ -250,7 +250,7 @@ maximum of 2 tasks at a time, with `10s` between updates. For more information,
 refer to the [rolling updates
 tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
-### Set environment variables (-e, --env)
+### <a name=env></a> Set environment variables (-e, --env)
 
 This sets an environment variable for all tasks in a service. For example:
 
@@ -274,7 +274,7 @@ $ docker service create \
   redis:3.0.6
 ```
 
-### Create a service with specific hostname (--hostname)
+### <a name=hostname></a> Create a service with specific hostname (--hostname)
 
 This option sets the docker service containers hostname to a specific string.
 For example:
@@ -283,7 +283,7 @@ For example:
 $ docker service create --name redis --hostname myredis redis:3.0.6
 ```
 
-### Set metadata on a service (-l, --label)
+### <a name=label></a> Set metadata on a service (-l, --label)
 
 A label is a `key=value` pair that applies metadata to a service. To label a
 service with two labels:
@@ -662,7 +662,7 @@ $ docker service create \
  redis:3.0.6
 ```
 
-### Specify service constraints (--constraint)
+### <a name=constraint></a> Specify service constraints (--constraint)
 
 You can limit the set of nodes where a task can be scheduled by defining
 constraint expressions. Constraint expressions can either use a _match_ (`==`)
@@ -729,7 +729,7 @@ ID                  NAME     MODE         REPLICAS   IMAGE               PORTS
 b6lww17hrr4e        web      replicated   1/1        nginx:alpine
 ```
 
-### Specify service placement preferences (--placement-pref)
+### <a name=placement-pref></a> Specify service placement preferences (--placement-pref)
 
 You can set up the service to divide tasks evenly over different categories of
 nodes. One example of where this can be useful is to balance tasks over a set
@@ -800,7 +800,7 @@ appends a new placement preference after all existing placement preferences.
 `--placement-pref-rm` removes an existing placement preference that matches the
 argument.
 
-### Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
+### <a name=reserve-memory></a> Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
 
 If your service needs a minimum amount of memory in order to run correctly,
 you can use `--reserve-memory` to specify that the service should only be
@@ -868,7 +868,7 @@ On Linux, you can also limit a service's overall memory footprint on a given
 host at the level of the host operating system, using `cgroups` or other
 relevant operating system tools.
 
-### Specify maximum replicas per node (--replicas-max-per-node)
+### <a name=replicas-max-per-node></a> Specify maximum replicas per node (--replicas-max-per-node)
 
 Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
 The following command creates a nginx service with 2 replica tasks but only one replica task per node.
@@ -888,7 +888,7 @@ $ docker service create \
   nginx
 ```
 
-### Attach a service to an existing network (--network)
+### <a name=network></a> Attach a service to an existing network (--network)
 
 You can use overlay networks to connect one or more services within the swarm.
 
@@ -925,7 +925,7 @@ Containers on the same network can access each other using
 Long form syntax of `--network` allows to specify list of aliases and driver options:
 `--network name=my-network,alias=web1,driver-opt=field1=value1`
 
-### Publish service ports externally to the swarm (-p, --publish)
+### <a name=publish></a> Publish service ports externally to the swarm (-p, --publish)
 
 You can publish service ports to make them available externally to the swarm
 using the `--publish` flag. The `--publish` flag can take two different styles
@@ -996,7 +996,7 @@ on a node can only be bound once. You can only set the publication mode using
 the long syntax. For more information refer to
 [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
 
-### Provide credential specs for managed service accounts (Windows only)
+### <a name=credentials-spec></a> Provide credential specs for managed service accounts (--credentials-spec)
 
 This option is only used for services using Windows containers. The
 `--credential-spec` must be in the format `file://<filename>` or
@@ -1091,7 +1091,7 @@ $ docker inspect --format="{{.Config.Hostname}}" 2e7a8a9c4da2-wo41w8hg8qanxwjwsg
 x3ti0erg11rjpg64m75kej2mz-hosttempl
 ```
 
-### Specify isolation mode (Windows)
+### <a name=isolation></a> Specify isolation mode on Windows (--isolation)
 
 By default, tasks scheduled on Windows nodes are run using the default isolation mode
 configured for this particular node. To force a specific isolation mode, you can use
@@ -1106,7 +1106,7 @@ Supported isolation modes on Windows are:
 - `process`: use process isolation (Windows server only)
 - `hyperv`: use Hyper-V isolation
 
-### Create services requesting Generic Resources
+### <a name=generic-resources></a> Create services requesting Generic Resources (--generic-resources)
 
 You can narrow the kind of nodes your task can land on through the using the
 `--generic-resource` flag (if the nodes advertise these resources):

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -117,7 +117,7 @@ dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
 a8q9dasaafud  redis2  global      1/1       redis:3.0.6
 ```
 
-#### <a name=with-registry-auth></a>Create a service using an image on a private registry (--with-registry-auth)
+#### <a name="with-registry-auth"></a> Create a service using an image on a private registry (--with-registry-auth)
 
 If your image is available on a private registry which requires login, use the
 `--with-registry-auth` flag with `docker service create`, after logging in. If
@@ -137,7 +137,7 @@ This passes the login token from your local client to the swarm nodes where the
 service is deployed, using the encrypted WAL logs. With this information, the
 nodes are able to log into the registry and pull the image.
 
-### <a name=replicas></a>Create a service with 5 replica tasks (--replicas)
+### <a name="replicas"></a> Create a service with 5 replica tasks (--replicas)
 
 Use the `--replicas` flag to set the number of replica tasks for a replicated
 service. The following command creates a `redis` service with `5` replica tasks:
@@ -173,7 +173,7 @@ ID            NAME   MODE        REPLICAS  IMAGE
 4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
 ```
 
-### <a name=secret></a>Create a service with secrets (--secret)
+### <a name="secret"></a> Create a service with secrets (--secret)
 
 Use the `--secret` flag to give a container access to a
 [secret](secret_create.md).
@@ -205,7 +205,7 @@ in the container. If a target is specified, that is used as the filename. In the
 example above, two files are created: `/run/secrets/ssh` and
 `/run/secrets/app` for each of the secret targets specified.
 
-### <a name=config></a>Create a service with configs (--config)
+### <a name="config"></a> Create a service with configs (--config)
 
 Use the `--config` flag to give a container access to a
 [config](config_create.md).
@@ -234,7 +234,7 @@ Configs are located in `/` in the container if no target is specified. If no
 target is specified, the name of the config is used as the name of the file in
 the container. If a target is specified, that is used as the filename.
 
-### <a name=update-delay></a>Create a service with a rolling update policy
+### <a name="update-delay"></a> Create a service with a rolling update policy
 
 ```console
 $ docker service create \
@@ -250,7 +250,7 @@ maximum of 2 tasks at a time, with `10s` between updates. For more information,
 refer to the [rolling updates
 tutorial](https://docs.docker.com/engine/swarm/swarm-tutorial/rolling-update/).
 
-### <a name=env></a> Set environment variables (-e, --env)
+### <a name="env"></a> Set environment variables (-e, --env)
 
 This sets an environment variable for all tasks in a service. For example:
 
@@ -274,7 +274,7 @@ $ docker service create \
   redis:3.0.6
 ```
 
-### <a name=hostname></a> Create a service with specific hostname (--hostname)
+### <a name="hostname"></a> Create a service with specific hostname (--hostname)
 
 This option sets the docker service containers hostname to a specific string.
 For example:
@@ -283,7 +283,7 @@ For example:
 $ docker service create --name redis --hostname myredis redis:3.0.6
 ```
 
-### <a name=label></a> Set metadata on a service (-l, --label)
+### <a name="label"></a> Set metadata on a service (-l, --label)
 
 A label is a `key=value` pair that applies metadata to a service. To label a
 service with two labels:
@@ -299,7 +299,7 @@ $ docker service create \
 For more information about labels, refer to [apply custom
 metadata](https://docs.docker.com/config/labels-custom-metadata/).
 
-### <a name=mount></a> Add bind mounts, volumes or memory filesystems (--mount)
+### <a name="mount"></a> Add bind mounts, volumes or memory filesystems (--mount)
 
 Docker supports three different kinds of mounts, which allow containers to read
 from or write to files or directories, either on the host operating system, or
@@ -662,7 +662,7 @@ $ docker service create \
  redis:3.0.6
 ```
 
-### <a name=constraint></a> Specify service constraints (--constraint)
+### <a name="constraint"></a> Specify service constraints (--constraint)
 
 You can limit the set of nodes where a task can be scheduled by defining
 constraint expressions. Constraint expressions can either use a _match_ (`==`)
@@ -729,7 +729,7 @@ ID                  NAME     MODE         REPLICAS   IMAGE               PORTS
 b6lww17hrr4e        web      replicated   1/1        nginx:alpine
 ```
 
-### <a name=placement-pref></a> Specify service placement preferences (--placement-pref)
+### <a name="placement-pref"></a> Specify service placement preferences (--placement-pref)
 
 You can set up the service to divide tasks evenly over different categories of
 nodes. One example of where this can be useful is to balance tasks over a set
@@ -800,7 +800,7 @@ appends a new placement preference after all existing placement preferences.
 `--placement-pref-rm` removes an existing placement preference that matches the
 argument.
 
-### <a name=reserve-memory></a> Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
+### <a name="reserve-memory"></a> Specify memory requirements and constraints for a service (--reserve-memory and --limit-memory)
 
 If your service needs a minimum amount of memory in order to run correctly,
 you can use `--reserve-memory` to specify that the service should only be
@@ -868,7 +868,7 @@ On Linux, you can also limit a service's overall memory footprint on a given
 host at the level of the host operating system, using `cgroups` or other
 relevant operating system tools.
 
-### <a name=replicas-max-per-node></a> Specify maximum replicas per node (--replicas-max-per-node)
+### <a name="replicas-max-per-node"></a> Specify maximum replicas per node (--replicas-max-per-node)
 
 Use the `--replicas-max-per-node` flag to set the maximum number of replica tasks that can run on a node.
 The following command creates a nginx service with 2 replica tasks but only one replica task per node.
@@ -888,7 +888,7 @@ $ docker service create \
   nginx
 ```
 
-### <a name=network></a> Attach a service to an existing network (--network)
+### <a name="network"></a> Attach a service to an existing network (--network)
 
 You can use overlay networks to connect one or more services within the swarm.
 
@@ -925,7 +925,7 @@ Containers on the same network can access each other using
 Long form syntax of `--network` allows to specify list of aliases and driver options:
 `--network name=my-network,alias=web1,driver-opt=field1=value1`
 
-### <a name=publish></a> Publish service ports externally to the swarm (-p, --publish)
+### <a name="publish"></a> Publish service ports externally to the swarm (-p, --publish)
 
 You can publish service ports to make them available externally to the swarm
 using the `--publish` flag. The `--publish` flag can take two different styles
@@ -996,7 +996,7 @@ on a node can only be bound once. You can only set the publication mode using
 the long syntax. For more information refer to
 [Use swarm mode routing mesh](https://docs.docker.com/engine/swarm/ingress/).
 
-### <a name=credentials-spec></a> Provide credential specs for managed service accounts (--credentials-spec)
+### <a name="credentials-spec"></a> Provide credential specs for managed service accounts (--credentials-spec)
 
 This option is only used for services using Windows containers. The
 `--credential-spec` must be in the format `file://<filename>` or
@@ -1091,7 +1091,7 @@ $ docker inspect --format="{{.Config.Hostname}}" 2e7a8a9c4da2-wo41w8hg8qanxwjwsg
 x3ti0erg11rjpg64m75kej2mz-hosttempl
 ```
 
-### <a name=isolation></a> Specify isolation mode on Windows (--isolation)
+### <a name="isolation"></a> Specify isolation mode on Windows (--isolation)
 
 By default, tasks scheduled on Windows nodes are run using the default isolation mode
 configured for this particular node. To force a specific isolation mode, you can use
@@ -1106,7 +1106,7 @@ Supported isolation modes on Windows are:
 - `process`: use process isolation (Windows server only)
 - `hyperv`: use Hyper-V isolation
 
-### <a name=generic-resources></a> Create services requesting Generic Resources (--generic-resources)
+### <a name="generic-resources"></a> Create services requesting Generic Resources (--generic-resources)
 
 You can narrow the kind of nodes your task can land on through the using the
 `--generic-resource` flag (if the nodes advertise these resources):

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -678,7 +678,7 @@ follows:
 | `node.platform.os`   | Node operating system          | `node.platform.os==windows`                   |
 | `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`                  |
 | `node.labels`        | User-defined node labels       | `node.labels.security==high`                  |
-| `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-14.04` |
+| `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-22.04` |
 
 `engine.labels` apply to Docker Engine labels like operating system, drivers,
 etc. Swarm administrators add `node.labels` for operational purposes by using

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -299,7 +299,7 @@ $ docker service create \
 For more information about labels, refer to [apply custom
 metadata](https://docs.docker.com/config/labels-custom-metadata/).
 
-### Add bind mounts, volumes or memory filesystems
+### <a name=mount></a> Add bind mounts, volumes or memory filesystems (--mount)
 
 Docker supports three different kinds of mounts, which allow containers to read
 from or write to files or directories, either on the host operating system, or

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -113,7 +113,7 @@ $ docker service inspect dmu1ept4cxcf
 ]
 ```
 
-### Formatting
+### <a name=pretty></a> Formatting (--pretty)
 
 You can print the inspect output in a human-readable format instead of the default
 JSON output, by using the `--pretty` option:

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -146,9 +146,9 @@ Ports:
 
 You can also use `--format pretty` for the same effect.
 
+### <a name=format></a> Format the output (--format)
 
-#### Find the number of tasks running as part of a service
-
+You can use the --format option to obtain specific information about a
 The `--format` option can be used to obtain specific information about a
 service. For example, the following command outputs the number of replicas
 of the "redis" service.

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -113,7 +113,7 @@ $ docker service inspect dmu1ept4cxcf
 ]
 ```
 
-### <a name=pretty></a> Formatting (--pretty)
+### <a name="pretty"></a> Formatting (--pretty)
 
 You can print the inspect output in a human-readable format instead of the default
 JSON output, by using the `--pretty` option:
@@ -146,7 +146,7 @@ Ports:
 
 You can also use `--format pretty` for the same effect.
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 You can use the --format option to obtain specific information about a
 The `--format` option can be used to obtain specific information about a

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -51,7 +51,7 @@ the service. If the service is in `replicated-job` or `global-job`, it will
 additionally show the completion status of the job as completed tasks over
 total tasks the job will execute.
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -123,7 +123,7 @@ ID            NAME   MODE        REPLICAS  IMAGE
 0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints services output
 using a Go template.

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -51,7 +51,7 @@ the service. If the service is in `replicated-job` or `global-job`, it will
 additionally show the completion status of the job as completed tasks over
 total tasks the job will execute.
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -123,7 +123,7 @@ ID            NAME   MODE        REPLICAS  IMAGE
 0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints services output
 using a Go template.

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -93,7 +93,7 @@ bk658fpbex0d57cqcwoe3jthu   redis.2      redis:3.0.6@sha256:6a692a76c2081888b589
 nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -150,7 +150,7 @@ ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE     
 
 The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output
 using a Go template.

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -93,7 +93,7 @@ bk658fpbex0d57cqcwoe3jthu   redis.2      redis:3.0.6@sha256:6a692a76c2081888b589
 nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -150,7 +150,7 @@ ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE     
 
 The `desired-state` filter can take the values `running`, `shutdown`, or `accepted`.
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output
 using a Go template.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -131,7 +131,7 @@ rolling restart without any changes to the service parameters.
 $ docker service update --limit-cpu 2 redis
 ```
 
-### Perform a rolling restart with no parameter changes
+### <a name=update-parallelism></a> Perform a rolling restart with no parameter changes
 
 ```console
 $ docker service update --force --update-parallelism 1 --update-delay 30s redis
@@ -144,7 +144,7 @@ that only one task is replaced at a time (this is the default behavior). The
 `--update-delay 30s` setting introduces a 30 second delay between tasks, so
 that the rolling restart happens gradually.
 
-### Add or remove mounts
+### <a name=mount-add></a> Add or remove mounts (--mount-add, --mount-rm)
 
 Use the `--mount-add` or `--mount-rm` options add or remove a service's bind mounts
 or volumes.
@@ -180,7 +180,7 @@ $ docker service update --mount-rm /somewhere myservice
 myservice
 ```
 
-### Add or remove published service ports
+### <a name=publish-add></a> Add or remove published service ports (--publish-add, --publish-rm)
 
 Use the `--publish-add` or `--publish-rm` flags to add or remove a published
 port for a service. You can use the short or long syntax discussed in the
@@ -195,7 +195,7 @@ $ docker service update \
   myservice
 ```
 
-### Add or remove network
+### <a name=network-add></a> Add or remove network (--network-add, --network-rm)
 
 Use the `--network-add` or `--network-rm` flags to add or remove a network for
 a service. You can use the short or long syntax discussed in the
@@ -211,7 +211,7 @@ $ docker service update \
   myservice
 ```
 
-### Roll back to the previous version of a service
+### <a name=rollback></a> Roll back to the previous version of a service (--rollback)
 
 Use the `--rollback` option to roll back to the previous version of the service.
 
@@ -277,7 +277,7 @@ will update one task at a time during a normal update, but during a rollback, 3
 tasks at a time will get rolled back. These rollback parameters are respected both
 during automatic rollbacks and for rollbacks initiated manually using `--rollback`.
 
-### Add or remove secrets
+### <a name=secret-add></a> Add or remove secrets (--secret-add, --secret-rm)
 
 Use the `--secret-add` or `--secret-rm` options add or remove a service's
 secrets.
@@ -297,7 +297,7 @@ Some flags of `service update` support the use of templating.
 See [`service create`](service_create.md#create-services-using-templates) for the reference.
 
 
-### Specify isolation mode (Windows)
+### <a name=isolation></a> Specify isolation mode on Windows (--isolation)
 
 `service update` supports the same `--isolation` flag as `service create`
 See [`service create`](service_create.md) for the reference.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -156,7 +156,7 @@ point, effectively removing the `test-data` volume. Each command returns the
 service name.
 
 - The `--mount-add` flag takes the same parameters as the `--mount` flag on
-  `service create`. Refer to the [volumes and bind mounts](service_create.md#mount-add)
+  `service create`. Refer to the [volumes and bind mounts](service_create.md#mount)
   section in the `service create` reference for details.
 
 - The `--mount-rm` flag takes the `target` path of the mount.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -131,7 +131,7 @@ rolling restart without any changes to the service parameters.
 $ docker service update --limit-cpu 2 redis
 ```
 
-### <a name=update-parallelism></a> Perform a rolling restart with no parameter changes
+### <a name="update-parallelism"></a> Perform a rolling restart with no parameter changes
 
 ```console
 $ docker service update --force --update-parallelism 1 --update-delay 30s redis
@@ -144,7 +144,7 @@ that only one task is replaced at a time (this is the default behavior). The
 `--update-delay 30s` setting introduces a 30 second delay between tasks, so
 that the rolling restart happens gradually.
 
-### <a name=mount-add></a> Add or remove mounts (--mount-add, --mount-rm)
+### <a name="mount-add"></a> Add or remove mounts (--mount-add, --mount-rm)
 
 Use the `--mount-add` or `--mount-rm` options add or remove a service's bind mounts
 or volumes.
@@ -180,7 +180,7 @@ $ docker service update --mount-rm /somewhere myservice
 myservice
 ```
 
-### <a name=publish-add></a> Add or remove published service ports (--publish-add, --publish-rm)
+### <a name="publish-add"></a> Add or remove published service ports (--publish-add, --publish-rm)
 
 Use the `--publish-add` or `--publish-rm` flags to add or remove a published
 port for a service. You can use the short or long syntax discussed in the
@@ -195,7 +195,7 @@ $ docker service update \
   myservice
 ```
 
-### <a name=network-add></a> Add or remove network (--network-add, --network-rm)
+### <a name="network-add"></a> Add or remove network (--network-add, --network-rm)
 
 Use the `--network-add` or `--network-rm` flags to add or remove a network for
 a service. You can use the short or long syntax discussed in the
@@ -211,7 +211,7 @@ $ docker service update \
   myservice
 ```
 
-### <a name=rollback></a> Roll back to the previous version of a service (--rollback)
+### <a name="rollback"></a> Roll back to the previous version of a service (--rollback)
 
 Use the `--rollback` option to roll back to the previous version of the service.
 
@@ -277,7 +277,7 @@ will update one task at a time during a normal update, but during a rollback, 3
 tasks at a time will get rolled back. These rollback parameters are respected both
 during automatic rollbacks and for rollbacks initiated manually using `--rollback`.
 
-### <a name=secret-add></a> Add or remove secrets (--secret-add, --secret-rm)
+### <a name="secret-add"></a> Add or remove secrets (--secret-add, --secret-rm)
 
 Use the `--secret-add` or `--secret-rm` options add or remove a service's
 secrets.
@@ -297,7 +297,7 @@ Some flags of `service update` support the use of templating.
 See [`service create`](service_create.md#create-services-using-templates) for the reference.
 
 
-### <a name=isolation></a> Specify isolation mode on Windows (--isolation)
+### <a name="isolation"></a> Specify isolation mode on Windows (--isolation)
 
 `service update` supports the same `--isolation` flag as `service create`
 See [`service create`](service_create.md) for the reference.

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -156,7 +156,7 @@ point, effectively removing the `test-data` volume. Each command returns the
 service name.
 
 - The `--mount-add` flag takes the same parameters as the `--mount` flag on
-  `service create`. Refer to the [volumes and bind mounts](service_create.md#add-bind-mounts-volumes-or-memory-filesystems)
+  `service create`. Refer to the [volumes and bind mounts](service_create.md#mount-add)
   section in the `service create` reference for details.
 
 - The `--mount-rm` flag takes the `target` path of the mount.
@@ -184,7 +184,7 @@ myservice
 
 Use the `--publish-add` or `--publish-rm` flags to add or remove a published
 port for a service. You can use the short or long syntax discussed in the
-[docker service create](service_create.md#publish-service-ports-externally-to-the-swarm--p---publish)
+[docker service create](service_create.md#publish)
 reference.
 
 The following example adds a published service port to an existing service.
@@ -199,7 +199,7 @@ $ docker service update \
 
 Use the `--network-add` or `--network-rm` flags to add or remove a network for
 a service. You can use the short or long syntax discussed in the
-[docker service create](service_create.md#attach-a-service-to-an-existing-network---network)
+[docker service create](service_create.md#network)
 reference.
 
 The following example adds a new alias name to an existing service already connected to network my-network:

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -39,7 +39,7 @@ Create and update a stack from a `compose` file on the swarm.
 
 ## Examples
 
-### Compose file
+### <a name=compose-file></a> Compose file (--compose-file)
 
 The `deploy` command supports compose file version `3.0` and above.
 

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -39,7 +39,7 @@ Create and update a stack from a `compose` file on the swarm.
 
 ## Examples
 
-### <a name=compose-file></a> Compose file (--compose-file)
+### <a name="compose-file"></a> Compose file (--compose-file)
 
 The `deploy` command supports compose file version `3.0` and above.
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -45,7 +45,7 @@ myapp              2                   Kubernetes
 vossibility-stack  6                   Swarm
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints stacks using a Go template.
 

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -45,7 +45,7 @@ myapp              2                   Kubernetes
 vossibility-stack  6                   Swarm
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints stacks using a Go template.
 

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -54,7 +54,7 @@ kqgdmededccb        voting_vote.2         dockersamples/examplevotingapp_vote:be
 t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 3 minutes ago
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -123,7 +123,7 @@ kqgdmededccb        voting_vote.2         dockersamples/examplevotingapp_vote:be
 t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 21 minutes ago
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output using a Go template.
 
@@ -160,7 +160,7 @@ voting_vote.2: dockersamples/examplevotingapp_vote:before
 voting_redis.2: redis:alpine
 ```
 
-### <a name=no-resolve></a> Do not map IDs to Names (--no-resolve)
+### <a name="no-resolve"></a> Do not map IDs to Names (--no-resolve)
 
 The `--no-resolve` option shows IDs for task name, without mapping IDs to Names.
 
@@ -178,7 +178,7 @@ kqgdmededccb        qyprtqw1g5nrki557i974ou1d.2   dockersamples/examplevotingapp
 t72q3z038jeh        tg61x8myx563ueo3urmn1ic6m.2   redis:alpine                                   kanqcxfajd1r16wlnqcblobmm   Running        Running 31 minutes ago
 ```
 
-### <a name=no-trunc></a> Do not truncate output (--no-trunc)
+### <a name="no-trunc"></a> Do not truncate output (--no-trunc)
 
 When deploying a service, docker resolves the digest for the service's
 image, and pins the service to that digest. The digest is not shown by
@@ -199,7 +199,7 @@ kqgdmededccbhz2wuc0e9hx7g   voting_vote.2         dockersamples/examplevotingapp
 t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Runnin 32 minutes ago
 ```
 
-### <a name=quiet></a> Only display task IDs (-q, --quiet)
+### <a name="quiet"></a> Only display task IDs (-q, --quiet)
 
 The `-q ` or `--quiet` option only shows IDs of the tasks in the stack.
 This example outputs all task IDs of the "voting" stack;

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -54,7 +54,7 @@ kqgdmededccb        voting_vote.2         dockersamples/examplevotingapp_vote:be
 t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 3 minutes ago
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -123,7 +123,7 @@ kqgdmededccb        voting_vote.2         dockersamples/examplevotingapp_vote:be
 t72q3z038jeh        voting_redis.2        redis:alpine                                   node3  Running        Running 21 minutes ago
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints tasks output using a Go template.
 
@@ -160,7 +160,7 @@ voting_vote.2: dockersamples/examplevotingapp_vote:before
 voting_redis.2: redis:alpine
 ```
 
-### Do not map IDs to Names
+### <a name=no-resolve></a> Do not map IDs to Names (--no-resolve)
 
 The `--no-resolve` option shows IDs for task name, without mapping IDs to Names.
 
@@ -178,7 +178,7 @@ kqgdmededccb        qyprtqw1g5nrki557i974ou1d.2   dockersamples/examplevotingapp
 t72q3z038jeh        tg61x8myx563ueo3urmn1ic6m.2   redis:alpine                                   kanqcxfajd1r16wlnqcblobmm   Running        Running 31 minutes ago
 ```
 
-### Do not truncate output
+### <a name=no-trunc></a> Do not truncate output (--no-trunc)
 
 When deploying a service, docker resolves the digest for the service's
 image, and pins the service to that digest. The digest is not shown by
@@ -199,7 +199,7 @@ kqgdmededccbhz2wuc0e9hx7g   voting_vote.2         dockersamples/examplevotingapp
 t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Runnin 32 minutes ago
 ```
 
-### Only display task IDs
+### <a name=quiet></a> Only display task IDs (-q, --quiet)
 
 The `-q ` or `--quiet` option only shows IDs of the tasks in the stack.
 This example outputs all task IDs of the "voting" stack;

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -44,7 +44,7 @@ ID            NAME            REPLICAS  IMAGE                                   
 dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -81,7 +81,7 @@ The currently supported filters are:
   * Swarm: not supported
   * Kubernetes: supported
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints services output
 using a Go template.

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -44,7 +44,7 @@ ID            NAME            REPLICAS  IMAGE                                   
 dn7m7nhhfb9y  myapp_db        1/1       mysql@sha256:a9a5b559f8821fe73d58c3606c812d1c044868d42c63817fa5125fd9d8b7b539
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is a `key=value` pair. If there
 is more than one filter, then pass multiple flags (e.g. `--filter "foo=bar" --filter "bif=baz"`).
@@ -81,7 +81,7 @@ The currently supported filters are:
   * Swarm: not supported
   * Kubernetes: supported
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints services output
 using a Go template.

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -131,7 +131,7 @@ CONTAINER ID        NAME                CPU %               PRIV WORKING SET    
 9db7aa4d986d        mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints container output
 using a Go template.

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -131,7 +131,7 @@ CONTAINER ID        NAME                CPU %               PRIV WORKING SET    
 9db7aa4d986d        mad_wilson          9.59%               40.09 MiB           27.6 kB / 8.81 kB   17 MB / 20.1 MB
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints container output
 using a Go template.

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -63,7 +63,7 @@ e5c383697914        test-1951.1.kay7x1lh1twk9c0oig50sd5tr   0.00%               
 4bda148efbc0        random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
 ```
 
-If you don't [specify a format string using `--format`](#formatting), the
+If you don't [specify a format string using `--format`](#format), the
 following columns are shown.
 
 | Column name               | Description                                                                                   |

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -83,7 +83,7 @@ gyg5u9Iliel99l7SuMhNeLkrU7fXs+Of1nTyyM73ig==
 -----END CERTIFICATE-----
 ```
 
-### `--rotate`
+### <a name=rotate></a> Root CA rotation (--rotate)
 
 Root CA Rotation is recommended if one or more of the swarm managers have been
 compromised, so that those managers can no longer connect to or be trusted by
@@ -106,7 +106,7 @@ reasonable amount of time, try running
 see if any nodes are down or otherwise unable to rotate TLS certificates.
 
 
-### `--detach`
+### <a name=detach></a> Run root CA rotation in detached mode (--detach)
 
 Initiate the root CA rotation, but do not wait for the completion of or display the
 progress of the rotation.

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -83,7 +83,7 @@ gyg5u9Iliel99l7SuMhNeLkrU7fXs+Of1nTyyM73ig==
 -----END CERTIFICATE-----
 ```
 
-### <a name=rotate></a> Root CA rotation (--rotate)
+### <a name="rotate"></a> Root CA rotation (--rotate)
 
 Root CA Rotation is recommended if one or more of the swarm managers have been
 compromised, so that those managers can no longer connect to or be trusted by
@@ -106,7 +106,7 @@ reasonable amount of time, try running
 see if any nodes are down or otherwise unable to rotate TLS certificates.
 
 
-### <a name=detach></a> Run root CA rotation in detached mode (--detach)
+### <a name="detach"></a> Run root CA rotation in detached mode (--detach)
 
 Initiate the root CA rotation, but do not wait for the completion of or display the
 progress of the rotation.

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -79,7 +79,7 @@ volumes or in systems where some images, containers, or volumes have very large
 filesystems with many files. You should also be careful not to run this command
 in systems where performance is critical.
 
-## Format the output
+### <a name=format></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints the disk usage output
 using a Go template.

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -79,7 +79,7 @@ volumes or in systems where some images, containers, or volumes have very large
 filesystems with many files. You should also be careful not to run this command
 in systems where performance is critical.
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty prints the disk usage output
 using a Go template.

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -118,7 +118,7 @@ that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
 seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
 fraction of a second no more than nine digits long.
 
-#### Filtering
+#### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
 like to use multiple filters, pass multiple flags (e.g.,
@@ -143,16 +143,6 @@ The currently supported filters are:
 * plugin (`plugin=<name or id>`)
 * type (`type=<container or image or volume or network or daemon or plugin>`)
 * volume (`volume=<name or id>`)
-
-#### Format
-
-If a format (`--format`) is specified, the given template will be executed
-instead of the default
-format. Go's [text/template](https://golang.org/pkg/text/template/) package
-describes all the details of the format.
-
-If a format is set to `{{json .}}`, the events are streamed as valid JSON
-Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 
 ## Examples
 
@@ -315,7 +305,11 @@ $ docker system events --filter 'type=plugin'
 2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
 ```
 
-### Format the output
+### <a name=format></a> Format the output (--format)
+
+If a format (`--format`) is specified, the given template will be executed
+instead of the default format. Go's [text/template](https://golang.org/pkg/text/template/)
+package describes all the details of the format.
 
 ```console
 $ docker system events --filter 'type=container' --format 'Type={{.Type}}  Status={{.Status}}  ID={{.ID}}'
@@ -329,6 +323,9 @@ Type=container  Status=destroy  ID=2ee349dac409e97974ce8d01b70d250b85e0ba8189299
 ```
 
 #### Format as JSON
+
+If a format is set to `{{json .}}`, the events are streamed as valid JSON
+Lines. For information about JSON Lines, please refer to https://jsonlines.org/ .
 
 ```console
 $ docker system events --format '{{json .}}'

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -118,7 +118,7 @@ that have elapsed since January 1, 1970 (midnight UTC/GMT), not counting leap
 seconds (aka Unix epoch or Unix time), and the optional .nanoseconds field is a
 fraction of a second no more than nine digits long.
 
-#### <a name=filter></a> Filtering (--filter)
+#### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If you would
 like to use multiple filters, pass multiple flags (e.g.,
@@ -305,7 +305,7 @@ $ docker system events --filter 'type=plugin'
 2016-07-25T17:30:14.888127370Z plugin enable ec7b87f2ce84330fe076e666f17dfc049d2d7ae0b8190763de94e1f2d105993f (name=tiborvass/sample-volume-plugin:latest)
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 If a format (`--format`) is specified, the given template will be executed
 instead of the default format. Go's [text/template](https://golang.org/pkg/text/template/)

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -282,8 +282,8 @@ $ docker system events --filter 'type=network'
 
 $ docker system events --filter 'container=container_1' --filter 'container=container_2'
 
-2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04  )
+2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04  )
 2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
 2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -97,7 +97,7 @@ deleted: sha256:3a88a5c81eb5c283e72db2dbc6d65cbfd8e80b6c89bb6e714cfaaa0eed99c548
 Total reclaimed space: 13.5 MB
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -97,7 +97,7 @@ deleted: sha256:3a88a5c81eb5c283e72db2dbc6d65cbfd8e80b6c89bb6e714cfaaa0eed99c548
 Total reclaimed space: 13.5 MB
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -53,7 +53,7 @@ a running container with kernel memory initialized.
 
 The following sections illustrate ways to use this command.
 
-### Update a container's cpu-shares
+### <a name=cpu-shares></a> Update a container's cpu-shares (--cpu-shares)
 
 To limit a container's cpu-shares to 512, first identify the container
 name or ID. You can use `docker ps` to find these values. You can also
@@ -63,7 +63,7 @@ use the ID returned from the `docker run` command.  Then, do the following:
 $ docker update --cpu-shares 512 abebf7571666
 ```
 
-### Update a container with cpu-shares and memory
+### <a name=memory></a> Update a container with cpu-shares and memory (-m, --memory)
 
 To update multiple resource configurations for multiple containers:
 
@@ -71,7 +71,7 @@ To update multiple resource configurations for multiple containers:
 $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ```
 
-### Update a container's kernel memory constraints
+### <a name=kernel-memory></a> Update a container's kernel memory constraints (--kernel-memory)
 
 You can update a container's kernel memory limit using the `--kernel-memory`
 option. On kernel version older than 4.6, this option can be updated on a
@@ -108,7 +108,7 @@ start it, the container uses the new value.
 Kernel version newer than (include) 4.6 does not have this limitation, you
 can use `--kernel-memory` the same way as other options.
 
-### Update a container's restart policy
+### <a name=restart></a> Update a container's restart policy (--restart)
 
 You can change a container's restart policy on a running container. The new
 restart policy takes effect instantly after you run `docker update` on a

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -53,7 +53,7 @@ a running container with kernel memory initialized.
 
 The following sections illustrate ways to use this command.
 
-### <a name=cpu-shares></a> Update a container's cpu-shares (--cpu-shares)
+### <a name="cpu-shares"></a> Update a container's cpu-shares (--cpu-shares)
 
 To limit a container's cpu-shares to 512, first identify the container
 name or ID. You can use `docker ps` to find these values. You can also
@@ -63,7 +63,7 @@ use the ID returned from the `docker run` command.  Then, do the following:
 $ docker update --cpu-shares 512 abebf7571666
 ```
 
-### <a name=memory></a> Update a container with cpu-shares and memory (-m, --memory)
+### <a name="memory"></a> Update a container with cpu-shares and memory (-m, --memory)
 
 To update multiple resource configurations for multiple containers:
 
@@ -71,7 +71,7 @@ To update multiple resource configurations for multiple containers:
 $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ```
 
-### <a name=kernel-memory></a> Update a container's kernel memory constraints (--kernel-memory)
+### <a name="kernel-memory"></a> Update a container's kernel memory constraints (--kernel-memory)
 
 You can update a container's kernel memory limit using the `--kernel-memory`
 option. On kernel version older than 4.6, this option can be updated on a
@@ -108,7 +108,7 @@ start it, the container uses the new value.
 Kernel version newer than (include) 4.6 does not have this limitation, you
 can use `--kernel-memory` the same way as other options.
 
-### <a name=restart></a> Update a container's restart policy (--restart)
+### <a name="restart"></a> Update a container's restart policy (--restart)
 
 You can change a container's restart policy on a running container. The new
 restart policy takes effect instantly after you run `docker update` on a

--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -117,7 +117,7 @@ Server: Docker Engine - Community
 
 ## Examples
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting option (`--format`) pretty-prints the output using a Go template,
 which allows you to customize the output format, or to obtain specific information

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -53,7 +53,7 @@ A volume named  "hello"  already exists with the "some-other" driver. Choose a d
 If you specify a volume name already in use on the current driver, Docker
 assumes you want to re-use the existing volume and does not return an error.
 
-### Driver-specific options
+### <a name=opt></a> Driver-specific options (-o, --opt)
 
 Some volume drivers may take options to customize the volume creation. Use the
 `-o` or `--opt` flags to pass driver options:

--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -53,7 +53,7 @@ A volume named  "hello"  already exists with the "some-other" driver. Choose a d
 If you specify a volume name already in use on the current driver, Docker
 assumes you want to re-use the existing volume and does not return an error.
 
-### <a name=opt></a> Driver-specific options (-o, --opt)
+### <a name="opt"></a> Driver-specific options (-o, --opt)
 
 Some volume drivers may take options to customize the volume creation. Use the
 `-o` or `--opt` flags to pass driver options:

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -54,6 +54,8 @@ The output is in JSON format, for example:
 ]
 ```
 
+### <a name=format></a> Format the output (--format)
+
 Use the `--format` flag to format the output using a Go template, for example,
 to print the `Mountpoint` property:
 

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -54,7 +54,7 @@ The output is in JSON format, for example:
 ]
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 Use the `--format` flag to format the output using a Go template, for example,
 to print the `Mountpoint` property:

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -51,7 +51,7 @@ local               rosemary
 local               tyler
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
@@ -151,7 +151,7 @@ DRIVER              VOLUME NAME
 local               rosemary
 ```
 
-### <a name=format></a> Format the output (--format)
+### <a name="format"></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints volumes output
 using a Go template.

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -28,7 +28,7 @@ Options:
 ## Description
 
 List all the volumes known to Docker. You can filter using the `-f` or
-`--filter` flag. Refer to the [filtering](#filtering) section for more
+`--filter` flag. Refer to the [filtering](#filter) section for more
 information about available filter options.
 
 ## Examples
@@ -51,7 +51,7 @@ local               rosemary
 local               tyler
 ```
 
-### Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -151,7 +151,7 @@ DRIVER              VOLUME NAME
 local               rosemary
 ```
 
-### Formatting
+### <a name=format></a> Format the output (--format)
 
 The formatting options (`--format`) pretty-prints volumes output
 using a Go template.

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -35,7 +35,7 @@ my-named-vol
 Total reclaimed space: 36 B
 ```
 
-## Filtering
+### <a name=filter></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -35,7 +35,7 @@ my-named-vol
 Total reclaimed space: 36 B
 ```
 
-### <a name=filter></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -187,7 +187,7 @@ PID files):
 
 While not strictly a means of identifying a container, you can specify a version of an
 image you'd like to run the container with by adding `image[:tag]` to the command. For
-example, `docker run ubuntu:14.04`.
+example, `docker run ubuntu:22.04`.
 
 ### Image[@digest]
 
@@ -837,14 +837,14 @@ We have four ways to set user memory usage:
 Examples:
 
 ```console
-$ docker run -it ubuntu:14.04 /bin/bash
+$ docker run -it ubuntu:22.04 /bin/bash
 ```
 
 We set nothing about memory, this means the processes in the container can use
 as much memory and swap memory as they need.
 
 ```console
-$ docker run -it -m 300M --memory-swap -1 ubuntu:14.04 /bin/bash
+$ docker run -it -m 300M --memory-swap -1 ubuntu:22.04 /bin/bash
 ```
 
 We set memory limit and disabled swap memory limit, this means the processes in
@@ -852,7 +852,7 @@ the container can use 300M memory and as much swap memory as they need (if the
 host supports swap memory).
 
 ```console
-$ docker run -it -m 300M ubuntu:14.04 /bin/bash
+$ docker run -it -m 300M ubuntu:22.04 /bin/bash
 ```
 
 We set memory limit only, this means the processes in the container can use
@@ -861,7 +861,7 @@ We set memory limit only, this means the processes in the container can use
 would be 2*300M, so processes can use 300M swap memory as well.
 
 ```console
-$ docker run -it -m 300M --memory-swap 1G ubuntu:14.04 /bin/bash
+$ docker run -it -m 300M --memory-swap 1G ubuntu:22.04 /bin/bash
 ```
 
 We set both memory and swap memory, so the processes in the container can use
@@ -887,7 +887,7 @@ The following example limits the memory (`-m`) to 500M and sets the memory
 reservation to 200M.
 
 ```console
-$ docker run -it -m 500M --memory-reservation 200M ubuntu:14.04 /bin/bash
+$ docker run -it -m 500M --memory-reservation 200M ubuntu:22.04 /bin/bash
 ```
 
 Under this configuration, when the container consumes memory more than 200M and
@@ -897,7 +897,7 @@ memory below 200M.
 The following example set memory reservation to 1G without a hard memory limit.
 
 ```console
-$ docker run -it --memory-reservation 1G ubuntu:14.04 /bin/bash
+$ docker run -it --memory-reservation 1G ubuntu:22.04 /bin/bash
 ```
 
 The container can use as much memory as it needs. The memory reservation setting
@@ -915,13 +915,13 @@ The following example limits the memory to 100M and disables the OOM killer for
 this container:
 
 ```console
-$ docker run -it -m 100M --oom-kill-disable ubuntu:14.04 /bin/bash
+$ docker run -it -m 100M --oom-kill-disable ubuntu:22.04 /bin/bash
 ```
 
 The following example, illustrates a dangerous way to use the flag:
 
 ```console
-$ docker run -it --oom-kill-disable ubuntu:14.04 /bin/bash
+$ docker run -it --oom-kill-disable ubuntu:22.04 /bin/bash
 ```
 
 The container has unlimited memory which can cause the host to run out memory
@@ -991,14 +991,14 @@ limit and "K" the kernel limit. There are three possible ways to set limits:
 Examples:
 
 ```console
-$ docker run -it -m 500M --kernel-memory 50M ubuntu:14.04 /bin/bash
+$ docker run -it -m 500M --kernel-memory 50M ubuntu:22.04 /bin/bash
 ```
 
 We set memory and kernel memory, so the processes in the container can use
 500M memory in total, in this 500M memory, it can be 50M kernel memory tops.
 
 ```console
-$ docker run -it --kernel-memory 50M ubuntu:14.04 /bin/bash
+$ docker run -it --kernel-memory 50M ubuntu:22.04 /bin/bash
 ```
 
 We set kernel memory without **-m**, so the processes in the container can
@@ -1015,7 +1015,7 @@ between 0 and 100. A value of 0 turns off anonymous page swapping. A value of
 For example, you can set:
 
 ```console
-$ docker run -it --memory-swappiness=0 ubuntu:14.04 /bin/bash
+$ docker run -it --memory-swappiness=0 ubuntu:22.04 /bin/bash
 ```
 
 Setting the `--memory-swappiness` option is helpful when you want to retain the
@@ -1066,7 +1066,7 @@ And usually `--cpu-period` should work with `--cpu-quota`.
 Examples:
 
 ```console
-$ docker run -it --cpu-period=50000 --cpu-quota=25000 ubuntu:14.04 /bin/bash
+$ docker run -it --cpu-period=50000 --cpu-quota=25000 ubuntu:22.04 /bin/bash
 ```
 
 If there is 1 CPU, this means the container can get 50% CPU worth of run-time every 50ms.
@@ -1087,13 +1087,13 @@ We can set cpus in which to allow execution for containers.
 Examples:
 
 ```console
-$ docker run -it --cpuset-cpus="1,3" ubuntu:14.04 /bin/bash
+$ docker run -it --cpuset-cpus="1,3" ubuntu:22.04 /bin/bash
 ```
 
 This means processes in container can be executed on cpu 1 and cpu 3.
 
 ```console
-$ docker run -it --cpuset-cpus="0-2" ubuntu:14.04 /bin/bash
+$ docker run -it --cpuset-cpus="0-2" ubuntu:22.04 /bin/bash
 ```
 
 This means processes in container can be executed on cpu 0, cpu 1 and cpu 2.
@@ -1104,14 +1104,14 @@ on NUMA systems.
 Examples:
 
 ```console
-$ docker run -it --cpuset-mems="1,3" ubuntu:14.04 /bin/bash
+$ docker run -it --cpuset-mems="1,3" ubuntu:22.04 /bin/bash
 ```
 
 This example restricts the processes in the container to only use memory from
 memory nodes 1 and 3.
 
 ```console
-$ docker run -it --cpuset-mems="0-2" ubuntu:14.04 /bin/bash
+$ docker run -it --cpuset-mems="0-2" ubuntu:22.04 /bin/bash
 ```
 
 This example restricts the processes in the container to only use memory from
@@ -1143,8 +1143,8 @@ For example, the commands below create two containers with different blkio
 weight:
 
 ```console
-$ docker run -it --name c1 --blkio-weight 300 ubuntu:14.04 /bin/bash
-$ docker run -it --name c2 --blkio-weight 600 ubuntu:14.04 /bin/bash
+$ docker run -it --name c1 --blkio-weight 300 ubuntu:22.04 /bin/bash
+$ docker run -it --name c2 --blkio-weight 600 ubuntu:22.04 /bin/bash
 ```
 
 If you do block IO in the two containers at the same time, by, for example:
@@ -1359,11 +1359,11 @@ For interacting with the network stack, instead of using `--privileged` they
 should use `--cap-add=NET_ADMIN` to modify the network interfaces.
 
 ```console
-$ docker run -it --rm  ubuntu:14.04 ip link add dummy0 type dummy
+$ docker run -it --rm  ubuntu:22.04 ip link add dummy0 type dummy
 
 RTNETLINK answers: Operation not permitted
 
-$ docker run -it --rm --cap-add=NET_ADMIN ubuntu:14.04 ip link add dummy0 type dummy
+$ docker run -it --rm --cap-add=NET_ADMIN ubuntu:22.04 ip link add dummy0 type dummy
 ```
 
 To mount a FUSE based filesystem, you need to combine both `--cap-add` and

--- a/man/src/container/attach.md
+++ b/man/src/container/attach.md
@@ -11,7 +11,7 @@ configure the key sequence using the **--detach-keys** option or a configuration
 file. See **config-json(5)** for documentation on using a configuration file.
 
 It is forbidden to redirect the standard input of a **docker attach** command while
-attaching to a tty-enabled container (i.e.: launched with `-t`).
+attaching to a TTY-enabled container (i.e., launched with `-i` and `-t`).
 
 # Override the detach sequence
 
@@ -41,12 +41,12 @@ containers, see **docker(1)**.
 
 ## Attaching to a container
 
-In this example the top command is run inside a container, from an image called
-fedora, in detached mode. The ID from the container is passed into the **docker
-attach** command:
+In this example the top command is run inside a container from an ubuntu image,
+in detached mode, then attaches to it, and then terminates the container
+with `CTRL-c`:
 
-    $ ID=$(sudo docker run -d ubuntu:20.04 /usr/bin/top -b)
-    $ sudo docker attach $ID
+    $ docker run -d --name topdemo ubuntu:20.04 /usr/bin/top -b
+    $ docker attach topdemo
     top - 00:07:01 up  4:54,  0 users,  load average: 0.83, 0.91, 0.82
     Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
     %Cpu(s):  2.3 us,  1.6 sy,  0.0 ni, 95.9 id,  0.0 wa,  0.1 hi,  0.1 si,  0.0 st
@@ -55,12 +55,4 @@ attach** command:
     
         PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
           1 root      20   0    5976   3256   2828 R   0.0   0.0   0:00.04 top
-    
-    top - 00:07:04 up  4:54,  0 users,  load average: 0.76, 0.89, 0.81
-    Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-    %Cpu(s):  2.0 us,  1.4 sy,  0.0 ni, 96.5 id,  0.0 wa,  0.1 hi,  0.0 si,  0.0 st
-    MiB Mem :  15846.2 total,   5727.5 free,   2594.4 used,   7524.3 buff/cache
-    MiB Swap:  16384.0 total,  16384.0 free,      0.0 used.  12095.6 avail Mem 
-    
-        PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
-      1 root      20   0    5976   3256   2828 R   0.0   0.0   0:00.04 top
+    ^C

--- a/man/src/container/ls.md
+++ b/man/src/container/ls.md
@@ -48,10 +48,10 @@ Valid placeholders for the Go template are listed below:
 
     $ docker container ls -a
     CONTAINER ID        IMAGE                 COMMAND                CREATED             STATUS      PORTS    NAMES
-    a87ecb4f327c        fedora:20             /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
-    01946d9d34d8        vpavlin/rhel7:latest  /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
+    a87ecb4f327c        ubuntu:22.04          /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
+    01946d9d34d8        busybox               /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
     c1d3b0166030        acffc0358b9e          /bin/sh -c yum -y up   2 weeks ago         Exit 1               determined_torvalds
-    41d50ecd2f57        fedora:20             /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
+    41d50ecd2f57        ubuntu:22.04          /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
 
 ## Display only IDs of all containers, including non-running
 
@@ -87,10 +87,10 @@ Valid placeholders for the Go template are listed below:
 
     $ docker container ls --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
     CONTAINER ID        NODE
-    a87ecb4f327c        ubuntu
+    a87ecb4f327c        worker-1
     01946d9d34d8
-    c1d3b0166030        debian
-    41d50ecd2f57        fedora
+    c1d3b0166030        worker-1
+    41d50ecd2f57        worker-2
 
 ## Display containers with `remote-volume` mounted
 

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -10,7 +10,7 @@ The title REPOSITORY for the first title may seem confusing. It is essentially
 the image name. However, because you can tag a specific image, and multiple tags
 (image instances) can be associated with a single name, the name is really a
 repository for all tagged images of the same name. For example consider an image
-called fedora. It may be tagged with 18, 19, or 20, etc. to manage different
+called ubuntu. It may be tagged with 20.04 or 22.04, etc. to manage different
 versions.
 
 ## Filters

--- a/man/src/image/pull.md
+++ b/man/src/image/pull.md
@@ -11,52 +11,51 @@ registry located at `registry-1.docker.io` by default.
 ### Pull an image from Docker Hub
 
 To download a particular image, or set of images (i.e., a repository), use
-`docker image pull`. If no tag is provided, Docker Engine uses the `:latest` tag as a
-default. This command pulls the `debian:latest` image:
+`docker image pull` (or the `docker pull` shorthand). If no tag is provided,
+Docker Engine uses the `:latest` tag as a default. This example pulls the
+`debian:latest` image:
 
     $ docker image pull debian
 
     Using default tag: latest
     latest: Pulling from library/debian
-    fdd5d7827f33: Pull complete
-    a3ed95caeb02: Pull complete
-    Digest: sha256:e7d38b3517548a1c71e41bffe9c8ae6d6d29546ce46bf62159837aad072c90aa
+    e756f3fdd6a3: Pull complete
+    Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
     Status: Downloaded newer image for debian:latest
+    docker.io/library/debian:latest
 
 Docker images can consist of multiple layers. In the example above, the image
-consists of two layers; `fdd5d7827f33` and `a3ed95caeb02`.
+consists of a single layer; `e756f3fdd6a3`.
 
-Layers can be reused by images. For example, the `debian:jessie` image shares
-both layers with `debian:latest`. Pulling the `debian:jessie` image therefore
-only pulls its metadata, but not its layers, because all layers are already
-present locally:
+Layers can be reused by images. For example, the `debian:bullseye` image shares
+its layer with the `debian:latest`. Pulling the `debian:bullseye` image therefore
+only pulls its metadata, but not its layers, because the layer is already present
+locally:
 
-    $ docker image pull debian:jessie
+    $ docker image pull debian:bullseye
 
-    jessie: Pulling from library/debian
-    fdd5d7827f33: Already exists
-    a3ed95caeb02: Already exists
-    Digest: sha256:a9c958be96d7d40df920e7041608f2f017af81800ca5ad23e327bc402626b58e
-    Status: Downloaded newer image for debian:jessie
+    bullseye: Pulling from library/debian
+    Digest: sha256:3f1d6c17773a45c97bd8f158d665c9709d7b29ed7917ac934086ad96f92e4510
+    Status: Downloaded newer image for debian:bullseye
+    docker.io/library/debian:bullseye
 
 To see which images are present locally, use the **docker-images(1)**
 command:
 
     $ docker images
 
-    REPOSITORY   TAG      IMAGE ID        CREATED      SIZE
-    debian       jessie   f50f9524513f    5 days ago   125.1 MB
-    debian       latest   f50f9524513f    5 days ago   125.1 MB
+    REPOSITORY   TAG        IMAGE ID       CREATED        SIZE
+    debian       bullseye   4eacea30377a   8 days ago     124MB
+    debian       latest     4eacea30377a   8 days ago     124MB
 
 Docker uses a content-addressable image store, and the image ID is a SHA256
 digest covering the image's configuration and layers. In the example above,
-`debian:jessie` and `debian:latest` have the same image ID because they are
-actually the *same* image tagged with different names. Because they are the
-same image, their layers are stored only once and do not consume extra disk
-space.
+`debian:bullseye` and `debian:latest` have the same image ID because they are
+the *same* image tagged with different names. Because they are the same image,
+their layers are stored only once and do not consume extra disk space.
 
 For more information about images, layers, and the content-addressable store,
-refer to [about storage drivers](https://docs.docker.com/storage/storagedriver/)
+refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/)
 in the online documentation.
 
 
@@ -65,8 +64,8 @@ in the online documentation.
 So far, you've pulled images by their name (and "tag"). Using names and tags is
 a convenient way to work with images. When using tags, you can `docker image pull` an
 image again to make sure you have the most up-to-date version of that image.
-For example, `docker image pull ubuntu:14.04` pulls the latest version of the Ubuntu
-14.04 image.
+For example, `docker image pull ubuntu:22.04` pulls the latest version of the Ubuntu
+22.04 image.
 
 In some cases you don't want images to be updated to newer versions, but prefer
 to use a fixed version of an image. Docker enables you to pull an image by its
@@ -75,50 +74,47 @@ of an image to pull. Doing so, allows you to "pin" an image to that version,
 and guarantee that the image you're using is always the same.
 
 To know the digest of an image, pull the image first. Let's pull the latest
-`ubuntu:14.04` image from Docker Hub:
+`ubuntu:22.04` image from Docker Hub:
 
-    $ docker image pull ubuntu:14.04
+    $ docker image pull ubuntu:22.04
 
-    14.04: Pulling from library/ubuntu
-    5a132a7e7af1: Pull complete
-    fd2731e4c50c: Pull complete
-    28a2f68d1120: Pull complete
-    a3ed95caeb02: Pull complete
-    Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-    Status: Downloaded newer image for ubuntu:14.04
+    22.04: Pulling from library/ubuntu
+    125a6e411906: Pull complete
+    Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    Status: Downloaded newer image for ubuntu:22.04
+    docker.io/library/ubuntu:22.04
 
 Docker prints the digest of the image after the pull has finished. In the example
 above, the digest of the image is:
 
-    sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 
 Docker also prints the digest of an image when *pushing* to a registry. This
 may be useful if you want to pin to a version of the image you just pushed.
 
-A digest takes the place of the tag when pulling an image, for example, to 
+A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
-    $ docker image pull ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    $ docker image pull ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 
-    sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2: Pulling from library/ubuntu
-    5a132a7e7af1: Already exists
-    fd2731e4c50c: Already exists
-    28a2f68d1120: Already exists
-    a3ed95caeb02: Already exists
-    Digest: sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-    Status: Downloaded newer image for ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d: Pulling from library/ubuntu
+    Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    Status: Image is up to date for ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
 
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
-    FROM ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+    FROM ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
     LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 
-> **Note**: Using this feature "pins" an image to a specific version in time.
-> Docker will therefore not pull updated versions of an image, which may include 
+> **Note**
+>
+> Using this feature "pins" an image to a specific version in time.
+> Docker does therefore not pull updated versions of an image, which may include
 > security updates. If you want to pull an updated image, you need to change the
 > digest accordingly.
 
-## Pulling from a different registry
+## Pull from a different registry
 
 By default, `docker image pull` pulls images from Docker Hub. It is also possible to
 manually specify the path of a registry to pull from. For example, if you have
@@ -144,46 +140,48 @@ By default, `docker image pull` pulls a *single* image from the registry. A repo
 can contain multiple images. To pull all images from a repository, provide the
 `-a` (or `--all-tags`) option when using `docker image pull`.
 
-This command pulls all images from the `fedora` repository:
+This command pulls all images from the `ubuntu` repository:
 
-    $ docker image pull --all-tags fedora
+    $ docker image pull --all-tags ubuntu
 
-    Pulling repository fedora
+    Pulling repository ubuntu
     ad57ef8d78d7: Download complete
     105182bb5e8b: Download complete
     511136ea3c5a: Download complete
     73bd853d2ea5: Download complete
     ....
 
-    Status: Downloaded newer image for fedora
+    Status: Downloaded newer image for ubuntu
 
-After the pull has completed use the `docker images` command to see the
-images that were pulled. The example below shows all the `fedora` images
-that are present locally:
+After the pull has completed use the `docker image ls` (or `docker images` shorthand)
+command to see the images that were pulled. The example below shows all the `ubuntu`
+images that are present locally:
 
-    $ docker images fedora
+    $ docker image ls --filter reference=ubuntu
+    REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
+    ubuntu       18.04     c6ad7e71ba7d   5 weeks ago    63.2MB
+    ubuntu       bionic    c6ad7e71ba7d   5 weeks ago    63.2MB
+    ubuntu       22.04     5ccefbfc0416   2 months ago   78MB
+    ubuntu       focal     ff0fea8310f3   2 months ago   72.8MB
+    ubuntu       latest    ff0fea8310f3   2 months ago   72.8MB
+    ubuntu       jammy     41ba606c8ab9   3 months ago   79MB
+    ubuntu       20.04     ba6acccedd29   7 months ago   72.8MB
+    ...
 
-    REPOSITORY   TAG         IMAGE ID        CREATED      SIZE
-    fedora       rawhide     ad57ef8d78d7    5 days ago   359.3 MB
-    fedora       20          105182bb5e8b    5 days ago   372.7 MB
-    fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
-    fedora       latest      105182bb5e8b    5 days ago   372.7 MB
-
-
-## Canceling a pull
+## Cancel a pull
 
 Killing the `docker image pull` process, for example by pressing `CTRL-c` while it is
 running in a terminal, will terminate the pull operation.
 
-    $ docker image pull fedora
+    $ docker image pull ubuntu
 
     Using default tag: latest
-    latest: Pulling from library/fedora
+    latest: Pulling from library/ubuntu
     a3ed95caeb02: Pulling fs layer
     236608c7b546: Pulling fs layer
     ^C
 
-> **Note**: Technically, the Engine terminates a pull operation when the
-> connection between the Docker Engine daemon and the Docker Engine client
-> initiating the pull is lost. If the connection with the Engine daemon is
-> lost for other reasons than a manual interaction, the pull is also aborted.
+The Engine terminates a pull operation when the connection between the Docker
+Engine daemon and the Docker Engine client initiating the pull is lost. If the
+connection with the Engine daemon is lost for other reasons than a manual
+interaction, the pull is also aborted.

--- a/man/src/system/events.md
+++ b/man/src/system/events.md
@@ -62,8 +62,8 @@ The following example outputs all events that were generated in the last 3 minut
 relative to the current time on the client machine:
 
     # docker events --since '3m'
-    2015-05-12T11:51:30.999999999Z07:00  4386fb97867d: (from ubuntu-1:14.04) die
-    2015-05-12T15:52:12.999999999Z07:00  4386fb97867d: (from ubuntu-1:14.04) stop
+    2015-05-12T11:51:30.999999999Z07:00  4386fb97867d: (from ubuntu:22.04) die
+    2015-05-12T15:52:12.999999999Z07:00  4386fb97867d: (from ubuntu:22.04) stop
     2015-05-12T15:53:45.999999999Z07:00  7805c1d35632: (from redis:2.8) die
     2015-05-12T15:54:03.999999999Z07:00  7805c1d35632: (from redis:2.8) stop
 
@@ -97,21 +97,21 @@ Lines. For information about JSON Lines, please refer to http://jsonlines.org/ .
 ## Filters
 
     $ docker events --filter 'event=stop'
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
     2014-09-03T17:42:14.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 
-    $ docker events --filter 'image=ubuntu-1:14.04'
-    2014-05-10T17:42:14.999999999Z07:00 container start 4386fb97867d (image=ubuntu-1:14.04)
-    2014-05-10T17:42:14.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+    $ docker events --filter 'image=ubuntu:22.04'
+    2014-05-10T17:42:14.999999999Z07:00 container start 4386fb97867d (image=ubuntu:22.04)
+    2014-05-10T17:42:14.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
 
     $ docker events --filter 'container=7805c1d35632'
     2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
     2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image= redis:2.8)
 
     $ docker events --filter 'container=7805c1d35632' --filter 'container=4386fb97867d'
-    2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu-1:14.04)
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu-1:14.04)
+    2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
     2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
     2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
 

--- a/man/src/system/info.md
+++ b/man/src/system/info.md
@@ -20,150 +20,79 @@ available on the volume where `/var/lib/docker` is mounted.
 
 ## Display Docker system information
 
-Here is a sample output for a daemon running on Ubuntu, using the overlay2
-storage driver:
+The example below shows the output for a daemon running on Ubuntu Linux,
+using the `overlay2` storage driver. As can be seen in the output, additional
+information about the `overlay2` storage driver is shown:
 
-    $ docker -D info
-    Client:
-     Debug Mode: true
+```console
+$ docker info
 
-    Server:
-     Containers: 14
-      Running: 3
-      Paused: 1
-      Stopped: 10
-     Images: 52
-     Server Version: 1.13.0
-     Storage Driver: overlay2
-      Backing Filesystem: extfs
-      Supports d_type: true
-      Native Overlay Diff: false
-     Logging Driver: json-file
-     Cgroup Driver: cgroupfs
-     Plugins:
-      Volume: local
-      Network: bridge host macvlan null overlay
-     Swarm: active
-      NodeID: rdjq45w1op418waxlairloqbm
-      Is Manager: true
-      ClusterID: te8kdyw33n36fqiz74bfjeixd
-      Managers: 1
-      Nodes: 2
-      Orchestration:
-       Task History Retention Limit: 5
-      Raft:
-       Snapshot Interval: 10000
-       Number of Old Snapshots to Retain: 0
-       Heartbeat Tick: 1
-       Election Tick: 3
-      Dispatcher:
-       Heartbeat Period: 5 seconds
-      CA Configuration:
-       Expiry Duration: 3 months
-      Node Address: 172.16.66.128 172.16.66.129
-      Manager Addresses:
-       172.16.66.128:2477
-     Runtimes: runc
-     Default Runtime: runc
-     Init Binary: docker-init
-     containerd version: 8517738ba4b82aff5662c97ca4627e7e4d03b531
-     runc version: ac031b5bf1cc92239461125f4c1ffb760522bbf2
-     init version: N/A (expected: v0.13.0)
-     Security Options:
-      apparmor
-      seccomp
-       Profile: default
-     Kernel Version: 4.4.0-31-generic
-     Operating System: Ubuntu 16.04.1 LTS
-     OSType: linux
-     Architecture: x86_64
-     CPUs: 2
-     Total Memory: 1.937 GiB
-     Name: ubuntu
-     ID: H52R:7ZR6:EIIA:76JG:ORIY:BVKF:GSFU:HNPG:B5MK:APSC:SZ3Q:N326
-     Docker Root Dir: /var/lib/docker
-     Debug Mode: true
-      File Descriptors: 30
-      Goroutines: 123
-      System Time: 2016-11-12T17:24:37.955404361-08:00
-      EventsListeners: 0
-     Http Proxy: http://test:test@proxy.example.com:8080
-     Https Proxy: https://test:test@proxy.example.com:8080
-     No Proxy: localhost,127.0.0.1,docker-registry.somecorporation.com
-     Registry: https://index.docker.io/v1/
-     WARNING: No swap limit support
-     Labels:
-      storage=ssd
-      staging=true
-     Experimental: false
-     Insecure Registries:
-      127.0.0.0/8
-     Registry Mirrors:
-       http://192.168.1.2/
-       http://registry-mirror.example.com:5000/
-     Live Restore Enabled: false
- 
+Client:
+ Context:    default
+ Debug Mode: false
+ Plugins:
+  buildx: Docker Buildx (Docker Inc.)
+    Version:  v0.8.2
+    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
+  compose: Docker Compose (Docker Inc.)
+    Version:  v2.6.0
+    Path:     /usr/libexec/docker/cli-plugins/docker-compose
+  scan: Docker Scan (Docker Inc.)
+    Version:  v0.17.0
+    Path:     /usr/libexec/docker/cli-plugins/docker-scan
 
+Server:
+ Containers: 14
+  Running: 3
+  Paused: 1
+  Stopped: 10
+ Images: 52
+ Server Version: 22.06.0
+ Storage Driver: overlay2
+  Backing Filesystem: extfs
+  Supports d_type: true
+  Using metacopy: false
+  Native Overlay Diff: true
+  userxattr: false
+ Logging Driver: json-file
+ Cgroup Driver: systemd
+ Cgroup Version: 2
+ Plugins:
+  Volume: local
+  Network: bridge host ipvlan macvlan null overlay
+  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
+ Swarm: inactive
+ Runtimes: io.containerd.runc.v2 io.containerd.runtime.v1.linux runc
+ Default Runtime: runc
+ Init Binary: docker-init
+ containerd version: 212e8b6fa2f44b9c21b2798135fc6fb7c53efc16
+ runc version: v1.1.1-0-g52de29d
+ init version: de40ad0
+ Security Options:
+  apparmor
+  seccomp
+   Profile: builtin
+  cgroupns
+ Kernel Version: 5.15.0-25-generic
+ Operating System: Ubuntu 22.04 LTS
+ OSType: linux
+ Architecture: x86_64
+ CPUs: 1
+ Total Memory: 991.7 MiB
+ Name: ip-172-30-0-91.ec2.internal
+ ID: 4cee4408-10d2-4e17-891c-a41736ac4536
+ Docker Root Dir: /var/lib/docker
+ Debug Mode: false
+ Username: gordontheturtle
+ Registry: https://index.docker.io/v1/
+ Experimental: false
+ Insecure registries:
+  myinsecurehost:5000
+  127.0.0.0/8
+ Live Restore Enabled: false
+```
 
-The global `-D` option tells all `docker` commands to output debug information.
-
-The example below shows the output for a daemon running on Red Hat Enterprise Linux,
-using the devicemapper storage driver. As can be seen in the output, additional
-information about the devicemapper storage driver is shown:
-
-    $ docker info
-    Client:
-     Debug Mode: false
-
-    Server:
-     Containers: 14
-      Running: 3
-      Paused: 1
-      Stopped: 10
-     Untagged Images: 52
-     Server Version: 1.10.3
-     Storage Driver: devicemapper
-      Pool Name: docker-202:2-25583803-pool
-      Pool Blocksize: 65.54 kB
-      Base Device Size: 10.74 GB
-      Backing Filesystem: xfs
-      Data file: /dev/loop0
-      Metadata file: /dev/loop1
-      Data Space Used: 1.68 GB
-      Data Space Total: 107.4 GB
-      Data Space Available: 7.548 GB
-      Metadata Space Used: 2.322 MB
-      Metadata Space Total: 2.147 GB
-      Metadata Space Available: 2.145 GB
-      Udev Sync Supported: true
-      Deferred Removal Enabled: false
-      Deferred Deletion Enabled: false
-      Deferred Deleted Device Count: 0
-      Data loop file: /var/lib/docker/devicemapper/devicemapper/data
-      Metadata loop file: /var/lib/docker/devicemapper/devicemapper/metadata
-      Library Version: 1.02.107-RHEL7 (2015-12-01)
-     Execution Driver: native-0.2
-     Logging Driver: json-file
-     Plugins:
-      Volume: local
-      Network: null host bridge
-     Kernel Version: 3.10.0-327.el7.x86_64
-     Operating System: Red Hat Enterprise Linux Server 7.2 (Maipo)
-     OSType: linux
-     Architecture: x86_64
-     CPUs: 1
-     Total Memory: 991.7 MiB
-     Name: ip-172-30-0-91.ec2.internal
-     ID: I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S
-     Docker Root Dir: /var/lib/docker
-     Debug Mode: false
-     Username: gordontheturtle
-     Registry: https://index.docker.io/v1/
-     Insecure registries:
-      myinsecurehost:5000
-      127.0.0.0/8
- 
 You can also specify the output format:
 
     $ docker info --format '{{json .}}'
-	{"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}
+    {"ID":"I54V:OLXT:HVMM:TPKO:JPHQ:CQCD:JNLC:O3BZ:4ZVJ:43XJ:PFHZ:6N2S","Containers":14, ...}


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3523

back ports:

- remaining commits from https://github.com/docker/cli/pull/3509
- https://github.com/docker/cli/pull/3730
- https://github.com/docker/cli/pull/3661
- partial backport (omitting the "usage output" changes) https://github.com/docker/cli/pull/3837
- https://github.com/docker/cli/pull/3838
- https://github.com/docker/cli/pull/3948
- https://github.com/docker/cli/pull/3949
- https://github.com/docker/cli/pull/3924 (https://github.com/docker/cli/commit/186dcf30b1088b230e4ba1dc77b991d82188febc)

Some minor conflicts in the last cherry-pick due to adjacent line changes that are not in 20.10
I'm keeping this separate, as these commits require some changes in the docs repository.


**- A picture of a cute animal (not mandatory but encouraged)**

