### PR TITLE
cli/command: embed "Streams" interface in "Cli"

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -48,9 +48,7 @@ type Streams interface {
 // Cli represents the docker command line client.
 type Cli interface {
 	Client() client.APIClient
-	Out() *streams.Out
-	Err() io.Writer
-	In() *streams.In
+	Streams
 	SetIn(in *streams.In)
 	Apply(ops ...DockerCliOption) error
 	ConfigFile() *configfile.ConfigFile


### PR DESCRIPTION
The DockerCLI interface was repeating the Streams interface. Embed the interface to make it more transparent that they're the same.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

