### PR TITLE
complete the "-g" / "--graph" daemon option deprecation

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -633,13 +633,12 @@ and `docker service scale` in Docker 17.10.
 
 **Deprecated In Release: v17.05**
 
+**Removed In Release: v22.06**
+
 The `-g` or `--graph` flag for the `dockerd` or `docker daemon` command was
 used to indicate the directory in which to store persistent data and resource
 configuration and has been replaced with the more descriptive `--data-root`
-flag.
-
-These flags were added before Docker 1.0, so will not be _removed_, only
-_hidden_, to discourage their use.
+flag. These flags were deprecated and hidden in v17.05, and removed in v22.06.
 
 ### Top-level network properties in NetworkSettings
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/28696
- relates to https://github.com/moby/moby/pull/43981

These options were soft-deprecated in Docker 17.05 (https://github.com/moby/moby/pull/28696), and at the time considered to not be removed. However, with the move towards containerd snapshotters, having these options around adds additional complexity to handle fallbacks for deprecated (and hidden) flags, so completing the deprecation.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
complete the "-g" / "--graph" daemon option deprecation
```



**- A picture of a cute animal (not mandatory but encouraged)**

