### PR TITLE
[20.10 backport Fix section docker ps --size

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -73,7 +73,7 @@ The `docker ps --size` (or `-s`) command displays two different on-disk-sizes fo
 ```console
 $ docker ps --size
 
-CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE                                                                                      SIZE
+CONTAINER ID   IMAGE          COMMAND                  CREATED        STATUS       PORTS   NAMES        SIZE
 e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours           my_nginx     35.58 kB (virtual 109.2 MB)
 00c6131c5e30   telegraf:1.5   "/entrypoint.sh"         11 weeks ago   Up 11 weeks          my_telegraf  0 B (virtual 209.5 MB)
 ```


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3977

Remove the extra item "Size"

(cherry picked from commit be30cb370e3886dd940e0a6601bcd95fc4f3c34c)


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

