### PR TITLE
Document `--chmod` flag in ADD and COPY statements new in 20.10

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1095,15 +1095,15 @@ RUN apt-get update && apt-get install -y ...
 ADD has two forms:
 
 ```dockerfile
-ADD [--chown=<user>:<group>] <src>... <dest>
-ADD [--chown=<user>:<group>] ["<src>",... "<dest>"]
+ADD [--chown=<user>:<group>] [--chmod=<perms>] <src>... <dest>
+ADD [--chown=<user>:<group>] [--chmod=<perms>] ["<src>",... "<dest>"]
 ```
 
 The latter form is required for paths containing whitespace.
 
 > **Note**
 >
-> The `--chown` feature is only supported on Dockerfiles used to build Linux containers,
+> The `--chown` and `--chmod` features are only supported on Dockerfiles used to build Linux containers,
 > and will not work on Windows containers. Since user and group ownership concepts do
 > not translate between Linux and Windows, the use of `/etc/passwd` and `/etc/group` for
 > translating user and group names to IDs restricts this feature to only be viable
@@ -1172,6 +1172,7 @@ ADD --chown=55:mygroup files* /somedir/
 ADD --chown=bin files* /somedir/
 ADD --chown=1 files* /somedir/
 ADD --chown=10:11 files* /somedir/
+ADD --chown=myuser:mygroup --chmod=655 files* /somedir/
 ```
 
 If the container root filesystem does not contain either `/etc/passwd` or
@@ -1271,15 +1272,15 @@ guide – Leverage build cache](https://docs.docker.com/develop/develop-images/
 COPY has two forms:
 
 ```dockerfile
-COPY [--chown=<user>:<group>] <src>... <dest>
-COPY [--chown=<user>:<group>] ["<src>",... "<dest>"]
+COPY [--chown=<user>:<group>] [--chmod=<perms>] <src>... <dest>
+COPY [--chown=<user>:<group>] [--chmod=<perms>] ["<src>",... "<dest>"]
 ```
 
 This latter form is required for paths containing whitespace
 
 > **Note**
 >
-> The `--chown` feature is only supported on Dockerfiles used to build Linux containers,
+> The `--chown` and `--chmod` features are only supported on Dockerfiles used to build Linux containers,
 > and will not work on Windows containers. Since user and group ownership concepts do
 > not translate between Linux and Windows, the use of `/etc/passwd` and `/etc/group` for
 > translating user and group names to IDs restricts this feature to only be viable for
@@ -1347,6 +1348,7 @@ COPY --chown=55:mygroup files* /somedir/
 COPY --chown=bin files* /somedir/
 COPY --chown=1 files* /somedir/
 COPY --chown=10:11 files* /somedir/
+COPY --chown=myuser:mygroup --chmod=644 files* /somedir/
 ```
 
 If the container root filesystem does not contain either `/etc/passwd` or


### PR DESCRIPTION
**- What I did**

I added missing documentation about the new `--chmod` flag in `ADD` and `COPY` statements originally proposed in https://github.com/moby/moby/issues/34819 and implemented in version 20.10.

**- How I did it**

I edited `./docs/reference/builder.md`

**- How to verify it**

It's just a docs change. 🤷‍♂️

**- Description for the changelog**

Updated BuildKit docs to mention the recently implemented --chmod flag now available in ADD and COPY statements in Dockerfiles since version 20.10.

**- A picture of a cute animal (not mandatory but encouraged)**

Here's my cat behind my LEGO _International Space Station_: 😸
![image](https://user-images.githubusercontent.com/941331/163731184-1b6f58ce-4b05-486f-8412-b8f09cc3c0bf.png)

