### PR TITLE
[24.0 backport] cli/command: fix GoDoc referencing wrong const

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -381,7 +381,7 @@ func (cli *DockerCli) ContextStore() store.Store {
 // the "default" context is used if:
 //
 //   - The "--host" option is set
-//   - The "DOCKER_HOST" ([DefaultContextName]) environment variable is set
+//   - The "DOCKER_HOST" ([client.EnvOverrideHost]) environment variable is set
 //     to a non-empty value.
 //
 // In these cases, the default context is used, which uses the host as


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/4324

(cherry picked from commit 0692d762aca4b0e5a5125157f78e413a1512a2b6)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

