### PR TITLE
cli: use DisplayJSONMessagesToStream

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -199,10 +199,9 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	config := containerConfig.Config
 	hostConfig := containerConfig.HostConfig
 	networkingConfig := containerConfig.NetworkingConfig
-	stderr := dockerCli.Err()
 
-	warnOnOomKillDisable(*hostConfig, stderr)
-	warnOnLocalhostDNS(*hostConfig, stderr)
+	warnOnOomKillDisable(*hostConfig, dockerCli.Err())
+	warnOnLocalhostDNS(*hostConfig, dockerCli.Err())
 
 	var (
 		trustedRef reference.Canonical
@@ -233,7 +232,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	}
 
 	pullAndTagImage := func() error {
-		pullOut := stderr
+		pullOut := dockerCli.Err()
 		if opts.quiet {
 			pullOut = io.Discard
 		}
@@ -273,7 +272,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 		if apiclient.IsErrNotFound(err) && namedRef != nil && opts.pull == PullImageMissing {
 			if !opts.quiet {
 				// we don't want to write to stdout anything apart from container.ID
-				fmt.Fprintf(stderr, "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
+				fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
 			}
 
 			if err := pullAndTagImage(); err != nil {
@@ -291,7 +290,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	}
 
 	for _, warning := range response.Warnings {
-		fmt.Fprintf(stderr, "WARNING: %s\n", warning)
+		fmt.Fprintf(dockerCli.Err(), "WARNING: %s\n", warning)
 	}
 	err = containerIDFile.Write(response.ID)
 	return &response, err

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/opts"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -141,12 +142,7 @@ func pullImage(ctx context.Context, dockerCli command.Cli, image string, platfor
 	}
 	defer responseBody.Close()
 
-	return jsonmessage.DisplayJSONMessagesStream(
-		responseBody,
-		out,
-		dockerCli.Out().FD(),
-		dockerCli.Out().IsTerminal(),
-		nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(out), nil)
 }
 
 type cidFile struct {


### PR DESCRIPTION
This utility function is a wrapper for DisplayJSONMessagesStream, and
already used in various other places, so updating this for consistency.

FWIW; we should look if this function is actually better located inside the CLI code, as only the CLI uses this


**- A picture of a cute animal (not mandatory but encouraged)**

