### PR TITLE
scripts/warn-outside-container: fix escapes

### DIFF
--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eu
 
 target="${1:-}"
@@ -11,14 +11,14 @@ if [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
 			*)
 				(
 						echo
-						echo "\033[1mWARNING\033[0m: you are not in a container."
+						echo -e "\033[1mWARNING\033[0m: you are not in a container."
 						echo
-						echo 'Use "\033[1mmake dev\033[0m" to start an interactive development container,'
-						echo "use \"\033[1mmake -f docker.Makefile $target\033[0m\" to execute this target"
-						echo "in a container, or set \033[1mDISABLE_WARN_OUTSIDE_CONTAINER=1\033[0m to"
-						echo "disable this warning."
+						echo -e 'Use "\033[1mmake dev\033[0m" to start an interactive development container,'
+						echo -e "use \"\033[1mmake -f docker.Makefile $target\033[0m\" to execute this target"
+						echo -e "in a container, or set \033[1mDISABLE_WARN_OUTSIDE_CONTAINER=1\033[0m to"
+						echo -e "disable this warning."
 						echo
-						echo "Press \033[1mCtrl+C\033[0m now to abort, or wait for the script to continue.."
+						echo -e "Press \033[1mCtrl+C\033[0m now to abort, or wait for the script to continue.."
 						echo
 				) >&2
 				sleep 5


### PR DESCRIPTION
By default, echo does not interpret escape sequences, resulting in the following output (literal):

	\033[1mWARNING\033[0m: you are not in a container.

I don't think this was intended.

Add -e option to echo so it can work as intended.

Also, use bash instead of sh because in POSIX shell echo does not take any options.

Fixes: 94e08f2e2db2eb9

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

