### PR TITLE
Improvements to makefile and development container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ shellcheck: ## run shellcheck validation
 	find scripts/ contrib/completion/bash -type f | grep -v scripts/winresources | grep -v '.*.ps1' | xargs shellcheck
 
 .PHONY: fmt
-fmt:
+fmt: ## run gofmt
 	go list -f {{.Dir}} ./... | xargs gofmt -w -s -d
 
 .PHONY: binary

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,17 @@ all: binary
 
 _:=$(shell ./scripts/warn-outside-container $(MAKECMDGOALS))
 
+.PHONY: dev
+dev: ## start a build container in interactive mode for in-container development
+	@if [ -n "${DISABLE_WARN_OUTSIDE_CONTAINER}" ]; then \
+		echo "you are already in the dev container"; \
+	else \
+		$(MAKE) -f docker.Makefile dev; \
+	fi
+
+.PHONY: shell
+shell: dev ## alias for dev
+
 .PHONY: clean
 clean: ## remove build artifacts
 	rm -rf ./build/* man/man[1-9] docs/yaml

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -35,7 +35,7 @@ DOCKER_RUN_NAME_OPTION := $(if $(DOCKER_CLI_CONTAINER_NAME),--name $(DOCKER_CLI_
 DOCKER_RUN := docker run --rm $(ENVVARS) $(DOCKER_CLI_MOUNTS) $(DOCKER_RUN_NAME_OPTION)
 
 .PHONY: binary
-binary:
+binary: ## build executable
 	PACKAGER_NAME=$(PACKAGER_NAME) docker buildx bake binary
 
 build: binary ## alias for binary

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -29,8 +29,12 @@ RUN  apk add --no-cache \
     ca-certificates \
     coreutils \
     curl \
-    git
+    git \
+    jq \
+    nano
 
+RUN echo -e "\nYou are now in a development container. Run '\e\033[1mmake help\e\033[0m' to learn about\navailable make targets.\n" > /etc/motd \
+ && echo -e "cat /etc/motd\nPS1=\"\e[0;32m\u@docker-cli-dev\\$ \e[0m\"" >> /root/.bashrc
 CMD bash
 ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENV PATH=$PATH:/go/src/github.com/docker/cli/build

--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -3,16 +3,25 @@ set -eu
 
 target="${1:-}"
 
-if [ "$target" != "help" ] && [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
-    (
-        echo
-        echo
-        echo "WARNING: you are not in a container."
-        echo "Use \"make -f docker.Makefile $target\" or set"
-        echo "DISABLE_WARN_OUTSIDE_CONTAINER=1 to disable this warning."
-        echo
-        echo "Press Ctrl+C now to abort."
-        echo
-    ) >&2
-    sleep 10
+if [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
+		case $target in
+			clean|dev|help|shell)
+				# no warning needed for these targets
+				;;
+			*)
+				(
+						echo
+						echo "\033[1mWARNING\033[0m: you are not in a container."
+						echo
+						echo 'Use "\033[1mmake dev\033[0m" to start an interactive development container,'
+						echo "use \"\033[1mmake -f docker.Makefile $target\033[0m\" to execute this target"
+						echo "in a container, or set \033[1mDISABLE_WARN_OUTSIDE_CONTAINER=1\033[0m to"
+						echo "disable this warning."
+						echo
+						echo "Press \033[1mCtrl+C\033[0m now to abort, or wait for the script to continue.."
+						echo
+				) >&2
+				sleep 5
+				;;
+		esac
 fi


### PR DESCRIPTION
This makes some small improvements to the makefile and development container:

### Makefile: add missing help messages for some targets

Some targets didn't have a help message. After this:

<img width="1139" alt="Screenshot 2022-04-06 at 19 13 15" src="https://user-images.githubusercontent.com/1804568/162030622-092a31e2-9c67-4f46-b1e3-f8399109427d.png">

### Dockerfile.dev: set prompt, add nano and jq, and set MOTD

This makes some minor improvments to the dev container:

- add `nano` as an alternative to `vi` to help beginning contributors, or people
  that don't remember how to quit `vi` ;-)
- add `jq` as it's often handy to have available to debug JSON output.
- set a custom prompt to make it clearer that the user is in a container
- add a short MOTD that shows that the user is in a container, and a pointer
  to 'make help' (we can add more help/instructions to this MOTD in future).

Before this patch:

```bash
make -f docker.Makefile dev
...
bash-5.1#
```

With this patch:

```bash
make -f docker.Makefile dev
...

You are now in a development container. Run 'make help' to learn about
available make targets.

root@docker-cli-dev$
```

<img width="528" alt="Screenshot 2022-04-06 at 18 49 22" src="https://user-images.githubusercontent.com/1804568/162030733-c7494dc0-f000-4270-ae13-9c935df6d7cf.png">

### Makefile: don't warn "outside container" for some targets

This change allows some make targets to be ran outside the dev-container for
easier discovery and use:

- `make clean` can be used on the host (as artifacts created from within the
  development container are usually stored on the host).
- `make help` was already allowed
- `make dev` and `make shell` are added to the regular Makefile, to make it
  easier to create and start the development container.
- When attempting to run `make dev` from within the development container, a
  message is printed, and the target is cancelled:

    ```bash
    root@docker-cli-dev$ make dev
    you are already in the dev container
    ```

The warning has also been tweaked slightly:

<img width="464" alt="Screenshot 2022-04-06 at 19 15 42" src="https://user-images.githubusercontent.com/1804568/162031088-761a8f2c-2d2c-484f-b020-66b9baefb3b4.png">


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

