### PR TITLE
docs: fix anchor links

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -123,7 +123,7 @@ This release marks the beginning of the deprecation cycle of the classic ("legac
 builder for Linux images. No active development will happen on the classic builder
 (except for bugfixes). BuildKit development started five Years ago, left the
 "experimental" phase since Docker 18.09, and is already the default builder for
-[Docker Desktop](https://docs.docker.com/desktop/mac/release-notes/3.x/#docker-desktop-320).
+[Docker Desktop](https://docs.docker.com/desktop/previous-versions/3.x-mac/#docker-desktop-320).
 While we're comfortable that BuildKit is stable for general use, there may be
 some changes in behavior. If you encounter issues with BuildKit, we encourage
 you to report issues in the [BuildKit issue tracker on GitHub](https://github.com/moby/buildkit/){:target="_blank" rel="noopener" class="_"}

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -405,7 +405,7 @@ used in the build will be run with the [corresponding `docker run` flag](../run.
 ### <a name=ulimit></a> Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` will cause each build step's
-container to be started using those [`--ulimit` flag values](run.md#set-ulimits-in-container---ulimit).
+container to be started using those [`--ulimit` flag values](run.md#ulimit).
 
 ### <a name=build-arg></a> Set build-time variables (--build-arg)
 
@@ -442,7 +442,7 @@ $ export HTTP_PROXY=http://10.20.30.2:1234
 $ docker build --build-arg HTTP_PROXY .
 ```
 
-This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
+This is similar to how `docker run -e` works. Refer to the [`docker run` documentation](run.md#env)
 for more information.
 
 ### <a name=security-opt></a> Optional security options (--security-opt)

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -153,17 +153,17 @@ different location.
 These fields allow you to customize the default output format for some commands
 if no `--format` flag is provided.
 
-| Property               | Description                                                                                                                                                                                                                         |
-|:-----------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `configFormat`         | Custom default format for `docker config ls` output. Refer to the [**format the output** section in the `docker config ls` documentation](config_ls.md#format-the-output) for a list of supported formatting directives.            |
-| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. Refer to the [**format the output** section in the `docker images` documentation](images.md#format-the-output) for a list of supported formatting directives. |
-| `nodesFormat`          | Custom default format for `docker node ls` output. Refer to the [**formatting** section in the `docker node ls` documentation](node_ls.md#formatting) for a list of supported formatting directives.                                |
-| `pluginsFormat`        | Custom default format for `docker plugin ls` output. Refer to the [**formatting** section in the `docker plugin ls` documentation](plugin_ls.md#formatting) for a list of supported formatting directives.                          |
-| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. Refer to the [**formatting** section in the `docker ps` documentation](ps.md#formatting) for a list of supported formatting directives.                       |
-| `secretFormat`         | Custom default format for `docker secret ls` output. Refer to the [**format the output** section in the `docker secret ls` documentation](secret_ls.md#format-the-output) for a list of supported formatting directives.            |
-| `serviceInspectFormat` | Custom default format for `docker service inspect` output. Refer to the [**formatting** section in the `docker service inspect` documentation](service_inspect.md#formatting) for a list of supported formatting directives.        |
-| `servicesFormat`       | Custom default format for `docker service ls` output. Refer to the [**formatting** section in the `docker service ls` documentation](service_ls.md#formatting) for a list of supported formatting directives.                       |
-| `statsFormat`          | Custom default format for `docker stats` output. Refer to the [**formatting** section in the `docker stats` documentation](stats.md#formatting) for a list of supported formatting directives.                                      |
+| Property               | Description                                                                                                                                                                                                              |
+|:-----------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `configFormat`         | Custom default format for `docker config ls` output. Refer to the [**format the output** section in the `docker config ls` documentation](config_ls.md#format) for a list of supported formatting directives.            |
+| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. Refer to the [**format the output** section in the `docker images` documentation](images.md#format) for a list of supported formatting directives. |
+| `nodesFormat`          | Custom default format for `docker node ls` output. Refer to the [**formatting** section in the `docker node ls` documentation](node_ls.md#format) for a list of supported formatting directives.                         |
+| `pluginsFormat`        | Custom default format for `docker plugin ls` output. Refer to the [**formatting** section in the `docker plugin ls` documentation](plugin_ls.md#format) for a list of supported formatting directives.                   |
+| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. Refer to the [**formatting** section in the `docker ps` documentation](ps.md#format) for a list of supported formatting directives.                |
+| `secretFormat`         | Custom default format for `docker secret ls` output. Refer to the [**format the output** section in the `docker secret ls` documentation](secret_ls.md#format) for a list of supported formatting directives.            |
+| `serviceInspectFormat` | Custom default format for `docker service inspect` output. Refer to the [**formatting** section in the `docker service inspect` documentation](service_inspect.md#format) for a list of supported formatting directives. |
+| `servicesFormat`       | Custom default format for `docker service ls` output. Refer to the [**formatting** section in the `docker service ls` documentation](service_ls.md#format) for a list of supported formatting directives.                |
+| `statsFormat`          | Custom default format for `docker stats` output. Refer to the [**formatting** section in the `docker stats` documentation](stats.md#format) for a list of supported formatting directives.                               |
 
 
 ### Custom HTTP headers

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -115,7 +115,7 @@ $ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"
 ### Corner cases
 
 It is not possible to copy certain system files such as resources under
-`/proc`, `/sys`, `/dev`, [tmpfs](run.md#mount-tmpfs---tmpfs), and mounts created by
+`/proc`, `/sys`, `/dev`, [tmpfs](run.md#tmpfs), and mounts created by
 the user in the container. However, you can still copy such files by manually
 running `tar` in `docker exec`. Both of the following examples do the same thing
 in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):

--- a/docs/reference/commandline/export.md
+++ b/docs/reference/commandline/export.md
@@ -26,7 +26,7 @@ with the container. If a volume is mounted on top of an existing directory in
 the container, `docker export` will export the contents of the *underlying*
 directory, not the contents of the volume.
 
-Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes)
+Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes)
 in the user guide for examples on exporting data in a volume.
 
 ## Examples

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -156,7 +156,7 @@ point, effectively removing the `test-data` volume. Each command returns the
 service name.
 
 - The `--mount-add` flag takes the same parameters as the `--mount` flag on
-  `service create`. Refer to the [volumes and bind mounts](service_create.md#add-bind-mounts-volumes-or-memory-filesystems)
+  `service create`. Refer to the [volumes and bind mounts](service_create.md#mount-add)
   section in the `service create` reference for details.
 
 - The `--mount-rm` flag takes the `target` path of the mount.
@@ -184,7 +184,7 @@ myservice
 
 Use the `--publish-add` or `--publish-rm` flags to add or remove a published
 port for a service. You can use the short or long syntax discussed in the
-[docker service create](service_create.md#publish-service-ports-externally-to-the-swarm--p---publish)
+[docker service create](service_create.md#publish)
 reference.
 
 The following example adds a published service port to an existing service.
@@ -199,7 +199,7 @@ $ docker service update \
 
 Use the `--network-add` or `--network-rm` flags to add or remove a network for
 a service. You can use the short or long syntax discussed in the
-[docker service create](service_create.md#attach-a-service-to-an-existing-network---network)
+[docker service create](service_create.md#network)
 reference.
 
 The following example adds a new alias name to an existing service already connected to network my-network:

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -66,7 +66,7 @@ e5c383697914        test-1951.1.kay7x1lh1twk9c0oig50sd5tr   0.00%               
 4bda148efbc0        random.1.vnc8on831idyr42slu578u3cr      0.00%               1.672MiB / 1.952GiB   0.08%               110kB / 0B          578kB / 0B          2
 ```
 
-If you don't [specify a format string using `--format`](#formatting), the
+If you don't [specify a format string using `--format`](#format), the
 following columns are shown.
 
 | Column name               | Description                                                                                   |


### PR DESCRIPTION
To help validation in the docs repository (links on GitHub itself still used as they didn't use the custom id's)

Relates to:

- https://github.com/docker/cli/pull/3509
- https://github.com/docker/cli/pull/3924
- https://github.com/docker/docs/pull/16416