### PR TITLE
cli/command/context: remove deprecated k8s / orchestrator option-stubs

### DIFF
--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -51,18 +51,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Description, "description", "", "Description of the context")
-	flags.String(
-		"default-stack-orchestrator", "",
-		`Default orchestrator for stack operations to use with this context ("swarm", "kubernetes", "all")`,
-	)
-	flags.SetAnnotation("default-stack-orchestrator", "deprecated", nil)
-	flags.SetAnnotation("default-stack-orchestrator", "deprecated", nil)
-	flags.MarkDeprecated("default-stack-orchestrator", "option will be ignored")
 	flags.StringToStringVar(&opts.Docker, "docker", nil, "set the docker endpoint")
-	flags.StringToString("kubernetes", nil, "set the kubernetes endpoint")
-	flags.SetAnnotation("kubernetes", "kubernetes", nil)
-	flags.SetAnnotation("kubernetes", "deprecated", nil)
-	flags.MarkDeprecated("kubernetes", "option will be ignored")
 	flags.StringVar(&opts.From, "from", "", "create context from a named context")
 	return cmd
 }

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -19,13 +19,14 @@ type ExportOptions struct {
 }
 
 func newExportCommand(dockerCli command.Cli) *cobra.Command {
-	opts := &ExportOptions{}
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "export [OPTIONS] CONTEXT [FILE|-]",
 		Short: "Export a context to a tar archive FILE or a tar stream on STDOUT.",
 		Args:  cli.RequiresRangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.ContextName = args[0]
+			opts := &ExportOptions{
+				ContextName: args[0],
+			}
 			if len(args) == 2 {
 				opts.Dest = args[1]
 			} else {
@@ -34,13 +35,6 @@ func newExportCommand(dockerCli command.Cli) *cobra.Command {
 			return RunExport(dockerCli, opts)
 		},
 	}
-
-	flags := cmd.Flags()
-	flags.Bool("kubeconfig", false, "Export as a kubeconfig file")
-	flags.MarkDeprecated("kubeconfig", "option will be ignored")
-	flags.SetAnnotation("kubeconfig", "kubernetes", nil)
-	flags.SetAnnotation("kubeconfig", "deprecated", nil)
-	return cmd
 }
 
 func writeTo(dockerCli command.Cli, reader io.Reader, dest string) error {

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -47,17 +47,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.Description, "description", "", "Description of the context")
-	flags.String(
-		"default-stack-orchestrator", "",
-		"Default orchestrator for stack operations to use with this context (swarm|kubernetes|all)",
-	)
-	flags.SetAnnotation("default-stack-orchestrator", "deprecated", nil)
-	flags.MarkDeprecated("default-stack-orchestrator", "option will be ignored")
 	flags.StringToStringVar(&opts.Docker, "docker", nil, "set the docker endpoint")
-	flags.StringToString("kubernetes", nil, "set the kubernetes endpoint")
-	flags.SetAnnotation("kubernetes", "kubernetes", nil)
-	flags.SetAnnotation("kubernetes", "deprecated", nil)
-	flags.MarkDeprecated("kubernetes", "option will be ignored")
 	return cmd
 }
 


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/issues/2967
- https://github.com/docker/cli/pull/3139
- https://github.com/docker/cli/pull/3166
- https://github.com/docker/cli/pull/3167
- https://github.com/docker/cli/pull/3174


support for kubernetes contexts was deprecated in docker 20.10 through b639ea8b89b162c3abe99d3ac90b258c48e2039c, 0793f9639440d8980226485189ce0eb43e0af28b, and 1d37fb302789c6ce4ba120bc4ad577c92674467f, and removed altoghether in 23.0 through 193ede9b12b53e8aa595356e8b823f883e49bdc5.

This patch removes the remaining stubs for options that were deprecated and no longer used.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

