### PR TITLE
[20.10] update docker/docker and buildkit

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e4
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             1f9b5b8cb6aca13deee947511801cf89447c1bfe # v0.5.0
 github.com/docker/distribution                      b5ca020cfbe998e5af3457fda087444cf5116496 # v2.8.1
-github.com/docker/docker                            03df974ae9e6c219862907efdd76ec2e77ec930b # v20.10.20
+github.com/docker/docker                            3056208812eb5e792fa99736c9167d1e10f4ab49 # v20.10.21
 github.com/docker/docker-credential-helpers         fc9290adbcf1594e78910e2f0334090eaee0e1ee # v0.6.4
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor.conf
+++ b/vendor.conf
@@ -46,7 +46,7 @@ github.com/Microsoft/go-winio                       5b44b70ab3ab4d291a7c1d28afe7
 github.com/Microsoft/hcsshim                        5bc557dd210ff2caf615e6e22d398123de77fc11 # v0.8.9
 github.com/miekg/pkcs11                             210dc1e16747c5ba98a03bcbcf728c38086ea357 # v1.0.3
 github.com/mitchellh/mapstructure                   d16e9488127408e67948eb43b6d3fbb9f222da10 # v1.3.2
-github.com/moby/buildkit                            c014937225cba29cfb1d5161fd134316c0e9bdaa # v0.8.3-31-gc0149372
+github.com/moby/buildkit                            eeb7b65ab7d651770a5ec52a06ea7c96eb97a249 # v0.8.4-0.20221020190723-eeb7b65ab7d6
 github.com/moby/sys                                 1bc8673b57550ddf85262eb0fed0aac651a37dab # symlink/v0.1.0 (latest tag, either mount/vXXX, mountinfo/vXXX or symlink/vXXX)
 github.com/moby/term                                3f7ff695adc6a35abc925370dd0a4dafb48ec64d
 github.com/modern-go/concurrent                     bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94 # 1.0.3

--- a/vendor/github.com/docker/docker/builder/remotecontext/git/gitutils.go
+++ b/vendor/github.com/docker/docker/builder/remotecontext/git/gitutils.go
@@ -21,6 +21,7 @@ type gitRepo struct {
 	isolateConfig bool
 }
 
+// CloneOption changes the behaviour of Clone().
 type CloneOption func(*gitRepo)
 
 // WithIsolatedConfig disables reading the user or system gitconfig files when
@@ -213,7 +214,7 @@ func (repo gitRepo) gitWithinDir(dir string, args ...string) ([]byte, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	// Disable unsafe remote protocols.
-	cmd.Env = append(cmd.Env, "GIT_PROTOCOL_FROM_USER=0")
+	cmd.Env = append(os.Environ(), "GIT_PROTOCOL_FROM_USER=0")
 
 	if repo.isolateConfig {
 		cmd.Env = append(cmd.Env,

--- a/vendor/github.com/docker/docker/registry/service_v2.go
+++ b/vendor/github.com/docker/docker/registry/service_v2.go
@@ -9,6 +9,9 @@ import (
 
 func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, err error) {
 	tlsConfig := tlsconfig.ServerDefault()
+
+	ana := allowNondistributableArtifacts(s.config, hostname)
+
 	if hostname == DefaultNamespace || hostname == IndexHostname {
 		for _, mirror := range s.config.Mirrors {
 			if !strings.HasPrefix(mirror, "http://") && !strings.HasPrefix(mirror, "https://") {
@@ -36,12 +39,12 @@ func (s *DefaultService) lookupV2Endpoints(hostname string) (endpoints []APIEndp
 			Official:     true,
 			TrimHostname: true,
 			TLSConfig:    tlsConfig,
+
+			AllowNondistributableArtifacts: ana,
 		})
 
 		return endpoints, nil
 	}
-
-	ana := allowNondistributableArtifacts(s.config, hostname)
 
 	tlsConfig, err = s.tlsConfig(hostname)
 	if err != nil {

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -1,4 +1,4 @@
-github.com/Azure/go-ansiterm                        d6e3b3328b783f23731bc4d058875b0371ff8109
+github.com/Azure/go-ansiterm                        d185dfc1b5a126116ea5a19e148e29d16b4574c9
 github.com/Microsoft/hcsshim                        a11a2c44e8a4aa9d66314b1d759ef582df5ab5e8 # moby branch
 github.com/Microsoft/go-winio                       7e149e8c70409f36773c1b2cf3447a7ab7697368 # v0.4.20
 github.com/docker/libtrust                          9cbd2a1374f46905c68a4eb3694a130610adc62a
@@ -7,7 +7,7 @@ github.com/google/uuid                              0cd6bf5da1e1c83f8b45653022c7
 github.com/gorilla/mux                              98cb6bf42e086f6af920b965c38cacc07402d51b # v1.8.0
 github.com/Microsoft/opengcs                        a10967154e143a36014584a6f664344e3bb0aa64
 github.com/moby/locker                              281af2d563954745bea9d1487c965f24d30742fe # v1.0.1
-github.com/moby/term                                bea5bbe245bf407372d477f1361d2ff042d2f556
+github.com/moby/term                                3f7ff695adc6a35abc925370dd0a4dafb48ec64d
 
 # Note that this dependency uses submodules, providing the github.com/moby/sys/mount,
 # github.com/moby/sys/mountinfo, and github.com/moby/sys/symlink modules. Our vendoring
@@ -33,7 +33,8 @@ github.com/imdario/mergo                            1afb36080aec31e0d1528973ebe6
 golang.org/x/sync                                   cd5d95a43a6e21273425c7ae415d3df9ea832eeb
 
 # buildkit
-github.com/moby/buildkit                            c014937225cba29cfb1d5161fd134316c0e9bdaa # v0.8.3-31-gc0149372
+github.com/armon/circbuf                            5111143e8da2e98b4ea6a8f32b9065ea1821c191
+github.com/moby/buildkit                            eeb7b65ab7d651770a5ec52a06ea7c96eb97a249 # v0.8.4-0.20221020190723-eeb7b65ab7d6
 github.com/tonistiigi/fsutil                        0834f99b7b85462efb69b4f571a4fa3ca7da5ac9
 github.com/tonistiigi/units                         6950e57a87eaf136bbe44ef2ec8e75b9e3569de2
 github.com/grpc-ecosystem/grpc-opentracing          8e809c8a86450a29b90dcc9efbf062d0fe6d9746

--- a/vendor/github.com/moby/buildkit/go.mod
+++ b/vendor/github.com/moby/buildkit/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15
 	github.com/Microsoft/hcsshim v0.8.10
+	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58 // indirect
 	github.com/containerd/console v1.0.1
 	github.com/containerd/containerd v1.4.1-0.20201117152358-0edc412565dc // the actual version is replaced in replace()


### PR DESCRIPTION
### vendor: github.com/moby/buildkit v0.8.4-0.20221020190723-eeb7b65ab7d6

full diff: https://github.com/moby/buildkit/compare/c014937225cba29cfb1d5161fd134316c0e9bdaa...eeb7b65ab7d651770a5ec52a06ea7c96eb97a249

### vendor: github.com/docker/docker v20.10.21

full diff: https://github.com/docker/docker/compare/v20.10.20...v20.10.21
