### PR TITLE
[20.10] docs: fix duplicated format anchor in plugin_ls

### DIFF
--- a/docs/reference/commandline/plugin_ls.md
+++ b/docs/reference/commandline/plugin_ls.md
@@ -38,7 +38,7 @@ ID            NAME                                    DESCRIPTION               
 69553ca1d123  tiborvass/sample-volume-plugin:latest   A test plugin for Docker   true
 ```
 
-### <a name="format"></a> Filtering (--filter)
+### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`-f` or `--filter`) format is of "key=value". If there is more
 than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/1512#issuecomment-1381910608

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>