### PR TITLE
Fix typo in reference doc for docker exec

### DIFF
--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -37,7 +37,7 @@ has a custom directory specified with the WORKDIR directive in its Dockerfile,
 this directory is used instead.
 
 COMMAND must be an executable. A chained or a quoted command does not work.
-For example, `docker exec -it my_container sh -c "echo a && echo b"` works,
+For example, `docker exec -it my_container sh -c "echo a && echo b"` does
 work, but `docker exec -it my_container "echo a && echo b"` does not.
 
 ## Examples


### PR DESCRIPTION
Signed-off-by: Craig Osterhout <craig.osterhout@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed double occurrence of a word in `docker exec` reference documentation.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

