### PR TITLE
Loads .env file if existing at the very beginning

### DIFF
--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/compose/loader"
 	"github.com/docker/cli/cli/compose/schema"
 	composetypes "github.com/docker/cli/cli/compose/types"
+	"github.com/docker/cli/opts"
 	"github.com/pkg/errors"
 )
 
@@ -97,21 +98,8 @@ func GetConfigDetails(composefiles []string, stdin io.Reader) (composetypes.Conf
 	}
 	// Take the first file version (2 files can't have different version)
 	details.Version = schema.Version(details.ConfigFiles[0].Config)
-	details.Environment, err = buildEnvironment(os.Environ())
+	details.Environment, err = opts.BuildEnvironment(os.Environ())
 	return details, err
-}
-
-func buildEnvironment(env []string) (map[string]string, error) {
-	result := make(map[string]string, len(env))
-	for _, s := range env {
-		// if value is empty, s is like "K=", not "K".
-		if !strings.Contains(s, "=") {
-			return result, errors.Errorf("unexpected environment %q", s)
-		}
-		kv := strings.SplitN(s, "=", 2)
-		result[kv[0]] = kv[1]
-	}
-	return result, nil
 }
 
 func loadConfigFiles(filenames []string, stdin io.Reader) ([]composetypes.ConfigFile, error) {

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -195,3 +195,8 @@ func StringSliceReplaceAt(s, old, new []string, requireIndex int) ([]string, boo
 	out = append(out, s[idx+len(old):]...)
 	return out, true
 }
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return !errors.Is(err, os.ErrNotExist)
+}

--- a/opts/envfile.go
+++ b/opts/envfile.go
@@ -2,7 +2,12 @@ package opts
 
 import (
 	"os"
+	"strings"
+
+	"github.com/pkg/errors"
 )
+
+const DefaultEnvFileName = ".env"
 
 // ParseEnvFile reads a file with environment variables enumerated by lines
 //
@@ -19,4 +24,17 @@ import (
 // nothing more.
 func ParseEnvFile(filename string) ([]string, error) {
 	return parseKeyValueFile(filename, os.LookupEnv)
+}
+
+func BuildEnvironment(env []string) (map[string]string, error) {
+	result := make(map[string]string, len(env))
+	for _, s := range env {
+		// if value is empty, s is like "K=", not "K".
+		if !strings.Contains(s, "=") {
+			return result, errors.Errorf("unexpected environment %q", s)
+		}
+		kv := strings.SplitN(s, "=", 2)
+		result[kv[0]] = kv[1]
+	}
+	return result, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Load .env files when existing

**- How I did it**
Load it as the very first thing we do in `main`

**- How to verify it**
Setting `DOCKER_BUILDKIT=X` or `DOCKER_HOST=XXXXX` in a `.env` file in `$PWD`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Load .env files when existing

**- A picture of a cute animal (not mandatory but encouraged)**

