### PR TITLE
Don't calculate container size unless explicitly asked for

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -9,7 +10,9 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
+	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -73,6 +76,19 @@ func buildContainerListOptions(opts *psOptions) (*types.ContainerListOptions, er
 
 	if opts.nLatest && opts.last == -1 {
 		options.Limit = 1
+	}
+
+	// if `--format` is used, check if template is valid
+	if len(opts.format) > 0 {
+		tmpl, err := templates.NewParse("", opts.format)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse template")
+		}
+
+		optionsProcessor := formatter.NewContainerContext()
+		if err := tmpl.Execute(io.Discard, optionsProcessor); err != nil {
+			return nil, errors.Wrap(err, "failed to execute template")
+		}
 	}
 
 	return options, nil

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -150,6 +150,18 @@ func TestContainerListErrors(t *testing.T) {
 		expectedError     string
 	}{
 		{
+			flags: map[string]string{
+				"format": "{{invalid}}",
+			},
+			expectedError: `function "invalid" not defined`,
+		},
+		{
+			flags: map[string]string{
+				"format": "{{join}}",
+			},
+			expectedError: `wrong number of args for join`,
+		},
+		{
 			containerListFunc: func(_ types.ContainerListOptions) ([]types.Container, error) {
 				return nil, fmt.Errorf("error listing containers")
 			},


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Previously, we were doing special logic to figure out if the template passed in to `docker ps --format=...` requires the size field, and if so automatically applying the `--size` option to the request.
This causes an issue where, if a user wants a full json representation of the output of `docker ps`, they are unable to opt-out of getting the size. This has big performance implication, and can make `docker ps --format=...` unusable to the point of taking tens of seconds to complete.

This commit removes the special logic for this parameter, to enable users to get a json representation of the container withous `Size`, which can still be returned by setting `--size` alongside with `--format=...`.

I also noticed an inconsistency where previously we would validate the template passed in `--format=[template]` but only inside this edge case logic, which made it so we only validated the template if `--quiet` and `--size` were not passed in. This PR makes it so that if `--format` is used, we always validate the template for consistency.

**- How I did it**

With Neovim 👀 

**- How to verify it**

Run a container, then run:
- `docker ps --format={{json .}}`
- `docker ps --size --format={{json .}}`
- compare the output

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```
Container size is no longer calculated by default when using a template which requires it.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="549" alt="image" src="https://user-images.githubusercontent.com/70572044/221906701-5493152d-09f8-4c4c-8f5b-250a8b3d84f4.png">

