### PR TITLE
cli/container: Don't ignore error when parsing volume spec

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -358,7 +358,10 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	volumes := copts.volumes.GetMap()
 	// add any bind targets to the list of container volumes
 	for bind := range copts.volumes.GetMap() {
-		parsed, _ := loader.ParseVolume(bind)
+		parsed, err := loader.ParseVolume(bind)
+		if err != nil {
+			return nil, err
+		}
 
 		if parsed.Source != "" {
 			toBind := bind

--- a/cli/compose/loader/volume_test.go
+++ b/cli/compose/loader/volume_test.go
@@ -223,3 +223,8 @@ func TestParseVolumeInvalidSections(t *testing.T) {
 	_, err := ParseVolume("/foo::rw")
 	assert.ErrorContains(t, err, "invalid spec")
 }
+
+func TestParseVolumeWithEmptySource(t *testing.T) {
+	_, err := ParseVolume(":/vol")
+	assert.ErrorContains(t, err, "empty section between colons")
+}

--- a/e2e/container/create_test.go
+++ b/e2e/container/create_test.go
@@ -101,3 +101,19 @@ func TestTrustedCreateFromBadTrustServer(t *testing.T) {
 		Err:      "could not rotate trust to a new trusted root",
 	})
 }
+
+func TestCreateWithEmptySourceVolume(t *testing.T) {
+	icmd.RunCmd(icmd.Command("docker", "create", "-v", ":/volume", fixtures.AlpineImage)).
+		Assert(t, icmd.Expected{
+			ExitCode: 125,
+			Err:      "empty section between colons",
+		})
+}
+
+func TestCreateWithEmptyVolumeSpec(t *testing.T) {
+	icmd.RunCmd(icmd.Command("docker", "create", "-v", "", fixtures.AlpineImage)).
+		Assert(t, icmd.Expected{
+			ExitCode: 125,
+			Err:      "invalid empty volume spec",
+		})
+}


### PR DESCRIPTION
- Related to: https://github.com/docker/cli/pull/152

- Fixes: https://github.com/docker/cli/issues/4053

**- What I did**
Handle error when parsing an invalid volume spec.

This was discovered when analyzing issue reported by @trungutt  where
`docker run -v $empty_var:/vol  alpine` would result in anonymous volume being mounted at `/vol`.

**- How I did it**

**- How to verify it**
CI tests:
unit: TestParseVolumeWithEmptySource
e2e: TestCreateWithEmptySourceVolume
e2e: TestCreateWithEmptyVolumeSpec

**- Description for the changelog**
- Fix container being created with unexpected volume configuration when volume specification can't be parsed correctly

**- A picture of a cute animal (not mandatory but encouraged)**

