### PR TITLE
docs/reference: update dockerd docs for changes in 23.0

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -123,19 +123,19 @@ the [installation](https://docs.docker.com/install/) instructions for your opera
 The following list of environment variables are supported by the `docker` command
 line:
 
-| Variable                      | Description                                                                                                                             |
-|:------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------|
-| `DOCKER_API_VERSION`          | Override the negotiated API version to use for debugging (e.g. `1.19`)                                                                  |
-| `DOCKER_CERT_PATH`            | Location of your authentication keys. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md)             |
-| `DOCKER_CONFIG`               | The location of your client configuration files.                                                                                        |
-| `DOCKER_CONTENT_TRUST_SERVER` | The URL of the Notary server to use. Defaults to the same URL as the registry.                                                          |
-| `DOCKER_CONTENT_TRUST`        | When set Docker uses notary to sign and verify images. Equates to `--disable-content-trust=false` for build, create, pull, push, run.   |
-| `DOCKER_CONTEXT`              | Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)                 |
-| `DOCKER_DEFAULT_PLATFORM`     | Default platform for commands that take the `--platform` flag.                                                                          |
-| `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release, at which point this environment-variable is removed. |
-| `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                            |
-| `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md) |
-| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`). |
+| Variable                      | Description                                                                                                                                                                                                                                                  |
+|:------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DOCKER_API_VERSION`          | Override the negotiated API version to use for debugging (e.g. `1.19`)                                                                                                                                                                                       |
+| `DOCKER_CERT_PATH`            | Location of your authentication keys. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md)                                                                                                                                  |
+| `DOCKER_CONFIG`               | The location of your client configuration files.                                                                                                                                                                                                             |
+| `DOCKER_CONTENT_TRUST_SERVER` | The URL of the Notary server to use. Defaults to the same URL as the registry.                                                                                                                                                                               |
+| `DOCKER_CONTENT_TRUST`        | When set Docker uses notary to sign and verify images. Equates to `--disable-content-trust=false` for build, create, pull, push, run.                                                                                                                        |
+| `DOCKER_CONTEXT`              | Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)                                                                                                                                      |
+| `DOCKER_DEFAULT_PLATFORM`     | Default platform for commands that take the `--platform` flag.                                                                                                                                                                                               |
+| `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release. |
+| `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                                                                                                                                                 |
+| `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md)                                                                                                                      |
+| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](build.md) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`).                                                        |
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -140,13 +140,14 @@ line:
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:
 
-* `HTTP_PROXY`
-* `HTTPS_PROXY`
-* `NO_PROXY`
+| Variable      | Description                                                                    |
+|:--------------|:-------------------------------------------------------------------------------|
+| `HTTP_PROXY`  | Proxy URL for HTTP requests unless overridden by NoProxy.                      |
+| `HTTPS_PROXY` | Proxy URL for HTTPS requests unless overridden by NoProxy.                     |
+| `NO_PROXY`    | Comma-separated values specifying hosts that should be excluded from proxying. |
 
-These Go environment variables are case-insensitive. See the
-[Go specification](https://golang.org/pkg/net/http/) for details on these
-variables.
+See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config)
+for details on these variables.
 
 ## Configuration files
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -90,7 +90,7 @@ Options:
       --raw-logs                              Full timestamps without ANSI coloring
       --registry-mirror list                  Preferred registry mirror
       --rootless                              Enable rootless mode; typically used with RootlessKit
-      --seccomp-profile string                Path to seccomp profile
+      --seccomp-profile string                Path to seccomp profile. Use "unconfined" to disable the default seccomp profile (default "builtin")
       --selinux-enabled                       Enable selinux support
       --shutdown-timeout int                  Set the default shutdown timeout (default 15)
   -s, --storage-driver string                 Storage driver to use

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -85,7 +85,7 @@ Options:
       --network-control-plane-mtu int         Network Control plane MTU (default 1500)
       --no-new-privileges                     Set no-new-privileges by default for new containers
       --node-generic-resource list            Advertise user-defined resource
-      --oom-score-adjust int                  Set the oom_score_adj for the daemon (default -500)
+      --oom-score-adjust int                  Set the oom_score_adj for the daemon
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
       --registry-mirror list                  Preferred registry mirror
@@ -1259,7 +1259,7 @@ This is a full example of the allowed configuration options on Linux:
     "NVIDIA-GPU=UUID1",
     "NVIDIA-GPU=UUID2"
   ],
-  "oom-score-adjust": -500,
+  "oom-score-adjust": 0,
   "pidfile": "",
   "raw-logs": false,
   "registry-mirrors": [],

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -129,11 +129,17 @@ to [the `daemon.json` file](#daemon-configuration-file).
 For easy reference, the following list of environment variables are supported
 by the `dockerd` command line:
 
-* `DOCKER_DRIVER` The graph driver to use.
-* `DOCKER_RAMDISK` If set this will disable 'pivot_root'.
-* `DOCKER_TMPDIR` Location for temporary Docker files.
-* `MOBY_DISABLE_PIGZ` Do not use [`unpigz`](https://linux.die.net/man/1/pigz) to
-  decompress layers in parallel when pulling images, even if it is installed.
+| Variable            | Description                                                                                                                                                                       |
+|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DOCKER_CERT_PATH`  | Location of your authentication keys. This variable is used both by the [`docker` CLI](cli.md) and the `dockerd` daemon.                                                          |
+| `DOCKER_DRIVER`     | The storage driver to use.                                                                                                                                                        |
+| `DOCKER_RAMDISK`    | If set this disables 'pivot_root'.                                                                                                                                                |
+| `DOCKER_TLS_VERIFY` | When set Docker uses TLS and verifies the remote. This variable is used both by the  [`docker` CLI](cli.md) and the `dockerd` daemon.                                             |
+| `DOCKER_TMPDIR`     | Location for temporary files created by the daemon.                                                                                                                               |
+| `HTTP_PROXY`        | Proxy URL for HTTP requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                      |
+| `HTTPS_PROXY`       | Proxy URL for HTTPS requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                     |
+| `MOBY_DISABLE_PIGZ` | Disables the use of [`unpigz`](https://linux.die.net/man/1/pigz) to  decompress layers in parallel when pulling images, even if it is installed.                                  |                                                                                                                                                               |
+| `NO_PROXY`          | Comma-separated values specifying hosts that should be excluded from proxying. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details. |
 
 ## Examples
 

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -130,8 +130,6 @@ For easy reference, the following list of environment variables are supported
 by the `dockerd` command line:
 
 * `DOCKER_DRIVER` The graph driver to use.
-* `DOCKER_NOWARN_KERNEL_VERSION` Prevent warnings that your Linux kernel is
-  unsuitable for Docker.
 * `DOCKER_RAMDISK` If set this will disable 'pivot_root'.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 * `MOBY_DISABLE_PIGZ` Do not use [`unpigz`](https://linux.die.net/man/1/pigz) to

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -18,7 +18,7 @@ redirect_from:
 # daemon
 
 ```markdown
-Usage: dockerd COMMAND
+Usage: dockerd [OPTIONS]
 
 A self-sufficient runtime for containers.
 
@@ -35,14 +35,14 @@ Options:
       --containerd-namespace string           Containerd namespace to use (default "moby")
       --containerd-plugins-namespace string   Containerd namespace to use for plugins (default "plugins.moby")
       --cpu-rt-period int                     Limit the CPU real-time period in microseconds for the
-                                              parent cgroup for all containers
+                                              parent cgroup for all containers (not supported with cgroups v2)
       --cpu-rt-runtime int                    Limit the CPU real-time runtime in microseconds for the
-                                              parent cgroup for all containers
+                                              parent cgroup for all containers (not supported with cgroups v2)
       --cri-containerd                        start containerd with cri
       --data-root string                      Root directory of persistent Docker state (default "/var/lib/docker")
   -D, --debug                                 Enable debug mode
       --default-address-pool pool-options     Default address pools for node specific local networks
-      --default-cgroupns-mode string          Default mode for containers cgroup namespace ("host" | "private") (default "host")
+      --default-cgroupns-mode string          Default mode for containers cgroup namespace ("host" | "private") (default "private")
       --default-gateway ip                    Container default gateway IPv4 address
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-ipc-mode string               Default mode for containers ipc ("shareable" | "private") (default "private")
@@ -62,6 +62,8 @@ Options:
   -H, --host list                             Daemon socket(s) to connect to
       --host-gateway-ip ip                    IP address that the special 'host-gateway' string in --add-host resolves to.
                                               Defaults to the IP address of the default bridge
+      --http-proxy string                     HTTP proxy URL to use for outgoing traffic
+      --https-proxy string                    HTTPS proxy URL to use for outgoing traffic
       --icc                                   Enable inter-container communication (default true)
       --init                                  Run an init in the container to forward signals and reap processes
       --init-path string                      Path to the docker-init binary
@@ -69,8 +71,8 @@ Options:
       --ip ip                                 Default IP when binding container ports (default 0.0.0.0)
       --ip-forward                            Enable net.ipv4.ip_forward (default true)
       --ip-masq                               Enable IP masquerading (default true)
+      --ip6tables                             Enable addition of ip6tables rules (experimental)
       --iptables                              Enable addition of iptables rules (default true)
-      --ip6tables                             Enable addition of ip6tables rules (default false)
       --ipv6                                  Enable IPv6 networking
       --label list                            Set key=value labels to the daemon
       --live-restore                          Enable live restore of docker when containers are still running
@@ -81,9 +83,10 @@ Options:
       --max-concurrent-uploads int            Set the max concurrent uploads (default 5)
       --max-download-attempts int             Set the max download attempts for each pull (default 5)
       --metrics-addr string                   Set default address and port to serve the metrics api on
-      --mtu int                               Set the containers network MTU
+      --mtu int                               Set the containers network MTU (default 1500)
       --network-control-plane-mtu int         Network Control plane MTU (default 1500)
       --no-new-privileges                     Set no-new-privileges by default for new containers
+      --no-proxy string                       Comma-separated list of hosts or IP addresses for which the proxy is skipped
       --node-generic-resource list            Advertise user-defined resource
       --oom-score-adjust int                  Set the oom_score_adj for the daemon
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
@@ -142,6 +145,28 @@ by the `dockerd` command line:
 | `NO_PROXY`          | Comma-separated values specifying hosts that should be excluded from proxying. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details. |
 
 ## Examples
+
+### Proxy configuration
+
+> **Note**
+> 
+> Refer to the [Docker Desktop manual](https://docs.docker.com/desktop/networking/#httphttps-proxy-support)
+> if you are running [Docker Desktop](https://docs.docker.com/desktop/).
+
+If you are behind an HTTP proxy server, for example in corporate settings,
+you may have to configure the Docker daemon to use the proxy server for
+operations such as pulling and pushing images. The daemon can be configured
+in three ways:
+
+1. Using environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`).
+2. Using the "http-proxy", "https-proxy", and "no-proxy" fields in the
+  [daemon configuration file](#daemon-configuration-file) (Docker Engine 23.0 or newer).
+3. Using the `--http-proxy`, `--https-proxy`, and `--no-proxy` command-line
+  options. (Docker Engine 23.0 or newer).
+
+The command-line and configuration file options take precedence over environment
+variables. Refer to [control and configure Docker with systemd](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
+to set these environment variables on a host using `systemd`.
 
 ### Daemon socket option
 
@@ -1226,6 +1251,9 @@ This is a full example of the allowed configuration options on Linux:
   "fixed-cidr-v6": "",
   "group": "",
   "hosts": [],
+  "http-proxy": "http://proxy.example.com:80",
+  "https-proxy": "https://proxy.example.com:443",
+  "no-proxy": "*.test.example.com,.example.org",
   "icc": false,
   "init": false,
   "init-path": "/usr/libexec/docker-init",

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -34,10 +34,8 @@ use `docker pull`.
 
 If you are behind an HTTP proxy server, for example in corporate settings,
 before open a connect to registry, you may need to configure the Docker
-daemon's proxy settings, using the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
-environment variables. To set these environment variables on a host using
-`systemd`, refer to the [control and configure Docker with systemd](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
-for variables configuration.
+daemon's proxy settings, refer to the [dockerd command-line reference](dockerd.md#proxy-configuration)
+for details.
 
 ### Concurrent downloads
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -35,6 +35,8 @@ dockerd - Enable daemon mode
 [**-G**|**--group**[=*docker*]]
 [**-H**|**--host**[=*[]*]]
 [**--help**]
+[**--http-proxy**[*""*]]
+[**--https-proxy**[*""*]]
 [**--icc**[=*true*]]
 [**--init**[=*false*]]
 [**--init-path**[=*""*]]
@@ -54,6 +56,7 @@ dockerd - Enable daemon mode
 [**--max-concurrent-downloads**[=*3*]]
 [**--max-concurrent-uploads**[=*5*]]
 [**--max-download-attempts**[=*5*]]
+[**--no-proxy**[*""*]]
 [**--node-generic-resources**[=*[]*]]
 [**-p**|**--pidfile**[=*/var/run/docker.pid*]]
 [**--raw-logs**]
@@ -233,6 +236,12 @@ unix://[/path/to/socket] to use.
 **--help**
   Print usage statement
 
+**--http-proxy***""*
+  Proxy URL for HTTP requests unless overridden by NoProxy.
+
+**--https-proxy***""*
+  Proxy URL for HTTPS requests unless overridden by NoProxy.
+
 **--icc**=*true*|*false*
   Allow unrestricted inter\-container and Docker daemon host communication. If
   disabled, containers can still be linked together using the **--link** option
@@ -324,6 +333,9 @@ unix://[/path/to/socket] to use.
 
 **--max-download-attempts**=*5*
   Set the max download attempts for each pull. Default is `5`.
+
+**--no-proxy**=*""*"
+  Comma-separated values specifying hosts that should be excluded from proxying.
 
 **--node-generic-resources**=*[]*
   Advertise user-defined resource. Default is `[]`.


### PR DESCRIPTION
### docs/reference: remove mention of DOCKER_NOWARN_KERNEL_VERSION

Support for this environment variable was removed in docker 23.0 in
- https://github.com/moby/moby/commit/1240f8b41d34abe9252b882bddd42e140b62b83b (https://github.com/moby/moby/pull/43253)

From that patch:

> All regular, non-EOL Linux distros now come with more recent kernels
> out of the box. There may still be users trying to run on kernel 3.10
> or older (some embedded systems, e.g.), but those should be a rare
> exception, which we don't have to take into account.
>
> This patch removes the kernel version check on Linux, and the corresponding
> DOCKER_NOWARN_KERNEL_VERSION environment that was there to skip this
> check.

### docs/reference: reformat env-vars table, and simplify

No need to mention that the env-var may be removed at that point to keep
the description more to-the-point.

### docs/reference: use table for proxy env-vars

Adding a description based on the Go documentation.

### docs/reference: dockerd: use table for env-vars

### docs/reference: dockerd: update seccomp flag description

Update the description for the changes made in;
- https://github.com/moby/moby/commit/68e96f88ee1598563a66a1f53b8844291423fc88 (https://github.com/moby/moby/pull/42481)

### docs/reference: dockerd: remove default oom-score-adjust

The daemon no longer adjusts its oom-score by default; see

- https://github.com/moby/moby/commit/2b8e68ef06ca3daf2b0e17e51ba72999773b6270 (https://github.com/moby/moby/pull/41528)
- https://github.com/moby/moby/commit/cf7a5be0f2ee8bb4a3f7961682e13b89bc625299 (https://github.com/moby/moby/pull/41527)

### docs: update dockerd usage output for new proxy-options

Adds documentation for the options that were added in
- https://github.com/moby/moby/commit/427c7cc5f86364466c7173e8ca59b97c3876471d (https://github.com/moby/moby/pull/42835)

**- A picture of a cute animal (not mandatory but encouraged)**

