### PR TITLE
Fix plugin completion results parsing for `ShellCompDirectiveFilterFileExt`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1155,7 +1155,20 @@ __docker_complete_plugin() {
 			resultArray+=( "$value" )
 		fi
 	done
-	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
+	local rawResult=$(eval "${resultArray[*]}" 2> /dev/null)
+	local result=$(grep -v '^:[0-9]*$' <<< "$rawResult")
+
+	# Compose V2 completions sometimes returns returns `:8` (ShellCompDirectiveFilterFileExt)
+	# with the expected file extensions (such as `yml`, `yaml`) to indicate that the shell should
+	# provide autocompletions for files with matching extensions
+	local completionFlag=$(tail -1 <<< "$rawResult")
+	if [ "$completionFlag" == ":8" ]; then
+		# format a valid glob pattern for the provided file extensions
+		local filePattern=$(tr '\n' '|' <<< "$result")
+
+		_filedir "$filePattern"
+		return
+	fi
 
 	# if result empty, just use filename completion as fallback
 	if [ -z "$result" ]; then


### PR DESCRIPTION
Compose V2 (and other plugins eventually) provide the extensions they want the shell to filter the autocompletion of files for:
```console
$ /usr/libexec/docker/cli-plugins/docker-compose __completeNoDesc -f ""
yaml
yml
:8
Completion ended with directive: ShellCompDirectiveFilterFileExt
```

The current script does not process these results correctly, and instead we just provide a `y` (common beginning between `yaml` and `yml`)

```console
$ docker compose -f <TAB><TAB>
yaml
yml
```

which is not the desired outcome.

**- What I did**

Check if the completion flag is `:8` (`ShellCompDirectiveFilterFileExt`) and format a valid glob pattern to feed into `_filedir` when this is the case

**- How to verify it**

Load the new completion script, and type
```
docker compose -f <TAB><TAB>
```
verify that completions are provided for files with the extension `.yaml` or `.yml`,

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

