### PR TITLE
Introduce support for CLI plugin hooks

### DIFF
--- a/cli-plugins/hooks/printer.go
+++ b/cli-plugins/hooks/printer.go
@@ -1,0 +1,18 @@
+package hooks
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/morikuni/aec"
+)
+
+func PrintNextSteps(out io.Writer, messages []string) {
+	if len(messages) == 0 {
+		return
+	}
+	fmt.Fprintln(out, aec.Bold.Apply("\nWhat's next:"))
+	for _, n := range messages {
+		_, _ = fmt.Fprintf(out, "    %s\n", n)
+	}
+}

--- a/cli-plugins/hooks/printer_test.go
+++ b/cli-plugins/hooks/printer_test.go
@@ -1,0 +1,38 @@
+package hooks
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/morikuni/aec"
+	"gotest.tools/v3/assert"
+)
+
+func TestPrintHookMessages(t *testing.T) {
+	testCases := []struct {
+		messages       []string
+		expectedOutput string
+	}{
+		{
+			messages:       []string{},
+			expectedOutput: "",
+		},
+		{
+			messages: []string{"Bork!"},
+			expectedOutput: aec.Bold.Apply("\nWhat's next:") + "\n" +
+				"    Bork!\n",
+		},
+		{
+			messages: []string{"Foo", "bar"},
+			expectedOutput: aec.Bold.Apply("\nWhat's next:") + "\n" +
+				"    Foo\n" +
+				"    bar\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		w := bytes.Buffer{}
+		PrintNextSteps(&w, tc.messages)
+		assert.Equal(t, w.String(), tc.expectedOutput)
+	}
+}

--- a/cli-plugins/hooks/template.go
+++ b/cli-plugins/hooks/template.go
@@ -1,0 +1,115 @@
+package hooks
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+type HookType int
+
+const (
+	NextSteps = iota
+)
+
+// HookMessage represents a plugin hook response. Plugins
+// declaring support for CLI hooks need to print a json
+// representation of this type when their hook subcommand
+// is invoked.
+type HookMessage struct {
+	Type     HookType
+	Template string
+}
+
+// TemplateReplaceSubcommandName returns a hook template string
+// that will be replaced by the CLI subcommand being executed
+//
+// Example:
+//
+// "you ran the subcommand: " + TemplateReplaceSubcommandName()
+//
+// when being executed after the command:
+// `docker run --name "my-container" alpine`
+// will result in the message:
+// `you ran the subcommand: run`
+func TemplateReplaceSubcommandName() string {
+	return hookTemplateCommandName
+}
+
+// TemplateReplaceFlagValue returns a hook template string
+// that will be replaced by the flags value.
+//
+// Example:
+//
+// "you ran a container named: " + TemplateReplaceFlagValue("name")
+//
+// when being executed after the command:
+// `docker run --name "my-container" alpine`
+// will result in the message:
+// `you ran a container named: my-container`
+func TemplateReplaceFlagValue(flag string) string {
+	return fmt.Sprintf(hookTemplateFlagValue, flag)
+}
+
+// TemplateReplaceArg takes an index i and returns a hook
+// template string that the CLI will replace the template with
+// the ith argument, after processing the passed flags.
+//
+// Example:
+//
+// "run this image with `docker run " + TemplateReplaceArg(0) + "`"
+//
+// when being executed after the command:
+// `docker pull alpine`
+// will result in the message:
+// "Run this image with `docker run alpine`"
+func TemplateReplaceArg(i int) string {
+	return fmt.Sprintf(hookTemplateArg, strconv.Itoa(i))
+}
+
+func ParseTemplate(hookTemplate string, cmd *cobra.Command) (string, error) {
+	tmpl := template.New("").Funcs(commandFunctions)
+	tmpl, err := tmpl.Parse(hookTemplate)
+	if err != nil {
+		return "", err
+	}
+	b := bytes.Buffer{}
+	err = tmpl.Execute(&b, cmd)
+	if err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+var ErrHookTemplateParse = errors.New("failed to parse hook template")
+
+const (
+	hookTemplateCommandName = "{{.Name}}"
+	hookTemplateFlagValue   = `{{flag . "%s"}}`
+	hookTemplateArg         = "{{arg . %s}}"
+)
+
+var commandFunctions = template.FuncMap{
+	"flag": getFlagValue,
+	"arg":  getArgValue,
+}
+
+func getFlagValue(cmd *cobra.Command, flag string) (string, error) {
+	cmdFlag := cmd.Flag(flag)
+	if cmdFlag == nil {
+		return "", ErrHookTemplateParse
+	}
+	return cmdFlag.Value.String(), nil
+}
+
+func getArgValue(cmd *cobra.Command, i int) (string, error) {
+	flags := cmd.Flags()
+	if flags == nil {
+		return "", ErrHookTemplateParse
+	}
+	return flags.Arg(i), nil
+}

--- a/cli-plugins/hooks/template_test.go
+++ b/cli-plugins/hooks/template_test.go
@@ -1,0 +1,82 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+func TestParseTemplate(t *testing.T) {
+	type testFlag struct {
+		name  string
+		value string
+	}
+	testCases := []struct {
+		template       string
+		flags          []testFlag
+		args           []string
+		expectedOutput string
+	}{
+		{
+			template:       "",
+			expectedOutput: "",
+		},
+		{
+			template:       "a plain template message",
+			expectedOutput: "a plain template message",
+		},
+		{
+			template: TemplateReplaceFlagValue("tag"),
+			flags: []testFlag{
+				{
+					name:  "tag",
+					value: "my-tag",
+				},
+			},
+			expectedOutput: "my-tag",
+		},
+		{
+			template: TemplateReplaceFlagValue("test-one") + " " + TemplateReplaceFlagValue("test2"),
+			flags: []testFlag{
+				{
+					name:  "test-one",
+					value: "value",
+				},
+				{
+					name:  "test2",
+					value: "value2",
+				},
+			},
+			expectedOutput: "value value2",
+		},
+		{
+			template:       TemplateReplaceArg(0) + " " + TemplateReplaceArg(1),
+			args:           []string{"zero", "one"},
+			expectedOutput: "zero one",
+		},
+		{
+			template:       "You just pulled " + TemplateReplaceArg(0),
+			args:           []string{"alpine"},
+			expectedOutput: "You just pulled alpine",
+		},
+	}
+
+	for _, tc := range testCases {
+		testCmd := &cobra.Command{
+			Use:  "pull",
+			Args: cobra.ExactArgs(len(tc.args)),
+		}
+		for _, f := range tc.flags {
+			_ = testCmd.Flags().String(f.name, "", "")
+			err := testCmd.Flag(f.name).Value.Set(f.value)
+			assert.NilError(t, err)
+		}
+		err := testCmd.Flags().Parse(tc.args)
+		assert.NilError(t, err)
+
+		out, err := ParseTemplate(tc.template, testCmd)
+		assert.NilError(t, err)
+		assert.Equal(t, out, tc.expectedOutput)
+	}
+}

--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -41,6 +41,9 @@ func (e *pluginError) MarshalText() (text []byte, err error) {
 // wrapAsPluginError wraps an error in a pluginError with an
 // additional message, analogous to errors.Wrapf.
 func wrapAsPluginError(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
 	return &pluginError{cause: errors.Wrap(err, msg)}
 }
 

--- a/cli-plugins/manager/hooks.go
+++ b/cli-plugins/manager/hooks.go
@@ -1,0 +1,127 @@
+package manager
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/docker/cli/cli-plugins/hooks"
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// HookPluginData is the type representing the information
+// that plugins declaring support for hooks get passed when
+// being invoked following a CLI command execution.
+type HookPluginData struct {
+	RootCmd string
+	Flags   map[string]string
+}
+
+// RunPluginHooks calls the hook subcommand for all present
+// CLI plugins that declare support for hooks in their metadata
+// and parses/prints their responses.
+func RunPluginHooks(dockerCli command.Cli, rootCmd, subCommand *cobra.Command, plugin string, args []string) error {
+	subCmdName := subCommand.Name()
+	if plugin != "" {
+		subCmdName = plugin
+	}
+	var flags map[string]string
+	if plugin == "" {
+		flags = getCommandFlags(subCommand)
+	} else {
+		flags = getNaiveFlags(args)
+	}
+	nextSteps := invokeAndCollectHooks(dockerCli, rootCmd, subCommand, subCmdName, flags)
+
+	hooks.PrintNextSteps(dockerCli.Err(), nextSteps)
+	return nil
+}
+
+func invokeAndCollectHooks(dockerCli command.Cli, rootCmd, subCmd *cobra.Command, hookCmdName string, flags map[string]string) []string {
+	pluginsCfg := dockerCli.ConfigFile().Plugins
+	if pluginsCfg == nil {
+		return nil
+	}
+
+	nextSteps := make([]string, 0, len(pluginsCfg))
+	for pluginName, cfg := range pluginsCfg {
+		if !registersHook(cfg, hookCmdName) {
+			continue
+		}
+
+		p, err := GetPlugin(pluginName, dockerCli, rootCmd)
+		if err != nil {
+			continue
+		}
+
+		hookReturn, err := p.RunHook(hookCmdName, flags)
+		if err != nil {
+			// skip misbehaving plugins, but don't halt execution
+			continue
+		}
+
+		var hookMessageData hooks.HookMessage
+		err = json.Unmarshal(hookReturn, &hookMessageData)
+		if err != nil {
+			continue
+		}
+
+		// currently the only hook type
+		if hookMessageData.Type != hooks.NextSteps {
+			continue
+		}
+
+		processedHook, err := hooks.ParseTemplate(hookMessageData.Template, subCmd)
+		if err != nil {
+			continue
+		}
+		nextSteps = append(nextSteps, processedHook)
+	}
+	return nextSteps
+}
+
+func registersHook(pluginCfg map[string]string, subCmdName string) bool {
+	hookCmdStr, ok := pluginCfg["hooks"]
+	if !ok {
+		return false
+	}
+	commands := strings.Split(hookCmdStr, ",")
+	for _, hookCmd := range commands {
+		if hookCmd == subCmdName {
+			return true
+		}
+	}
+	return false
+}
+
+func getCommandFlags(cmd *cobra.Command) map[string]string {
+	flags := make(map[string]string)
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		var fValue string
+		if f.Value.Type() == "bool" {
+			fValue = f.Value.String()
+		}
+		flags[f.Name] = fValue
+	})
+	return flags
+}
+
+// getNaiveFlags string-matches argv and parses them into a map.
+// This is used when calling hooks after a plugin command, since
+// in this case we can't rely on the cobra command tree to parse
+// flags in this case. In this case, no values are ever passed,
+// since we don't have enough information to process them.
+func getNaiveFlags(args []string) map[string]string {
+	flags := make(map[string]string)
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--") {
+			flags[arg[2:]] = ""
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			flags[arg[1:]] = ""
+		}
+	}
+	return flags
+}

