### PR TITLE
tweak description of login/logout

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -80,6 +80,6 @@ End-to-end test should run the `docker` binary using
 and make assertions about the exit code, stdout, stderr, and local file system.
 
 Any Docker image or registry operations should use `registry:5000/<image name>`
-to communicate with the local instance of the Docker registry. To load 
+to communicate with the local instance of the registry. To load 
 additional fixture images to the registry see
 [scripts/test/e2e/run](https://github.com/docker/cli/blob/master/scripts/test/e2e/run).

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -35,8 +35,8 @@ func NewLoginCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login [OPTIONS] [SERVER]",
-		Short: "Log in to a Docker registry",
-		Long:  "Log in to a Docker registry.\nIf no server is specified, the default is defined by the daemon.",
+		Short: "Log in to a registry",
+		Long:  "Log in to a registry.\nIf no server is specified, the default is defined by the daemon.",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -13,8 +13,8 @@ import (
 func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout [SERVER]",
-		Short: "Log out from a Docker registry",
-		Long:  "Log out from a Docker registry.\nIf no server is specified, the default is defined by the daemon.",
+		Short: "Log out from a registry",
+		Long:  "Log out from a registry.\nIf no server is specified, the default is defined by the daemon.",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var serverAddress string

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -108,7 +108,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -s l -l log-level -d 'Set
 complete -c docker -f -n '__fish_docker_no_subcommand' -l label -d 'Set key=value labels to the daemon (displayed in `docker info`)'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l mtu -d 'Set the containers network MTU'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s p -l pidfile -d 'Path to use for daemon PID file'
-complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Specify a preferred Docker registry mirror'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Specify a preferred registry mirror'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s s -l storage-driver -d 'Force the Docker runtime to use a specific storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l selinux-enabled -d 'Enable selinux support. SELinux does not presently support the BTRFS storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l storage-opt -d 'Set storage driver options'
@@ -358,14 +358,14 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from load' -s i -l input -d 
 complete -c docker -A -f -n '__fish_seen_subcommand_from load' -s q -l quiet -d 'Suppress the load output'
 
 # login
-complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Log in to a Docker registry server'
+complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Log in to a registry'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s p -l password -d 'Password'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -l password-stdin -d 'Take the password from stdin'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s u -l username -d 'Username'
 
 # logout
-complete -c docker -f -n '__fish_docker_no_subcommand' -a logout -d 'Log out from a Docker registry server'
+complete -c docker -f -n '__fish_docker_no_subcommand' -a logout -d 'Log out from a registry'
 
 # logs
 complete -c docker -f -n '__fish_docker_no_subcommand' -a logs -d 'Fetch the logs of a container'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2779,7 +2779,7 @@ __docker_subcommand() {
                 "($help)--oom-score-adjust=[Set the oom_score_adj for the daemon]:oom-score:(-500)" \
                 "($help -p --pidfile)"{-p=,--pidfile=}"[Path to use for daemon PID file]:PID file:_files" \
                 "($help)--raw-logs[Full timestamps without ANSI coloring]" \
-                "($help)*--registry-mirror=[Preferred Docker registry mirror]:registry mirror: " \
+                "($help)*--registry-mirror=[Preferred registry mirror]:registry mirror: " \
                 "($help)--seccomp-profile=[Path to seccomp profile]:path:_files -g \"*.json\"" \
                 "($help -s --storage-driver)"{-s=,--storage-driver=}"[Storage driver to use]:driver:(aufs btrfs devicemapper overlay overlay2 vfs zfs)" \
                 "($help)--selinux-enabled[Enable selinux support]" \

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -88,7 +88,7 @@ Options:
       --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
-      --registry-mirror list                  Preferred Docker registry mirror
+      --registry-mirror list                  Preferred registry mirror
       --rootless                              Enable rootless mode; typically used with RootlessKit
       --seccomp-profile string                Path to seccomp profile
       --selinux-enabled                       Enable selinux support

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -76,8 +76,8 @@ read the [`dockerd`](dockerd.md) reference page.
 
 | Command             | Description                                                             |
 |:--------------------|:------------------------------------------------------------------------|
-| [login](login.md)   | Register or log in to a Docker registry                                 |
-| [logout](logout.md) | Log out from a Docker registry                                          |
+| [login](login.md)   | Log in to a registry                                                    |
+| [logout](logout.md) | Log out from a registry                                                 |
 | [pull](pull.md)     | Download an image from a registry                                       |
 | [push](push.md)     | Upload an image to a registry                                           |
 | [search](search.md) | Search Docker Hub for images                                            |

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -9,7 +9,7 @@ keywords: "registry, login, image"
 ```markdown
 Usage:  docker login [OPTIONS] [SERVER]
 
-Log in to a Docker registry.
+Log in to a registry.
 If no server is specified, the default is defined by the daemon.
 
 Options:

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -9,7 +9,7 @@ keywords: "logout, docker, registry"
 ```markdown
 Usage:  docker logout [SERVER]
 
-Log out from a Docker registry.
+Log out from a registry.
 If no server is specified, the default is defined by the daemon.
 
 Options:

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -98,7 +98,7 @@ Options:
 
 ### Working with insecure registries
 
-The manifest command interacts solely with a Docker registry. Because of this,
+The manifest command interacts solely with a registry. Because of this,
 it has no way to query the engine for the list of allowed insecure registries.
 To allow the CLI to interact with an insecure registry, some `docker manifest`
 commands have an `--insecure` flag. For each transaction, such as a `create`,

--- a/man/src/login.md
+++ b/man/src/login.md
@@ -19,4 +19,4 @@ credentials.  When you log in, the command stores encoded credentials in
     # docker login localhost:8080
 
 # See also
-**docker-logout(1)** to log out from a Docker registry.
+**docker-logout(1)** to log out from a registry.

--- a/man/src/logout.md
+++ b/man/src/logout.md
@@ -10,4 +10,4 @@ located at `https://registry-1.docker.io/` by default.
     # docker logout localhost:8080
 
 # See also
-**docker-login(1)** to log in to a Docker registry server.
+**docker-login(1)** to log in to a registry.


### PR DESCRIPTION
follow-up to https://github.com/docker/cli/pull/3508

Remove "Docker" from registry, as the registry specification is no
longer docker-specific, but part of the OCI distribution spec.

Also removed "Register" from one of the docs pages, as the login
command hasn't supported creating a new acccount on Docker Hub for
a long time.

I'm wondering if we should be more explicit about what log in / out
does (effectively; authenticate, and on success store the credentials
or token, and on log out; remove credentials/token).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

