### PR TITLE
Add bash completion for `docker stack config`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -4882,6 +4882,7 @@ _docker_search() {
 
 _docker_stack() {
 	local subcommands="
+		config
 		deploy
 		ls
 		ps
@@ -4908,6 +4909,21 @@ _docker_stack() {
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
 			;;
 	esac
+}
+
+_docker_stack_config() {
+	case "$prev" in
+		--compose-file|-c)
+			_filedir yml
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--compose-file -c --help --skip-interpolation" -- "$cur" ) )
+			;;
+  esac
 }
 
 _docker_stack_deploy() {

--- a/docs/reference/commandline/stack_config.md
+++ b/docs/reference/commandline/stack_config.md
@@ -11,9 +11,6 @@ Usage:	docker stack config [OPTIONS]
 
 Outputs the final config file, after doing merges and interpolations
 
-Aliases:
-  config, cfg
-
 Options:
   -c, --compose-file strings   Path to a Compose file, or "-" to read from stdin
       --orchestrator string    Orchestrator to use (swarm|kubernetes|all)


### PR DESCRIPTION
This adds bash completion for #3544.
Also removes the unsupported alias `docker stack cfg` from help output.