### PR TITLE
[24.0 backport] configfile: Initialize nil AuthConfigs

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -94,6 +94,9 @@ func (configFile *ConfigFile) ContainsAuth() bool {
 
 // GetAuthConfigs returns the mapping of repo to auth configuration
 func (configFile *ConfigFile) GetAuthConfigs() map[string]types.AuthConfig {
+	if configFile.AuthConfigs == nil {
+		configFile.AuthConfigs = make(map[string]types.AuthConfig)
+	}
 	return configFile.AuthConfigs
 }
 

--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -52,7 +52,8 @@ func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
 
 // Store saves the given credentials in the file store.
 func (c *fileStore) Store(authConfig types.AuthConfig) error {
-	c.file.GetAuthConfigs()[authConfig.ServerAddress] = authConfig
+	authConfigs := c.file.GetAuthConfigs()
+	authConfigs[authConfig.ServerAddress] = authConfig
 	return c.file.Save()
 }
 


### PR DESCRIPTION
- (properly) backport: https://github.com/docker/cli/pull/4418

Initialize AuthConfigs map if it's nil before returning it. This fixes fileStore.Store nil dereference panic when adding a new key to the map.


(cherry picked from commit ad43df5e86f990a7e768087e546f1da75b887023)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

