### PR TITLE
Use gofumpt if available, and enable gofumpt linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - depguard
     - dogsled
     - gocyclo
+    - gofumpt
     - goimports
     - gosec
     - gosimple

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ mind when nudging others to comply.
 
 The rules:
 
-1. All code should be formatted with `gofmt -s`.
+1. All code should be formatted with `gofumpt` (preferred) or `gofmt -s`.
 2. All code should pass the default levels of
    [`golint`](https://github.com/golang/lint).
 3. All code should follow the guidelines covered in [Effective

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@
 # Sets the name of the company that produced the windows binary.
 PACKAGER_NAME ?=
 
+# The repository doesn't have a go.mod, but "go list", and "gotestsum"
+# expect to be run from a module.
+GO111MODULE=auto
+export GO111MODULE
+
 all: binary
 
 _:=$(shell ./scripts/warn-outside-container $(MAKECMDGOALS))
@@ -45,8 +50,12 @@ shellcheck: ## run shellcheck validation
 	find scripts/ contrib/completion/bash -type f | grep -v scripts/winresources | grep -v '.*.ps1' | xargs shellcheck
 
 .PHONY: fmt
-fmt: ## run gofmt
-	go list -f {{.Dir}} ./... | xargs gofmt -w -s -d
+fmt: ## run gofumpt (if present) or gofmt
+	@if command -v gofumpt > /dev/null; then \
+		gofumpt -w -d -lang=1.19 . ; \
+	else \
+		go list -f {{.Dir}} ./... | xargs gofmt -w -s -d ; \
+	fi
 
 .PHONY: binary
 binary: ## build executable for Linux

--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -86,10 +86,10 @@ func TestGetPlugin(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(),
 		fs.WithFile("docker-bbb", `
 #!/bin/sh
-echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0777)),
+echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0o777)),
 		fs.WithFile("docker-aaa", `
 #!/bin/sh
-echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0777)),
+echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 
@@ -109,10 +109,10 @@ func TestListPluginsIsSorted(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(),
 		fs.WithFile("docker-bbb", `
 #!/bin/sh
-echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0777)),
+echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0o777)),
 		fs.WithFile("docker-aaa", `
 #!/bin/sh
-echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0777)),
+echo '{"SchemaVersion":"0.1.0"}'`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 

--- a/cli/command/context/export-import_test.go
+++ b/cli/command/context/export-import_test.go
@@ -69,7 +69,7 @@ func TestExportExistingFile(t *testing.T) {
 	contextFile := filepath.Join(t.TempDir(), "exported")
 	cli := makeFakeCli(t)
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, os.WriteFile(contextFile, []byte{}, 0644))
+	assert.NilError(t, os.WriteFile(contextFile, []byte{}, 0o644))
 	err := RunExport(cli, &ExportOptions{ContextName: "test", Dest: contextFile})
 	assert.Assert(t, os.IsExist(err))
 }

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -52,7 +52,7 @@ func writeTo(dockerCli command.Cli, reader io.Reader, dest string) error {
 		}
 		writer = dockerCli.Out()
 	} else {
-		f, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		f, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {
 			return err
 		}

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -400,7 +400,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 		if imageID == "" {
 			return errors.Errorf("Server did not provide an image ID. Cannot write %s", options.imageIDFile)
 		}
-		if err := os.WriteFile(options.imageIDFile, []byte(imageID), 0666); err != nil {
+		if err := os.WriteFile(options.imageIDFile, []byte(imageID), 0o666); err != nil {
 			return err
 		}
 	}

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -384,7 +384,7 @@ func AddDockerfileToBuildContext(dockerfileCtx io.ReadCloser, buildCtx io.ReadCl
 		randomName: func(_ string, _ *tar.Header, _ io.Reader) (*tar.Header, []byte, error) {
 			header := &tar.Header{
 				Name:       randomName,
-				Mode:       0600,
+				Mode:       0o600,
 				ModTime:    now,
 				Typeflag:   tar.TypeReg,
 				AccessTime: now,
@@ -397,7 +397,7 @@ func AddDockerfileToBuildContext(dockerfileCtx io.ReadCloser, buildCtx io.ReadCl
 			if h == nil {
 				h = &tar.Header{
 					Name:       ".dockerignore",
-					Mode:       0600,
+					Mode:       0o600,
 					ModTime:    now,
 					Typeflag:   tar.TypeReg,
 					AccessTime: now,

--- a/cli/command/image/build/context_test.go
+++ b/cli/command/image/build/context_test.go
@@ -233,7 +233,7 @@ func createTestTempDir(t *testing.T) string {
 func createTestTempFile(t *testing.T, dir, filename, contents string) string {
 	t.Helper()
 	filePath := filepath.Join(dir, filename)
-	err := os.WriteFile(filePath, []byte(contents), 0777)
+	err := os.WriteFile(filePath, []byte(contents), 0o777)
 	assert.NilError(t, err)
 	return filePath
 }

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -139,9 +139,9 @@ func TestRunBuildFromLocalGitHubDir(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
 
 	buildDir := filepath.Join(t.TempDir(), "github.com", "docker", "no-such-repository")
-	err := os.MkdirAll(buildDir, 0777)
+	err := os.MkdirAll(buildDir, 0o777)
 	assert.NilError(t, err)
-	err = os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM busybox\n"), 0644)
+	err = os.WriteFile(filepath.Join(buildDir, "Dockerfile"), []byte("FROM busybox\n"), 0o644)
 	assert.NilError(t, err)
 
 	client := test.NewFakeCli(&fakeClient{})

--- a/cli/command/service/create_test.go
+++ b/cli/command/service/create_test.go
@@ -118,7 +118,7 @@ func TestSetConfigsWithCredSpecAndConfigs(t *testing.T) {
 			// these are the default field values
 			UID:  "0",
 			GID:  "0",
-			Mode: 0444,
+			Mode: 0o444,
 		},
 	}), "expected configRefs to contain bar config")
 }
@@ -229,7 +229,7 @@ func TestSetConfigsOnlyConfigs(t *testing.T) {
 			// these are the default field values
 			UID:  "0",
 			GID:  "0",
-			Mode: 0444,
+			Mode: 0o444,
 		},
 	}))
 }

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1066,7 +1066,7 @@ func TestUpdateGetUpdatedConfigs(t *testing.T) {
 				Name: "foo",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 		"barRef": {
@@ -1076,7 +1076,7 @@ func TestUpdateGetUpdatedConfigs(t *testing.T) {
 				Name: "bar",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 		"bazRef": {
@@ -1086,7 +1086,7 @@ func TestUpdateGetUpdatedConfigs(t *testing.T) {
 				Name: "baz",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 		"credRef": {

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	nonOwnerReadWriteMask = 0077
+	nonOwnerReadWriteMask = 0o077
 )
 
 type keyLoadOptions struct {

--- a/cli/command/trust/key_load_test.go
+++ b/cli/command/trust/key_load_test.go
@@ -175,7 +175,7 @@ func TestLoadKeyTooPermissive(t *testing.T) {
 func testLoadKeyTooPermissive(t *testing.T, privKeyFixture []byte) {
 	privKeyDir := t.TempDir()
 	privKeyFilepath := filepath.Join(privKeyDir, "privkey477.pem")
-	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0477))
+	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0o477))
 
 	// import the key to our keyStorageDir
 	_, err := getPrivKeyBytesFromPath(privKeyFilepath)
@@ -183,27 +183,27 @@ func testLoadKeyTooPermissive(t *testing.T, privKeyFixture []byte) {
 	assert.Error(t, err, expected)
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey667.pem")
-	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0677))
+	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0o677))
 
 	_, err = getPrivKeyBytesFromPath(privKeyFilepath)
 	expected = fmt.Sprintf("private key file %s must not be readable or writable by others", privKeyFilepath)
 	assert.Error(t, err, expected)
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey777.pem")
-	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0777))
+	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0o777))
 
 	_, err = getPrivKeyBytesFromPath(privKeyFilepath)
 	expected = fmt.Sprintf("private key file %s must not be readable or writable by others", privKeyFilepath)
 	assert.Error(t, err, expected)
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey400.pem")
-	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0400))
+	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0o400))
 
 	_, err = getPrivKeyBytesFromPath(privKeyFilepath)
 	assert.NilError(t, err)
 
 	privKeyFilepath = filepath.Join(privKeyDir, "privkey600.pem")
-	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0600))
+	assert.NilError(t, os.WriteFile(privKeyFilepath, privKeyFixture, 0o600))
 
 	_, err = getPrivKeyBytesFromPath(privKeyFilepath)
 	assert.NilError(t, err)

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -117,7 +117,7 @@ func ingestPublicKeys(pubKeyPaths []string) ([]data.PublicKey, error) {
 	pubKeys := []data.PublicKey{}
 	for _, pubKeyPath := range pubKeyPaths {
 		// Read public key bytes from PEM file, limit to 1 KiB
-		pubKeyFile, err := os.OpenFile(pubKeyPath, os.O_RDONLY, 0666)
+		pubKeyFile, err := os.OpenFile(pubKeyPath, os.O_RDONLY, 0o666)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read public key from file")
 		}

--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -39,10 +39,10 @@ func TestValidateOutputPath(t *testing.T) {
 	basedir := t.TempDir()
 	dir := filepath.Join(basedir, "dir")
 	notexist := filepath.Join(basedir, "notexist")
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0o755)
 	assert.NilError(t, err)
 	file := filepath.Join(dir, "file")
-	err = os.WriteFile(file, []byte("hi"), 0644)
+	err = os.WriteFile(file, []byte("hi"), 0o644)
 	assert.NilError(t, err)
 	testcases := []struct {
 		path string

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -406,7 +406,7 @@ func convertFileObject(
 	}
 	mode := config.Mode
 	if mode == nil {
-		mode = uint32Ptr(0444)
+		mode = uint32Ptr(0o444)
 	}
 
 	return swarmReferenceObject{

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -427,7 +427,7 @@ func TestConvertFileObject(t *testing.T) {
 		Target: "target",
 		UID:    "user",
 		GID:    "group",
-		Mode:   uint32Ptr(0644),
+		Mode:   uint32Ptr(0o644),
 	}
 	swarmRef, err := convertFileObject(namespace, config, lookupConfig)
 	assert.NilError(t, err)
@@ -438,7 +438,7 @@ func TestConvertFileObject(t *testing.T) {
 			Name: config.Target,
 			UID:  config.UID,
 			GID:  config.GID,
-			Mode: os.FileMode(0644),
+			Mode: os.FileMode(0o644),
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, swarmRef))
@@ -463,7 +463,7 @@ func TestConvertFileObjectDefaults(t *testing.T) {
 			Name: config.Source,
 			UID:  "0",
 			GID:  "0",
-			Mode: os.FileMode(0444),
+			Mode: os.FileMode(0o444),
 		},
 	}
 	assert.Check(t, is.DeepEqual(expected, swarmRef))
@@ -511,7 +511,7 @@ func TestConvertServiceSecrets(t *testing.T) {
 				Name: "bar_secret",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 		{
@@ -520,7 +520,7 @@ func TestConvertServiceSecrets(t *testing.T) {
 				Name: "foo_secret",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 	}
@@ -570,7 +570,7 @@ func TestConvertServiceConfigs(t *testing.T) {
 				Name: "bar_config",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 		{
@@ -583,7 +583,7 @@ func TestConvertServiceConfigs(t *testing.T) {
 				Name: "foo_config",
 				UID:  "0",
 				GID:  "0",
-				Mode: 0444,
+				Mode: 0o444,
 			},
 		},
 	}

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -58,7 +58,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 					Target: "/my_config",
 					UID:    "103",
 					GID:    "103",
-					Mode:   uint32Ptr(0440),
+					Mode:   uint32Ptr(0o440),
 				},
 			},
 			ContainerName: "my-web-container",
@@ -342,7 +342,7 @@ func services(workingDir, homeDir string) []types.ServiceConfig {
 					Target: "my_secret",
 					UID:    "103",
 					GID:    "103",
-					Mode:   uint32Ptr(0440),
+					Mode:   uint32Ptr(0o440),
 				},
 			},
 			SecurityOpt: []string{

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -72,7 +72,7 @@ func TestEmptyFile(t *testing.T) {
 	tmpHome := t.TempDir()
 
 	fn := filepath.Join(tmpHome, ConfigFileName)
-	err := os.WriteFile(fn, []byte(""), 0600)
+	err := os.WriteFile(fn, []byte(""), 0o600)
 	assert.NilError(t, err)
 
 	_, err = Load(tmpHome)
@@ -83,7 +83,7 @@ func TestEmptyJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 
 	fn := filepath.Join(tmpHome, ConfigFileName)
-	err := os.WriteFile(fn, []byte("{}"), 0600)
+	err := os.WriteFile(fn, []byte("{}"), 0o600)
 	assert.NilError(t, err)
 
 	config, err := Load(tmpHome)
@@ -116,7 +116,7 @@ func TestNewJSON(t *testing.T) {
 
 	fn := filepath.Join(tmpHome, ConfigFileName)
 	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv" } } }`
-	if err := os.WriteFile(fn, []byte(js), 0600); err != nil {
+	if err := os.WriteFile(fn, []byte(js), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,7 +148,7 @@ func TestNewJSONNoEmail(t *testing.T) {
 
 	fn := filepath.Join(tmpHome, ConfigFileName)
 	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv" } } }`
-	if err := os.WriteFile(fn, []byte(js), 0600); err != nil {
+	if err := os.WriteFile(fn, []byte(js), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -183,7 +183,7 @@ func TestJSONWithPsFormat(t *testing.T) {
 		"auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } },
 		"psFormat": "table {{.ID}}\\t{{.Label \"com.docker.label.cpu\"}}"
 }`
-	if err := os.WriteFile(fn, []byte(js), 0600); err != nil {
+	if err := os.WriteFile(fn, []byte(js), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,7 +210,7 @@ func TestJSONWithCredentialStore(t *testing.T) {
 		"auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } },
 		"credsStore": "crazy-secure-storage"
 }`
-	if err := os.WriteFile(fn, []byte(js), 0600); err != nil {
+	if err := os.WriteFile(fn, []byte(js), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -237,7 +237,7 @@ func TestJSONWithCredentialHelpers(t *testing.T) {
 		"auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } },
 		"credHelpers": { "images.io": "images-io", "containers.com": "crazy-secure-storage" }
 }`
-	if err := os.WriteFile(fn, []byte(js), 0600); err != nil {
+	if err := os.WriteFile(fn, []byte(js), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -325,7 +325,7 @@ func TestJSONSaveWithNoFile(t *testing.T) {
 	tmpHome := t.TempDir()
 
 	fn := filepath.Join(tmpHome, ConfigFileName)
-	f, _ := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	f, _ := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	defer f.Close()
 
 	assert.NilError(t, config.SaveToWriter(f))
@@ -350,7 +350,7 @@ func TestLoadDefaultConfigFile(t *testing.T) {
 
 	filename := filepath.Join(dir, ConfigFileName)
 	content := []byte(`{"PsFormat": "format"}`)
-	err := os.WriteFile(filename, content, 0644)
+	err := os.WriteFile(filename, content, 0o644)
 	assert.NilError(t, err)
 
 	configFile := LoadDefaultConfigFile(buffer)

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -139,7 +139,7 @@ func (configFile *ConfigFile) Save() (retErr error) {
 	}
 
 	dir := filepath.Dir(configFile.Filename)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	temp, err := os.CreateTemp(dir, filepath.Base(configFile.Filename))

--- a/cli/config/configfile/file_unix.go
+++ b/cli/config/configfile/file_unix.go
@@ -12,7 +12,7 @@ import (
 // ignoring any error during the process.
 func copyFilePermissions(src, dst string) {
 	var (
-		mode     os.FileMode = 0600
+		mode     os.FileMode = 0o600
 		uid, gid int
 	)
 

--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -28,14 +28,14 @@ func (s *metadataStore) contextDir(id contextdir) string {
 
 func (s *metadataStore) createOrUpdate(meta Metadata) error {
 	contextDir := s.contextDir(contextdirOf(meta.Name))
-	if err := os.MkdirAll(contextDir, 0755); err != nil {
+	if err := os.MkdirAll(contextDir, 0o755); err != nil {
 		return err
 	}
 	bytes, err := json.Marshal(&meta)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0644)
+	return os.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0o644)
 }
 
 func parseTypedOrMap(payload []byte, getter TypeGetter) (interface{}, error) {

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -246,7 +246,7 @@ func Export(name string, s Reader) io.ReadCloser {
 		}
 		if err = tw.WriteHeader(&tar.Header{
 			Name: metaFile,
-			Mode: 0644,
+			Mode: 0o644,
 			Size: int64(len(metaBytes)),
 		}); err != nil {
 			writer.CloseWithError(err)
@@ -263,7 +263,7 @@ func Export(name string, s Reader) io.ReadCloser {
 		}
 		if err = tw.WriteHeader(&tar.Header{
 			Name:     "tls",
-			Mode:     0700,
+			Mode:     0o700,
 			Size:     0,
 			Typeflag: tar.TypeDir,
 		}); err != nil {
@@ -273,7 +273,7 @@ func Export(name string, s Reader) io.ReadCloser {
 		for endpointName, endpointFiles := range tlsFiles {
 			if err = tw.WriteHeader(&tar.Header{
 				Name:     path.Join("tls", endpointName),
-				Mode:     0700,
+				Mode:     0o700,
 				Size:     0,
 				Typeflag: tar.TypeDir,
 			}); err != nil {
@@ -288,7 +288,7 @@ func Export(name string, s Reader) io.ReadCloser {
 				}
 				if err = tw.WriteHeader(&tar.Header{
 					Name: path.Join("tls", endpointName, fileName),
-					Mode: 0600,
+					Mode: 0o600,
 					Size: int64(len(data)),
 				}); err != nil {
 					writer.CloseWithError(err)

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -139,7 +139,7 @@ func TestImportTarInvalid(t *testing.T) {
 	tw := tar.NewWriter(f)
 	hdr := &tar.Header{
 		Name: "dummy-file",
-		Mode: 0600,
+		Mode: 0o600,
 		Size: int64(len("hello world")),
 	}
 	err = tw.WriteHeader(hdr)

--- a/cli/context/store/tlsstore.go
+++ b/cli/context/store/tlsstore.go
@@ -24,14 +24,14 @@ func (s *tlsStore) endpointDir(name, endpointName string) string {
 
 func (s *tlsStore) createOrUpdate(name, endpointName, filename string, data []byte) error {
 	parentOfRoot := filepath.Dir(s.root)
-	if err := os.MkdirAll(parentOfRoot, 0755); err != nil {
+	if err := os.MkdirAll(parentOfRoot, 0o755); err != nil {
 		return err
 	}
 	endpointDir := s.endpointDir(name, endpointName)
-	if err := os.MkdirAll(endpointDir, 0700); err != nil {
+	if err := os.MkdirAll(endpointDir, 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(endpointDir, filename), data, 0600)
+	return os.WriteFile(filepath.Join(endpointDir, filename), data, 0o600)
 }
 
 func (s *tlsStore) getData(name, endpointName, filename string) ([]byte, error) {

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -136,12 +136,12 @@ func (s *fsStore) Save(listRef reference.Reference, manifest reference.Reference
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filename, bytes, 0644)
+	return os.WriteFile(filename, bytes, 0o644)
 }
 
 func (s *fsStore) createManifestListDirectory(transaction string) error {
 	path := filepath.Join(s.root, makeFilesafeName(transaction))
-	return os.MkdirAll(path, 0755)
+	return os.MkdirAll(path, 0o755)
 }
 
 func manifestToFilename(root, manifestList, manifest string) string {

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -23,7 +23,7 @@ func init() {
 func TestBuildWithBuilder(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(),
 		fs.WithFile(pluginFilename, `#!/bin/sh
-echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortDescription":"Build with BuildKit"}'`, fs.WithMode(0777)),
+echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortDescription":"Build with BuildKit"}'`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 
@@ -47,7 +47,7 @@ func TestBuildkitDisabled(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
 
 	dir := fs.NewDir(t, t.Name(),
-		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0777)),
+		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 
@@ -74,7 +74,7 @@ func TestBuildkitDisabled(t *testing.T) {
 
 func TestBuilderBroken(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(),
-		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0777)),
+		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 
@@ -104,7 +104,7 @@ func TestBuilderBrokenEnforced(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "1")
 
 	dir := fs.NewDir(t, t.Name(),
-		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0777)),
+		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0o777)),
 	)
 	defer dir.Remove()
 

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -76,7 +76,7 @@ shellcheck: ## run shellcheck validation
 	docker buildx bake shellcheck
 
 .PHONY: fmt
-fmt: ## run gofmt
+fmt: ## run gofumpt
 	$(DOCKER_RUN) $(DEV_DOCKER_IMAGE_NAME) make fmt
 
 .PHONY: vendor

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -8,6 +8,14 @@ FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx
 FROM golang:${GO_VERSION}-alpine AS golang
 ENV  CGO_ENABLED=0
 
+FROM golang AS gofumpt
+ARG GOFUMPT_VERSION=v0.4.0
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=tmpfs,target=/go/src/ \
+    GO111MODULE=on go install "mvdan.cc/gofumpt@${GOFUMPT_VERSION}" \
+    && gofumpt --version
+
 FROM golang AS gotestsum
 ARG GOTESTSUM_VERSION=v0.4.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
@@ -40,6 +48,7 @@ ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENV PATH=$PATH:/go/src/github.com/docker/cli/build
 
 COPY --from=buildx          /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --from=gofumpt         /go/bin/* /go/bin/
 COPY --from=gotestsum       /go/bin/* /go/bin/
 COPY --from=goversioninfo   /go/bin/* /go/bin/
 

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -21,7 +21,7 @@ func TestBuildFromContextDirectoryWithTag(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
 
 	dir := fs.NewDir(t, "test-build-context-dir",
-		fs.WithFile("run", "echo running", fs.WithMode(0755)),
+		fs.WithFile("run", "echo running", fs.WithMode(0o755)),
 		fs.WithDir("data", fs.WithFile("one", "1111")),
 		fs.WithFile("Dockerfile", fmt.Sprintf(`
 	FROM %s

--- a/e2e/image/push_test.go
+++ b/e2e/image/push_test.go
@@ -406,7 +406,7 @@ func notaryListTargetsInRole(t *testing.T, notaryDir, homeDir *fs.Dir, baseRef, 
 }
 
 func setupNotaryConfig(t *testing.T, dockerConfigDir fs.Dir) *fs.Dir {
-	return fs.NewDir(t, "notary_test", fs.WithMode(0700),
+	return fs.NewDir(t, "notary_test", fs.WithMode(0o700),
 		fs.WithFile("client-config.json", fmt.Sprintf(`
 {
 	"trust_dir": "%s",

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -34,7 +34,7 @@ func SetupConfigFile(t *testing.T) fs.Dir {
 // with the given notaryURL
 func SetupConfigWithNotaryURL(t *testing.T, path, notaryURL string) fs.Dir {
 	t.Helper()
-	dir := fs.NewDir(t, path, fs.WithMode(0700), fs.WithFile("config.json", fmt.Sprintf(`
+	dir := fs.NewDir(t, path, fs.WithMode(0o700), fs.WithFile("config.json", fmt.Sprintf(`
 	{
 		"auths": {
 			"registry:5000": {

--- a/e2e/plugin/basic/basic.go
+++ b/e2e/plugin/basic/basic.go
@@ -14,7 +14,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := os.MkdirAll(p, 0755); err != nil {
+	if err := os.MkdirAll(p, 0o755); err != nil {
 		panic(err)
 	}
 	l, err := net.Listen("unix", filepath.Join(p, "basic.sock"))

--- a/e2e/plugin/trust_test.go
+++ b/e2e/plugin/trust_test.go
@@ -86,8 +86,8 @@ func preparePluginDir(t *testing.T) *fs.Dir {
 	assert.NilError(t, err)
 
 	dir := fs.NewDir(t, "plugin_test",
-		fs.WithFile("config.json", string(configJSON), fs.WithMode(0644)),
-		fs.WithDir("rootfs", fs.WithMode(0755)),
+		fs.WithFile("config.json", string(configJSON), fs.WithMode(0o644)),
+		fs.WithDir("rootfs", fs.WithMode(0o755)),
 	)
 	icmd.RunCommand("/bin/cp", binPath, dir.Join("rootfs", p.Entrypoint[0])).Assert(t, icmd.Success)
 	return dir

--- a/opts/config.go
+++ b/opts/config.go
@@ -27,7 +27,7 @@ func (o *ConfigOpt) Set(value string) error {
 		File: &swarmtypes.ConfigReferenceFileTarget{
 			UID:  "0",
 			GID:  "0",
-			Mode: 0444,
+			Mode: 0o444,
 		},
 	}
 

--- a/opts/config_test.go
+++ b/opts/config_test.go
@@ -59,7 +59,7 @@ func TestConfigOptions(t *testing.T) {
 			fileName:   "testing",
 			uid:        "1000",
 			gid:        "1001",
-			fileMode:   0444,
+			fileMode:   0o444,
 		},
 	}
 

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -205,7 +205,7 @@ func TestMountOptSetTmpfsNoError(t *testing.T) {
 			Target: "/target",
 			TmpfsOptions: &mounttypes.TmpfsOptions{
 				SizeBytes: 1024 * 1024, // not 1000 * 1000
-				Mode:      os.FileMode(0700),
+				Mode:      os.FileMode(0o700),
 			},
 		}, mounts[0]))
 	}

--- a/opts/secret.go
+++ b/opts/secret.go
@@ -27,7 +27,7 @@ func (o *SecretOpt) Set(value string) error {
 		File: &swarmtypes.SecretReferenceFileTarget{
 			UID:  "0",
 			GID:  "0",
-			Mode: 0444,
+			Mode: 0o444,
 		},
 	}
 

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -59,7 +59,7 @@ func TestSecretOptions(t *testing.T) {
 			fileName:   "testing",
 			uid:        "1000",
 			gid:        "1001",
-			fileMode:   0444,
+			fileMode:   0o444,
 		},
 	}
 


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3794
- relates to https://github.com/docker/cli/pull/3770


gofumpt (https://github.com/mvdan/gofumpt) provides a supserset of gofmt / go fmt, but not every developer may have
it installed, so for situations where it's not available, fall back to gofmt.

As our code has been formatted with gofumpt already, in most cases contributions
will follow those formatting rules, but in some cases there may be a difference,
which would already be flagged by manual code review, but let's also enable the
gofumpt linter.

With this change, `make fmt` will use gofumpt is available; gofumpt has been
added to the dev-container, so `make -f docker.Makefile fmt` will always use it.