### PR TITLE
info: fix output including "Labels:" if no labels were set

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -311,7 +311,7 @@ func prettyPrintServerInfo(dockerCli command.Cli, info types.Info) []error {
 		fmt.Fprintln(dockerCli.Out(), " Registry:", info.IndexServerAddress)
 	}
 
-	if info.Labels != nil {
+	if len(info.Labels) > 0 {
 		fmt.Fprintln(dockerCli.Out(), " Labels:")
 		for _, lbl := range info.Labels {
 			fmt.Fprintln(dockerCli.Out(), "  "+lbl)

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -259,6 +259,11 @@ func TestPrettyPrintInfo(t *testing.T) {
 	sampleInfoBadSecurity := sampleInfoNoSwarm
 	sampleInfoBadSecurity.SecurityOptions = []string{"foo="}
 
+	sampleInfoLabelsNil := sampleInfoNoSwarm
+	sampleInfoLabelsNil.Labels = nil
+	sampleInfoLabelsEmpty := sampleInfoNoSwarm
+	sampleInfoLabelsEmpty.Labels = []string{}
+
 	for _, tc := range []struct {
 		doc        string
 		dockerInfo info
@@ -292,6 +297,22 @@ func TestPrettyPrintInfo(t *testing.T) {
 			prettyGolden:   "docker-info-plugins",
 			jsonGolden:     "docker-info-plugins",
 			warningsGolden: "docker-info-plugins-warnings",
+		},
+		{
+			doc: "info with nil labels",
+			dockerInfo: info{
+				Info:       &sampleInfoLabelsNil,
+				ClientInfo: &clientInfo{Context: "default"},
+			},
+			prettyGolden: "docker-info-with-labels-nil",
+		},
+		{
+			doc: "info with empty labels",
+			dockerInfo: info{
+				Info:       &sampleInfoLabelsEmpty,
+				ClientInfo: &clientInfo{Context: "default"},
+			},
+			prettyGolden: "docker-info-with-labels-empty",
 		},
 		{
 
@@ -371,10 +392,12 @@ func TestPrettyPrintInfo(t *testing.T) {
 				assert.Check(t, is.Equal("", cli.ErrBuffer().String()))
 			}
 
-			cli = test.NewFakeCli(&fakeClient{})
-			assert.NilError(t, formatInfo(cli, tc.dockerInfo, "{{json .}}"))
-			golden.Assert(t, cli.OutBuffer().String(), tc.jsonGolden+".json.golden")
-			assert.Check(t, is.Equal("", cli.ErrBuffer().String()))
+			if tc.jsonGolden != "" {
+				cli = test.NewFakeCli(&fakeClient{})
+				assert.NilError(t, formatInfo(cli, tc.dockerInfo, "{{json .}}"))
+				golden.Assert(t, cli.OutBuffer().String(), tc.jsonGolden+".json.golden")
+				assert.Check(t, is.Equal("", cli.ErrBuffer().String()))
+			}
 		})
 	}
 }

--- a/cli/command/system/testdata/docker-info-with-labels-empty.golden
+++ b/cli/command/system/testdata/docker-info-with-labels-empty.golden
@@ -1,0 +1,55 @@
+Client:
+ Context:    default
+ Debug Mode: false
+
+Server:
+ Containers: 0
+  Running: 0
+  Paused: 0
+  Stopped: 0
+ Images: 0
+ Server Version: 17.06.1-ce
+ Storage Driver: aufs
+  Root Dir: /var/lib/docker/aufs
+  Backing Filesystem: extfs
+  Dirs: 0
+  Dirperm1 Supported: true
+ Logging Driver: json-file
+ Cgroup Driver: cgroupfs
+ Plugins:
+  Volume: local
+  Network: bridge host macvlan null overlay
+  Log: awslogs fluentd gcplogs gelf journald json-file logentries splunk syslog
+ Swarm: inactive
+ Runtimes: runc
+ Default Runtime: runc
+ Init Binary: docker-init
+ containerd version: 6e23458c129b551d5c9871e5174f6b1b7f6d1170
+ runc version: 810190ceaa507aa2727d7ae6f4790c76ec150bd2
+ init version: 949e6fa
+ Security Options:
+  apparmor
+  seccomp
+   Profile: default
+ Kernel Version: 4.4.0-87-generic
+ Operating System: Ubuntu 16.04.3 LTS
+ OSType: linux
+ Architecture: x86_64
+ CPUs: 2
+ Total Memory: 1.953GiB
+ Name: system-sample
+ ID: EKHL:QDUU:QZ7U:MKGD:VDXK:S27Q:GIPU:24B7:R7VT:DGN6:QCSF:2UBX
+ Docker Root Dir: /var/lib/docker
+ Debug Mode: true
+  File Descriptors: 33
+  Goroutines: 135
+  System Time: 2017-08-24T17:44:34.077811894Z
+  EventsListeners: 0
+ Registry: https://index.docker.io/v1/
+ Experimental: false
+ Insecure Registries:
+  127.0.0.0/8
+ Live Restore Enabled: false
+ Default Address Pools:
+   Base: 10.123.0.0/16, Size: 24
+

--- a/cli/command/system/testdata/docker-info-with-labels-nil.golden
+++ b/cli/command/system/testdata/docker-info-with-labels-nil.golden
@@ -1,0 +1,55 @@
+Client:
+ Context:    default
+ Debug Mode: false
+
+Server:
+ Containers: 0
+  Running: 0
+  Paused: 0
+  Stopped: 0
+ Images: 0
+ Server Version: 17.06.1-ce
+ Storage Driver: aufs
+  Root Dir: /var/lib/docker/aufs
+  Backing Filesystem: extfs
+  Dirs: 0
+  Dirperm1 Supported: true
+ Logging Driver: json-file
+ Cgroup Driver: cgroupfs
+ Plugins:
+  Volume: local
+  Network: bridge host macvlan null overlay
+  Log: awslogs fluentd gcplogs gelf journald json-file logentries splunk syslog
+ Swarm: inactive
+ Runtimes: runc
+ Default Runtime: runc
+ Init Binary: docker-init
+ containerd version: 6e23458c129b551d5c9871e5174f6b1b7f6d1170
+ runc version: 810190ceaa507aa2727d7ae6f4790c76ec150bd2
+ init version: 949e6fa
+ Security Options:
+  apparmor
+  seccomp
+   Profile: default
+ Kernel Version: 4.4.0-87-generic
+ Operating System: Ubuntu 16.04.3 LTS
+ OSType: linux
+ Architecture: x86_64
+ CPUs: 2
+ Total Memory: 1.953GiB
+ Name: system-sample
+ ID: EKHL:QDUU:QZ7U:MKGD:VDXK:S27Q:GIPU:24B7:R7VT:DGN6:QCSF:2UBX
+ Docker Root Dir: /var/lib/docker
+ Debug Mode: true
+  File Descriptors: 33
+  Goroutines: 135
+  System Time: 2017-08-24T17:44:34.077811894Z
+  EventsListeners: 0
+ Registry: https://index.docker.io/v1/
+ Experimental: false
+ Insecure Registries:
+  127.0.0.0/8
+ Live Restore Enabled: false
+ Default Address Pools:
+   Base: 10.123.0.0/16, Size: 24
+


### PR DESCRIPTION
Ths prettyPrintServerInfo() was checking for the Labels property to be nil, but didn't check for empty slices.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

