### PR TITLE
Remove deprecated note about `docker logs` limitations

### DIFF
--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -28,11 +28,6 @@ Options:
 
 The `docker logs` command batch-retrieves logs present at the time of execution.
 
-> **Note**
->
-> This command is only functional for containers that are started with the
-> `json-file` or `journald` logging driver.
-
 For more information about selecting and configuring logging drivers, refer to
 [Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
 


### PR DESCRIPTION
Specify that `docker logs` works with all logging drivers if dual logging is enabled

Signed-off-by: Mathieu Rollet <matletix@gmail.com>

- What I did

Since Docker Engine 20.10, dual logging allows `docker logs` to work regardless of the logging driver used. This is not specified in the note mentioning the limitations of `docker logs`.

- How I did it

Add a link to the dual logging documentation in the aforementioned note.

- How to verify it

Check the diff

- Description for the changelog

Minor update to the CLI docker logs documentation

