### PR TITLE
container: validate --pull option on create and run

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -79,6 +79,10 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, options *createOptions, copts *containerOptions) error {
+	if err := validatePullOpt(options.pull); err != nil {
+		reportError(dockerCli.Err(), "create", err.Error(), true)
+		return cli.StatusError{StatusCode: 125}
+	}
 	proxyConfig := dockerCli.ConfigFile().ParseProxyConfig(dockerCli.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetAll()))
 	newEnv := []string{}
 	for k, v := range proxyConfig {
@@ -322,4 +326,20 @@ var localhostIPRegexp = regexp.MustCompile(ipLocalhost)
 // localhost addresses
 func isLocalhost(ip string) bool {
 	return localhostIPRegexp.MatchString(ip)
+}
+
+func validatePullOpt(val string) error {
+	switch val {
+	case PullImageAlways, PullImageMissing, PullImageNever, "":
+		// valid option, but nothing to do yet
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid pull option: '%s': must be one of %q, %q or %q",
+			val,
+			PullImageAlways,
+			PullImageMissing,
+			PullImageNever,
+		)
+	}
 }

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -91,6 +91,10 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copts *containerOptions) error {
+	if err := validatePullOpt(ropts.pull); err != nil {
+		reportError(dockerCli.Err(), "run", err.Error(), true)
+		return cli.StatusError{StatusCode: 125}
+	}
 	proxyConfig := dockerCli.ConfigFile().ParseProxyConfig(dockerCli.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetAll()))
 	newEnv := []string{}
 	for k, v := range proxyConfig {


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/3681

Before this change, specifying the `--pull` flag without a value, could
result in the flag after it, or the positional argument to be used as
value.

This patch makes sure that the value is an expected value;

    docker create --pull --rm hello-world
    docker: invalid pull option: '--rm': must be one of "always", "missing" or "never".

    docker run --pull --rm hello-world
    docker: invalid pull option: '--rm': must be one of "always", "missing" or "never".

    docker run --pull hello-world
    docker: invalid pull option: 'hello-world': must be one of "always", "missing" or "never".


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

