### PR TITLE
[23.0 backport] Handle empty DOCKER_BUILDKIT like unset

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -164,8 +164,8 @@ func (cli *DockerCli) ContentTrustEnabled() bool {
 
 // BuildKitEnabled returns buildkit is enabled or not.
 func (cli *DockerCli) BuildKitEnabled() (bool, error) {
-	// use DOCKER_BUILDKIT env var value if set
-	if v, ok := os.LookupEnv("DOCKER_BUILDKIT"); ok {
+	// use DOCKER_BUILDKIT env var value if set and not empty
+	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return false, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -44,9 +44,9 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	var buildKitDisabled, useBuilder, useAlias bool
 	var envs []string
 
-	// check DOCKER_BUILDKIT env var is present and
-	// if not assume we want to use the builder component
-	if v, ok := os.LookupEnv("DOCKER_BUILDKIT"); ok {
+	// check DOCKER_BUILDKIT env var is not empty
+	// if it is assume we want to use the builder component
+	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return args, osargs, nil, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/4216

This fixes the cli erroring out if the variable is set to an empty value.
The behavior for empty variable will be the same as if it was undefined.

```bash
$ export DOCKER_BUILDKIT=
$ docker version
DOCKER_BUILDKIT environment variable expects boolean value: strconv.ParseBool: parsing "": invalid syntax
```

**- What I did**

**- How I did it**
Use `os.Getenv` instead of `os.LookupEnv`

**- How to verify it**
```bash
DOCKER_BUILDKIT= docker version
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

