### PR TITLE
cli: createContainer() remove intermediate variable

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -203,10 +203,9 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	config := containerConfig.Config
 	hostConfig := containerConfig.HostConfig
 	networkingConfig := containerConfig.NetworkingConfig
-	stderr := dockerCli.Err()
 
-	warnOnOomKillDisable(*hostConfig, stderr)
-	warnOnLocalhostDNS(*hostConfig, stderr)
+	warnOnOomKillDisable(*hostConfig, dockerCli.Err())
+	warnOnLocalhostDNS(*hostConfig, dockerCli.Err())
 
 	var (
 		trustedRef reference.Canonical
@@ -237,7 +236,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	}
 
 	pullAndTagImage := func() error {
-		pullOut := stderr
+		pullOut := dockerCli.Err()
 		if opts.quiet {
 			pullOut = io.Discard
 		}
@@ -277,7 +276,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 		if apiclient.IsErrNotFound(err) && namedRef != nil && opts.pull == PullImageMissing {
 			if !opts.quiet {
 				// we don't want to write to stdout anything apart from container.ID
-				fmt.Fprintf(stderr, "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
+				fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
 			}
 
 			if err := pullAndTagImage(); err != nil {
@@ -295,7 +294,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 	}
 
 	for _, warning := range response.Warnings {
-		fmt.Fprintf(stderr, "WARNING: %s\n", warning)
+		fmt.Fprintf(dockerCli.Err(), "WARNING: %s\n", warning)
 	}
 	err = containerIDFile.Write(response.ID)
 	return &response, err


### PR DESCRIPTION
Having the intermediate variable made it difficult to see if it was
possibly mutated and/or something special done with it, so just use
the cli's accessors to get its Err().


**- A picture of a cute animal (not mandatory but encouraged)**

