### PR TITLE
lint: update some nolint comments:

### DIFF
--- a/cli/command/container/hijack.go
+++ b/cli/command/container/hijack.go
@@ -185,7 +185,6 @@ func setRawTerminal(streams command.Streams) error {
 	return streams.Out().SetRawTerminal()
 }
 
-// nolint: unparam
 func restoreTerminal(streams command.Streams, in io.Closer) error {
 	streams.In().RestoreTerminal()
 	streams.Out().RestoreTerminal()

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -329,7 +329,6 @@ func convertTarget(t client.Target) (target, error) {
 }
 
 // TagTrusted tags a trusted ref
-// nolint: interfacer
 func TagTrusted(ctx context.Context, cli command.Cli, trustedRef reference.Canonical, ref reference.NamedTagged) error {
 	// Use familiar references when interacting with client and output
 	familiarRef := reference.FamiliarString(ref)

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -208,7 +208,6 @@ func buildBlobRequestList(imageManifest types.ImageManifest, repoName reference.
 	return blobReqs, nil
 }
 
-// nolint: interfacer
 func buildPutManifestRequest(imageManifest types.ImageManifest, targetRef reference.Named) (mountRequest, error) {
 	refWithoutTag, err := reference.WithName(targetRef.Name())
 	if err != nil {

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -78,7 +78,6 @@ func isLastSignerForReleases(roleWithSig data.Role, allRoles []client.RoleWithSi
 
 // removeSingleSigner attempts to remove a single signer and returns whether signer removal happened.
 // The signer not being removed doesn't necessarily raise an error e.g. user choosing "No" when prompted for confirmation.
-// nolint: unparam
 func removeSingleSigner(cli command.Cli, repoName, signerName string, forceYes bool) (bool, error) {
 	ctx := context.Background()
 	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), repoName)


### PR DESCRIPTION
found this branch locally 😂 🤷‍♂️ 

```
cli/command/container/hijack.go:188:1:warning: nolint directive did not match any issue (nolint)
cli/command/image/trust.go:346:1:warning: nolint directive did not match any issue (nolint)
cli/command/manifest/push.go:211:1:warning: nolint directive did not match any issue (nolint)
cli/command/trust/signer_remove.go:79:1:warning: nolint directive did not match any issue (nolint)
internal/pkg/containerized/snapshot.go:95:1:warning: nolint directive did not match any issue (nolint)
internal/pkg/containerized/snapshot.go:138:1:warning: nolint directive did not match any issue (nolint)
```


**- A picture of a cute animal (not mandatory but encouraged)**

