### PR TITLE
[23.0 backport] docker ps: always use --quiet, also combined with --format

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -120,6 +120,8 @@ func runPs(dockerCli command.Cli, options *psOptions) error {
 	if len(options.format) == 0 {
 		// load custom psFormat from CLI config (if any)
 		options.format = dockerCli.ConfigFile().PsFormat
+	} else if options.quiet {
+		_, _ = dockerCli.Err().Write([]byte("WARNING: Ignoring custom format, because both --format and --quiet are set.\n"))
 	}
 
 	listOptions, err := buildContainerListOptions(options)

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -324,6 +324,7 @@ func TestContainerListWithFormat(t *testing.T) {
 		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
 		assert.Check(t, cmd.Flags().Set("quiet", "true"))
 		assert.NilError(t, cmd.Execute())
+		assert.Equal(t, cli.ErrBuffer().String(), "WARNING: Ignoring custom format, because both --format and --quiet are set.\n")
 		golden.Assert(t, cli.OutBuffer().String(), "container-list-quiet.golden")
 	})
 }

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -309,8 +309,21 @@ func TestContainerListWithFormat(t *testing.T) {
 			}, nil
 		},
 	})
-	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}")
-	assert.NilError(t, cmd.Execute())
-	golden.Assert(t, cli.OutBuffer().String(), "container-list-with-format.golden")
+
+	t.Run("with format", func(t *testing.T) {
+		cli.OutBuffer().Reset()
+		cmd := newListCommand(cli)
+		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
+		assert.NilError(t, cmd.Execute())
+		golden.Assert(t, cli.OutBuffer().String(), "container-list-with-format.golden")
+	})
+
+	t.Run("with format and quiet", func(t *testing.T) {
+		cli.OutBuffer().Reset()
+		cmd := newListCommand(cli)
+		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
+		assert.Check(t, cmd.Flags().Set("quiet", "true"))
+		assert.NilError(t, cmd.Execute())
+		golden.Assert(t, cli.OutBuffer().String(), "container-list-quiet.golden")
+	})
 }

--- a/cli/command/container/testdata/container-list-quiet.golden
+++ b/cli/command/container/testdata/container-list-quiet.golden
@@ -1,0 +1,2 @@
+container_id
+container_id

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -55,6 +55,9 @@ ports: {{- pad .Ports 1 0}}
 		}
 		return Format(format)
 	default: // custom format
+		if quiet {
+			return DefaultQuietFormat
+		}
 		return Format(source)
 	}
 }

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -163,7 +163,7 @@ containerID2   ubuntu    ""        24 hours ago                       foobar_bar
 		},
 		{
 			Context{Format: NewContainerFormat("table {{.Image}}", true, false)},
-			"IMAGE\nubuntu\nubuntu\n",
+			"containerID1\ncontainerID2\n",
 		},
 		{
 			Context{Format: NewContainerFormat("table", true, false)},


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/3666

----

- follow-up to https://github.com/docker/cli/pull/3640
- see the discussion on https://github.com/photra/cli/pull/1#issuecomment-1148364089
- fixes https://github.com/docker/cli/issues/4093
- supersedes / closes https://github.com/docker/cli/pull/4040
 

Previously, the formatter would ignore the quiet option if a custom format
was passed; this situation was handled in runPs(), where custom formats
would only be applied if the quiet option was not set, but only if the
format was set in the CLI's config.

This patch updates NewContainerFormat() to do the same, even if a `--format`
was passed on the command-line.

This is a change in behavior, so may need some discussion; possible alternatives;

- produce an error if both `--format` and `--quiet` are passed
- print a warning if both are passed (but use the logic from this patch)

Before this patch:

```console
docker ps --format '{{.Image}}'
ubuntu:22.04
alpine

docker ps --format '{{.Image}}' --quiet
ubuntu:22.04
alpine

mkdir -p ~/.docker/
echo '{"psFormat": "{{.Image}}" > ~/.docker/config.json

docker ps
ubuntu:22.04
alpine

docker ps --quiet
ubuntu:22.04
alpine
```

With this patch applied:

```console
docker ps --format '{{.Image}}'
ubuntu:22.04
alpine

docker ps --format '{{.Image}}' --quiet
40111f61d5c5
482efdf39fac

mkdir -p ~/.docker/
echo '{"psFormat": "{{.Image}}" > ~/.docker/config.json

docker ps
ubuntu:22.04
alpine

docker ps --quiet
40111f61d5c5
482efdf39fac
```

### docker ps: print warning if both --format and --quiet are set

Of both "--quiet" and "--format" are set, --quiet takes precedence. This
patch adds a warning to inform the user that their custom format is not
used:

    docker ps --format='{{.Image}}'
    ubuntu:22.04
    alpine
    
    docker ps --format='{{.Image}}' --quiet
    WARNING: Ignoring custom format, because both --format and --quiet are set.
    40111f61d5c5
    482efdf39fac
    
The warning is printed on STDERR, so can be redirected:

    docker ps --format='{{.Image}}' --quiet 2> /dev/null
    40111f61d5c5
    482efdf39fac

The warning is only shown if the format is set using the "--format" option.
No warning is shown if a custom format is set through the CLI configuration
file:

    mkdir -p ~/.docker/
    echo '{"psFormat": "{{.Image}}"}' > ~/.docker/config.json

    docker ps
    ubuntu:22.04
    alpine
    
    docker ps --quiet
    40111f61d5c5
    482efdf39fac



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

