### PR TITLE
[23.0 backport] Dockerfile.vendor: update GOPROXY to use default with fallback

### DIFF
--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -9,7 +9,7 @@ RUN apk add --no-cache bash git rsync
 WORKDIR /src
 
 FROM base AS vendored
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN --mount=target=/context \
     --mount=target=.,type=tmpfs  \
     --mount=target=/go/pkg/mod,type=cache <<EOT


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4327
- relates to https://github.com/docker/cli/pull/4324#issuecomment-1573501977
- relates to https://github.com/docker/docker-ce-packaging/pull/745



Use the default proxy, to assist with vanity domains mis-behaving, but keep a fallback for situations where we need to get modules from GitHub directly.

This should hopefully help with the gopkg.in/yaml.v2 domain often going AWOL;

    #14 245.9 	gopkg.in/yaml.v2@v2.4.0: unrecognized import path "gopkg.in/yaml.v2": reading https://gopkg.in/yaml.v2?go-get=1: 502 Bad Gateway
    #14 245.9 	server response: Cannot obtain refs from GitHub: cannot talk to GitHub: Get https://github.com/go-yaml/yaml.git/info/refs?service=git-upload-pack: write tcp 10.131.9.188:60820->140.82.121.3:443: write: broken pipe

    curl 'https://gopkg.in/yaml.v2?go-get=1'
    Cannot obtain refs from GitHub: cannot talk to GitHub: Get https://github.com/go-yaml/yaml.git/info/refs?service=git-upload-pack: write tcp 10.131.9.188:60820->140.82.121.3:443: write: broken pipe

From the Go documentation; https://go.dev/ref/mod#goproxy-protocol

> List elements may be separated by commas (,) or pipes (|), which determine error
> fallback behavior. When a URL is followed by a comma, the go command falls back
> to later sources only after a 404 (Not Found) or 410 (Gone) response. When a URL
> is followed by a pipe, the go command falls back to later sources after any error,
> including non-HTTP errors such as timeouts. This error handling behavior lets a
> proxy act as a gatekeeper for unknown modules. For example, a proxy could respond
> with error 403 (Forbidden) for modules not on an approved list (see Private proxy
> serving private modules).


(cherry picked from commit 6458dcbe5140d8fbf71e60da24f3355d3f1852ba)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

