### PR TITLE
vendor: github.com/docker/docker-credential-helpers v0.7.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -11,7 +11,7 @@ require (
 	github.com/creack/pty v1.1.11
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/docker v20.10.18+incompatible // v22.06.x - see "replace" for the actual version
-	github.com/docker/docker-credential-helpers v0.6.4
+	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/fvbommel/sortorder v1.0.2

--- a/vendor.sum
+++ b/vendor.sum
@@ -97,7 +97,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
-github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -107,8 +106,8 @@ github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible h1:jKymmAFHtINHFMdm1PiDofRqnedBzHmZ9I+p2z8Upg4=
 github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
-github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
+github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
+github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c/go.mod h1:CADgU4DSXK5QUlFslkQu2yW2TKzFZcXq/leZfM0UH5Q=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/credentials.go
@@ -169,8 +169,8 @@ func Erase(helper Helper, reader io.Reader) error {
 	return helper.Delete(serverURL)
 }
 
-//List returns all the serverURLs of keys in
-//the OS store as a list of strings
+// List returns all the serverURLs of keys in
+// the OS store as a list of strings
 func List(helper Helper, writer io.Writer) error {
 	accts, err := helper.List()
 	if err != nil {
@@ -179,8 +179,8 @@ func List(helper Helper, writer io.Writer) error {
 	return json.NewEncoder(writer).Encode(accts)
 }
 
-//PrintVersion outputs the current version.
+// PrintVersion outputs the current version.
 func PrintVersion(writer io.Writer) error {
-	fmt.Fprintln(writer, Version)
+	fmt.Fprintf(writer, "%s (%s) %s\n", Name, Package, Version)
 	return nil
 }

--- a/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
+++ b/vendor/github.com/docker/docker-credential-helpers/credentials/version.go
@@ -1,4 +1,16 @@
 package credentials
 
-// Version holds a string describing the current version
-const Version = "0.6.4"
+var (
+	// Name is filled at linking time
+	Name = ""
+
+	// Package is filled at linking time
+	Package = "github.com/docker/docker-credential-helpers"
+
+	// Version holds the complete version number. Filled in at linking time.
+	Version = "v0.0.0+unknown"
+
+	// Revision is filled with the VCS (e.g. git) revision being used to build
+	// the program at linking time.
+	Revision = ""
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,8 +75,8 @@ github.com/docker/docker/pkg/streamformatter
 github.com/docker/docker/pkg/stringid
 github.com/docker/docker/pkg/system
 github.com/docker/docker/registry
-# github.com/docker/docker-credential-helpers v0.6.4
-## explicit; go 1.13
+# github.com/docker/docker-credential-helpers v0.7.0
+## explicit; go 1.18
 github.com/docker/docker-credential-helpers/client
 github.com/docker/docker-credential-helpers/credentials
 # github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3759

no significant local changes

full diff: https://github.com/docker/docker-credential-helpers/compare/v0.6.4...v0.7.0
