### PR TITLE
[20.10 backport] lint: update golangci-lint to v1.45.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,10 @@ linters:
     - dogsled
     - gocyclo
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - megacheck
     - misspell
@@ -21,6 +19,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - revive
     - varcheck
 
   disable:
@@ -54,30 +53,65 @@ issues:
     - parameter .* always receives
 
   exclude-rules:
-    # These are copied from the default exclude rules, except for "ineffective break statement"
-    # and GoDoc checks.
-    # https://github.com/golangci/golangci-lint/blob/0cc87df732aaf1d5ad9ce9ca538d38d916918b36/pkg/config/config.go#L36
-    - text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*printf?|os\\.(Un)?Setenv). is not checked"
+    # We prefer to use an "exclude-list" so that new "default" exclusions are not
+    # automatically inherited. We can decide whether or not to follow upstream
+    # defaults when updating golang-ci-lint versions.
+    # Unfortunately, this means we have to copy the whole exclusion pattern, as
+    # (unlike the "include" option), the "exclude" option does not take exclusion
+    # ID's.
+    #
+    # These exclusion patterns are copied from the default excluses at:
+    # https://github.com/golangci/golangci-lint/blob/v1.44.0/pkg/config/issues.go#L10-L104
+
+    # EXC0001
+    - text: "Error return value of .((os\\.)?std(out|err)\\..*|.*Close|.*Flush|os\\.Remove(All)?|.*print(f|ln)?|os\\.(Un)?Setenv). is not checked"
       linters:
         - errcheck
+    # EXC0003
     - text: "func name will be used as test\\.Test.* by other packages, and that stutters; consider calling this"
       linters:
-        - golint
-    - text: "G103: Use of unsafe calls should be audited"
+        - revive
+    # EXC0006
+    - text: "Use of unsafe calls should be audited"
       linters:
         - gosec
-    - text: "G104: Errors unhandled"
+    # EXC0007
+    - text: "Subprocess launch(ed with variable|ing should be audited)"
       linters:
         - gosec
-    - text: "G204: Subprocess launch(ed with (variable|function call)|ing should be audited)"
+    # EXC0008
+    # TODO: evaluate these and fix where needed: G307: Deferring unsafe method "*os.File" on type "Close" (gosec)
+    - text: "(G104|G307)"
       linters:
         - gosec
-    - text: "(G301|G302): (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)"
+    # EXC0009
+    - text: "(Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)"
       linters:
         - gosec
-    - text: "G304: Potential file inclusion via variable"
+    # EXC0010
+    - text: "Potential file inclusion via variable"
       linters:
         - gosec
-    - text: "(G201|G202): SQL string (formatting|concatenation)"
+
+    # Looks like the match in "EXC0007" above doesn't catch this one
+    # TODO: consider upstreaming this to golangci-lint's default exclusion rules
+    - text: "G204: Subprocess launched with a potential tainted input or cmd arguments"
       linters:
         - gosec
