### PR TITLE
vendor: docker v20.10.3-0.20220922131805-e143eed8bc4f (22.06 branch)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -77,7 +77,7 @@ require (
 )
 
 replace (
-	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220909113731-8af2e62556de+incompatible // 22.06 branch (v22.06-dev)
+	github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible // 22.06 branch (v22.06-dev)
 
 	// Resolve dependency hell with github.com/cloudflare/cfssl (transitive via
 	// swarmkit) by pinning the certificate-transparency-go version. Remove once

--- a/vendor.sum
+++ b/vendor.sum
@@ -105,8 +105,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xb
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.3-0.20220909113731-8af2e62556de+incompatible h1:lzZdObw3Peiyj/aiSPKl+NqJk3hqo8a1LeT/sitg9/c=
-github.com/docker/docker v20.10.3-0.20220909113731-8af2e62556de+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible h1:jKymmAFHtINHFMdm1PiDofRqnedBzHmZ9I+p2z8Upg4=
+github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/client/container_create.go
+++ b/vendor/github.com/docker/docker/client/container_create.go
@@ -26,21 +26,23 @@ func (cli *Client) ContainerCreate(ctx context.Context, config *container.Config
 	if err := cli.NewVersionError("1.25", "stop timeout"); config != nil && config.StopTimeout != nil && err != nil {
 		return response, err
 	}
-
-	clientVersion := cli.ClientVersion()
-
-	// When using API 1.24 and under, the client is responsible for removing the container
-	if hostConfig != nil && versions.LessThan(clientVersion, "1.25") {
-		hostConfig.AutoRemove = false
-	}
-
-	// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
-	if hostConfig != nil && platform != nil && platform.OS == "linux" && versions.LessThan(clientVersion, "1.42") {
-		hostConfig.ConsoleSize = [2]uint{0, 0}
-	}
-
 	if err := cli.NewVersionError("1.41", "specify container image platform"); platform != nil && err != nil {
 		return response, err
+	}
+
+	if hostConfig != nil {
+		if versions.LessThan(cli.ClientVersion(), "1.25") {
+			// When using API 1.24 and under, the client is responsible for removing the container
+			hostConfig.AutoRemove = false
+		}
+		if versions.GreaterThanOrEqualTo(cli.ClientVersion(), "1.42") || versions.LessThan(cli.ClientVersion(), "1.40") {
+			// KernelMemory was added in API 1.40, and deprecated in API 1.42
+			hostConfig.KernelMemory = 0
+		}
+		if platform != nil && platform.OS == "linux" && versions.LessThan(cli.ClientVersion(), "1.42") {
+			// When using API under 1.42, the Linux daemon doesn't respect the ConsoleSize
+			hostConfig.ConsoleSize = [2]uint{0, 0}
+		}
 	}
 
 	query := url.Values{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -39,7 +39,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v20.10.18+incompatible => github.com/docker/docker v20.10.3-0.20220909113731-8af2e62556de+incompatible
+# github.com/docker/docker v20.10.18+incompatible => github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
@@ -394,5 +394,5 @@ gotest.tools/v3/internal/format
 gotest.tools/v3/internal/source
 gotest.tools/v3/poll
 gotest.tools/v3/skip
-# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220909113731-8af2e62556de+incompatible
+# github.com/docker/docker => github.com/docker/docker v20.10.3-0.20220922131805-e143eed8bc4f+incompatible
 # github.com/google/certificate-transparency-go => github.com/google/certificate-transparency-go v1.0.20


### PR DESCRIPTION
full diff: https://github.com/docker/docker/compare/8af2e62556de...e143eed8bc4fcdd5eff73d649130f0d97c2e7723

- client: ignore kernel-memory on API >= 1.42


**- A picture of a cute animal (not mandatory but encouraged)**

