### PR TITLE
[20.10 backport] docs: fix links to BuildKit backend

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -323,13 +323,13 @@ directory from the context. Its effect can be seen in the changed size of the
 uploaded context. The builder reference contains detailed information on
 [creating a .dockerignore file](../builder.md#dockerignore-file).
 
-When using the [BuildKit backend](../builder.md#buildkit), `docker build` searches
-for a `.dockerignore` file relative to the Dockerfile name. For example, running
-`docker build -f myapp.Dockerfile .` will first look for an ignore file named
-`myapp.Dockerfile.dockerignore`. If such a file is not found, the `.dockerignore`
-file is used if present. Using a Dockerfile based `.dockerignore` is useful if a
-project contains multiple Dockerfiles that expect to ignore different sets of
-files.
+When using the [BuildKit backend](https://docs.docker.com/build/buildkit/),
+`docker build` searches for a `.dockerignore` file relative to the Dockerfile
+name. For example, running `docker build -f myapp.Dockerfile .` will first look
+for an ignore file named `myapp.Dockerfile.dockerignore`. If such a file is not
+found, the `.dockerignore` file is used if present. Using a Dockerfile based
+`.dockerignore` is useful if a project contains multiple Dockerfiles that
+expect to ignore different sets of files.
 
 
 ### Tag an image (-t)
@@ -585,8 +585,9 @@ vndr
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
-> [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
-> plugin which provides more output type options.
+> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
+> use the [buildx](https://github.com/docker/buildx) plugin which provides more
+> output type options.
 
 ### Specifying external cache sources
 
@@ -627,9 +628,9 @@ $ docker build --cache-from myname/myapp .
 > **Note**
 >
 > This feature requires the BuildKit backend. You can either
-> [enable BuildKit](../builder.md#buildkit) or use the [buildx](https://github.com/docker/buildx)
-> plugin. The previous builder has limited support for reusing cache from
-> pre-pulled images.
+> [enable BuildKit](https://docs.docker.com/build/buildkit/#getting-started) or
+> use the [buildx](https://github.com/docker/buildx) plugin. The previous
+> builder has limited support for reusing cache from pre-pulled images.
 
 ### Squash an image's layers (--squash) (experimental)
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -78,7 +78,7 @@ line:
 | `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                          |
 | `DOCKER_STACK_ORCHESTRATOR`   | Configure the default orchestrator to use when using `docker stack` management commands.                                              |
 | `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md) |
-| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](../builder.md#buildkit). Use plain to show container output (default `auto`). |
+| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`). |
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:


### PR DESCRIPTION
* backport of https://github.com/docker/cli/pull/3831