### PR TITLE
feat: add 'docker containers' alias to match the 'docker images' logic

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -40,7 +40,7 @@ func NewPsCommand(dockerCli command.Cli) *cobra.Command {
 		},
 		Annotations: map[string]string{
 			"category-top": "3",
-			"aliases":      "docker container ls, docker container list, docker container ps, docker ps",
+			"aliases":      "docker container ls, docker container list, docker container ps, docker ps, docker containers",
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}


### PR DESCRIPTION
Signed-off-by: Piotr Ostrowski <piotrostr@google.com>

Added another alias for `docker container ls` command. 

With an already existing `docker images`, `docker containers` would be a nice alias to match the logic and make a consistent command line interface.