### PR TITLE
cli/command/container: remove unused NetworkDisabled field

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -598,24 +598,20 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		ExposedPorts: ports,
 		User:         copts.user,
 		Tty:          copts.tty,
-		// TODO: deprecated, it comes from -n, --networking
-		// it's still needed internally to set the network to disabled
-		// if e.g. bridge is none in daemon opts, and in inspect
-		NetworkDisabled: false,
-		OpenStdin:       copts.stdin,
-		AttachStdin:     attachStdin,
-		AttachStdout:    attachStdout,
-		AttachStderr:    attachStderr,
-		Env:             envVariables,
-		Cmd:             runCmd,
-		Image:           copts.Image,
-		Volumes:         volumes,
-		MacAddress:      copts.macAddress,
-		Entrypoint:      entrypoint,
-		WorkingDir:      copts.workingDir,
-		Labels:          opts.ConvertKVStringsToMap(labels),
-		StopSignal:      copts.stopSignal,
-		Healthcheck:     healthConfig,
+		OpenStdin:    copts.stdin,
+		AttachStdin:  attachStdin,
+		AttachStdout: attachStdout,
+		AttachStderr: attachStderr,
+		Env:          envVariables,
+		Cmd:          runCmd,
+		Image:        copts.Image,
+		Volumes:      volumes,
+		MacAddress:   copts.macAddress,
+		Entrypoint:   entrypoint,
+		WorkingDir:   copts.workingDir,
+		Labels:       opts.ConvertKVStringsToMap(labels),
+		StopSignal:   copts.stopSignal,
+		Healthcheck:  healthConfig,
 	}
 	if flags.Changed("stop-timeout") {
 		config.StopTimeout = &copts.stopTimeout


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/17724

This comment was added in https://github.com/moby/moby/commit/7929888214741c4ab194c44e0b14ac08aca06556 (https://github.com/moby/moby/pull/17724) when this code was still in the Moby repository. That comment doesn't appear to apply to the CLI's usage of this struct though, as nothing in the CLI sets this field (or uses it), so this should be safe to remove.


**- A picture of a cute animal (not mandatory but encouraged)**

