### PR TITLE
cli/command: fix documentation of CopyToFile mentioning ioutil

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -19,7 +19,7 @@ import (
 // CopyToFile writes the content of the reader to the specified file
 func CopyToFile(outfile string, r io.Reader) error {
 	// We use sequential file access here to avoid depleting the standby list
-	// on Windows. On Linux, this is a call directly to ioutil.TempFile
+	// on Windows. On Linux, this is a call directly to os.CreateTemp
 	tmpFile, err := system.TempFileSequential(filepath.Dir(outfile), ".docker_temp_")
 	if err != nil {
 		return err


### PR DESCRIPTION
The package we're using was updated, so this no longer was correct.

**- A picture of a cute animal (not mandatory but encouraged)**

