### PR TITLE
cli: pass dockerCLI's in/out/err to cobra cmds

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -133,7 +133,9 @@ func newPluginCommand(dockerCli *command.DockerCli, plugin *cobra.Command, meta 
 	}
 	opts, flags := cli.SetupPluginRootCommand(cmd)
 
+	cmd.SetIn(dockerCli.In())
 	cmd.SetOut(dockerCli.Out())
+	cmd.SetErr(dockerCli.Err())
 
 	cmd.AddCommand(
 		plugin,

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -51,6 +51,10 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 			DisableDescriptions: true,
 		},
 	}
+	cmd.SetIn(dockerCli.In())
+	cmd.SetOut(dockerCli.Out())
+	cmd.SetErr(dockerCli.Err())
+
 	opts, flags, helpCmd = cli.SetupRootCommand(cmd)
 	registerCompletionFuncForGlobalFlags(dockerCli, cmd)
 	flags.BoolP("version", "v", false, "Print version information and quit")


### PR DESCRIPTION
Both the DockerCLI and Cobra Commands provide accessors for Input, Output, and Error streams (usually STDIN, STDOUT, STDERR). While we were already passing DockerCLI's Output to Cobra, we were not doing so for the other streams (and were passing none for plugin commands), potentially resulting in DockerCLI output/input to mean something else than a Cobra Command's intput/output/error.

This patch sets them to the same streams when constructing the Cobra command.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

