### PR TITLE
[20.10 backport] test/cli: Use empty array as empty output of images/json

### DIFF
--- a/cli/command/image/client_test.go
+++ b/cli/command/image/client_test.go
@@ -91,7 +91,7 @@ func (cli *fakeClient) ImageList(ctx context.Context, options types.ImageListOpt
 	if cli.imageListFunc != nil {
 		return cli.imageListFunc(options)
 	}
-	return []types.ImageSummary{{}}, nil
+	return []types.ImageSummary{}, nil
 }
 
 func (cli *fakeClient) ImageInspectWithRaw(_ context.Context, image string) (types.ImageInspect, []byte, error) {

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -30,7 +30,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 			name:          "failed-list",
 			expectedError: "something went wrong",
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
-				return []types.ImageSummary{{}}, errors.Errorf("something went wrong")
+				return []types.ImageSummary{}, errors.Errorf("something went wrong")
 			},
 		},
 	}
@@ -66,7 +66,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			args: []string{"image"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
 				assert.Check(t, is.Equal("image", options.Filters.Get("reference")[0]))
-				return []types.ImageSummary{{}}, nil
+				return []types.ImageSummary{}, nil
 			},
 		},
 		{
@@ -74,7 +74,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 			args: []string{"--filter", "name=value"},
 			imageListFunc: func(options types.ImageListOptions) ([]types.ImageSummary, error) {
 				assert.Check(t, is.Equal("value", options.Filters.Get("name")[0]))
-				return []types.ImageSummary{{}}, nil
+				return []types.ImageSummary{}, nil
 			},
 		},
 	}


### PR DESCRIPTION
- Backport: https://github.com/docker/cli/pull/4050

Tests mocking the output of GET images/json with fakeClient used an array with one empty element as an empty response. Change it to just an empty array.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>
(cherry picked from commit a1953e19b266126bdbf906dfd06b735d73d8d27c)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

