### PR TITLE
docs: use correct separator in --security-opt

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -687,7 +687,7 @@ the container exits**, you can add the `--rm` flag:
 | `--security-opt="label=level:LEVEL"`      | Set the label level for the container                                     |
 | `--security-opt="label=disable"`          | Turn off label confinement for the container                              |
 | `--security-opt="apparmor=PROFILE"`       | Set the apparmor profile to be applied to the container                   |
-| `--security-opt="no-new-privileges:true"` | Disable container processes from gaining new privileges                   |
+| `--security-opt="no-new-privileges=true"` | Disable container processes from gaining new privileges                   |
 | `--security-opt="seccomp=unconfined"`     | Turn off seccomp confinement for the container                            |
 | `--security-opt="seccomp=profile.json"`   | White-listed syscalls seccomp Json file to be used as a seccomp filter    |
 


### PR DESCRIPTION
> Security options with `:` as a separator are deprecated and will be completely unsupported in 17.04, use `=` instead.

Signed-off-by: Felix Geyer <debfx@fobos.de>