### PR TITLE
docs: inspect: remove trailing whitespace from example

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -66,9 +66,9 @@ $ docker run --name database -d redis
 3b2cbf074c99db4a0cad35966a9e24d7bc277f5565c17233386589029b7db273
 $ docker inspect --size database -f '{{ .SizeRootFs }}'
 123125760
-$ docker inspect --size database -f '{{ .SizeRw }}'                 
+$ docker inspect --size database -f '{{ .SizeRw }}'
 8192
-$ docker exec database fallocate -l 1000 /newfile 
+$ docker exec database fallocate -l 1000 /newfile
 $ docker inspect --size database -f '{{ .SizeRw }}'
 12288
 ```


### PR DESCRIPTION
Current versions of the docs generator take this into account, but on the 20.10 branch, the trailing whitespace can make the YAML generator switch to use "compact" formatting, which is hard to read, and hard to review diffs when updating.


**- A picture of a cute animal (not mandatory but encouraged)**

