### PR TITLE
Update wording in ps.md of --filter name

### DIFF
--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -128,7 +128,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 9b6247364a03        busybox             "top"               2 minutes ago       Up 2 minutes                            nostalgic_stallman
 ```
 
-You can also filter for a substring in a name as this shows:
+You can only filter for a substring in a name as this shows:
 
 ```console
 $ docker ps --filter "name=nostalgic"


### PR DESCRIPTION
As there is no mechanism for filtering container names by anything other than substring, the use of `also` in the sentence is inappropriate.

This change fixes the wording to more accurately reflect reality.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

