### PR TITLE
docs: update start docs to add examples

### DIFF
--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -30,7 +30,15 @@ To start a container, specify the container ID or image name. For example:
 $ docker start my_container
 ```
 
-### Start a container and attach to its STDOUT/STDERR
+### <a name="attach"></a>  Start a container and attach to its STDOUT/STDERR (--attach, -a)
+
+> This option is experimental.
+>
+> This command is experimental on the Docker daemon. It should not be used in
+> production environments.
+> To enable experimental features on the Docker daemon, edit the
+> [daemon.json](/engine/reference/commandline/dockerd/
+#daemon-configuration-file)
 
 To start a container and attach to its STDOUT/STDERR and forward signals, use the `--attach` or `-a` option. For example, if you create an nginx container named my_nginx_container, you can start it and monitor its logs using the following:
 
@@ -45,7 +53,12 @@ $ docker start -a my_nginx_container
 ...
 ```
 
-### Start a contianer and restore from a checkpoint
+### <a name="checkpoint"></a> Start a container and restore from a checkpoint (--checkpoint) (experimental)
+
+The `--checkpoint` option is an experimental feature, and should not be
+considered stable. To read about experimental daemon options and how to enable
+them, see
+[Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file).
 
 To start a container and restore it from a checkpoint, use the `--checkpoint` option. For example:
 
@@ -60,7 +73,12 @@ checkpoint1
 $ docker start --checkpoint checkpoint1 cr
 ```
 
-### Start a container and restore from a custom checkpoint storage
+### <a name="checkpoint-dir"></a>  Start a container and restore from a custom checkpoint storage (--checkpoint-dir) (experimental)
+
+The `--checkpoint-dir` option is an experimental feature, and should not be
+considered stable. To read about experimental daemon options and how to enable
+them, see
+[Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file).
 
 To start a container and restore it from a checkpoint in a custom checkpoint storage directory, use the `--checkpoint-dir` option. For example:
 
@@ -75,7 +93,7 @@ checkpoint2
 $ docker start --checkpoint-dir /path/to/checkpoints --checkpoint checkpoint2 cr
 ```
 
-### Start a container and override the detach key sequence
+### <a name="detach-keys"></a> Start a container and override the detach key sequence (--detach-keys)
 
 To start a container and override the key sequence for detaching a container, use the `--detach-keys` option. For example to change the detach sequence to `ctrl` plus `x`, use the following:
 
@@ -83,7 +101,7 @@ To start a container and override the key sequence for detaching a container, us
 $ docker start -a --detach-keys="ctrl-x" my_container
 ```
 
-### Start a container and attach to its STDIN
+### <a name="interactive"></a> Start a container and attach to its STDIN (--interactive, -i)
 
 To start a container and attach to its STDIN, use the `--interactive` or `-i` option. For example, if you create an ubuntu container named my_ubuntu_container, you can start it and interact with its shell using the following:
 

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -22,6 +22,75 @@ Start one or more stopped containers
 
 ## Examples
 
+### Start a container
+
+To start a container, specify the container ID or image name. For example:
+
 ```console
 $ docker start my_container
+```
+
+### Start a container and attach to its STDOUT/STDERR
+
+To start a container and attach to its STDOUT/STDERR and forward signals, use the `--attach` or `-a` option. For example, if you create an nginx container named my_nginx_container, you can start it and monitor its logs using the following:
+
+```console
+$ docker create --name my_nginx_container -p 80:80 nginx
+ca5a4351c9c4b43c0b0c69d4d925aa1d8a53a3b33742250ad227f22096accab6
+
+$ docker start -a my_nginx_container
+/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
+/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
+/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+...
+```
+
+### Start a contianer and restore from a checkpoint
+
+To start a container and restore it from a checkpoint, use the `--checkpoint` option. For example:
+
+```console
+$ docker run --security-opt=seccomp:unconfined --name cr -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
+db316bda7d64b4154d207a3d659c90c982d0b35a3e177fc396e809a6a93a147f
+
+$ docker checkpoint create cr checkpoint1
+checkpoint1
+
+# <later>
+$ docker start --checkpoint checkpoint1 cr
+```
+
+### Start a container and restore from a custom checkpoint storage
+
+To start a container and restore it from a checkpoint in a custom checkpoint storage directory, use the `--checkpoint-dir` option. For example:
+
+```console
+$ docker run --security-opt=seccomp:unconfined --name cr -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
+db316bda7d64b4154d207a3d659c90c982d0b35a3e177fc396e809a6a93a147f
+
+$ docker checkpoint create --checkpoint-dir /path/to/checkpoints cr checkpoint2
+checkpoint2
+
+# <later>
+$ docker start --checkpoint-dir /path/to/checkpoints --checkpoint checkpoint2 cr
+```
+
+### Start a container and override the detach key sequence
+
+To start a container and override the key sequence for detaching a container, use the `--detach-keys` option. For example to change the detach sequence to `ctrl` plus `x`, use the following:
+
+```console
+$ docker start -a --detach-keys="ctrl-x" my_container
+```
+
+### Start a container and attach to its STDIN
+
+To start a container and attach to its STDIN, use the `--interactive` or `-i` option. For example, if you create an ubuntu container named my_ubuntu_container, you can start it and interact with its shell using the following:
+
+```console
+$ docker create -it --name my_ubuntu_container ubuntu
+6facdc392ec364d53d5cca760791d33b173d89525aff8f6f7c73a68bda0ab33c
+
+$ docker start -i my_ubuntu_container
+root@6facdc392ec3:/#
 ```

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -32,14 +32,6 @@ $ docker start my_container
 
 ### <a name="attach"></a>  Start a container and attach to its STDOUT/STDERR (--attach, -a)
 
-> This option is experimental.
->
-> This command is experimental on the Docker daemon. It should not be used in
-> production environments.
-> To enable experimental features on the Docker daemon, edit the
-> [daemon.json](/engine/reference/commandline/dockerd/
-#daemon-configuration-file)
-
 To start a container and attach to its STDOUT/STDERR and forward signals, use the `--attach` or `-a` option. For example, if you create an nginx container named my_nginx_container, you can start it and monitor its logs using the following:
 
 ```console

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -24,7 +24,7 @@ Start one or more stopped containers
 
 ### Start a container
 
