### PR TITLE
improve and load plugin command stubs when required

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -1,15 +1,18 @@
 package manager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/fvbommel/sortorder"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 	exec "golang.org/x/sys/execabs"
 )
 
@@ -146,19 +149,31 @@ func ListPlugins(dockerCli command.Cli, rootcmd *cobra.Command) ([]Plugin, error
 	}
 
 	var plugins []Plugin
+	var mu sync.Mutex
+	eg, _ := errgroup.WithContext(context.TODO())
 	for _, paths := range candidates {
-		if len(paths) == 0 {
-			continue
-		}
-		c := &candidate{paths[0]}
-		p, err := newPlugin(c, rootcmd)
-		if err != nil {
-			return nil, err
-		}
-		if !IsNotFound(p.Err) {
-			p.ShadowedPaths = paths[1:]
-			plugins = append(plugins, p)
-		}
+		func(paths []string) {
+			eg.Go(func() error {
+				if len(paths) == 0 {
+					return nil
+				}
+				c := &candidate{paths[0]}
+				p, err := newPlugin(c, rootcmd)
+				if err != nil {
+					return err
+				}
+				if !IsNotFound(p.Err) {
+					p.ShadowedPaths = paths[1:]
+					mu.Lock()
+					defer mu.Unlock()
+					plugins = append(plugins, p)
+				}
+				return nil
+			})
+		}(paths)
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	sort.Slice(plugins, func(i, j int) bool {

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -204,6 +204,16 @@ func DisableFlagsInUseLine(cmd *cobra.Command) {
 	})
 }
 
+// HasCompletionArg returns true if a cobra completion arg request is found.
+func HasCompletionArg(args []string) bool {
+	for _, arg := range args {
+		if arg == cobra.ShellCompRequestCmd || arg == cobra.ShellCompNoDescRequestCmd {
+			return true
+		}
+	}
+	return false
+}
+
 var helpCommand = &cobra.Command{
 	Use:               "help [command]",
 	Short:             "Help about the command",

--- a/e2e/cli-plugins/run_test.go
+++ b/e2e/cli-plugins/run_test.go
@@ -83,7 +83,7 @@ func TestHelpBad(t *testing.T) {
 
 	res := icmd.RunCmd(run("help", "badmeta"))
 	res.Assert(t, icmd.Expected{
-		ExitCode: 0,
+		ExitCode: 1,
 		Out:      icmd.None,
 	})
 	golden.Assert(t, res.Stderr(), "docker-help-badmeta-err.golden")
@@ -110,8 +110,8 @@ func TestBadHelp(t *testing.T) {
 	res.Assert(t, icmd.Expected{
 		ExitCode: 0,
 		// This should be identical to the --help case above
-		Out: usage,
-		Err: shortHFlagDeprecated,
+		Out: shortHFlagDeprecated + usage,
+		Err: icmd.None,
 	})
 }
 

--- a/vendor.mod
+++ b/vendor.mod
@@ -37,6 +37,7 @@ require (
 	github.com/theupdateframework/notary v0.7.1-0.20210315103452-bf96a202a09a
 	github.com/tonistiigi/go-rosetta v0.0.0-20200727161949-f79598599c5d
 	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.5.0
 	golang.org/x/term v0.5.0
 	golang.org/x/text v0.7.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -524,6 +524,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,132 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -276,6 +276,9 @@ golang.org/x/net/internal/socks
 golang.org/x/net/internal/timeseries
 golang.org/x/net/proxy
 golang.org/x/net/trace
+# golang.org/x/sync v0.1.0
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.5.0
 ## explicit; go 1.17
 golang.org/x/sys/execabs


### PR DESCRIPTION
fixes #3621 
related to https://github.com/docker/cli/pull/3429
closes #4119
closes #4120

**- What I did**

We are currently loading plugin commands stubs for every command invocation to add support for Cobra v2 completion. This causes a significant performance hit if there are a lot of plugins in the user space (7 atm in Docker Desktop):

```
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc., v0.10.3)
  compose: Docker Compose (Docker Inc., v2.15.1)
  dev: Docker Dev Environments (Docker Inc., v0.1.0)
  extension: Manages Docker extensions (Docker Inc., v0.2.18)
  sbom: View the packaged-based Software Bill Of Materials (SBOM) for an image (Anchore Inc., 0.6.0)
  scan: Docker Scan (Docker Inc., v0.25.0)
  scout: Command line tool for Docker Scout (Docker Inc., v0.6.0)
```

`docker --version` takes ~93ms currently:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `docker-20.10.12` | 19.2 ± 1.3 | 18.4 | 21.4 | 2.04 ± 0.47 |
| `docker-20.10.17` | 19.5 ± 0.8 | 18.5 | 20.5 | 2.07 ± 0.47 |
| `docker-20.10.23` | 15.3 ± 2.4 | 12.6 | 19.0 | 1.63 ± 0.44 |
| `docker-23.0.1` | 93.9 ± 1.8 | 91.0 | 95.8 | 9.96 ± 2.22 |
| `docker-dev-pr-3419-a4b6fe1` | 17.5 ± 1.0 | 16.8 | 19.1 | 1.85 ± 0.42 |
| `docker-dev-pr-3429-a09e61a` | 93.7 ± 0.8 | 92.5 | 94.5 | 9.94 ± 2.21 |

Instead of removing completion for plugins to fix the regression as suggested in #4119, we can slightly improve plugins discovery by spawning a goroutine for each iteration in the loop when listing plugins:

`docker --version` now takes ~38ms

But there is still a significant performance hit compared to `20.10.23`. With second commit we are now loading plugins only if cobra completion arg request is found and also make sure plugin command stubs are loaded once.

With this change `docker --version` now takes ~9ms:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `docker-20.10.12` | 19.2 ± 1.3 | 18.4 | 21.4 | 2.04 ± 0.47 |
| `docker-20.10.17` | 19.5 ± 0.8 | 18.5 | 20.5 | 2.07 ± 0.47 |
| `docker-20.10.23` | 15.3 ± 2.4 | 12.6 | 19.0 | 1.63 ± 0.44 |
| `docker-23.0.1` | 93.9 ± 1.8 | 91.0 | 95.8 | 9.96 ± 2.22 |
| `docker-dev-pr-3419-a4b6fe1` | 17.5 ± 1.0 | 16.8 | 19.1 | 1.85 ± 0.42 |
| `docker-dev-pr-3429-a09e61a` | 93.7 ± 0.8 | 92.5 | 94.5 | 9.94 ± 2.21 |
| `docker-dev-fix-perf-reg-2` | 9.4 ± 2.1 | 7.6 | 12.6 | 1.00 |

We should also look if every plugin we currently ship doesn't introduce performance regressions when invoked through the plugin manager in https://github.com/docker/cli/blob/f5d698a331f520e6fa1583911e5dedff428693f3/cli-plugins/manager/candidate.go#L22 to load metadata:

```
/usr/local/lib/docker/cli-plugins/docker-buildx docker-cli-plugin-metadata
```

Full benchmark can be seen at https://github.com/crazy-max/docker-cli-bench/blob/main/bench.md

**- How to verify it**

```
$ make -f docker.Makefile binary
```

Check completion still working for commands and plugins per #3429:

```
$ ./build/docker __completeNoDesc "b"
build
builder
buildx
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

$ ./build/docker __completeNoDesc "c"
checkpoint
commit
compose
config
container
context
cp
create
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

$ ./build/docker __complete --context "de"
./build/docker __complete --context "de"
desktop-linux
default
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
```

Check a plugin help output:

```
$ ./build/docker buildx bake --help

Usage:  docker buildx bake [OPTIONS] [TARGET...]

Build from a file

Aliases:
  docker buildx bake, docker buildx f

Options:
      --builder string         Override the configured builder instance
  -f, --file stringArray       Build definition file
      --load                   Shorthand for "--set=*.output=type=docker"
      --metadata-file string   Write build result metadata to the file
      --no-cache               Do not use cache when building the image
      --print                  Print the options without building
      --progress string        Set type of progress output ("auto", "plain", "tty"). Use plain to show container output (default "auto")
      --provenance string      Shorthand for "--set=*.attest=type=provenance"
      --pull                   Always attempt to pull all referenced images
      --push                   Shorthand for "--set=*.output=type=registry"
      --sbom string            Shorthand for "--set=*.attest=type=sbom"
      --set stringArray        Override target value (e.g., "targetpattern.key=value")
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

