### PR TITLE
docker stack config environment variable merge is not as expected

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -126,7 +126,9 @@ func toServiceVolumeConfigsMap(s interface{}) (map[interface{}]interface{}, erro
 	}
 	m := map[interface{}]interface{}{}
 	for _, v := range volumes {
-		m[v.Target] = v
+		if _, exists := m[v.Target]; !exists {
+			m[v.Target] = v
+		}
 	}
 	return m, nil
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

Fixes #4417 

Please provide the following information:
-->

**- What I did**
When making changes, if the destination slice already has a volume configuration with a specific Target value, it will not be replaced by a volume configuration from the source slice with the same Target value during the merging process.

**- How I did it**
I added if statement.

**- How to verify it**

Reproduce
1. Create a docker-compose file as a base with name override.yml
```
version: "3.8"
services:
  test:
    environment:
      TEST: "1"
      TEST_ENV: test_value
```
2. Create a docker-compose file with the name main.yml as overwrite with an environment variable with an empty value
```
version: "3.8"
services:
  test:
    environment:
      TEST_ENV: ''
```
3. Run docker stack config -c main.yml -c override.yml to merge the files

**Expected behavior**
The output of docker stack config -c main.yml -c override.yml should be
```
version: '3.8'
services:
  test:
    environment:
      TEST: 1
      TEST_ENV: ''
```
**- Description for the changelog**
When making changes, if the destination slice already has a volume configuration with a specific Target value, it will not be replaced by a volume configuration from the source slice with the same Target value during the merging process.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/6159524/51f06265-83d4-4eff-8148-9bba2a466dff)

