### PR TITLE
commandconn: return original error while closing

### DIFF
--- a/cli/connhelper/commandconn/commandconn.go
+++ b/cli/connhelper/commandconn/commandconn.go
@@ -163,9 +163,8 @@ func (c *commandConn) Read(p []byte) (int, error) {
 	// Close might get called
 	if c.closing.Load() {
 		// If we're currently closing the connection
-		// we don't want to call onEOF, but we do want
-		// to return an io.EOF
-		return 0, io.EOF
+		// we don't want to call onEOF
+		return n, err
 	}
 
 	return n, c.handleEOF(err)
@@ -178,9 +177,8 @@ func (c *commandConn) Write(p []byte) (int, error) {
 	// Close might get called
 	if c.closing.Load() {
 		// If we're currently closing the connection
-		// we don't want to call onEOF, but we do want
-		// to return an io.EOF
-		return 0, io.EOF
+		// we don't want to call onEOF
+		return n, err
 	}
 
 	return n, c.handleEOF(err)

--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -5,6 +5,7 @@ package commandconn
 import (
 	"context"
 	"io"
+	"io/fs"
 	"testing"
 	"time"
 
@@ -178,7 +179,8 @@ func TestCloseWhileWriting(t *testing.T) {
 	assert.Check(t, !process.Alive(cmdConn.cmd.Process.Pid))
 
 	writeErr := <-writeErrC
-	assert.ErrorContains(t, writeErr, "EOF")
+	assert.ErrorContains(t, writeErr, "file already closed")
+	assert.Check(t, is.ErrorIs(writeErr, fs.ErrClosed))
 }
 
 func TestCloseWhileReading(t *testing.T) {
@@ -208,5 +210,5 @@ func TestCloseWhileReading(t *testing.T) {
 	assert.Check(t, !process.Alive(cmdConn.cmd.Process.Pid))
 
 	readErr := <-readErrC
-	assert.ErrorContains(t, readErr, "EOF")
+	assert.Check(t, is.ErrorIs(readErr, fs.ErrClosed))
 }


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/4356

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixes the flaky `TestCloseWhileWriting` and `TestCloseWhileReading` tests.

**- How I did it**

Changes the `Read` and `Write` error handling logic to return the original error while closing the connection. We still skip calling `handleEOF` if already closing the connection.

**- How to verify it**

`go test -v ./...`, and make sure everything still works.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
