### PR TITLE
Sleep for 1.5 seconds before looking at the resize error

### DIFF
--- a/cli/command/container/tty_test.go
+++ b/cli/command/container/tty_test.go
@@ -25,6 +25,6 @@ func TestInitTtySizeErrors(t *testing.T) {
 	ctx := context.Background()
 	cli := test.NewFakeCli(&fakeClient{containerExecResizeFunc: fakeContainerExecResizeFunc})
 	initTtySize(ctx, cli, "8mm8nn8tt8bb", true, fakeResizeTtyFunc)
-	time.Sleep(750 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	assert.Check(t, is.Equal(expectedError, cli.ErrBuffer().String()))
 }


### PR DESCRIPTION
**- What I did**

Sleep for 1.5 seconds before looking at the resize error

This test is very flaky, the retry loop runs for 550ms and some more, 750ms is cleary not enough for everything to set and for the cli to return the tty resize error. A sleep of 1.5 seconds in this test should be enough for the retry loop to finish.

Relates to #3554

**- How I did it**

**- How to verify it**

Run the CI a lot of times

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/99933/166257618-8157cbe3-30de-4222-b25e-92190626a82b.png)
