### PR TITLE
[20.10 backport] update go to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,12 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.16.15
+ARG GO_VERSION=1.17.8
 ARG XX_VERSION=1.1.0
-
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS gostable
-FROM --platform=$BUILDPLATFORM golang:1.17rc1-${BASE_VARIANT} AS golatest
-
-FROM gostable AS go-linux
-FROM gostable AS go-darwin
-FROM gostable AS go-windows-amd64
-FROM gostable AS go-windows-386
-FROM gostable AS go-windows-arm
-FROM golatest AS go-windows-arm64
-FROM go-windows-${TARGETARCH} AS go-windows
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM go-${TARGETOS} AS build-base-alpine
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS build-base-alpine
 COPY --from=xx / /
 RUN apk add --no-cache clang lld llvm file git
 WORKDIR /go/src/github.com/docker/cli
@@ -27,7 +16,7 @@ ARG TARGETPLATFORM
 # gcc is installed for libgcc only
 RUN xx-apk add --no-cache musl-dev gcc
 
-FROM go-${TARGETOS} AS build-base-buster
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-buster AS build-base-buster
 COPY --from=xx / /
 RUN apt-get update && apt-get install --no-install-recommends -y clang lld file
 WORKDIR /go/src/github.com/docker/cli

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.16.15
+  GOVERSION: 1.17.8
   DEPVERSION: v0.4.1
 
 install:

--- a/cli-plugins/manager/manager_unix.go
+++ b/cli-plugins/manager/manager_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package manager

--- a/cli-plugins/manager/suffix_unix.go
+++ b/cli-plugins/manager/suffix_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package manager

--- a/cli/command/container/signals_unix.go
+++ b/cli/command/container/signals_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package container

--- a/cli/command/container/signals_unix_test.go
+++ b/cli/command/container/signals_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package container

--- a/cli/command/image/build/context_unix.go
+++ b/cli/command/image/build/context_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package build

--- a/cli/command/image/build/context_windows.go
+++ b/cli/command/image/build/context_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package build
 
 import (

--- a/cli/config/configfile/file_unix.go
+++ b/cli/config/configfile/file_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package configfile

--- a/cli/config/credentials/default_store_unsupported.go
+++ b/cli/config/credentials/default_store_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin && !linux
 // +build !windows,!darwin,!linux
 
 package credentials

--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package commandconn

--- a/cli/connhelper/commandconn/pdeathsig_nolinux.go
+++ b/cli/connhelper/commandconn/pdeathsig_nolinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package commandconn

--- a/cli/connhelper/commandconn/session_unix.go
+++ b/cli/connhelper/commandconn/session_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package commandconn

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,6 @@
+variable "GO_VERSION" {
+    default = "1.17.8"
+}
 variable "VERSION" {
     default = ""
 }

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.15
+ARG GO_VERSION=1.17.8
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.15
+ARG GO_VERSION=1.17.8
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.16.15
+ARG GO_VERSION=1.17.8
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.16.15
+ARG GO_VERSION=1.17.8
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/opts/hosts_unix.go
+++ b/opts/hosts_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package opts

--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package opts
 
 // defaultHost constant defines the default host string used by docker on Windows


### PR DESCRIPTION
- [x] backport of https://github.com/docker/cli/pull/3383
- [x] backport of https://github.com/docker/cli/pull/3495
- [x] depends on https://github.com/docker/cli/pull/3521
- [x] depends on https://github.com/docker/cli/pull/3527
