### PR TITLE
fix: remove asterisk from docker command suggestions

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2653,7 +2653,7 @@ __docker_commands() {
     then
         local -a lines
         lines=(${(f)"$(_call_program commands docker 2>&1)"})
-        _docker_subcommands=(${${${(M)${lines[$((${lines[(i)*Commands:]} + 1)),-1]}:# *}## #}/ ##/:})
+        _docker_subcommands=(${${${(M)${lines[$((${lines[(i)*Commands:]} + 1)),-1]}:# *}## #}/\*# ##/:})
         _docker_subcommands=($_docker_subcommands 'daemon:Enable daemon mode' 'help:Show help for a command')
         (( $#_docker_subcommands > 2 )) && _store_cache docker_subcommands _docker_subcommands
     fi


### PR DESCRIPTION
**- What I did**

Some commands in the output of `docker` show up with an asterisk, like `app`, `build`, `buildx` or `scan`.

![image](https://user-images.githubusercontent.com/1441704/162021526-f80e9fba-29ff-440d-b4e0-55a1a4f56069.png)

This tweak removes them so that the asterisk is not filled in when choosing those commands.

**- How I did it**

In `__docker_commands`, the output of `docker` is parsed to get the list of valid commands. The function already trims whitespace from left and right. I just added a zsh-regex pattern for an asterisk on the right-hand side to remove it as well.

The zsh regex `\*#` is equivalent to POSIX regex `\**` (0 or more occurrences of `*`) (note that this requires `setopt extendedglob`).

**- How to verify it**

1. Clone this PR and `cd` into the project root.
2. Run `unfunction _docker` if docker completion has been attempted before.
3. Run `autoload -Uz $PWD/contrib/completion/zsh/_docker`.
4. Attempt to complete `docker `.

Suggestion entries should appear without a trailing asterisk:

![image](https://user-images.githubusercontent.com/1441704/162021535-ac546869-0b99-4658-9fef-6c2285a2812d.png)

**- Description for the changelog**

Remove trailing asterisk from zsh completion for docker commands.

**- A picture of a cute animal (not mandatory but encouraged)**

![kitten at computer](https://user-images.githubusercontent.com/1441704/162040067-68e3f3ef-1c9c-44cf-94d8-f2a458a5e511.png)
