### PR TITLE
remove uses of client.IsErrUnauthorized()

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -168,7 +169,7 @@ func loginWithCredStoreCreds(ctx context.Context, dockerCli command.Cli, authCon
 	cliClient := dockerCli.Client()
 	response, err := cliClient.RegistryLogin(ctx, *authConfig)
 	if err != nil {
-		if client.IsErrUnauthorized(err) {
+		if errdefs.IsUnauthorized(err) {
 			fmt.Fprintf(dockerCli.Err(), "Stored credentials invalid or expired\n")
 		} else {
 			fmt.Fprintf(dockerCli.Err(), "Login did not succeed, error: %s\n", err)

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -64,8 +64,6 @@ func TestLoginWithCredStoreCreds(t *testing.T) {
 			expectedMsg: "Authenticating with existing credentials...\n",
 			expectedErr: fmt.Sprintf("Login did not succeed, error: %s\n", testAuthErrMsg),
 		},
-		// can't easily test the 401 case because client.IsErrUnauthorized(err) involving
-		// creating an error of a private type
 	}
 	ctx := context.Background()
 	for _, tc := range testCases {


### PR DESCRIPTION
This function is scheduled to be deprecated, so replacing its use.

- relates to https://github.com/moby/moby/pull/43789


**- A picture of a cute animal (not mandatory but encouraged)**

