### PR TITLE
Clear go.mod after vendor scripts ran

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,15 @@ plugins: ## build example CLI plugins
 .PHONY: vendor
 vendor: ## update vendor with go modules
 	rm -rf vendor
-	./scripts/vendor update
+	./scripts/vendor update -c
 
 .PHONY: validate-vendor
 validate-vendor: ## validate vendor
-	./scripts/vendor validate
+	./scripts/vendor validate -c
 
 .PHONY: mod-outdated
 mod-outdated: ## check outdated dependencies
-	./scripts/vendor outdated
+	./scripts/vendor outdated -c
 
 .PHONY: authors
 authors: ## generate AUTHORS file from git history

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -14,7 +14,7 @@ RUN --mount=target=/context \
     --mount=target=/go/pkg/mod,type=cache <<EOT
 set -e
 rsync -a /context/. .
-./scripts/vendor update
+./scripts/vendor update -c
 mkdir /out
 cp -r vendor.mod vendor.sum vendor /out
 EOT
@@ -30,7 +30,7 @@ rsync -a /context/. .
 git add -A
 rm -rf vendor
 cp -rf /out/* .
-./scripts/vendor validate
+./scripts/vendor validate -c
 EOT
 
 FROM psampaz/go-mod-outdated:${MODOUTDATED_VERSION} AS go-mod-outdated
@@ -39,4 +39,4 @@ ARG UUID
 RUN --mount=target=.,rw \
     --mount=target=/go/pkg/mod,type=cache \
     --mount=from=go-mod-outdated,source=/home/go-mod-outdated,target=/usr/bin/go-mod-outdated \
-    ./scripts/vendor outdated
+    ./scripts/vendor outdated -c

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -29,6 +29,8 @@ trap clean EXIT
   go build -mod=vendor -modfile=vendor.mod -tags manpages -o /tmp/gen-manpages ./man/generate.go
   # build go-md2man
   go build -mod=vendor -modfile=vendor.mod -o /tmp/go-md2man ./vendor/github.com/cpuguy83/go-md2man/v2
+  # clean vendor
+  ./scripts/vendor clean
 )
 
 mkdir -p man/man1

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -27,6 +27,8 @@ trap clean EXIT
   ./scripts/vendor update
   # build docsgen
   go build -mod=vendor -modfile=vendor.mod -tags docsgen -o /tmp/docsgen ./docs/generate.go
+  # clean vendor
+  ./scripts/vendor clean
 )
 
 mkdir -p docs/yaml

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -13,6 +13,10 @@ if [ -z "$TYP" ]; then
   usage
 fi
 
+clean() {
+  rm go.mod
+}
+
 init() {
   # create dummy go.mod, see comment in vendor.mod
   cat > go.mod <<EOL
@@ -43,6 +47,7 @@ outdated() {
   (set -x ; go list -mod=vendor -mod=readonly -modfile=vendor.mod -u -m -json all | go-mod-outdated -update -direct)
 }
 
+
 case $TYP in
   "init")
     init
@@ -50,15 +55,18 @@ case $TYP in
   "update")
     init
     update
+    clean
     ;;
   "validate")
     init
     update
+    clean
     validate
     ;;
   "outdated")
     init
     outdated
+    clean
     ;;
   *)
     echo >&2 "Unknown type $TYP"

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -2,19 +2,12 @@
 
 set -eu
 
-TYP=$1
-
 usage() {
-  echo "usage: ./scripts/vendor <init|update|validate|outdated>"
+  echo "usage: ./scripts/vendor <init|update|validate|outdated|clean> [-c]"
+  echo
+  echo "options:"
+  echo "  c  remove dummy go.mod after command execution"
   exit 1
-}
-
-if [ -z "$TYP" ]; then
-  usage
-fi
-
-clean() {
-  rm go.mod
 }
 
 init() {
@@ -47,29 +40,49 @@ outdated() {
   (set -x ; go list -mod=vendor -mod=readonly -modfile=vendor.mod -u -m -json all | go-mod-outdated -update -direct)
 }
 
+clean() {
+  echo "Remove dummy go.mod file"
+  rm go.mod
+}
 
-case $TYP in
+command="${1:-"usage"}"
+if [ $# -gt 1 ]; then
+  shift # Remove command from the argument list
+fi
+
+case $command in
   "init")
     init
+    exit 0
     ;;
   "update")
     init
     update
-    clean
     ;;
   "validate")
     init
     update
-    clean
     validate
     ;;
   "outdated")
     init
     outdated
+    ;;
+  "clean")
     clean
+    exit 0
     ;;
   *)
-    echo >&2 "Unknown type $TYP"
-    exit 1
+    usage
     ;;
 esac
+
+while getopts ":c" opt; do
+  case $opt in
+    c)
+      clean
+      ;;
+    *)
+      ;;
+  esac
+done


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR adds an option to remove the go.mod stub when executing a `./script/vendor` command. It avoids `go build` to fail because of unconsistencies between go.mod and vendor/modules.txt files.

This PR also
- fixes the `./scripts/vendor` to display the usage command when no command is passed
- adds the `clean` command called after yaml and man docs have been generated

**- How I did it**

When the following commands are ran
```bash
make vendor
make binary
```

`go build` fails with the message
```bash
go build -o build/docker-linux-arm64 -tags  -ldflags ' -w -X "github.com/docker/cli/cli/version.GitCommit=b82d9a7742" -X "github.com/docker/cli/cli/version.BuildTime=2022-04-06T11:45:13Z" -X "github.com/docker/cli/cli/version.Version=20.10.0-dev"' github.com/docker/cli/cmd/docker
go: inconsistent vendoring in /go/src/github.com/docker/cli:
	github.com/Azure/go-ansiterm@v0.0.0-20210617225240-d185dfc1b5a1: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
...
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Clean up `go.mod` file after vendors have been updated, validated or list outdated.


**- A picture of a cute animal (not mandatory but encouraged)**

