### PR TITLE
replace some basic uses of fmt.Sprintf(), and minor refactor

### DIFF
--- a/cli/command/config/formatter.go
+++ b/cli/command/config/formatter.go
@@ -103,7 +103,7 @@ func (c *configContext) Labels() string {
 	}
 	var joinLabels []string
 	for k, v := range mapLabels {
-		joinLabels = append(joinLabels, fmt.Sprintf("%s=%s", k, v))
+		joinLabels = append(joinLabels, k+"="+v)
 	}
 	return strings.Join(joinLabels, ",")
 }

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -91,7 +91,7 @@ func runCreate(dockerCli command.Cli, flags *pflag.FlagSet, options *createOptio
 		if v == nil {
 			newEnv = append(newEnv, k)
 		} else {
-			newEnv = append(newEnv, fmt.Sprintf("%s=%s", k, *v))
+			newEnv = append(newEnv, k+"="+*v)
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -101,7 +101,7 @@ func runRun(dockerCli command.Cli, flags *pflag.FlagSet, ropts *runOptions, copt
 		if v == nil {
 			newEnv = append(newEnv, k)
 		} else {
-			newEnv = append(newEnv, fmt.Sprintf("%s=%s", k, *v))
+			newEnv = append(newEnv, k+"="+*v)
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -247,7 +247,7 @@ func (c *ContainerContext) Labels() string {
 
 	var joinLabels []string
 	for k, v := range c.c.Labels {
-		joinLabels = append(joinLabels, fmt.Sprintf("%s=%s", k, v))
+		joinLabels = append(joinLabels, k+"="+v)
 	}
 	return strings.Join(joinLabels, ",")
 }

--- a/cli/command/network/formatter.go
+++ b/cli/command/network/formatter.go
@@ -103,7 +103,7 @@ func (c *networkContext) Labels() string {
 
 	var joinLabels []string
 	for k, v := range c.n.Labels {
-		joinLabels = append(joinLabels, fmt.Sprintf("%s=%s", k, v))
+		joinLabels = append(joinLabels, k+"="+v)
 	}
 	return strings.Join(joinLabels, ",")
 }

--- a/cli/command/secret/formatter.go
+++ b/cli/command/secret/formatter.go
@@ -110,7 +110,7 @@ func (c *secretContext) Labels() string {
 	}
 	var joinLabels []string
 	for k, v := range mapLabels {
-		joinLabels = append(joinLabels, fmt.Sprintf("%s=%s", k, v))
+		joinLabels = append(joinLabels, k+"="+v)
 	}
 	return strings.Join(joinLabels, ",")
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -133,7 +133,7 @@ func prettyPrintEvent(out io.Writer, event eventtypes.Message) error {
 		sort.Strings(keys)
 		for _, k := range keys {
 			v := event.Actor.Attributes[k]
-			attrs = append(attrs, fmt.Sprintf("%s=%s", k, v))
+			attrs = append(attrs, k+"="+v)
 		}
 		fmt.Fprintf(out, " (%s)", strings.Join(attrs, ", "))
 	}

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -1,7 +1,6 @@
 package convert
 
 import (
-	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -605,7 +604,7 @@ func convertEnvironment(source map[string]*string) []string {
 		case nil:
 			output = append(output, name)
 		default:
-			output = append(output, fmt.Sprintf("%s=%s", name, *value))
+			output = append(output, name+"="+*value)
 		}
 	}
 

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -133,7 +133,7 @@ func Service(
 				Hosts:           convertExtraHosts(service.ExtraHosts),
 				DNSConfig:       dnsConfig,
 				Healthcheck:     healthcheck,
-				Env:             sortStrings(convertEnvironment(service.Environment)),
+				Env:             convertEnvironment(service.Environment),
 				Labels:          AddStackLabel(namespace, service.Labels),
 				Dir:             service.WorkingDir,
 				User:            service.User,
@@ -197,11 +197,6 @@ func getPlacementPreference(preferences []composetypes.PlacementPreferences) []s
 		})
 	}
 	return result
-}
-
-func sortStrings(strs []string) []string {
-	sort.Strings(strs)
-	return strs
 }
 
 func convertServiceNetworks(
@@ -596,6 +591,8 @@ func convertEndpointSpec(endpointMode string, source []composetypes.ServicePortC
 	}
 }
 
+// convertEnvironment converts key/value mappings to a slice, and sorts
+// the results.
 func convertEnvironment(source map[string]*string) []string {
 	var output []string
 
@@ -607,7 +604,7 @@ func convertEnvironment(source map[string]*string) []string {
 			output = append(output, name+"="+*value)
 		}
 	}
-
+	sort.Strings(output)
 	return output
 }
 

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -3,7 +3,6 @@ package convert
 import (
 	"context"
 	"os"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -59,7 +58,6 @@ func TestConvertEnvironment(t *testing.T) {
 		"key": strPtr("value"),
 	}
 	env := convertEnvironment(source)
-	sort.Strings(env)
 	assert.Check(t, is.DeepEqual([]string{"foo=bar", "key=value"}, env))
 }
 


### PR DESCRIPTION
### replace some basic uses of fmt.Sprintf()

Really tiny gains here, and doesn't significantly impact readability:

    BenchmarkSprintf
    BenchmarkSprintf-10    11528700     91.59 ns/op   32 B/op  1 allocs/op
    BenchmarkConcat
    BenchmarkConcat-10    100000000     11.76 ns/op    0 B/op  0 allocs/op

### cli/compose/convert: convertEnvironment: sort results

All users of this function sorted the results afterwards, so let's
do it as part of the function itself.


**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

