### PR TITLE
cmd/docker: improve error message if BUILDKIT_ENABLED=0

### DIFF
--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -155,6 +155,7 @@ func TestBuildkitDisabled(t *testing.T) {
 
 	output.Assert(t, b.String(), map[int]func(string) error{
 		0: output.Suffix("DEPRECATED: The legacy builder is deprecated and will be removed in a future release."),
+		1: output.Suffix("BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0"),
 	})
 }
 

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -36,12 +36,12 @@ func TestBuildFromContextDirectoryWithTag(t *testing.T) {
 		withWorkingDir(dir))
 	defer icmd.RunCommand("docker", "image", "rm", "myimage")
 
-	const buildxMissingWarning = `DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
-            Install the buildx component to build images with BuildKit:
-            https://docs.docker.com/go/buildx/
+	const buildkitDisabledWarning = `DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
+            BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0
+            environment-variable.
 `
 
-	result.Assert(t, icmd.Expected{Err: buildxMissingWarning})
+	result.Assert(t, icmd.Expected{Err: buildkitDisabledWarning})
 	output.Assert(t, result.Stdout(), map[int]func(string) error{
 		0:  output.Prefix("Sending build context to Docker daemon"),
 		1:  output.Suffix("Step 1/4 : FROM registry:5000/alpine:3.6"),


### PR DESCRIPTION
Before this change, the error would suggest installing buildx:

    echo "FROM scratch" | DOCKER_BUILDKIT=0  docker build -
    DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
                Install the buildx component to build images with BuildKit:
                https://docs.docker.com/go/buildx/

    ...

However, this error would also be shown if buildx is actually installed, but disabled through "DOCKER_BUILDKIT=0";

    docker buildx version
    github.com/docker/buildx v0.9.1 ed00243

With this patch, it reports that it's disabled, and how to fix:

    echo "FROM scratch" | DOCKER_BUILDKIT=0  docker build -
    DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
                BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0
                environment-variable.


**- A picture of a cute animal (not mandatory but encouraged)**