-To start a container, specify the container ID or image name. For example:
+To start a container, specify the container name or ID. For example:
 
 ```console
 $ docker start my_container
@@ -32,7 +32,10 @@ $ docker start my_container
 
 ### <a name="attach"></a>  Start a container and attach to its STDOUT/STDERR (--attach, -a)
 
-To start a container and attach to its STDOUT/STDERR and forward signals, use the `--attach` or `-a` option. For example, if you create an nginx container named my_nginx_container, you can start it and monitor its logs using the following:
+To start a container and attach to its STDOUT/STDERR and forward signals, use
+the `--attach` or `-a` option. For example, if you create an nginx container
+named my_nginx_container, you can start it and monitor its logs using the
+following:
 
 ```console
 $ docker create --name my_nginx_container -p 80:80 nginx
@@ -55,10 +58,10 @@ them, see
 To start a container and restore it from a checkpoint, use the `--checkpoint` option. For example:
 
 ```console
-$ docker run --security-opt=seccomp:unconfined --name cr -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
+$ docker run --name my_container -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 db316bda7d64b4154d207a3d659c90c982d0b35a3e177fc396e809a6a93a147f
 
-$ docker checkpoint create cr checkpoint1
+$ docker checkpoint create my_container checkpoint1
 checkpoint1
 
 # <later>
@@ -72,22 +75,25 @@ considered stable. To read about experimental daemon options and how to enable
 them, see
 [Daemon configuration file](https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file).
 
-To start a container and restore it from a checkpoint in a custom checkpoint storage directory, use the `--checkpoint-dir` option. For example:
+To start a container and restore it from a checkpoint in a custom checkpoint
+storage directory, use the `--checkpoint-dir` option. For example:
 
 ```console
-$ docker run --security-opt=seccomp:unconfined --name cr -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
+$ docker run --name my_container -d busybox /bin/sh -c 'i=0; while true; do echo $i; i=$(expr $i + 1); sleep 1; done'
 db316bda7d64b4154d207a3d659c90c982d0b35a3e177fc396e809a6a93a147f
 
-$ docker checkpoint create --checkpoint-dir /path/to/checkpoints cr checkpoint2
+$ docker checkpoint create --checkpoint-dir /path/to/checkpoints my_container checkpoint2
 checkpoint2
 
 # <later>
-$ docker start --checkpoint-dir /path/to/checkpoints --checkpoint checkpoint2 cr
+$ docker start --checkpoint-dir /path/to/checkpoints --checkpoint checkpoint2 my_container
 ```
 
 ### <a name="detach-keys"></a> Start a container and override the detach key sequence (--detach-keys)
 
-To start a container and override the key sequence for detaching a container, use the `--detach-keys` option. For example to change the detach sequence to `ctrl` plus `x`, use the following:
+To start a container and override the key sequence for detaching a container,
+use the `--detach-keys` option. For example to change the detach sequence to
+`ctrl` plus `x`, use the following:
 
 ```console
 $ docker start -a --detach-keys="ctrl-x" my_container
@@ -95,7 +101,10 @@ $ docker start -a --detach-keys="ctrl-x" my_container
 
 ### <a name="interactive"></a> Start a container and attach to its STDIN (--interactive, -i)
 
-To start a container and attach to its STDIN, use the `--interactive` or `-i` option. For example, if you create an ubuntu container named my_ubuntu_container, you can start it and interact with its shell using the following:
+To start a container and attach to its STDIN, use the `--interactive` or `-i`
+option. For example, if you create an ubuntu container named
+my_ubuntu_container, you can start it and interact with its shell using the
+following:
 
 ```console
 $ docker create -it --name my_ubuntu_container ubuntu

--- a/docs/reference/commandline/start.md
+++ b/docs/reference/commandline/start.md
@@ -65,7 +65,7 @@ $ docker checkpoint create my_container checkpoint1
 checkpoint1
 
 # <later>
-$ docker start --checkpoint checkpoint1 cr
+$ docker start --checkpoint checkpoint1 my_container
 ```
 
 ### <a name="checkpoint-dir"></a>  Start a container and restore from a custom checkpoint storage (--checkpoint-dir) (experimental)


### PR DESCRIPTION
**- What I did**
There are no examples in the documentation for the `docker start` options.
I created examples in the documentation for every option.

**- How I did it**
I created examples based on examples from related commands. Then, verified that they worked.
For 3 options, I was unable to verify the results. No CLI errors were given using the example syntax. I added them assuming it was not a CLI syntax issue. 

- For `--checkpoint`, when I run docker start, it just hangs. On Linux with experimental enabled and criu installed.
- For `--checkpoint-dir`, it gives a message that it's not supported. Already a moby issue opened regarding this.
- For `--detach-keys`, I was unable to get it to work on Windows or Linux.

**- How to verify it**
Run the examples.

**- Description for the changelog**
Updated start docs to add examples


