### PR TITLE
[20.10] vendor: github.com/docker/docker v20.10.22

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -13,7 +13,7 @@ github.com/creack/pty                               2a38352e8b4d7ab6c336eef107e4
 github.com/davecgh/go-spew                          8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/docker/compose-on-kubernetes             1f9b5b8cb6aca13deee947511801cf89447c1bfe # v0.5.0
 github.com/docker/distribution                      b5ca020cfbe998e5af3457fda087444cf5116496 # v2.8.1
-github.com/docker/docker                            3056208812eb5e792fa99736c9167d1e10f4ab49 # v20.10.21
+github.com/docker/docker                            42c8b314993e5eb3cc2776da0bbe41d5eb4b707b # v20.10.22
 github.com/docker/docker-credential-helpers         fc9290adbcf1594e78910e2f0334090eaee0e1ee # v0.6.4
 github.com/docker/go                                d30aec9fd63c35133f8f79c3412ad91a3b08be06 # Contains a customized version of canonical/json and is used by Notary. The package is periodically rebased on current Go versions.
 github.com/docker/go-connections                    7395e3f8aa162843a74ed6d48e79627d9792ac55 # v0.4.0

--- a/vendor/github.com/docker/docker/vendor.conf
+++ b/vendor/github.com/docker/docker/vendor.conf
@@ -48,7 +48,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        3c51f7f332123e8be5a157c0802a
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        0dde5c895075df6e3630e76f750a447cf63f4789
+github.com/docker/libnetwork                        dcdf8f176d1e13ad719e913e796fb698d846de98
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         f0300d1749da6fa982027e449ec0c7a145510c3c # v0.4.1


### PR DESCRIPTION
No changes in vendored code.

Full diff: https://github.com/docker/docker/compare/v20.10.21...v20.10.22


**- A picture of a cute animal (not mandatory but encouraged)**

