### PR TITLE
docs: fix the max-concurrent-downloads and max-concurrent-uploads configs documentation

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2765,8 +2765,8 @@ __docker_subcommand() {
                 "($help)--live-restore[Enable live restore of docker when containers are still running]" \
                 "($help)--log-driver=[Default driver for container logs]:logging driver:__docker_complete_log_drivers" \
                 "($help)*--log-opt=[Default log driver options for containers]:log driver options:__docker_complete_log_options" \
-                "($help)--max-concurrent-downloads[Set the max concurrent downloads for each pull]" \
-                "($help)--max-concurrent-uploads[Set the max concurrent uploads for each push]" \
+                "($help)--max-concurrent-downloads[Set the max concurrent downloads]" \
+                "($help)--max-concurrent-uploads[Set the max concurrent uploads]" \
                 "($help)--max-download-attempts[Set the max download attempts for each pull]" \
                 "($help)--mtu=[Network MTU]:mtu:(0 576 1420 1500 9000)" \
                 "($help)--oom-score-adjust=[Set the oom_score_adj for the daemon]:oom-score:(-500)" \

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -77,8 +77,8 @@ Options:
       --log-driver string                     Default driver for container logs (default "json-file")
   -l, --log-level string                      Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
       --log-opt map                           Default log driver options for containers (default map[])
-      --max-concurrent-downloads int          Set the max concurrent downloads for each pull (default 3)
-      --max-concurrent-uploads int            Set the max concurrent uploads for each push (default 5)
+      --max-concurrent-downloads int          Set the max concurrent downloads (default 3)
+      --max-concurrent-uploads int            Set the max concurrent uploads (default 5)
       --max-download-attempts int             Set the max download attempts for each pull (default 5)
       --metrics-addr string                   Set default address and port to serve the metrics api on
       --mtu int                               Set the containers network MTU

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -317,10 +317,10 @@ unix://[/path/to/socket] to use.
   Set the containers network mtu. Default is `0`.
 
 **--max-concurrent-downloads**=*3*
-  Set the max concurrent downloads for each pull. Default is `3`.
+  Set the max concurrent downloads. Default is `3`.
 
 **--max-concurrent-uploads**=*5*
-  Set the max concurrent uploads for each push. Default is `5`.
+  Set the max concurrent uploads. Default is `5`.
 
 **--max-download-attempts**=*5*
   Set the max download attempts for each pull. Default is `5`.


### PR DESCRIPTION
Fixes moby/moby#44346.

**- What I did**

The `max-concurrent-downloads` and `max-concurrent-uploads` limits are applied for the whole engine and not for each pull/push command, as informed on the commands docs.

This PR fixes the `max-concurrent-downloads` and `max-concurrent-uploads` command documentation.

**- How I did it**

Fixed the docs. All the investigation part is documented on moby/moby#44346

**- How to verify it**

See moby/moby#44346

**- Description for the changelog**

Fix the max-concurrent-downloads and max-concurrent-uploads configs documentation. The `max-concurrent-downloads` and `max-concurrent-uploads` limits are applied for the whole engine and not for each pull/push command.
