### PR TITLE
hide swarm-related commands based on the current swarm status and role

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -159,7 +159,7 @@ func TestInitializeFromClient(t *testing.T) {
 
 			cli := &DockerCli{client: apiclient}
 			cli.initializeFromClient()
-			assert.DeepEqual(t, cli.serverInfo, testcase.expectedServer)
+			assert.DeepEqual(t, cli.ServerInfo(), testcase.expectedServer)
 			assert.Equal(t, apiclient.negotiated, testcase.negotiated)
 		})
 	}

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -16,7 +16,7 @@ func NewConfigCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.30",
-			"swarm":   "",
+			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -20,7 +20,7 @@ func NewNodeCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
-			"swarm":   "",
+			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -16,7 +16,7 @@ func NewSecretCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
-			"swarm":   "",
+			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -16,7 +16,7 @@ func NewServiceCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
-			"swarm":   "",
+			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -17,7 +17,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
-			"swarm":   "",
+			"swarm":   "manager",
 		},
 	}
 	defaultHelpFunc := cmd.HelpFunc()

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -35,7 +35,10 @@ func newCACommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCA(dockerCli, cmd.Flags(), opts)
 		},
-		Annotations: map[string]string{"version": "1.30"},
+		Annotations: map[string]string{
+			"version": "1.30",
+			"swarm":   "manager",
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -16,7 +16,7 @@ func NewSwarmCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
-			"swarm":   "",
+			"swarm":   "", // swarm command itself does not require swarm to be enabled (so swarm init and join is always available on API 1.24 and up)
 		},
 	}
 	cmd.AddCommand(

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -39,6 +39,10 @@ func newInitCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInit(dockerCli, cmd.Flags(), opts)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "", // swarm init does not require swarm to be active, and is always available on API 1.24 and up
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -36,6 +36,10 @@ func newJoinCommand(dockerCli command.Cli) *cobra.Command {
 			opts.remote = args[0]
 			return runJoin(dockerCli, cmd.Flags(), opts)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "", // swarm join does not require swarm to be active, and is always available on API 1.24 and up
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -28,6 +28,10 @@ func newJoinTokenCommand(dockerCli command.Cli) *cobra.Command {
 			opts.role = args[0]
 			return runJoinToken(dockerCli, opts)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "manager",
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -23,6 +23,10 @@ func newLeaveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLeave(dockerCli, opts)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "active",
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -24,6 +24,10 @@ func newUnlockCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUnlock(dockerCli)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "manager",
+		},
 	}
 
 	return cmd

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -27,6 +27,10 @@ func newUnlockKeyCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUnlockKey(dockerCli, opts)
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "manager",
+		},
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -28,6 +28,10 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return nil
 		},
+		Annotations: map[string]string{
+			"version": "1.24",
+			"swarm":   "manager",
+		},
 	}
 
 	cmd.Flags().BoolVar(&opts.autolock, flagAutolock, false, "Change manager autolocking setting (true|false)")


### PR DESCRIPTION
- hide swarm-related commands based on the current swarm status and role
- cli: initializeFromClient(): detect swarm status from ping (if available)

Output of `docker --help` with swarm disabled:

