### PR TITLE
docker swarm init: fix help printing

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -229,14 +229,11 @@ func setupHelpCommand(dockerCli command.Cli, rootCmd, helpCmd *cobra.Command) {
 	}
 }
 
-func tryRunPluginHelp(dockerCli command.Cli, ccmd *cobra.Command, cargs []string) error {
-	root := ccmd.Root()
-
-	cmd, _, err := root.Traverse(cargs)
-	if err != nil {
-		return err
+func tryRunPluginHelp(dockerCli command.Cli, ccmd *cobra.Command) error {
+	if !pluginmanager.IsPluginCommand(ccmd) {
+		return errdefs.ErrNotFound
 	}
-	helpcmd, err := pluginmanager.PluginRunCommand(dockerCli, cmd.Name(), root)
+	helpcmd, err := pluginmanager.PluginRunCommand(dockerCli, ccmd.Name(), ccmd.Root())
 	if err != nil {
 		return err
 	}
@@ -251,8 +248,8 @@ func setHelpFunc(dockerCli command.Cli, cmd *cobra.Command) {
 			return
 		}
 
-		if len(args) >= 1 {
-			err := tryRunPluginHelp(dockerCli, ccmd, args)
+		if pluginmanager.IsPluginCommand(ccmd) {
+			err := tryRunPluginHelp(dockerCli, ccmd)
 			if err == nil {
 				return
 			}

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -204,4 +206,40 @@ func TestVisitAll(t *testing.T) {
 	})
 	expected := []string{"sub1sub1", "sub1sub2", "sub1", "sub2", "root"}
 	assert.DeepEqual(t, expected, visited)
+}
+
+func TestSwarmInitHelpNotDelegatedToInitPlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+	pluginScript := `#!/bin/sh
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	echo "PLUGIN INIT HELP"
+	exit 0
+fi
+printf '%s' '{"SchemaVersion":"0.1.0","ShortDescription":"Docker Init"}'
+`
+	pluginPath := filepath.Join(tmpDir, "docker-init")
+	err := os.WriteFile(pluginPath, []byte(pluginScript), 0o755)
+	assert.NilError(t, err)
+
+	var b bytes.Buffer
+	ctx := context.Background()
+	cli, err := command.NewDockerCli(
+		command.WithBaseContext(ctx),
+		command.WithCombinedStreams(&b),
+	)
+	assert.NilError(t, err)
+	cli.ConfigFile().CLIPluginsExtraDirs = []string{tmpDir}
+
+	tcmd := newDockerCommand(cli)
+	tcmd.SetArgs([]string{"swarm", "init", "--help"})
+	cmd, args, err := tcmd.HandleGlobalFlags()
+	assert.NilError(t, err)
+	assert.NilError(t, tcmd.Initialize())
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	assert.NilError(t, err)
+
+	out := b.String()
+	assert.Assert(t, is.Contains(out, "Initialize a swarm"))
+	assert.Assert(t, !strings.Contains(out, "PLUGIN INIT HELP"), "output: %s", out)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

fixes #4400

On the `setHelpFunc` function it tries to execute plugins's helps at first based in the ammount of arguments, the help for `docker swarm init --help` was getting matched with `docker-init` plugin, thus printing pluging help to output

To fix this we make sure that even thought we have 1 or more arguments it will check if the command it's first level of command by checking that the root command is the same as the parent command 

**- What I did**

**- How I did it**

**- How to verify it**

* compile with `docker buildx bake`
* execute `swarm init` command with `--help` flag `./build/docker swarm init --help`

expected output
```
➜  cli git:(fix-swarm-init-help) ./build/docker swarm init --help

Usage:  docker swarm init [OPTIONS]

Initialize a swarm

Options:
      --advertise-addr string                  Advertised address (format: "<ip|interface>[:port]")
      --autolock                               Enable manager autolocking (requiring an unlock key to start a stopped manager)
      --availability string                    Availability of the node ("active", "pause", "drain") (default "active")
      --cert-expiry duration                   Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
      --data-path-addr string                  Address or interface to use for data path traffic (format: "<ip|interface>")
      --data-path-port uint32                  Port number to use for data path traffic (1024 - 49151). If no value is set or is set to 0, the default port
                                               (4789) is used.
      --default-addr-pool ipNetSlice           default address pool in CIDR format (default [])
      --default-addr-pool-mask-length uint32   default address pool subnet mask length (default 24)
      --dispatcher-heartbeat duration          Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
      --external-ca external-ca                Specifications of one or more certificate signing endpoints
      --force-new-cluster                      Force create a new cluster from current state
      --listen-addr node-addr                  Listen address (format: "<ip|interface>[:port]") (default 0.0.0.0:2377)
      --max-snapshots uint                     Number of additional Raft snapshots to retain
      --snapshot-interval uint                 Number of log entries between Raft snapshots (default 10000)
      --task-history-limit int                 Task history retention limit (default 5)
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix to prevent wrong help message for commands with same name than docker plugins

**- A picture of a cute animal (not mandatory but encouraged)**
![ebdde703e6208406edeeabccf29ec2d6](https://github.com/docker/cli/assets/7015094/585db25f-0d20-4d34-a55c-99a44469ba9b)

