### PR TITLE
vendor: github.com/docker/docker v24.0.0-rc.2

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/containerd v1.6.21
 	github.com/creack/pty v1.1.18
 	github.com/docker/distribution v2.8.1+incompatible
-	github.com/docker/docker v24.0.0-rc.1.0.20230505222407-8d9a40a82034+incompatible
+	github.com/docker/docker v24.0.0-rc.2+incompatible
 	github.com/docker/docker-credential-helpers v0.7.0
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -96,8 +96,8 @@ github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xb
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v24.0.0-rc.1.0.20230505222407-8d9a40a82034+incompatible h1:Y2oMmZDlVZhIkKzBUCeY48pi8ophHyEAoW04ABKn3DU=
-github.com/docker/docker v24.0.0-rc.1.0.20230505222407-8d9a40a82034+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.0-rc.2+incompatible h1:ItFfSgvZ73G/8pg5Yd6XLnif7zpeurAREnRbd7u6v04=
+github.com/docker/docker v24.0.0-rc.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v24.0.0-rc.1.0.20230505222407-8d9a40a82034+incompatible
+# github.com/docker/docker v24.0.0-rc.2+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
no diff, because it's the same as the previous commit, but now tagged;

https://github.com/docker/docker/compare/8d9a40a820349860405e142249c55215aa4da8e3...v24.0.0-rc.2


**- A picture of a cute animal (not mandatory but encouraged)**

