### PR TITLE
[20.10 backport] update gotestsum to v1.8.2

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GO111MODULE=on go install github.com/mjibson/esc@${ESC_VERSION}
 
 FROM golang AS gotestsum
-ARG GOTESTSUM_VERSION=v0.4.0
+ARG GOTESTSUM_VERSION=v1.8.2
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -18,7 +18,7 @@ ARG NOTARY_VERSION=v0.6.1
 RUN curl -fsSL https://github.com/theupdateframework/notary/releases/download/${NOTARY_VERSION}/notary-Linux-amd64 -o /usr/local/bin/notary \
     && chmod +x /usr/local/bin/notary
 
-ARG GOTESTSUM_VERSION=0.4.0
+ARG GOTESTSUM_VERSION=1.8.2
 RUN curl -fsSL https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz -o gotestsum.tar.gz \
     && tar -xf gotestsum.tar.gz gotestsum \
     && mv gotestsum /usr/local/bin/gotestsum \


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3869

release notes: https://github.com/gotestyourself/gotestsum/releases/tag/v1.8.2

- Show shuffle seed
- Update tests, and cleanup formats
- Update dependencies
- Test against go1.19, remove go1.15
- Add project name to junit.xml output
- Adding in support for s390x and ppc64le

full diff: https://github.com/gotestyourself/gotestsum/compare/v1.8.1...v1.8.2

(cherry picked from commit 700099159c70f396e76adca0ca832c864a138490)


**- A picture of a cute animal (not mandatory but encouraged)**

