### PR TITLE
docs/reference: run.md update confusing example name

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -591,14 +591,15 @@ retrieve the container's ID once the container has finished running.
 ### <a name=device></a> Add host device to container (--device)
 
 ```console
-$ docker run --device=/dev/sdc:/dev/xvdc \
-             --device=/dev/sdd --device=/dev/zero:/dev/nulo \
-             -i -t \
-             ubuntu ls -l /dev/{xvdc,sdd,nulo}
+$ docker run -it --rm \
+    --device=/dev/sdc:/dev/xvdc \
+    --device=/dev/sdd \
+    --device=/dev/zero:/dev/foobar \
+    ubuntu ls -l /dev/{xvdc,sdd,foobar}
 
 brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
 brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
-crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
+crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/foobar
 ```
 
 It is often necessary to directly expose devices to a container. The `--device`


### PR DESCRIPTION
- replaces / closes https://github.com/docker/docs/pull/15827
- replaces / closes https://github.com/docker/cli/pull/2451

This example was mounting `/dev/zero` as `/dev/nulo` inside the container. The `nulo` name was intended to be a "made up / custom" name, but various readers thought it to be a typo for `/dev/null`.

This patch updates the example to use `/dev/foobar` as name, which should make it more clear that it's a custom name.