--- a/cli-plugins/manager/hooks_test.go
+++ b/cli-plugins/manager/hooks_test.go
@@ -1,0 +1,38 @@
+package manager
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestGetNaiveFlags(t *testing.T) {
+	testCases := []struct {
+		args          []string
+		expectedFlags map[string]string
+	}{
+		{
+			args:          []string{"docker"},
+			expectedFlags: map[string]string{},
+		},
+		{
+			args: []string{"docker", "build", "-q", "--file", "test.Dockerfile", "."},
+			expectedFlags: map[string]string{
+				"q":    "",
+				"file": "",
+			},
+		},
+		{
+			args: []string{"docker", "--context", "a-context", "pull", "-q", "--progress", "auto", "alpine"},
+			expectedFlags: map[string]string{
+				"context":  "",
+				"q":        "",
+				"progress": "",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.DeepEqual(t, getNaiveFlags(tc.args), tc.expectedFlags)
+	}
+}

--- a/cli-plugins/manager/metadata.go
+++ b/cli-plugins/manager/metadata.go
@@ -8,6 +8,11 @@ const (
 	// which must be supported by every plugin and returns the
 	// plugin metadata.
 	MetadataSubcommandName = "docker-cli-plugin-metadata"
+
+	// HookSubcommandName is the name of the plugin subcommand
+	// which must be implemented by plugins declaring support
+	// for hooks in their metadata.
+	HookSubcommandName = "docker-cli-plugin-hooks"
 )
 
 // Metadata provided by the plugin.

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -187,6 +187,36 @@ func (cli *DockerCli) BuildKitEnabled() (bool, error) {
 	return cli.ServerInfo().OSType != "windows", nil
 }
 
+// HooksEnabled returns whether plugin hooks are enabled.
+func (cli *DockerCli) HooksEnabled() bool {
+	// legacy support DOCKER_CLI_HINTS env var
+	if v := os.Getenv("DOCKER_CLI_HINTS"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return enabled
+	}
+	// use DOCKER_CLI_HOOKS env var value if set and not empty
+	if v := os.Getenv("DOCKER_CLI_HOOKS"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return enabled
+	}
+	featuresMap := cli.ConfigFile().Features
+	if v, ok := featuresMap["hooks"]; ok {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			return false
+		}
+		return enabled
+	}
+	// default to false
+	return false
+}
+
 // ManifestStore returns a store for local manifests
 func (cli *DockerCli) ManifestStore() manifeststore.Store {
 	// TODO: support override default location from config file

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -307,3 +307,56 @@ func TestInitializeShouldAlwaysCreateTheContextStore(t *testing.T) {
 	})))
 	assert.Check(t, cli.ContextStore() != nil)
 }
