### PR TITLE
docs: fix misleading example of setting an env variable for a single command

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1060,7 +1060,7 @@ If an environment variable is only needed during build, and not in the final
 image, consider setting a value for a single command instead:
 
 ```dockerfile
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y ...
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ...
 ```
  
 Or using [`ARG`](#arg), which is not persisted in the final image:


### PR DESCRIPTION
**- What I did**

Fix a misleading example of setting an environment variable for a single command.

**- How I did it**

The `DEBIAN_FRONTEND` environment variable is used to control the interface by which debconf questions are presented to the user (see [`man 7 debconf`][1]). In `DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y`, the `DEBIAN_FRONTEND` environment variable is only set for the `apt-get update` command which does not ask debconf questions, and will not affect the `apt-get install` command where these questions are actually asked. It should be the other way around.

  [1]: https://manpages.debian.org/debconf.7.html

**- How to verify it**

The way environment variables work for single commands can be tested thus:

```sh
% foo=bar sh -c 'echo "$0: |$foo|"' first_shell && sh -c 'echo "$0: |$foo|"' second_shell
first_shell: |bar|
second_shell: ||
% sh -c 'echo "$0: |$foo|"' first_shell && foo=bar sh -c 'echo "$0: |$foo|"' second_shell
first_shell: ||
second_shell: |bar|
% (export foo=bar; sh -c 'echo "$0: |$foo|"' first_shell && sh -c 'echo "$0: |$foo|"' second_shell)    
first_shell: |bar|
second_shell: |bar|
```

(In the last example, I'm running the commands in a subshell to avoid affecting the environment of my current shell.)

**- Description for the changelog**
Fix misleading example of setting an environment variable for a single command


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/4310271/174573827-4ea09a32-57c7-4f7c-ac79-5b7eecace989.png)