+    # Looks like the match in "EXC0009" above doesn't catch this one
+    # TODO: consider upstreaming this to golangci-lint's default exclusion rules
+    - text: "G306: Expect WriteFile permissions to be 0600 or less"
+      linters:
+        - gosec
+
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/cli/command/config/formatter_test.go
+++ b/cli/command/config/formatter_test.go
@@ -19,13 +19,11 @@ func TestConfigContextFormatWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{formatter.Context{Format: NewFormat("table", false)},

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -36,7 +36,7 @@ func TestConfigInspectErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 		{
 			args: []string{"foo", "bar"},

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -155,7 +155,7 @@ func (cid *cidFile) Close() error {
 		return nil
 	}
 	if err := os.Remove(cid.path); err != nil {
-		return errors.Errorf("failed to remove the CID file '%s': %s \n", cid.path, err)
+		return errors.Wrapf(err, "failed to remove the CID file '%s'", cid.path)
 	}
 
 	return nil
@@ -166,7 +166,7 @@ func (cid *cidFile) Write(id string) error {
 		return nil
 	}
 	if _, err := cid.file.Write([]byte(id)); err != nil {
-		return errors.Errorf("Failed to write the container ID to the file: %s", err)
+		return errors.Wrap(err, "failed to write the container ID to the file")
 	}
 	cid.written = true
 	return nil
@@ -177,12 +177,12 @@ func newCIDFile(path string) (*cidFile, error) {
 		return &cidFile{}, nil
 	}
 	if _, err := os.Stat(path); err == nil {
-		return nil, errors.Errorf("Container ID file found, make sure the other container isn't running or delete %s", path)
+		return nil, errors.Errorf("container ID file found, make sure the other container isn't running or delete %s", path)
 	}
 
 	f, err := os.Create(path)
 	if err != nil {
-		return nil, errors.Errorf("Failed to create the container ID file: %s", err)
+		return nil, errors.Wrap(err, "failed to create the container ID file")
 	}
 
 	return &cidFile{path: path, file: f}, nil

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -39,7 +39,7 @@ func TestNewCIDFileWhenFileAlreadyExists(t *testing.T) {
 	defer tempfile.Remove()
 
 	_, err := newCIDFile(tempfile.Path())
-	assert.ErrorContains(t, err, "Container ID file found")
+	assert.ErrorContains(t, err, "container ID file found")
 }
 
 func TestCIDFileCloseWithNoWrite(t *testing.T) {

--- a/cli/command/container/formatter_stats.go
+++ b/cli/command/container/formatter_stats.go
@@ -181,14 +181,14 @@ func (c *statsContext) ID() string {
 
 func (c *statsContext) CPUPerc() string {
 	if c.s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%.2f%%", c.s.CPUPercentage)
 }
 
 func (c *statsContext) MemUsage() string {
 	if c.s.IsInvalid {
-		return fmt.Sprintf("-- / --")
+		return "-- / --"
 	}
 	if c.os == winOSType {
 		return units.BytesSize(c.s.Memory)
@@ -198,28 +198,28 @@ func (c *statsContext) MemUsage() string {
 
 func (c *statsContext) MemPerc() string {
 	if c.s.IsInvalid || c.os == winOSType {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%.2f%%", c.s.MemoryPercentage)
 }
 
 func (c *statsContext) NetIO() string {
 	if c.s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(c.s.NetworkRx, 3), units.HumanSizeWithPrecision(c.s.NetworkTx, 3))
 }
 
 func (c *statsContext) BlockIO() string {
 	if c.s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(c.s.BlockRead, 3), units.HumanSizeWithPrecision(c.s.BlockWrite, 3))
 }
 
 func (c *statsContext) PIDs() string {
 	if c.s.IsInvalid || c.os == winOSType {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%d", c.s.PidsCurrent)
 }

--- a/cli/command/container/formatter_stats_test.go
+++ b/cli/command/container/formatter_stats_test.go
@@ -54,13 +54,11 @@ func TestContainerStatsContextWrite(t *testing.T) {
 	}{
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		{
 			formatter.Context{Format: "table {{.MemUsage}}"},

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -130,13 +130,11 @@ func TestContainerContextWrite(t *testing.T) {
 		// Errors
 		{
 			Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table Format
 		{

--- a/cli/command/formatter/disk_usage_test.go
+++ b/cli/command/formatter/disk_usage_test.go
@@ -61,8 +61,7 @@ CACHE ID   CACHE TYPE   SIZE      CREATED   LAST USED   USAGE     SHARED
 					Format: "{{InvalidFunction}}",
 				},
 			},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			DiskUsageContext{
@@ -70,8 +69,7 @@ CACHE ID   CACHE TYPE   SIZE      CREATED   LAST USED   USAGE     SHARED
 					Format: "{{nil}}",
 				},
 			},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table Format
 		{

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -64,7 +64,7 @@ func (c *Context) preFormat() {
 func (c *Context) parseFormat() (*template.Template, error) {
 	tmpl, err := templates.Parse(c.finalFormat)
 	if err != nil {
-		return tmpl, errors.Errorf("Template parsing error: %v\n", err)
+		return tmpl, errors.Wrap(err, "template parsing error")
 	}
 	return tmpl, err
 }
@@ -85,7 +85,7 @@ func (c *Context) postFormat(tmpl *template.Template, subContext SubContext) {
 
 func (c *Context) contextFormat(tmpl *template.Template, subContext SubContext) error {
 	if err := tmpl.Execute(c.buffer, subContext); err != nil {
-		return errors.Errorf("Template parsing error: %v\n", err)
+		return errors.Wrap(err, "template parsing error")
 	}
 	if c.Format.IsTable() && c.header != nil {
 		c.header = subContext.FullHeader()

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -119,8 +119,7 @@ func TestImageContextWrite(t *testing.T) {
 					Format: "{{InvalidFunction}}",
 				},
 			},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			ImageContext{
@@ -128,8 +127,7 @@ func TestImageContextWrite(t *testing.T) {
 					Format: "{{nil}}",
 				},
 			},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table Format
 		{

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -62,13 +62,11 @@ func TestVolumeContextWrite(t *testing.T) {
 		// Errors
 		{
 			Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -297,7 +297,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		}
 
 		if err := build.ValidateContextDirectory(contextDir, excludes); err != nil {
-			return errors.Errorf("error checking context: '%s'.", err)
+			return errors.Wrap(err, "error checking context")
 		}
 
 		// And canonicalize dockerfile name to a platform-independent one

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -44,7 +44,7 @@ func NewTemplateInspectorFromString(out io.Writer, tmplStr string) (Inspector, e
 
 	tmpl, err := templates.Parse(tmplStr)
 	if err != nil {
-		return nil, errors.Errorf("Template parsing error: %s", err)
+		return nil, errors.Errorf("template parsing error: %s", err)
 	}
 	return NewTemplateInspector(out, tmpl), nil
 }
@@ -94,7 +94,7 @@ func (i *TemplateInspector) Inspect(typedElement interface{}, rawElement []byte)
 	buffer := new(bytes.Buffer)
 	if err := i.tmpl.Execute(buffer, typedElement); err != nil {
 		if rawElement == nil {
-			return errors.Errorf("Template parsing error: %v", err)
+			return errors.Errorf("template parsing error: %v", err)
 		}
 		return i.tryRawInspectFallback(rawElement)
 	}
@@ -118,7 +118,7 @@ func (i *TemplateInspector) tryRawInspectFallback(rawElement []byte) error {
 
 	tmplMissingKey := i.tmpl.Option("missingkey=error")
 	if rawErr := tmplMissingKey.Execute(buffer, raw); rawErr != nil {
-		return errors.Errorf("Template parsing error: %v", rawErr)
+		return errors.Errorf("template parsing error: %v", rawErr)
 	}
 
 	i.buffer.Write(buffer.Bytes())

--- a/cli/command/inspect/inspector_test.go
+++ b/cli/command/inspect/inspector_test.go
@@ -62,7 +62,7 @@ func TestTemplateInspectorTemplateError(t *testing.T) {
 		t.Fatal("Expected error got nil")
 	}
 
-	if !strings.HasPrefix(err.Error(), "Template parsing error") {
+	if !strings.HasPrefix(err.Error(), "template parsing error") {
 		t.Fatalf("Expected template error, got %v", err)
 	}
 }
@@ -98,7 +98,7 @@ func TestTemplateInspectorRawFallbackError(t *testing.T) {
 		t.Fatal("Expected error got nil")
 	}
 
-	if !strings.HasPrefix(err.Error(), "Template parsing error") {
+	if !strings.HasPrefix(err.Error(), "template parsing error") {
 		t.Fatalf("Expected template error, got %v", err)
 	}
 }

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -79,13 +79,11 @@ func TestNetworkContextWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/node/formatter_test.go
+++ b/cli/command/node/formatter_test.go
@@ -62,15 +62,13 @@ func TestNodeContextWrite(t *testing.T) {
 
 		// Errors
 		{
-			context: formatter.Context{Format: "{{InvalidFunction}}"},
-			expected: `Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			context:     formatter.Context{Format: "{{InvalidFunction}}"},
+			expected:    `template parsing error: template: :1: function "InvalidFunction" not defined`,
 			clusterInfo: swarm.ClusterInfo{TLSInfo: swarm.TLSInfo{TrustRoot: "hi"}},
 		},
 		{
-			context: formatter.Context{Format: "{{nil}}"},
-			expected: `Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			context:     formatter.Context{Format: "{{nil}}"},
+			expected:    `template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 			clusterInfo: swarm.ClusterInfo{TLSInfo: swarm.TLSInfo{TrustRoot: "hi"}},
 		},
 		// Table format

--- a/cli/command/plugin/formatter_test.go
+++ b/cli/command/plugin/formatter_test.go
@@ -59,13 +59,11 @@ func TestPluginContextWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/plugin/inspect_test.go
+++ b/cli/command/plugin/inspect_test.go
@@ -61,7 +61,7 @@ func TestInspectErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 	}
 

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -41,7 +41,7 @@ func TestListErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 	}
 

--- a/cli/command/registry/formatter_search_test.go
+++ b/cli/command/registry/formatter_search_test.go
@@ -112,13 +112,11 @@ func TestSearchContextWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/secret/formatter_test.go
+++ b/cli/command/secret/formatter_test.go
@@ -19,13 +19,11 @@ func TestSecretContextFormatWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{formatter.Context{Format: NewFormat("table", false)},

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -36,7 +36,7 @@ func TestSecretInspectErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 		{
 			args: []string{"foo", "bar"},

--- a/cli/command/service/formatter_test.go
+++ b/cli/command/service/formatter_test.go
@@ -29,13 +29,11 @@ func TestServiceContextWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -914,7 +914,7 @@ func addServiceFlags(flags *pflag.FlagSet, opts *serviceOptions, defaultFlagValu
 }
 
 const (
-	flagCredentialSpec          = "credential-spec"
+	flagCredentialSpec          = "credential-spec" //nolint:gosec // ignore G101: Potential hardcoded credentials
 	flagPlacementPref           = "placement-pref"
 	flagPlacementPrefAdd        = "placement-pref-add"
 	flagPlacementPrefRemove     = "placement-pref-rm"

--- a/cli/command/stack/formatter/formatter_test.go
+++ b/cli/command/stack/formatter/formatter_test.go
@@ -16,13 +16,11 @@ func TestStackContextWrite(t *testing.T) {
 		// Errors
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table format
 		{

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -33,7 +33,7 @@ func TestListErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 		{
 			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -28,6 +28,7 @@ func LoadComposefile(dockerCli command.Cli, opts options.Deploy) (*composetypes.
 	config, err := loader.Load(configDetails)
 	if err != nil {
 		if fpe, ok := err.(*loader.ForbiddenPropertiesError); ok {
+			//nolint:revive // ignore capitalization error; this error is intentionally formatted multi-line
 			return nil, errors.Errorf("Compose file contains unsupported options:\n\n%s\n",
 				propertyWarnings(fpe.Properties))
 		}

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -62,7 +62,7 @@ func TestStackServicesErrors(t *testing.T) {
 			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
 				return []swarm.Service{*Service()}, nil
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 	}
 

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -506,7 +506,7 @@ func formatInfo(dockerCli command.Cli, info info, format string) error {
 	tmpl, err := templates.Parse(format)
 	if err != nil {
 		return cli.StatusError{StatusCode: 64,
-			Status: "Template parsing error: " + err.Error()}
+			Status: "template parsing error: " + err.Error()}
 	}
 	err = tmpl.Execute(dockerCli.Out(), info)
 	dockerCli.Out().Write([]byte{'\n'})

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -394,7 +394,7 @@ func TestFormatInfo(t *testing.T) {
 		{
 			doc:           "syntax",
 			template:      "{{}",
-			expectedError: `Status: Template parsing error: template: :1: unexpected "}" in command, Code: 64`,
+			expectedError: `Status: template parsing error: template: :1: unexpected "}" in command, Code: 64`,
 		},
 		{
 			doc:           "syntax",

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -235,7 +235,7 @@ func newVersionTemplate(templateFormat string) (*template.Template, error) {
 	tmpl := templates.New("version").Funcs(template.FuncMap{"getDetailsOrder": getDetailsOrder})
 	tmpl, err := tmpl.Parse(templateFormat)
 
-	return tmpl, errors.Wrap(err, "Template parsing error")
+	return tmpl, errors.Wrap(err, "template parsing error")
 }
 
 func getDetailsOrder(v types.ComponentVersion) []string {

--- a/cli/command/task/formatter_test.go
+++ b/cli/command/task/formatter_test.go
@@ -20,13 +20,11 @@ func TestTaskContextWrite(t *testing.T) {
 	}{
 		{
 			formatter.Context{Format: "{{InvalidFunction}}"},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{Format: "{{nil}}"},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		{
 			formatter.Context{Format: NewTaskFormat("table", true)},

--- a/cli/command/trust/formatter_test.go
+++ b/cli/command/trust/formatter_test.go
@@ -95,15 +95,13 @@ func TestTrustTagContextWrite(t *testing.T) {
 			formatter.Context{
 				Format: "{{InvalidFunction}}",
 			},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{
 				Format: "{{nil}}",
 			},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table Format
 		{
@@ -191,15 +189,13 @@ func TestSignerInfoContextWrite(t *testing.T) {
 			formatter.Context{
 				Format: "{{InvalidFunction}}",
 			},
-			`Template parsing error: template: :1: function "InvalidFunction" not defined
-`,
+			`template parsing error: template: :1: function "InvalidFunction" not defined`,
 		},
 		{
 			formatter.Context{
 				Format: "{{nil}}",
 			},
-			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
-`,
+			`template parsing error: template: :1:2: executing "" at <nil>: nil is not a command`,
 		},
 		// Table Format
 		{

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -32,7 +32,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				if options.name != "" {
-					return errors.Errorf("Conflicting options: either specify --name or provide positional arg, not both\n")
+					return errors.Errorf("conflicting options: either specify --name or provide positional arg, not both")
 				}
 				options.name = args[0]
 			}

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -26,7 +26,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 			flags: map[string]string{
 				"name": "volumeName",
 			},
-			expectedError: "Conflicting options: either specify --name or provide positional arg, not both",
+			expectedError: "conflicting options: either specify --name or provide positional arg, not both",
 		},
 		{
 			args:          []string{"too", "many"},

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -35,7 +35,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 			flags: map[string]string{
 				"format": "{{invalid format}}",
 			},
-			expectedError: "Template parsing error",
+			expectedError: "template parsing error",
 		},
 		{
 			args: []string{"foo", "bar"},

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -99,7 +99,7 @@ func newPathError(path Path, err error) error {
 		return nil
 	case *template.InvalidTemplateError:
 		return errors.Errorf(
-			"invalid interpolation format for %s: %#v. You may need to escape any $ with another $.",
+			"invalid interpolation format for %s: %#v; you may need to escape any $ with another $",
 			path, err.Template)
 	default:
 		return errors.Wrapf(err, "error while interpolating %s", path)

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -58,7 +58,7 @@ func TestInvalidInterpolation(t *testing.T) {
 		},
 	}
 	_, err := Interpolate(services, Options{LookupValue: defaultMapping})
-	assert.Error(t, err, `invalid interpolation format for servicea.image: "${". You may need to escape any $ with another $.`)
+	assert.Error(t, err, `invalid interpolation format for servicea.image: "${"; you may need to escape any $ with another $`)
 }
 
 func TestInterpolateWithDefaults(t *testing.T) {

--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	remoteCredentialsPrefix = "docker-credential-"
+	remoteCredentialsPrefix = "docker-credential-" //nolint:gosec // ignore G101: Potential hardcoded credentials
 	tokenUsername           = "<token>"
 )
 

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG GO_VERSION=1.17.13
-ARG GOLANGCI_LINTER_SHA="v1.21.0"
+ARG GOLANGCI_LINTER_SHA=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build
 ENV     CGO_ENABLED=0


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3502