### PR TITLE
Update docs/command output for volume pruning

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -48,7 +48,7 @@ func newPruneCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused images not just dangling ones")
-	flags.BoolVar(&options.pruneVolumes, "volumes", false, "Prune volumes")
+	flags.BoolVar(&options.pruneVolumes, "volumes", false, "Prune anonymous volumes")
 	flags.Var(&options.filter, "filter", `Provide filter values (e.g. "label=<key>=<value>")`)
 	// "filter" flag is available in 1.28 (docker 17.04) and up
 	flags.SetAnnotation("filter", "version", []string{"1.28"})
@@ -114,7 +114,7 @@ func confirmationMessage(dockerCli command.Cli, options pruneOptions) string {
 		"all networks not used by at least one container",
 	}
 	if options.pruneVolumes {
-		warnings = append(warnings, "all volumes not used by at least one container")
+		warnings = append(warnings, "all anonymous volumes not used by at least one container")
 	}
 	if options.all {
 		warnings = append(warnings, "all images without at least one container associated to them")

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -27,7 +27,7 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prune [OPTIONS]",
-		Short: "Remove all unused local volumes",
+		Short: "Remove unused local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			spaceReclaimed, output, err := runPrune(dockerCli, options)

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -101,7 +101,7 @@ read the [`dockerd`](dockerd.md) reference page.
 | [volume create](volume_create.md)   | Creates a new volume where containers can consume and store data |
 | [volume inspect](volume_inspect.md) | Display information about a volume                               |
 | [volume ls](volume_ls.md)           | Lists all the volumes Docker knows about                         |
-| [volume prune](volume_prune.md)     | Remove all unused local volumes                                  |
+| [volume prune](volume_prune.md)     | Remove unused local volumes                                      |
 | [volume rm](volume_rm.md)           | Remove one or more volumes                                       |
 
 ### Swarm node commands

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -10,7 +10,7 @@ Remove unused data
 | `-a`, `--all`         |          |         | Remove all unused images not just dangling ones    |
 | [`--filter`](#filter) | `filter` |         | Provide filter values (e.g. `label=<key>=<value>`) |
 | `-f`, `--force`       |          |         | Do not prompt for confirmation                     |
-| `--volumes`           |          |         | Prune volumes                                      |
+| `--volumes`           |          |         | Prune anonymous volumes                            |
 
 
 <!---MARKER_GEN_END-->
@@ -50,7 +50,7 @@ Total reclaimed space: 1.84kB
 
 By default, volumes are not removed to prevent important data from being
 deleted if there is currently no container using the volume. Use the `--volumes`
-flag when running the command to prune volumes as well:
+flag when running the command to prune anonymous volumes as well:
 
 ```console
 $ docker system prune -a --volumes
@@ -58,7 +58,7 @@ $ docker system prune -a --volumes
 WARNING! This will remove:
         - all stopped containers
         - all networks not used by at least one container
-        - all volumes not used by at least one container
+        - all anonymous volumes not used by at least one container
         - all images without at least one container associated to them
         - all build cache
 Are you sure you want to continue? [y/N] y

--- a/docs/reference/commandline/volume.md
+++ b/docs/reference/commandline/volume.md
@@ -10,7 +10,7 @@ Manage volumes
 | [`create`](volume_create.md)   | Create a volume                                     |
 | [`inspect`](volume_inspect.md) | Display detailed information on one or more volumes |
 | [`ls`](volume_ls.md)           | List volumes                                        |
-| [`prune`](volume_prune.md)     | Remove all unused local volumes                     |
+| [`prune`](volume_prune.md)     | Remove unused local volumes                         |
 | [`rm`](volume_rm.md)           | Remove one or more volumes                          |
 | [`update`](volume_update.md)   | Update a volume (cluster volumes only)              |
 

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -1,7 +1,7 @@
 # volume prune
 
 <!---MARKER_GEN_START-->
-Remove all unused local volumes
+Remove unused local volumes
 
 ### Options
 


### PR DESCRIPTION
In previous versions of the Docker API, `system prune --volumes` and `volume prune` would remove all dangling volumes. With API v1.42, this was changed so that only anonymous volumes would be removed unless the all filter was specified.

Some of the docs were updated in #4218, however, there were a couple of places left that didn't make the anonymous vs named volumes distinction clear.

This replaces #4079, which was bitrotted by #4218. See also #4028.

Closes #4079.

**- What I did**
* Updated the `docker system prune --help` usage text's description of the `--volumes` option
* Updated the command log output for `docker system prune --volumes` to be clearer that only anonymous volumes will be removed
* Updated the `docker volume prune --help` usage text, so the overall command description no longer confusingly uses the word "all", given that by default it doesn't remove all volumes

**- How I did it**
See above

**- How to verify it**
Run `docker system prune --help`, `docker system prune --volumes` and `docker volume prune --help`.

**- Description for the changelog**
N/A (since these are only single word edits to usage text/misc command output, I don't think it needs a changelog entry - happy to add one if preferred though).

**- A picture of a cute animal (not mandatory but encouraged)**

