### PR TITLE
[20.10 backport] Update golang to 1.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.18.4
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18.0
+ARG GO_VERSION=1.18.1
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.18.5
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.17.13
+ARG GO_VERSION=1.18.0
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.17.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
-ARG GO_VERSION=1.18.2
+ARG GO_VERSION=1.18.3
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.18.0
+  GOVERSION: 1.18.1
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.18.3
+  GOVERSION: 1.18.4
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.17.13
+  GOVERSION: 1.18.0
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.18.4
+  GOVERSION: 1.18.5
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.18.1
+  GOVERSION: 1.18.2
   DEPVERSION: v0.4.1
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_folder: c:\gopath\src\github.com\docker\cli
 
 environment:
   GOPATH: c:\gopath
-  GOVERSION: 1.18.2
+  GOVERSION: 1.18.3
   DEPVERSION: v0.4.1
 
 install:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.18.3"
+    default = "1.18.4"
 }
 variable "VERSION" {
     default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.18.0"
+    default = "1.18.1"
 }
 variable "VERSION" {
     default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.18.1"
+    default = "1.18.2"
 }
 variable "VERSION" {
     default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.18.4"
+    default = "1.18.5"
 }
 variable "VERSION" {
     default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.17.13"
+    default = "1.18.0"
 }
 variable "VERSION" {
     default = ""

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.18.2"
+    default = "1.18.3"
 }
 variable "VERSION" {
     default = ""

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.18.5
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.18.4
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.2
+ARG GO_VERSION=1.18.3
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.13
+ARG GO_VERSION=1.18.0
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.binary-native
+++ b/dockerfiles/Dockerfile.binary-native
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.0
+ARG GO_VERSION=1.18.1
 
 FROM    golang:${GO_VERSION}-alpine
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.0
+ARG GO_VERSION=1.18.1
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.17.13
 

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.2
+ARG GO_VERSION=1.18.3
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.18.4
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.18.5
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.17.13
+ARG GO_VERSION=1.18.0
 
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.2
+ARG GO_VERSION=1.18.3
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.18.5
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.0
+ARG GO_VERSION=1.18.1
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.17.13
+ARG GO_VERSION=1.18.0
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.18.4
 
 # Use Debian based image as docker-compose requires glibc.
 FROM golang:${GO_VERSION}-buster

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.0
+ARG GO_VERSION=1.18.1
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.17.13
 ARG GOLANGCI_LINTER_SHA=v1.45.2

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,16 +1,16 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.17.13
-ARG GOLANGCI_LINTER_SHA=v1.45.2
+ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build
 ENV     CGO_ENABLED=0
 RUN     apk add --no-cache git
-ARG     GOLANGCI_LINTER_SHA
+ARG     GOLANGCI_LINT_VERSION
 ARG     GO111MODULE=on
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-        go get github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINTER_SHA}
+        go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
 FROM    golang:${GO_VERSION}-alpine AS lint
 ENV     GO111MODULE=off

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.4
+ARG GO_VERSION=1.18.5
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.2
+ARG GO_VERSION=1.18.3
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.3
+ARG GO_VERSION=1.18.4
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.17.13
+ARG GO_VERSION=1.18.0
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
 FROM    golang:${GO_VERSION}-alpine AS build

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -20,7 +20,7 @@ var basicFunctions = template.FuncMap{
 	},
 	"split":    strings.Split,
 	"join":     strings.Join,
-	"title":    strings.Title,
+	"title":    strings.Title, //nolint:staticcheck // strings.Title is deprecated, but we only use it for ASCII, so replacing with golang.org/x/text is out of scope
 	"lower":    strings.ToLower,
 	"upper":    strings.ToUpper,
 	"pad":      padWithSpace,


### PR DESCRIPTION
Backports:

- https://github.com/docker/cli/pull/3501
- https://github.com/docker/cli/pull/3562
- https://github.com/docker/cli/pull/3600
    - golang.org/x/sys update was already done in https://github.com/docker/cli/pull/3601
- https://github.com/docker/cli/pull/3646
- https://github.com/docker/cli/pull/3706
- https://github.com/docker/cli/pull/3725


Some manual find/replace was needed due to differences between master and this branch