### PR TITLE
cli/command/system: prettyPrintServerInfo: don't depend on IndexServerAddress and credential-store

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
+	"github.com/docker/docker/registry"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
@@ -319,12 +320,8 @@ func prettyPrintServerInfo(dockerCli command.Cli, info types.Info) []error {
 	fprintlnNonEmpty(dockerCli.Out(), " HTTPS Proxy:", info.HTTPSProxy)
 	fprintlnNonEmpty(dockerCli.Out(), " No Proxy:", info.NoProxy)
 
-	if info.IndexServerAddress != "" {
-		u := dockerCli.ConfigFile().AuthConfigs[info.IndexServerAddress].Username
-		if len(u) > 0 {
-			fmt.Fprintln(dockerCli.Out(), " Username:", u)
-		}
-	}
+	u := dockerCli.ConfigFile().AuthConfigs[registry.IndexServer].Username
+	fprintlnNonEmpty(dockerCli.Out(), " Username:", u)
 
 	if len(info.Labels) > 0 {
 		fmt.Fprintln(dockerCli.Out(), " Labels:")

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -115,6 +115,7 @@ func runInfo(cmd *cobra.Command, dockerCli command.Cli, opts *infoOptions) error
 
 	if opts.format == "" {
 		info.UserName = dockerCli.ConfigFile().AuthConfigs[registry.IndexServer].Username
+		info.ClientInfo.APIVersion = dockerCli.CurrentVersion()
 		return prettyPrintInfo(dockerCli, info)
 	}
 	return formatInfo(dockerCli, info, opts.format)
@@ -366,7 +367,7 @@ func prettyPrintServerInfo(dockerCli command.Cli, info *info) []error {
 
 	fmt.Fprint(dockerCli.Out(), "\n")
 
-	printServerWarnings(dockerCli, *info.Info)
+	printServerWarnings(dockerCli, info)
 	return errs
 }
 
@@ -440,16 +441,16 @@ func printSwarmInfo(dockerCli command.Cli, info types.Info) {
 	}
 }
 
-func printServerWarnings(dockerCli command.Cli, info types.Info) {
-	if versions.LessThan(dockerCli.Client().ClientVersion(), "1.42") {
-		printSecurityOptionsWarnings(dockerCli, info)
+func printServerWarnings(dockerCli command.Cli, info *info) {
+	if versions.LessThan(info.ClientInfo.APIVersion, "1.42") {
+		printSecurityOptionsWarnings(dockerCli, *info.Info)
 	}
 	if len(info.Warnings) > 0 {
 		fmt.Fprintln(dockerCli.Err(), strings.Join(info.Warnings, "\n"))
 		return
 	}
 	// daemon didn't return warnings. Fallback to old behavior
-	printServerWarningsLegacy(dockerCli, info)
+	printServerWarningsLegacy(dockerCli, *info.Info)
 }
 
 // printSecurityOptionsWarnings prints warnings based on the security options


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/2819

### cli/command/system: prettyPrintServerInfo: simplify username

Starting with b4ca1c7368daeead400fcc1b8f2d61951a0d9d1e (https://github.com/docker/cli/pull/2819), docker login  no longer depends on info.IndexServerAddress to determine the default registry.

The prettyPrintServerInfo() still depended on this information, which could potentially show the wrong information.

This patch changes it to also depend on the same information as docker login now does.

### cli/command/system: prettyPrintServerInfo: move out collecting username

Make this function only _print_ the info we have, and not read the username
from the credential-store.

This patch adds a Username field to the (local) `info` type, and sets it
when needed, so that prettyPrintServerInfo only has to format and print
the information, instead of calling out to the credential-store.

### cli/command/system: printServerWarnings: use client API version from info

Set the client's API version that's used in the info, instead of requesting
it as part of printing.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

