### PR TITLE
Deflake TestVolumeCreateClusterOpts

### DIFF
--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -3,6 +3,7 @@ package volume
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -153,6 +154,9 @@ func runCreate(dockerCli command.Cli, options createOptions) error {
 				},
 			)
 		}
+		sort.SliceStable(volOpts.ClusterVolumeSpec.Secrets, func(i, j int) bool {
+			return volOpts.ClusterVolumeSpec.Secrets[i].Key < volOpts.ClusterVolumeSpec.Secrets[j].Key
+		})
 
 		// TODO(dperny): ignore if no topology specified
 		topology := &volume.TopologyRequirement{}

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -3,6 +3,7 @@ package volume
 import (
 	"io"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -192,6 +193,9 @@ func TestVolumeCreateClusterOpts(t *testing.T) {
 
 	cli := test.NewFakeCli(&fakeClient{
 		volumeCreateFunc: func(body volume.CreateOptions) (volume.Volume, error) {
+			sort.SliceStable(body.ClusterVolumeSpec.Secrets, func(i, j int) bool {
+				return body.ClusterVolumeSpec.Secrets[i].Key < body.ClusterVolumeSpec.Secrets[j].Key
+			})
 			assert.DeepEqual(t, body, expectedBody)
 			return volume.Volume{}, nil
 		},


### PR DESCRIPTION
**- What I did**
Fixes #3636

**- How I did it**
Added sorting logic to test to ensure consistent ordering of `Secrets`

**- How to verify it**
Run the full test suite multiple times to validate this fix

**- Description for the changelog**
Deflaked TestVolumeCreateClusterOpts


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/97828583/171150495-37e26230-47b4-4573-beac-56cb9c21479c.png)

