### PR TITLE
scripts/build: fix build-date generation on macOS, and make sure it's in UTC

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -16,10 +16,10 @@ GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 if [ "$(uname)" = "Darwin" ]; then
     # Using BSD date (macOS), which doesn't suppoort the --date option
     # date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
-    BUILDTIME=${BUILDTIME:-$(date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+    BUILDTIME=${BUILDTIME:-$(TZ=UTC date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
 else
     # Using GNU date (Linux)
-    BUILDTIME=${BUILDTIME:-$(date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+    BUILDTIME=${BUILDTIME:-$(TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
 fi
 
 GOOS="$(go env GOOS)"

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -12,7 +12,15 @@ TARGET=${TARGET:-"build"}
 PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
-BUILDTIME=${BUILDTIME:-$(date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+
+if [ "$(uname)" = "Darwin" ]; then
+    # Using BSD date (macOS), which doesn't suppoort the --date option
+    # date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
+    BUILDTIME=${BUILDTIME:-$(date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+else
+    # Using GNU date (Linux)
+    BUILDTIME=${BUILDTIME:-$(date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+fi
 
 GOOS="$(go env GOOS)"
 GOARCH="$(go env GOARCH)"


### PR DESCRIPTION
### scripts/build: fix date formatting on macOS

This was introduced in 9d40c7464eb2a351e8b2e63dd1fdce6a43f2c70f (https://github.com/docker/cli/pull/2855), which added support for `SOURCE_DATE_EPOCH` to override the build-time.

macOS uses the BSD flavor of `date`, which does not support the `--date` option to set a custom time.

Before this:

    DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    ./scripts/build/binary
    date: illegal option -- -
    usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
    [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]

After this:

    DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    ./scripts/build/binary
    Building static docker-darwin-amd64
    + go build -o build/docker-darwin-amd64 -tags ' osusergo pkcs11' -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=a4b6fe16a" -X "github.com/docker/cli/cli/version.BuildTime=2022-04-06T10:57:25Z" -X "github.com/docker/cli/cli/version.Version=20.10.2-589-ga4b6fe16a.m"' -buildmode=pie github.com/docker/cli/cmd/docker
    ...

### scripts/build: make sure build-time is in UTC

Before this:

    SOURCE_DATE_EPOCH=1606660000 DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    ...
    + go build -o build/docker-darwin-amd64 -tags ' osusergo pkcs11' -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=090dd58dc" -X "github.com/docker/cli/cli/version.BuildTime=2020-11-29T15:26:40Z" -X "github.com/docker/cli/cli/version.Version=20.10.2-590-g090dd58dc"' -buildmode=pie github.com/docker/cli/cmd/docker
    ...

    make -f docker.Makefile shell
    SOURCE_DATE_EPOCH=1606660000 make binary
    ...
    + go build -o build/docker-linux-amd64 -tags  -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=090dd58dc" -X "github.com/docker/cli/cli/version.BuildTime=2020-11-29T14:26:40Z" -X "github.com/docker/cli/cli/version.Version=20.10.0-dev"' github.com/docker/cli/cmd/docker
    ...


Notice that `version.BuildTime` is `2020-11-29T15:26:40Z` outside the container, and `2020-11-29T14:26:40Z` inside.

After this:

    SOURCE_DATE_EPOCH=1606660000 DISABLE_WARN_OUTSIDE_CONTAINER=1 make binary
    ...
    + go build -o build/docker-darwin-amd64 -tags ' osusergo pkcs11' -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=090dd58dc" -X "github.com/docker/cli/cli/version.BuildTime=2020-11-29T14:26:40Z" -X "github.com/docker/cli/cli/version.Version=20.10.2-590-g090dd58dc.m"' -buildmode=pie github.com/docker/cli/cmd/docker
    ...


    make -f docker.Makefile shell
    SOURCE_DATE_EPOCH=1606660000 make binary
    ...
    + go build -o build/docker-linux-amd64 -tags  -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=090dd58dc" -X "github.com/docker/cli/cli/version.BuildTime=2020-11-29T14:26:40Z" -X "github.com/docker/cli/cli/version.Version=20.10.0-dev"' github.com/docker/cli/cmd/docker
    ...

Notice that `version.BuildTime` is `2020-11-29T14:26:40Z` both outside and inside the container.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

