### PR TITLE
cli/trust: remove special handling for "plugin" Class

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -227,7 +227,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerConfig
 
 		if taggedRef, ok := namedRef.(reference.NamedTagged); ok && !opts.untrusted {
 			var err error
-			trustedRef, err = image.TrustedReference(ctx, dockerCli, taggedRef, nil)
+			trustedRef, err = image.TrustedReference(ctx, dockerCli, taggedRef)
 			if err != nil {
 				return nil, err
 			}

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -279,7 +279,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 	var resolvedTags []*resolvedTag
 	if !options.untrusted {
 		translator := func(ctx context.Context, ref reference.NamedTagged) (reference.Canonical, error) {
-			return TrustedReference(ctx, dockerCli, ref, nil)
+			return TrustedReference(ctx, dockerCli, ref)
 		}
 		// if there is a tar wrapper, the dockerfile needs to be replaced inside it
 		if buildCtx != nil {

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -69,7 +69,7 @@ func RunPull(cli command.Cli, opts PullOptions) error {
 	}
 
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, AuthResolver(cli), distributionRef.String())
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(cli), distributionRef.String())
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -186,7 +186,7 @@ func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.Image
 		if err != nil {
 			return err
 		}
-		updatedImgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, AuthResolver(cli), trustedRef.String())
+		updatedImgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(cli), trustedRef.String())
 		if err != nil {
 			return err
 		}
@@ -289,8 +289,8 @@ func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth tru
 }
 
 // TrustedReference returns the canonical trusted reference for an image reference
-func TrustedReference(ctx context.Context, cli command.Cli, ref reference.NamedTagged, rs registry.Service) (reference.Canonical, error) {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, rs, AuthResolver(cli), ref.String())
+func TrustedReference(ctx context.Context, cli command.Cli, ref reference.NamedTagged) (reference.Canonical, error) {
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(cli), ref.String())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -54,26 +54,6 @@ func newInstallCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-type pluginRegistryService struct {
-	registry.Service
-}
-
-func (s pluginRegistryService) ResolveRepository(name reference.Named) (*registry.RepositoryInfo, error) {
-	repoInfo, err := s.Service.ResolveRepository(name)
-	if repoInfo != nil {
-		repoInfo.Class = "plugin"
-	}
-	return repoInfo, err
-}
-
-func newRegistryService() (registry.Service, error) {
-	svc, err := registry.NewService(registry.ServiceOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return pluginRegistryService{Service: svc}, nil
-}
-
 func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOptions, cmdName string) (types.PluginInstallOptions, error) {
 	// Names with both tag and digest will be treated by the daemon
 	// as a pull by digest with a local name for the tag
@@ -98,12 +78,7 @@ func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOpti
 			return types.PluginInstallOptions{}, errors.Errorf("invalid name: %s", ref.String())
 		}
 
-		ctx := context.Background()
-		svc, err := newRegistryService()
-		if err != nil {
-			return types.PluginInstallOptions{}, err
-		}
-		trusted, err := image.TrustedReference(ctx, dockerCli, nt, svc)
+		trusted, err := image.TrustedReference(context.Background(), dockerCli, nt)
 		if err != nil {
 			return types.PluginInstallOptions{}, err
 		}

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -68,7 +68,6 @@ func runPush(dockerCli command.Cli, opts pushOptions) error {
 	defer responseBody.Close()
 
 	if !opts.untrusted {
-		repoInfo.Class = "plugin"
 		return image.PushTrustedReference(dockerCli, repoInfo, named, authConfig, responseBody)
 	}
 

--- a/cli/command/trust/common.go
+++ b/cli/command/trust/common.go
@@ -53,7 +53,7 @@ type trustKey struct {
 // This information is to be pretty printed or serialized into a machine-readable format.
 func lookupTrustInfo(cli command.Cli, remote string) ([]trustTagRow, []client.RoleWithSignatures, []data.Role, error) {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
 	if err != nil {
 		return []trustTagRow{}, []client.RoleWithSignatures{}, []data.Role{}, err
 	}

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -36,7 +36,7 @@ func newRevokeCommand(dockerCli command.Cli) *cobra.Command {
 
 func revokeTrust(cli command.Cli, remote string, options revokeOptions) error {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -43,7 +43,7 @@ func newSignCommand(dockerCli command.Cli) *cobra.Command {
 func runSignImage(cli command.Cli, options signOptions) error {
 	imageName := options.imageName
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), imageName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), imageName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -81,7 +81,7 @@ func addSigner(cli command.Cli, options signerAddOptions) error {
 
 func addSignerToRepo(cli command.Cli, signerName string, repoName string, signerPubKeys []data.PublicKey) error {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), repoName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -80,7 +80,7 @@ func isLastSignerForReleases(roleWithSig data.Role, allRoles []client.RoleWithSi
 // The signer not being removed doesn't necessarily raise an error e.g. user choosing "No" when prompted for confirmation.
 func removeSingleSigner(cli command.Cli, repoName, signerName string, forceYes bool) (bool, error) {
 	ctx := context.Background()
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, nil, image.AuthResolver(cli), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), repoName)
 	if err != nil {
 		return false, err
 	}

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -160,7 +160,7 @@ func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo
 	scope := auth.RepositoryScope{
 		Repository: repoInfo.Name.Name(),
 		Actions:    actions,
-		Class:      repoInfo.Class,
+		Class:      repoInfo.Class, // TODO(thaJeztah): Class is no longer needed for plugins and can likely be removed; see https://github.com/docker/cli/pull/4114#discussion_r1145430825
 	}
 	creds := simpleCredentialStore{auth: *authConfig}
 	tokenHandlerOptions := auth.TokenHandlerOptions{
@@ -301,7 +301,7 @@ type ImageRefAndAuth struct {
 
 // GetImageReferencesAndAuth retrieves the necessary reference and auth information for an image name
 // as an ImageRefAndAuth struct
-func GetImageReferencesAndAuth(ctx context.Context, rs registry.Service,
+func GetImageReferencesAndAuth(ctx context.Context,
 	authResolver func(ctx context.Context, index *registrytypes.IndexInfo) types.AuthConfig,
 	imgName string,
 ) (ImageRefAndAuth, error) {
@@ -311,13 +311,7 @@ func GetImageReferencesAndAuth(ctx context.Context, rs registry.Service,
 	}
 
 	// Resolve the Repository name from fqn to RepositoryInfo
-	var repoInfo *registry.RepositoryInfo
-	if rs != nil {
-		repoInfo, err = rs.ResolveRepository(ref)
-	} else {
-		repoInfo, err = registry.ParseRepositoryInfo(ref)
-	}
-
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
 	if err != nil {
 		return ImageRefAndAuth{}, err
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4010
- relates to https://github.com/moby/moby/pull/45086 (https://github.com/moby/moby/commit/7b3acdff5d01c6bbac5ddd38d3bc01277f06ee64 removed the interface, so we can no longer use that).
- relates to https://github.com/docker/hub-feedback/issues/2107
- replaces / closes https://github.com/docker/cli/pull/4111


This code depended on the registry Service interface, which has been removed,
so needed to be refactored. Digging further into the reason this code existed,
it looked like the Class=plugin was previously required on Docker Hub to handle
plugins, but this requirement is no longer there, so we can remove this special
handling.

This patch removes the special handling to both remove the use of the registry.Service
interface, as well as removing complexity that is no longer needed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

