### PR TITLE
run plugin with context so they can be canceled by SIGTERM

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/fvbommel/sortorder"
+	"github.com/moby/buildkit/util/appcontext"
 	"github.com/spf13/cobra"
 	exec "golang.org/x/sys/execabs"
 )
@@ -207,7 +208,7 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 			// TODO: why are we not returning plugin.Err?
 			return nil, errPluginNotFound(name)
 		}
-		cmd := exec.Command(plugin.Path, args...)
+		cmd := exec.CommandContext(appcontext.Context(), plugin.Path, args...)
 		// Using dockerCli.{In,Out,Err}() here results in a hang until something is input.
 		// See: - https://github.com/golang/go/issues/10338
 		//      - https://github.com/golang/go/commit/d000e8742a173aa0659584aa01b7ba2834ba28ab


### PR DESCRIPTION
closes https://github.com/docker/compose/issues/10179

**- What I did**
Create plugin command with context, so that child process get stopped on SIGTERM

**- How to verify it**

create compose.yaml file
```yaml
services:
  test:
    image: alpine
    command: ping localhost
```
run `docker compose logs -f`
on a second terminal, send TERM signal to `docker` CLI process `kill -s SIGTERM <ID>`

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/132757/213492626-63547a3d-303e-4cbd-877a-62631973f4d2.png)

