### PR TITLE
fixes #2413 - cli/command: fix docstring for ContainerFormat.CreatedAt and add CreatedAtTimestamp

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -189,9 +189,14 @@ func (c *ContainerContext) Command() string {
 	return strconv.Quote(command)
 }
 
-// CreatedAt returns the "Created" date/time of the container as a unix timestamp.
+// CreatedAt returns the "Created" date/time of the container as a stringified unix timestamp.
 func (c *ContainerContext) CreatedAt() string {
 	return time.Unix(c.c.Created, 0).String()
+}
+
+// CreatedAtTimestamp returns the "Created" date/time of the container as a unix timestamp.
+func (c *ContainerContext) CreatedAtTimestamp() time.Time {
+	return time.Unix(c.c.Created, 0)
 }
 
 // RunningFor returns a human-readable representation of the duration for which


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed docstring error and added function as described in https://github.com/docker/cli/issues/2413

**- How I did it**
Same as above

**- How to verify it**
See code diff

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed ContainerFormat.CreatedAt() docstring and added ContainerFormat.CreatedAtTimestamp()



**- A picture of a cute animal (not mandatory but encouraged)**
![baby turtle](https://i.ytimg.com/vi/fSORbMPkn9s/maxresdefault.jpg)

