### PR TITLE
info: improve handling of empty Info

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -85,8 +85,17 @@ func runInfo(cmd *cobra.Command, dockerCli command.Cli, opts *infoOptions) error
 		if dinfo, err := dockerCli.Client().Info(ctx); err == nil {
 			info.Info = &dinfo
 		} else {
-			fmt.Fprintln(dockerCli.Err(), err)
 			info.ServerErrors = append(info.ServerErrors, err.Error())
+			if opts.format == "" {
+				// reset the server info to prevent printing "empty" Server info
+				// and warnings, but don't reset it if a custom format was specified
+				// to prevent errors from Go's template parsing during format.
+				info.Info = nil
+			} else {
+				// if a format is provided, print the error, as it may be hidden
+				// otherwise if the template doesn't include the ServerErrors field.
+				fmt.Fprintln(dockerCli.Err(), err)
+			}
 		}
 	}
 

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -67,11 +67,12 @@ func NewInfoCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runInfo(cmd *cobra.Command, dockerCli command.Cli, opts *infoOptions) error {
-	var info info
-
-	info.ClientInfo = &clientInfo{
-		Context: dockerCli.CurrentContext(),
-		Debug:   debug.IsEnabled(),
+	info := info{
+		ClientInfo: &clientInfo{
+			Context: dockerCli.CurrentContext(),
+			Debug:   debug.IsEnabled(),
+		},
+		Info: &types.Info{},
 	}
 	if plugins, err := pluginmanager.ListPlugins(dockerCli, cmd.Root()); err == nil {
 		info.ClientInfo.Plugins = plugins
@@ -84,6 +85,7 @@ func runInfo(cmd *cobra.Command, dockerCli command.Cli, opts *infoOptions) error
 		if dinfo, err := dockerCli.Client().Info(ctx); err == nil {
 			info.Info = &dinfo
 		} else {
+			fmt.Fprintln(dockerCli.Err(), err)
 			info.ServerErrors = append(info.ServerErrors, err.Error())
 		}
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/issues/3593
- relates to https://github.com/docker/cli/pull/3179

Before this change, the function could print an error in some cases, for example;

```bash
docker -H tcp://127.0.0.1:2375 info --format '{{.LoggingDriver}}'

template: :1:2: executing "" at <.LoggingDriver>: reflect: indirection through nil pointer to embedded struct field Info
```

With this patch applied, the error is handled gracefully, and when failing to
connect with the daemon, the error is logged;

```bash
docker -H tcp://127.0.0.1:2375 info --format '{{.LoggingDriver}}'
Cannot connect to the Docker daemon at tcp://127.0.0.1:2375. Is the docker daemon running?

docker -H tcp://127.0.0.1:2375 info --format '{{json .}}'
Cannot connect to the Docker daemon at tcp://127.0.0.1:2375. Is the docker daemon running?
{"ID":"","Containers":0,"..."}}
```

Note that the connection error is also included in the JSON `ServerErrors` field,
so that the information does not get lost, even if STDERR would be redirected;

```bash
docker -H tcp://127.0.0.1:2375 info --format '{{json .ServerErrors}}' 2> /dev/null
["Cannot connect to the Docker daemon at tcp://127.0.0.1:2375. Is the docker daemon running?"]
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

