### PR TITLE
cli/command: NewDockerCli(): use WithStandardStreams()

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -29,7 +29,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/moby/term"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	notaryclient "github.com/theupdateframework/notary/client"
@@ -407,24 +406,13 @@ func NewDockerCli(ops ...DockerCliOption) (*DockerCli, error) {
 	defaultOps := []DockerCliOption{
 		WithContentTrustFromEnv(),
 		WithDefaultContextStoreConfig(),
+		WithStandardStreams(),
 	}
 	ops = append(defaultOps, ops...)
 
 	cli := &DockerCli{}
 	if err := cli.Apply(ops...); err != nil {
 		return nil, err
-	}
-	if cli.out == nil || cli.in == nil || cli.err == nil {
-		stdin, stdout, stderr := term.StdStreams()
-		if cli.in == nil {
-			cli.in = streams.NewIn(stdin)
-		}
-		if cli.out == nil {
-			cli.out = streams.NewOut(stdout)
-		}
-		if cli.err == nil {
-			cli.err = stderr
-		}
 	}
 	return cli, nil
 }


### PR DESCRIPTION
`NewDockerCli` was configuring the standard streams using local code; this patch
instead uses the available `WithStandardStreams()` option to do the same.

There is slight difference in the order of events;

Previously, user-provided options would be applied first, after which NewDockerCli
would check if any of "in", "out", or "err" were nil, and if so set them to the
default stream (or writer) for that output.

The new code unconditionally sets the defaults _before_ applying user-provided
options. In practive, howver, this makes no difference; the fields set are not
exported, and the only functions updating them are `WithStandardStreams`,
`WithInputStream`, and `WithCombinedStream`, neither of which checks the old
value (so always overrides).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

