### PR TITLE
Explicitly close docker client before exit

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -61,7 +61,11 @@ func Run(makeCmd func(command.Cli) *cobra.Command, meta manager.Metadata) {
 
 	plugin := makeCmd(dockerCli)
 
-	if err := RunPlugin(dockerCli, plugin, meta); err != nil {
+	err = RunPlugin(dockerCli, plugin, meta)
+	if client := dockerCli.Client(); client != nil {
+		client.Close()
+	}
+	if err != nil {
 		if sterr, ok := err.(cli.StatusError); ok {
 			if sterr.Status != "" {
 				fmt.Fprintln(dockerCli.Err(), sterr.Status)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -255,7 +255,11 @@ func main() {
 	}
 	logrus.SetOutput(dockerCli.Err())
 
-	if err := runDocker(dockerCli); err != nil {
+	err = runDocker(dockerCli)
+	if client := dockerCli.Client(); client != nil {
+		client.Close()
+	}
+	if err != nil {
 		if sterr, ok := err.(cli.StatusError); ok {
 			if sterr.Status != "" {
 				fmt.Fprintln(dockerCli.Err(), sterr.Status)


### PR DESCRIPTION
**- What I did**
Properly close the docker CLI Client before exiting.

When used over SSH, connections may remain open in idle state. Ultimately, the ssh subprocess would still be killed upon exit (probably by go or the os) but a proper, clean shutdown would be better :).

**- How I did it**
Call `client.Close()` just before exiting.

**- How to verify it**
I added logs in `connhelper/commandconn/commandconn.go` to verify that the call to `CloseIdleConnections()` in [Client.Close](https://github.com/moby/moby/blob/683b076a6e4a1e6d79915487ad2c8df29e69b73f/client/client.go#L177) will effectively terminate the SSH process.

* With docker/cli:
  **BEFORE**
  1. Checkout and build https://github.com/pdaig/docker-cli/tree/log-no-close
  2. Run `./docker -H ssh://__USER__@__HOST__ pull alpine`
  3. The output only shows `New connection: PID XXXX` without its corresponding `Close connection: PID XXXX`

  **AFTER**
  1. Checkout and build https://github.com/pdaig/docker-cli/tree/log-with-close
  2. Run `./docker -H ssh://__USER__@__HOST__ pull alpine`
  3. The output shows both `New connection: PID XXXX` and its corresponding `Close connection: PID XXXX`

* With docker/compose:
  **BEFORE**
  1. Checkout and build https://github.com/pdaig/docker-compose/tree/test-no-close
  2. `cd test-pull`
  3. `DOCKER_HOST=ssh://__USER__@__HOST__ ../bin/build/docker-compose ps`
  4. The output only shows `New connection: PID XXXX` without its corresponding `Close connection: PID XXXX`

  **AFTER**
  1. Checkout and build https://github.com/pdaig/docker-compose/tree/test-with-close
  2. `cd test-pull`
  3. `DOCKER_HOST=ssh://__USER__@__HOST__ ../bin/build/docker-compose ps`
  4. The output shows both `New connection: PID XXXX` and its corresponding `Close connection: PID XXXX`

**- Description for the changelog**
Fix client not properly closed before exit. SSH subprocesses were not explicitly terminated.

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://cdn.thealternativedaily.com/wp-content/uploads/2017/07/Cats-and-toddlers-both-like-to-open-closed-doors.jpg)
