### PR TITLE
cli/command/container: don't mutate ConfigFile.DetachKeys

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -86,8 +86,9 @@ func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 		return err
 	}
 
+	detachKeys := dockerCli.ConfigFile().DetachKeys
 	if opts.detachKeys != "" {
-		dockerCli.ConfigFile().DetachKeys = opts.detachKeys
+		detachKeys = opts.detachKeys
 	}
 
 	options := types.ContainerAttachOptions{
@@ -95,7 +96,7 @@ func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 		Stdin:      !opts.noStdin && c.Config.OpenStdin,
 		Stdout:     true,
 		Stderr:     true,
-		DetachKeys: dockerCli.ConfigFile().DetachKeys,
+		DetachKeys: detachKeys,
 	}
 
 	var in io.ReadCloser

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -72,12 +72,12 @@ func NewAttachCommand(dockerCli command.Cli) *cobra.Command {
 
 func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 	ctx := context.Background()
-	client := dockerCli.Client()
+	apiClient := dockerCli.Client()
 
 	// request channel to wait for client
-	resultC, errC := client.ContainerWait(ctx, opts.container, "")
+	resultC, errC := apiClient.ContainerWait(ctx, opts.container, "")
 
-	c, err := inspectContainerAndCheckState(ctx, client, opts.container)
+	c, err := inspectContainerAndCheckState(ctx, apiClient, opts.container)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 		defer signal.StopCatch(sigc)
 	}
 
-	resp, errAttach := client.ContainerAttach(ctx, opts.container, options)
+	resp, errAttach := apiClient.ContainerAttach(ctx, opts.container, options)
 	if errAttach != nil {
 		return errAttach
 	}
