### PR TITLE
vendor: github.com/docker/docker 38633e797195643580ce5c4af7c5422aad3eb7de

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -76,7 +76,7 @@ require (
 )
 
 replace (
-	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220603111527-cf4595265e77+incompatible // master (v22.06-dev)
+	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220603173024-38633e797195+incompatible // master (v22.06-dev)
 	github.com/gogo/googleapis => github.com/gogo/googleapis v1.3.2
 
 	// Resolve dependency hell with github.com/cloudflare/cfssl (transitive via

--- a/vendor.sum
+++ b/vendor.sum
@@ -105,8 +105,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xb
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.3-0.20220603111527-cf4595265e77+incompatible h1:Mr2hklp2oSmOMMfGutYutWNKCkyddzQ4zlGIN8cD7Gg=
-github.com/docker/docker v20.10.3-0.20220603111527-cf4595265e77+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.3-0.20220603173024-38633e797195+incompatible h1:Umt6HQyK0tja1Hi7xr/RLTwfvwMWcDjgzku3DmBPaek=
+github.com/docker/docker v20.10.3-0.20220603173024-38633e797195+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -39,7 +39,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v20.10.14+incompatible => github.com/docker/docker v20.10.3-0.20220603111527-cf4595265e77+incompatible
+# github.com/docker/docker v20.10.14+incompatible => github.com/docker/docker v20.10.3-0.20220603173024-38633e797195+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -390,6 +390,6 @@ gotest.tools/v3/internal/format
 gotest.tools/v3/internal/source
 gotest.tools/v3/poll
 gotest.tools/v3/skip
-# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220603111527-cf4595265e77+incompatible
+# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220603173024-38633e797195+incompatible
 # github.com/gogo/googleapis => github.com/gogo/googleapis v1.3.2
 # github.com/google/certificate-transparency-go => github.com/google/certificate-transparency-go v1.0.20


### PR DESCRIPTION
no changes in vendoring, just updating to latest master

full diff: https://github.com/docker/docker/compare/cf4595265e7703e1e9745a30f1dd265acbc075d3...38633e797195643580ce5c4af7c5422aad3eb7de



**- A picture of a cute animal (not mandatory but encouraged)**

![Dwarf-Puffer-fish](https://user-images.githubusercontent.com/1804568/171916944-3a85c723-97c9-4921-9558-e69a537076af.jpg)
