### PR TITLE
Fix issue where one bad credential helper causes no credentials to be returned

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -300,7 +300,8 @@ func (configFile *ConfigFile) GetAllCredentials() (map[string]types.AuthConfig, 
 	for registryHostname := range configFile.CredentialHelpers {
 		newAuth, err := configFile.GetAuthConfig(registryHostname)
 		if err != nil {
-			return nil, err
+			logrus.WithError(err).Warnf("Failed to get credentials for registry: %s", registryHostname)
+			continue
 		}
 		auths[registryHostname] = newAuth
 	}


### PR DESCRIPTION

Signed-off-by: Laura Brehm <laurabrehm@hey.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes https://github.com/docker/cli/issues/3716

**- What I did**

Instead of returning no credentials when a configured credential helper throws an error, skip the bad credential helper, return the remaining credentials, and warn the user about the error.

**- How to verify it**

Refer to the reproduction steps in https://github.com/docker/cli/issues/3716, or run the added unit tests 😄 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="573" alt="image" src="https://user-images.githubusercontent.com/70572044/215723638-cd259bf1-c6d7-4d49-aedc-847139d8e7e0.png">

