### PR TITLE
[20.10 backport] feat(docker): add context argument completion

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -3094,6 +3094,7 @@ _docker() {
     _arguments $(__docker_arguments) -C \
         "(: -)"{-h,--help}"[Print usage]" \
         "($help)--config[Location of client config files]:path:_directories" \
+        "($help -c --context)"{-c=,--context=}"[Execute the command in a docker context]:context:__docker_complete_contexts" \
         "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
         "($help -H --host)"{-H=,--host=}"[tcp://host:port to bind/connect to]:host: " \
         "($help -l --log-level)"{-l=,--log-level=}"[Logging level]:level:(debug info warn error fatal)" \
@@ -3109,7 +3110,8 @@ _docker() {
 
     local host=${opt_args[-H]}${opt_args[--host]}
     local config=${opt_args[--config]}
-    local docker_options="${host:+--host $host} ${config:+--config $config}"
+    local context=${opt_args[-c]}${opt_args[--context]}
+    local docker_options="${host:+--host $host} ${config:+--config $config} ${context:+--context $context} "
 
     case $state in
         (command)


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3130

(cherry picked from commit 79638e6ea45187910b46c4d05d632064f2a8a9c3)

