### PR TITLE
cli/container: Fill ConsoleSize in create

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -261,6 +261,8 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 		}
 	}
 
+	hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.Out().GetTtySize()
+
 	response, err := dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, opts.name)
 	if err != nil {
 		// Pull image if it does not exist locally and we have the PullImageMissing option. Default behavior.

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -97,7 +97,6 @@ func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copt
 // nolint: gocyclo
 func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptions, containerConfig *containerConfig) error {
 	config := containerConfig.Config
-	hostConfig := containerConfig.HostConfig
 	stdout, stderr := dockerCli.Out(), dockerCli.Err()
 	client := dockerCli.Client()
 
@@ -117,11 +116,6 @@ func runContainer(dockerCli command.Cli, opts *runOptions, copts *containerOptio
 		config.AttachStderr = false
 		config.StdinOnce = false
 	}
-
-	// Currently ignored on Linux daemons, in the Linux case the TTY size is
-	// set by calling MonitorTtySize.
-	// A Windows daemon will create the process with the right TTY size
-	hostConfig.ConsoleSize[0], hostConfig.ConsoleSize[1] = dockerCli.Out().GetTtySize()
 
 	ctx, cancelFun := context.WithCancel(context.Background())
 	defer cancelFun()


### PR DESCRIPTION
Related to https://github.com/moby/moby/pull/43593

**- What I did**
Fill HostConfig.ConsoleSize for both `docker run` and `docker create`

**- How I did it**
Move the code that sets the ConsoleSize from runContainer to createContainer.
This does not impact the runContainer, as it calls createContainer anyway.

**- How to verify it**
```
# Change terminal size from the default 24x80
docker create -t ubuntu sh -c 'tput lines; tput cols'
docker start <id>
docker logs <id>
# Check if the printed size is correct
```

**- A picture of a cute animal (not mandatory but encouraged)**

