### PR TITLE
cli/command: merge DockerCliOption and InitializeOpt types

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -83,7 +83,7 @@ func RunPlugin(dockerCli *command.DockerCli, plugin *cobra.Command, meta manager
 			cmd.SetContext(ctx)
 			closeOnCLISocketClose(cancel)
 
-			var opts []command.InitializeOpt
+			var opts []command.CLIOption
 			if os.Getenv("DOCKER_CLI_PLUGIN_USE_DIAL_STDIO") != "" {
 				opts = append(opts, withPluginClientConn(plugin.Name()))
 			}
@@ -129,7 +129,7 @@ func Run(makeCmd func(command.Cli) *cobra.Command, meta manager.Metadata) {
 	}
 }
 
-func withPluginClientConn(name string) command.InitializeOpt {
+func withPluginClientConn(name string) command.CLIOption {
 	return command.WithInitializeClient(func(dockerCli *command.DockerCli) (client.APIClient, error) {
 		cmd := "docker"
 		if x := os.Getenv(manager.ReexecEnvvar); x != "" {

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -176,7 +176,7 @@ func (tcmd *TopLevelCommand) HandleGlobalFlags() (*cobra.Command, []string, erro
 }
 
 // Initialize finalises global option parsing and initializes the docker client.
-func (tcmd *TopLevelCommand) Initialize(ops ...command.InitializeOpt) error {
+func (tcmd *TopLevelCommand) Initialize(ops ...command.CLIOption) error {
 	tcmd.opts.SetDefaultOptions(tcmd.flags)
 	return tcmd.dockerCli.Initialize(tcmd.opts, ops...)
 }

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -49,7 +49,7 @@ type Cli interface {
 	Client() client.APIClient
 	Streams
 	SetIn(in *streams.In)
-	Apply(ops ...DockerCliOption) error
+	Apply(ops ...CLIOption) error
 	ConfigFile() *configfile.ConfigFile
 	ServerInfo() ServerInfo
 	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
@@ -194,11 +194,8 @@ func (cli *DockerCli) RegistryClient(allowInsecure bool) registryclient.Registry
 	return registryclient.NewRegistryClient(resolver, UserAgent(), allowInsecure)
 }
 
-// InitializeOpt is the type of the functional options passed to DockerCli.Initialize
-type InitializeOpt func(dockerCli *DockerCli) error
-
 // WithInitializeClient is passed to DockerCli.Initialize by callers who wish to set a particular API Client for use by the CLI.
-func WithInitializeClient(makeClient func(dockerCli *DockerCli) (client.APIClient, error)) InitializeOpt {
+func WithInitializeClient(makeClient func(dockerCli *DockerCli) (client.APIClient, error)) CLIOption {
 	return func(dockerCli *DockerCli) error {
 		var err error
 		dockerCli.client, err = makeClient(dockerCli)
@@ -208,7 +205,7 @@ func WithInitializeClient(makeClient func(dockerCli *DockerCli) (client.APIClien
 
 // Initialize the dockerCli runs initialization that must happen after command
 // line flags are parsed.
-func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...InitializeOpt) error {
+func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption) error {
 	for _, o := range ops {
 		if err := o(cli); err != nil {
 			return err
@@ -450,7 +447,7 @@ func (cli *DockerCli) initialize() error {
 }
 
 // Apply all the operation on the cli
-func (cli *DockerCli) Apply(ops ...DockerCliOption) error {
+func (cli *DockerCli) Apply(ops ...CLIOption) error {
 	for _, op := range ops {
 		if err := op(cli); err != nil {
 			return err
@@ -479,8 +476,8 @@ type ServerInfo struct {
 // NewDockerCli returns a DockerCli instance with all operators applied on it.
 // It applies by default the standard streams, and the content trust from
 // environment.
-func NewDockerCli(ops ...DockerCliOption) (*DockerCli, error) {
-	defaultOps := []DockerCliOption{
+func NewDockerCli(ops ...CLIOption) (*DockerCli, error) {
+	defaultOps := []CLIOption{
 		WithContentTrustFromEnv(),
 		WithDefaultContextStoreConfig(),
 		WithStandardStreams(),

--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -10,11 +10,21 @@ import (
 	"github.com/moby/term"
 )
 
+// CLIOption applies a modification on a DockerCli.
+type CLIOption func(cli *DockerCli) error
+
 // DockerCliOption applies a modification on a DockerCli.
-type DockerCliOption func(cli *DockerCli) error
+//
+// Deprecated: use [CLIOption] instead.
+type DockerCliOption = CLIOption
+
+// InitializeOpt is the type of the functional options passed to DockerCli.Initialize
+//
+// Deprecated: use [CLIOption] instead.
+type InitializeOpt = CLIOption
 
 // WithStandardStreams sets a cli in, out and err streams with the standard streams.
-func WithStandardStreams() DockerCliOption {
+func WithStandardStreams() CLIOption {
 	return func(cli *DockerCli) error {
 		// Set terminal emulation based on platform as required.
 		stdin, stdout, stderr := term.StdStreams()
@@ -26,7 +36,7 @@ func WithStandardStreams() DockerCliOption {
 }
 
 // WithCombinedStreams uses the same stream for the output and error streams.
-func WithCombinedStreams(combined io.Writer) DockerCliOption {
+func WithCombinedStreams(combined io.Writer) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.out = streams.NewOut(combined)
 		cli.err = combined
@@ -35,7 +45,7 @@ func WithCombinedStreams(combined io.Writer) DockerCliOption {
 }
 
 // WithInputStream sets a cli input stream.
-func WithInputStream(in io.ReadCloser) DockerCliOption {
+func WithInputStream(in io.ReadCloser) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.in = streams.NewIn(in)
 		return nil
@@ -43,7 +53,7 @@ func WithInputStream(in io.ReadCloser) DockerCliOption {
 }
 
 // WithOutputStream sets a cli output stream.
-func WithOutputStream(out io.Writer) DockerCliOption {
+func WithOutputStream(out io.Writer) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.out = streams.NewOut(out)
 		return nil
@@ -51,7 +61,7 @@ func WithOutputStream(out io.Writer) DockerCliOption {
 }
 
 // WithErrorStream sets a cli error stream.
-func WithErrorStream(err io.Writer) DockerCliOption {
+func WithErrorStream(err io.Writer) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.err = err
 		return nil
@@ -59,7 +69,7 @@ func WithErrorStream(err io.Writer) DockerCliOption {
 }
 
 // WithContentTrustFromEnv enables content trust on a cli from environment variable DOCKER_CONTENT_TRUST value.
-func WithContentTrustFromEnv() DockerCliOption {
+func WithContentTrustFromEnv() CLIOption {
 	return func(cli *DockerCli) error {
 		cli.contentTrust = false
 		if e := os.Getenv("DOCKER_CONTENT_TRUST"); e != "" {
@@ -73,7 +83,7 @@ func WithContentTrustFromEnv() DockerCliOption {
 }
 
 // WithContentTrust enables content trust on a cli.
-func WithContentTrust(enabled bool) DockerCliOption {
+func WithContentTrust(enabled bool) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.contentTrust = enabled
 		return nil
@@ -81,7 +91,7 @@ func WithContentTrust(enabled bool) DockerCliOption {
 }
 
 // WithDefaultContextStoreConfig configures the cli to use the default context store configuration.
-func WithDefaultContextStoreConfig() DockerCliOption {
+func WithDefaultContextStoreConfig() CLIOption {
 	return func(cli *DockerCli) error {
 		cli.contextStoreConfig = DefaultContextStoreConfig()
 		return nil
@@ -89,7 +99,7 @@ func WithDefaultContextStoreConfig() DockerCliOption {
 }
 
 // WithAPIClient configures the cli to use the given API client.
-func WithAPIClient(c client.APIClient) DockerCliOption {
+func WithAPIClient(c client.APIClient) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.client = c
 		return nil


### PR DESCRIPTION
The cli/command package defined two option-types with the same signature.

This patch creates a new type instead (CLIOption), and makes the existing types an alias for this (deprecating their old names).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

