### PR TITLE
Remove "experimental" gates around "--platform" in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1912,6 +1912,7 @@ _docker_container_run_and_create() {
 		--oom-score-adj
 		--pid
 		--pids-limit
+		--platform
 		--publish -p
 		--pull
 		--restart
@@ -1938,9 +1939,6 @@ _docker_container_run_and_create() {
 		--io-maxbandwidth
 		--io-maxiops
 		--isolation
-	"
-	__docker_server_is_experimental && options_with_args+="
-		--platform
 	"
 
 	local boolean_options="
@@ -2761,6 +2759,7 @@ _docker_image_build() {
 		--memory -m
 		--memory-swap
 		--network
+		--platform
 		--shm-size
 		--tag -t
 		--target
@@ -2781,9 +2780,6 @@ _docker_image_build() {
 	"
 
 	if __docker_server_is_experimental ; then
-		options_with_args+="
-			--platform
-		"
 		boolean_options+="
 			--squash
 		"
@@ -2792,7 +2788,6 @@ _docker_image_build() {
 	if [ "$DOCKER_BUILDKIT" = "1" ] ; then
 		options_with_args+="
 			--output -o
-			--platform
 			--progress
 			--secret
 			--ssh
@@ -2923,8 +2918,7 @@ _docker_image_import() {
 
 	case "$cur" in
 		-*)
-			local options="--change -c --help --message -m"
-			__docker_server_is_experimental && options+=" --platform"
+			local options="--change -c --help --message -m --platform"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
@@ -3032,9 +3026,7 @@ _docker_image_pull() {
 
 	case "$cur" in
 		-*)
-			local options="--all-tags -a --disable-content-trust=false --help --quiet -q"
-			__docker_server_is_experimental && options+=" --platform"
-
+			local options="--all-tags -a --disable-content-trust=false --help --platform --quiet -q"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)


### PR DESCRIPTION
The `--platform` flag has been out of experimental for a while now. 🎉

(I'd also like to upgrade this to add reasonable completion for `--platform` values, but that's a little more involved :sweat_smile:)