### PR TITLE
introduce `docker stack config`

### DIFF
--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -29,6 +29,7 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 		defaultHelpFunc(c, args)
 	})
 	cmd.AddCommand(
+		newConfigCommand(dockerCli),
 		newDeployCommand(dockerCli),
 		newListCommand(dockerCli),
 		newPsCommand(dockerCli),

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -1,0 +1,48 @@
+package stack
+
+import (
+	"fmt"
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/stack/loader"
+	"github.com/docker/cli/cli/command/stack/options"
+	"github.com/docker/cli/cli/command/stack/swarm"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func newConfigCommand(dockerCli command.Cli) *cobra.Command {
+	var opts options.Deploy
+
+	cmd := &cobra.Command{
+		Use:   "config [OPTIONS]",
+		Short: "Parse and validate a stack configuration",
+		Args:  cli.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := loader.LoadComposefile(dockerCli, opts)
+			if err != nil {
+				return err
+			}
+			marshal, err := yaml.Marshal(config)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(marshal))
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, `Path to a Compose file, or "-" to read from stdin`)
+	flags.SetAnnotation("compose-file", "version", []string{"1.25"})
+	flags.BoolVar(&opts.SendRegistryAuth, "with-registry-auth", false, "Send registry authentication details to Swarm agents")
+	flags.SetAnnotation("with-registry-auth", "swarm", nil)
+	flags.BoolVar(&opts.Prune, "prune", false, "Prune services that are no longer referenced")
+	flags.SetAnnotation("prune", "version", []string{"1.27"})
+	flags.SetAnnotation("prune", "swarm", nil)
+	flags.StringVar(&opts.ResolveImage, "resolve-image", swarm.ResolveImageAlways,
+		`Query the registry to resolve image digest and supported platforms ("`+swarm.ResolveImageAlways+`"|"`+swarm.ResolveImageChanged+`"|"`+swarm.ResolveImageNever+`")`)
+	flags.SetAnnotation("resolve-image", "version", []string{"1.30"})
+	flags.SetAnnotation("resolve-image", "swarm", nil)
+	return cmd
+}


### PR DESCRIPTION
**- What I did**
Many user report interoperability issue trying to pipe `docker compose config` to `docker stack deploy``
Unclear to me why they do so, as `stack deploy` supports merging multiple compose file and variable substitution...
Anyway this PR introduces `docker stack config` to offer equivalent feature relying on stack's compose loader

**- How I did it**
load model the same way `stack deploy` does and marshal into yaml

**- How to verify it**
`docker stack config --compose-file compose.yml`

**- Description for the changelog**
introduce `docker stack config` command

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/165923098-fb20c68c-b22d-41b3-8288-790d28e09743.png)

