### PR TITLE
contrib/completion: bash `nounset` mode fixes

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -84,13 +84,13 @@ __docker_q() {
 # precedence over the environment setting.
 __docker_configs() {
 	local format
-	if [ "$1" = "--id" ] ; then
+	if [ "${1-}" = "--id" ] ; then
 		format='{{.ID}}'
 		shift
-	elif [ "$1" = "--name" ] ; then
+	elif [ "${1-}" = "--name" ] ; then
 		format='{{.Name}}'
 		shift
-	elif [ "$DOCKER_COMPLETION_SHOW_CONFIG_IDS" = yes ] ; then
+	elif [ "${DOCKER_COMPLETION_SHOW_CONFIG_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Name}}'
 	else
 		format='{{.Name}}'
@@ -120,13 +120,13 @@ __docker_complete_configs() {
 # precedence over the environment setting.
 __docker_containers() {
 	local format
-	if [ "$1" = "--id" ] ; then
+	if [ "${1-}" = "--id" ] ; then
 		format='{{.ID}}'
 		shift
-	elif [ "$1" = "--name" ] ; then
+	elif [ "${1-}" = "--name" ] ; then
 		format='{{.Names}}'
 		shift
-	elif [ "${DOCKER_COMPLETION_SHOW_CONTAINER_IDS}" = yes ] ; then
+	elif [ "${DOCKER_COMPLETION_SHOW_CONTAINER_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Names}}'
 	else
 		format='{{.Names}}'
@@ -139,7 +139,7 @@ __docker_containers() {
 # Additional filters may be appended, see `__docker_containers`.
 __docker_complete_containers() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -191,7 +191,7 @@ __docker_complete_container_ids() {
 __docker_contexts() {
 	local add=()
 	while true ; do
-		case "$1" in
+		case "${1-}" in
 			--add)
 				add+=("$2")
 				shift 2
@@ -236,12 +236,12 @@ __docker_images() {
 	local all
 	local format
 
-	if [ "$DOCKER_COMPLETION_SHOW_IMAGE_IDS" = "all" ] ; then
+	if [ "${DOCKER_COMPLETION_SHOW_IMAGE_IDS-}" = "all" ] ; then
 		all='--all'
 	fi
 
 	while true ; do
-		case "$1" in
+		case "${1-}" in
 			--repo)
 				format+="$repo_format\n"
 				shift
@@ -253,7 +253,7 @@ __docker_images() {
 				shift
 				;;
 			--id)
-				if [[ $DOCKER_COMPLETION_SHOW_IMAGE_IDS =~ ^(all|non-intermediate)$ ]] ; then
+				if [[ ${DOCKER_COMPLETION_SHOW_IMAGE_IDS-} =~ ^(all|non-intermediate)$ ]] ; then
 					format+="$id_format\n"
 				fi
 				shift
@@ -269,7 +269,7 @@ __docker_images() {
 		esac
 	done
 
-	__docker_q image ls --no-trunc --format "${format%\\n}" $all "$@" | grep -v '<none>$'
+	__docker_q image ls --no-trunc --format "${format%\\n}" ${all-} "$@" | grep -v '<none>$'
 }
 
 # __docker_complete_images applies completion of images based on the current value of `$cur` or
@@ -277,7 +277,7 @@ __docker_images() {
 # See __docker_images for customization of the returned items.
 __docker_complete_images() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -295,13 +295,13 @@ __docker_complete_images() {
 # precedence over the environment setting.
 __docker_networks() {
 	local format
-	if [ "$1" = "--id" ] ; then
+	if [ "${1-}" = "--id" ] ; then
 		format='{{.ID}}'
 		shift
-	elif [ "$1" = "--name" ] ; then
+	elif [ "${1-}" = "--name" ] ; then
 		format='{{.Name}}'
 		shift
-	elif [ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS}" = yes ] ; then
+	elif [ "${DOCKER_COMPLETION_SHOW_NETWORK_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Name}}'
 	else
 		format='{{.Name}}'
@@ -314,7 +314,7 @@ __docker_networks() {
 # Additional filters may be appended, see `__docker_networks`.
 __docker_complete_networks() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -340,7 +340,7 @@ __docker_volumes() {
 # Additional filters may be appended, see `__docker_volumes`.
 __docker_complete_volumes() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -356,7 +356,7 @@ __docker_complete_volumes() {
 __docker_plugins_bundled() {
 	local type add=() remove=()
 	while true ; do
-		case "$1" in
+		case "${1-}" in
 			--type)
 				type="$2"
 				shift 2
@@ -390,7 +390,7 @@ __docker_plugins_bundled() {
 # `__docker_complete_plugins_installed`.
 __docker_complete_plugins_bundled() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -406,7 +406,7 @@ __docker_complete_plugins_bundled() {
 # For built-in pugins, see `__docker_plugins_bundled`.
 __docker_plugins_installed() {
 	local format
-	if [ "$DOCKER_COMPLETION_SHOW_PLUGIN_IDS" = yes ] ; then
+	if [ "${DOCKER_COMPLETION_SHOW_PLUGIN_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Name}}'
 	else
 		format='{{.Name}}'
@@ -421,7 +421,7 @@ __docker_plugins_installed() {
 # For completion of built-in pugins, see `__docker_complete_plugins_bundled`.
 __docker_complete_plugins_installed() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -446,13 +446,13 @@ __docker_complete_runtimes() {
 # precedence over the environment setting.
 __docker_secrets() {
 	local format
-	if [ "$1" = "--id" ] ; then
+	if [ "${1-}" = "--id" ] ; then
 		format='{{.ID}}'
 		shift
-	elif [ "$1" = "--name" ] ; then
+	elif [ "${1-}" = "--name" ] ; then
 		format='{{.Name}}'
 		shift
-	elif [ "$DOCKER_COMPLETION_SHOW_SECRET_IDS" = yes ] ; then
+	elif [ "${DOCKER_COMPLETION_SHOW_SECRET_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Name}}'
 	else
 		format='{{.Name}}'
@@ -465,7 +465,7 @@ __docker_secrets() {
 # of `$cur` or the value of the optional first option `--cur`, if given.
 __docker_complete_secrets() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -481,7 +481,7 @@ __docker_stacks() {
 # of `$cur` or the value of the optional first option `--cur`, if given.
 __docker_complete_stacks() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -499,7 +499,7 @@ __docker_complete_stacks() {
 # Completions may be added with `--add`, e.g. `--add self`.
 __docker_nodes() {
 	local format
-	if [ "$DOCKER_COMPLETION_SHOW_NODE_IDS" = yes ] ; then
+	if [ "${DOCKER_COMPLETION_SHOW_NODE_IDS-}" = yes ] ; then
 		format='{{.ID}} {{.Hostname}}'
 	else
 		format='{{.Hostname}}'
@@ -508,7 +508,7 @@ __docker_nodes() {
 	local add=()
 
 	while true ; do
-		case "$1" in
+		case "${1-}" in
 			--id)
 				format='{{.ID}}'
 				shift
@@ -535,7 +535,7 @@ __docker_nodes() {
 # Additional filters may be appended, see `__docker_nodes`.
 __docker_complete_nodes() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -552,12 +552,12 @@ __docker_complete_nodes() {
 # precedence over the environment setting.
 __docker_services() {
 	local format='{{.Name}}'  # default: service name only
-	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS}" = yes ] && format='{{.ID}} {{.Name}}' # ID & name
+	[ "${DOCKER_COMPLETION_SHOW_SERVICE_IDS-}" = yes ] && format='{{.ID}} {{.Name}}' # ID & name
 
-	if [ "$1" = "--id" ] ; then
+	if [ "${1-}" = "--id" ] ; then
 		format='{{.ID}}' # IDs only
 		shift
-	elif [ "$1" = "--name" ] ; then
+	elif [ "${1-}" = "--name" ] ; then
 		format='{{.Name}}' # names only
 		shift
 	fi
@@ -570,7 +570,7 @@ __docker_services() {
 # Additional filters may be appended, see `__docker_services`.
 __docker_complete_services() {
 	local current="$cur"
-	if [ "$1" = "--cur" ] ; then
+	if [ "${1-}" = "--cur" ] ; then
 		current="$2"
 		shift 2
 	fi
@@ -601,7 +601,7 @@ __docker_append_to_completions() {
 # several variables with the results.
 # The result is cached for the duration of one invocation of bash completion.
 __docker_fetch_info() {
-	if [ -z "$info_fetched" ] ; then
+	if [ -z "${info_fetched-}" ] ; then
 		read -r server_experimental server_os <<< "$(__docker_q version -f '{{.Server.Experimental}} {{.Server.Os}}')"
 		info_fetched=true
 	fi
@@ -629,7 +629,7 @@ __docker_server_os_is() {
 # you should pass a glob describing those options, e.g. "--option1|-o|--option2"
 # Use this function to restrict completions to exact positions after the argument list.
 __docker_pos_first_nonflag() {
-	local argument_flags=$1
+	local argument_flags=${1-}
 
 	local counter=$((${subcommand_pos:-${command_pos}} + 1))
 	while [ "$counter" -le "$cword" ]; do
@@ -766,7 +766,7 @@ __docker_local_interfaces() {
 	command -v ip >/dev/null 2>&1 || return
 
 	local format
-	if [ "$1" = "--ip-only" ] ; then
+	if [ "${1-}" = "--ip-only" ] ; then
 		format='\1'
 		shift
 	else
@@ -781,7 +781,7 @@ __docker_local_interfaces() {
 # An additional value can be added to the possible completions with an `--add` argument.
 __docker_complete_local_interfaces() {
 	local additional_interface
-	if [ "$1" = "--add" ] ; then
+	if [ "${1-}" = "--add" ] ; then
 		additional_interface="$2"
 		shift 2
 	fi
@@ -1125,7 +1125,7 @@ __docker_complete_ulimits() {
 		sigpending
 		stack
 	"
-	if [ "$1" = "--rm" ] ; then
+	if [ "${1-}" = "--rm" ] ; then
 		COMPREPLY=( $( compgen -W "$limits" -- "$cur" ) )
 	else
 		COMPREPLY=( $( compgen -W "$limits" -S = -- "$cur" ) )
@@ -2785,7 +2785,7 @@ _docker_image_build() {
 		"
 	fi
 
-	if [ "$DOCKER_BUILDKIT" = "1" ] ; then
+	if [ "${DOCKER_BUILDKIT-}" = "1" ] ; then
 		options_with_args+="
 			--output -o
 			--progress
@@ -3133,7 +3133,7 @@ _docker_inspect() {
 	local preselected_type
 	local type
 
-	if [ "$1" = "--type" ] ; then
+	if [ "${1-}" = "--type" ] ; then
 		preselected_type=yes
 		type="$2"
 	else
@@ -5409,7 +5409,7 @@ _docker_compose() {
 	done
 	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
 
-	COMPREPLY=( $(compgen -W "${result}" -- "$current") )
+	COMPREPLY=( $(compgen -W "${result}" -- "${current-}") )
 }
 
 _docker() {
@@ -5492,7 +5492,7 @@ _docker() {
 	)
 
 	local commands=(${management_commands[*]} ${top_level_commands[*]} ${known_plugin_commands[*]})
-	[ -z "$DOCKER_HIDE_LEGACY_COMMANDS" ] && commands+=(${legacy_commands[*]})
+	[ -z "${DOCKER_HIDE_LEGACY_COMMANDS-}" ] && commands+=(${legacy_commands[*]})
 
 	# These options are valid as global options for all client commands
 	# and valid as command options for `docker daemon`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed all instances I've come across that produce errors with the bash completion and the shell in `nounset` mode.

**- How I did it**

Guarded variable accesses like `${something-}` instead of directly accessing `$something` or `${something}` where the variable can be unset.

**- How to verify it**

Set bash in `nounset` mode (`set -u` or `set -o nounset`), use the bash completion. Observe errors before this PR, no errors after.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

A number of problems using the bash completion with the shell in `nounset` mode have been fixed.

**- A picture of a cute animal (not mandatory but encouraged)**

:=}