### PR TITLE
docs: Fix template error in cli example (#3727)

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -107,7 +107,7 @@ $ docker inspect --format='{{.Config.Image}}' $INSTANCE_ID
 You can loop over arrays and maps in the results to produce simple text output:
 
 ```console
-$ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' $INSTANCE_ID
+$ docker inspect --format='{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{with $conf}}{{(index . 0).HostPort}}{{else}}none{{end}} {{end}}' $INSTANCE_ID
 ```
 
 ### Find a specific port mapping


### PR DESCRIPTION
Fixes issue #3727 

```
Template parsing error: template: :1:75: executing "" at <index $conf 0>: error calling index: index of untyped nil
```
