### PR TITLE
[23.0 backport] cli-plugins/manager: fix deprecation comment of Metadata.Experimental

### DIFF
--- a/cli-plugins/manager/metadata.go
+++ b/cli-plugins/manager/metadata.go
@@ -23,6 +23,7 @@ type Metadata struct {
 	// URL is a pointer to the plugin's homepage.
 	URL string `json:",omitempty"`
 	// Experimental specifies whether the plugin is experimental.
+	//
 	// Deprecated: experimental features are now always enabled in the CLI
 	Experimental bool `json:",omitempty"`
 }


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4276
- relates to https://github.com/docker/cli/pull/27740

This field was marked deprecated in 977d3ae046ec6c64be8788a8712251ed547a2bdb (https://github.com/docker/cli/pull/27740, which is part of v20.10 and up, but the comment was missing a newline before the deprecation message, which may be picked up by IDEs, but  is not matching the correct format, so may not be picked up by linters.

This patch fixes the format, to make sure linters pick up that the field is deprecated.


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

