### PR TITLE
cli: additionalHelp() don't decorate output if it's piped, and add extra newline

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -511,6 +511,7 @@ Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 {{- if hasAdditionalHelp .}}
 
 {{ additionalHelp . }}
+
 {{- end}}
 `
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -234,9 +234,13 @@ func isExperimental(cmd *cobra.Command) bool {
 }
 
 func additionalHelp(cmd *cobra.Command) string {
-	if additionalHelp, ok := cmd.Annotations["additionalHelp"]; ok {
+	if msg, ok := cmd.Annotations["additionalHelp"]; ok {
+		out := cmd.OutOrStderr()
+		if _, isTerminal := term.GetFdInfo(out); !isTerminal {
+			return msg
+		}
 		style := aec.EmptyBuilder.Bold().ANSI
-		return style.Apply(additionalHelp)
+		return style.Apply(msg)
 	}
 	return ""
 }


### PR DESCRIPTION
Relates to:


- https://github.com/docker/cli/pull/2857
- https://github.com/docker/cli/pull/2884
- https://github.com/docker/docs/issues/12488
- https://github.com/docker/docs/issues/13146
- https://github.com/docker/docs/issues/13838
- https://github.com/docker/docs/issues/14008
- https://github.com/docker/docs/issues/15583
- https://github.com/docker/docs/issues/15584
- https://github.com/docker/docs/issues/15599
- https://github.com/docker/docs/issues/16464

### cli: additionalHelp() don't decorate output if it's piped

This prevents the escape-characters being included when piping the
output, e.g. `docker --help > output.txt`, or `docker --help | something`.
These control-characters could cause issues if users copy/pasted the URL
from the output, resulting in them becoming part of the URL they tried
to visit, which would fail, e.g. when copying the output from:

    To get more help with docker, check out our guides at https://docs.docker.com/go/guides/

Users ended up on URLs like;

    https://docs.docker.com/go/guides/ESC
    https://docs.docker.com/go/guides/%1B[0m

Before this patch, control characters ("bold") would be printed, even if
no TTY was attached;

    docker --help > output.txt
    cat output.txt | grep 'For more help' | od -c
    0000000 033   [   1   m   F   o   r       m   o   r   e       h   e   l
    0000020   p       o   n       h   o   w       t   o       u   s   e
    0000040   D   o   c   k   e   r   ,       h   e   a   d       t   o
    0000060   h   t   t   p   s   :   /   /   d   o   c   s   .   d   o   c
    0000100   k   e   r   .   c   o   m   /   g   o   /   g   u   i   d   e
    0000120   s   / 033   [   0   m  \n
    0000127

    docker --help | grep 'For more help' | od -c
    0000000 033   [   1   m   F   o   r       m   o   r   e       h   e   l
    0000020   p       o   n       h   o   w       t   o       u   s   e
    0000040   D   o   c   k   e   r   ,       h   e   a   d       t   o
    0000060   h   t   t   p   s   :   /   /   d   o   c   s   .   d   o   c
    0000100   k   e   r   .   c   o   m   /   g   o   /   g   u   i   d   e
    0000120   s   / 033   [   0   m  \n
    0000127

With this patch, no control characters are included:

    docker --help > output.txt
    cat output.txt | grep 'For more help' | od -c
    0000000   F   o   r       m   o   r   e       h   e   l   p       o   n
    0000020       h   o   w       t   o       u   s   e       D   o   c   k
    0000040   e   r   ,       h   e   a   d       t   o       h   t   t   p
    0000060   s   :   /   /   d   o   c   s   .   d   o   c   k   e   r   .
    0000100   c   o   m   /   g   o   /   g   u   i   d   e   s   /  \n
    0000117

    docker --help | grep 'For more help' | od -c
    0000000   F   o   r       m   o   r   e       h   e   l   p       o   n
    0000020       h   o   w       t   o       u   s   e       D   o   c   k
    0000040   e   r   ,       h   e   a   d       t   o       h   t   t   p
    0000060   s   :   /   /   d   o   c   s   .   d   o   c   k   e   r   .
    0000100   c   o   m   /   g   o   /   g   u   i   d   e   s   /  \n
    0000117

### Add extra newline after additionalHelp output

The additionalHelp message is printed at the end of the --help output;

    To get more help with docker, check out our guides at https://docs.docker.com/go/guides/
    PS>

As this message may contain an URL, users may copy/paste the URL to open it
in their browser, but can easily end up copying their prompt (as there's
no whitespace after it), and as a result end up on a broken URL, for example:

    https://docs.docker.com/go/guides/PS

This patch adds an extra newline at the end to provide some whitespace
around the message, making it less error-prone to copy the URL;

    To get more help with docker, check out our guides at https://docs.docker.com/go/guides/

    PS>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

