### PR TITLE
test/e2e: Fix running `test-e2e` on non-amd64 platforms

### DIFF
--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -34,7 +34,7 @@ func TestRunBuildDockerfileFromStdinWithCompress(t *testing.T) {
 
 	cli := test.NewFakeCli(&fakeClient{imageBuildFunc: fakeImageBuild})
 	dockerfile := bytes.NewBufferString(`
-		FROM alpine:3.6
+		FROM alpine:frozen
 		COPY foo /
 	`)
 	cli.SetIn(streams.NewIn(io.NopCloser(dockerfile)))
@@ -66,7 +66,7 @@ func TestRunBuildResetsUidAndGidInContext(t *testing.T) {
 	dir := fs.NewDir(t, "test-build-context",
 		fs.WithFile("foo", "some content", fs.AsUser(65534, 65534)),
 		fs.WithFile("Dockerfile", `
-			FROM alpine:3.6
+			FROM alpine:frozen
 			COPY foo bar /
 		`),
 	)
@@ -155,7 +155,7 @@ func TestRunBuildFromLocalGitHubDir(t *testing.T) {
 func TestRunBuildWithSymlinkedContext(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
 	dockerfile := `
-FROM alpine:3.6
+FROM alpine:frozen
 RUN echo hello world
 `
 

--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -18,6 +18,10 @@ const registryPrefix = "registry:5000"
 func TestRunAttachedFromRemoteImageAndRemove(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
 
+	// Digests in golden file are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
+
 	image := createRemoteImage(t)
 
 	result := icmd.RunCommand("docker", "run", "--rm", image,

--- a/e2e/container/testdata/run-attached-from-remote-and-remove.golden
+++ b/e2e/container/testdata/run-attached-from-remote-and-remove.golden
@@ -1,4 +1,4 @@
 Unable to find image 'registry:5000/alpine:test-run-pulls' locally
 test-run-pulls: Pulling from alpine
-Digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
+Digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501
 Status: Downloaded newer image for registry:5000/alpine:test-run-pulls

--- a/e2e/image/build_test.go
+++ b/e2e/image/build_test.go
@@ -44,7 +44,7 @@ func TestBuildFromContextDirectoryWithTag(t *testing.T) {
 	result.Assert(t, icmd.Expected{Err: buildkitDisabledWarning})
 	output.Assert(t, result.Stdout(), map[int]func(string) error{
 		0:  output.Prefix("Sending build context to Docker daemon"),
-		1:  output.Suffix("Step 1/4 : FROM registry:5000/alpine:3.6"),
+		1:  output.Suffix("Step 1/4 : FROM registry:5000/alpine:frozen"),
 		3:  output.Suffix("Step 2/4 : COPY run /usr/bin/run"),
 		5:  output.Suffix("Step 3/4 : RUN run"),
 		7:  output.Suffix("running"),

--- a/e2e/image/pull_test.go
+++ b/e2e/image/pull_test.go
@@ -17,6 +17,10 @@ const registryPrefix = "registry:5000"
 func TestPullWithContentTrust(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
 
+	// Digests in golden files are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
+
 	dir := fixtures.SetupConfigFile(t)
 	defer dir.Remove()
 	image := fixtures.CreateMaskedTrustedRemoteImage(t, registryPrefix, "trust-pull", "latest")

--- a/e2e/image/pull_test.go
+++ b/e2e/image/pull_test.go
@@ -41,7 +41,7 @@ func TestPullWithContentTrust(t *testing.T) {
 func TestPullQuiet(t *testing.T) {
 	result := icmd.RunCommand("docker", "pull", "--quiet", fixtures.AlpineImage)
 	result.Assert(t, icmd.Success)
-	assert.Check(t, is.Equal(result.Stdout(), "registry:5000/alpine:3.6\n"))
+	assert.Check(t, is.Equal(result.Stdout(), "registry:5000/alpine:frozen\n"))
 	assert.Check(t, is.Equal(result.Stderr(), ""))
 }
 

--- a/e2e/image/push_test.go
+++ b/e2e/image/push_test.go
@@ -44,11 +44,11 @@ func TestPushAllTags(t *testing.T) {
 	golden.Assert(t, result.Stderr(), "push-with-content-trust-err.golden")
 	output.Assert(t, result.Stdout(), map[int]func(string) error{
 		0:  output.Equals("The push refers to repository [registry:5000/push-all-tags]"),
-		1:  output.Equals("5bef08742407: Preparing"),
-		3:  output.Equals("latest: digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d size: 528"),
-		6:  output.Equals("v1: digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d size: 528"),
-		9:  output.Equals("v1.0: digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d size: 528"),
-		12: output.Equals("v1.0.1: digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d size: 528"),
+		1:  output.Equals("7cd52847ad77: Preparing"),
+		3:  output.Equals("latest: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528"),
+		6:  output.Equals("v1: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528"),
+		9:  output.Equals("v1.0: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528"),
+		12: output.Equals("v1.0.1: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528"),
 	})
 }
 
@@ -73,8 +73,8 @@ func TestPushWithContentTrust(t *testing.T) {
 	golden.Assert(t, result.Stderr(), "push-with-content-trust-err.golden")
 	output.Assert(t, result.Stdout(), map[int]func(string) error{
 		0: output.Equals("The push refers to repository [registry:5000/trust-push]"),
-		1: output.Equals("5bef08742407: Preparing"),
-		3: output.Equals("latest: digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d size: 528"),
+		1: output.Equals("7cd52847ad77: Preparing"),
+		3: output.Equals("latest: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528"),
 		4: output.Equals("Signing and pushing trust metadata"),
 		5: output.Equals(`Finished initializing "registry:5000/trust-push"`),
 		6: output.Equals("Successfully signed registry:5000/trust-push:latest"),

--- a/e2e/image/push_test.go
+++ b/e2e/image/push_test.go
@@ -33,6 +33,10 @@ const (
 func TestPushAllTags(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
 
+	// Compared digests are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
+
 	_ = createImage(t, "push-all-tags", "latest", "v1", "v1.0", "v1.0.1")
 	result := icmd.RunCmd(icmd.Command("docker", "push", "--all-tags", registryPrefix+"/push-all-tags"))
 
@@ -50,6 +54,10 @@ func TestPushAllTags(t *testing.T) {
 
 func TestPushWithContentTrust(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
+
+	// Compared digests are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
 
 	dir := fixtures.SetupConfigFile(t)
 	defer dir.Remove()

--- a/e2e/image/testdata/pull-with-content-trust-err.golden
+++ b/e2e/image/testdata/pull-with-content-trust-err.golden
@@ -1,1 +1,1 @@
-Tagging registry:5000/trust-pull@sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d as registry:5000/trust-pull:latest
+Tagging registry:5000/trust-pull@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 as registry:5000/trust-pull:latest

--- a/e2e/image/testdata/pull-with-content-trust.golden
+++ b/e2e/image/testdata/pull-with-content-trust.golden
@@ -1,5 +1,5 @@
-Pull (1 of 1): registry:5000/trust-pull:latest@sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
-sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d: Pulling from trust-pull
-Digest: sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
-Status: Downloaded newer image for registry:5000/trust-pull@sha256:641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d
+Pull (1 of 1): registry:5000/trust-pull:latest@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501
+sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501: Pulling from trust-pull
+Digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501
+Status: Downloaded newer image for registry:5000/trust-pull@sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501
 registry:5000/trust-pull:latest

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -15,11 +15,11 @@ const (
 	// EvilNotaryURL is the location of the evil notary server
 	EvilNotaryURL = "https://evil-notary-server:4444"
 	// AlpineImage is an image in the test registry
-	AlpineImage = "registry:5000/alpine:3.6"
+	AlpineImage = "registry:5000/alpine:frozen"
 	// AlpineSha is the sha of the alpine image
 	AlpineSha = "641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d"
 	// BusyboxImage is an image in the test registry
-	BusyboxImage = "registry:5000/busybox:1.27.2"
+	BusyboxImage = "registry:5000/busybox:frozen"
 	// BusyboxSha is the sha of the busybox image
 	BusyboxSha = "030fcb92e1487b18c974784dcc110a93147c9fc402188370fbfd17efabffc6af"
 )

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -17,7 +17,7 @@ const (
 	// AlpineImage is an image in the test registry
 	AlpineImage = "registry:5000/alpine:frozen"
 	// AlpineSha is the sha of the alpine image
-	AlpineSha = "641b95ddb2ea9dc2af1a0113b6b348ebc20872ba615204fbe12148e98fd6f23d"
+	AlpineSha = "e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501"
 	// BusyboxImage is an image in the test registry
 	BusyboxImage = "registry:5000/busybox:frozen"
 	// BusyboxSha is the sha of the busybox image

--- a/e2e/stack/testdata/full-stack.yml
+++ b/e2e/stack/testdata/full-stack.yml
@@ -2,8 +2,8 @@ version: '3.3'
 
 services:
   one:
-    image: registry:5000/alpine:3.6
+    image: registry:5000/alpine:frozen
     command: top
   two:
-    image: registry:5000/alpine:3.6
+    image: registry:5000/alpine:frozen
     command: top

--- a/e2e/stack/testdata/stack-with-named-resources.yml
+++ b/e2e/stack/testdata/stack-with-named-resources.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
   web:
-    image: registry:5000/alpine:3.6
+    image: registry:5000/alpine:frozen
     command: top
     networks: [network1, network2]
     volumes: [volume1, volume2]

--- a/e2e/testdata/Dockerfile.evil-notary-server
+++ b/e2e/testdata/Dockerfile.evil-notary-server
@@ -1,4 +1,4 @@
-ARG NOTARY_VERSION=0.5.0
+ARG NOTARY_VERSION=0.6.1
 FROM notary:server-${NOTARY_VERSION}
 
 COPY ./notary-evil/ /fixtures/

--- a/e2e/testdata/Dockerfile.notary-server
+++ b/e2e/testdata/Dockerfile.notary-server
@@ -1,4 +1,4 @@
-ARG NOTARY_VERSION=0.5.0
+ARG NOTARY_VERSION=0.6.1
 FROM notary:server-${NOTARY_VERSION}
 
 COPY ./notary/ /fixtures/

--- a/e2e/trust/sign_test.go
+++ b/e2e/trust/sign_test.go
@@ -20,6 +20,9 @@ const (
 
 func TestSignLocalImage(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
+	// Digests in golden files are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
 
 	dir := fixtures.SetupConfigFile(t)
 	defer dir.Remove()
@@ -35,6 +38,9 @@ func TestSignLocalImage(t *testing.T) {
 
 func TestSignWithLocalFlag(t *testing.T) {
 	skip.If(t, environment.RemoteDaemon())
+	// Digests in golden files are linux/amd64 specific.
+	// TODO: Fix this test and make it work on all platforms.
+	environment.SkipIfNotPlatform(t, "linux/amd64")
 
 	dir := fixtures.SetupConfigFile(t)
 	defer dir.Remove()

--- a/internal/test/environment/testenv.go
+++ b/internal/test/environment/testenv.go
@@ -98,3 +98,13 @@ func SkipIfCgroupNamespacesNotSupported(t *testing.T) {
 
 	skip.If(t, !cgroupNsFound, fmt.Sprintf("running against a daemon that doesn't support cgroup namespaces (security options: %s)", result.Stdout()))
 }
+
+// SkipIfNotPlatform skips the test if the running docker daemon is not running on a specific platform.
+// platform should be in format os/arch (for example linux/arm64).
+func SkipIfNotPlatform(t *testing.T, platform string) {
+	t.Helper()
+	result := icmd.RunCmd(icmd.Command("docker", "version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"))
+	result.Assert(t, icmd.Expected{Err: icmd.None})
+	daemonPlatform := strings.TrimSpace(result.Stdout())
+	skip.If(t, daemonPlatform != platform, "running against a non %s daemon", platform)
+}

--- a/scripts/test/e2e/load-image
+++ b/scripts/test/e2e/load-image
@@ -2,7 +2,7 @@
 # Fetch images used for e2e testing
 set -eu -o pipefail
 
-alpine_src=alpine@sha256:f006ecbb824d87947d0b51ab8488634bf69fe4094959d935c0c103f4820a417d
+alpine_src=alpine@sha256:69665d02cb32192e52e07644d76bc6f25abeb5410edc1c7a81a10ba3f0efb90a
 alpine_dest=registry:5000/alpine:frozen
 
 busybox_src=busybox@sha256:3e8fa85ddfef1af9ca85a5cfb714148956984e02f00bec3f7f49d3925a91e0e7

--- a/scripts/test/e2e/load-image
+++ b/scripts/test/e2e/load-image
@@ -3,10 +3,10 @@
 set -eu -o pipefail
 
 alpine_src=alpine@sha256:f006ecbb824d87947d0b51ab8488634bf69fe4094959d935c0c103f4820a417d
-alpine_dest=registry:5000/alpine:3.6
+alpine_dest=registry:5000/alpine:frozen
 
 busybox_src=busybox@sha256:3e8fa85ddfef1af9ca85a5cfb714148956984e02f00bec3f7f49d3925a91e0e7
-busybox_dest=registry:5000/busybox:1.27.2
+busybox_dest=registry:5000/busybox:frozen
 
 fetch_tag_image() {
     docker pull "$1"


### PR DESCRIPTION
**- What I did**
- Updated notary server and alpine to versions with multi-platform images (previous ones were `linux/amd64` only)
- Skip tests which check `linux/amd64` digests on non-`linux/amd64` platforms (and add TODOs)

NOTE: This doesn't fix all failing tests (at least for me) on non amd64 platforms but at least makes the `test-e2e` start and run tests (it didn't even launch the tests before).


**- How I did it**

**- How to verify it**
```
make -f docker.Makefile E2E_ENGINE_VERSION=stable-dind  test-e2e
```

**- Description for the changelog**


**- A picture of a cute animal (not mandatory but encouraged)**

