### PR TITLE
Removing feminine refs in documentation

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1430,7 +1430,7 @@ logging drivers.  For detailed information on working with logging drivers, see
 ## Overriding Dockerfile image defaults
 
 When a developer builds an image from a [*Dockerfile*](https://docs.docker.com/engine/reference/builder/)
-or when she commits it, the developer can set a number of default parameters
+or when committing it, the developer can set a number of default parameters
 that take effect when the image starts up as a container.
 
 Four of the Dockerfile commands cannot be overridden at runtime: `FROM`,

--- a/vendor/github.com/spf13/cobra/active_help.md
+++ b/vendor/github.com/spf13/cobra/active_help.md
@@ -126,7 +126,7 @@ ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([
 ```
 **Note 1**: If the `<PROGRAM>_ACTIVE_HELP` environment variable is set to the string "0", Cobra will automatically disable all Active Help output (even if some output was specified by the program using the `cobra.AppendActiveHelp(...)` function).  Using "0" can simplify your code in situations where you want to blindly disable Active Help without having to call `cobra.GetActiveHelpConfig(cmd)` explicitly.
 
-**Note 2**: If a user wants to disable Active Help for every single program based on Cobra, the environment variable `COBRA_ACTIVE_HELP` can be set to "0".  In this case `cobra.GetActiveHelpConfig(cmd)` will return "0" no matter what the variable `<PROGRAM>_ACTIVE_HELP` is set to.
+**Note 2**: If a user wants to disable Active Help for every single program based on Cobra, she can set the environment variable `COBRA_ACTIVE_HELP` to "0".  In this case `cobra.GetActiveHelpConfig(cmd)` will return "0" no matter what the variable `<PROGRAM>_ACTIVE_HELP` is set to.
 
 **Note 3**: If the user does not set `<PROGRAM>_ACTIVE_HELP` or `COBRA_ACTIVE_HELP` (which will be a common case), the default value for the Active Help configuration returned by `cobra.GetActiveHelpConfig(cmd)` will be the empty string. 
 ## Active Help with Cobra's default completion command

--- a/vendor/github.com/spf13/cobra/active_help.md
+++ b/vendor/github.com/spf13/cobra/active_help.md
@@ -126,7 +126,7 @@ ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([
 ```
 **Note 1**: If the `<PROGRAM>_ACTIVE_HELP` environment variable is set to the string "0", Cobra will automatically disable all Active Help output (even if some output was specified by the program using the `cobra.AppendActiveHelp(...)` function).  Using "0" can simplify your code in situations where you want to blindly disable Active Help without having to call `cobra.GetActiveHelpConfig(cmd)` explicitly.
 
-**Note 2**: If a user wants to disable Active Help for every single program based on Cobra, she can set the environment variable `COBRA_ACTIVE_HELP` to "0".  In this case `cobra.GetActiveHelpConfig(cmd)` will return "0" no matter what the variable `<PROGRAM>_ACTIVE_HELP` is set to.
+**Note 2**: If a user wants to disable Active Help for every single program based on Cobra, the environment variable `COBRA_ACTIVE_HELP` can be set to "0".  In this case `cobra.GetActiveHelpConfig(cmd)` will return "0" no matter what the variable `<PROGRAM>_ACTIVE_HELP` is set to.
 
 **Note 3**: If the user does not set `<PROGRAM>_ACTIVE_HELP` or `COBRA_ACTIVE_HELP` (which will be a common case), the default value for the Active Help configuration returned by `cobra.GetActiveHelpConfig(cmd)` will be the empty string. 
 ## Active Help with Cobra's default completion command


### PR DESCRIPTION
This is a minor change, but the documentation was assuming a developer woman instead of just a developer using Docker.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update a minor detail in the documentation

**- How I did it**
Changing the wording

**- How to verify it**
Reading the change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The `docker run` documentation was assuming a developer woman instead of just a developer using Docker.


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://i.pinimg.com/originals/47/c0/dc/47c0dcf071aa4bdafa58781ea5c8d1f6.jpg)
