### PR TITLE
test/cli: Use empty array as empty output of images/json

### DIFF
--- a/cli/command/image/client_test.go
+++ b/cli/command/image/client_test.go
@@ -91,7 +91,7 @@ func (cli *fakeClient) ImageList(ctx context.Context, options types.ImageListOpt
 	if cli.imageListFunc != nil {
 		return cli.imageListFunc(options)
 	}
-	return []types.ImageSummary{{}}, nil
+	return []types.ImageSummary{}, nil
 }
 
 func (cli *fakeClient) ImageInspectWithRaw(_ context.Context, image string) (types.ImageInspect, []byte, error) {

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -30,7 +30,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 			name:          "failed-list",
 			expectedError: "something went wrong",
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
-				return []types.ImageSummary{{}}, errors.Errorf("something went wrong")
+				return []types.ImageSummary{}, errors.Errorf("something went wrong")
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			args: []string{"image"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
 				assert.Check(t, is.Equal("image", options.Filters.Get("reference")[0]))
-				return []types.ImageSummary{{}}, nil
+				return []types.ImageSummary{}, nil
 			},
 		},
 		{
@@ -74,7 +74,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			args: []string{"--filter", "name=value"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
 				assert.Check(t, is.Equal("value", options.Filters.Get("name")[0]))
-				return []types.ImageSummary{{}}, nil
+				return []types.ImageSummary{}, nil
 			},
 		},
 	}


### PR DESCRIPTION
Tests mocking the output of GET images/json with fakeClient used an array with one empty element as an empty response. Change it to just an empty array.

See discussion: https://github.com/docker/cli/pull/4046#discussion_r1116709729


