### PR TITLE
ci: fix branch filter pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]{2}'
+      - '[0-9]+.[0-9]+'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]{2}'
+      - '[0-9]+.[0-9]+'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]{2}'
+      - '[0-9]+.[0-9]+'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - 'master'
-      - '[0-9]+.[0-9]{2}'
+      - '[0-9]+.[0-9]+'
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
**- What I did**

Similar to https://github.com/moby/moby/pull/44158, found out workflows are not triggered on `23.0` branch. Looking at the docs https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet, the branch filter pattern does not support matching a defined number of consecutive characters.

**- How I did it**

Update branch filter pattern in workflows

**- How to verify it**

CI

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

