### PR TITLE
docs: fix broken contribution guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Want to hack on Docker? Awesome!  We have a contributor's guide that explains
 [setting up a Docker development environment and the contribution
-process](https://docs.docker.com/opensource/project/who-written-for/). 
+process](https://docs.docker.com/contribute/overview/). 
 
 This page contains information about reporting issues as well as some tips and
 guidelines useful to experienced open source contributors. Finally, make sure


### PR DESCRIPTION
**- What I did**
Updated a broken contribution guide link.

**- How I did it**
Changed https://docs.docker.com/opensource/project/who-written-for/ to https://docs.docker.com/contribute/overview/

**- How to verify it**
Visit https://docs.docker.com/opensource/project/who-written-for/

**- Description for the changelog**
Updated a broken contribution guide link.

Closes #4036 

