### PR TITLE
cli/config/credentials: skip unneeded exec.LookPath()

### DIFF
--- a/cli/config/credentials/default_store.go
+++ b/cli/config/credentials/default_store.go
@@ -5,17 +5,20 @@ import (
 )
 
 // DetectDefaultStore return the default credentials store for the platform if
-// the store executable is available.
+// no user-defined store is passed, and the store executable is available.
 func DetectDefaultStore(store string) string {
-	platformDefault := defaultCredentialsStore()
-
-	// user defined or no default for platform
-	if store != "" || platformDefault == "" {
+	if store != "" {
+		// use user-defined
 		return store
 	}
 
-	if _, err := exec.LookPath(remoteCredentialsPrefix + platformDefault); err == nil {
-		return platformDefault
+	platformDefault := defaultCredentialsStore()
+	if platformDefault == "" {
+		return ""
 	}
-	return ""
+
+	if _, err := exec.LookPath(remoteCredentialsPrefix + platformDefault); err != nil {
+		return ""
+	}
+	return platformDefault
 }


### PR DESCRIPTION
defaultCredentialsStore() on Linux does an exec.LookPath() for "pass", but if a custom credential-store is passed to DetectDefaultStore, the result of that won't be used.

This patch changes the logic to return early if a custom credential-store is passed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

