### PR TITLE
docker info: don't print "registry" (IndexServerAddress)

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -324,7 +324,6 @@ func prettyPrintServerInfo(dockerCli command.Cli, info types.Info) []error {
 		if len(u) > 0 {
 			fmt.Fprintln(dockerCli.Out(), " Username:", u)
 		}
-		fmt.Fprintln(dockerCli.Out(), " Registry:", info.IndexServerAddress)
 	}
 
 	if len(info.Labels) > 0 {

--- a/cli/command/system/testdata/docker-info-badsec.golden
+++ b/cli/command/system/testdata/docker-info-badsec.golden
@@ -41,7 +41,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Labels:
   provider=digitalocean
  Experimental: false

--- a/cli/command/system/testdata/docker-info-no-swarm.golden
+++ b/cli/command/system/testdata/docker-info-no-swarm.golden
@@ -46,7 +46,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Labels:
   provider=digitalocean
  Experimental: false

--- a/cli/command/system/testdata/docker-info-plugins.golden
+++ b/cli/command/system/testdata/docker-info-plugins.golden
@@ -51,7 +51,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Labels:
   provider=digitalocean
  Experimental: false

--- a/cli/command/system/testdata/docker-info-with-labels-empty.golden
+++ b/cli/command/system/testdata/docker-info-with-labels-empty.golden
@@ -45,7 +45,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Experimental: false
  Insecure Registries:
   127.0.0.0/8

--- a/cli/command/system/testdata/docker-info-with-labels-nil.golden
+++ b/cli/command/system/testdata/docker-info-with-labels-nil.golden
@@ -45,7 +45,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Experimental: false
  Insecure Registries:
   127.0.0.0/8

--- a/cli/command/system/testdata/docker-info-with-swarm.golden
+++ b/cli/command/system/testdata/docker-info-with-swarm.golden
@@ -67,7 +67,6 @@ Server:
   Goroutines: 135
   System Time: 2017-08-24T17:44:34.077811894Z
   EventsListeners: 0
- Registry: https://index.docker.io/v1/
  Labels:
   provider=digitalocean
  Experimental: false

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -102,7 +102,6 @@ Server:
  Docker Root Dir: /var/lib/docker
  Debug Mode: false
  Username: gordontheturtle
- Registry: https://index.docker.io/v1/
  Experimental: false
  Insecure Registries:
   myinsecurehost:5000
@@ -164,7 +163,6 @@ Server:
  ID: 2880d38d-464e-4d01-91bd-c76f33ba3981
  Docker Root Dir: C:\ProgramData\docker
  Debug Mode: false
- Registry: https://index.docker.io/v1/
  Experimental: true
  Insecure Registries:
   myregistry:5000

--- a/man/src/system/info.md
+++ b/man/src/system/info.md
@@ -82,7 +82,6 @@ Server:
  Docker Root Dir: /var/lib/docker
  Debug Mode: false
  Username: gordontheturtle
- Registry: https://index.docker.io/v1/
  Experimental: false
  Insecure Registries:
   myinsecurehost:5000


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/3793
- relates to https://github.com/docker/cli/pull/2819
- relates to https://github.com/docker/cli/pull/4110


The IndexServerAddress field was  as part of the initial Windows implementation of the engine. For legal reasons, Microsoft Windows (and thus Docker images based on Windows) were not allowed to be distributed through non-Microsoft infrastructure. As a temporary solution, a dedicated "registry-win-tp3.docker.io" registry was created to serve Windows images.

Currently, this field always shows "https://index.docker.io/v1/", which is confusing, because that address is not used for the registry (only for authentication and "v1" search).

    docker info
    ...
    Registry: https://index.docker.io/v1/

Starting with b4ca1c7368daeead400fcc1b8f2d61951a0d9d1e, this field is also no longer used during authentication, and a3d56e7d067b38b98548a864436880eef526f971 removed the (deprecated) ElectAuthServer() which was previously used to query it.

Given that there's currently no practical use for this information, and it only adds "noise" (and confusion), this patch removes it from the default output.

For now, the field is (still) available for those that want to use it;

    docker info --format '{{.IndexServerAddress}}'
    https://index.docker.io/v1/

But it won't be printed by default.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

