### PR TITLE
Dockerfile: build binary if no target specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,8 @@ CMD ./scripts/test/e2e/entry
 FROM build-base-${BASE_VARIANT} AS dev
 COPY . .
 
-FROM scratch AS binary
-COPY --from=build /out .
-
 FROM scratch AS plugins
 COPY --from=build-plugins /out .
+
+FROM scratch AS binary
+COPY --from=build /out .


### PR DESCRIPTION
**- What I did**

Binary should be built if no target is specified when building the Dockerfile.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

