### PR TITLE
[20.10 backport] docs: update deprecation status for "overlay2.override_kernel_check"

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -67,6 +67,7 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03     | v20.10 |
 | Removed    | [Top-level `docker deploy` subcommand (experimental)](#top-level-docker-deploy-subcommand-experimental)                            | v19.03     | v20.10 |
 | Removed    | [`docker stack deploy` using "dab" files (experimental)](#docker-stack-deploy-using-dab-files-experimental)                        | v19.03     | v20.10 |
+| Disabled   | [Support for the `overlay2.override_kernel_check` storage option](#support-for-the-overlay2override_kernel_check-storage-option)   | v19.03     | -      |
 | Deprecated | [AuFS storage driver](#aufs-storage-driver)                                                                                        | v19.03     | -      |
 | Deprecated | [Legacy "overlay" storage driver](#legacy-overlay-storage-driver)                                                                  | v18.09     | -      |
 | Deprecated | [Device mapper storage driver](#device-mapper-storage-driver)                                                                      | v18.09     | -      |
@@ -323,6 +324,19 @@ format, support for the DAB file format and the top-level docker deploy command
 (hidden by default in 19.03), will be removed, in favour of `docker stack deploy`
 using compose files.
 
+### Support for the `overlay2.override_kernel_check` storage option
+
+**Deprecated in Release: v19.03**
+**Disabled in Release: v19.03**
+
+This daemon configuration option disabled the Linux kernel version check used
+to detect if the kernel supported OverlayFS with multiple lower dirs, which is
+required for the overlay2 storage driver. Starting with Docker v19.03.7, the
+detection was improved to no longer depend on the kernel _version_, so this
+option was no longer used.
+
+Docker v22.06 logs a warning in the daemon logs if this option is set, and
+users should remove this option from their daemon configuration.
 
 ### AuFS storage driver
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -820,20 +820,11 @@ $ sudo dockerd -s btrfs --storage-opt btrfs.min_space=10G
 
 #### Overlay2 options
 
-##### `overlay2.override_kernel_check`
-
-Overrides the Linux kernel version check allowing overlay2. Support for
-specifying multiple lower directories needed by overlay2 was added to the
-Linux kernel in 4.0.0. However, some older kernel versions may be patched
-to add multiple lower directory support for OverlayFS. This option should
-only be used after verifying this support exists in the kernel. Applying
-this option on a kernel without this support will cause failures on mount.
-
 ##### `overlay2.size`
 
 Sets the default max size of the container. It is supported only when the
 backing fs is `xfs` and mounted with `pquota` mount option. Under these
-conditions the user can pass any size less then the backing fs size.
+conditions the user can pass any size less than the backing fs size.
 
 ###### Example
 


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3806
- relates to https://github.com/moby/moby/pull/35527
- relates to https://github.com/moby/moby/pull/40210
- relates to https://github.com/moby/moby/pull/40462

Commit https://github.com/docker/docker/commit/955c1f881ac94af19c99f0f7d5635e6a574789f2 (v17.12.0) replaced detection of support for multiple lowerdirs (as required by overlay2) to not depend on the kernel version. The `overlay2.override_kernel_check` was still used to print a warning that older kernel versions may not have full support.

After this, https://github.com/docker/docker/commit/e226aea280efdc18f887e853b5eefd763b602937 (v20.10, but backported to v19.03.7) removed uses of the option altogether.

(cherry picked from commit bacc5e3aadfb60d71fcb4bb903cf406444667e23)

