### PR TITLE
cli/command/context: "docker context show": don't validate context

### DIFF
--- a/cli/command/context/show.go
+++ b/cli/command/context/show.go
@@ -16,19 +16,14 @@ func newShowCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Print the name of the current context",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runShow(dockerCli)
+			runShow(dockerCli)
+			return nil
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
 	return cmd
 }
 
-func runShow(dockerCli command.Cli) error {
-	context := dockerCli.CurrentContext()
-	metadata, err := dockerCli.ContextStore().GetMetadata(context)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(dockerCli.Out(), metadata.Name)
-	return nil
+func runShow(dockerCli command.Cli) {
+	fmt.Fprintln(dockerCli.Out(), dockerCli.CurrentContext())
 }

--- a/cli/command/context/show_test.go
+++ b/cli/command/context/show_test.go
@@ -3,7 +3,6 @@ package context
 import (
 	"testing"
 
-	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )
 
@@ -13,6 +12,6 @@ func TestShow(t *testing.T) {
 	cli.SetCurrentContext("current")
 
 	cli.OutBuffer().Reset()
-	assert.NilError(t, runShow(cli))
+	runShow(cli)
 	golden.Assert(t, cli.OutBuffer().String(), "show.golden")
 }


### PR DESCRIPTION
- subset of https://github.com/docker/cli/pull/3847

The "docker context show" command is intended to show the currently configured
context. While the context that's configured may not be valid (e.g., in case
an environment variable was set to configure the context, or if the context
was removed from the filesystem), we should still be able to _show_ the
context.

This patch removes the context validation, and instead only shows the context.
This can help in cases where the context is used to (e.g.) set the command-
prompt, but the user removed the context. With this change, the context name
can still be shown, but commands that _require_ the context will still fail.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

