### PR TITLE
[20.10] deprecation: mark btrfs driver as deprecated for CentOS 7 and RHEL7

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
+| Deprecated | [Btrfs storage driver on CentOS 7 and RHEL 7](#btrfs-storage-driver-on-centos-7-and-rhel-7)                                        | v20.10     | -      |
 | Deprecated | [Support for encrypted TLS private keys](#support-for-encrypted-tls-private-keys)                                                  | v20.10     | -      |
 | Deprecated | [Kubernetes stack and context support](#kubernetes-stack-and-context-support)                                                      | v20.10     | -      |
 | Deprecated | [Pulling images from non-compliant image registries](#pulling-images-from-non-compliant-image-registries)                          | v20.10     | -      |
@@ -100,6 +101,21 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09 |
 | Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13  |
 | Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12  |
+
+
+### Btrfs storage driver on CentOS 7 and RHEL 7
+
+**Deprecated in Release: v20.10.0**
+
+**Target For Removal In Release: v23.0.0**
+
+The `btrfs` storage driver on CentOS and RHEL was provided as a technology preview
+by CentOS and RHEL, but has been deprecated since the [Red Hat Enterprise Linux 7.4 release](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-btrfs),
+and removed in CentOS 8 and RHEL 8. Users of the `btrfs` storage driver on CentOS
+are recommended to migrate to a different storage driver, such as `overlay2`, which
+is now the default storage driver. Docker 23.0 continues to provide the `btrfs`
+storage driver to allow users to migrate to an alternative driver. The next release
+of Docker will no longer provide this driver.
 
 ### Support for encrypted TLS private keys
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/3956
- relates to https://github.com/docker/cli/pull/3954
- relates to https://github.com/docker/docker-ce-packaging/pull/811


Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit bdc7e37b309c4e0bfc925e4acbf034fe260ac0de)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

