### PR TITLE
[24.0 backport] docs: move "--detach-keys" example to examples section, add to "docker run" as well 

### DIFF
--- a/docs/reference/commandline/attach.md
+++ b/docs/reference/commandline/attach.md
@@ -9,11 +9,11 @@ Attach local standard input, output, and error streams to a running container
 
 ### Options
 
-| Name            | Type     | Default | Description                                         |
-|:----------------|:---------|:--------|:----------------------------------------------------|
-| `--detach-keys` | `string` |         | Override the key sequence for detaching a container |
-| `--no-stdin`    |          |         | Do not attach STDIN                                 |
-| `--sig-proxy`   |          |         | Proxy all received signals to the process           |
+| Name                            | Type     | Default | Description                                         |
+|:--------------------------------|:---------|:--------|:----------------------------------------------------|
+| [`--detach-keys`](#detach-keys) | `string` |         | Override the key sequence for detaching a container |
+| `--no-stdin`                    |          |         | Do not attach STDIN                                 |
+| `--sig-proxy`                   |          |         | Proxy all received signals to the process           |
 
 
 <!---MARKER_GEN_END-->
@@ -55,30 +55,6 @@ applications like SSH. Because of this, it is not recommended to run
 performance critical applications that generate a lot of output in the
 foreground over a slow client connection. Instead, users should use the
 `docker logs` command to get access to the logs.
-
-### Override the detach sequence
-
-If you want, you can configure an override the Docker key sequence for detach.
-This is useful if the Docker default sequence conflicts with key sequence you
-use for other applications. There are two ways to define your own detach key
-sequence, as a per-container override or as a configuration property on  your
-entire configuration.
-
-To override the sequence for an individual container, use the
-`--detach-keys="<sequence>"` flag with the `docker attach` command. The format of
-the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
-the following:
-
-* `a-z` (a single lowercase alpha character )
-* `@` (at sign)
-* `[` (left bracket)
-* `\\` (two backward slashes)
-*  `_` (underscore)
-* `^` (caret)
-
-These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
-sequences. To configure a different configuration default key sequence for all
-containers, see [**Configuration file** section](cli.md#configuration-files).
 
 ## Examples
 
@@ -168,3 +144,27 @@ $ docker ps -a --filter name=test
 CONTAINER ID   IMAGE     COMMAND     CREATED              STATUS                       PORTS     NAMES
 a2fe3fd886db   alpine    "/bin/sh"   About a minute ago   Exited (13) 40 seconds ago             test
 ```
+
+### <a name="detach-keys"></a> Override the detach sequence (--detach-keys)
+
+Use the `--detach-keys` option to override the Docker key sequence for detach.
+This is useful if the Docker default sequence conflicts with key sequence you
+use for other applications. There are two ways to define your own detach key
+sequence, as a per-container override or as a configuration property on  your
+entire configuration.
+
+To override the sequence for an individual container, use the
+`--detach-keys="<sequence>"` flag with the `docker attach` command. The format of
+the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
+the following:
+
+* `a-z` (a single lowercase alpha character )
+* `@` (at sign)
+* `[` (left bracket)
+* `\\` (two backward slashes)
+*  `_` (underscore)
+* `^` (caret)
+
+These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
+sequences. To configure a different configuration default key sequence for all
+containers, see [**Configuration file** section](cli.md#configuration-files).

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -32,7 +32,7 @@ Create and run a new container from an image
 | `--cpuset-cpus`                               | `string`      |           | CPUs in which to allow execution (0-3, 0,1)                                                                                                                                                                                                                                                                      |
 | `--cpuset-mems`                               | `string`      |           | MEMs in which to allow execution (0-3, 0,1)                                                                                                                                                                                                                                                                      |
 | `-d`, `--detach`                              |               |           | Run container in background and print container ID                                                                                                                                                                                                                                                               |
-| `--detach-keys`                               | `string`      |           | Override the key sequence for detaching a container                                                                                                                                                                                                                                                              |
+| [`--detach-keys`](#detach-keys)               | `string`      |           | Override the key sequence for detaching a container                                                                                                                                                                                                                                                              |
 | [`--device`](#device)                         | `list`        |           | Add a host device to the container                                                                                                                                                                                                                                                                               |
 | [`--device-cgroup-rule`](#device-cgroup-rule) | `list`        |           | Add a rule to the cgroup allowed devices list                                                                                                                                                                                                                                                                    |
 | `--device-read-bps`                           | `list`        |           | Limit read rate (bytes per second) from a device                                                                                                                                                                                                                                                                 |
@@ -568,6 +568,30 @@ useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
 See also [the `docker cp` command](cp.md).
+
+### <a name="detach-keys"></a> Override the detach sequence (--detach-keys)
+
+Use the `--detach-keys` option to override the Docker key sequence for detach.
+This is useful if the Docker default sequence conflicts with key sequence you
+use for other applications. There are two ways to define your own detach key
+sequence, as a per-container override or as a configuration property on  your
+entire configuration.
+
+To override the sequence for an individual container, use the
+`--detach-keys="<sequence>"` flag with the `docker attach` command. The format of
+the `<sequence>` is either a letter [a-Z], or the `ctrl-` combined with any of
+the following:
+
+* `a-z` (a single lowercase alpha character )
+* `@` (at sign)
+* `[` (left bracket)
+* `\\` (two backward slashes)
+*  `_` (underscore)
+* `^` (caret)
+
+These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
+sequences. To configure a different configuration default key sequence for all
+containers, see [**Configuration file** section](cli.md#configuration-files).
 
 ### <a name="device"></a> Add host device to container (--device)
 

--- a/man/src/container/attach.md
+++ b/man/src/container/attach.md
@@ -13,9 +13,29 @@ file. See **config-json(5)** for documentation on using a configuration file.
 It is forbidden to redirect the standard input of a **docker attach** command while
 attaching to a TTY-enabled container (i.e., launched with `-i` and `-t`).
 
-# Override the detach sequence
+# EXAMPLES
 
-If you want, you can configure an override the Docker key sequence for detach.
+## Attaching to a container
+
+In this example the top command is run inside a container from an ubuntu image,
+in detached mode, then attaches to it, and then terminates the container
+with `CTRL-c`:
+
+    $ docker run -d --name topdemo ubuntu:20.04 /usr/bin/top -b
+    $ docker attach topdemo
+    top - 00:07:01 up  4:54,  0 users,  load average: 0.83, 0.91, 0.82
+    Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+    %Cpu(s):  2.3 us,  1.6 sy,  0.0 ni, 95.9 id,  0.0 wa,  0.1 hi,  0.1 si,  0.0 st
+    MiB Mem :  15846.2 total,   5729.2 free,   2592.5 used,   7524.4 buff/cache
+    MiB Swap:  16384.0 total,  16384.0 free,      0.0 used.  12097.3 avail Mem 
+    
+        PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+          1 root      20   0    5976   3256   2828 R   0.0   0.0   0:00.04 top
+    ^C
+
+## Override the detach sequence
+
+Use the **--detach-keys** option to override the Docker key sequence for detach.
 This is useful if the Docker default sequence conflicts with key sequence you
 use for other applications. There are two ways to define your own detach key
 sequence, as a per-container override or as a configuration property on  your
@@ -37,22 +57,3 @@ These **a**, **ctrl-a**, **X**, or **ctrl-\\** values are all examples of valid 
 sequences. To configure a different configuration default key sequence for all
 containers, see **docker(1)**.
 
-# EXAMPLES
-
-## Attaching to a container
-
-In this example the top command is run inside a container from an ubuntu image,
-in detached mode, then attaches to it, and then terminates the container
-with `CTRL-c`:
-
-    $ docker run -d --name topdemo ubuntu:20.04 /usr/bin/top -b
-    $ docker attach topdemo
-    top - 00:07:01 up  4:54,  0 users,  load average: 0.83, 0.91, 0.82
-    Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-    %Cpu(s):  2.3 us,  1.6 sy,  0.0 ni, 95.9 id,  0.0 wa,  0.1 hi,  0.1 si,  0.0 st
-    MiB Mem :  15846.2 total,   5729.2 free,   2592.5 used,   7524.4 buff/cache
-    MiB Swap:  16384.0 total,  16384.0 free,      0.0 used.  12097.3 avail Mem 
-    
-        PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
-          1 root      20   0    5976   3256   2828 R   0.0   0.0   0:00.04 top
-    ^C


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4336