### PR TITLE
cli/command: remove deprecated ElectAuthServer()

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -21,13 +21,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ElectAuthServer returns the default registry to use.
-//
-// Deprecated: use [registry.IndexServer] instead.
-func ElectAuthServer(_ context.Context, _ Cli) string {
-	return registry.IndexServer
-}
-
 // EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload
 func EncodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
 	buf, err := json.Marshal(authConfig)


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/2819

This function was deprecated in b4ca1c7368daeead400fcc1b8f2d61951a0d9d1e (https://github.com/docker/cli/pull/2819), which is part of the v23.0 release, and is no longer used, so we can remove it.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


```markdown
- cli/command: remove deprecated ElectAuthServer()
```

**- A picture of a cute animal (not mandatory but encouraged)**

