### PR TITLE
Fixed scientific convention issue in image size

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -250,7 +250,7 @@ func (c *imageContext) CreatedAt() string {
 }
 
 func (c *imageContext) Size() string {
-	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
+	return units.HumanSize(float64(c.i.Size))
 }
 
 func (c *imageContext) Containers() string {

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -41,6 +41,11 @@ func TestImageContext(t *testing.T) {
 			call:     ctx.Size,
 		},
 		{
+			imageCtx: imageContext{i: types.ImageSummary{Size: 999900000}, trunc: true},
+			expValue: "999.9MB",
+			call:     ctx.Size,
+		},
+		{
 			imageCtx: imageContext{i: types.ImageSummary{Created: unix}, trunc: true},
 			expValue: time.Unix(unix, 0).String(), call: ctx.CreatedAt,
 		},


### PR DESCRIPTION
This fixes #3091

In this code [`HumanSizeWithPrecision()`](https://github.com/docker/go-units/blob/master/size.go) method is used.

This method takes two parameters `size` and `precision`. 

**- Here is what I did:**

I tried to reproduce the bug with this code.

```
package main

import (
	"fmt"

	"github.com/docker/go-units"
)

func main() {
	fmt.Println(units.HumanSizeWithPrecision(float64(999900000), 3))
}
```
And this resulted in `1e+03MB` being output.

So I changed precision from `3` to `4` like the following.

```
package main

import (
	"fmt"

	"github.com/docker/go-units"
)

func main() {
	fmt.Println(units.HumanSizeWithPrecision(float64(999900000), 4))
}

``` 
And this gave me `999.9MB` output.

In conclusion, this unexpected scientific convention results when we use precision `3`.

In [go-unit](https://github.com/docker/go-units/blob/master/size.go) library the `HumanSize()` method uses `HumanSizeWithPrecision(size, 4)`  method under the hood, So I used `HumanSize()` instead of using `HumanSizeWithPrecision()`.


**- Description for the changelog**

Replaced HumanSizeWithPrecision() with HumanSize().


**- A picture of a cute animal (not mandatory but encouraged)**
![An image of a cool looking cat](https://t4.ftcdn.net/jpg/05/62/99/31/360_F_562993122_e7pGkeY8yMfXJcRmclsoIjtOoVDDgIlh.jpg "a title")

