### PR TITLE
remove pre-go1.17 build-tags

### DIFF
--- a/cli-plugins/manager/manager_unix.go
+++ b/cli-plugins/manager/manager_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package manager
 

--- a/cli-plugins/manager/suffix_unix.go
+++ b/cli-plugins/manager/suffix_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package manager
 

--- a/cli/command/container/signals_unix.go
+++ b/cli/command/container/signals_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container
 

--- a/cli/command/container/signals_unix_test.go
+++ b/cli/command/container/signals_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package container
 

--- a/cli/command/image/build/context_unix.go
+++ b/cli/command/image/build/context_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package build
 

--- a/cli/config/configfile/file_unix.go
+++ b/cli/config/configfile/file_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package configfile
 

--- a/cli/config/credentials/default_store_unsupported.go
+++ b/cli/config/credentials/default_store_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin && !linux
-// +build !windows,!darwin,!linux
 
 package credentials
 

--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package commandconn
 

--- a/cli/connhelper/commandconn/pdeathsig_nolinux.go
+++ b/cli/connhelper/commandconn/pdeathsig_nolinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package commandconn
 

--- a/cli/connhelper/commandconn/session_unix.go
+++ b/cli/connhelper/commandconn/session_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package commandconn
 

--- a/cmd/docker/docker_windows_386.go
+++ b/cmd/docker/docker_windows_386.go
@@ -1,5 +1,4 @@
 //go:build windows && 386
-// +build windows,386
 
 //go:generate goversioninfo -o=../../cli/winresources/resource.syso -icon=winresources/docker.ico -manifest=winresources/docker.exe.manifest ../../cli/winresources/versioninfo.json
 

--- a/cmd/docker/docker_windows_amd64.go
+++ b/cmd/docker/docker_windows_amd64.go
@@ -1,5 +1,4 @@
 //go:build windows && amd64
-// +build windows,amd64
 
 //go:generate goversioninfo -64=true -o=../../cli/winresources/resource.syso -icon=winresources/docker.ico -manifest=winresources/docker.exe.manifest ../../cli/winresources/versioninfo.json
 

--- a/cmd/docker/docker_windows_arm.go
+++ b/cmd/docker/docker_windows_arm.go
@@ -1,5 +1,4 @@
 //go:build windows && arm
-// +build windows,arm
 
 //go:generate goversioninfo -arm=true -o=../../cli/winresources/resource.syso -icon=winresources/docker.ico -manifest=winresources/docker.exe.manifest ../../cli/winresources/versioninfo.json
 

--- a/cmd/docker/docker_windows_arm64.go
+++ b/cmd/docker/docker_windows_arm64.go
@@ -1,5 +1,4 @@
 //go:build windows && arm64
-// +build windows,arm64
 
 //go:generate goversioninfo -arm=true -64=true -o=../../cli/winresources/resource.syso -icon=winresources/docker.ico -manifest=winresources/docker.exe.manifest ../../cli/winresources/versioninfo.json
 

--- a/opts/hosts_unix.go
+++ b/opts/hosts_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package opts
 


### PR DESCRIPTION
Removed pre-go1.17 build-tags with go fix;

    go mod init
    go fix -mod=readonly ./...
    rm go.mod


**- A picture of a cute animal (not mandatory but encouraged)**

