### PR TITLE
cli: move "config" flag to cli/flags/ClientOptions.InstallFlags()

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -9,7 +9,6 @@ import (
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/config"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/registry"
@@ -24,10 +23,8 @@ import (
 // setupCommonRootCommand contains the setup common to
 // SetupRootCommand and SetupPluginRootCommand.
 func setupCommonRootCommand(rootCmd *cobra.Command) (*cliflags.ClientOptions, *pflag.FlagSet, *cobra.Command) {
-	opts := cliflags.NewClientOptions()
 	flags := rootCmd.Flags()
-
-	flags.StringVar(&opts.ConfigDir, "config", config.Dir(), "Location of client config files")
+	opts := cliflags.NewClientOptions()
 	opts.InstallFlags(flags)
 
 	cobra.AddTemplateFunc("add", func(a, b int) int { return a + b })

--- a/cli/flags/options.go
+++ b/cli/flags/options.go
@@ -73,10 +73,12 @@ func NewClientOptions() *ClientOptions {
 
 // InstallFlags adds flags for the common options on the FlagSet
 func (o *ClientOptions) InstallFlags(flags *pflag.FlagSet) {
+	configDir := config.Dir()
 	if dockerCertPath == "" {
-		dockerCertPath = config.Dir()
+		dockerCertPath = configDir
 	}
 
+	flags.StringVar(&o.ConfigDir, "config", configDir, "Location of client config files")
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug", "info", "warn", "error", "fatal")`)
 	flags.BoolVar(&o.TLS, "tls", dockerTLS, "Use TLS; implied by --tlsverify")


### PR DESCRIPTION
This flag was kept separate from the other flags, because at the time, the CLI code and Daemon code still used the same codebase, and shared some parts. This option only applied to the `docker` CLI, and thus was kept separate when migrating to Cobra in https://github.com/moby/moby/commit/0452ff5a4dd1b8fba707235d6f12a4038208f34b (https://github.com/moby/moby/pull/25354)

Now that this code is only used for the CLI (and plugins), we can move this flag together with the other flags.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

