### PR TITLE
[20.10 backport] docs/run: Fix url to blog "Docker can now run within Docker"

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1254,7 +1254,7 @@ executes `docker run --privileged`, Docker will enable access to all devices on
 the host as well as set some configuration in AppArmor or SELinux to allow the
 container nearly all the same access to the host as processes running outside
 containers on the host. Additional information about running with `--privileged`
-is available on the [Docker Blog](https://blog.docker.com/2013/09/docker-can-now-run-within-docker/).
+is available on the [Docker Blog](https://www.docker.com/blog/docker-can-now-run-within-docker/).
 
 If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that


### PR DESCRIPTION
Backport:
- https://github.com/docker/cli/pull/3939

Fixes:
- https://github.com/docker/cli/issues/3938

Changed URL which redirected to Docker Blog main page instead of the specific "Docker can now run within Docker" blog post. 

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit 720a6a823987967a9fd6a7918907b271f8dbee55)

