### PR TITLE
docs: document what AuthConfig.Auth is

### DIFF
--- a/cli/config/types/authconfig.go
+++ b/cli/config/types/authconfig.go
@@ -4,7 +4,8 @@ package types
 type AuthConfig struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
+	// Auth is the base64 encoding of the concatenation of username and password.
+	Auth string `json:"auth,omitempty"`
 
 	// Email is an optional value associated with the username.
 	// This field is deprecated and will be removed in a later


### PR DESCRIPTION
PR enables folks to understand what `Auth` is without the need to trace code to: 

https://github.com/docker/cli/blob/65d3f7830d8f73aeabe649ca17386f5ae5655210/cli/config/configfile/file.go#L228-L229

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>
