### PR TITLE
remove uses of golang.org/x/sys/execabs

### DIFF
--- a/cli-plugins/manager/candidate.go
+++ b/cli-plugins/manager/candidate.go
@@ -1,8 +1,6 @@
 package manager
 
-import (
-	exec "golang.org/x/sys/execabs"
-)
+import "os/exec"
 
 // Candidate represents a possible plugin candidate, for mocking purposes
 type Candidate interface {

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/fvbommel/sortorder"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	exec "golang.org/x/sys/execabs"
 )
 
 // ReexecEnvvar is the name of an ennvar which is set to the command

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/moby/patternmatcher"
 	"github.com/pkg/errors"
-	exec "golang.org/x/sys/execabs"
 )
 
 const (

--- a/cli/config/credentials/default_store.go
+++ b/cli/config/credentials/default_store.go
@@ -1,8 +1,6 @@
 package credentials
 
-import (
-	exec "golang.org/x/sys/execabs"
-)
+import "os/exec"
 
 // DetectDefaultStore return the default credentials store for the platform if
 // no user-defined store is passed, and the store executable is available.

--- a/cli/connhelper/commandconn/commandconn.go
+++ b/cli/connhelper/commandconn/commandconn.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"sync"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	exec "golang.org/x/sys/execabs"
 )
 
 // New returns net.Conn


### PR DESCRIPTION
the "golang.org/x/sys/execabs" package was introduced to address a security issue on Windows, and changing the default behavior of os/exec was considered a breaking change. go1.19 applied the behavior that was previously implemented in the execabs package;

from the release notes: https://go.dev/doc/go1.19#os-exec-path

> Command and LookPath no longer allow results from a PATH search to be found
> relative to the current directory. This removes a common source of security
> problems but may also break existing programs that depend on using, say,
> exec.Command("prog") to run a binary named prog (or, on Windows, prog.exe)
> in the current directory. See the os/exec package documentation for information
> about how best to update such programs.
>
> On Windows, Command and LookPath now respect the NoDefaultCurrentDirectoryInExePath
> environment variable, making it possible to disable the default implicit search
> of “.” in PATH lookups on Windows systems.

With those changes, we no longer need to use the execabs package, and we can switch back to os/exec.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

