### PR TITLE
replace uses of client.IsErrNotFound for errdefs.IsNotFound

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
-	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -255,7 +255,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	response, err := dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, opts.name)
 	if err != nil {
 		// Pull image if it does not exist locally and we have the PullImageMissing option. Default behavior.
-		if apiclient.IsErrNotFound(err) && namedRef != nil && opts.pull == PullImageMissing {
+		if errdefs.IsNotFound(err) && namedRef != nil && opts.pull == PullImageMissing {
 			if !opts.quiet {
 				// we don't want to write to stdout anything apart from container.ID
 				fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -350,5 +350,5 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 
 type fakeNotFound struct{}
 
-func (f fakeNotFound) NotFound() bool { return true }
-func (f fakeNotFound) Error() string  { return "error fake not found" }
+func (f fakeNotFound) NotFound()     {}
+func (f fakeNotFound) Error() string { return "error fake not found" }

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
-	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +63,7 @@ func runRemove(dockerCli command.Cli, opts removeOptions, images []string) error
 	for _, img := range images {
 		dels, err := client.ImageRemove(ctx, img, options)
 		if err != nil {
-			if !apiclient.IsErrNotFound(err) {
+			if !errdefs.IsNotFound(err) {
 				fatalErr = true
 			}
 			errs = append(errs, err.Error())

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -21,9 +21,7 @@ func (n notFound) Error() string {
 	return fmt.Sprintf("Error: No such image: %s", n.imageID)
 }
 
-func (n notFound) NotFound() bool {
-	return true
-}
+func (n notFound) NotFound() {}
 
 func TestNewRemoveCommandAlias(t *testing.T) {
 	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}))

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
-	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -57,7 +57,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 	getRef := func(ref string) (interface{}, []byte, error) {
 		// Service inspect shows defaults values in empty fields.
 		service, _, err := client.ServiceInspectWithRaw(ctx, ref, types.ServiceInspectOptions{InsertDefaults: true})
-		if err == nil || !apiclient.IsErrNotFound(err) {
+		if err == nil || !errdefs.IsNotFound(err) {
 			return service, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such service: %s", ref)
@@ -65,7 +65,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 
 	getNetwork := func(ref string) (interface{}, []byte, error) {
 		network, _, err := client.NetworkInspectWithRaw(ctx, ref, types.NetworkInspectOptions{Scope: "swarm"})
-		if err == nil || !apiclient.IsErrNotFound(err) {
+		if err == nil || !errdefs.IsNotFound(err) {
 			return network, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such network: %s", ref)

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
@@ -99,12 +100,12 @@ func runLogs(dockerCli command.Cli, opts *logsOptions) error {
 	service, _, err := cli.ServiceInspectWithRaw(ctx, opts.target, types.ServiceInspectOptions{})
 	if err != nil {
 		// if it's any error other than service not found, it's Real
-		if !client.IsErrNotFound(err) {
+		if !errdefs.IsNotFound(err) {
 			return err
 		}
 		task, _, err := cli.TaskInspectWithRaw(ctx, opts.target)
 		if err != nil {
-			if client.IsErrNotFound(err) {
+			if errdefs.IsNotFound(err) {
 				// if the task isn't found, rewrite the error to be clear
 				// that we looked for services AND tasks and found none
 				err = fmt.Errorf("no such task or service: %v", opts.target)

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 )
 
@@ -85,7 +86,7 @@ func validateExternalNetworks(ctx context.Context, client apiclient.NetworkAPICl
 		}
 		network, err := client.NetworkInspect(ctx, networkName, types.NetworkInspectOptions{})
 		switch {
-		case apiclient.IsErrNotFound(err):
+		case errdefs.IsNotFound(err):
 			return errors.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)
 		case err != nil:
 			return err
@@ -107,7 +108,7 @@ func createSecrets(ctx context.Context, dockerCli command.Cli, secrets []swarm.S
 			if err := client.SecretUpdate(ctx, secret.ID, secret.Meta.Version, secretSpec); err != nil {
 				return errors.Wrapf(err, "failed to update secret %s", secretSpec.Name)
 			}
-		case apiclient.IsErrNotFound(err):
+		case errdefs.IsNotFound(err):
 			// secret does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating secret %s\n", secretSpec.Name)
 			if _, err := client.SecretCreate(ctx, secretSpec); err != nil {
@@ -131,7 +132,7 @@ func createConfigs(ctx context.Context, dockerCli command.Cli, configs []swarm.C
 			if err := client.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
 				return errors.Wrapf(err, "failed to update config %s", configSpec.Name)
 			}
-		case apiclient.IsErrNotFound(err):
+		case errdefs.IsNotFound(err):
 			// config does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating config %s\n", configSpec.Name)
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {

--- a/cli/command/stack/swarm/deploy_composefile_test.go
+++ b/cli/command/stack/swarm/deploy_composefile_test.go
@@ -14,9 +14,7 @@ type notFound struct {
 	error
 }
 
-func (n notFound) NotFound() bool {
-	return true
-}
+func (n notFound) NotFound() {}
 
 func TestValidateExternalNetworks(t *testing.T) {
 	testcases := []struct {

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
-	apiclient "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -213,7 +213,7 @@ func inspectAll(ctx context.Context, dockerCli command.Cli, getSize bool, typeCo
 }
 
 func isErrSkippable(err error) bool {
-	return apiclient.IsErrNotFound(err) ||
+	return errdefs.IsNotFound(err) ||
 		strings.Contains(err.Error(), "not supported") ||
 		strings.Contains(err.Error(), "invalid reference format")
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/45513

None of the client will return the old error-types, so there's no need to keep the compatibility code. We can consider deprecating this function in favor of the errdefs equivalent this.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

