### PR TITLE
metrics-addr is not experimental anymore since 20.10

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -958,8 +958,6 @@ the `--cgroup-parent` option on the daemon.
 #### Daemon metrics
 
 The `--metrics-addr` option takes a TCP address to serve the metrics API.
-This feature is still experimental, therefore, the daemon must be running in experimental
-mode for this feature to work.
 
 To serve the metrics API on `localhost:9323` you would specify `--metrics-addr 127.0.0.1:9323`,
 allowing you to make requests on the API at `127.0.0.1:9323/metrics` to receive metrics in the


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/40427
- relates to https://github.com/moby/moby/issues/27307

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Removed obsolete phrases about `experimental` aspect of `metrics-addr`, see https://github.com/moby/moby/commit/f337a8d21d9902772a766f57475a5512405c86c5

**- How to verify it**
Preview the page [docs/reference/commandline/dockerd.md](docs/reference/commandline/dockerd.md) of this commit

**- Description for the changelog**
Fix doc mentioning `metrics-addr` as still `experimental`


**- A picture of a cute animal (not mandatory but encouraged)**
https://twitter.com/TweetsOfCats/status/1674110876863823891
