### PR TITLE
Added missing backslash to documentation cli snippet

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -291,7 +291,7 @@ service with two labels:
 ```console
 $ docker service create \
   --name redis_2 \
-  --label com.example.foo="bar"
+  --label com.example.foo="bar" \
   --label bar=baz \
   redis:3.0.6
 ```


### PR DESCRIPTION
I think the cli code block misses a backslash to brevent line break when copy/pasting it to a terminal. I doubt that this is intentional, if it is, feel free to reject the pr.

Signed-off-by: Julian <gitea+julian@ic.thejulian.uk>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I added a (likely missing) backslash to a console code block, I notice while reading through the page on docs.docker.com
I think the code block should be copy-pastable, without the backslash it interprets the line break as end of command, which likely isn't intended (*if it is, feel free to reject the pull request*).

**- How I did it**

added a backslash (nothing other then that changed)

**- How to verify it**

don't know look at it 🤷 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

added missing backslash `\` to code block in documentation for `docker service create`

**- A picture of a cute animal (not mandatory but encouraged)**

