### PR TITLE
[20.10 backport] Added missing backslash to documentation sites cli snippet

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -291,7 +291,7 @@ service with two labels:
 ```console
 $ docker service create \
   --name redis_2 \
-  --label com.example.foo="bar"
+  --label com.example.foo="bar" \
   --label bar=baz \
   redis:3.0.6
 ```


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3923

I think the cli code block misses a backslash to brevent line break when copy/pasting it to a terminal. I doubt that this is intentional, if it is, feel free to reject the pr.

(cherry picked from commit 895e7a3df858852e84983c391b3bd1957efe1ee1)


**- A picture of a cute animal (not mandatory but encouraged)**

