### PR TITLE
Move notes about required buildkit

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -495,6 +495,13 @@ $ docker build -t mybuildimage --target build-env .
 
 ### <a name=output></a> Custom build outputs (--output)
 
+> **Note**
+>
+> This feature requires the BuildKit backend. You can either
+> [enable BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) or
+> use the [buildx](https://github.com/docker/buildx) plugin which provides more
+> output type options.
+
 By default, a local container image is created from the build result. The
 `--output` (or `-o`) flag allows you to override this behavior, and a specify a
 custom exporter. For example, custom exporters allow you to export the build
@@ -580,14 +587,14 @@ $ ls ./out
 vndr
 ```
 
+### <a name=cache-from></a> Specifying external cache sources (--cache-from)
+
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
 > [enable BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) or
-> use the [buildx](https://github.com/docker/buildx) plugin which provides more
-> output type options.
-
-### <a name=cache-from></a> Specifying external cache sources (--cache-from)
+> use the [buildx](https://github.com/docker/buildx) plugin. The previous
+> builder has limited support for reusing cache from pre-pulled images.
 
 In addition to local build cache, the builder can reuse the cache generated from
 previous builds with the `--cache-from` flag pointing to an image in the registry.
@@ -622,13 +629,6 @@ On another machine:
 ```console
 $ docker build --cache-from myname/myapp .
 ```
-
-> **Note**
->
-> This feature requires the BuildKit backend. You can either
-> [enable BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) or
-> use the [buildx](https://github.com/docker/buildx) plugin. The previous
-> builder has limited support for reusing cache from pre-pulled images.
 
 ### <a name=squash></a> Squash an image's layers (--squash) (experimental)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

The `docker build` command silently ignores the `--output` flag when buildkit is not used (see #2680 and #2736). It would help to make it clear from the begining of the documentation that this feature requires buildkit.

**- How I did it**

I just moved the note specifying the need for buildkit from the end to the begining of the related section in the documentation. I also did the same for the section about external cache sources.

**- How to verify it**

Check the diff

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Minor update to the CLI `docker build` documentation
