### PR TITLE
cli-plugins/manager: add IsPluginCommand(() utility

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -224,3 +224,8 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 	}
 	return nil, errPluginNotFound(name)
 }
+
+// IsPluginCommand checks if the given cmd is a plugin-stub.
+func IsPluginCommand(cmd *cobra.Command) bool {
+	return cmd.Annotations[CommandAnnotationPlugin] == "true"
+}

--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -69,7 +69,7 @@ func newPlugin(c Candidate, rootcmd *cobra.Command) (Plugin, error) {
 			// Ignore conflicts with commands which are
 			// just plugin stubs (i.e. from a previous
 			// call to AddPluginCommandStubs).
-			if p := cmd.Annotations[CommandAnnotationPlugin]; p == "true" {
+			if IsPluginCommand(cmd) {
 				continue
 			}
 			if cmd.Name() == p.Name {

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -237,7 +237,7 @@ func hasAdditionalHelp(cmd *cobra.Command) bool {
 }
 
 func isPlugin(cmd *cobra.Command) bool {
-	return cmd.Annotations[pluginmanager.CommandAnnotationPlugin] == "true"
+	return pluginmanager.IsPluginCommand(cmd)
 }
 
 func hasAliases(cmd *cobra.Command) bool {

--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -28,7 +28,7 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 			return args, osArgs, errors.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
 		}
 		if c, _, err := cmd.Find(strings.Split(v, " ")); err == nil {
-			if c.Annotations[pluginmanager.CommandAnnotationPlugin] != "true" {
+			if !pluginmanager.IsPluginCommand(c) {
 				return args, osArgs, errors.Errorf("not allowed to alias with builtin %q as target", v)
 			}
 		}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -131,7 +131,7 @@ func tryRunPluginHelp(dockerCli command.Cli, ccmd *cobra.Command, cargs []string
 func setHelpFunc(dockerCli command.Cli, cmd *cobra.Command) {
 	defaultHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(ccmd *cobra.Command, args []string) {
-		if ccmd.Annotations[pluginmanager.CommandAnnotationPlugin] == "true" {
+		if pluginmanager.IsPluginCommand(ccmd) {
 			err := tryRunPluginHelp(dockerCli, ccmd, args)
 			if !pluginmanager.IsNotFound(err) {
 				ccmd.Println(err)
@@ -229,8 +229,8 @@ func runDocker(dockerCli *command.DockerCli) error {
 	}
 
 	if len(args) > 0 {
-		command, _, err := cmd.Find(args)
-		if err != nil || command.Annotations[pluginmanager.CommandAnnotationPlugin] == "true" {
+		ccmd, _, err := cmd.Find(args)
+		if err != nil || pluginmanager.IsPluginCommand(ccmd) {
 			err := tryPluginRun(dockerCli, cmd, args[0])
 			if !pluginmanager.IsNotFound(err) {
 				return err


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3795

This makes it more convenient to check if a command is a plugin-stub


**- A picture of a cute animal (not mandatory but encouraged)**

