### PR TITLE
[20.10 backport] Remove "experimental" gates around "--platform" in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1954,6 +1954,7 @@ _docker_container_run_and_create() {
 		--oom-score-adj
 		--pid
 		--pids-limit
+		--platform
 		--publish -p
 		--pull
 		--restart
@@ -1980,9 +1981,6 @@ _docker_container_run_and_create() {
 		--io-maxbandwidth
 		--io-maxiops
 		--isolation
-	"
-	__docker_server_is_experimental && options_with_args+="
-		--platform
 	"
 
 	local boolean_options="
@@ -2831,6 +2829,7 @@ _docker_image_build() {
 		--memory -m
 		--memory-swap
 		--network
+		--platform
 		--shm-size
 		--tag -t
 		--target
@@ -2851,9 +2850,6 @@ _docker_image_build() {
 	"
 
 	if __docker_server_is_experimental ; then
-		options_with_args+="
-			--platform
-		"
 		boolean_options+="
 			--squash
 		"
@@ -2862,7 +2858,6 @@ _docker_image_build() {
 	if [ "$DOCKER_BUILDKIT" = "1" ] ; then
 		options_with_args+="
 			--output -o
-			--platform
 			--progress
 			--secret
 			--ssh
@@ -2993,8 +2988,7 @@ _docker_image_import() {
 
 	case "$cur" in
 		-*)
-			local options="--change -c --help --message -m"
-			__docker_server_is_experimental && options+=" --platform"
+			local options="--change -c --help --message -m --platform"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)
@@ -3102,9 +3096,7 @@ _docker_image_pull() {
 
 	case "$cur" in
 		-*)
-			local options="--all-tags -a --disable-content-trust=false --help --quiet -q"
-			__docker_server_is_experimental && options+=" --platform"
-
+			local options="--all-tags -a --disable-content-trust=false --help --platform --quiet -q"
 			COMPREPLY=( $( compgen -W "$options" -- "$cur" ) )
 			;;
 		*)


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3821

The `--platform` flag has been out of experimental for a while now. 🎉

(cherry picked from commit 9505330b0711e9882af85f298e4dfa5f16c4a507)


