### PR TITLE
feat(cli): add --http-header option

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -269,7 +269,7 @@ func newAPIClientFromEndpoint(opts *cliflags.CommonOptions, ep docker.Endpoint, 
 	}
 
 	for i := 0; i < len(opts.HttpHeaders); i++ {
-		split := strings.Split(opts.HttpHeaders[i], ":")
+		split := strings.SplitN(opts.HttpHeaders[i], ":", 2)
 		k := strings.TrimSpace(split[0])
 		v := strings.TrimSpace(split[1])
 		customHeaders[k] = v

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -89,7 +89,7 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&commonOpts.Context, "context", "c", "",
 		`Name of the context to use to connect to the daemon (overrides `+client.EnvOverrideHost+` env var and default context set with "docker context use")`)
 	httpHeaderOpt := opts.NewNamedListOptsRef("http-headers", &commonOpts.HttpHeaders, nil)
-	flags.VarP(httpHeaderOpt, "http-header", "", "Custom HTTP headers")
+	flags.Var(httpHeaderOpt, "http-header", "Custom HTTP headers")
 }
 
 // SetDefaultOptions sets default values for options after flag parsing is

--- a/cli/flags/common.go
+++ b/cli/flags/common.go
@@ -45,13 +45,14 @@ var (
 
 // CommonOptions are options common to both the client and the daemon.
 type CommonOptions struct {
-	Debug      bool
-	Hosts      []string
-	LogLevel   string
-	TLS        bool
-	TLSVerify  bool
-	TLSOptions *tlsconfig.Options
-	Context    string
+	Debug       bool
+	Hosts       []string
+	LogLevel    string
+	TLS         bool
+	TLSVerify   bool
+	TLSOptions  *tlsconfig.Options
+	Context     string
+	HttpHeaders []string
 }
 
 // NewCommonOptions returns a new CommonOptions
@@ -87,6 +88,8 @@ func (commonOpts *CommonOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.VarP(hostOpt, "host", "H", "Daemon socket(s) to connect to")
 	flags.StringVarP(&commonOpts.Context, "context", "c", "",
 		`Name of the context to use to connect to the daemon (overrides `+client.EnvOverrideHost+` env var and default context set with "docker context use")`)
+	httpHeaderOpt := opts.NewNamedListOptsRef("http-headers", &commonOpts.HttpHeaders, nil)
+	flags.VarP(httpHeaderOpt, "http-header", "", "Custom HTTP headers")
 }
 
 // SetDefaultOptions sets default values for options after flag parsing is


### PR DESCRIPTION
Signed-off-by: Zhaofeng Miao <522856232@qq.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add `--http-header` option to CLI to allow adding custom http headers when doing `docker command` 

**- How I did it**

See the diff

**- How to verify it**

I tested it locally, if you think it's good to continue, I'll add test for it and polish the code.

<img width="1151" alt="Screen Shot 2022-05-30 at 4 19 23 PM" src="https://user-images.githubusercontent.com/4194287/170949278-08acb527-9bf1-4918-89af-26f7767ae8e6.png">


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add `--http-header` option to CLI to allow specifying http headers. `docker --http-header "key: value" version`

**- A picture of a cute animal (not mandatory but encouraged)**

: )
