### PR TITLE
docs: added example for specifying socket path with -H

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -428,6 +428,13 @@ to the `/var/run/docker.sock` Unix socket on the SSH host.
 $ docker -H ssh://user@192.168.64.5 ps
 ```
 
+You can optionally specify the location of the socket by appending a path
+component to the end of the SSH address.
+
+```console
+$ docker -H ssh://user@192.168.64.5/var/run/docker.sock ps
+```
+
 ### Display help text
 
 To list the help on any command just execute the command, followed by the


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4073

Signed-off-by: David Karlsson <david.karlsson@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added an example in docs on specifying the socket path with `-H ssh://`

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

🐖
