### PR TITLE
Fix wrong docker run command

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -1036,7 +1036,7 @@ $ docker run -it --rm --gpus device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a ubu
 The example below exposes the first and third GPUs.
 
 ```console
-$ docker run -it --rm --gpus '"device=0,2"' nvidia-smi
+$ docker run -it --rm --gpus '"device=0,2"' ubuntu nvidia-smi
 ```
 
 ### <a name="restart"></a> Restart policies (--restart)


### PR DESCRIPTION
It forgot the image name ubuntu.


**- How to verify it**

`docker run -it --rm --gpus '"device=0,2"' nvidia-smi` throws error

> Unable to find image 'nvidia-smi:latest' locally
> docker: Error response from daemon: pull access denied for nvidia-smi, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
> See 'docker run --help'.

but mine does not.


