### PR TITLE
[24.0 backport] login: Add message about using PATs

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/docker/cli/cli/hints"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -18,6 +19,10 @@ import (
 	"github.com/moby/term"
 	"github.com/pkg/errors"
 )
+
+const patSuggest = "You can log in with your password or a Personal Access " +
+	"Token (PAT). Using a limited-scope PAT grants better security and is required " +
+	"for organizations using SSO. Learn more at https://docs.docker.com/go/access-tokens/"
 
 // EncodeAuthToBase64 serializes the auth configuration as JSON base64 payload.
 //
@@ -113,7 +118,11 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 	if flUser = strings.TrimSpace(flUser); flUser == "" {
 		if isDefaultRegistry {
 			// if this is a default registry (docker hub), then display the following message.
-			fmt.Fprintln(cli.Out(), "Login with your Docker ID to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com to create one.")
+			fmt.Fprintln(cli.Out(), "Log in with your Docker ID or email address to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com/ to create one.")
+			if hints.Enabled() {
+				fmt.Fprintln(cli.Out(), patSuggest)
+				fmt.Fprintln(cli.Out())
+			}
 		}
 		promptWithDefault(cli.Out(), "Username", authconfig.Username)
 		var err error

--- a/cli/hints/hints.go
+++ b/cli/hints/hints.go
@@ -1,0 +1,18 @@
+package hints
+
+import (
+	"os"
+	"strconv"
+)
+
+// Enabled returns whether cli hints are enabled or not
+func Enabled() bool {
+	if v := os.Getenv("DOCKER_CLI_HINTS"); v != "" {
+		enabled, err := strconv.ParseBool(v)
+		if err != nil {
+			return true
+		}
+		return enabled
+	}
+	return true
+}


### PR DESCRIPTION
- Backport of https://github.com/docker/cli/pull/4478
- Slight conflict due to a lack of https://github.com/docker/cli/pull/4280

---

**- What I did**

Added a hint about using PATs

```console
$ docker login
Log in with your Docker ID or email address to push and pull images from Docker Hub. If you don't have a Docker ID, head over to https://hub.docker.com/ to create one.
You can log in with your password or a Personal Access Token (PAT). Using a limited-scope PAT grants better security and is required for organizations using SSO. Learn more at https://docs.docker.com/go/access-tokens/

Username: 
```

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

