### PR TITLE
Add bash completion for available plugins

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1142,6 +1142,29 @@ __docker_complete_user_group() {
 	fi
 }
 
+DOCKER_PLUGINS_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{.Path}}:{{end}}')
+
+__docker_complete_plugin() {
+	local path=$1
+	local completionCommand="__completeNoDesc"
+	local resultArray=($path $completionCommand)
+	for value in "${words[@]:2}"; do
+		if [ -z "$value" ]; then
+			resultArray+=( "''" )
+		else
+			resultArray+=( "$value" )
+		fi
+	done
+	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
+
+	# if result empty, just use filename completion as fallback
+	if [ -z "$result" ]; then
+		_filedir
+	else
+		COMPREPLY=( $(compgen -W "${result}" -- "${current-}") )
+	fi
+}
+
 _docker_docker() {
 	# global options that may appear after the docker command
 	local boolean_options="
@@ -5395,23 +5418,6 @@ _docker_wait() {
 	_docker_container_wait
 }
 
-COMPOSE_PLUGIN_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{if eq .Name "compose"}}{{.Path}}{{end}}{{end}}')
-
-_docker_compose() {
-	local completionCommand="__completeNoDesc"
-	local resultArray=($COMPOSE_PLUGIN_PATH $completionCommand compose)
-	for value in "${words[@]:2}"; do
-		if [ -z "$value" ]; then
-			resultArray+=( "''" )
-		else
-			resultArray+=( "$value" )
-		fi
-	done
-	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
-
-	COMPREPLY=( $(compgen -W "${result}" -- "${current-}") )
-}
-
 _docker() {
 	local previous_extglob_setting=$(shopt -p extglob)
 	shopt -s extglob
@@ -5481,11 +5487,16 @@ _docker() {
 		wait
 	)
 
+	# Create completion functions for all registered plugins
 	local known_plugin_commands=()
-
-	if [ -f "$COMPOSE_PLUGIN_PATH" ] ; then
-		known_plugin_commands+=("compose")
-	fi
+	local plugin_name=""
+	for plugin_path in ${DOCKER_PLUGINS_PATH//:/ }; do
+		plugin_name=$(basename "$plugin_path" | sed 's/ *$//')
+		plugin_name=${plugin_name#docker-}
+		plugin_name=${plugin_name%%.*}
+		eval "_docker_${plugin_name}() { __docker_complete_plugin \"${plugin_path}\"; }"
+		known_plugin_commands+=(${plugin_name})
+	done
 
 	local experimental_server_commands=(
 		checkpoint


### PR DESCRIPTION
closes https://github.com/docker/cli/pull/4089

**- What I did**

This is a follow-up of https://github.com/docker/cli/pull/4089#discussion_r1133670411 to enable bash completion for available plugins.

**- How I did it**

**- How to verify it**

```
$ mkdir -p ~/.local/share/bash-completion/completions
$ cp ./contrib/completion/bash/docker ~/.local/share/bash-completion/completions/docker
$ _completion_loader docker

$ docker info --format '{{json .ClientInfo.Plugins}}' | jq
[
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "v0.10.0-rc2-175-g00bb9c5c.m",
    "ShortDescription": "Docker Buildx",
    "Name": "buildx",
    "Path": "/home/crazy/.docker/cli-plugins/docker-buildx",
    "ShadowedPaths": [
      "/usr/libexec/docker/cli-plugins/docker-buildx"
    ]
  },
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "v2.16.0",
    "ShortDescription": "Docker Compose",
    "Name": "compose",
    "Path": "/usr/libexec/docker/cli-plugins/docker-compose"
  },
  {
    "SchemaVersion": "0.1.0",
    "Vendor": "Docker Inc.",
    "Version": "v0.23.0",
    "ShortDescription": "Docker Scan",
    "Name": "scan",
    "Path": "/usr/libexec/docker/cli-plugins/docker-scan"
  }
]

$ docker build [tab][tab]
build    builder  buildx

$ docker buildx [tab][tab]
bake        create      help        inspect     prune       stop        version     
build       du          imagetools  ls          rm          use

$ docker buildx b [tab][tab]
bake   build

$ docker co [tab][tab]
commit     compose    config     container  context

$ docker compose [tab][tab]
build    cp       down     exec     kill     ls       port     pull     restart  run      stop     unpause  version  
config   create   events   images   logs     pause    ps       push     rm       start    top      up
```

To make it works with buildx plugin you need https://github.com/docker/buildx/pull/1674

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

cc @silvin-lubecki @ulyssessouza