### PR TITLE
[23.0 backport] Fix plugin completion parsing for plugins using `ShellCompDirectiveFilterFileExt`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1155,7 +1155,20 @@ __docker_complete_plugin() {
 			resultArray+=( "$value" )
 		fi
 	done
-	local result=$(eval "${resultArray[*]}" 2> /dev/null | grep -v '^:[0-9]*$')
+	local rawResult=$(eval "${resultArray[*]}" 2> /dev/null)
+	local result=$(grep -v '^:[0-9]*$' <<< "$rawResult")
+
+	# Compose V2 completions sometimes returns returns `:8` (ShellCompDirectiveFilterFileExt)
+	# with the expected file extensions (such as `yml`, `yaml`) to indicate that the shell should
+	# provide autocompletions for files with matching extensions
+	local completionFlag=$(tail -1 <<< "$rawResult")
+	if [ "$completionFlag" == ":8" ]; then
+		# format a valid glob pattern for the provided file extensions
+		local filePattern=$(tr '\n' '|' <<< "$result")
+
+		_filedir "$filePattern"
+		return
+	fi
 
 	# if result empty, just use filename completion as fallback
 	if [ -z "$result" ]; then


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4136
- relates to / addresses  https://github.com/docker/compose/issues/10315
- relates to / addresses  https://github.com/docker/compose/issues/10420
- relates to / addresses  https://github.com/docker/compose/issues/9941


(cherry picked from commit 683e4bf0c4887b9f6fb37bddf03725dd5831ac01)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

