### PR TITLE
Add bindMaps feature (#3786)

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -100,6 +100,8 @@ func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, options *createOptio
 		reportError(dockerCli.Err(), "create", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}
 	}
+	dockerCli.ConfigFile().ApplyBindMap(dockerCli.Client().DaemonHost(), containerConfig.HostConfig.Binds)
+	dockerCli.ConfigFile().ApplyBindMapToMounts(dockerCli.Client().DaemonHost(), containerConfig.HostConfig.Mounts)
 	if err = validateAPIVersion(containerConfig, dockerCli.Client().ClientVersion()); err != nil {
 		reportError(dockerCli.Err(), "create", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -111,6 +111,8 @@ func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copt
 		reportError(dockerCli.Err(), "run", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}
 	}
+	dockerCli.ConfigFile().ApplyBindMap(dockerCli.Client().DaemonHost(), containerConfig.HostConfig.Binds)
+	dockerCli.ConfigFile().ApplyBindMapToMounts(dockerCli.Client().DaemonHost(), containerConfig.HostConfig.Mounts)
 	if err = validateAPIVersion(containerConfig, dockerCli.CurrentVersion()); err != nil {
 		reportError(dockerCli.Err(), "run", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -220,6 +220,25 @@ sections for configuring proxy settings for the cli and daemon.
 > the container's configuration, and as such can be inspected through the remote
 > API or committed to an image when using `docker commit`.
 
+### Auto-mappings for host paths in bind mounts
+
+The property `bindMaps` specifies maps for host paths in bind mounts. It's useful when your docker daemon is running on another host and filesystem is shared via network.
+Consider a case that your home directory is located at `/home/user1` and it's mounted on `/nfs/hostA/user1` on the machine where the docker daemon is running. You can run `docker run -v /home/user1/work:/workspace ...` successfully with following configuration for that case:
+
+```json
+{% raw %}
+{
+  "bindMaps": {
+    "default": {
+      "/home/user1": "/nfs/hostA/user1"
+    }
+  }
+}
+{% endraw %}
+```
+
+docker-cli converts the volume mount option `/home/user1/work:/workspace` to `/nfs/hostA/user1/work:/workspace` automatically. `"default"` is the configuration used for any docker daemon. Instead you can configure them for a specific host (docker daemon) like `"https://docker-daemon1.example.com"`.
+
 ### Default key-sequence to detach from containers
 
 Once attached to a container, users detach from it and leave it running using
@@ -294,7 +313,16 @@ various fields:
       "httpProxy":  "http://user:pass@example.com:3128",
       "httpsProxy": "https://my-proxy.example.com:3129"
     }
-  }
+  },
+  "bindMaps": {
+    "default": {
+      "/frompath1": "/topath1",
+      "/frompath2": "/topath2"
+    },
+    "tcp://127.0.0.1:2375": {
+      "C:\\": "/mnt/c/"
+    }
+  },
 }
 {% endraw %}
 ```


### PR DESCRIPTION
- implements https://github.com/docker/cli/issues/3786

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This change allows host paths in bind mounts specified in `docker` command line automatically mapped to the paths suitable in hosts where dockerd runs.

**- How I did it**

I introduced a new `"bindMaps`" member in `.docker/config.json`.
It defines paths to map.

For example, if your local path `/home/ikedam` is actually located on `/exports/ikedam` on the host where dockerd run, your `.docker/config.json` would be like this:

```
{
  "bindMaps": {
    "/home/ikedam": "/exports/ikedam"
  }
}
```

That configuration converts `docker run -v "/home/ikedam/work:/worksapce" ...` to `docker run -v "/exports/ikedam/work:/workspace", and that would work correct on the remote machine.
It would be especially useful when used with `docker run -v "./work:/workspace" ...` or `docker run -v "$(pwd)/work:/workspace" ...`.

**- How to verify it**

Instructions to test on Windows and WSL2:

* Build `docker` command:

    * checkout this branch.
    * Build a command for Windows (This must be performed on an environment with docker):

        ```
        docker buildx bake --set binary.platform=windows/amd64
        ```

    * `build\docker-windows-amd64.exe` will be available and rename that to `docker.exe`.

* Set up WSL2 distribution (You can skip here if you have already an appropriate WSL2 distribution available):
    * Set the version of WSL to 2.

        ```
        wsl --set-default-version 2
        ```

    * Install Ubuntu-20.04.
        ```
         wsl --install -d Ubuntu-20.04
        ```
    * Set up your unix user.

* Install dockerd on WSL2:

    * Install Docker Engine following the instructions in https://docs.docker.com/engine/install/ubuntu/
        * Note: dockerd doesn't launch automatically.
    * Configure dockerd to accept 127.0.0.1:2375 (for access from Windows)

        ```
        $ cat /etc/default/docker
        ...
        DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://127.0.0.1:2375"
        ...
        ```

    * Start dockerd. NOTE: dockerd doesn't start automatically, and you must start it every time you log onto Windows.

        ```
        $ sudo service docker start
        ```

* Test bindMaps feature from Windows:

    * Create %USERPROFILE%\.docker\config.json like this:

        ```
        {
          "bindMaps": {
            "default": {
              "C:\\": "/mnt/c"
            }
          }
        }
        ```

    * Configure DOCKER_HOST to connect to dockerd on WSL2:

        ```
        > ${ENV:DOCKER_HOST}="tcp://127.0.0.1:2375"
        ```

        * expected to be run on Powershell.

    * Run `docker` command. Consider built `docker` command is available in the current directory:

        ```
        > echo "test!" >index.html
        > .\docker run --rm -p 8080:80 -v ".:/usr/local/apache2/htdocs" --name httpd -d httpd:2.4-alpine
        > Invoke-WebRequest http://127.0.0.1:8080
        > .\docker stop httpd
        ```

        * The output from `Invoke-WebResuest` would contain "test!". That means bindMaps feature allows you to specify bind mount with Windows paths, even though the docker daemon run on a WSL2 distribution.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Add bindMaps feature: host paths in bind mounts can be mapped to another paths, like actual paths on the remote machine


closes #3786 
