### PR TITLE
[23.0 backport] cli/command: fix documentation for ResolveAuthConfig

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -56,9 +56,12 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
 	}
 }
 
-// ResolveAuthConfig is like registry.ResolveAuthConfig, but if using the
-// default index, it uses the default index name for the daemon's platform,
-// not the client's platform.
+// ResolveAuthConfig returns auth-config for the given registry from the
+// credential-store. It returns an empty AuthConfig if no credentials were
+// found.
+//
+// It is similar to [registry.ResolveAuthConfig], but uses the credentials-
+// store, instead of looking up credentials from a map.
 func ResolveAuthConfig(_ context.Context, cli Cli, index *registrytypes.IndexInfo) types.AuthConfig {
 	configKey := index.Name
 	if index.Official {


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/4192


This function no longer uses the /info endpoint to resolve the registry to use. The documentation for this function was still referring to the (once used) special registry for Windows images, which is no longer in use, so update the docs to reflect reality :)


(cherry picked from commit 5bd359132b20af4fa3a7f6627146eb5ad0c5caf6)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

