### PR TITLE
Fix bug where incorrect response is returned [carry 3845]

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -306,7 +306,7 @@ func hideSubcommandIf(subcmd *cobra.Command, condition func(string) bool, annota
 func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) error {
 	var (
 		notExperimental = func(_ string) bool { return !details.ServerInfo().HasExperimental }
-		notOSType       = func(v string) bool { return v != details.ServerInfo().OSType }
+		notOSType       = func(v string) bool { return details.ServerInfo().OSType != "" && v != details.ServerInfo().OSType }
 		notSwarmStatus  = func(v string) bool {
 			s := details.ServerInfo().SwarmStatus
 			if s == nil {
@@ -419,10 +419,11 @@ func areSubcommandsSupported(cmd *cobra.Command, details versionDetails) error {
 		if cmdVersion, ok := curr.Annotations["version"]; ok && versions.LessThan(details.CurrentVersion(), cmdVersion) {
 			return fmt.Errorf("%s requires API version %s, but the Docker daemon API version is %s", cmd.CommandPath(), cmdVersion, details.CurrentVersion())
 		}
-		if ost, ok := curr.Annotations["ostype"]; ok && ost != details.ServerInfo().OSType {
-			return fmt.Errorf("%s is only supported on a Docker daemon running on %s, but the Docker daemon is running on %s", cmd.CommandPath(), ost, details.ServerInfo().OSType)
+		si := details.ServerInfo()
+		if ost, ok := curr.Annotations["ostype"]; ok && si.OSType != "" && ost != si.OSType {
+			return fmt.Errorf("%s is only supported on a Docker daemon running on %s, but the Docker daemon is running on %s", cmd.CommandPath(), ost, si.OSType)
 		}
-		if _, ok := curr.Annotations["experimental"]; ok && !details.ServerInfo().HasExperimental {
+		if _, ok := curr.Annotations["experimental"]; ok && !si.HasExperimental {
 			return fmt.Errorf("%s is only supported on a Docker daemon with experimental features enabled", cmd.CommandPath())
 		}
 	}


### PR DESCRIPTION
- depends on https://github.com/docker/cli/pull/3903
- replaces https://github.com/docker/cli/issues/3845
- fixes https://github.com/docker/cli/issues/3844


When server is unreachable and docker checkpoint (or any command that needs to check the server type) is run, incorrect error was returned.

When checking if the daemon had the right OS, we compared the OSType from the clients ServerInfo(). In situations where the client cannot connect to the daemon, a "stub" Info is used for this, in which we assume the daemon has experimental enabled, and is running the latest API version.

However, we cannot fill in the correct OSType, so this field is empty in this situation.

This patch only compares the OSType if the field is non-empty, otherwise assumes the platform matches.

before this:

    docker -H unix:///no/such/socket.sock checkpoint create test test
    docker checkpoint create is only supported on a Docker daemon running on linux, but the Docker daemon is running on

with this patch:

    docker -H unix:///no/such/socket.sock checkpoint create test test
    Cannot connect to the Docker daemon at unix:///no/such/socket.sock. Is the docker daemon running?


**- A picture of a cute animal (not mandatory but encouraged)**

