### PR TITLE
remove uses of deprecated VirtualSize field

### DIFF
--- a/cli/command/formatter/disk_usage.go
+++ b/cli/command/formatter/disk_usage.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultDiskUsageImageTableFormat      = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.VirtualSize}}\t{{.SharedSize}}\t{{.UniqueSize}}\t{{.Containers}}"
+	defaultDiskUsageImageTableFormat      = "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}\t{{.SharedSize}}\t{{.UniqueSize}}\t{{.Containers}}"
 	defaultDiskUsageContainerTableFormat  = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.LocalVolumes}}\t{{.Size}}\t{{.RunningFor}}\t{{.Status}}\t{{.Names}}"
 	defaultDiskUsageVolumeTableFormat     = "table {{.Name}}\t{{.Links}}\t{{.Size}}"
 	defaultDiskUsageBuildCacheTableFormat = "table {{.ID}}\t{{.CacheType}}\t{{.Size}}\t{{.CreatedSince}}\t{{.LastUsedSince}}\t{{.UsageCount}}\t{{.Shared}}"
@@ -296,10 +296,10 @@ func (c *diskUsageImagesContext) Reclaimable() string {
 
 	for _, i := range c.images {
 		if i.Containers != 0 {
-			if i.VirtualSize == -1 || i.SharedSize == -1 {
+			if i.Size == -1 || i.SharedSize == -1 {
 				continue
 			}
-			used += i.VirtualSize - i.SharedSize
+			used += i.Size - i.SharedSize
 		}
 	}
 

--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -205,7 +205,7 @@ func newImageContext() *imageContext {
 		"CreatedAt":    CreatedAtHeader,
 		"Size":         SizeHeader,
 		"Containers":   containersHeader,
-		"VirtualSize":  SizeHeader,
+		"VirtualSize":  SizeHeader, // Deprecated: VirtualSize is deprecated, and equivalent to Size.
 		"SharedSize":   sharedSizeHeader,
 		"UniqueSize":   uniqueSizeHeader,
 	}
@@ -260,8 +260,13 @@ func (c *imageContext) Containers() string {
 	return fmt.Sprintf("%d", c.i.Containers)
 }
 
+// VirtualSize shows the virtual size of the image and all of its parent
+// images. Starting with docker 1.10, images are self-contained, and
+// the VirtualSize is identical to Size.
+//
+// Deprecated: VirtualSize is deprecated, and equivalent to [imageContext.Size].
 func (c *imageContext) VirtualSize() string {
-	return units.HumanSize(float64(c.i.VirtualSize))
+	return units.HumanSize(float64(c.i.Size))
 }
 
 func (c *imageContext) SharedSize() string {
@@ -272,8 +277,8 @@ func (c *imageContext) SharedSize() string {
 }
 
 func (c *imageContext) UniqueSize() string {
-	if c.i.VirtualSize == -1 || c.i.SharedSize == -1 {
+	if c.i.Size == -1 || c.i.SharedSize == -1 {
 		return "N/A"
 	}
-	return units.HumanSize(float64(c.i.VirtualSize - c.i.SharedSize))
+	return units.HumanSize(float64(c.i.Size - c.i.SharedSize))
 }

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -36,7 +36,7 @@ func TestImageContext(t *testing.T) {
 			call:     ctx.ID,
 		},
 		{
-			imageCtx: imageContext{i: types.ImageSummary{Size: 10, VirtualSize: 10}, trunc: true},
+			imageCtx: imageContext{i: types.ImageSummary{Size: 10}, trunc: true},
 			expValue: "10B",
 			call:     ctx.Size,
 		},
@@ -70,9 +70,9 @@ func TestImageContext(t *testing.T) {
 			call:     ctx.Containers,
 		},
 		{
-			imageCtx: imageContext{i: types.ImageSummary{VirtualSize: 10000}},
+			imageCtx: imageContext{i: types.ImageSummary{Size: 10000}},
 			expValue: "10kB",
-			call:     ctx.VirtualSize,
+			call:     ctx.VirtualSize, //nolint:staticcheck // ignore SA1019: field is deprecated, but still set on API < v1.44.
 		},
 		{
 			imageCtx: imageContext{i: types.ImageSummary{SharedSize: 10000}},
@@ -80,7 +80,7 @@ func TestImageContext(t *testing.T) {
 			call:     ctx.SharedSize,
 		},
 		{
-			imageCtx: imageContext{i: types.ImageSummary{SharedSize: 5000, VirtualSize: 20000}},
+			imageCtx: imageContext{i: types.ImageSummary{SharedSize: 5000, Size: 20000}},
 			expValue: "15kB",
 			call:     ctx.UniqueSize,
 		},


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4236
- relates to https://github.com/moby/moby/pull/45346
- relates to https://github.com/moby/moby/pull/17924


The VirtualSize field is deprecated and the upcoming API version v1.44 will no longer propagate the field. See:
https://github.com/moby/moby/commit/1261fe69a3586bb102182aa885197822419c768c (https://github.com/moby/moby/pull/45346).

Given that in docker 1.10 and up (API v1.22), the VirtualSize and Size fields contain the same value, and the "df" endpoint was not supported until API v1.25, we can "safely" use Size instead; see:

- https://github.com/docker/cli/commit/4ae7176ffb8d37c60d2152fb155678e659af5b99
- https://github.com/moby/moby/commit/4352da7803d182a6013a5238ce20a7c749db979a (https://github.com/moby/moby/pull/17924)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

