### PR TITLE
context use: don't create/update config file and directories if not needed

### DIFF
--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -37,9 +37,14 @@ func RunUse(dockerCli command.Cli, name string) error {
 		configValue = name
 	}
 	dockerConfig := dockerCli.ConfigFile()
-	dockerConfig.CurrentContext = configValue
-	if err := dockerConfig.Save(); err != nil {
-		return err
+	// Avoid updating the config-file if nothing changed. This also prevents
+	// creating the file and config-directory if the default is used and
+	// no config-file existed yet.
+	if dockerConfig.CurrentContext != configValue {
+		dockerConfig.CurrentContext = configValue
+		if err := dockerConfig.Save(); err != nil {
+			return err
+		}
 	}
 	fmt.Fprintln(dockerCli.Out(), name)
 	fmt.Fprintf(dockerCli.Err(), "Current context is now %q\n", name)

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -25,15 +25,16 @@ func newUseCommand(dockerCli command.Cli) *cobra.Command {
 
 // RunUse set the current Docker context
 func RunUse(dockerCli command.Cli, name string) error {
-	if err := store.ValidateContextName(name); err != nil && name != "default" {
-		return err
-	}
-	if _, err := dockerCli.ContextStore().GetMetadata(name); err != nil && name != "default" {
-		return err
-	}
-	configValue := name
-	if configValue == "default" {
-		configValue = ""
+	// configValue uses an empty string for "default"
+	var configValue string
+	if name != command.DefaultContextName {
+		if err := store.ValidateContextName(name); err != nil {
+			return err
+		}
+		if _, err := dockerCli.ContextStore().GetMetadata(name); err != nil {
+			return err
+		}
+		configValue = name
 	}
 	dockerConfig := dockerCli.ConfigFile()
 	dockerConfig.CurrentContext = configValue


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/3668

### context use: skip validation for "default" context

This code was handling validation and parsing, only to discard the results if it was the default context.


### context use: don't create/update config file and directories if not needed

Avoid updating the config-file if nothing changed. This also prevents creating
the file and config-directory if the default is used and no config-file existed
yet.

`config.Save()` performs various steps (creating the directory, updating
or copying permissions, etc etc), which are not needed if the defaults are
used; https://github.com/docker/cli/blob/a445d97c2536f0de37469d0ea9881288d6c49cbf/cli/config/configfile/file.go#L135-L176

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
The client no longer creates or updates the CLI config file when running `docker context use` and the selected context is the current context.
```


**- A picture of a cute animal (not mandatory but encouraged)**

