### PR TITLE
Fix psFormat's Size handling in config file

### DIFF
--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -246,13 +246,13 @@ func TestContainerListWithConfigFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ types.ContainerListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1", WithLabel("some.label", "value")),
-				*Container("c2", WithName("foo/bar"), WithLabel("foo", "bar")),
+				*Container("c1", WithLabel("some.label", "value"), WithSize(10700000)),
+				*Container("c2", WithName("foo/bar"), WithLabel("foo", "bar"), WithSize(3200000)),
 			}, nil
 		},
 	})
 	cli.SetConfigFile(&configfile.ConfigFile{
-		PsFormat: "{{ .Names }} {{ .Image }} {{ .Labels }}",
+		PsFormat: "{{ .Names }} {{ .Image }} {{ .Labels }} {{ .Size}}",
 	})
 	cmd := newListCommand(cli)
 	assert.NilError(t, cmd.Execute())

--- a/cli/command/container/testdata/container-list-with-config-format.golden
+++ b/cli/command/container/testdata/container-list-with-config-format.golden
@@ -1,2 +1,2 @@
-c1 busybox:latest some.label=value
-c2 busybox:latest foo=bar
+c1 busybox:latest some.label=value 10.7MB
+c2 busybox:latest foo=bar 3.2MB

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -27,7 +27,7 @@ const (
 // NewContainerFormat returns a Format for rendering using a Context
 func NewContainerFormat(source string, quiet bool, size bool) Format {
 	switch source {
-	case TableFormatKey:
+	case TableFormatKey, "": // table formatting is the default if none is set.
 		if quiet {
 			return DefaultQuietFormat
 		}
@@ -54,8 +54,9 @@ ports: {{- pad .Ports 1 0}}
 			format += `size: {{.Size}}\n`
 		}
 		return Format(format)
+	default: // custom format
+		return Format(source)
 	}
-	return Format(source)
 }
 
 // ContainerWrite renders the context for a list of containers

--- a/internal/test/builders/container.go
+++ b/internal/test/builders/container.go
@@ -61,6 +61,15 @@ func WithPort(privateport, publicport uint16, builders ...func(*types.Port)) fun
 	}
 }
 
+// WithSize adds size in bytes to the container
+func WithSize(size int64) func(*types.Container) {
+	return func(c *types.Container) {
+		if size >= 0 {
+			c.SizeRw = size
+		}
+	}
+}
+
 // IP sets the ip of the port
 func IP(ip string) func(*types.Port) {
 	return func(p *types.Port) {


### PR DESCRIPTION
**- What I did**
Fixed #3632 

**- How I did it**
1. Added check for `Size` usage in config file's `PsFormat`, and moved this logic before calling `containerList`
2. Added `WithSize` function in test builder to allow specifying container size in unit tests
3. Amended `TestContainerListWithConfigFormat` to test for changes above

**- How to verify it**
Run the full test suite via `docker buildx bake test`, then attempt to reproduce issue above

**- Description for the changelog**
Fixed incorrect size handling in config file when using docker ps

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/97828583/171077300-bf6409b0-fedb-45ea-a63a-59b55600bfcb.png)

