### PR TITLE
[20.10 backport] Enable ssh forwarding when building a remote target

### DIFF
--- a/cli/command/image/build_buildkit.go
+++ b/cli/command/image/build_buildkit.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/session/sshforward/sshprovider"
 	"github.com/moby/buildkit/util/appcontext"
+	"github.com/moby/buildkit/util/gitutil"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	"github.com/pkg/errors"
@@ -185,10 +186,15 @@ func runBuildBuildKit(dockerCli command.Cli, options buildOptions) error {
 		}
 		s.Allow(sp)
 	}
-	if len(options.ssh) > 0 {
-		sshp, err := parseSSHSpecs(options.ssh)
+
+	sshSpecs := options.ssh
+	if len(sshSpecs) == 0 && isGitSSH(remote) {
+		sshSpecs = []string{"default"}
+	}
+	if len(sshSpecs) > 0 {
+		sshp, err := parseSSHSpecs(sshSpecs)
 		if err != nil {
-			return errors.Wrapf(err, "could not parse ssh: %v", options.ssh)
+			return errors.Wrapf(err, "could not parse ssh: %v", sshSpecs)
 		}
 		s.Allow(sshp)
 	}
@@ -510,4 +516,9 @@ func parseSSH(value string) *sshprovider.AgentConfig {
 		cfg.Paths = strings.Split(parts[1], ",")
 	}
 	return &cfg
+}
+
+func isGitSSH(url string) bool {
+	_, gitProtocol := gitutil.ParseProtocol(url)
+	return gitProtocol == gitutil.SSHProtocol
 }


### PR DESCRIPTION
fixes #4112 

* backport of https://github.com/docker/cli/pull/3050

cc @thaJeztah 