### PR TITLE
[20.10] circleci: update buildx to v0.8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
     docker: [{image: 'docker:20.10-git'}]
     environment:
       DOCKER_BUILDKIT: 1
-      BUILDX_VERSION: "v0.5.1"
+      BUILDX_VERSION: "v0.8.2"
     parallelism: 3
     steps:
       - checkout


### PR DESCRIPTION
release notes: https://github.com/docker/buildx/releases/tag/v0.8.2

Notable changes:

- Update Compose spec used by buildx bake to v1.2.1 to fix parsing ports definition
- Fix possible crash on handling progress streams from BuildKit v0.10
- Fix parsing groups in buildx bake when already loaded by a parent group


**- A picture of a cute animal (not mandatory but encouraged)**

