### PR TITLE
cli/command: some cleanups / refactoring, and fixes related to auth

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -16,11 +16,9 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/versions"
 	apiclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/registry"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -114,19 +112,7 @@ func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, options *createOptio
 }
 
 func pullImage(ctx context.Context, dockerCli command.Cli, image string, platform string, out io.Writer) error {
-	ref, err := reference.ParseNormalizedNamed(image)
-	if err != nil {
-		return err
-	}
-
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := registry.ParseRepositoryInfo(ref)
-	if err != nil {
-		return err
-	}
-
-	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
+	encodedAuth, err := command.RetrieveAuthTokenFromImage(ctx, dockerCli, image)
 	if err != nil {
 		return err
 	}

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -131,12 +131,10 @@ func pullImage(ctx context.Context, dockerCli command.Cli, image string, platfor
 		return err
 	}
 
-	options := types.ImageCreateOptions{
+	responseBody, err := dockerCli.Client().ImageCreate(ctx, image, types.ImageCreateOptions{
 		RegistryAuth: encodedAuth,
 		Platform:     platform,
-	}
-
-	responseBody, err := dockerCli.Client().ImageCreate(ctx, image, options)
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/versions"
 	apiclient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -125,7 +126,7 @@ func pullImage(ctx context.Context, dockerCli command.Cli, image string, platfor
 	}
 
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
@@ -76,7 +77,7 @@ func RunPush(dockerCli command.Cli, opts pushOptions) error {
 
 	// Resolve the Auth config relevant for this server
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -264,7 +264,7 @@ func getTrustedPullTargets(cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth)
 func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts PullOptions) error {
 	ref := reference.FamiliarString(imgRefAndAuth.Reference())
 
-	encodedAuth, err := command.EncodeAuthToBase64(*imgRefAndAuth.AuthConfig())
+	encodedAuth, err := registrytypes.EncodeAuthConfig(*imgRefAndAuth.AuthConfig())
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -262,20 +262,17 @@ func getTrustedPullTargets(cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth)
 
 // imagePullPrivileged pulls the image and displays it to the output
 func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts PullOptions) error {
-	ref := reference.FamiliarString(imgRefAndAuth.Reference())
-
 	encodedAuth, err := registrytypes.EncodeAuthConfig(*imgRefAndAuth.AuthConfig())
 	if err != nil {
 		return err
 	}
 	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(cli, imgRefAndAuth.RepoInfo().Index, "pull")
-	options := types.ImagePullOptions{
+	responseBody, err := cli.Client().ImagePull(ctx, reference.FamiliarString(imgRefAndAuth.Reference()), types.ImagePullOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,
 		All:           opts.all,
 		Platform:      opts.platform,
-	}
-	responseBody, err := cli.Client().ImagePull(ctx, ref, options)
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
@@ -86,8 +87,7 @@ func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOpti
 	}
 
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 	if err != nil {
 		return types.PluginInstallOptions{}, err
 	}

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/distribution/reference"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
@@ -55,8 +56,7 @@ func runPush(dockerCli command.Cli, opts pushOptions) error {
 		return err
 	}
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 	if err != nil {
 		return err
 	}

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -118,7 +118,6 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 		if err != nil {
 			return err
 		}
-		flUser = strings.TrimSpace(flUser)
 		if flUser == "" {
 			flUser = authconfig.Username
 		}
@@ -153,13 +152,14 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 }
 
 // readInput reads, and returns user input from in. It tries to return a
-// single line, not including the end-of-line bytes.
+// single line, not including the end-of-line bytes, and trims leading
+// and trailing whitespace.
 func readInput(in io.Reader) (string, error) {
 	line, _, err := bufio.NewReader(in).ReadLine()
 	if err != nil {
 		return "", errors.Wrap(err, "error while reading input")
 	}
-	return string(line), nil
+	return strings.TrimSpace(string(line)), nil
 }
 
 func promptWithDefault(out io.Writer, prompt string, configDefault string) {

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -89,7 +89,14 @@ func GetDefaultAuthConfig(cli Cli, checkCredStore bool, serverAddress string, is
 
 // ConfigureAuth handles prompting of user's username and password if needed
 func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes.AuthConfig, isDefaultRegistry bool) error {
-	// On Windows, force the use of the regular OS stdin stream. Fixes #14336/#14210
+	// On Windows, force the use of the regular OS stdin stream.
+	//
+	// See:
+	// - https://github.com/moby/moby/issues/14336
+	// - https://github.com/moby/moby/issues/14210
+	// - https://github.com/moby/moby/pull/17738
+	//
+	// TODO(thaJeztah): we need to confirm if this special handling is still needed, as we may not be doing this in other places.
 	if runtime.GOOS == "windows" {
 		cli.SetIn(streams.NewIn(os.Stdin))
 	}

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
 )
@@ -54,15 +55,13 @@ func runSearch(dockerCli command.Cli, options searchOptions) error {
 	}
 
 	ctx := context.Background()
-
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, indexInfo)
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, indexInfo, "search")
-
-	encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 	if err != nil {
 		return err
 	}
 
+	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, indexInfo, "search")
 	results, err := dockerCli.Client().ImageSearch(ctx, options.term, types.ImageSearchOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -63,16 +63,12 @@ func runSearch(dockerCli command.Cli, options searchOptions) error {
 		return err
 	}
 
-	searchOptions := types.ImageSearchOptions{
+	results, err := dockerCli.Client().ImageSearch(ctx, options.term, types.ImageSearchOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,
 		Filters:       options.filter.Value(),
 		Limit:         options.limit,
-	}
-
-	clnt := dockerCli.Client()
-
-	results, err := clnt.ImageSearch(ctx, options.term, searchOptions)
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/docker/api/types"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary/client"
@@ -93,7 +94,7 @@ func runSignImage(cli command.Cli, options signOptions) error {
 			fmt.Fprintf(cli.Err(), "Signing and pushing trust data for local image %s, may overwrite remote trust data\n", imageName)
 
 			authConfig := command.ResolveAuthConfig(ctx, cli, imgRefAndAuth.RepoInfo().Index)
-			encodedAuth, err := command.EncodeAuthToBase64(authConfig)
+			encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### cli/command: ConfigureAuth: fix terminal state not being restored on error

ConfigureAuth used the readInput() utility to read the username and password.
However, this utility did not return errors it encountered, but instead did
an os.Exit(1). A result of this was that the terminal was not restored if
an error happened. When reading the password, the terminal is configured to
disable echo (i.e. characters are not printed), and failing to restore
the previous state means that the terminal is now "non-functional".

This patch:

- changes readInput() to return errors it encounters
- uses a defer() to restore terminal state

### cli/command: ConfigureAuth: trim whitespace both for username and password

changes readInput() to trim whitespace. The existing code tried to be
conservative and only trimmed whitespace for username (not for password).
Passwords with leading/trailing whitespace would be _very_ unlikely, and
trimming whitespace is generally accepted.


### cli/command/registry: remove intermediate var that collided

This also simplifies the code a bit.

### cli/command: replace EncodeAuthToBase64 for registry.EncodeAuthConfig

Replace uses of this function in favor of the implementation in the
API types, so that we have a single, canonical implementation.

### cli/command/container/create: pullImage(): use RetrieveAuthTokenFromImage

replace the local code with RetrieveAuthTokenFromImage, which does exactly the same;
https://github.com/docker/cli/blob/623356001f6310fef7a8cca0b9ba0ac1b735bb38/cli/command/registry.go#L163-L188

### cli/command/container/create: pullImage() remove intermediate vars

### cli/command/container: pullImage: use DisplayJSONMessagesToStream utility

This utility provides the same logic as was implemented here (and using it
aligns with the "docker pull" equivalent).

Also added a TODO to replace this function with the regular "docker pull"
code.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

