### PR TITLE
[23.0 backport] stack/loader: Ignore cmd.exe special env variables

### DIFF
--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -120,7 +120,7 @@ func buildEnvironment(env []string) (map[string]string, error) {
 
 		k, v, ok := strings.Cut(s, "=")
 		if !ok || k == "" {
-			return result, errors.Errorf("unexpected environment %q", s)
+			return result, errors.Errorf("unexpected environment variable '%s'", s)
 		}
 		// value may be set, but empty if "s" is like "K=", not "K".
 		result[k] = v

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -104,6 +105,19 @@ func GetConfigDetails(composefiles []string, stdin io.Reader) (composetypes.Conf
 func buildEnvironment(env []string) (map[string]string, error) {
 	result := make(map[string]string, len(env))
 	for _, s := range env {
+		if runtime.GOOS == "windows" && len(s) > 0 {
+			// cmd.exe can have special environment variables which names start with "=".
+			// They are only there for MS-DOS compatibility and we should ignore them.
+			// See TestBuildEnvironment for examples.
+			//
+			// https://ss64.com/nt/syntax-variables.html
+			// https://devblogs.microsoft.com/oldnewthing/20100506-00/?p=14133
+			// https://github.com/docker/cli/issues/4078
+			if s[0] == '=' {
+				continue
+			}
+		}
+
 		k, v, ok := strings.Cut(s, "=")
 		if !ok || k == "" {
 			return result, errors.Errorf("unexpected environment %q", s)


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4081
- fixes https://github.com/docker/cli/issues/4078

-----


On Windows, ignore all variables that start with "=" when building an environment variables map for stack.

For MS-DOS compatibility cmd.exe can set some special environment variables that start with a "=" characters, which breaks the general assumption that the first encountered "=" separates a variable name from variable value and causes trouble when parsing.

These variables don't seem to be documented anywhere, but they are described by some third-party sources and confirmed empirically on my Windows installation.

Useful sources:
https://devblogs.microsoft.com/oldnewthing/20100506-00/?p=14133
https://ss64.com/nt/syntax-variables.html

Known variables:

- `=ExitCode` stores the exit code returned by external command (in hex format)
- `=ExitCodeAscii` - same as above, except the value is the ASCII representation of the code (so exit code 65 (0x41) becomes 'A').
- `=::=::\` and friends - store drive specific working directory. There is one env variable for each separate drive letter that was accessed in the shell session and stores the working directory for that specific drive. The general format for these is: `=<DRIVE_LETTER>:=<CWD>`  (key=`=<DRIVE_LETTER>:`, value=`<CWD>`) where <CWD> is a working directory for the drive that is assigned to the letter <DRIVE_LETTER>

  A couple of examples: `=C:=C:\some\dir`  (key: `=C:`, value: `C:\some\dir`) `=D:=D:\some\other\dir`  (key: `=C:`, value: `C:\some\dir`) `=Z:=Z:\`  (key: `=Z:`, value: `Z:\`)

  `=::=::\` is the one that seems to be always set and I'm not exactly sure what this one is for (what's drive `::`?). Others are set as soon as you CD to a path on some drive. Considering that you start a cmd.exe also has some working directory, there are 2 of these on start.

All these variables can be safely ignored because they can't be deliberately set by the user, their meaning is only relevant to the cmd.exe session and they're all are related to the MS-DOS/Batch feature that are irrelevant for us.

**- What I did**

**- How I did it**

**- How to verify it**
TestBuildEnvironment test

**- Description for the changelog**
Fix `docker stack deploy` failing when running from `cmd.exe` on Windows

**- A picture of a cute animal (not mandatory but encouraged)**
