### PR TITLE
Removed feminine reference

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1430,7 +1430,7 @@ logging drivers.  For detailed information on working with logging drivers, see
 ## Overriding Dockerfile image defaults
 
 When a developer builds an image from a [*Dockerfile*](builder.md)
-or when she commits it, the developer can set a number of default parameters
+or when committing it, the developer can set a number of default parameters
 that take effect when the image starts up as a container.
 
 Four of the Dockerfile commands cannot be overridden at runtime: `FROM`,


### PR DESCRIPTION
This is a minor change, but the documentation was assuming a developer woman instead of just a developer using Docker.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update a minor detail in the documentation

**- How I did it**
Changing the wording

**- How to verify it**
Reading the change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The `docker run` documentation was assuming a developer woman instead of just a developer using Docker.


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://i.pinimg.com/originals/47/c0/dc/47c0dcf071aa4bdafa58781ea5c8d1f6.jpg)
