### PR TITLE
cli: set a timeout for the initial connection ping

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -35,6 +35,8 @@ import (
 	notaryclient "github.com/theupdateframework/notary/client"
 )
 
+const defaultInitTimeout = 2 * time.Second
+
 // Streams is an interface which exposes the standard input and output streams
 type Streams interface {
 	In() *streams.In
@@ -77,6 +79,7 @@ type DockerCli struct {
 	currentContext     string
 	dockerEndpoint     docker.Endpoint
 	contextStoreConfig store.Config
+	initTimeout        time.Duration
 }
 
 // DefaultVersion returns api.defaultVersion.
@@ -313,13 +316,21 @@ func resolveDefaultDockerEndpoint(opts *cliflags.CommonOptions) (docker.Endpoint
 	}, nil
 }
 
+func (cli *DockerCli) getInitTimeout() time.Duration {
+	if cli.initTimeout != 0 {
+		return cli.initTimeout
+	}
+	return defaultInitTimeout
+}
+
 func (cli *DockerCli) initializeFromClient() {
 	ctx := context.Background()
-	if strings.HasPrefix(cli.DockerEndpoint().Host, "tcp://") {
+	host := cli.DockerEndpoint().Host
+	if !strings.HasPrefix(host, "ssh://") {
 		// @FIXME context.WithTimeout doesn't work with connhelper / ssh connections
 		// time="2020-04-10T10:16:26Z" level=warning msg="commandConn.CloseWrite: commandconn: failed to wait: signal: killed"
 		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		ctx, cancel = context.WithTimeout(ctx, cli.getInitTimeout())
 		defer cancel()
 	}
 


### PR DESCRIPTION
Note that this does not fully fix the referenced issue, but
at least makes sure that API clients don't hang forever on
the initialization step. (now it hangs on a later request)

See: https://github.com/docker/cli/issues/3652

**- What I did**
see attached issue

**- How I did it**
see attached issue

**- How to verify it**
The `docker ps` in the attached issue still hangs, but now hangs at a later step. You can see this by running `kill -s ABRT` on the hung process to see where it's hanging

**- Description for the changelog**
Add timeout to initial docker client initialization

**- A picture of a cute animal (not mandatory but encouraged)**
![IMG_20200502_114336](https://user-images.githubusercontent.com/278641/172203770-9cbe5461-d1b2-41cd-81e9-8751f14630b6.jpg)


