### PR TITLE
[20.10] vendor: docker/docker 20.10.14, docker/distribution v2.8.1, image-spec v1.0.2

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -53,7 +53,7 @@ github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac
 github.com/modern-go/reflect2                       4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd # 1.0.1
 github.com/morikuni/aec                             39771216ff4c63d11f5e604076f9c45e8be1067b # v1.0.0
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
-github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/image-spec                67d2d5658fe0476ab9bf414cec164077ebff3920 # v1.0.2
 github.com/opencontainers/runc                      ff819c7e9184c13b7c2607fe6c30ae19403a7aff # v1.0.0-rc92
 github.com/opentracing/opentracing-go               d34af3eaa63c4d08ab54863a4bdd0daa45212e12 # v1.2.0
 github.com/pkg/errors                               614d223910a179a466c1767a985424175c39b465 # v0.9.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/cpuguy83/go-md2man/v2                    b1ec32e02fe539480dc03e3bf381
 github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e42a55e72e7fbc # v1.1.11
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             1f9b5b8cb6aca13deee947511801cf89447c1bfe # v0.5.0
-github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/distribution                      b5ca020cfbe998e5af3457fda087444cf5116496 # v2.8.1
 github.com/docker/docker                            87a90dc786bda134c9eb02adbae2c6a7342fb7f6 # v20.10.14
 github.com/docker/docker-credential-helpers         fc9290adbcf1594e78910e2f0334090eaee0e1ee # v0.6.4
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.

--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e4
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             1f9b5b8cb6aca13deee947511801cf89447c1bfe # v0.5.0
 github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
-github.com/docker/docker                            b0f5bc36fea9dfb9672e1e9b1278ebab797b9ee0 # v20.10.7
+github.com/docker/docker                            87a90dc786bda134c9eb02adbae2c6a7342fb7f6 # v20.10.14
 github.com/docker/docker-credential-helpers         fc9290adbcf1594e78910e2f0334090eaee0e1ee # v0.6.4
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor/github.com/docker/distribution/README.md
+++ b/vendor/github.com/docker/distribution/README.md
@@ -2,7 +2,7 @@
 
 The Docker toolset to pack, ship, store, and deliver content.
 
