### PR TITLE
docs: fix static ip example, network needs a subnet

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -485,10 +485,12 @@ $ docker run -itd --network=my-net busybox
 ```
 
 You can also choose the IP addresses for the container with `--ip` and `--ip6`
-flags when you start the container on a user-defined network.
+flags when you start the container on a user-defined network. To assign a
+static IP to containers, you must specify subnet block for the network.
 
 ```console
-$ docker run -itd --network=my-net --ip=10.10.9.75 busybox
+$ docker network create --subnet 192.0.2.0/24 my-net
+$ docker run -itd --network=my-net --ip=192.0.2.69 busybox
 ```
 
 If you want to add a running container to a network use the `docker network connect` subcommand.


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/45806

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Clarify that static container IPs require networks with an explicit subnet block

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

