### PR TITLE
[23.0 backport] changed the container name in docker stats page

### DIFF
--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -95,16 +95,16 @@ $ docker stats nginx --no-stream --format "{{ json . }}"
 Running `docker stats` with customized format on all (Running and Stopped) containers.
 
 ```console
-$ docker stats --all --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" fervent_panini 5acfcb1b4fd1 drunk_visvesvaraya big_heisenberg
+$ docker stats --all --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" fervent_panini 5acfcb1b4fd1 humble_visvesvaraya big_heisenberg
 
 CONTAINER                CPU %               MEM USAGE / LIMIT
 fervent_panini           0.00%               56KiB / 15.57GiB
 5acfcb1b4fd1             0.07%               32.86MiB / 15.57GiB
-drunk_visvesvaraya       0.00%               0B / 0B
+humble_visvesvaraya      0.00%               0B / 0B
 big_heisenberg           0.00%               0B / 0B
 ```
 
-`drunk_visvesvaraya` and `big_heisenberg` are stopped containers in the above example.
+`humble_visvesvaraya` and `big_heisenberg` are stopped containers in the above example.
 
 Running `docker stats` on all running containers against a Windows daemon.
 


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4031
- (carry of https://github.com/docker/cli/pull/4027)
- addresses https://github.com/docker/docs/issues/16720


(cherry picked from commit d2f726d5addaa0b2fddbd439d4bd7463e588fbd2)


**- A picture of a cute animal (not mandatory but encouraged)**

