### PR TITLE
cli/command: deprecate EncodeAuthToBase64 (take 2)

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -20,6 +20,8 @@ import (
 )
 
 // EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload.
+//
+// Deprecated: use [registrytypes.EncodeAuthConfig] instead.
 func EncodeAuthToBase64(authConfig registrytypes.AuthConfig) (string, error) {
 	return registrytypes.EncodeAuthConfig(authConfig)
 }


### PR DESCRIPTION
- replaces https://github.com/docker/cli/pull/4191 after a bad rebase 😂 


Deprecate this function in favor of the implementation in the API types, considering that to be the canonical implementation.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

