### PR TITLE
Allow extensions in `build` field in `docker-compose.yaml` schema

### DIFF
--- a/cli/compose/schema/data/config_schema_v3.9.json
+++ b/cli/compose/schema/data/config_schema_v3.9.json
@@ -91,7 +91,8 @@
                 "shm_size": {"type": ["integer", "string"]},
                 "extra_hosts": {"$ref": "#/definitions/list_or_dict"}
               },
-              "additionalProperties": false
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
             }
           ]
         },


### PR DESCRIPTION
Enable support of [x-bake extension](https://docs.docker.com/build/bake/compose-file/#extension-field-with-x-bake) in json schema.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add `patternProperties` in latest json schema for `build` field.

**- Description for the changelog**
Add support for `x-` fields in `build` field in docker-compose.yaml
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
```
               ((`\
            ___ \\ '--._
         .'`   `'    o  )
        /    \   '. __.'
       _|    /_  \ \_\_
jgs   {_\______\-'\__\_\
```