### PR TITLE
Add bash completion for docker-buildx plugin

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5395,6 +5395,23 @@ _docker_wait() {
 	_docker_container_wait
 }
 
+BUILDX_PLUGIN_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{if eq .Name "buildx"}}{{.Path}}{{end}}{{end}}')
+
+_docker_buildx() {
+	local completionCommand="__completeNoDesc"
+	local resultArray=($BUILDX_PLUGIN_PATH $completionCommand)
+	for value in "${words[@]:2}"; do
+		if [ -z "$value" ]; then
+			resultArray+=( "''" )
+		else
+			resultArray+=( "$value" )
+		fi
+	done
+	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
+
+	COMPREPLY=( $(compgen -W "${result}" -- "${current-}") )
+}
+
 COMPOSE_PLUGIN_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{if eq .Name "compose"}}{{.Path}}{{end}}{{end}}')
 
 _docker_compose() {
@@ -5483,6 +5500,9 @@ _docker() {
 
 	local known_plugin_commands=()
 
+	if [ -f "$BUILDX_PLUGIN_PATH" ] ; then
+		known_plugin_commands+=("buildx")
+	fi
 	if [ -f "$COMPOSE_PLUGIN_PATH" ] ; then
 		known_plugin_commands+=("compose")
 	fi


### PR DESCRIPTION
**- What I did**

I was working on targets completion for the `buildx bake` command in https://github.com/docker/buildx/pull/1674 and found out we don't have any bash completion for docker-buildx plugin.

**- How I did it**

**- How to verify it**

```
$ mkdir -p ~/.local/share/bash-completion/completions
$ cp ./contrib/completion/bash/docker ~/.local/share/bash-completion/completions/docker
$ _completion_loader docker

$ docker build [tab][tab]
build    builder  buildx

$ docker buildx [tab][tab]
bake        create      help        inspect     prune       stop        version     
build       du          imagetools  ls          rm          use

$ docker buildx b [tab][tab]
bake   build
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

