### PR TITLE
un-skip history test and fix golden mismatches

### DIFF
--- a/cli/command/image/testdata/history-command-success.non-human.golden
+++ b/cli/command/image/testdata/history-command-success.non-human.golden
@@ -1,2 +1,2 @@
-IMAGE               CREATED AT             CREATED BY          SIZE                COMMENT
-abcdef              2017-01-01T12:00:03Z   rose                0                   new history item!
+IMAGE     CREATED AT             CREATED BY   SIZE      COMMENT
+abcdef    2017-01-01T12:00:03Z   rose         0         new history item!

--- a/cli/command/image/testdata/history-command-success.simple.golden
+++ b/cli/command/image/testdata/history-command-success.simple.golden
@@ -1,2 +1,2 @@
-IMAGE               CREATED                  CREATED BY          SIZE                COMMENT
-123456789012        Less than a second ago                       0B                  
+IMAGE          CREATED                  CREATED BY   SIZE      COMMENT
+123456789012   Less than a second ago                0B        


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

As discovered in https://github.com/docker/cli/pull/3779#discussion_r974281026, these tests were skipped because CI doesn't run in UTC. The failures don't seem to require UTC, only updating the golden file's column spacing to match current reality.

**- What I did**

Un-skipped tests in history_test.go

**- How I did it**

Removed `skip` from `history_test.go`, added `t.Run` wrappers so that failed assertions didn't stop other tests from running. Updated golden files to match test expectations.

**- How to verify it**

`make dev && make test-unit`

**- Description for the changelog**

Image history tests are no longer skipped on CI.

**- A picture of a cute animal (not mandatory but encouraged)**

![octoeyes](https://user-images.githubusercontent.com/210737/191036904-caba95b7-d275-4b9b-98b3-a1c6eab6af09.jpeg)

cc @thaJeztah 