### PR TITLE
Retry initializing TTY size a bit more

### DIFF
--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -45,7 +45,7 @@ func resizeTty(ctx context.Context, cli command.Cli, id string, isExec bool) err
 	return resizeTtyTo(ctx, cli.Client(), id, height, width, isExec)
 }
 
-// initTtySize is to init the tty's size to the same as the window, if there is an error, it will retry 5 times.
+// initTtySize is to init the tty's size to the same as the window, if there is an error, it will retry 10 times.
 func initTtySize(ctx context.Context, cli command.Cli, id string, isExec bool, resizeTtyFunc func(ctx context.Context, cli command.Cli, id string, isExec bool) error) {
 	rttyFunc := resizeTtyFunc
 	if rttyFunc == nil {
@@ -54,8 +54,8 @@ func initTtySize(ctx context.Context, cli command.Cli, id string, isExec bool, r
 	if err := rttyFunc(ctx, cli, id, isExec); err != nil {
 		go func() {
 			var err error
-			for retry := 0; retry < 5; retry++ {
-				time.Sleep(10 * time.Millisecond)
+			for retry := 0; retry < 10; retry++ {
+				time.Sleep(time.Duration(retry+1) * 10 * time.Millisecond)
 				if err = rttyFunc(ctx, cli, id, isExec); err == nil {
 					break
 				}

--- a/cli/command/container/tty_test.go
+++ b/cli/command/container/tty_test.go
@@ -25,6 +25,6 @@ func TestInitTtySizeErrors(t *testing.T) {
 	ctx := context.Background()
 	cli := test.NewFakeCli(&fakeClient{containerExecResizeFunc: fakeContainerExecResizeFunc})
 	initTtySize(ctx, cli, "8mm8nn8tt8bb", true, fakeResizeTtyFunc)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(750 * time.Millisecond)
 	assert.Check(t, is.Equal(expectedError, cli.ErrBuffer().String()))
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I some cases, for example if there is a heavy load, the initialization of the TTY size would fail. This change makes the cli retry more times, 10 instead of 5 and we wait incrementally from 10ms to 100ms between two calls to resize the TTY.

Running 150 containers (see script below) takes ~2 minutes to complete without this change, with this change the time to complete was ~1m55s and 2m12s so I don't think this change will impact users.

Running one container `docker run --rm -t hello-world` takes the same amount of time (1.5s on my machine) with or without this change.

Relates to #3554

**- How I did it**
Changed the retry logic to retry 10 times instead of 5 and increase the wait between retries to 100ms

**- How to verify it**

Running this script shouldn't show any `failed to resize tty, using default size` errors.

```bash
#!/bin/bash

for A in $(seq 1 10); do
    echo $A

    for a in $(seq 1 15); do
        com.docker.cli run --rm -t alpine echo $A/$a &
    done

    wait
    date
done
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

