### PR TITLE
build: replace uses of archive.CanonicalTarNameForPath

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -265,7 +265,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		}
 
 		// And canonicalize dockerfile name to a platform-independent one
-		relDockerfile = archive.CanonicalTarNameForPath(relDockerfile)
+		relDockerfile = filepath.ToSlash(relDockerfile)
 
 		excludes = build.TrimBuildFilesFromExcludes(excludes, relDockerfile, options.dockerfileFromStdin())
 		buildCtx, err = archive.TarWithOptions(contextDir, &archive.TarOptions{

--- a/cli/command/image/build/dockerignore.go
+++ b/cli/command/image/build/dockerignore.go
@@ -32,6 +32,9 @@ func TrimBuildFilesFromExcludes(excludes []string, dockerfile string, dockerfile
 	if keep, _ := fileutils.Matches(".dockerignore", excludes); keep {
 		excludes = append(excludes, "!.dockerignore")
 	}
+
+	// canonicalize dockerfile name to be platform-independent.
+	dockerfile = filepath.ToSlash(dockerfile)
 	if keep, _ := fileutils.Matches(dockerfile, excludes); keep && !dockerfileFromStdin {
 		excludes = append(excludes, "!"+dockerfile)
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/44060
- relates to https://github.com/moby/moby/pull/37356#discussion_r198622023

As it's just an alias for filepath.IsAbs. Also added a normalize step in
TrimBuildFilesFromExcludes, so that callers are not _required_ to first
normalize the path.

We are considering deprecating and/or removing this function in the archive
package, so removing it in the cli code helps transitioning if we decide to
deprecate and/or remove it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

