### PR TITLE
cli/command/volume: suppress err output in tests

### DIFF
--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -50,6 +50,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 			cmd.Flags().Set(key, value)
 		}
 		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -62,6 +62,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 			cmd.Flags().Set(key, value)
 		}
 		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -43,6 +43,7 @@ func TestVolumeListErrors(t *testing.T) {
 			cmd.Flags().Set(key, value)
 		}
 		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -49,6 +49,7 @@ func TestVolumePruneErrors(t *testing.T) {
 			cmd.Flags().Set(key, value)
 		}
 		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -33,6 +33,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
 }


### PR DESCRIPTION
- extracted from https://github.com/docker/cli/pull/4010

These tests were deliberately producing errors as part of the test, but printing those errors could be confusing / make it more difficult to find actual test-failures.

Before this patch:

    === RUN   TestVolumeCreateErrors
    Error: conflicting options: either specify --name or provide positional arg, not both
    Error: "create" requires at most 1 argument.
    See 'create --help'.

    Usage:  create [OPTIONS] [VOLUME] [flags]

    Create a volume
    Error: error creating volume
    --- PASS: TestVolumeCreateErrors (0.00s)
    PASS

With this patch applied:

    === RUN   TestVolumeCreateErrors
    --- PASS: TestVolumeCreateErrors (0.00s)
    PASS


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

