### PR TITLE
[20.10] update remaining Dockerfiles to go 1.16.15

### DIFF
--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.10
+ARG GO_VERSION=1.16.15
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.10
+ARG GO_VERSION=1.16.15
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster


### PR DESCRIPTION
These were missed, probably because they are no longer present
in the master branch.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

