### PR TITLE
cli/command/stack: remove deprecated RunDeploy, RunPS, RunRemove, GetServices

### DIFF
--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -6,9 +6,7 @@ import (
 	"github.com/docker/cli/cli/command/stack/loader"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
-	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newDeployCommand(dockerCli command.Cli) *cobra.Command {
@@ -45,11 +43,4 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 		`Query the registry to resolve image digest and supported platforms ("`+swarm.ResolveImageAlways+`", "`+swarm.ResolveImageChanged+`", "`+swarm.ResolveImageNever+`")`)
 	flags.SetAnnotation("resolve-image", "version", []string{"1.30"})
 	return cmd
-}
-
-// RunDeploy performs a stack deploy against the specified swarm cluster.
-//
-// Deprecated: use [swarm.RunDeploy] instead.
-func RunDeploy(dockerCli command.Cli, _ *pflag.FlagSet, config *composetypes.Config, opts options.Deploy) error {
-	return swarm.RunDeploy(dockerCli, opts, config)
 }

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -8,7 +8,6 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	cliopts "github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newPsCommand(dockerCli command.Cli) *cobra.Command {
@@ -36,11 +35,4 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.Quiet, "quiet", "q", false, "Only display task IDs")
 	flags.StringVar(&opts.Format, "format", "", flagsHelper.FormatHelp)
 	return cmd
-}
-
-// RunPs performs a stack ps against the specified swarm cluster.
-//
-// Deprecated: use [swarm.RunPS] instead.
-func RunPs(dockerCli command.Cli, _ *pflag.FlagSet, opts options.PS) error {
-	return swarm.RunPS(dockerCli, opts)
 }

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -6,7 +6,6 @@ import (
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
@@ -29,11 +28,4 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	return cmd
-}
-
-// RunRemove performs a stack remove against the specified swarm cluster.
-//
-// Deprecated: use [swarm.RunRemove] instead.
-func RunRemove(dockerCli command.Cli, _ *pflag.FlagSet, opts options.Remove) error {
-	return swarm.RunRemove(dockerCli, opts)
 }

--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -15,7 +15,6 @@ import (
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/fvbommel/sortorder"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newServicesCommand(dockerCli command.Cli) *cobra.Command {
@@ -50,13 +49,6 @@ func RunServices(dockerCli command.Cli, opts options.Services) error {
 		return err
 	}
 	return formatWrite(dockerCli, services, opts)
-}
-
-// GetServices returns the services for the specified swarm cluster.
-//
-// Deprecated: use [swarm.GetServices] instead.
-func GetServices(dockerCli command.Cli, _ *pflag.FlagSet, opts options.Services) ([]swarmtypes.Service, error) {
-	return swarm.GetServices(dockerCli, opts)
 }
 
 func formatWrite(dockerCli command.Cli, services []swarmtypes.Service, opts options.Services) error {


### PR DESCRIPTION
These were deprecated in f08252c10a16beac0ad40348118a96fa6b447f19, which is part of the v24.0 release, so we can remove these on master.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

