### PR TITLE
Remove bash completion for deprecated orchestrator flags

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -624,31 +624,6 @@ __docker_server_os_is() {
 	[ "$server_os" = "$expected_os" ]
 }
 
-# __docker_stack_orchestrator_is tests whether the client is configured to use
-# the orchestrator that is passed in as the first argument.
-__docker_stack_orchestrator_is() {
-	case "$1" in
-		kubernetes)
-			if [ -z "$stack_orchestrator_is_kubernetes" ] ; then
-				__docker_q stack ls --help | grep -qe --namespace
-				stack_orchestrator_is_kubernetes=$?
-			fi
-			return $stack_orchestrator_is_kubernetes
-			;;
-		swarm)
-			if [ -z "$stack_orchestrator_is_swarm" ] ; then
-				__docker_q stack deploy --help | grep -qe "with-registry-auth"
-				stack_orchestrator_is_swarm=$?
-			fi
-			return $stack_orchestrator_is_swarm
-			;;
-		*)
-			return 1
-			;;
-
-	esac
-}
-
 # __docker_pos_first_nonflag finds the position of the first word that is neither
 # option nor an option's argument. If there are options that require arguments,
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
@@ -1126,23 +1101,6 @@ __docker_complete_signals() {
 		SIGUSR2
 	)
 	COMPREPLY=( $( compgen -W "${signals[*]} ${signals[*]#SIG}" -- "$( echo "$cur" | tr '[:lower:]' '[:upper:]')" ) )
-}
-
-__docker_complete_stack_orchestrator_options() {
-	case "$prev" in
-		--kubeconfig)
-			_filedir
-			return 0
-			;;
-		--namespace)
-			return 0
-			;;
-		--orchestrator)
-			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur") )
-			return 0
-			;;
-	esac
-	return 1
 }
 
 __docker_complete_ulimits() {
@@ -2391,11 +2349,7 @@ _docker_context() {
 
 _docker_context_create() {
 	case "$prev" in
-		--default-stack-orchestrator)
-			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur" ) )
-			return
-			;;
-		--description|--docker|--kubernetes)
+		--description|--docker)
 			return
 			;;
 		--from)
@@ -2406,7 +2360,7 @@ _docker_context_create() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--default-stack-orchestrator --description --docker --from --help --kubernetes" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--description --docker --from --help" -- "$cur" ) )
 			;;
 	esac
 }
@@ -2414,7 +2368,7 @@ _docker_context_create() {
 _docker_context_export() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help --kubeconfig" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)
@@ -2495,18 +2449,14 @@ _docker_context_rm() {
 
 _docker_context_update() {
 	case "$prev" in
-		--default-stack-orchestrator)
-			COMPREPLY=( $( compgen -W "all kubernetes swarm" -- "$cur" ) )
-			return
-			;;
-		--description|--docker|--kubernetes)
+		--description|--docker)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--default-stack-orchestrator --description --docker --help --kubernetes" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--description --docker --help" -- "$cur" ) )
 			;;
 		*)
 			local counter=$(__docker_pos_first_nonflag)
@@ -4895,14 +4845,11 @@ _docker_stack() {
 		up
 	"
 
-	__docker_complete_stack_orchestrator_options && return
 	__docker_subcommands "$subcommands $aliases" && return
 
 	case "$cur" in
 		-*)
-			local options="--help --orchestrator"
-			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "$subcommands" -- "$cur" ) )
@@ -4911,8 +4858,6 @@ _docker_stack() {
 }
 
 _docker_stack_deploy() {
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$prev" in
 		--compose-file|-c)
 			_filedir yml
@@ -4926,13 +4871,10 @@ _docker_stack_deploy() {
 
 	case "$cur" in
 		-*)
-			local options="--compose-file -c --help --orchestrator"
-			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
-			__docker_stack_orchestrator_is swarm && options+=" --prune --resolve-image --with-registry-auth"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--compose-file -c --help --prune --resolve-image --with-registry-auth" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--compose-file|-c|--kubeconfig|--namespace|--orchestrator|--resolve-image')
+			local counter=$(__docker_pos_first_nonflag '--compose-file|-c|--resolve-image')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -4949,8 +4891,6 @@ _docker_stack_list() {
 }
 
 _docker_stack_ls() {
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$prev" in
 		--format)
 			return
@@ -4959,9 +4899,7 @@ _docker_stack_ls() {
 
 	case "$cur" in
 		-*)
-			local options="--format --help --orchestrator"
-			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format --help" -- "$cur" ) )
 			;;
 	esac
 }
@@ -4983,8 +4921,6 @@ _docker_stack_ps() {
 			;;
 	esac
 
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id name desired-state" -- "$cur" ) )
@@ -4998,12 +4934,10 @@ _docker_stack_ps() {
 
 	case "$cur" in
 		-*)
-			local options="--filter -f --format --help --no-resolve --no-trunc --orchestrator --quiet -q"
-			__docker_stack_orchestrator_is kubernetes && options+=" --all-namespaces --kubeconfig --namespace"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --format --help --no-resolve --no-trunc --quiet -q" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--all-namespaces|--filter|-f|--format|--kubeconfig|--namespace')
+			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -5016,13 +4950,9 @@ _docker_stack_remove() {
 }
 
 _docker_stack_rm() {
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$cur" in
 		-*)
-			local options="--help --orchestrator"
-			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
 			;;
 		*)
 			__docker_complete_stacks
@@ -5046,8 +4976,6 @@ _docker_stack_services() {
 			;;
 	esac
 
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$prev" in
 		--filter|-f)
 			COMPREPLY=( $( compgen -S = -W "id label name" -- "$cur" ) )
@@ -5061,12 +4989,10 @@ _docker_stack_services() {
 
 	case "$cur" in
 		-*)
-			local options="--filter -f --format --help --orchestrator --quiet -q"
-			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig --namespace"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--filter -f --format --help --quiet -q" -- "$cur" ) )
 			;;
 		*)
-			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format|--kubeconfig|--namespace|--orchestrator')
+			local counter=$(__docker_pos_first_nonflag '--filter|-f|--format')
 			if [ "$cword" -eq "$counter" ]; then
 				__docker_complete_stacks
 			fi
@@ -5337,8 +5263,6 @@ _docker_top() {
 }
 
 _docker_version() {
-	__docker_complete_stack_orchestrator_options && return
-
 	case "$prev" in
 		--format|-f)
 			return
@@ -5348,8 +5272,7 @@ _docker_version() {
 	case "$cur" in
 		-*)
 			local options="--format -f --help"
-			__docker_stack_orchestrator_is kubernetes && options+=" --kubeconfig"
-			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
 			;;
 	esac
 }
@@ -5605,8 +5528,6 @@ _docker() {
 
 	# variables to cache server info, populated on demand for performance reasons
 	local info_fetched server_experimental server_os
-	# variables to cache client info, populated on demand for performance reasons
-	local stack_orchestrator_is_kubernetes stack_orchestrator_is_swarm
 
 	local host config context
 


### PR DESCRIPTION
- supersedes https://github.com/docker/cli/pull/3439
- closes https://github.com/docker/cli/pull/3439
- Follow up to https://github.com/docker/cli/pull/3139
- Addresses https://github.com/docker/cli/issues/2967

See 039018b6d3f4bb84ce0093e29ba4a5429a60c92b for corresponding docs change.