### PR TITLE
cli/command: add EnvOverrideContext const for "DOCKER_CONTEXT"

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -370,7 +370,7 @@ func (cli *DockerCli) ContextStore() store.Store {
 // order of preference:
 //
 //  1. The "--context" command-line option.
-//  2. The "DOCKER_CONTEXT" environment variable.
+//  2. The "DOCKER_CONTEXT" environment variable ([EnvOverrideContext]).
 //  3. The current context as configured through the in "currentContext"
 //     field in the CLI configuration file ("~/.docker/config.json").
 //  4. If no context is configured, use the "default" context.
@@ -412,7 +412,7 @@ func resolveContextName(opts *cliflags.ClientOptions, config *configfile.ConfigF
 	if os.Getenv(client.EnvOverrideHost) != "" {
 		return DefaultContextName
 	}
-	if ctxName := os.Getenv("DOCKER_CONTEXT"); ctxName != "" {
+	if ctxName := os.Getenv(EnvOverrideContext); ctxName != "" {
 		return ctxName
 	}
 	if config != nil && config.CurrentContext != "" {

--- a/cli/command/defaultcontextstore.go
+++ b/cli/command/defaultcontextstore.go
@@ -11,6 +11,12 @@ import (
 const (
 	// DefaultContextName is the name reserved for the default context (config & env based)
 	DefaultContextName = "default"
+
+	// EnvOverrideContext is the name of the environment variable that can be
+	// used to override the context to use. If set, it overrides the context
+	// that's set in the CLI's configuration file, but takes no effect if the
+	// "DOCKER_HOST" env-var is set (which takes precedence.
+	EnvOverrideContext = "DOCKER_CONTEXT"
 )
 
 // DefaultContext contains the default context data for all endpoints


### PR DESCRIPTION
Add a const for the name of the environment-variable we accept, so that we can document its purpose in code.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

