### PR TITLE
Add support for --detach flag in stack rm

### DIFF
--- a/cli/command/stack/options/opts.go
+++ b/cli/command/stack/options/opts.go
@@ -38,6 +38,7 @@ type PS struct {
 // Remove holds docker stack remove options
 type Remove struct {
 	Namespaces []string
+	Detach     bool
 }
 
 // Services holds docker stack services options

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -27,5 +27,8 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			return completeNames(dockerCli)(cmd, args, toComplete)
 		},
 	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.Detach, "detach", "d", true, "Do not wait for stack removal")
 	return cmd
 }

--- a/cli/command/stack/swarm/common.go
+++ b/cli/command/stack/swarm/common.go
@@ -44,3 +44,7 @@ func getStackSecrets(ctx context.Context, apiclient client.APIClient, namespace 
 func getStackConfigs(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Config, error) {
 	return apiclient.ConfigList(ctx, types.ConfigListOptions{Filters: getStackFilter(namespace)})
 }
+
+func getStackTasks(ctx context.Context, apiclient client.APIClient, namespace string) ([]swarm.Task, error) {
+	return apiclient.TaskList(ctx, types.TaskListOptions{Filters: getStackFilter(namespace)})
+}

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -7,6 +7,12 @@ Remove one or more stacks
 
 `docker stack rm`, `docker stack remove`, `docker stack down`
 
+### Options
+
+| Name             | Type   | Default | Description                   |
+|:-----------------|:-------|:--------|:------------------------------|
+| `-d`, `--detach` | `bool` | `true`  | Do not wait for stack removal |
+
 
 <!---MARKER_GEN_END-->
 


### PR DESCRIPTION
Part of #373 along with https://github.com/docker/cli/pull/4258

Added --detach to stack rm. Setting --detach=false waits until all of the stack tasks have reached a terminal state.

