### PR TITLE
cli/command: remove deprecated EncodeAuthToBase64

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -19,13 +19,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload.
-//
-// Deprecated: use [registrytypes.EncodeAuthConfig] instead.
-func EncodeAuthToBase64(authConfig registrytypes.AuthConfig) (string, error) {
-	return registrytypes.EncodeAuthConfig(authConfig)
-}
-
 // RegistryAuthenticationPrivilegedFunc returns a RequestPrivilegeFunc from the specified registry index info
 // for the given command.
 func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInfo, cmdName string) types.RequestPrivilegeFunc {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4203

This function was deprecated in b87ed343510b1cf71d1aba02294f52268f754386 (https://github.com/docker/cli/pull/4203), which is part of the v24.0 release, so we can remove it from master.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

