### PR TITLE
connhelper: Allow socket path when using SSH

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -47,7 +47,12 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 		}
 		return &ConnectionHelper{
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args("docker", "system", "dial-stdio")...)...)
+				args := []string{"docker"}
+				if sp.Path != "" {
+					args = append(args, "--host", "unix://"+sp.Path)
+				}
+				args = append(args, "system", "dial-stdio")
+				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args(args...)...)...)
 			},
 			Host: "http://docker.example.com",
 		}, nil

--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -30,9 +30,7 @@ func ParseURL(daemonURL string) (*Spec, error) {
 		return nil, errors.Errorf("no host specified")
 	}
 	sp.Port = u.Port()
-	if u.Path != "" {
-		return nil, errors.Errorf("extra path after the host: %q", u.Path)
-	}
+	sp.Path = u.Path
 	if u.RawQuery != "" {
 		return nil, errors.Errorf("extra query after the host: %q", u.RawQuery)
 	}
@@ -47,6 +45,7 @@ type Spec struct {
 	User string
 	Host string
 	Port string
+	Path string
 }
 
 // Args returns args except "ssh" itself combined with optional additional command args

--- a/cli/connhelper/ssh/ssh_test.go
+++ b/cli/connhelper/ssh/ssh_test.go
@@ -32,8 +32,10 @@ func TestParseURL(t *testing.T) {
 			expectedError: "plain-text password is not supported",
 		},
 		{
-			url:           "ssh://foo/bar",
-			expectedError: `extra path after the host: "/bar"`,
+			url: "ssh://foo/bar",
+			expectedArgs: []string{
+				"--", "foo",
+			},
 		},
 		{
 			url:           "ssh://foo?bar",

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -213,6 +213,7 @@ precedence over `HTTP_PROXY`.
 The Docker client supports connecting to a remote daemon via SSH:
 
 ```console
+$ docker -H ssh://me@example.com:22/var/run/docker.sock ps
 $ docker -H ssh://me@example.com:22 ps
 $ docker -H ssh://me@example.com ps
 $ docker -H ssh://example.com ps


### PR DESCRIPTION
**- What I did**

Modified `connhelper` to allow socket path in SSH URI

**- How I did it**

Removed error if path is specified when using `ssh://` scheme
Added capture of URI Path
Append `--host` flag with formatted socket path as `unix://%s` between passed args

**- How to verify it**

Run below

Linux/macOS:

```shell
DOCKER_HOST='ssh://host/var/run/docker.sock' docker system info
```

Windows
```powershell
$env:DOCKER_HOST='ssh://host/var/run/docker.sock'
docker system info
```

**- Description for the changelog**

Allow specifying socket path when connecting via SSH

**- A picture of a cute animal (not mandatory but encouraged)**
![fiji](https://user-images.githubusercontent.com/50457605/222903295-3d7f8d0a-f488-4fc3-a726-a9391c2d8246.jpg)


