### PR TITLE
docs: update link location for the overlay driver

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -916,7 +916,7 @@ $ docker service create \
 The swarm extends my-network to each node running the service.
 
 Containers on the same network can access each other using
-[service discovery](https://docs.docker.com/network/overlay/#container-discovery).
+[service discovery](https://docs.docker.com/network/drivers/overlay/#container-discovery).
 
 Long form syntax of `--network` allows to specify list of aliases and driver options:
 `--network name=my-network,alias=web1,driver-opt=field1=value1`


### PR DESCRIPTION
**- What I did**

Updated a docs link due to file restructure in docs pr: docker/docs#17176

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

<img width="1219" alt="image" src="https://github.com/docker/cli/assets/35727626/594d8672-ecff-465e-84af-43943546161b">

