### PR TITLE
remove cobra v2 completion for plugins

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -133,13 +133,20 @@ func tryRunPluginHelp(dockerCli command.Cli, ccmd *cobra.Command, cargs []string
 func setHelpFunc(dockerCli command.Cli, cmd *cobra.Command) {
 	defaultHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(ccmd *cobra.Command, args []string) {
-		if pluginmanager.IsPluginCommand(ccmd) {
+		if err := pluginmanager.AddPluginCommandStubs(dockerCli, ccmd.Root()); err != nil {
+			ccmd.Println(err)
+			return
+		}
+
+		if len(args) >= 1 {
 			err := tryRunPluginHelp(dockerCli, ccmd, args)
+			if err == nil {
+				return
+			}
 			if !pluginmanager.IsNotFound(err) {
 				ccmd.Println(err)
+				return
 			}
-			cmd.PrintErrf("unknown help topic: %v\n", ccmd.Name())
-			return
 		}
 
 		if err := isSupported(ccmd, dockerCli); err != nil {
@@ -227,14 +234,8 @@ func runDocker(dockerCli *command.DockerCli) error {
 		return err
 	}
 
-	err = pluginmanager.AddPluginCommandStubs(dockerCli, cmd)
-	if err != nil {
-		return err
-	}
-
 	if len(args) > 0 {
-		ccmd, _, err := cmd.Find(args)
-		if err != nil || pluginmanager.IsPluginCommand(ccmd) {
+		if _, _, err := cmd.Find(args); err != nil {
 			err := tryPluginRun(dockerCli, cmd, args[0], envs)
 			if !pluginmanager.IsNotFound(err) {
 				return err

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -83,7 +83,7 @@ func TestHelpBad(t *testing.T) {
 
 	res := icmd.RunCmd(run("help", "badmeta"))
 	res.Assert(t, icmd.Expected{
-		ExitCode: 0,
+		ExitCode: 1,
 		Out:      icmd.None,
 	})
 	golden.Assert(t, res.Stderr(), "docker-help-badmeta-err.golden")
@@ -110,8 +110,8 @@ func TestBadHelp(t *testing.T) {
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		// This should be identical to the --help case above
-		Out: usage,
-		Err: shortHFlagDeprecated,
+		Out: shortHFlagDeprecated + usage,
+		Err: icmd.None,
 	})
 }
 


### PR DESCRIPTION
fixes #3621 
related to https://github.com/docker/cli/pull/3429

#3429 adds Cobra completion v2 support for commands and plugins. Since this change every invocation takes ~+60ms.

For `docker --version`:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `docker-19.03.15` | 61.4 ± 2.6 | 57.5 | 64.4 | 6.56 ± 1.19 |
| `docker-20.10.0` | 18.0 ± 2.9 | 14.6 | 21.8 | 1.93 ± 0.46 |
| `docker-20.10.12` | 17.6 ± 0.9 | 16.3 | 18.9 | 1.88 ± 0.35 |
| `docker-20.10.17` | 16.5 ± 1.5 | 15.4 | 19.1 | 1.77 ± 0.35 |
| `docker-20.10.23` | 13.9 ± 1.0 | 12.7 | 15.3 | 1.49 ± 0.28 |
| `docker-23.0.1` | 68.2 ± 2.2 | 64.7 | 70.3 | 7.29 ± 1.31 |
| `docker-dev-pr-3419-a4b6fe1` | 15.7 ± 0.7 | 14.9 | 16.5 | 1.68 ± 0.30 |
| `docker-dev-pr-3429-a09e61a` | 69.3 ± 2.5 | 66.7 | 73.1 | 7.41 ± 1.33 |

See the diff between `docker-dev-pr-3419-a4b6fe1` and `docker-dev-pr-3429-a09e61a`.

Looking at the changes, we are now loading plugins for every invocation: https://github.com/docker/cli/blob/f5d698a331f520e6fa1583911e5dedff428693f3/cmd/docker/docker.go#L230-L233

So the more plugins are in place in the user space, the worst it would be. And we have a lot of them in Docker Desktop atm:

```
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc., v0.10.3)
  compose: Docker Compose (Docker Inc., v2.15.1)
  dev: Docker Dev Environments (Docker Inc., v0.1.0)
  extension: Manages Docker extensions (Docker Inc., v0.2.18)
  sbom: View the packaged-based Software Bill Of Materials (SBOM) for an image (Anchore Inc., 0.6.0)
  scan: Docker Scan (Docker Inc., v0.25.0)
  scout: Command line tool for Docker Scout (Docker Inc., v0.6.0)
```

**- What I did**

Remove completion for plugins to fix the regression.

Also wants to note that Cobra v2 completion is not implemented in our [completion scripts](https://github.com/docker/cli/tree/master/contrib/completion) atm. #3429 is just a preliminary work for Cobra v2 completion support afaik. If we want full support we need to revisit the completion scripts and remove hand-written funcs. We could rely on a single function and let Cobra do the completion. Pretty much like https://github.com/docker/cli/pull/4094 for plugins. All this to say that with this change it does not break the current workflow.

**- How I did it**

**- How to verify it**

Here is the benchmark result (see last row):

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `docker-19.03.15` | 61.4 ± 2.6 | 57.5 | 64.4 | 6.56 ± 1.19 |
| `docker-20.10.0` | 18.0 ± 2.9 | 14.6 | 21.8 | 1.93 ± 0.46 |
| `docker-20.10.12` | 17.6 ± 0.9 | 16.3 | 18.9 | 1.88 ± 0.35 |
| `docker-20.10.17` | 16.5 ± 1.5 | 15.4 | 19.1 | 1.77 ± 0.35 |
| `docker-20.10.23` | 13.9 ± 1.0 | 12.7 | 15.3 | 1.49 ± 0.28 |
| `docker-23.0.1` | 68.2 ± 2.2 | 64.7 | 70.3 | 7.29 ± 1.31 |
| `docker-dev-pr-3419-a4b6fe1` | 15.7 ± 0.7 | 14.9 | 16.5 | 1.68 ± 0.30 |
| `docker-dev-pr-3429-a09e61a` | 69.3 ± 2.5 | 66.7 | 73.1 | 7.41 ± 1.33 |
| `docker-dev-rm-plugins-completion` | 10.1 ± 0.5 | 9.4 | 10.8 | 1.08 ± 0.20 |

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

