### PR TITLE
cli/context/docker: rename receiver for Endpoint

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -40,23 +40,23 @@ func WithTLSData(s store.Reader, contextName string, m EndpointMeta) (Endpoint, 
 }
 
 // tlsConfig extracts a context docker endpoint TLS config
-func (c *Endpoint) tlsConfig() (*tls.Config, error) {
-	if c.TLSData == nil && !c.SkipTLSVerify {
+func (ep *Endpoint) tlsConfig() (*tls.Config, error) {
+	if ep.TLSData == nil && !ep.SkipTLSVerify {
 		// there is no specific tls config
 		return nil, nil
 	}
 	var tlsOpts []func(*tls.Config)
-	if c.TLSData != nil && c.TLSData.CA != nil {
+	if ep.TLSData != nil && ep.TLSData.CA != nil {
 		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(c.TLSData.CA) {
+		if !certPool.AppendCertsFromPEM(ep.TLSData.CA) {
 			return nil, errors.New("failed to retrieve context tls info: ca.pem seems invalid")
 		}
 		tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
 			cfg.RootCAs = certPool
 		})
 	}
-	if c.TLSData != nil && c.TLSData.Key != nil && c.TLSData.Cert != nil {
-		keyBytes := c.TLSData.Key
+	if ep.TLSData != nil && ep.TLSData.Key != nil && ep.TLSData.Cert != nil {
+		keyBytes := ep.TLSData.Key
 		pemBlock, _ := pem.Decode(keyBytes)
 		if pemBlock == nil {
 			return nil, errors.New("no valid private key found")
@@ -65,7 +65,7 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 			return nil, errors.New("private key is encrypted - support for encrypted private keys has been removed, see https://docs.docker.com/go/deprecated/")
 		}
 
-		x509cert, err := tls.X509KeyPair(c.TLSData.Cert, keyBytes)
+		x509cert, err := tls.X509KeyPair(ep.TLSData.Cert, keyBytes)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to retrieve context tls info")
 		}
@@ -73,7 +73,7 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 			cfg.Certificates = []tls.Certificate{x509cert}
 		})
 	}
-	if c.SkipTLSVerify {
+	if ep.SkipTLSVerify {
 		tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
 			cfg.InsecureSkipVerify = true
 		})
@@ -82,21 +82,21 @@ func (c *Endpoint) tlsConfig() (*tls.Config, error) {
 }
 
 // ClientOpts returns a slice of Client options to configure an API client with this endpoint
-func (c *Endpoint) ClientOpts() ([]client.Opt, error) {
+func (ep *Endpoint) ClientOpts() ([]client.Opt, error) {
 	var result []client.Opt
-	if c.Host != "" {
-		helper, err := connhelper.GetConnectionHelper(c.Host)
+	if ep.Host != "" {
+		helper, err := connhelper.GetConnectionHelper(ep.Host)
 		if err != nil {
 			return nil, err
 		}
 		if helper == nil {
-			tlsConfig, err := c.tlsConfig()
+			tlsConfig, err := ep.tlsConfig()
 			if err != nil {
 				return nil, err
 			}
 			result = append(result,
 				withHTTPClient(tlsConfig),
-				client.WithHost(c.Host),
+				client.WithHost(ep.Host),
 			)
 
 		} else {


### PR DESCRIPTION
Code in methods of this type also used the Client, and having this receiver named "c" made it easy to confuse it for referring to Client ("c").

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

