### PR TITLE
cli: hide old CREATED times, instead of "52 years ago"

### DIFF
--- a/cli/command/image/formatter_history.go
+++ b/cli/command/image/formatter_history.go
@@ -82,9 +82,15 @@ func (c *historyContext) CreatedAt() string {
 	return time.Unix(c.h.Created, 0).Format(time.RFC3339)
 }
 
+// epoch is the time before which created-at dates are not displayed with human units.
+var epoch = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
 func (c *historyContext) CreatedSince() string {
 	if !c.human {
 		return c.CreatedAt()
+	}
+	if c.h.Created <= epoch {
+		return ""
 	}
 	created := units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
 	return created + " ago"


### PR DESCRIPTION
Fixes https://github.com/docker/cli/issues/2995

**- What I did**

Changed formatting code for the `CREATED` column to display no text if the date being formatted is older than the year 2000. This value was chosen because it is (currently) unlikely that an image was actually created before that date.

**- How I did it**

I updated `formatter_history.go` to handle this new case when displaying dates for human consumption (the default).

**- How to verify it**

I added unit tests, which pass in my environment. I'm happy to add any other tests that reviewers may find useful.

**- Description for the changelog**

Hide `CREATED` dates that are older than the year 2000, where normal relative dates (e.g., "52 years ago") are likely misleading.

**- A picture of a cute animal (not mandatory but encouraged)**

![tinyoctopus](https://user-images.githubusercontent.com/210737/190668848-099fd5f6-6f4a-4c0d-a360-2f5dce167de5.jpeg)
