### PR TITLE
cli/command: fix documentation for ResolveAuthConfig

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -49,9 +49,12 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
 	}
 }
 
-// ResolveAuthConfig is like registry.ResolveAuthConfig, but if using the
-// default index, it uses the default index name for the daemon's platform,
-// not the client's platform.
+// ResolveAuthConfig returns auth-config for the given registry from the
+// credential-store. It returns an empty AuthConfig if no credentials were
+// found.
+//
+// It is similar to [registry.ResolveAuthConfig], but uses the credentials-
+// store, instead of looking up credentials from a map.
 func ResolveAuthConfig(_ context.Context, cli Cli, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
 	configKey := index.Name
 	if index.Official {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/2819

This function no longer uses the /info endpoint to resolve the registry to use. The documentation for this function was still referring to the (once used) special registry for Windows images, which is no longer in use, so update the docs to reflect reality :)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

