### PR TITLE
build: error if Dockerfile name is passed with Dockerfile from stdin

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -34,8 +34,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var errStdinConflict = errors.New("invalid argument: can't use stdin for both build context and dockerfile")
-
 type buildOptions struct {
 	context        string
 	dockerfileName string
@@ -189,7 +187,7 @@ func runBuild(dockerCli command.Cli, options buildOptions) error {
 
 	if options.dockerfileFromStdin() {
 		if options.contextFromStdin() {
-			return errStdinConflict
+			return errors.New("invalid argument: can't use stdin for both build context and dockerfile")
 		}
 		dockerfileCtx = dockerCli.In()
 	}

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -155,6 +155,9 @@ func GetContextFromReader(rc io.ReadCloser, dockerfileName string) (out io.ReadC
 	if dockerfileName == "-" {
 		return nil, "", errors.New("build context is not an archive")
 	}
+	if dockerfileName != "" {
+		return nil, "", errors.New("ambiguous Dockerfile source: both stdin and flag correspond to Dockerfiles")
+	}
 
 	dockerfileDir, err := WriteTempDockerfile(rc)
 	if err != nil {

--- a/cli/command/image/build/context_test.go
+++ b/cli/command/image/build/context_test.go
@@ -152,6 +152,13 @@ func TestGetContextFromReaderString(t *testing.T) {
 	}
 }
 
+func TestGetContextFromReaderStringConflict(t *testing.T) {
+	rdr, relDockerfile, err := GetContextFromReader(io.NopCloser(strings.NewReader(dockerfileContents)), "custom.Dockerfile")
+	assert.Check(t, is.Equal(rdr, nil))
+	assert.Check(t, is.Equal(relDockerfile, ""))
+	assert.Check(t, is.ErrorContains(err, "ambiguous Dockerfile source: both stdin and flag correspond to Dockerfiles"))
+}
+
 func TestGetContextFromReaderTar(t *testing.T) {
 	contextDir := createTestTempDir(t)
 	createTestTempFile(t, contextDir, DefaultDockerfileName, dockerfileContents)


### PR DESCRIPTION
- fixes https://github.com/moby/moby/issues/45700 (https://github.com/moby/moby/issues/45700#issuecomment-1588696429)

When passing a Dockerfile through stdin, it's not possible to specify the
name of the Dockerfile (using the `-f` option). When building with BuildKit
enabled, an error is already produced for this case, but the classic builder
silently ignored it.

This patch adds an error for this situation:

    echo -e 'FROM busybox' | DOCKER_BUILDKIT=0 docker build -f some.Dockerfile -
    DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
    BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
    environment-variable.
    
    unable to prepare context: ambiguous Dockerfile source: both stdin and flag correspond to Dockerfiles

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

