### PR TITLE
context: don't validate context when looking up name

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -200,7 +200,8 @@ func TestInitializeFromClientHangs(t *testing.T) {
 
 	go func() {
 		cli := &DockerCli{client: apiClient, initTimeout: time.Millisecond}
-		cli.Initialize(flags.NewClientOptions())
+		err := cli.Initialize(flags.NewClientOptions())
+		assert.Check(t, err)
 		close(initializedCh)
 	}()
 


### PR DESCRIPTION
While we should produce an error when trying to use the context, it's ok to look up the currently configured context (name) without validating if it's valid (or exists). This helps with situations where (e.g.) an invalid context is configured, but the user only needs to run "local" commands that don't require a server connection.

Note that the above is not yet possible with this fix alone (will be addressed in https://github.com/docker/cli/pull/3847)


### cli/command: resolveContextName() don't validate if context exists

resolveContextName() is used to find which context to use, based on the
available configuration options. Once resolved, the context name is
used to load the actual context, which will fail if the context doesn't
exist, so there's no need to produce an error at this stage; only
check priority of the configuration options to pick the context
with the highest priority.

### cli/command: resolveContextName() move conflicting options check

There's no strict need to perform this validation inside this function;
validating flags should happen earlier, to allow faster detecting of
configuration issues (we may want to have a central config "validate"
function though).

### cli/command: DockerCli.CurrentContext: improve GoDoc

Also move the resolveContextName() function together with the
method for easier cross-referencing.