### PR TITLE
don't use null values in the bake definition

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,14 +1,14 @@
 variable "GO_VERSION" {
-    default = null
+    default = "1.19.7"
 }
 variable "VERSION" {
-    default = null
+    default = ""
 }
 variable "USE_GLIBC" {
-    default = null
+    default = ""
 }
 variable "STRIP_TARGET" {
-    default = null
+    default = ""
 }
 variable "IMAGE_NAME" {
     default = "docker-cli"


### PR DESCRIPTION
- follow-up https://github.com/docker/docker-ce-packaging/pull/866#issuecomment-1484745221
- updates https://github.com/docker/cli/pull/4117

**- What I did**

Remove null values in the bake definition to avoid issues with environments with old Buildx version (< 0.10).

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

