### PR TITLE
remove some swarm annotations from flags

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -840,7 +840,6 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 	flags.Var(&opts.resources.resMemBytes, flagReserveMemory, "Reserve Memory")
 	flags.Int64Var(&opts.resources.limitPids, flagLimitPids, 0, "Limit maximum number of processes (default 0 = unlimited)")
 	flags.SetAnnotation(flagLimitPids, "version", []string{"1.41"})
-	flags.SetAnnotation(flagLimitPids, "swarm", nil)
 
 	flags.Var(&opts.stopGrace, flagStopGracePeriod, flagDesc(flagStopGracePeriod, "Time to wait before force killing a container (ns|us|ms|s|m|h)"))
 	flags.Var(&opts.replicas, flagReplicas, "Number of tasks")

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -36,14 +36,11 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringSliceVarP(&opts.Composefiles, "compose-file", "c", []string{}, `Path to a Compose file, or "-" to read from stdin`)
 	flags.SetAnnotation("compose-file", "version", []string{"1.25"})
 	flags.BoolVar(&opts.SendRegistryAuth, "with-registry-auth", false, "Send registry authentication details to Swarm agents")
-	flags.SetAnnotation("with-registry-auth", "swarm", nil)
 	flags.BoolVar(&opts.Prune, "prune", false, "Prune services that are no longer referenced")
 	flags.SetAnnotation("prune", "version", []string{"1.27"})
-	flags.SetAnnotation("prune", "swarm", nil)
 	flags.StringVar(&opts.ResolveImage, "resolve-image", swarm.ResolveImageAlways,
 		`Query the registry to resolve image digest and supported platforms ("`+swarm.ResolveImageAlways+`"|"`+swarm.ResolveImageChanged+`"|"`+swarm.ResolveImageNever+`")`)
 	flags.SetAnnotation("resolve-image", "version", []string{"1.30"})
-	flags.SetAnnotation("resolve-image", "swarm", nil)
 	return cmd
 }
 


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3139

These annotations were added because these options were not supported
when using kubernetes as an orchestrator. Now that this feature was
removed, we can remove these annotations.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

