### PR TITLE
[20.10 backport] docs: inspect: remove trailing whitespace from example

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -71,9 +71,9 @@ $ docker run --name database -d redis
 3b2cbf074c99db4a0cad35966a9e24d7bc277f5565c17233386589029b7db273
 $ docker inspect --size database -f '{{ .SizeRootFs }}'
 123125760
-$ docker inspect --size database -f '{{ .SizeRw }}'                 
+$ docker inspect --size database -f '{{ .SizeRw }}'
 8192
-$ docker exec database fallocate -l 1000 /newfile 
+$ docker exec database fallocate -l 1000 /newfile
 $ docker inspect --size database -f '{{ .SizeRw }}'
 12288
 ```


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3952

Current versions of the docs generator take this into account, but on the 20.10 branch, the trailing whitespace can make the YAML generator switch to use "compact" formatting, which is hard to read, and hard to review diffs when updating.

(cherry picked from commit 35d7fbc8183d72a73f670176a82123f3a4c44266)


**- A picture of a cute animal (not mandatory but encouraged)**

