### PR TITLE
cli/flags: add EnvEnableTLS const for "DOCKER_TLS"

### DIFF
--- a/cli/flags/options.go
+++ b/cli/flags/options.go
@@ -14,6 +14,18 @@ import (
 )
 
 const (
+	// EnvEnableTLS is the name of the environment variable that can be used
+	// to enable TLS for client connections. When set to a non-empty value, TLS
+	// is enabled for API connections using TCP. For backward-compatibility, this
+	// environment-variable can only be used to enable TLS, not to disable.
+	//
+	// Note that TLS is always enabled implicitly if the "--tls-verify" option
+	// or "DOCKER_TLS_VERIFY" ([github.com/docker/docker/client.EnvTLSVerify])
+	// env var is set to, which could be to either enable or disable TLS certification
+	// validation. In both cases, TLS is enabled but, depending on the setting,
+	// with verification disabled.
+	EnvEnableTLS = "DOCKER_TLS"
+
 	// DefaultCaFile is the default filename for the CA pem file
 	DefaultCaFile = "ca.pem"
 	// DefaultKeyFile is the default filename for the key pem file
@@ -39,8 +51,7 @@ Refer to https://docs.docker.com/go/formatting/ for more information about forma
 var (
 	dockerCertPath  = os.Getenv(client.EnvOverrideCertPath)
 	dockerTLSVerify = os.Getenv(client.EnvTLSVerify) != ""
-	// TODO(thaJeztah) the 'DOCKER_TLS' environment variable is not documented, and does not have a const.
-	dockerTLS = os.Getenv("DOCKER_TLS") != ""
+	dockerTLS       = os.Getenv(EnvEnableTLS) != ""
 )
 
 // ClientOptions are the options used to configure the client cli.


### PR DESCRIPTION
Add a const to allow documenting the environment variable in code. The location of this const is a bit "unfortunate", due to CLI and Client-config to be spread over the cli/config, cli/config/configfile, and docker/docker/client packages (some options are for the client, others for the CLI), and some reorganizing may be useful for easier consumption.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

