### PR TITLE
docs: update release notes link from deprecated.md

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -18,7 +18,7 @@ keywords: "docker, documentation, about, technology, deprecate"
 This page provides an overview of features that are deprecated in Engine. Changes
 in packaging, and supported (Linux) distributions are not included. To learn
 about end of support for Linux distributions, refer to the
-[release notes](https://docs.docker.com/engine/release-notes/).
+[release notes](https://docs.docker.com/engine/release-notes/23.0/).
 
 ## Feature Deprecation Policy
 


### PR DESCRIPTION

Signed-off-by: David Karlsson <david.karlsson@docker.com>

**- What I did**

This temporarily updates the link to point to v23.0 release notes

We plan to add a new listing/overview page for release notes.
When that page is added, we will update this link again.

**- How I did it**
-

**- How to verify it**
-

**- Description for the changelog**
-

**- A picture of a cute animal (not mandatory but encouraged)**

