### PR TITLE
Explain the auto-removal of anonymous volumes at the description of 'create --rm' and 'run --rm'

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -251,7 +251,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s p -l publish
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s P -l publish-all -d 'Publish all exposed ports to random ports'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l read-only -d "Mount the container's root filesystem as read only"
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l restart -d 'Restart policy to apply when a container exits'
-complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l rm -d 'Automatically remove the container when it exits'
+complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l rm -d 'Automatically remove the container and its associated anonymous volumes when it exits'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l runtime -d 'Runtime to use for this container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l security-opt -d 'Security Options'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l shm-size -d 'Size of /dev/shm'

--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1233,7 +1233,7 @@ the container and remove the file system when the container exits, use the
 `--rm` flag:
 
 ```text
---rm: Automatically remove the container when it exits
+--rm: Automatically remove the container and its associated anonymous volumes when it exits
 ```
 
 > [!NOTE]

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -618,7 +618,7 @@ its root filesystem mounted as read only prohibiting any writes.
 Default is **no**.
 
 **--rm** **true**|**false**
-   Automatically remove the container when it exits. The default is **false**.
+   Automatically remove the container and its associated anonymous volumes when it exits. The default is **false**.
    `--rm` flag can work together with `-d`, and auto-removal will be done on
    daemon side. Note that it's incompatible with any restart policy other than
   `none`.


### PR DESCRIPTION
Original:
Automatically remove the container when it exits
Change to:
Automatically remove the container and its associated anonymous volumes when it exits

The behavior is currently not properly documented and can be a source of confusion. Only docs/reference/run.md has a note about it.  `podman run --rm` has similar behavior and it [is documented](https://docs.podman.io/en/latest/markdown/podman-run.1.html#rm).

It is the same as calling `docker rm -v` on container exit. [code](https://github.com/docker/engine/blob/8955d8da8951695a98eb7e15bead19d402c6eb27/daemon/start.go#L137)
