### PR TITLE
Update link to libnetwork docs

### DIFF
--- a/docs/extend/plugins_network.md
+++ b/docs/extend/plugins_network.md
@@ -72,7 +72,7 @@ plugin protocol
 
 The network driver protocol, in addition to the plugin activation call, is
 documented as part of libnetwork:
-[https://github.com/docker/libnetwork/blob/master/docs/remote.md](https://github.com/docker/libnetwork/blob/master/docs/remote.md).
+[https://github.com/moby/moby/blob/master/libnetwork/docs/remote.md](https://github.com/moby/moby/blob/master/libnetwork/docs/remote.md).
 
 ## Related Information
 


### PR DESCRIPTION
Just a small docs update. Fixing a link pointing to the soon to be deleted moby/libnetwork repo to the docs new location in the moby/moby repo.
