### PR TITLE
docker info: fix condition for printing debug information

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -313,7 +313,12 @@ func prettyPrintServerInfo(streams command.Streams, info *info) []error {
 	fprintln(output, " Docker Root Dir:", info.DockerRootDir)
 	fprintln(output, " Debug Mode:", info.Debug)
 
-	if info.Debug {
+	// The daemon collects this information regardless if "debug" is
+	// enabled. Print the debugging information if either the daemon,
+	// or the client has debug enabled. We should probably improve this
+	// logic and print any of these if set (but some special rules are
+	// needed for file-descriptors, which may use "-1".
+	if info.Debug || debug.IsEnabled() {
 		fprintln(output, "  File Descriptors:", info.NFd)
 		fprintln(output, "  Goroutines:", info.NGoroutines)
 		fprintln(output, "  System Time:", info.SystemTime)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/45848
- https://github.com/moby/moby/issues/45842


The daemon collects this information regardless if "debug" is enabled. Print the debugging information if either the daemon, or the client has debug enabled.

We should probably improve this logic and print any of these if set (but some special rules are needed for file-descriptors, which may use "-1".

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

