### PR TITLE
context: adjust the file write logic to avoid corrupt context meta.json files

### DIFF
--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -2,12 +2,14 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
 
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/fvbommel/sortorder"
 	"github.com/pkg/errors"
 )
@@ -35,7 +37,7 @@ func (s *metadataStore) createOrUpdate(meta Metadata) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(contextDir, metaFile), bytes, 0o644)
+	return ioutils.AtomicWriteFile(filepath.Join(contextDir, metaFile), bytes, 0o644)
 }
 
 func parseTypedOrMap(payload []byte, getter TypeGetter) (interface{}, error) {
@@ -65,7 +67,8 @@ func (s *metadataStore) get(name string) (Metadata, error) {
 }
 
 func (s *metadataStore) getByID(id contextdir) (Metadata, error) {
-	bytes, err := os.ReadFile(filepath.Join(s.contextDir(id), metaFile))
+	fileName := filepath.Join(s.contextDir(id), metaFile)
+	bytes, err := os.ReadFile(fileName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return Metadata{}, errdefs.NotFound(errors.Wrap(err, "context not found"))
@@ -77,15 +80,15 @@ func (s *metadataStore) getByID(id contextdir) (Metadata, error) {
 		Endpoints: make(map[string]interface{}),
 	}
 	if err := json.Unmarshal(bytes, &untyped); err != nil {
-		return Metadata{}, err
+		return Metadata{}, fmt.Errorf("parsing %s: %v", fileName, err)
 	}
 	r.Name = untyped.Name
 	if r.Metadata, err = parseTypedOrMap(untyped.Metadata, s.config.contextType); err != nil {
-		return Metadata{}, err
+		return Metadata{}, fmt.Errorf("parsing %s: %v", fileName, err)
 	}
 	for k, v := range untyped.Endpoints {
 		if r.Endpoints[k], err = parseTypedOrMap(v, s.config.endpointTypes[k]); err != nil {
-			return Metadata{}, err
+			return Metadata{}, fmt.Errorf("parsing %s: %v", fileName, err)
 		}
 	}
 	return r, err

--- a/cli/context/store/tlsstore.go
+++ b/cli/context/store/tlsstore.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/pkg/errors"
 )
 
@@ -31,7 +32,7 @@ func (s *tlsStore) createOrUpdate(name, endpointName, filename string, data []by
 	if err := os.MkdirAll(endpointDir, 0o700); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(endpointDir, filename), data, 0o600)
+	return ioutils.AtomicWriteFile(filepath.Join(endpointDir, filename), data, 0o600)
 }
 
 func (s *tlsStore) getData(name, endpointName, filename string) ([]byte, error) {


### PR DESCRIPTION

**- What I did**
context: adjust the file write logic to avoid corrupt context meta.json files

**- How I did it**
Write to a tempfile then move, so that if the
process dies mid-write it doesn't corrupt the store.

Also improve error messaging so that if a file does get corrupted, the user has some hope of figuring
out which file is broken.

For background, see:
https://github.com/docker/for-win/issues/13180
https://github.com/docker/for-win/issues/12561

I have other fixes in DD 4.17 that will help with these issues as well.

**- How to verify it**

I've been using this sandbox to repro the issue:
https://github.com/nicks/contextstore-sandbox

I verified that after these changes, the test.sh script no longer leaves files corrupt.

**- Description for the changelog**
context: adjust the file write logic to avoid corrupt context meta.json files

**- A picture of a cute animal (not mandatory but encouraged)**
![PXL_20211217_145609846](https://user-images.githubusercontent.com/278641/220376147-bc5e9055-6b8f-4790-8a7a-be215a0d6b32.jpg)

