### PR TITLE
cmd/docker: fix typo in deprecation warning

### DIFF
--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -21,7 +21,7 @@ const (
             https://docs.docker.com/go/buildx/`
 
 	buildkitDisabledWarning = `DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
-            BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0
+            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
             environment-variable.`
 
 	buildxMissingError = `ERROR: BuildKit is enabled but the buildx component is missing or broken.

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -155,7 +155,7 @@ func TestBuildkitDisabled(t *testing.T) {
 
 	output.Assert(t, b.String(), map[int]func(string) error{
 		0: output.Suffix("DEPRECATED: The legacy builder is deprecated and will be removed in a future release."),
-		1: output.Suffix("BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0"),
+		1: output.Suffix("BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0"),
 	})
 }
 

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -37,7 +37,7 @@ func TestBuildFromContextDirectoryWithTag(t *testing.T) {
 	defer icmd.RunCommand("docker", "image", "rm", "myimage")
 
 	const buildkitDisabledWarning = `DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
-            BuildKit is currently disabled; enabled it by removing the DOCKER_BUILDKIT=0
+            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
             environment-variable.
 `
 


### PR DESCRIPTION
- introduced in https://github.com/docker/cli/pull/3905


**- A picture of a cute animal (not mandatory but encouraged)**

# 🙈 