### PR TITLE
cli/command/container: exit 126 on EISDIR error

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -308,7 +308,8 @@ func runStartContainerErr(err error) error {
 		strings.Contains(trimmedErr, "no such file or directory") ||
 		strings.Contains(trimmedErr, "system cannot find the file specified") {
 		statusError = cli.StatusError{StatusCode: 127}
-	} else if strings.Contains(trimmedErr, syscall.EACCES.Error()) {
+	} else if strings.Contains(trimmedErr, syscall.EACCES.Error()) ||
+		strings.Contains(trimmedErr, syscall.EISDIR.Error()) {
 		statusError = cli.StatusError{StatusCode: 126}
 	}
 


### PR DESCRIPTION
The error returned from "os/exec".Command when attempting to execute a directory has been changed from syscall.EACCESS to syscall.EISDIR on Go 1.20. https://github.com/golang/go/commit/2b8f21409480931b45c983853a78dc7984ed634e Consequently, any runc runtime built against Go 1.20 will return an error containing 'is a directory' and not 'permission denied'. Update the string matching so the CLI exits with status code 126 on 'is a directory' errors (EISDIR) in addition to 'permission denied' (EACCESS).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

