### PR TITLE
rm: allow `docker container remove` as an alias

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -27,15 +27,16 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 	var opts rmOptions
 
 	cmd := &cobra.Command{
-		Use:   "rm [OPTIONS] CONTAINER [CONTAINER...]",
-		Short: "Remove one or more containers",
-		Args:  cli.RequiresMinArgs(1),
+		Use:     "rm [OPTIONS] CONTAINER [CONTAINER...]",
+		Aliases: []string{"remove"},
+		Short:   "Remove one or more containers",
+		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
 			return runRm(dockerCli, &opts)
 		},
 		Annotations: map[string]string{
-			"aliases": "docker container rm, docker rm",
+			"aliases": "docker container rm, docker container remove, docker rm",
 		},
 		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
 	}


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes #3985

**- How I did it**

Added `docker container remove` as an alias of `docker container rm`

**- How to verify it**
`docker container remove foo`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
rm: allow `docker container remove` as an alias

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 