### PR TITLE
[23.0 backport] scripts/docs/generate-md.sh: fix location of generate code

### DIFF
--- a/docs/reference/commandline/container_rm.md
+++ b/docs/reference/commandline/container_rm.md
@@ -5,7 +5,7 @@ Remove one or more containers
 
 ### Aliases
 
-`docker container rm`, `docker rm`
+`docker container rm`, `docker container remove`, `docker rm`
 
 ### Options
 

--- a/docs/reference/commandline/rm.md
+++ b/docs/reference/commandline/rm.md
@@ -5,7 +5,7 @@ Remove one or more containers
 
 ### Aliases
 
-`docker container rm`, `docker rm`
+`docker container rm`, `docker container remove`, `docker rm`
 
 ### Options
 

--- a/scripts/docs/generate-md.sh
+++ b/scripts/docs/generate-md.sh
@@ -25,11 +25,11 @@ trap clean EXIT
   # install cli-docs-tool and copy docs/tools.go in root folder
   # to be able to fetch the required depedencies
   go mod edit -modfile=vendor.mod -require=github.com/docker/cli-docs-tool@${CLI_DOCS_TOOL_VERSION}
-  cp docs/tools.go .
+  cp docs/generate/tools.go .
   # update vendor
   ./scripts/vendor update
   # build docsgen
-  go build -mod=vendor -modfile=vendor.mod -tags docsgen -o /tmp/docsgen ./docs/generate.go
+  go build -mod=vendor -modfile=vendor.mod -tags docsgen -o /tmp/docsgen ./docs/generate/generate.go
 )
 
 # yaml generation on docs repo needs the cli.md file: https://github.com/docker/cli/pull/3924#discussion_r1059986605


### PR DESCRIPTION
- backport of  https://github.com/docker/cli/pull/4169

relates to:

- https://github.com/docker/cli/pull/3991
- https://github.com/docker/cli/pull/3986


### scripts/docs/generate-md.sh: fix location of generate code

Commit 1e3622c50cc80bb578c59dc242630ee815e678fd (https://github.com/docker/cli/pull/3991) moved the generator code
to a subdirectory, but forgot to update the markdown version of this script.


### docs: regenerate markdown docs

This adds the new aliases that were added in 9b54d860cd8b131890b92e8591c6ddd650f4d340 (https://github.com/docker/cli/pull/3986)



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

