### PR TITLE
cli/config: add EnvOverrideConfigDir const

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -16,7 +16,15 @@ import (
 )
 
 const (
-	// ConfigFileName is the name of config file
+	// EnvOverrideConfigDir is the name of the environment variable that can be
+	// used to override the location of the client configuration files (~/.docker).
+	//
+	// It takes priority over the default, but can be overridden by the "--config"
+	// command line option.
+	EnvOverrideConfigDir = "DOCKER_CONFIG"
+
+	// ConfigFileName is the name of the client configuration file inside the
+	// config-directory.
 	ConfigFileName = "config.json"
 	configFileDir  = ".docker"
 	contextsDir    = "contexts"
@@ -30,7 +38,7 @@ var (
 // Dir returns the directory the configuration file is stored in
 func Dir() string {
 	initConfigDir.Do(func() {
-		configDir = os.Getenv("DOCKER_CONFIG")
+		configDir = os.Getenv(EnvOverrideConfigDir)
 		if configDir == "" {
 			configDir = filepath.Join(homedir.Get(), configFileDir)
 		}

--- a/e2e/context/context_test.go
+++ b/e2e/context/context_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/cli/cli/config"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/icmd"
@@ -11,7 +12,7 @@ import (
 
 func TestContextList(t *testing.T) {
 	cmd := icmd.Command("docker", "context", "ls")
-	cmd.Env = append(cmd.Env, "DOCKER_CONFIG=testdata/test-dockerconfig")
+	cmd.Env = append(cmd.Env, config.EnvOverrideConfigDir+"=testdata/test-dockerconfig")
 	result := icmd.RunCmd(cmd).Assert(t, icmd.Expected{
 		Err:      icmd.None,
 		ExitCode: 0,
@@ -22,13 +23,11 @@ func TestContextList(t *testing.T) {
 func TestContextImportNoTLS(t *testing.T) {
 	d := t.TempDir()
 	cmd := icmd.Command("docker", "context", "import", "remote", "./testdata/test-dockerconfig.tar")
-	cmd.Env = append(cmd.Env,
-		"DOCKER_CONFIG="+d,
-	)
+	cmd.Env = append(cmd.Env, config.EnvOverrideConfigDir+"="+d)
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 	cmd = icmd.Command("docker", "context", "ls")
-	cmd.Env = append(cmd.Env, "DOCKER_CONFIG="+d)
+	cmd.Env = append(cmd.Env, config.EnvOverrideConfigDir+"="+d)
 	result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 	golden.Assert(t, result.Stdout(), "context-ls.golden")
 }
@@ -36,15 +35,11 @@ func TestContextImportNoTLS(t *testing.T) {
 func TestContextImportTLS(t *testing.T) {
 	d := t.TempDir()
 	cmd := icmd.Command("docker", "context", "import", "test", "./testdata/test-dockerconfig-tls.tar")
-	cmd.Env = append(cmd.Env,
-		"DOCKER_CONFIG="+d,
-	)
+	cmd.Env = append(cmd.Env, config.EnvOverrideConfigDir+"="+d)
 	icmd.RunCmd(cmd).Assert(t, icmd.Success)
 
 	cmd = icmd.Command("docker", "context", "ls")
-	cmd.Env = append(cmd.Env,
-		"DOCKER_CONFIG="+d,
-	)
+	cmd.Env = append(cmd.Env, config.EnvOverrideConfigDir+"="+d)
 	result := icmd.RunCmd(cmd).Assert(t, icmd.Success)
 	golden.Assert(t, result.Stdout(), "context-ls-tls.golden")
 

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/cli/cli/config"
 	"gotest.tools/v3/fs"
 	"gotest.tools/v3/icmd"
 )
@@ -53,7 +54,7 @@ func SetupConfigWithNotaryURL(t *testing.T, path, notaryURL string) fs.Dir {
 // WithConfig sets an environment variable for the docker config location
 func WithConfig(dir string) func(cmd *icmd.Cmd) {
 	return func(cmd *icmd.Cmd) {
-		addEnvs(cmd, "DOCKER_CONFIG="+dir)
+		addEnvs(cmd, config.EnvOverrideConfigDir+"="+dir)
 	}
 }
 


### PR DESCRIPTION
Add a const for the DOCKER_CONFIG to allow documenting its purpose in code.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

