### PR TITLE
cli/compose/types: ServiceVolumeConfig: use strong type for Type and Consistency fields

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -380,7 +380,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		if parsed.Source != "" {
 			toBind := bind
 
-			if parsed.Type == string(mount.TypeBind) {
+			if parsed.Type == mount.TypeBind {
 				if hostPart, targetPath, ok := strings.Cut(bind, ":"); ok {
 					if !filepath.IsAbs(hostPart) && strings.HasPrefix(hostPart, ".") {
 						if absHostPart, err := filepath.Abs(hostPart); err == nil {

--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -30,7 +30,7 @@ func createMountFromVolume(volume composetypes.ServiceVolumeConfig) mount.Mount 
 		Target:      volume.Target,
 		ReadOnly:    volume.ReadOnly,
 		Source:      volume.Source,
-		Consistency: mount.Consistency(volume.Consistency),
+		Consistency: volume.Consistency,
 	}
 }
 

--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -26,7 +26,7 @@ func Volumes(serviceVolumes []composetypes.ServiceVolumeConfig, stackVolumes vol
 
 func createMountFromVolume(volume composetypes.ServiceVolumeConfig) mount.Mount {
 	return mount.Mount{
-		Type:        mount.Type(volume.Type),
+		Type:        volume.Type,
 		Target:      volume.Target,
 		ReadOnly:    volume.ReadOnly,
 		Source:      volume.Source,
@@ -235,23 +235,19 @@ func handleClusterToMount(
 	return result, nil
 }
 
-func convertVolumeToMount(
-	volume composetypes.ServiceVolumeConfig,
-	stackVolumes volumes,
-	namespace Namespace,
-) (mount.Mount, error) {
+func convertVolumeToMount(volume composetypes.ServiceVolumeConfig, stackVolumes volumes, namespace Namespace) (mount.Mount, error) {
 	switch volume.Type {
-	case "volume", "":
+	case mount.TypeVolume, "":
 		return handleVolumeToMount(volume, stackVolumes, namespace)
-	case "image":
+	case mount.TypeImage:
 		return handleImageToMount(volume)
-	case "bind":
+	case mount.TypeBind:
 		return handleBindToMount(volume)
-	case "tmpfs":
+	case mount.TypeTmpfs:
 		return handleTmpfsToMount(volume)
-	case "npipe":
+	case mount.TypeNamedPipe:
 		return handleNpipeToMount(volume)
-	case "cluster":
+	case mount.TypeCluster:
 		return handleClusterToMount(volume, stackVolumes, namespace)
 	}
 	return mount.Mount{}, errors.New("volume type must be volume, bind, tmpfs, npipe, or cluster")

--- a/internal/volumespec/types.go
+++ b/internal/volumespec/types.go
@@ -1,8 +1,10 @@
 package volumespec
 
+import "github.com/moby/moby/api/types/mount"
+
 // VolumeConfig are references to a volume used by a service
 type VolumeConfig struct {
-	Type        string       `yaml:",omitempty" json:"type,omitempty"`
+	Type        mount.Type   `yaml:",omitempty" json:"type,omitempty"`
 	Source      string       `yaml:",omitempty" json:"source,omitempty"`
 	Target      string       `yaml:",omitempty" json:"target,omitempty"`
 	ReadOnly    bool         `mapstructure:"read_only" yaml:"read_only,omitempty" json:"read_only,omitempty"`

--- a/internal/volumespec/types.go
+++ b/internal/volumespec/types.go
@@ -4,16 +4,16 @@ import "github.com/moby/moby/api/types/mount"
 
 // VolumeConfig are references to a volume used by a service
 type VolumeConfig struct {
-	Type        mount.Type   `yaml:",omitempty" json:"type,omitempty"`
-	Source      string       `yaml:",omitempty" json:"source,omitempty"`
-	Target      string       `yaml:",omitempty" json:"target,omitempty"`
-	ReadOnly    bool         `mapstructure:"read_only" yaml:"read_only,omitempty" json:"read_only,omitempty"`
-	Consistency string       `yaml:",omitempty" json:"consistency,omitempty"`
-	Bind        *BindOpts    `yaml:",omitempty" json:"bind,omitempty"`
-	Volume      *VolumeOpts  `yaml:",omitempty" json:"volume,omitempty"`
-	Image       *ImageOpts   `yaml:",omitempty" json:"image,omitempty"`
-	Tmpfs       *TmpFsOpts   `yaml:",omitempty" json:"tmpfs,omitempty"`
-	Cluster     *ClusterOpts `yaml:",omitempty" json:"cluster,omitempty"`
+	Type        mount.Type        `yaml:",omitempty" json:"type,omitempty"`
+	Source      string            `yaml:",omitempty" json:"source,omitempty"`
+	Target      string            `yaml:",omitempty" json:"target,omitempty"`
+	ReadOnly    bool              `mapstructure:"read_only" yaml:"read_only,omitempty" json:"read_only,omitempty"`
+	Consistency mount.Consistency `yaml:",omitempty" json:"consistency,omitempty"`
+	Bind        *BindOpts         `yaml:",omitempty" json:"bind,omitempty"`
+	Volume      *VolumeOpts       `yaml:",omitempty" json:"volume,omitempty"`
+	Image       *ImageOpts        `yaml:",omitempty" json:"image,omitempty"`
+	Tmpfs       *TmpFsOpts        `yaml:",omitempty" json:"tmpfs,omitempty"`
+	Cluster     *ClusterOpts      `yaml:",omitempty" json:"cluster,omitempty"`
 }
 
 // BindOpts are options for a service volume of type bind

--- a/internal/volumespec/volumespec.go
+++ b/internal/volumespec/volumespec.go
@@ -25,7 +25,7 @@ func Parse(spec string) (VolumeConfig, error) {
 		return volume, errors.New("invalid empty volume spec")
 	case 1, 2:
 		volume.Target = spec
-		volume.Type = string(mount.TypeVolume)
+		volume.Type = mount.TypeVolume
 		return volume, nil
 	}
 
@@ -97,11 +97,11 @@ func populateType(volume *VolumeConfig) {
 	switch {
 	// Anonymous volume
 	case volume.Source == "":
-		volume.Type = string(mount.TypeVolume)
+		volume.Type = mount.TypeVolume
 	case isFilePath(volume.Source):
-		volume.Type = string(mount.TypeBind)
+		volume.Type = mount.TypeBind
 	default:
-		volume.Type = string(mount.TypeVolume)
+		volume.Type = mount.TypeVolume
 	}
 }
 


### PR DESCRIPTION
### cli/compose/types: ServiceVolumeConfig: use strong type for Type field

Using a strong type for this field, to make it clearer what's supported,
and to allow assigning values without having to convert them to a string.

Also renamed a variable that collided with an import.

### cli/compose/types: ServiceVolumeConfig: use strong type for Consistency field

Using a strong type for this field, to make it clearer what's supported,
and to allow assigning values without having to cast them.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

