### PR TITLE
completion v2: some small follow-ups

### DIFF
--- a/cli/command/checkpoint/create.go
+++ b/cli/command/checkpoint/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			opts.checkpoint = args[1]
 			return runCreate(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/system"
@@ -36,6 +37,7 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 			createOpts.File = args[1]
 			return RunConfigCreate(dockerCli, createOpts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.Labels, "label", "l", "Config labels")

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -55,7 +55,9 @@ func NewAttachCommand(dockerCli command.Cli) *cobra.Command {
 			opts.container = args[0]
 			return runAttach(dockerCli, &opts)
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(container types.Container) bool {
+			return container.State != "paused"
+		}),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -54,7 +54,9 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 			options.Command = args[1:]
 			return RunExec(dockerCli, options)
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(container types.Container) bool {
+			return container.State != "paused"
+		}),
 		Annotations: map[string]string{
 			"category-top": "2",
 		},

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
@@ -44,7 +45,8 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			opts.Name = args[0]
 			return RunCreate(dockerCli, opts)
 		},
-		Long: longCreateDescription(),
+		Long:              longCreateDescription(),
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Description, "description", "", "Description of the context")

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
@@ -37,6 +38,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "5",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 			opts.images = args
 			return RunSave(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -26,6 +27,7 @@ func NewTagCommand(dockerCli command.Cli) *cobra.Command {
 			opts.name = args[1]
 			return runTag(dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
@@ -52,6 +53,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			options.name = args[0]
 			return runCreate(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
@@ -75,6 +76,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			options.context = args[1]
 			return runCreate(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -47,6 +48,7 @@ func NewLoginCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "8",
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -26,6 +26,7 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "9",
 		},
+		// TODO (thaJeztah) add completion for registries we have authentication stored for
 	}
 
 	return cmd

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
@@ -29,6 +30,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runCreate(dockerCli, cmd.Flags(), opts)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.mode, flagMode, "replicated", "Service mode (replicated, global, replicated-job, or global-job)")

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/pkg/errors"
@@ -38,6 +39,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runCreate(dockerCli, options)
 		},
+		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&options.driver, "driver", "d", "local", "Specify volume driver name")


### PR DESCRIPTION
- some quick follow-ups to https://github.com/docker/cli/pull/3429

Changes:

- Prevent completion on "create" subcommands to prevent them
  from completing with local filenames
- Add completion for "docker image save"
- Add completion for "docker image tag"
- Disable completion for "docker login"
- Exclude "paused" containers for "docker container attach" and
  "docker container exec"


**- A picture of a cute animal (not mandatory but encouraged)**

