### PR TITLE
[20.10 backport] Dockerfile: add ALPINE_VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@
 
 ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.18.8
+ARG ALPINE_VERSION=3.16
 ARG XX_VERSION=1.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-${BASE_VARIANT} AS build-base-alpine
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build-base-alpine
 COPY --from=xx / /
 RUN apk add --no-cache clang lld llvm file git
 WORKDIR /go/src/github.com/docker/cli

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.18.8
+ARG ALPINE_VERSION=3.16
 
-FROM golang:${GO_VERSION}-alpine AS golang
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS golang
 ENV  CGO_ENABLED=0
 
 FROM golang AS esc

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.18.8
+ARG ALPINE_VERSION=3.16
 ARG GOLANGCI_LINT_VERSION=v1.45.2
 
-FROM    golang:${GO_VERSION}-alpine AS build
+FROM    golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
 ENV     CGO_ENABLED=0
 RUN     apk add --no-cache git
 ARG     GOLANGCI_LINT_VERSION
@@ -12,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
         go install github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}
 
-FROM    golang:${GO_VERSION}-alpine AS lint
+FROM    golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS lint
 ENV     GO111MODULE=off
 ENV     CGO_ENABLED=0
 ENV     DISABLE_WARN_OUTSIDE_CONTAINER=1


### PR DESCRIPTION
backports:

- https://github.com/docker/cli/pull/3896

relates to:

- https://github.com/docker/docker-ce-packaging/pull/790
- https://github.com/moby/moby/issues/44570
- https://github.com/golang/go/issues/57044
- https://github.com/golang/go/pull/57067

This allows us to pin to a specific version of Alpine, in case the golang:alpine image switches to a newer version, which may at times be incompatible, e.g. see https://github.com/moby/moby/issues/44570


**- A picture of a cute animal (not mandatory but encouraged)**

This allows us to pin to a specific version of Alpine, in case the golang:alpine image switches to a newer version, which may at times be incompatible, e.g. see https://github.com/moby/moby/issues/44570

(cherry picked from commit 1b0d6fc804a7333b96615e9a2835ccffc1281343)


**- A picture of a cute animal (not mandatory but encouraged)**

