### PR TITLE
cli: use N/A as placeholder for old CREATED dates

### DIFF
--- a/cli/command/image/formatter_history.go
+++ b/cli/command/image/formatter_history.go
@@ -90,7 +90,7 @@ func (c *historyContext) CreatedSince() string {
 		return c.CreatedAt()
 	}
 	if c.h.Created <= epoch {
-		return ""
+		return "N/A"
 	}
 	created := units.HumanDuration(time.Now().UTC().Sub(time.Unix(c.h.Created, 0)))
 	return created + " ago"


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

As suggested by @tianon in https://github.com/docker/cli/pull/3778#discussion_r973280677

ref https://github.com/docker/cli/issues/2995

@thaJeztah @tonistiigi 

NB: This also fixes a test failure introduced in #3778, ignored because the test was [skipped](https://github.com/docker/cli/actions/runs/3068753322/jobs/4956973050#step:4:364), because GitHub Runners don't run in UTC. The test that was skipped doesn't seem to actually require UTC though, so I've removed the skip and fixed the failure. The test now correctly checks that an image reported as being created 11 years ago prints `11 years ago`.

edit: the UTC skip was added 3 years ago in https://github.com/docker/cli/pull/2427, I'm not sure if that's still needed for some situations. If we add it back we should make sure the test isn't skipped in CI at least.

**- What I did**

Changed placeholder text for old `CREATED` dates to `N/A` from an empty string

**- How I did it**

I carefully edited text files describing the behavior the program should follow.

**- How to verify it**

`make test-unit`, now with 100% more actually running tests.

**- Description for the changelog**

Images that report a `created` date before the years 2000 are displayed with a `CREATED` date of `N/A`.

**- A picture of a cute animal (not mandatory but encouraged)**

![tiny_octopus](https://user-images.githubusercontent.com/210737/190728286-3b7e79ae-26f8-45a0-9892-2d2555d710a1.jpeg)
