### PR TITLE
cli: do not apply configfile's psFormat when --quiet is passed

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -109,7 +109,7 @@ func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, er
 func runPs(dockerCli command.Cli, options *psOptions) error {
 	ctx := context.Background()
 
-	if len(options.format) == 0 {
+	if !options.quiet && len(options.format) == 0 {
 		// load custom psFormat from CLI config (if any)
 		options.format = dockerCli.ConfigFile().PsFormat
 	}


### PR DESCRIPTION
**- What I did**

My vscode was failing to start/create devcontainers after I upgrade docker-ce from 20.10 to 23.0. I realized that table headers were shown in the logs when vscode was running `docker ps -q -a --filter label=vsch.local.folder=.......`. Manually running `docker ps -aq` confirmed the issue (the full formatted container list was shown).

**- How I did it**

As I have a custom `psFormat` in my `~/.docker/config.json`, I removed it and after that `docker ps -aq` behaved correctly.

**- How to verify it**

For example, add `"psFormat": "table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"` to your `~/.docker/config.json` and try to run `docker ps -aq`.

**- Description for the changelog**

Fix `--quiet` flag being ignored when a custom `psFormat` is set in the config file

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/6538664/219801496-e0dd4402-8fdd-49fe-9d43-8003c7bab197.png)
