### PR TITLE
add ability to override ints in compose files with 0

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -61,6 +61,7 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 			reflect.TypeOf([]types.ServiceVolumeConfig{}):    mergeSlice(toServiceVolumeConfigsMap, toServiceVolumeConfigsSlice),
 			reflect.TypeOf(types.ShellCommand{}):             mergeShellCommand,
 			reflect.TypeOf(&types.ServiceNetworkConfig{}):    mergeServiceNetworkConfig,
+			reflect.PointerTo(reflect.TypeOf(uint64(1))):     mergeUint64,
 		},
 	}
 	for name, overrideService := range overrideServices {
@@ -255,6 +256,14 @@ func mergeServiceNetworkConfig(dst, src reflect.Value) error {
 		if ipv6 := src.Elem().FieldByName("Ipv6Address").Interface().(string); ipv6 != "" {
 			dst.Elem().FieldByName("Ipv6Address").SetString(ipv6)
 		}
+	}
+	return nil
+}
+
+//nolint:unparam
+func mergeUint64(dst, src reflect.Value) error {
+	if !src.IsNil() {
+		dst.Elem().Set(src.Elem())
 	}
 	return nil
 }

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -1237,3 +1237,60 @@ func TestMergeServiceNetworkConfig(t *testing.T) {
 		},
 	)
 }
+
+// issue #3293
+func TestMergeServiceOverrideReplicasZero(t *testing.T) {
+	base := types.ServiceConfig{
+		Name: "someService",
+		Deploy: types.DeployConfig{
+			Replicas: uint64Ptr(3),
+		},
+	}
+	override := types.ServiceConfig{
+		Name: "someService",
+		Deploy: types.DeployConfig{
+			Replicas: uint64Ptr(0),
+		},
+	}
+	services, err := mergeServices([]types.ServiceConfig{base}, []types.ServiceConfig{override})
+	assert.NilError(t, err)
+	assert.Equal(t, len(services), 1)
+	actual := services[0]
+	assert.DeepEqual(
+		t,
+		actual,
+		types.ServiceConfig{
+			Name: "someService",
+			Deploy: types.DeployConfig{
+				Replicas: uint64Ptr(0),
+			},
+		},
+	)
+}
+
+func TestMergeServiceOverrideReplicasNotNil(t *testing.T) {
+	base := types.ServiceConfig{
+		Name: "someService",
+		Deploy: types.DeployConfig{
+			Replicas: uint64Ptr(3),
+		},
+	}
+	override := types.ServiceConfig{
+		Name:   "someService",
+		Deploy: types.DeployConfig{},
+	}
+	services, err := mergeServices([]types.ServiceConfig{base}, []types.ServiceConfig{override})
+	assert.NilError(t, err)
+	assert.Equal(t, len(services), 1)
+	actual := services[0]
+	assert.DeepEqual(
+		t,
+		actual,
+		types.ServiceConfig{
+			Name: "someService",
+			Deploy: types.DeployConfig{
+				Replicas: uint64Ptr(3),
+			},
+		},
+	)
+}


### PR DESCRIPTION
fixes #3293

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow the number for `replicas` to be overridden with 0 when using multiple compose files.

**- How I did it**
I added a custom merge function for the type `*uint64`. Maybe there is a more elegant way, but I was struggling to find documentation or examples for the used library "mergo". [This issue](https://github.com/imdario/mergo/issues/131) of the library might be related.

**- How to verify it**
See the reproduction steps in the linked issue.

**- Description for the changelog**
Fix overriding ints with 0 when using multiple compose files

:whale: 
Signed-off-by: Marco Spiess <marco.spiess@hotmail.de>