```
Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Common Commands:
  run         Create and run a new container from an image
  exec        Execute a command in a running container
  ps          List containers
  build       Build an image from a Dockerfile
  pull        Download an image from a registry
  push        Upload an image to a registry
  images      List images
  login       Log in to a registry
  logout      Log out from a registry
  search      Search Docker Hub for images
  version     Show the Docker version information
  info        Display system-wide information

Management Commands:
  builder     Manage builds
  buildx*     Docker Buildx (Docker Inc., v0.8.2)
  checkpoint  Manage checkpoints
  container   Manage containers
  context     Manage contexts
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  network     Manage networks
  plugin      Manage plugins
  system      Manage Docker
  trust       Manage trust on Docker images
  volume      Manage volumes

Swarm Commands:
  swarm       Manage Swarm

Commands:
  attach      Attach local standard input, output, and error streams to a running container
  commit      Create a new image from a container's changes
  cp          Copy files/folders between a container and the local filesystem
  create      Create a new container
  diff        Inspect changes to files or directories on a container's filesystem
  events      Get real time events from the server
  export      Export a container's filesystem as a tar archive
  history     Show the history of an image
  import      Import the contents from a tarball to create a filesystem image
  inspect     Return low-level information on Docker objects
  kill        Kill one or more running containers
  load        Load an image from a tar archive or STDIN
  logs        Fetch the logs of a container
  pause       Pause all processes within one or more containers
  port        List port mappings or a specific mapping for the container
  rename      Rename a container
  restart     Restart one or more containers
  rm          Remove one or more containers
  rmi         Remove one or more images
  save        Save one or more images to a tar archive (streamed to STDOUT by default)
  start       Start one or more stopped containers
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop one or more running containers
  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
  top         Display the running processes of a container
  unpause     Unpause all processes within one or more containers
  update      Update configuration of one or more containers
  wait        Block until one or more containers stop, then print their exit codes

Global Options:
      --config string      Location of client config files (default "/root/.docker")
  -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with "docker context use")
  -D, --debug              Enable debug mode
  -H, --host list          Daemon socket(s) to connect to
  -l, --log-level string   Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
      --tls                Use TLS; implied by --tlsverify
      --tlscacert string   Trust certs signed only by this CA (default "/root/.docker/ca.pem")
      --tlscert string     Path to TLS certificate file (default "/root/.docker/cert.pem")
      --tlskey string      Path to TLS key file (default "/root/.docker/key.pem")
      --tlsverify          Use TLS and verify the remote
  -v, --version            Print version information and quit

Run 'docker COMMAND --help' for more information on a command.

To get more help with docker, check out our guides at https://docs.docker.com/go/guides/
```

Output of `docker --help` with swarm enabled:

```
Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Common Commands:
  run         Create and run a new container from an image
  exec        Execute a command in a running container
  ps          List containers
  build       Build an image from a Dockerfile
  pull        Download an image from a registry
  push        Upload an image to a registry
  images      List images
  login       Log in to a registry
  logout      Log out from a registry
  search      Search Docker Hub for images
  version     Show the Docker version information
  info        Display system-wide information

Management Commands:
  builder     Manage builds
  buildx*     Docker Buildx (Docker Inc., v0.8.2)
  checkpoint  Manage checkpoints
  container   Manage containers
  context     Manage contexts
  image       Manage images
  manifest    Manage Docker image manifests and manifest lists
  network     Manage networks
  plugin      Manage plugins
  system      Manage Docker
  trust       Manage trust on Docker images
  volume      Manage volumes

Swarm Commands:
  config      Manage Swarm configs
  node        Manage Swarm nodes
  secret      Manage Swarm secrets
  service     Manage Swarm services
  stack       Manage Swarm stacks
  swarm       Manage Swarm

Commands:
  attach      Attach local standard input, output, and error streams to a running container
  commit      Create a new image from a container's changes
  cp          Copy files/folders between a container and the local filesystem
  create      Create a new container
  diff        Inspect changes to files or directories on a container's filesystem
  events      Get real time events from the server
  export      Export a container's filesystem as a tar archive
  history     Show the history of an image
  import      Import the contents from a tarball to create a filesystem image
  inspect     Return low-level information on Docker objects
  kill        Kill one or more running containers
  load        Load an image from a tar archive or STDIN
  logs        Fetch the logs of a container
  pause       Pause all processes within one or more containers
  port        List port mappings or a specific mapping for the container
  rename      Rename a container
  restart     Restart one or more containers
  rm          Remove one or more containers
  rmi         Remove one or more images
  save        Save one or more images to a tar archive (streamed to STDOUT by default)
  start       Start one or more stopped containers
  stats       Display a live stream of container(s) resource usage statistics
  stop        Stop one or more running containers
  tag         Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
  top         Display the running processes of a container
  unpause     Unpause all processes within one or more containers
  update      Update configuration of one or more containers
  wait        Block until one or more containers stop, then print their exit codes

Global Options:
      --config string      Location of client config files (default "/root/.docker")
  -c, --context string     Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with "docker context use")
  -D, --debug              Enable debug mode
  -H, --host list          Daemon socket(s) to connect to
  -l, --log-level string   Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
      --tls                Use TLS; implied by --tlsverify
      --tlscacert string   Trust certs signed only by this CA (default "/root/.docker/ca.pem")
      --tlscert string     Path to TLS certificate file (default "/root/.docker/cert.pem")
      --tlskey string      Path to TLS key file (default "/root/.docker/key.pem")
      --tlsverify          Use TLS and verify the remote
  -v, --version            Print version information and quit

Run 'docker COMMAND --help' for more information on a command.

To get more help with docker, check out our guides at https://docs.docker.com/go/guides/
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

