### PR TITLE
info: update plugin section to show installed path

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -180,11 +180,9 @@ func prettyPrintClientInfo(dockerCli command.Cli, info clientInfo) {
 		fmt.Fprintln(dockerCli.Out(), " Plugins:")
 		for _, p := range info.Plugins {
 			if p.Err == nil {
-				var version string
-				if p.Version != "" {
-					version = ", " + p.Version
-				}
-				fmt.Fprintf(dockerCli.Out(), "  %s: %s (%s%s)\n", p.Name, p.ShortDescription, p.Vendor, version)
+				fmt.Fprintf(dockerCli.Out(), "  %s: %s (%s)\n", p.Name, p.ShortDescription, p.Vendor)
+				fprintlnNonEmpty(dockerCli.Out(), "    Version: ", p.Version)
+				fprintlnNonEmpty(dockerCli.Out(), "    Path:    ", p.Path)
 			} else {
 				info.Warnings = append(info.Warnings, fmt.Sprintf("WARNING: Plugin %q is not valid: %s", p.Path, p.Err))
 			}

--- a/cli/command/system/testdata/docker-info-plugins.golden
+++ b/cli/command/system/testdata/docker-info-plugins.golden
@@ -2,8 +2,11 @@ Client:
  Context:    default
  Debug Mode: false
  Plugins:
-  goodplugin: unit test is good (ACME Corp, 0.1.0)
+  goodplugin: unit test is good (ACME Corp)
+    Version:  0.1.0
+    Path:     /path/to/docker-goodplugin
   unversionedplugin: this plugin has no version (ACME Corp)
+    Path:     /path/to/docker-unversionedplugin
 
 Server:
  Containers: 0


### PR DESCRIPTION
This updates the pretty-print format of docker info to provide more
details on installed plugins, to help users find where a specific
plugin is installed (e.g. to update it, or to uninstall it).

Before this patch:

```bash
Client:
 Context:    desktop-linux
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc., v0.8.2)
  compose: Docker Compose (Docker Inc., v2.4.1)
  sbom: View the packaged-based Software Bill Of Materials (SBOM) for an image (Anchore Inc., 0.6.0)
  scan: Docker Scan (Docker Inc., v0.17.0)

Server:
...
```

With this patch applied:

```bash
docker info

Client:
 Context:    desktop-linux
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.8.2
    Path:     /usr/local/lib/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v2.4.1
    Path:     /usr/local/lib/docker/cli-plugins/docker-compose
  sbom: View the packaged-based Software Bill Of Materials (SBOM) for an image (Anchore Inc.)
    Version:  0.6.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-sbom
  scan: Docker Scan (Docker Inc.)
    Version:  v0.17.0
    Path:     /usr/local/lib/docker/cli-plugins/docker-scan

Server:
...
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

