### PR TITLE
fix broken alias check is buildx is installed as alias for builder

### DIFF
--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -26,8 +27,10 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 		if _, ok := allowedAliases[k]; !ok {
 			return args, osArgs, errors.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
 		}
-		if _, _, err := cmd.Find(strings.Split(v, " ")); err == nil {
-			return args, osArgs, errors.Errorf("not allowed to alias with builtin %q as target", v)
+		if c, _, err := cmd.Find(strings.Split(v, " ")); err == nil {
+			if c.Annotations[pluginmanager.CommandAnnotationPlugin] != "true" {
+				return args, osArgs, errors.Errorf("not allowed to alias with builtin %q as target", v)
+			}
 		}
 		aliases = append(aliases, [2][]string{{k}, {v}})
 	}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -218,12 +218,12 @@ func runDocker(dockerCli *command.DockerCli) error {
 		return err
 	}
 
-	err = pluginmanager.AddPluginCommandStubs(dockerCli, cmd)
+	args, os.Args, err = processAliases(dockerCli, cmd, args, os.Args)
 	if err != nil {
 		return err
 	}
 
-	args, os.Args, err = processAliases(dockerCli, cmd, args, os.Args)
+	err = pluginmanager.AddPluginCommandStubs(dockerCli, cmd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/3789
- relates to https://github.com/docker/cli/pull/3429
- relates to https://github.com/docker/cli/issues/3621


Commit cbec75e2f3f5afd3334db693829a6b150612076c (https://github.com/docker/cli/pull/3429) updated `runDocker()` to load plugin-stubs before `processAliases()` was executed. As a result, plugin stubs were considered as "builtin commands", causing the alias verification to fail;

Without alias installed:

```bash
docker version
Client:
 Version:           22.06.0-beta.0-140-g3dad26ca2.m
 API version:       1.42
 Go version:        go1.19.1
 Git commit:        3dad26ca2
 Built:             Wed Sep 28 22:36:09 2022
 OS/Arch:           darwin/arm64
 Context:           default
...
```

After running `docker buildx install`;

```bash
./build/docker buildx install

cat ~/.docker/config.json
{
    "aliases": {
        "builder": "buildx"
    }
}

./build/docker version
not allowed to alias with builtin "buildx" as target
```

This patch moves loading the stubs _after_ the call to `processAliases()`, so that verification passes. As an extra precaution, the `processAliases()` function is also updated to exclude plugin-stub commands.

Note that cbec75e2f3f5afd3334db693829a6b150612076c (https://github.com/docker/cli/pull/3429) also introduced a performance regression (https://github.com/docker/cli/issues/3621), which may be related to the early loading of plugins (and creating stubs); it looks like various other code locations may also be loading plugins, for example `tryPluginRun()` calls `pluginmanager.PluginRunCommand()`, which also traverses plugin directories.

We should look under what circumstances the plugin stub-commands are actually needed, and make sure that they're only created in those situations.


**- A picture of a cute animal (not mandatory but encouraged)**

