### PR TITLE
Dockerfile: add ALPINE_VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.19.3
+ARG ALPINE_VERSION=3.16
 ARG XX_VERSION=1.1.1
 ARG GOVERSIONINFO_VERSION=v1.3.0
 ARG GOTESTSUM_VERSION=v1.8.2
@@ -9,7 +10,7 @@ ARG BUILDX_VERSION=0.9.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS build-base-alpine
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build-base-alpine
 COPY --from=xx / /
 RUN apk add --no-cache bash clang lld llvm file git
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.authors
+++ b/dockerfiles/Dockerfile.authors
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.14 AS gen
+ARG ALPINE_VERSION=3.16
+
+FROM alpine:${ALPINE_VERSION} AS gen
 RUN apk add --no-cache bash git
 WORKDIR /src
 RUN --mount=type=bind,target=. \

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.19.3
+ARG ALPINE_VERSION=3.16
 
 ARG BUILDX_VERSION=0.9.0
 FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx
 
-FROM golang:${GO_VERSION}-alpine AS golang
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golang
 ENV  CGO_ENABLED=0
 
 FROM golang AS gofumpt

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,11 +1,12 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.19.3
+ARG ALPINE_VERSION=3.16
 ARG GOLANGCI_LINT_VERSION=v1.49.0
 
 FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 
-FROM golang:${GO_VERSION}-alpine AS lint
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS lint
 ENV GO111MODULE=off
 ENV CGO_ENABLED=0
 ENV GOGC=75

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.19.3
+ARG ALPINE_VERSION=3.16
 ARG MODOUTDATED_VERSION=v0.8.0
 
-FROM golang:${GO_VERSION}-alpine AS base
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
 RUN apk add --no-cache bash git rsync
 WORKDIR /src
 


### PR DESCRIPTION
relates to:

- https://github.com/docker/docker-ce-packaging/pull/790
- https://github.com/moby/moby/issues/44570
- https://github.com/golang/go/issues/57044
- https://github.com/golang/go/pull/57067

This allows us to pin to a specific version of Alpine, in case the golang:alpine image switches to a newer version, which may at times be incompatible, e.g. see https://github.com/moby/moby/issues/44570


**- A picture of a cute animal (not mandatory but encouraged)**