@@ -123,7 +123,7 @@ func runAttach(dockerCli command.Cli, opts *attachOptions) error {
 	// the container and not exit.
 	//
 	// Recheck the container's state to avoid attach block.
-	_, err = inspectContainerAndCheckState(ctx, client, opts.container)
+	_, err = inspectContainerAndCheckState(ctx, apiClient, opts.container)
 	if err != nil {
 		return err
 	}

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -93,18 +93,18 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 	cases := []struct {
 		PullPolicy      string
 		ExpectedPulls   int
-		ExpectedBody    container.CreateResponse
+		ExpectedID      string
 		ExpectedErrMsg  string
 		ResponseCounter int
 	}{
 		{
 			PullPolicy:    PullImageMissing,
 			ExpectedPulls: 1,
-			ExpectedBody:  container.CreateResponse{ID: containerID},
+			ExpectedID:    containerID,
 		}, {
 			PullPolicy:      PullImageAlways,
 			ExpectedPulls:   1,
-			ExpectedBody:    container.CreateResponse{ID: containerID},
+			ExpectedID:      containerID,
 			ResponseCounter: 1, // This lets us return a container on the first pull
 		}, {
 			PullPolicy:     PullImageNever,
@@ -142,7 +142,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 				},
 			}
 			fakeCLI := test.NewFakeCli(client)
-			body, err := createContainer(context.Background(), fakeCLI, config, &createOptions{
+			id, err := createContainer(context.Background(), fakeCLI, config, &createOptions{
 				name:      "name",
 				platform:  runtime.GOOS,
 				untrusted: true,
@@ -153,7 +153,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 				assert.Check(t, is.ErrorContains(err, tc.ExpectedErrMsg))
 			} else {
 				assert.Check(t, err)
-				assert.Check(t, is.DeepEqual(tc.ExpectedBody, *body))
+				assert.Check(t, is.Equal(tc.ExpectedID, id))
 			}
 
 			assert.Check(t, is.Equal(tc.ExpectedPulls, pullCounter))

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -79,8 +79,10 @@ func TestCIDFileCloseWithWrite(t *testing.T) {
 }
 
 func TestCreateContainerImagePullPolicy(t *testing.T) {
-	imageName := "does-not-exist-locally"
-	containerID := "abcdef"
+	const (
+		imageName   = "does-not-exist-locally"
+		containerID = "abcdef"
+	)
 	config := &containerConfig{
 		Config: &container.Config{
 			Image: imageName,
@@ -110,50 +112,52 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 			ExpectedErrMsg: "error fake not found",
 		},
 	}
-	for _, c := range cases {
-		c := c
-		pullCounter := 0
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.PullPolicy, func(t *testing.T) {
+			pullCounter := 0
 
-		client := &fakeClient{
-			createContainerFunc: func(
-				config *container.Config,
-				hostConfig *container.HostConfig,
-				networkingConfig *network.NetworkingConfig,
-				platform *specs.Platform,
-				containerName string,
-			) (container.CreateResponse, error) {
-				defer func() { c.ResponseCounter++ }()
-				switch c.ResponseCounter {
-				case 0:
-					return container.CreateResponse{}, fakeNotFound{}
-				default:
-					return container.CreateResponse{ID: containerID}, nil
-				}
-			},
-			imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
-				defer func() { pullCounter++ }()
-				return io.NopCloser(strings.NewReader("")), nil
-			},
-			infoFunc: func() (types.Info, error) {
-				return types.Info{IndexServerAddress: "https://indexserver.example.com"}, nil
-			},
-		}
-		cli := test.NewFakeCli(client)
-		body, err := createContainer(context.Background(), cli, config, &createOptions{
-			name:      "name",
-			platform:  runtime.GOOS,
-			untrusted: true,
-			pull:      c.PullPolicy,
+			client := &fakeClient{
+				createContainerFunc: func(
+					config *container.Config,
+					hostConfig *container.HostConfig,
+					networkingConfig *network.NetworkingConfig,
+					platform *specs.Platform,
+					containerName string,
+				) (container.CreateResponse, error) {
+					defer func() { tc.ResponseCounter++ }()
+					switch tc.ResponseCounter {
+					case 0:
+						return container.CreateResponse{}, fakeNotFound{}
+					default:
+						return container.CreateResponse{ID: containerID}, nil
+					}
+				},
+				imageCreateFunc: func(parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error) {
+					defer func() { pullCounter++ }()
+					return io.NopCloser(strings.NewReader("")), nil
+				},
+				infoFunc: func() (types.Info, error) {
+					return types.Info{IndexServerAddress: "https://indexserver.example.com"}, nil
+				},
+			}
+			fakeCLI := test.NewFakeCli(client)
+			body, err := createContainer(context.Background(), fakeCLI, config, &createOptions{
+				name:      "name",
+				platform:  runtime.GOOS,
+				untrusted: true,
+				pull:      tc.PullPolicy,
+			})
+
+			if tc.ExpectedErrMsg != "" {
+				assert.Check(t, is.ErrorContains(err, tc.ExpectedErrMsg))
+			} else {
+				assert.Check(t, err)
+				assert.Check(t, is.DeepEqual(tc.ExpectedBody, *body))
+			}
+
+			assert.Check(t, is.Equal(tc.ExpectedPulls, pullCounter))
 		})
-
-		if c.ExpectedErrMsg != "" {
-			assert.ErrorContains(t, err, c.ExpectedErrMsg)
-		} else {
-			assert.NilError(t, err)
-			assert.Check(t, is.DeepEqual(c.ExpectedBody, *body))
-		}
-
-		assert.Check(t, is.Equal(c.ExpectedPulls, pullCounter))
 	}
 }
 

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -94,8 +94,9 @@ func RunStart(dockerCli command.Cli, opts *StartOptions) error {
 			defer signal.StopCatch(sigc)
 		}
 
+		detachKeys := dockerCli.ConfigFile().DetachKeys
 		if opts.DetachKeys != "" {
-			dockerCli.ConfigFile().DetachKeys = opts.DetachKeys
+			detachKeys = opts.DetachKeys
 		}
 
 		options := types.ContainerAttachOptions{
@@ -103,7 +104,7 @@ func RunStart(dockerCli command.Cli, opts *StartOptions) error {
 			Stdin:      opts.OpenStdin && c.Config.OpenStdin,
 			Stdout:     true,
 			Stderr:     true,
-			DetachKeys: dockerCli.ConfigFile().DetachKeys,
+			DetachKeys: detachKeys,
 		}
 
 		var in io.ReadCloser


### PR DESCRIPTION
### cli/command/container: attach: rename var that collided with import

### cli/command/container: TestCreateContainerImagePullPolicy: use sub-tests


### cli/command/container: createContainer(): return container-ID

This function returned the whole response, but we already handled the
warnings included in the response as part of the function. All consumers
of this function only used the container-ID, so let's simplify and return
just that (it's a non-exported func, so we can change the signature again
if we really need it).


### cli/command/container: don't mutate ConfigFile.DetachKeys

This code was introduced in https://github.com/moby/moby/commit/15aa2a663b47b6126a66efefcadb64edfbffb9f5 (https://github.com/moby/moby/pull/15666),
but from those changes, it appears that overwriting the config value was
merely out of convenience, and that struct being used as an intermediate.

While changing the config here should be mostly ephemeral, and not written
back to the config-file, let's be clear on intent, and not mutatte the config
as part of this code.
