### PR TITLE
formatter: Consider empty RepoTags and RepoDigests as dangling

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -27,6 +27,9 @@ type ImageContext struct {
 }
 
 func isDangling(image types.ImageSummary) bool {
+	if len(image.RepoTags) == 0 && len(image.RepoDigests) == 0 {
+		return true
+	}
 	return len(image.RepoTags) == 1 && image.RepoTags[0] == "<none>:<none>" && len(image.RepoDigests) == 1 && image.RepoDigests[0] == "<none>@<none>"
 }
 


### PR DESCRIPTION
- Related to: https://github.com/moby/moby/pull/45068

From API 1.43 version `RepoTags` and `RepoDigests` will be empty for dangling images, instead of being an one-item array with magic constant string (`<none>:<none>`/`<none>@<none>`).

CLI output is not impacted and will still display <none> strings.

**- What I did**
Consider images with empty `RepoTags` and `RepoDigests` as dangling.

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

