### PR TITLE
docs: Deprecate buildkit's build information

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 | Status     | Feature                                                                                                                            | Deprecated | Remove  |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|---------|
+| Deprecated | [Buildkit build information](#buildkit-build-information)                                                                          | v23.0.0    | v23.1.0 |
 | Deprecated | [Legacy builder for Linux images](#legacy-builder-for-linux-images)                                                                | v23.0.0    | -       |
 | Deprecated | [Legacy builder fallback](#legacy-builder-fallback)                                                                                | v23.0.0    | -       |
 | Removed    | [Btrfs storage driver on CentOS 7 and RHEL 7](#btrfs-storage-driver-on-centos-7-and-rhel-7)                                        | v20.10     | v23.0.0 |
@@ -103,6 +104,17 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09  |
 | Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13   |
 | Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12   |
+
+### Buildkit build information
+
+**Deprecated in Release: v23.0.0**
+
+[Build information](https://github.com/moby/buildkit/blob/v0.11/docs/buildinfo.md)
+structures have been introduced in [BuildKit v0.10.0](https://github.com/moby/buildkit/releases/tag/v0.10.0)
+and are generated with build metadata that allows you to see all the sources
+(images, git repositories) that were used by the build with their exact
+versions and also the configuration that was passed to the build. This
+information is also embedded into the image configuration if one is generated.
 
 ### Legacy builder for Linux images
 


### PR DESCRIPTION
Related to:
- https://github.com/moby/buildkit/pull/3614
- https://github.com/moby/moby/pull/45095

Buildkit deprecated build information in favor of provenance attestations.
Mark it as deprecated in v23.0.0 and removed in the next v23.1.0.