### PR TITLE
vendor: github.com/docker/docker cb01202de88e20d5699c76efe948dfb065da873f

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -76,7 +76,7 @@ require (
 )
 
 replace (
-	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220520155652-8abb84c7342a+incompatible // master (v22.06-dev)
+	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220528210301-cb01202de88e+incompatible // master (v22.06-dev)
 	github.com/gogo/googleapis => github.com/gogo/googleapis v1.3.2
 
 	// Resolve dependency hell with github.com/cloudflare/cfssl (transitive via

--- a/vendor.sum
+++ b/vendor.sum
@@ -105,8 +105,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xb
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.3-0.20220520155652-8abb84c7342a+incompatible h1:o4OdN3hkN26XNH6g96X536mdfvOQhZJnHWigJWj1kMo=
-github.com/docker/docker v20.10.3-0.20220520155652-8abb84c7342a+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.3-0.20220528210301-cb01202de88e+incompatible h1:RnCjw82r3wn7omT1GBOX5dUDTyVZ4ONyUNXYG3QahI0=
+github.com/docker/docker v20.10.3-0.20220528210301-cb01202de88e+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -771,11 +771,13 @@ definitions:
           The time to wait between checks in nanoseconds. It should be 0 or at
           least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Timeout:
         description: |
           The time to wait before considering the check to have hung. It should
           be 0 or at least 1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
       Retries:
         description: |
           The number of consecutive failures needed to consider a container as
@@ -787,6 +789,7 @@ definitions:
           health-retries countdown in nanoseconds. It should be 0 or at least
           1000000 (1 ms). 0 means inherit.
         type: "integer"
+        format: "int64"
 
   Health:
     description: |
@@ -1625,7 +1628,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1826,7 +1829,7 @@ definitions:
           List of image names/tags in the local image cache that reference this
           image.
 
-          Multiple image tags can refer to the same imagem and this list may be
+          Multiple image tags can refer to the same image, and this list may be
           empty if no tags reference the image, in which case the image is
           "untagged", in which case it can still be referenced by its ID.
         type: "array"
@@ -1876,6 +1879,7 @@ definitions:
           This size is not calculated by default. `-1` indicates that the value
           has not been set / calculated.
         type: "integer"
+        format: "int64"
         x-nullable: false
         example: 1239828
       VirtualSize:
@@ -2023,6 +2027,7 @@ definitions:
         properties:
           Size:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               Amount of disk space used by the volume (in bytes). This information
@@ -2032,6 +2037,7 @@ definitions:
             x-nullable: false
           RefCount:
             type: "integer"
+            format: "int64"
             default: -1
             description: |
               The number of containers referencing this volume. This field
@@ -4655,6 +4661,7 @@ definitions:
       StatusCode:
         description: "Exit code of the container"
         type: "integer"
+        format: "int64"
         x-nullable: false
       Error:
         $ref: "#/definitions/ContainerWaitExitError"

--- a/vendor/github.com/docker/docker/api/types/image_summary.go
+++ b/vendor/github.com/docker/docker/api/types/image_summary.go
@@ -61,7 +61,7 @@ type ImageSummary struct {
 	// List of image names/tags in the local image cache that reference this
 	// image.
 	//
-	// Multiple image tags can refer to the same imagem and this list may be
+	// Multiple image tags can refer to the same image, and this list may be
 	// empty if no tags reference the image, in which case the image is
 	// "untagged", in which case it can still be referenced by its ID.
 	//

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -48,7 +48,7 @@ type ImageInspect struct {
 	// RepoTags is a list of image names/tags in the local image cache that
 	// reference this image.
 	//
-	// Multiple image tags can refer to the same imagem and this list may be
+	// Multiple image tags can refer to the same image, and this list may be
 	// empty if no tags reference the image, in which case the image is
 	// "untagged", in which case it can still be referenced by its ID.
 	RepoTags []string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -39,7 +39,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v20.10.14+incompatible => github.com/docker/docker v20.10.3-0.20220520155652-8abb84c7342a+incompatible
+# github.com/docker/docker v20.10.14+incompatible => github.com/docker/docker v20.10.3-0.20220528210301-cb01202de88e+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -390,6 +390,6 @@ gotest.tools/v3/internal/format
 gotest.tools/v3/internal/source
 gotest.tools/v3/poll
 gotest.tools/v3/skip
-# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220520155652-8abb84c7342a+incompatible
+# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220528210301-cb01202de88e+incompatible
 # github.com/gogo/googleapis => github.com/gogo/googleapis v1.3.2
 # github.com/google/certificate-transparency-go => github.com/google/certificate-transparency-go v1.0.20


### PR DESCRIPTION
no changes in vendored code other than a typo-fix, just aligning with latest master

https://github.com/docker/docker/compare/8abb84c7342a19009d777ef3d871c0b2a5c032a5...cb01202de88e20d5699c76efe948dfb065da873f

**- A picture of a cute animal (not mandatory but encouraged)**

