### PR TITLE
vendor: github.com/docker/docker v24.0.0-rc.1

### DIFF
--- a/cli/command/image/testdata/inspect-command-success.simple-many.golden
+++ b/cli/command/image/testdata/inspect-command-success.simple-many.golden
@@ -14,7 +14,6 @@
         "Architecture": "",
         "Os": "",
         "Size": 0,
-        "VirtualSize": 0,
         "GraphDriver": {
             "Data": null,
             "Name": ""
@@ -39,7 +38,6 @@
         "Architecture": "",
         "Os": "",
         "Size": 0,
-        "VirtualSize": 0,
         "GraphDriver": {
             "Data": null,
             "Name": ""

--- a/cli/command/image/testdata/inspect-command-success.simple.golden
+++ b/cli/command/image/testdata/inspect-command-success.simple.golden
@@ -14,7 +14,6 @@
         "Architecture": "",
         "Os": "",
         "Size": 0,
-        "VirtualSize": 0,
         "GraphDriver": {
             "Data": null,
             "Name": ""

--- a/vendor.mod
+++ b/vendor.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/containerd v1.6.20
 	github.com/creack/pty v1.1.18
 	github.com/docker/distribution v2.8.1+incompatible
-	github.com/docker/docker v24.0.0-beta.2+incompatible
+	github.com/docker/docker v24.0.0-rc.1+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -96,8 +96,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xb
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.0-beta.2+incompatible h1:pTEep8tbPw11AdIS/O8P8ULyLSQAS7HuOJphmQCHrNI=
-github.com/docker/docker v24.0.0-beta.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.0-rc.1+incompatible h1:xGLFfUFQ0mu4I22mzVJqGEdbWkdqDwIdloBIdr0rcJk=
+github.com/docker/docker v24.0.0-rc.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -1746,15 +1746,14 @@ definitions:
           Total size of the image including all layers it is composed of.
 
           In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Docker v1.10 and up
-          store images self-contained, and no longer use a parent-chain, making
-          this field an equivalent of the Size field.
+          the image itself and all of its parent images. Images are now stored
+          self-contained, and no longer use a parent-chain, making this field
+          an equivalent of the Size field.
 
-          This field is kept for backward compatibility, but may be removed in
-          a future version of the API.
+          > **Deprecated**: this field is kept for backward compatibility, but
+          > will be removed in API v1.44.
         type: "integer"
         format: "int64"
-        x-nullable: false
         example: 1239828
       GraphDriver:
         $ref: "#/definitions/GraphDriverData"
@@ -1802,7 +1801,6 @@ definitions:
       - Created
       - Size
       - SharedSize
-      - VirtualSize
       - Labels
       - Containers
     properties:
@@ -1888,19 +1886,17 @@ definitions:
         x-nullable: false
         example: 1239828
       VirtualSize:
-        description: |
+        description: |-
           Total size of the image including all layers it is composed of.
 
           In versions of Docker before v1.10, this field was calculated from
-          the image itself and all of its parent images. Docker v1.10 and up
-          store images self-contained, and no longer use a parent-chain, making
-          this field an equivalent of the Size field.
+          the image itself and all of its parent images. Images are now stored
+          self-contained, and no longer use a parent-chain, making this field
+          an equivalent of the Size field.
 
-          This field is kept for backward compatibility, but may be removed in
-          a future version of the API.
+          Deprecated: this field is kept for backward compatibility, and will be removed in API v1.44.
         type: "integer"
         format: "int64"
-        x-nullable: false
         example: 172064416
       Labels:
         description: "User-defined key/value metadata."
@@ -5243,7 +5239,8 @@ definitions:
       SecurityOptions:
         description: |
           List of security features that are enabled on the daemon, such as
-          apparmor, seccomp, SELinux, user-namespaces (userns), and rootless.
+          apparmor, seccomp, SELinux, user-namespaces (userns), rootless and
+          no-new-privileges.
 
           Additional configuration options for each security feature may
           be present, and are included as a comma-separated list of key/value
@@ -8229,7 +8226,7 @@ paths:
 
             Available filters:
 
-            - `until=<duration>`: duration relative to daemon's time, during which build cache was not used, in Go's duration format (e.g., '24h')
+            - `until=<timestamp>` remove cache older than `<timestamp>`. The `<timestamp>` can be Unix timestamps, date formatted timestamps, or Go duration strings (e.g. `10m`, `1h30m`) computed relative to the daemon's local time.
             - `id=<id>`
             - `parent=<id>`
             - `type=<string>`

--- a/vendor/github.com/docker/docker/api/types/image_summary.go
+++ b/vendor/github.com/docker/docker/api/types/image_summary.go
@@ -85,13 +85,10 @@ type ImageSummary struct {
 	// Total size of the image including all layers it is composed of.
 	//
 	// In versions of Docker before v1.10, this field was calculated from
-	// the image itself and all of its parent images. Docker v1.10 and up
-	// store images self-contained, and no longer use a parent-chain, making
-	// this field an equivalent of the Size field.
+	// the image itself and all of its parent images. Images are now stored
+	// self-contained, and no longer use a parent-chain, making this field
+	// an equivalent of the Size field.
 	//
-	// This field is kept for backward compatibility, but may be removed in
-	// a future version of the API.
-	//
-	// Required: true
-	VirtualSize int64 `json:"VirtualSize"`
+	// Deprecated: this field is kept for backward compatibility, and will be removed in API v1.44.
+	VirtualSize int64 `json:"VirtualSize,omitempty"`
 }

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -123,9 +123,8 @@ type ImageInspect struct {
 	// store images self-contained, and no longer use a parent-chain, making
 	// this field an equivalent of the Size field.
 	//
-	// This field is kept for backward compatibility, but may be removed in
-	// a future version of the API.
-	VirtualSize int64 // TODO(thaJeztah): deprecate this field
+	// Deprecated: Unused in API 1.43 and up, but kept for backward compatibility with older API versions.
+	VirtualSize int64 `json:"VirtualSize,omitempty"`
 
 	// GraphDriver holds information about the storage driver used to store the
 	// container's and image's filesystem.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v24.0.0-beta.2+incompatible
+# github.com/docker/docker v24.0.0-rc.1+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- [x] depends on https://github.com/docker/cli/pull/4235
- [x] depends on https://github.com/docker/cli/pull/4242

### vendor: github.com/docker/docker v24.0.0-rc.1

full diff: https://github.com/docker/docker/compare/v24.0.0-beta.2...v24.0.0-rc.1

