### PR TITLE
docs: fix default value for `dockerd --default-cgroupns` to `private`

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -42,7 +42,7 @@ Options:
       --data-root string                      Root directory of persistent Docker state (default "/var/lib/docker")
   -D, --debug                                 Enable debug mode
       --default-address-pool pool-options     Default address pools for node specific local networks
-      --default-cgroupns-mode string          Default mode for containers cgroup namespace ("host" | "private") (default "host")
+      --default-cgroupns-mode string          Default mode for containers cgroup namespace ("host" | "private") (default "private")
       --default-gateway ip                    Container default gateway IPv4 address
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-ipc-mode string               Default mode for containers ipc ("shareable" | "private") (default "private")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Changed the default value in the documentation of `dockerd` for the option `--default-cgroupns` to represent the actual behavior.

**- How I did it**
-

**- How to verify it**

```shell
❯ docker run --rm --interactive --tty alpine cat /proc/1/cgroup
0::/

❯ docker run --rm --interactive --tty --cgroupns=private alpine cat /proc/1/cgroup
0::/

❯ docker run --rm --interactive --tty --cgroupns=host alpine cat /proc/1/cgroup
0::/docker/b7c280374fd0ad3791520e7e52c9c80ec0a629f11a3a0877a4a4e3229ec061ee
```

On:

```
❯ docker version
Client:
 Cloud integration: v1.0.24
 Version:           20.10.17
 API version:       1.41
 Go version:        go1.17.11
 Git commit:        100c701
 Built:             Mon Jun  6 23:04:45 2022
 OS/Arch:           darwin/arm64
 Context:           default
 Experimental:      true

Server: Docker Desktop 4.10.1 (82475)
 Engine:
  Version:          20.10.17
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.11
  Git commit:       a89b842
  Built:            Mon Jun  6 23:01:01 2022
  OS/Arch:          linux/arm64
  Experimental:     true
 containerd:
  Version:          1.6.6
  GitCommit:        10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1
 runc:
  Version:          1.1.2
  GitCommit:        v1.1.2-0-ga916309
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix documented default value of `dockerd --default-cgroupns` to be `private`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/188284/177725384-b6c24373-9ae3-4bde-aed3-d43228e04511.png)


**Relates to**
- https://github.com/docker/cli/issues/1988
- https://github.com/docker/cli/pull/2024
- (https://github.com/docker/compose/issues/8167)