### PR TITLE
docs: fix links to BuildKit backend

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -321,7 +321,7 @@ directory from the context. Its effect can be seen in the changed size of the
 uploaded context. The builder reference contains detailed information on
 [creating a .dockerignore file](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
 
-When using the [BuildKit backend](https://docs.docker.com/engine/reference/builder/#buildkit),
+When using the [BuildKit backend](https://docs.docker.com/build/buildkit/),
 `docker build` searches for a `.dockerignore` file relative to the Dockerfile
 name. For example, running `docker build -f myapp.Dockerfile .` will first look
 for an ignore file named `myapp.Dockerfile.dockerignore`. If such a file is not
@@ -498,7 +498,7 @@ $ docker build -t mybuildimage --target build-env .
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
-> [enable BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) or
+> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
 > use the [buildx](https://github.com/docker/buildx) plugin which provides more
 > output type options.
 
@@ -592,7 +592,7 @@ vndr
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
-> [enable BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) or
+> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
 > use the [buildx](https://github.com/docker/buildx) plugin. The previous
 > builder has limited support for reusing cache from pre-pulled images.
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -77,7 +77,7 @@ line:
 | `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release, at which point this environment-variable is removed. |
 | `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                            |
 | `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md) |
-| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](https://docs.docker.com/engine/reference/builder/#buildkit). Use plain to show container output (default `auto`). |
+| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`). |
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:


### PR DESCRIPTION
BuildKit section will be moved from Dockerfile reference to the Build section.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>