### PR TITLE
remove "Experimental" client field from "docker version"

### DIFF
--- a/cli/command/system/testdata/docker-client-version.golden
+++ b/cli/command/system/testdata/docker-client-version.golden
@@ -6,7 +6,6 @@ Client:
  Built:             Wed May 30 22:21:05 2018
  OS/Arch:           linux/amd64
  Context:           my-context
- Experimental:      true
 
 Server: Docker Enterprise Edition (EE) 2.0
  Engine:

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -28,7 +28,6 @@ Client:{{if ne .Platform.Name ""}} {{.Platform.Name}}{{end}}
  Built:	{{.BuildTime}}
  OS/Arch:	{{.Os}}/{{.Arch}}
  Context:	{{.Context}}
- Experimental:	{{.Experimental}}
 {{- end}}
 
 {{- if .ServerOK}}{{with .Server}}
@@ -76,7 +75,6 @@ type clientVersion struct {
 	Arch              string
 	BuildTime         string `json:",omitempty"`
 	Context           string
-	Experimental      bool `json:",omitempty"` // Deprecated: experimental CLI features always enabled. This field is kept for backward-compatibility, and is always "true"
 }
 
 // ServerOK returns true when the client could connect to the docker server
@@ -140,7 +138,6 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 			BuildTime:         reformatDate(version.BuildTime),
 			Os:                runtime.GOOS,
 			Arch:              arch(),
-			Experimental:      true,
 			Context:           dockerCli.CurrentContext(),
 		},
 	}

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -42,7 +42,6 @@ func TestVersionAlign(t *testing.T) {
 			Arch:              "amd64",
 			BuildTime:         "Wed May 30 22:21:05 2018",
 			Context:           "my-context",
-			Experimental:      true,
 		},
 		Server: &types.Version{},
 	}

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -344,6 +344,10 @@ The `DOCKER_CLI_EXPERIMENTAL` environment variable and the corresponding `experi
 field in the CLI configuration file are deprecated. Experimental features are
 enabled by default, and these configuration options are no longer functional.
 
+Starting with v22.04, the Docker CLI no longer prints `Experimental` for the client
+in the output of `docker version`, and the field has been removed from the JSON
+format.
+
 ### CLI plugins support
 
 **Deprecated in Release: v20.10**


### PR DESCRIPTION
- [x] follow-up to https://github.com/docker/cli/pull/3542


Configuration (enabling/disabling) of Experimental client features was deprecated in Docker 19.03, and removed in 20.10. Experimental CLI features are now always enabled. In Docker 20.10, the Experimental field in `docker version` was kept (but always true).

This patch removes the field from the output (both "pretty" output and the JSON struct).


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