+
+func TestHooksEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cli, err := NewDockerCli()
+		assert.NilError(t, err)
+
+		assert.Check(t, !cli.HooksEnabled())
+	})
+
+	t.Run("enabled in configFile", func(t *testing.T) {
+		configFile := `{
+    "features": {
+      "hooks": "true"
+    }}`
+		dir := fs.NewDir(t, "", fs.WithFile("config.json", configFile))
+		defer dir.Remove()
+		cli, err := NewDockerCli()
+		assert.NilError(t, err)
+		config.SetDir(dir.Path())
+
+		assert.Check(t, cli.HooksEnabled())
+	})
+
+	t.Run("env var overrides configFile", func(t *testing.T) {
+		configFile := `{
+    "features": {
+      "hooks": "true"
+    }}`
+		t.Setenv("DOCKER_CLI_HOOKS", "false")
+		dir := fs.NewDir(t, "", fs.WithFile("config.json", configFile))
+		defer dir.Remove()
+		cli, err := NewDockerCli()
+		assert.NilError(t, err)
+		config.SetDir(dir.Path())
+
+		assert.Check(t, !cli.HooksEnabled())
+	})
+
+	t.Run("legacy env var overrides configFile", func(t *testing.T) {
+		configFile := `{
+    "features": {
+      "hooks": "true"
+    }}`
+		t.Setenv("DOCKER_CLI_HINTS", "false")
+		dir := fs.NewDir(t, "", fs.WithFile("config.json", configFile))
+		defer dir.Remove()
+		cli, err := NewDockerCli()
+		assert.NilError(t, err)
+		config.SetDir(dir.Path())
+
+		assert.Check(t, !cli.HooksEnabled())
+	})
+}

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -41,6 +41,7 @@ type ConfigFile struct {
 	CLIPluginsExtraDirs  []string                     `json:"cliPluginsExtraDirs,omitempty"`
 	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
 	Aliases              map[string]string            `json:"aliases,omitempty"`
+	Features             map[string]string            `json:"features,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings


### PR DESCRIPTION
**- What I did**

Introduce a "hooks" mechanism for CLI plugins, which enables CLI plugins adding useful, contextual messages/actions after a command has been executed.

This works by defining a special plugin command (such as the metadata command) which the CLI calls with some information about the just-executed command (currently, command and flag names). The plugin then prints a json-encoded to it's stdout with a template for the message it would like the CLI to print.

Using such a system, a plugin to help new docker users could, for example, declare intent to hook into `docker build`, and return a templated message instructing the user how to run their newly-built image.

A templating approach was chosen to allow plugin messages to include information from the original command execution (such as the tag used for the image in `build`), so that messages can provide more useful information (such as printing "Run your image with `docker run my-image`" after a `docker build -t my-image .`
Helpers are provided in the form of `manager.TemplateReplaceFlagValue("tag")` for this case, and use Go Templates under the hood.

The templating approach chosen also keeps sensitive data from leaving the CLI process.

This PR also introduces a "features" map into the CLI `config.json`, to allow for global enabling/disabling of this (and future) features.

<details>
  <summary><b>Example Plugin</b></summary>

```go
func main() {
	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
		cmd := RootCommand(dockerCli)
		originalPreRun := cmd.PersistentPreRunE
		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
			if err := plugin.PersistentPreRunE(cmd, args); err != nil {
				//nolint: wrapcheck
				return err
			}
			if originalPreRun != nil {
				return originalPreRun(cmd, args)
			}
			return nil
		}
		return cmd
	},
		manager.Metadata{
			SchemaVersion: "0.1.0",
			Vendor:        "Docker Inc.",
			Version:       "0.1",
			HookCommands:  []string{"build"},  // declare intent to hook into `build` subcommand invocations
		})
}

