### PR TITLE
Remove registry Service use

### DIFF
--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -289,7 +289,7 @@ func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth tru
 }
 
 // TrustedReference returns the canonical trusted reference for an image reference
-func TrustedReference(ctx context.Context, cli command.Cli, ref reference.NamedTagged, rs registry.Service) (reference.Canonical, error) {
+func TrustedReference(ctx context.Context, cli command.Cli, ref reference.NamedTagged, rs trust.RepositoryInfoResolver) (reference.Canonical, error) {
 	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, rs, AuthResolver(cli), ref.String())
 	if err != nil {
 		return nil, err

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -299,9 +299,12 @@ type ImageRefAndAuth struct {
 	digest     digest.Digest
 }
 
+// RepositoryInfoResolver returns repository info for the given reference.
+type RepositoryInfoResolver func(name reference.Named) (*registry.RepositoryInfo, error)
+
 // GetImageReferencesAndAuth retrieves the necessary reference and auth information for an image name
 // as an ImageRefAndAuth struct
-func GetImageReferencesAndAuth(ctx context.Context, rs registry.Service,
+func GetImageReferencesAndAuth(ctx context.Context, resolveFn RepositoryInfoResolver,
 	authResolver func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig,
 	imgName string,
 ) (ImageRefAndAuth, error) {
@@ -312,8 +315,8 @@ func GetImageReferencesAndAuth(ctx context.Context, rs registry.Service,
 
 	// Resolve the Repository name from fqn to RepositoryInfo
 	var repoInfo *registry.RepositoryInfo
-	if rs != nil {
-		repoInfo, err = rs.ResolveRepository(ref)
+	if resolveFn != nil {
+		repoInfo, err = resolveFn(ref)
 	} else {
 		repoInfo, err = registry.ParseRepositoryInfo(ref)
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4010
- relates to https://github.com/moby/moby/pull/45086 (https://github.com/moby/moby/commit/7b3acdff5d01c6bbac5ddd38d3bc01277f06ee64 removed the interface, so we can no longer use that).

Looks like the service is not needed, as we always pass an empty config, so we can use ParseRepositoryInfo instead.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

