### PR TITLE
Update docs/command output for volume prune to specify when named volumes will be deleted

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -114,7 +114,7 @@ func confirmationMessage(dockerCli command.Cli, options pruneOptions) string {
 		"all networks not used by at least one container",
 	}
 	if options.pruneVolumes {
-		warnings = append(warnings, "all volumes not used by at least one container")
+		warnings = append(warnings, "all anonymous volumes not used by at least one container")
 	}
 	if options.all {
 		warnings = append(warnings, "all images without at least one container associated to them")

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -23,7 +23,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
-		Short: "Remove all unused local volumes",
+		Short: "Remove all unused anonymous local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spaceReclaimed, output, err := runPrune(dockerCli, options)
@@ -47,7 +47,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-const warning = `WARNING! This will remove all local volumes not used by at least one container.
+const warning = `WARNING! This will remove all anonymous local volumes not used by at least one container.
 Are you sure you want to continue?`
 
 func runPrune(dockerCli command.Cli, options pruneOptions) (spaceReclaimed uint64, output string, err error) {

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -77,6 +77,23 @@ func TestVolumePruneForce(t *testing.T) {
 	}
 }
 
+func TestVolumePrunePromptAllNo(t *testing.T) {
+	// FIXME(vdemeester) make it work..
+	skip.If(t, runtime.GOOS == "windows", "TODO: fix test on windows")
+
+	for _, input := range []string{"1", "true"} {
+		cli := test.NewFakeCli(&fakeClient{
+			volumePruneFunc: simplePruneFunc,
+		})
+
+		cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader("n"))))
+		cmd := NewPruneCommand(cli)
+		cmd.Flags().Set("filter", fmt.Sprintf("all=%s", input))
+		assert.NilError(t, cmd.Execute())
+		golden.Assert(t, cli.OutBuffer().String(), "volume-prune-all-no.golden")
+	}
+}
+
 func TestVolumePrunePromptYes(t *testing.T) {
 	// FIXME(vdemeester) make it work..
 	skip.If(t, runtime.GOOS == "windows", "TODO: fix test on windows")

--- a/cli/command/volume/testdata/volume-prune-all-no.golden
+++ b/cli/command/volume/testdata/volume-prune-all-no.golden
@@ -1,0 +1,2 @@
+WARNING! This will remove all named and anonymous local volumes not used by at least one container.
+Are you sure you want to continue? [y/N] Total reclaimed space: 0B

--- a/cli/command/volume/testdata/volume-prune-no.golden
+++ b/cli/command/volume/testdata/volume-prune-no.golden
@@ -1,2 +1,2 @@
-WARNING! This will remove all local volumes not used by at least one container.
+WARNING! This will remove all anonymous local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] Total reclaimed space: 0B

--- a/cli/command/volume/testdata/volume-prune-yes.golden
+++ b/cli/command/volume/testdata/volume-prune-yes.golden
@@ -1,4 +1,4 @@
-WARNING! This will remove all local volumes not used by at least one container.
+WARNING! This will remove all anonymous local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] Deleted Volumes:
 foo
 bar

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -15,14 +15,27 @@ Remove all unused local volumes
 
 ## Description
 
-Remove all unused local volumes. Unused local volumes are those which are not referenced by any containers
+Remove all unused anonymous local volumes. Unused local volumes are those which
+are not referenced by any containers. Anonymous volumes have random names and
+are created by Docker during container or service creation.
+
+Named volumes can be also removed using the filter `all=1`.
 
 ## Examples
 
 ```console
 $ docker volume prune
 
-WARNING! This will remove all local volumes not used by at least one container.
+WARNING! This will remove all anonymous local volumes not used by at least one container.
+Are you sure you want to continue? [y/N] y
+Deleted Volumes:
+07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e
+
+Total reclaimed space: 36 B
+
+$ docker volume prune --filter all=1
+
+WARNING! This will remove all anonymous local volumes not used by at least one container.
 Are you sure you want to continue? [y/N] y
 Deleted Volumes:
 07c7bdf3e34ab76d921894c2b834f073721fccfbbcba792aa7648e3a7a664c2e
@@ -39,6 +52,7 @@ than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "b
 The currently supported filters are:
 
 * label (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) - only remove volumes with (or without, in case `label!=...` is used) the specified labels.
+* all (`all=0`, `all=1`) - whether named volumes should also be removed.
 
 The `label` filter accepts two formats. One is the `label=...` (`label=<key>` or `label=<key>=<value>`),
 which removes volumes with the specified labels. The other


### PR DESCRIPTION
In previous versions of the Docker API, `system prune --volumes` and `volume prune` would remove all dangling volumes. With API v1.42, this was changed so that only anonymous volumes would be removed unless the `all` filter was specified. Update the docs and command output to reflect this.

Fixes #4028 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated documentation/warning output for the `system_prune` and `volume_prune` commands to reflect that only anonymous volumes are removed by default.
**- How I did it**
* Updated doc files
* In `volume/prune.go`, specify that *anonymous* volumes will be removed. If `all=1` is set, indicate that named volumes will be removed too.

**- How to verify it**
`docker volume prune`
`docker volume prune --filter all=1`

**- Description for the changelog**
Update `volume prune` output to be more specific about whether named volumes will be removed.

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/5713415/223893253-f92c0006-af64-4fa1-83bf-9ab3f42a2edd.png)
