### PR TITLE
command: print appropriate warning messages on 'context list'/'contex…

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -456,7 +456,7 @@ func resolveContextName(opts *cliflags.CommonOptions, config *configfile.ConfigF
 	if len(opts.Hosts) > 0 {
 		return DefaultContextName, nil
 	}
-	if _, present := os.LookupEnv(client.EnvOverrideHost); present {
+	if os.Getenv(client.EnvOverrideHost) != "" {
 		return DefaultContextName, nil
 	}
 	if ctxName, ok := os.LookupEnv("DOCKER_CONTEXT"); ok {

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -459,7 +459,7 @@ func resolveContextName(opts *cliflags.CommonOptions, config *configfile.ConfigF
 	if os.Getenv(client.EnvOverrideHost) != "" {
 		return DefaultContextName, nil
 	}
-	if ctxName, ok := os.LookupEnv("DOCKER_CONTEXT"); ok {
+	if ctxName := os.Getenv("DOCKER_CONTEXT"); ctxName != "" {
 		return ctxName, nil
 	}
 	if config != nil && config.CurrentContext != "" {

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -42,7 +42,7 @@ func RunUse(dockerCli command.Cli, name string) error {
 	}
 	fmt.Fprintln(dockerCli.Out(), name)
 	fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)
-	if os.Getenv(client.EnvOverrideHost) != "" {
+	if name != command.DefaultContextName && os.Getenv(client.EnvOverrideHost) != "" {
 		fmt.Fprintf(dockerCli.Err(), "Warning: %[1]s environment variable overrides the active context. "+
 			"To use %[2]q, either set the global --context flag, or unset %[1]s environment variable.\n", client.EnvOverrideHost, name)
 	}

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -1,13 +1,17 @@
 package context
 
 import (
+	"bytes"
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/cli/cli/flags"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestUse(t *testing.T) {
@@ -40,4 +44,78 @@ func TestUseNoExist(t *testing.T) {
 	cli := makeFakeCli(t)
 	err := newUseCommand(cli).RunE(nil, []string{"test"})
 	assert.Check(t, store.IsErrContextDoesNotExist(err))
+}
+
+func TestUseHostOverride(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://ed:2375/")
+
+	configDir := t.TempDir()
+	configFilePath := filepath.Join(configDir, "config.json")
+	testCfg := configfile.New(configFilePath)
+	cli := makeFakeCli(t, withCliConfig(testCfg))
+	err := RunCreate(cli, &CreateOptions{
+		Name:   "test",
+		Docker: map[string]string{},
+	})
+	assert.NilError(t, err)
+
+	cli.ResetOutputBuffers()
+	err = newUseCommand(cli).RunE(nil, []string{"test"})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Contains(
+		cli.ErrBuffer().String(),
+		`Warning: DOCKER_HOST environment variable overrides the active context.`,
+	))
+	assert.Assert(t, is.Contains(cli.ErrBuffer().String(), `Current context is now "test"`))
+	assert.Equal(t, cli.OutBuffer().String(), "test\n")
+
+	// setting DOCKER_HOST with the default context should not print a warning
+	cli.ResetOutputBuffers()
+	err = newUseCommand(cli).RunE(nil, []string{"default"})
+	assert.NilError(t, err)
+	assert.Assert(t, is.Contains(cli.ErrBuffer().String(), `Current context is now "default"`))
+	assert.Equal(t, cli.OutBuffer().String(), "default\n")
+}
+
+// An empty DOCKER_HOST used to break the 'context use' flow.
+// So we have a test with fewer fakes that tests this flow holistically.
+// https://github.com/docker/cli/issues/3667
+func TestUseHostOverrideEmpty(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+
+	configDir := t.TempDir()
+	config.SetDir(configDir)
+
+	socketPath := "unix://" + filepath.Join(configDir, "docker.sock")
+
+	var out *bytes.Buffer
+	var cli *command.DockerCli
+
+	loadCli := func() {
+		out = bytes.NewBuffer(nil)
+
+		var err error
+		cli, err = command.NewDockerCli(command.WithCombinedStreams(out))
+		assert.NilError(t, err)
+		assert.NilError(t, cli.Initialize(flags.NewClientOptions()))
+	}
+	loadCli()
+	err := RunCreate(cli, &CreateOptions{
+		Name:   "test",
+		Docker: map[string]string{"host": socketPath},
+	})
+	assert.NilError(t, err)
+
+	err = newUseCommand(cli).RunE(nil, []string{"test"})
+	assert.NilError(t, err)
+	assert.Assert(t, !is.Contains(out.String(), "Warning")().Success())
+	assert.Assert(t, is.Contains(out.String(), `Current context is now "test"`))
+
+	loadCli()
+	err = newShowCommand(cli).RunE(nil, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, is.Contains(out.String(), "test"))
+
+	apiclient := cli.Client()
+	assert.Equal(t, apiclient.DaemonHost(), socketPath)
 }


### PR DESCRIPTION
**- What I did**
print appropriate warning messages on 'docker context list' and 'docker context use'

**- How I did it**
Makes sure that the use/list implementations use the same logic for checking env
variables as the code that processes the override.

**- How to verify it**
see attached issues

- fixes https://github.com/docker/cli/issues/3667
- fixes https://github.com/docker/cli/issues/1932

**- Description for the changelog**
print appropriate warning messages on 'docker context list' and 'docker context use'

**- A picture of a cute animal (not mandatory but encouraged)**
![PXL_20220522_172707042](https://user-images.githubusercontent.com/278641/172490132-2caf699e-dd06-4db1-ae81-d6efc2ceb72d.jpg)

