### PR TITLE
cli/command/info: Print OSVersion

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -283,6 +283,7 @@ func prettyPrintServerInfo(dockerCli command.Cli, info types.Info) []error {
 
 	fprintlnNonEmpty(dockerCli.Out(), " Kernel Version:", info.KernelVersion)
 	fprintlnNonEmpty(dockerCli.Out(), " Operating System:", info.OperatingSystem)
+	fprintlnNonEmpty(dockerCli.Out(), " OSVersion:", info.OSVersion)
 	fprintlnNonEmpty(dockerCli.Out(), " OSType:", info.OSType)
 	fprintlnNonEmpty(dockerCli.Out(), " Architecture:", info.Architecture)
 	fmt.Fprintln(dockerCli.Out(), " CPUs:", info.NCPU)


### PR DESCRIPTION
Add the Info.OSVersion to the `docker info` output

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>

**- What I did**
Add operating system version to the `docker info` output
**- How I did it**
Print info.OSVersion
**- How to verify it**
`docker info`
**- Description for the changelog**
Added operating system version to docker info output

**- A picture of a cute animal (not mandatory but encouraged)**