-This repository's main product is the Docker Registry 2.0 implementation
+This repository provides the Docker Registry 2.0 implementation
 for storing and distributing Docker images. It supersedes the
 [docker/docker-registry](https://github.com/docker/docker-registry)
 project with a new API design, focused around security and performance.

--- a/vendor/github.com/docker/distribution/blobs.go
+++ b/vendor/github.com/docker/distribution/blobs.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go/v1"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 var (

--- a/vendor/github.com/docker/distribution/registry/client/repository.go
+++ b/vendor/github.com/docker/distribution/registry/client/repository.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/distribution/registry/api/v2"
+	v2 "github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/distribution/registry/storage/cache"
 	"github.com/docker/distribution/registry/storage/cache/memory"
@@ -736,7 +736,12 @@ func (bs *blobs) Create(ctx context.Context, options ...distribution.BlobCreateO
 		return nil, err
 	}
 
-	resp, err := bs.client.Post(u, "", nil)
+	req, err := http.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := bs.client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/docker/distribution/vendor.conf
+++ b/vendor/github.com/docker/distribution/vendor.conf
@@ -7,8 +7,8 @@ github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/bugsnag/bugsnag-go b1d153021fcd90ca3f080db36bec96dc690fb274
 github.com/bugsnag/osext 0dd3f918b21bec95ace9dc86c7e70266cfc5c702
 github.com/bugsnag/panicwrap e2c28503fcd0675329da73bf48b33404db873782
-github.com/denverdino/aliyungo 6df11717a253d9c7d4141f9af4deaa7c580cd531
-github.com/dgrijalva/jwt-go a601269ab70c205d26370c16f7c81e9017c14e04
+github.com/denverdino/aliyungo afedced274aa9a7fcdd47ac97018f0f8db4e5de2
+github.com/dgrijalva/jwt-go 4bbdd8ac624fc7a9ef7aec841c43d99b5fe65a29 https://github.com/golang-jwt/jwt.git # v3.2.2
 github.com/docker/go-metrics 399ea8c73916000c64c2c76e8da00ca82f8387ab
 github.com/docker/libtrust fa567046d9b14f6aa788882a950d69651d230b21
 github.com/garyburd/redigo 535138d7bcd717d6531c701ef5933d98b1866257
@@ -48,4 +48,4 @@ gopkg.in/square/go-jose.v1 40d457b439244b546f023d056628e5184136899b
 gopkg.in/yaml.v2 v2.2.1
 rsc.io/letsencrypt e770c10b0f1a64775ae91d240407ce00d1a5bdeb https://github.com/dmcgowan/letsencrypt.git
 github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
-github.com/opencontainers/image-spec ab7389ef9f50030c9b245bc16b981c7ddf192882
+github.com/opencontainers/image-spec 67d2d5658fe0476ab9bf414cec164077ebff3920 # v1.0.2

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,6 +1,6 @@
 github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
-github.com/Microsoft/hcsshim                        89a9a3b524264d34985f1d48793ab2b2d2e430f6 # moby branch
-github.com/Microsoft/go-winio                       5b44b70ab3ab4d291a7c1d28afe7b4afeced0ed4 # v0.4.15
+github.com/Microsoft/hcsshim                        64a2b71405dacf76c95600f4c756a991ad09cf7c # moby branch
+github.com/Microsoft/go-winio                       7e149e8c70409f36773c1b2cf3447a7ab7697368 # v0.4.20
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
 github.com/golang/gddo                              72a348e765d293ed6d1ded7b699591f14d6cd921
 github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c74f71af0538a4 # v1.1.1
@@ -33,7 +33,7 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            244e8cde639f71a05a1a2e0670bd88e0206ce55c # v0.8.3-3-g244e8cde
+github.com/moby/buildkit                            bc07b2b81b1c6a62d29981ac564b16a15ce2bfa7 # v0.8.3-4-gbc07b2b8
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746
@@ -67,16 +67,18 @@ github.com/moby/ipvs                                4566ccea0e08d68e9614c3e7a64a
 github.com/BurntSushi/toml                          3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005 # v0.3.1
 github.com/samuel/go-zookeeper                      d0e0d8e11f318e000a8cc434616d69e329edc374
 github.com/deckarep/golang-set                      ef32fa3046d9f249d399f98ebaf9be944430fd1d
-github.com/coreos/etcd                              d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9 # v3.3.12
+github.com/coreos/etcd                              973882f697a8db3d59815bf132c6c506434334bd # v3.3.27
 github.com/coreos/go-semver                         8ab6407b697782a06568d4b7f1db25550ec2e4c6 # v0.2.0
-github.com/ugorji/go                                b4c50a2b199d93b13dc15e78929cfb23bfdf21ab # v1.1.1
 github.com/hashicorp/consul                         9a9cc9341bb487651a0399e3fc5e1e8a42e62dd9 # v0.5.2
 github.com/miekg/dns                                6c0c4e6581f8e173cc562c8b3363ab984e4ae071 # v1.1.27
 github.com/ishidawataru/sctp                        f2269e66cdee387bd321445d5d300893449805be
 go.etcd.io/bbolt                                    232d8fc87f50244f9c808f4745759e08a304c029 # v1.3.5
+github.com/json-iterator/go                         a1ca0830781e007c66b225121d2cdb3a649421f6 # v1.1.10
+github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3
+github.com/modern-go/reflect2                       94122c33edd36123c84d5368cfb2b69df93a0ec8 # v1.0.1
 
 # get graph and distribution packages
-github.com/docker/distribution                      0d3efadf0154c2b8a4e7b6621fff9809655cc580
+github.com/docker/distribution                      dcf66392d606f50bf3a9286dcb4bdcdfb7c0e83a # v2.8.0
 github.com/vbatts/tar-split                         620714a4c508c880ac1bdda9c8370a2b19af1a55 # v0.11.1
 github.com/opencontainers/go-digest                 ea51bea511f75cfa3ef6098cc253c5c3609b037a # v1.0.0
 
@@ -92,7 +94,7 @@ google.golang.org/grpc                              f495f5b15ae7ccda3b38c53a1bfc
 # packages but should be newer or equal.
 github.com/opencontainers/runc                      ff819c7e9184c13b7c2607fe6c30ae19403a7aff # v1.0.0-rc92
 github.com/opencontainers/runtime-spec              4d89ac9fbff6c455f46a5bb59c6b1bb7184a5e43 # v1.0.3-0.20200728170252-4d89ac9fbff6
-github.com/opencontainers/image-spec                d60099175f88c47cd379c4738d158884749ed235 # v1.0.1
+github.com/opencontainers/image-spec                67d2d5658fe0476ab9bf414cec164077ebff3920 # v1.0.2
 github.com/cyphar/filepath-securejoin               a261ee33d7a517f054effbf451841abaafe3e0fd # v0.2.2
 
 # go-systemd v17 is required by github.com/coreos/pkg/capnslog/journald_formatter.go
@@ -106,7 +108,7 @@ github.com/godbus/dbus/v5                           37bf87eef99d69c4f1d3528bd66e
 github.com/Graylog2/go-gelf                         1550ee647df0510058c9d67a45c56f18911d80b8 # v2 branch
 
 # fluent-logger-golang deps
-github.com/fluent/fluent-logger-golang              7a6c9dcd7f14c2ed5d8c55c11b894e5455ee311b # v1.4.0
+github.com/fluent/fluent-logger-golang              0b652e850a9140d0b1db6390d8925d0601e952db # v1.8.0
 github.com/philhofer/fwd                            bb6d471dc95d4fe11e432687f8b70ff496cf3136 # v1.0.0
 github.com/tinylib/msgp                             af6442a0fcf6e2a1b824f70dd0c734f01e817751 # v1.1.0
 
@@ -130,7 +132,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          3f1135a288c9a07e340ae8ba4cc6c7065a3160e8
 
 # containerd
-github.com/containerd/containerd                    0edc412565dcc6e3d6125ff9e4b009ad4b89c638 # master (v1.5.0-dev)
+github.com/containerd/containerd                    7cfa023d95d37076d5ab035003d4839f4b6ba791 https://github.com/moby/containerd.git # master (v1.5.0-dev) + patch for CVE-2021-41190 and CVE-2022-24769
 github.com/containerd/fifo                          0724c46b320cf96bb172a0550c19a4b1fca4dacb
 github.com/containerd/continuity                    efbc4488d8fe1bdc16bde3b2d2990d9b3a899165
 github.com/containerd/cgroups                       0b889c03f102012f1d93a97ddd3ef71cd6f4f510
@@ -142,7 +144,7 @@ github.com/gogo/googleapis                          01e0f9cca9b92166042241267ee2
 github.com/cilium/ebpf                              1c8d4c9ef7759622653a1d319284a44652333b28
 
 # cluster
-github.com/docker/swarmkit                          17d8d4e4d8bdec33d386e6362d3537fa9493ba00
+github.com/docker/swarmkit                          286f4575a2d2853c1574e1be10eb1a2450692dfc # bump_20.10
 github.com/gogo/protobuf                            5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf                          84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/cloudflare/cfssl                         5d63dbd981b5c408effbb58c442d54761ff94fbd # 1.3.2
@@ -151,7 +153,7 @@ github.com/google/certificate-transparency-go       37a384cd035e722ea46e55029093
 golang.org/x/crypto                                 c1f2f97bffc9c53fc40a1a28a5b460094c0050d9
 golang.org/x/time                                   555d28b269f0569763d25dbe1a237ae74c6bcc82
 github.com/hashicorp/go-memdb                       cb9a474f84cc5e41b273b20c6927680b2a8776ad
-github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git
+github.com/hashicorp/go-immutable-radix             826af9ccf0feeee615d546d69b11f8e98da8c8f1 https://github.com/tonistiigi/go-immutable-radix.git
 github.com/hashicorp/golang-lru                     7f827b33c0f158ec5dfbba01bb0b14a4541fd81d # v0.5.3
 github.com/coreos/pkg                               3ac0863d7acf3bc44daf49afef8919af12f704ef # v3
 code.cloudfoundry.org/clock                         02e53af36e6c978af692887ed449b74026d76fec # v1.0.0

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/index.go
@@ -21,6 +21,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Index struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.index.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Manifests references platform specific manifests.
 	Manifests []Descriptor `json:"manifests"`
 

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -20,6 +20,9 @@ import "github.com/opencontainers/image-spec/specs-go"
 type Manifest struct {
 	specs.Versioned
 
+	// MediaType specificies the type of this document data structure e.g. `application/vnd.oci.image.manifest.v1+json`
+	MediaType string `json:"mediaType,omitempty"`
+
 	// Config references a configuration object for a container, by digest.
 	// The referenced configuration object is a JSON blob that the runtime uses to set up the container.
 	Config Descriptor `json:"config"`

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -22,7 +22,7 @@ const (
 	// VersionMinor is for functionality in a backwards-compatible manner
 	VersionMinor = 0
 	// VersionPatch is for backwards-compatible bug fixes
-	VersionPatch = 1
+	VersionPatch = 2
 
 	// VersionDev indicates development branch. Releases will be empty string.
 	VersionDev = ""


### PR DESCRIPTION
### [20.10] vendor: github.com/docker/docker v20.10.14

no local changes in vendored files.

full diff: https://github.com/docker/docker/compare/v20.10.7...v20.10.14

### [20.10] vendor: github.com/opencontainers/image-spec v1.0.2

full diff: https://github.com/opencontainers/image-spec/compare/v1.0.1...v1.0.2

### [20.10] vendor: github.com/docker/distribution v2.8.1

previous commit was a commit from the master/main branch (~ v2.7); this switches
back to using a released version.

full diff: https://github.com/docker/distribution/compare/0d3efadf0154c2b8a4e7b6621fff9809655cc580..v2.8.1


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

