### PR TITLE
cli/compose: fix invalid interpretation of the version field

### DIFF
--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -43,7 +43,7 @@ func loadYAMLWithEnv(yaml string, env map[string]string) (*types.Config, error) 
 }
 
 var sampleYAML = `
-version: "3"
+version: "3.11"
 services:
   foo:
     image: busybox
@@ -73,7 +73,7 @@ networks:
 `
 
 var sampleDict = map[string]interface{}{
-	"version": "3",
+	"version": "3.11",
 	"services": map[string]interface{}{
 		"foo": map[string]interface{}{
 			"image":    "busybox",

--- a/cli/compose/schema/schema.go
+++ b/cli/compose/schema/schema.go
@@ -40,8 +40,8 @@ func init() {
 }
 
 // Version returns the version of the config, defaulting to the latest "3.x"
-// version (3.11). If only the major version "3" is specified, it is used as
-// version "3.x" and returns the default version (latest 3.x).
+// version (3.11). If only the major version "3" is specified, 0 is used by
+// default and not the latest minor version.
 func Version(config map[string]interface{}) string {
 	version, ok := config[versionField]
 	if !ok {
@@ -52,8 +52,10 @@ func Version(config map[string]interface{}) string {
 
 func normalizeVersion(version string) string {
 	switch version {
-	case "", "3":
+	case "":
 		return defaultVersion
+	case "3":
+		return "3.0"
 	default:
 		return version
 	}

--- a/cli/compose/schema/schema_test.go
+++ b/cli/compose/schema/schema_test.go
@@ -9,6 +9,33 @@ import (
 
 type dict map[string]interface{}
 
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		version         string
+		expectedVersion string
+	}{
+		{version: "", expectedVersion: defaultVersion},
+		{version: "3", expectedVersion: "3.0"},
+		{version: "3.4", expectedVersion: "3.4"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.version, func(t *testing.T) {
+			config := dict{
+				"version": tc.version,
+				"services": dict{
+					"foo": dict{
+						"image": "busybox",
+					},
+				},
+			}
+			actualVersion := Version(config)
+			assert.Equal(t, tc.expectedVersion, actualVersion)
+		})
+	}
+}
+
 func TestValidate(t *testing.T) {
 	config := dict{
 		"version": "3.0",
@@ -88,6 +115,7 @@ func TestValidateCredentialSpecs(t *testing.T) {
 		version     string
 		expectedErr string
 	}{
+		{version: "3", expectedErr: "credential_spec"},
 		{version: "3.0", expectedErr: "credential_spec"},
 		{version: "3.1", expectedErr: "credential_spec"},
 		{version: "3.2", expectedErr: "credential_spec"},
@@ -100,7 +128,6 @@ func TestValidateCredentialSpecs(t *testing.T) {
 		{version: "3.9"},
 		{version: "3.10"},
 		{version: "3.11"},
-		{version: "3"},
 		{version: ""},
 	}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #4006

**- What I did**
- I updated the way the `docker compose` and `docker stack deploy` command read the `version` field of the `docker-compose.yml` file

**- How I did it**
- I added one more `case` in the `switch-case` statement that checks if the version equals 3. In this case, it converts the version to `3 -> 3.0` as [the documentation mentions](https://docs.docker.com/compose/compose-file/compose-versioning/#version-3).

**- How to verify it**
- There are unit tests that verify it or
- Follow the instructions from the `Reproduce` section of the issue [comment](https://github.com/docker/cli/issues/4006#issue-1572946525).

**- Description for the changelog**
Fix the invalid interpretation of the version field in the `docker-compose.yml` files
