### PR TITLE
[24.0 backport] cli/command/context: don't use pkg/homedir in test

### DIFF
--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/homedir"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -57,7 +57,11 @@ func TestUseDefaultWithoutConfigFile(t *testing.T) {
 	// the _default_ configuration file. If we specify a custom configuration
 	// file, the CLI produces an error if the file doesn't exist.
 	tmpHomeDir := t.TempDir()
-	t.Setenv(homedir.Key(), tmpHomeDir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", tmpHomeDir)
+	} else {
+		t.Setenv("HOME", tmpHomeDir)
+	}
 	configDir := filepath.Join(tmpHomeDir, ".docker")
 	configFilePath := filepath.Join(configDir, "config.json")
 


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4370

I'm considering deprecating the "Key()" utility, as it was only used in tests.


(cherry picked from commit 79ff64f06d67231e067e1f3e48bec9970be54eb5)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

