### PR TITLE
Fix bug where incorrect response is returned

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -374,8 +375,12 @@ func findCommand(cmd *cobra.Command, commands []string) bool {
 	return findCommand(cmd.Parent(), commands)
 }
 
-func isSupported(cmd *cobra.Command, details versionDetails) error {
+func isSupported(cmd *cobra.Command, details command.Cli) error {
 	if err := areSubcommandsSupported(cmd, details); err != nil {
+		// Check if the command not being supported is due to Ping failing
+		if _, connectError := details.Client().Ping(context.Background()); connectError != nil {
+			return connectError
+		}
 		return err
 	}
 	return areFlagsSupported(cmd, details)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Check for server reachability when `areSubcommandsSupported` fails.

**- How I did it**
By calling the `/_ping` API using `APIClient.Ping()` and reporting the error.

**- How to verify it**
Run `docker checkpoint create test test` as a user without privilege to access the docker socket.

**- Description for the changelog**
Fixes #3844 incorrect error message when server unreachable.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://wallpaperaccess.com/full/30881.jpg)
