### PR TITLE
ci: enhanced build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,35 @@ on:
   pull_request:
 
 jobs:
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create matrix
+        id: platforms
+        run: |
+          echo "matrix=$(docker buildx bake cross --print | jq -cr '.target."cross".platforms')" >>${GITHUB_OUTPUT}
+      -
+        name: Show matrix
+        run: |
+          echo ${{ steps.platforms.outputs.matrix }}
+
   build:
     runs-on: ubuntu-20.04
+    needs:
+      - prepare
     strategy:
       fail-fast: false
       matrix:
         target:
-          - cross
-          - dynbinary-cross
+          - binary
+          - dynbinary
+        platform: ${{ fromJson(needs.prepare.outputs.matrix) }}
         use_glibc:
           - ""
           - glibc
@@ -36,22 +57,22 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Run ${{ matrix.target }}
+        name: Build
         uses: docker/bake-action@v2
         with:
           targets: ${{ matrix.target }}
+          set: |
+            *.platform=${{ matrix.platform }}
         env:
           USE_GLIBC: ${{ matrix.use_glibc }}
       -
-        name: Flatten artifacts
+        name: Create tarball
         working-directory: ./build
         run: |
-          for dir in */; do
-            base=$(basename "$dir")
-            echo "Creating ${base}.tar.gz ..."
-            tar -cvzf "${base}.tar.gz" "$dir"
-            rm -rf "$dir"
-          done
+          mkdir /tmp/out
+          platform=${{ matrix.platform }}
+          platformPair=${platform//\//-}
+          tar -cvzf "/tmp/out/docker-${platformPair}.tar.gz" .
           if [ -z "${{ matrix.use_glibc }}" ]; then
             echo "ARTIFACT_NAME=${{ matrix.target }}" >> $GITHUB_ENV
           else
@@ -62,11 +83,35 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          path: ./build/*
+          path: /tmp/out/*
           if-no-files-found: error
+
+  prepare-plugins:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Create matrix
+        id: platforms
+        run: |
+          echo "matrix=$(docker buildx bake plugins-cross --print | jq -cr '.target."plugins-cross".platforms')" >>${GITHUB_OUTPUT}
+      -
+        name: Show matrix
+        run: |
+          echo ${{ steps.platforms.outputs.matrix }}
 
   plugins:
     runs-on: ubuntu-20.04
+    needs:
+      - prepare-plugins
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(needs.prepare-plugins.outputs.matrix) }}
     steps:
       -
         name: Checkout
@@ -75,7 +120,9 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Build plugins
+        name: Build
         uses: docker/bake-action@v2
         with:
           targets: plugins-cross
+          set: |
+            *.platform=${{ matrix.platform }}


### PR DESCRIPTION
**- What I did**

Split binaries job so now each platform is built on its own runner.

Before ~15m

![image](https://user-images.githubusercontent.com/1951866/228114412-310c7e75-c923-4b27-8f34-e32b496f9d4a.png)

Now ~3m

![image](https://user-images.githubusercontent.com/1951866/228115980-5feafb07-3dc1-44e0-a5c3-b595a88ee3a8.png)

It spawns a significant amount of jobs but at least reduces build time.

@thaJeztah We also need to update the required GitHub Checks in the repo settings. I think we should just remove required for build imo.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

