### PR TITLE
Add support for --detach flag in stack deploy

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -139,7 +139,7 @@ func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, opts *serviceOptions
 		return nil
 	}
 
-	return waitOnService(ctx, dockerCli, response.ID, opts.quiet)
+	return WaitOnService(ctx, dockerCli, response.ID, opts.quiet)
 }
 
 // setConfigs does double duty: it both sets the ConfigReferences of the

--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -9,9 +9,9 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 )
 
-// waitOnService waits for the service to converge. It outputs a progress bar,
+// WaitOnService waits for the service to converge. It outputs a progress bar,
 // if appropriate based on the CLI flags.
-func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string, quiet bool) error {
+func WaitOnService(ctx context.Context, dockerCli command.Cli, serviceID string, quiet bool) error {
 	errChan := make(chan error, 1)
 	pipeReader, pipeWriter := io.Pipe()
 

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -143,7 +143,7 @@ func ServiceProgress(ctx context.Context, client client.APIClient, serviceID str
 		if converged && time.Since(convergedAt) >= monitor {
 			progressOut.WriteProgress(progress.Progress{
 				ID:     "verify",
-				Action: "Service converged",
+				Action: fmt.Sprintf("Service %s converged", serviceID),
 			})
 			if message != nil {
 				progressOut.WriteProgress(*message)

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -63,5 +63,5 @@ func runRollback(dockerCli command.Cli, options *serviceOptions, serviceID strin
 		return nil
 	}
 
-	return waitOnService(ctx, dockerCli, serviceID, options.quiet)
+	return WaitOnService(ctx, dockerCli, serviceID, options.quiet)
 }

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -82,7 +82,7 @@ func runScale(dockerCli command.Cli, options *scaleOptions, args []string) error
 	if len(serviceIDs) > 0 {
 		if !options.detach && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.29") {
 			for _, serviceID := range serviceIDs {
-				if err := waitOnService(ctx, dockerCli, serviceID, false); err != nil {
+				if err := WaitOnService(ctx, dockerCli, serviceID, false); err != nil {
 					errs = append(errs, fmt.Sprintf("%s: %v", serviceID, err))
 				}
 			}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -249,7 +249,7 @@ func runUpdate(dockerCli command.Cli, flags *pflag.FlagSet, options *serviceOpti
 		return nil
 	}
 
-	return waitOnService(ctx, dockerCli, serviceID, options.quiet)
+	return WaitOnService(ctx, dockerCli, serviceID, options.quiet)
 }
 
 //nolint:gocyclo

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -1,6 +1,8 @@
 package stack
 
 import (
+	"fmt"
+
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack/loader"
@@ -28,6 +30,14 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			if opts.Detach {
+				if !cmd.Flags().Changed("detach") {
+					fmt.Fprintln(dockerCli.Err(), "Since --detach=false was not specified, tasks will be created in the background.\n"+
+						"In a future release, --detach=false will become the default.")
+				}
+			}
+
 			return swarm.RunDeploy(dockerCli, opts, config)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -44,6 +54,8 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.ResolveImage, "resolve-image", swarm.ResolveImageAlways,
 		`Query the registry to resolve image digest and supported platforms ("`+swarm.ResolveImageAlways+`", "`+swarm.ResolveImageChanged+`", "`+swarm.ResolveImageNever+`")`)
 	flags.SetAnnotation("resolve-image", "version", []string{"1.30"})
+	flags.BoolVarP(&opts.Detach, "detach", "d", true, "Exit immediately instead of waiting for the stack services to converge")
+	flags.BoolVarP(&opts.Quiet, "quiet", "q", false, "Suppress progress output")
 	return cmd
 }
 

--- a/cli/command/stack/options/opts.go
+++ b/cli/command/stack/options/opts.go
@@ -9,6 +9,8 @@ type Deploy struct {
 	ResolveImage     string
 	SendRegistryAuth bool
 	Prune            bool
+	Detach           bool
+	Quiet            bool
 }
 
 // Config holds docker stack config options

--- a/cli/command/stack/swarm/deploy_test.go
+++ b/cli/command/stack/swarm/deploy_test.go
@@ -99,7 +99,7 @@ func TestServiceUpdateResolveImageChanged(t *testing.T) {
 					},
 				},
 			}
-			err := deployServices(ctx, client, spec, namespace, false, ResolveImageChanged)
+			err := deployServices(ctx, client, spec, namespace, false, ResolveImageChanged, true, true)
 			assert.NilError(t, err)
 			assert.Check(t, is.Equal(receivedOptions.QueryRegistry, tc.expectedQueryRegistry))
 			assert.Check(t, is.Equal(receivedService.TaskTemplate.ContainerSpec.Image, tc.expectedImage))


### PR DESCRIPTION
Part of #373 

Added `--detach` and `--quite` / `-q` flags to `stack deploy`. Setting `--detach=false` waits until all of the services have converged. Shows progress bars for each individual task, unless  `--quite` / `-q` is specified.

I have used the `WaitOnService` under the hood, so that the behavior is in line with `service update` or `service create` while using the `--detach` flag.

---

Linting was failing, so I opted to create a `waitOnServices` function in order to reduce the cyclomatic complexity of the `deployServices` function. Feel free to suggest a better alternative!