### PR TITLE
cli/command: add Cli.CurrentVersion() function

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -55,6 +55,7 @@ type Cli interface {
 	ServerInfo() ServerInfo
 	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
 	DefaultVersion() string
+	CurrentVersion() string
 	ManifestStore() manifeststore.Store
 	RegistryClient(bool) registryclient.RegistryClient
 	ContentTrustEnabled() bool
@@ -84,6 +85,15 @@ type DockerCli struct {
 // DefaultVersion returns api.defaultVersion.
 func (cli *DockerCli) DefaultVersion() string {
 	return api.DefaultVersion
+}
+
+// CurrentVersion returns the API version currently negotiated, or the default
+// version otherwise.
+func (cli *DockerCli) CurrentVersion() string {
+	if cli.client == nil {
+		return api.DefaultVersion
+	}
+	return cli.client.ClientVersion()
 }
 
 // Client returns the APIClient

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -111,7 +111,7 @@ func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copt
 		reportError(dockerCli.Err(), "run", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}
 	}
-	if err = validateAPIVersion(containerConfig, dockerCli.Client().ClientVersion()); err != nil {
+	if err = validateAPIVersion(containerConfig, dockerCli.CurrentVersion()); err != nil {
 		reportError(dockerCli.Err(), "run", err.Error(), true)
 		return cli.StatusError{StatusCode: 125}
 	}

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -136,7 +136,7 @@ func runVersion(dockerCli command.Cli, opts *versionOptions) error {
 		Client: clientVersion{
 			Platform:          struct{ Name string }{version.PlatformName},
 			Version:           version.Version,
-			APIVersion:        dockerCli.Client().ClientVersion(),
+			APIVersion:        dockerCli.CurrentVersion(),
 			DefaultAPIVersion: dockerCli.DefaultVersion(),
 			GoVersion:         runtime.Version(),
 			GitCommit:         version.GitCommit,

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -101,6 +101,11 @@ func (c *FakeCli) Client() client.APIClient {
 	return c.client
 }
 
+// CurrentVersion returns the API version used by FakeCli.
+func (c *FakeCli) CurrentVersion() string {
+	return c.DefaultVersion()
+}
+
 // Out returns the output stream (stdout) the cli should write on
 func (c *FakeCli) Out() *streams.Out {
 	return c.out


### PR DESCRIPTION
- subset of https://github.com/docker/cli/pull/3847

This internalizes constructing the Client(), which allows us to provide fallbacks when trying to determin the current API version.


**- A picture of a cute animal (not mandatory but encouraged)**

