### PR TITLE
add --signal option to stop and restart

### DIFF
--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -12,8 +12,8 @@ Usage:  docker restart [OPTIONS] CONTAINER [CONTAINER...]
 Restart one or more containers
 
 Options:
-      --help       Print usage
-  -t, --time int   Seconds to wait for stop before killing the container (default 10)
+  -s, --signal string   Signal to send to the container
+  -t, --time int        Seconds to wait before killing the container
 ```
 
 ## Examples

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -12,8 +12,8 @@ Usage:  docker stop [OPTIONS] CONTAINER [CONTAINER...]
 Stop one or more running containers
 
 Options:
-      --help       Print usage
-  -t, --time int   Seconds to wait for stop before killing it (default 10)
+  -s, --signal string   Signal to send to the container
+  -t, --time int        Seconds to wait before killing the container
 ```
 
 ## Description


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/43206

Wording and documentation still need to be updated, but will do
so in a follow-up.

Also removing the default "10 seconds" from the timeout flags, as
this default is not actually used, and may not match the actual
default (which is defined on the daemon side).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

