### PR TITLE
Fix bad ThrottleDevice path

### DIFF
--- a/opts/throttledevice.go
+++ b/opts/throttledevice.go
@@ -31,7 +31,7 @@ func ValidateThrottleBpsDevice(val string) (*blkiodev.ThrottleDevice, error) {
 	}
 
 	return &blkiodev.ThrottleDevice{
-		Path: v,
+		Path: k,
 		Rate: uint64(rate),
 	}, nil
 }


### PR DESCRIPTION
Fixes moby/moby#44904.

This error was introduced in 6c39bc1 (#3936) and affects only v23.0. 