### PR TITLE
Fix ssh process killed when context is done

### DIFF
--- a/cli/connhelper/commandconn/commandconn.go
+++ b/cli/connhelper/commandconn/commandconn.go
@@ -37,7 +37,7 @@ func New(ctx context.Context, cmd string, args ...string) (net.Conn, error) {
 		c   commandConn
 		err error
 	)
-	c.cmd = exec.CommandContext(ctx, cmd, args...)
+	c.cmd = exec.Command(cmd, args...)
 	// we assume that args never contains sensitive information
 	logrus.Debugf("commandconn: starting %s with %v", cmd, args)
 	c.cmd.Env = os.Environ()


### PR DESCRIPTION
**- What I did**
This solve the issue described in [docker/compose#9448](https://github.com/docker/compose/issues/9448#issuecomment-1264263721)

I've also reproduced the issue with the `docker compose down` command (basically, all commands that are run concurrently over ssh might be affected).

**- How I did it**
Please see my [comment](https://github.com/docker/compose/issues/9448#issuecomment-1264263721) on issue docker/compose#9448 for details on what causes the issue.

When `errgroup.Wait()` is called, it cancels the `Context` regardless of whether there was an error or not.
This in turns kills the ssh process and causes an error when go's `http.Client` tries to reuses this `net.Conn` (`commandConn`).

Not passing down the `Context` might seem counter-intuitive, but in this case, the lifetime of the process should be managed by the `http.Client`, not the caller's `Context`.

If the caller cancels the `Context` due to an error, (1) the `net.Conn` has no way to communicate that back to the `http.Client` (ie: mark itself as "errored") and (2) even in case of an error, the established ssh connection can still be reused for other requests, so there's really no need to shut it down.

The `http.Client` will automatically `Close()` the connection when it no longer needs it. The number of concurrent and idle connections it can keep can be configured in `http.Client`'s options.

**Sidenotes:**
[1] Currently it's possible that the program exits before the `http.Client` has a chance to close all idle connections because the docker Client object itself doesn't seem to be closed (see #3899). A clean shutdown would be preferable but I've not seen any ssh process left behind because it wasn't called (go and/or the OS probably kills them for us on exit).

[2] I've experimented a little bit with the `MaxConnsPerHost` option of [http.Transport](https://pkg.go.dev/net/http#Transport) (can be added [here](https://github.com/docker/cli/blob/b40c2f6b5deeb11ac6c485c940865ee40664f0f0/cli/context/docker/load.go#L121)). I only have anecdotal evidence, I've not run any meaningful benchmark so your experience might be different, but I've found that it's sometimes noticeably slower to start many ssh connections in parallel instead of just funneling all requests sequentially through one connection. Probably due to the added overhead of starting many ssh processes and each process having to establish its own connection from scratch. However, for long running tasks like pulling many large images, parallel may be faster (again depending on a variety of factors like the number of images, their sizes, network conditions, whether the image is already downloaded, etc.). In short, I see an optimization opportunity here for docker over ssh. Request that are expected to be fast like getting metadata on an image/container could be run sequentially while long running requests could run concurrently. Although it's greatly out of scope for this PR, I think it might be an interesting performance improvement. I would have liked to volunteer to work on this but at least for the foreseeable future, I unfortunately can't give it the proper attention it deserves to get it done. If someone else wants to get started on this, please go ahead (and let me know :)).

**- How to verify it**
1. Checkout and build https://github.com/pdaig/docker-compose/tree/test-fix-ssh-killed
2. `cd test-pull`
3. `DOCKER_HOST=ssh://__USER__@__HOST__ ../bin/build/docker-compose pull`

The pull should succeed. If you revert the fix (last commit on the branch), there's a chance the pull will fail. If you're (un)lucky, you might have to try it a few times to reproduce the issue.

Without the fix, I'm able to reproduce the issue about 9/10 times. Others have also confirmed the problem on their end (see docker/compose#9448).

With the fix, I've never had the problem again.

**- Description for the changelog**
Fix intermittent ssh error when docker compose runs some operations concurrently (like pulling multiple images)

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.charismaticplanet.com/wp-content/uploads/2019/02/2214.jpg)
