### PR TITLE
[23.0 backport] ci: add validation for generated docs, bump docker/bake-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Build
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: ${{ matrix.target }}
           set: |
@@ -121,7 +121,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Build
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: plugins-cross
           set: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Test
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: test-coverage
       -

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Run
-        uses: docker/bake-action@v2
+        uses: docker/bake-action@v3
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,8 +29,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       -
         name: Run
         uses: docker/bake-action@v2
@@ -70,8 +68,6 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       -
         name: Run
         shell: 'script --return --quiet --command "bash {0}"'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,27 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+  # check that the generated Markdown and the checked-in files match
+  validate-md:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Generate
+        shell: 'script --return --quiet --command "bash {0}"'
+        run: |
+          make -f docker.Makefile mddocs
+      -
+        name: Validate
+        run: |
+          if [[ $(git diff --stat) != '' ]]; then
+            echo 'fail: generated files do not match checked-in files'
+            git --no-pager diff
+            exit 1
+          fi
+
   validate-make:
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
backports:

- https://github.com/docker/cli/pull/4187
- https://github.com/docker/cli/pull/4213
- fixes #4171

----

