### PR TITLE
Config ls examples corrections in reference documentation

### DIFF
--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -83,7 +83,7 @@ The following filter matches only services with the `project` label with the
 `project-a` value.
 
 ```console
-$ docker service ls --filter label=project=test
+$ docker config ls --filter label=project=test
 
 ID                          NAME                        CREATED             UPDATED
 mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -83,7 +83,7 @@ The following filter matches only services with the `project` label with the
 `project-a` value.
 
 ```console
-$ docker config ls --filter label=project=test
+$ docker config ls --filter label=project=project-a
 
 ID                          NAME                        CREATED             UPDATED
 mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago
@@ -96,7 +96,7 @@ The `name` filter matches on all or prefix of a config's name.
 The following filter matches config with a name containing a prefix of `test`.
 
 ```console
-$ docker config ls --filter name=test_config
+$ docker config ls --filter name=test
 
 ID                          NAME                        CREATED             UPDATED
 mem02h8n73mybpgqjf0kfi1n0   test_config                 About an hour ago   About an hour ago


### PR DESCRIPTION
I just edited directly in the GitHub interface hence I do not have signed off commits. I think those are minor corrections but I can redo them with the Signed off added.