### PR TITLE
missing DWARF symbol table

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -86,6 +86,12 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo"
 fi
 if [ -n "$GO_STRIP" ]; then
+    # if stripping enabled and building with llvm < 12 against darwin/amd64
+    # platform, it will fail with:
+    #  # github.com/docker/cli/cmd/docker
+    #  /usr/local/go/pkg/tool/linux_amd64/link: /usr/local/go/pkg/tool/linux_amd64/link: running strip failed: exit status 1
+    #  llvm-strip: error: unsupported load command (cmd=0x5)
+    # more info: https://github.com/docker/cli/pull/3717
     GO_LDFLAGS="$GO_LDFLAGS -s -w"
 fi
 export GO_LDFLAGS="$GO_LDFLAGS" # https://github.com/koalaman/shellcheck/issues/2064

--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -71,7 +71,7 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$(go env GOOS)" != "windows" ]; then
 fi
 export GO_BUILDMODE
 
-GO_LDFLAGS="${GO_LDFLAGS:-} -w"
+GO_LDFLAGS="${GO_LDFLAGS:-}"
 GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\""
 GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\""
 GO_LDFLAGS="$GO_LDFLAGS -X \"github.com/docker/cli/cli/version.Version=${VERSION}\""
@@ -86,7 +86,7 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo"
 fi
 if [ -n "$GO_STRIP" ]; then
-    GO_LDFLAGS="$GO_LDFLAGS -s"
+    GO_LDFLAGS="$GO_LDFLAGS -s -w"
 fi
 export GO_LDFLAGS="$GO_LDFLAGS" # https://github.com/koalaman/shellcheck/issues/2064
 


### PR DESCRIPTION
Regression from https://github.com/docker/cli/pull/3320 which always strips DWARF symbol table.

I encounter this issue while trying to debug https://github.com/docker/cli/issues/3621 but also to improve our shell out operations with `debug/buildinfo` pkg (available since Go 1.18) for plugins discovery.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>