### PR TITLE
[23.0 backport] cli/command: fix deprecation comments for Stream types

### DIFF
--- a/cli/command/streams.go
+++ b/cli/command/streams.go
@@ -1,23 +1,32 @@
 package command
 
 import (
+	"io"
+
 	"github.com/docker/cli/cli/streams"
 )
 
 // InStream is an input stream used by the DockerCli to read user input
-// Deprecated: Use github.com/docker/cli/cli/streams.In instead
+//
+// Deprecated: Use [streams.In] instead.
 type InStream = streams.In
 
 // OutStream is an output stream used by the DockerCli to write normal program
 // output.
-// Deprecated: Use github.com/docker/cli/cli/streams.Out instead
+//
+// Deprecated: Use [streams.Out] instead.
 type OutStream = streams.Out
 
-var (
-	// NewInStream returns a new InStream object from a ReadCloser
-	// Deprecated: Use github.com/docker/cli/cli/streams.NewIn instead
-	NewInStream = streams.NewIn
-	// NewOutStream returns a new OutStream object from a Writer
-	// Deprecated: Use github.com/docker/cli/cli/streams.NewOut instead
-	NewOutStream = streams.NewOut
-)
+// NewInStream returns a new [streams.In] from an [io.ReadCloser].
+//
+// Deprecated: Use [streams.NewIn] instead.
+func NewInStream(in io.ReadCloser) *streams.In {
+	return streams.NewIn(in)
+}
+
+// NewOutStream returns a new [streams.Out] from an [io.Writer].
+//
+// Deprecated: Use [streams.NewOut] instead.
+func NewOutStream(out io.Writer) *streams.Out {
+	return streams.NewOut(out)
+}


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4152
- relates to https://github.com/docker/cli/pull/1633
- relates to https://github.com/docker/cli/pull/4146 https://github.com/docker/cli/pull/4146#discussion_r1155129505


These were deprecated in 6c400a9c2009bba9376ad61ab59c04c1ad675871 (docker 19.03), but the "Deprecated:" comments were missing a newline before them.

While most IDEs will detect such comments as "deprecated", pkg.go.dev and linters will ignore them, which may result in users not being aware of them being deprecated.

This patch;

- Fixes the "Deprecated:" comments.
- Changes the var aliases to functions, which is slightly more boilerplating, but makes sure the functions are documented as "function", instead of shown in the "variables" section on pkg.go.dev.
- Adds some punctuation and adds "doc links", which allows readers to navigate to related content on pkg.go.dev.

Before this patch:

 https://pkg.go.dev/github.com/docker/cli@v24.0.0-beta.1+incompatible/cli/command#InStream

<img width="1235" alt="Screenshot 2023-04-01 at 17 46 10" src="https://user-images.githubusercontent.com/1804568/229299664-71393ed8-4dc5-410c-9260-75a5052de9ef.png">

With this patch:

<img width="301" alt="Screenshot 2023-04-01 at 18 11 12" src="https://user-images.githubusercontent.com/1804568/229303092-72a19c7c-f610-4456-a74b-25e0800028f1.png">
<img width="536" alt="Screenshot 2023-04-01 at 18 15 04" src="https://user-images.githubusercontent.com/1804568/229303201-121b7de4-cf1e-40a0-b8cc-45bad58dc3e6.png">
<img width="773" alt="Screenshot 2023-04-01 at 18 33 25" src="https://user-images.githubusercontent.com/1804568/229303168-20c65c4e-583b-416d-8c2b-8c1224c5f2a1.png">




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