func RootCommand(dockerCli command.Cli) *cobra.Command {
	rootCmd := &cobra.Command{
		Short:            "Docker Hints",
		Use:              "hints",
		TraverseChildren: true,
	}

	rootCmd.AddCommand(hookCommand(dockerCli))
	return rootCmd
}

func hookCommand(dockerCli command.Cli) *cobra.Command {
	hookCmd := &cobra.Command{
		Use:   manager.HookSubcommandName,  // register hook command that the CLI will invoke
		Short: "runs the plugins hooks",
		RunE: utils.Adapt(func(ctx context.Context, args []string) error {
			runHooks(dockerCli.Out(), []byte(args[0]))
			return nil
		}),
		Args: cobra.ExactArgs(1),
	}

	return hookCmd
}

func runHooks(out io.Writer, input []byte) {
	var c manager.HookPluginData
	_ = json.Unmarshal(input, &c)

	hint := "Run this image with `docker run " + manager.TemplateReplaceFlagValue("tag") + "`" // template helper
	returnType := manager.HookMessage{
		Template: hint,
	}
	enc := json.NewEncoder(out)
	enc.SetEscapeHTML(false)
	enc.SetIndent("", "     ")
	_ = enc.Encode(returnType)
}
```

Which results in:
![image](https://github.com/docker/cli/assets/70572044/c30d45a1-8f58-48be-91ec-30a4f5d275a0)

</details>

-------------------------------

<details>
<summary><b>Performance Callouts</b></summary>

Edited: for current approach + benchmarks see https://github.com/docker/cli/pull/4376#issuecomment-2008580277

</details>
<details>
  <summary><b>Security Callouts</b></summary>

The current approach works by letting plugins declare a list of strings which are the CLI commands (such as `build`, `run`, etc.) whose execution the plugin wants to be hooked into. The CLI then only invokes each plugin for the commands the plugin has declared support for.

Since a plugin might want to be invoked for more than one command, some information must be passed into the plugin when it is invoked so that it can decide what information it wants to add – which for right now, is codified into the `HookPluginData` type and contains only a string representing the command being executed. Richer output is made possible by employing a _templating_ approach, wherein the plugin can return a template string with special values which the CLI then processes – e.g.
```
$ docker build -t my-image .

# a plugin returning
You can run the image you just built with `docker run {docker-cli-plugin-hook-flag-tag}`

# gets parsed into
You can run the image you just built with `docker run my-image`
```

This allows for plugins to provide useful/contextual messages, without passing any potentially sensitive information to any other binary.

Possible future developments to make this more secure are things such as always being explicit when a plugin is invoked, so that the user is aware, or prompting the user whether they are okay with a plugin hooking into a command execution on first execution.
</details>

----------------------

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="585" alt="image" src="https://github.com/docker/cli/assets/70572044/1ca99a20-5e7e-4f89-a13a-0724419d6814">
