### PR TITLE
context: minor refactoring and fixes

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -116,7 +116,13 @@ type TopLevelCommand struct {
 
 // NewTopLevelCommand returns a new TopLevelCommand object
 func NewTopLevelCommand(cmd *cobra.Command, dockerCli *command.DockerCli, opts *cliflags.ClientOptions, flags *pflag.FlagSet) *TopLevelCommand {
-	return &TopLevelCommand{cmd, dockerCli, opts, flags, os.Args[1:]}
+	return &TopLevelCommand{
+		cmd:       cmd,
+		dockerCli: dockerCli,
+		opts:      opts,
+		flags:     flags,
+		args:      os.Args[1:],
+	}
 }
 
 // SetArgs sets the args (default os.Args[:1] used to invoke the command

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -132,14 +132,11 @@ func ShowHelp(err io.Writer) func(*cobra.Command, []string) error {
 
 // ConfigFile returns the ConfigFile
 func (cli *DockerCli) ConfigFile() *configfile.ConfigFile {
+	// TODO(thaJeztah): when would this happen? Is this only in tests (where cli.Initialize() is not called first?)
 	if cli.configFile == nil {
-		cli.loadConfigFile()
+		cli.configFile = config.LoadDefaultConfigFile(cli.err)
 	}
 	return cli.configFile
-}
-
-func (cli *DockerCli) loadConfigFile() {
-	cli.configFile = config.LoadDefaultConfigFile(cli.err)
 }
 
 // ServerInfo returns the server version details for the host this client is
@@ -225,7 +222,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...Initialize
 		return errors.New("conflicting options: either specify --host or --context, not both")
 	}
 
-	cli.loadConfigFile()
+	cli.configFile = config.LoadDefaultConfigFile(cli.err)
 
 	baseContextStore := store.New(config.ContextStoreDir(), cli.contextStoreConfig)
 	cli.contextStore = &ContextStoreWithDefault{


### PR DESCRIPTION
- extracted from https://github.com/docker/cli/pull/3847

### cli: NewTopLevelCommand: don't use unnamed assignments

This prevents unexpected bugs if fields are added/moved.

### cli/command: remove DockerCli.loadConfigFile()

This makes it more transparent what's happening.

### cli/command: DockerCli: keep reference to options for later use

Store a reference to the options in the client, so that they are available for later use.