### PR TITLE
[20.10] update golang to 1.17.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.17.11
+ARG GO_VERSION=1.17.12
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.17.11
+  GOVERSION: 1.17.12
   DEPVERSION: v0.4.1
 
 install:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.17.11"
+    default = "1.17.12"
 }
 variable "VERSION" {
     default = ""

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.11
+ARG GO_VERSION=1.17.12
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.17.11
+ARG GO_VERSION=1.17.12
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.11
+ARG GO_VERSION=1.17.12
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.3
 
-ARG GO_VERSION=1.17.11
+ARG GO_VERSION=1.17.12
 ARG GOLANGCI_LINTER_SHA="v1.21.0"
 
 FROM    golang:${GO_VERSION}-alpine AS build


### PR DESCRIPTION
go1.17.12 (released 2022-07-12) includes security fixes to the compress/gzip,
encoding/gob, encoding/xml, go/parser, io/fs, net/http, and path/filepath
packages, as well as bug fixes to the compiler, the go command, the runtime,
and the runtime/metrics package. See the Go 1.17.12 milestone on the issue
tracker for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.17.12+label%3ACherryPickApproved

This update addresses:

CVE-2022-1705, CVE-2022-1962, CVE-2022-28131, CVE-2022-30630, CVE-2022-30631,
CVE-2022-30632, CVE-2022-30633, CVE-2022-30635, and CVE-2022-32148.

Full diff: https://github.com/golang/go/compare/go1.17.11...go1.17.12

From the security announcement;
https://groups.google.com/g/golang-announce/c/nqrv9fbR0zE

We have just released Go versions 1.18.4 and 1.17.12, minor point releases. These
minor releases include 9 security fixes following the security policy:

- net/http: improper sanitization of Transfer-Encoding header

  The HTTP/1 client accepted some invalid Transfer-Encoding headers as indicating
  a "chunked" encoding. This could potentially allow for request smuggling, but
  only if combined with an intermediate server that also improperly failed to
  reject the header as invalid.

  This is CVE-2022-1705 and https://go.dev/issue/53188.

- When `httputil.ReverseProxy.ServeHTTP` was called with a `Request.Header` map
  containing a nil value for the X-Forwarded-For header, ReverseProxy would set
  the client IP as the value of the X-Forwarded-For header, contrary to its
  documentation. In the more usual case where a Director function set the
  X-Forwarded-For header value to nil, ReverseProxy would leave the header
  unmodified as expected.

  This is https://go.dev/issue/53423 and CVE-2022-32148.

  Thanks to Christian Mehlmauer for reporting this issue.

- compress/gzip: stack exhaustion in Reader.Read

  Calling Reader.Read on an archive containing a large number of concatenated
  0-length compressed files can cause a panic due to stack exhaustion.

  This is CVE-2022-30631 and Go issue https://go.dev/issue/53168.

- encoding/xml: stack exhaustion in Unmarshal

  Calling Unmarshal on a XML document into a Go struct which has a nested field
  that uses the any field tag can cause a panic due to stack exhaustion.

  This is CVE-2022-30633 and Go issue https://go.dev/issue/53611.

- encoding/xml: stack exhaustion in Decoder.Skip

  Calling Decoder.Skip when parsing a deeply nested XML document can cause a
  panic due to stack exhaustion. The Go Security team discovered this issue, and
  it was independently reported by Juho Nurminen of Mattermost.

  This is CVE-2022-28131 and Go issue https://go.dev/issue/53614.

- encoding/gob: stack exhaustion in Decoder.Decode

  Calling Decoder.Decode on a message which contains deeply nested structures
  can cause a panic due to stack exhaustion.

  This is CVE-2022-30635 and Go issue https://go.dev/issue/53615.

- path/filepath: stack exhaustion in Glob

  Calling Glob on a path which contains a large number of path separators can
  cause a panic due to stack exhaustion.

  Thanks to Juho Nurminen of Mattermost for reporting this issue.

  This is CVE-2022-30632 and Go issue https://go.dev/issue/53416.

- io/fs: stack exhaustion in Glob

  Calling Glob on a path which contains a large number of path separators can
  cause a panic due to stack exhaustion.

  This is CVE-2022-30630 and Go issue https://go.dev/issue/53415.

- go/parser: stack exhaustion in all Parse* functions

  Calling any of the Parse functions on Go source code which contains deeply
  nested types or declarations can cause a panic due to stack exhaustion.

  Thanks to Juho Nurminen of Mattermost for reporting this issue.

  This is CVE-2022-1962 and Go issue https://go.dev/issue/53616.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```markdown
- Update Go runtime to 1.17.12 to address CVE-2022-1705, CVE-2022-1962, CVE-2022-28131,
  CVE-2022-30630, CVE-2022-30631, CVE-2022-30632, CVE-2022-30633, CVE-2022-30635,
  and CVE-2022-32148.
```

**- A picture of a cute animal (not mandatory but encouraged)**

