### PR TITLE
vendor: github.com/moby/term v0.0.0-20221120202655-abb19827d345

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -26,7 +26,7 @@ require (
 	github.com/moby/swarmkit/v2 v2.0.0-20221102165002-6341884e5fc9
 	github.com/moby/sys/sequential v0.5.0
 	github.com/moby/sys/signal v0.7.0
-	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
+	github.com/moby/term v0.0.0-20221120202655-abb19827d345
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220303224323-02efb9a75ee1

--- a/vendor.sum
+++ b/vendor.sum
@@ -287,8 +287,8 @@ github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.2.0 h1:tk1rOM+Ljp0nFmfOIBtlV3rTDlWOwFRhjEeAhZB0nZc=
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
+github.com/moby/term v0.0.0-20221120202655-abb19827d345 h1:J9c53/kxIH+2nTKBEfZYFMlhghtHpIHSXpm5VRGHSnU=
+github.com/moby/term v0.0.0-20221120202655-abb19827d345/go.mod h1:15ce4BGCFxt7I5NQKT+HV0yEDxmf6fSysfEDiVo3zFM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -376,7 +376,6 @@ github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431 h1:XTHrT015sxHyJ5FnQ0AeemSspZWaDq7DoTRW0EVsDCE=
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v0.0.0-20150530192845-be5ff3e4840c h1:2EejZtjFjKJGk71ANb+wtFK5EjUzUkEM3R0xnp559xg=
@@ -597,7 +596,6 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -749,7 +747,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/vendor/github.com/moby/term/tc.go
+++ b/vendor/github.com/moby/term/tc.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/github.com/moby/term/term.go
+++ b/vendor/github.com/moby/term/term.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Package term provides structures and helper functions to work with
@@ -14,10 +15,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
-	// ErrInvalidState is returned if the state of the terminal is invalid.
-	ErrInvalidState = errors.New("Invalid terminal state")
-)
+// ErrInvalidState is returned if the state of the terminal is invalid.
+var ErrInvalidState = errors.New("Invalid terminal state")
 
 // State represents the state of the terminal.
 type State struct {

--- a/vendor/github.com/moby/term/term_windows.go
+++ b/vendor/github.com/moby/term/term_windows.go
@@ -66,10 +66,6 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		}
 	}
 
-	// Temporarily use STD_INPUT_HANDLE, STD_OUTPUT_HANDLE and
-	// STD_ERROR_HANDLE from syscall rather than x/sys/windows as long as
-	// go-ansiterm hasn't switch to x/sys/windows.
-	// TODO: switch back to x/sys/windows once go-ansiterm has switched
 	if emulateStdin {
 		h := uint32(windows.STD_INPUT_HANDLE)
 		stdIn = windowsconsole.NewAnsiReader(int(h))

--- a/vendor/github.com/moby/term/termios.go
+++ b/vendor/github.com/moby/term/termios.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/github.com/moby/term/termios_bsd.go
+++ b/vendor/github.com/moby/term/termios_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || openbsd || netbsd
 // +build darwin freebsd openbsd netbsd
 
 package term

--- a/vendor/github.com/moby/term/termios_nonbsd.go
+++ b/vendor/github.com/moby/term/termios_nonbsd.go
@@ -1,4 +1,5 @@
-//+build !darwin,!freebsd,!netbsd,!openbsd,!windows
+//go:build !darwin && !freebsd && !netbsd && !openbsd && !windows
+// +build !darwin,!freebsd,!netbsd,!openbsd,!windows
 
 package term
 

--- a/vendor/github.com/moby/term/windows/ansi_reader.go
+++ b/vendor/github.com/moby/term/windows/ansi_reader.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole
@@ -190,7 +191,6 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 		// <Ctrl>-S  Suspends printing on the screen (does not stop the program).
 		// <Ctrl>-U  Deletes all characters on the current line. Also called the KILL key.
 		// <Ctrl>-E  Quits current command and creates a core
-
 	}
 
 	// <Alt>+Key generates ESC N Key

--- a/vendor/github.com/moby/term/windows/ansi_writer.go
+++ b/vendor/github.com/moby/term/windows/ansi_writer.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole

--- a/vendor/github.com/moby/term/windows/console.go
+++ b/vendor/github.com/moby/term/windows/console.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windowsconsole

--- a/vendor/github.com/moby/term/winsize.go
+++ b/vendor/github.com/moby/term/winsize.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,8 +178,8 @@ github.com/moby/sys/signal
 # github.com/moby/sys/symlink v0.2.0
 ## explicit; go 1.16
 github.com/moby/sys/symlink
-# github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
-## explicit; go 1.13
+# github.com/moby/term v0.0.0-20221120202655-abb19827d345
+## explicit; go 1.18
 github.com/moby/term
 github.com/moby/term/windows
 # github.com/morikuni/aec v1.0.0


### PR DESCRIPTION
no significant changes in vendored code, other than updating build-tags for go1.17, but removes some dependencies from the module, which can help with future updates;

full diff: https://github.com/moby/term/compoare/3f7ff695adc6...abb19827d345664b1f8d301092abf7c33bd7461e



**- A picture of a cute animal (not mandatory but encouraged)**

