### PR TITLE
mount: add `bind-recursive=<bool|string>` and deprecate `bind-nonrecursive=<bool>`

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -14,13 +14,13 @@ import (
 	"time"
 
 	cdi "github.com/container-orchestrated-devices/container-device-interface/pkg/parser"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/compose/loader"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/strslice"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
@@ -1119,8 +1119,8 @@ func validateAttach(val string) (string, error) {
 
 func validateAPIVersion(c *containerConfig, serverAPIVersion string) error {
 	for _, m := range c.HostConfig.Mounts {
-		if m.BindOptions != nil && m.BindOptions.NonRecursive && versions.LessThan(serverAPIVersion, "1.40") {
-			return errors.Errorf("bind-nonrecursive requires API v1.40 or later")
+		if err := command.ValidateMountWithAPIVersion(m, serverAPIVersion); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/google/shlex"
@@ -1043,8 +1043,8 @@ const (
 
 func validateAPIVersion(c swarm.ServiceSpec, serverAPIVersion string) error {
 	for _, m := range c.TaskTemplate.ContainerSpec.Mounts {
-		if m.BindOptions != nil && m.BindOptions.NonRecursive && versions.LessThan(serverAPIVersion, "1.40") {
-			return errors.Errorf("bind-nonrecursive requires API v1.40 or later")
+		if err := command.ValidateMountWithAPIVersion(m, serverAPIVersion); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
 )
 
 // MountOpt is a Value type for parsing mounts
@@ -112,6 +114,32 @@ func (m *MountOpt) Set(value string) error {
 			if err != nil {
 				return fmt.Errorf("invalid value for %s: %s", key, val)
 			}
+			logrus.Warn("bind-nonrecursive is deprecated, use bind-recursive=disabled instead")
+		case "bind-recursive":
+			valS := val
+			// Allow boolean as an alias to "enabled" or "disabled"
+			if b, err := strconv.ParseBool(valS); err == nil {
+				if b {
+					valS = "enabled"
+				} else {
+					valS = "disabled"
+				}
+			}
+			switch valS {
+			case "enabled": // read-only mounts are recursively read-only if Engine >= v25 && kernel >= v5.12, otherwise writable
+				// NOP
+			case "disabled": // alias of bind-nonrecursive=true
+				bindOptions().NonRecursive = true
+			case "writable": // conforms to the default read-only bind-mount of Docker v24; read-only mounts are recursively mounted but not recursively read-only
+				bindOptions().ReadOnlyNonRecursive = true
+			case "readonly": // force recursively read-only, or raise an error
+				bindOptions().ReadOnlyForceRecursive = true
+				// TODO: implicitly set propagation and error if the user specifies a propagation in a future refactor/UX polish pass
+				// https://github.com/docker/cli/pull/4316#discussion_r1341974730
+			default:
+				return fmt.Errorf("invalid value for %s: %s (must be \"enabled\", \"disabled\", \"writable\", or \"readonly\")",
+					key, val)
+			}
 		case "volume-nocopy":
 			volumeOptions().NoCopy, err = strconv.ParseBool(val)
 			if err != nil {
@@ -159,6 +187,22 @@ func (m *MountOpt) Set(value string) error {
 	}
 	if mount.TmpfsOptions != nil && mount.Type != mounttypes.TypeTmpfs {
 		return fmt.Errorf("cannot mix 'tmpfs-*' options with mount type '%s'", mount.Type)
+	}
+
+	if mount.BindOptions != nil {
+		if mount.BindOptions.ReadOnlyNonRecursive {
+			if !mount.ReadOnly {
+				return errors.New("option 'bind-recursive=writable' requires 'readonly' to be specified in conjunction")
+			}
+		}
+		if mount.BindOptions.ReadOnlyForceRecursive {
+			if !mount.ReadOnly {
+				return errors.New("option 'bind-recursive=readonly' requires 'readonly' to be specified in conjunction")
+			}
+			if mount.BindOptions.Propagation != mounttypes.PropagationRPrivate {
+				return errors.New("option 'bind-recursive=readonly' requires 'bind-propagation=rprivate' to be specified in conjunction")
+			}
+		}
 	}
 
 	m.values = append(m.values, mount)


### PR DESCRIPTION
For:
- moby/moby#45278


See `opts/mount_test.go:TestMountOptSetBindRecursive()` for the behavior:

- `bind-recursive=true`, `bind-recursive=enabled`: read-only mounts are recursively read-only if Engine >= v25 && kernel >= v5.12
- `bind-recursive=false`, `bind-recursive=disabled`: alias of `bind-nonrecursive=true`. Now this form is preferred over `bind-nonrecursive=true`.
- `bind-recursive=writable`: conforms to Docker v24; read-only mounts are recursively mounted but not recursively read-only
- `bind-recursive=readonly`: force recursively read-only, or raise an error

    
Documentation will be added separately after reaching consensus on the design.

<details><summary>Backup (2023-05-29)</summary>
<p>

https://github.com/AkihiroSuda/cli/commit/6ebf6ba27841a15021f8fc4e1da36eda108b5f80

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added the CLI and the docs for:
- moby/moby#45278

**- How I did it**

The `-v` options are implemented on the daemon side.
- `ro-non-recursive`
- `ro-force-recursive` (alias: `rro`)

The following "CSV" options for `--mount` are newly added in this CLI-side PR:
- `bind-readonly-nonrecursive` (alias: `bind-ro-nonrecursive`) (Do not confuse this with the exiswting `bind-nonrecursive`)
- `bind-readonly-forcerecursive` (alias: `bind-ro-forcerecursive`)

**- How to verify it**
Run `docker run --mount type=bind,source=/mnt,target=/mnt,bind-ro-forcerecursive,bind-propagation=rprivate`, and make sure the mount is made recursively read-only.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add CLI and docs for recursively read-only mounts

**- A picture of a cute animal (not mandatory but encouraged)**
🐧 

</p>

</details>