### PR TITLE
cli/command/container: deprecate NewStartOptions

### DIFF
--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -27,7 +27,9 @@ type StartOptions struct {
 	Containers []string
 }
 
-// NewStartOptions creates a new StartOptions
+// NewStartOptions creates a new StartOptions.
+//
+// Deprecated: create a new [StartOptions] directly.
 func NewStartOptions() StartOptions {
 	return StartOptions{}
 }


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/10828

It's unused in the CLI itself, and does nothing other than initializing a new, empty StartOptions struct.


**- A picture of a cute animal (not mandatory but encouraged)**

