### PR TITLE
cli/command/system/runInfo: set client API defaults, and negotiated API version when available

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -101,11 +101,14 @@ func runInfo(ctx context.Context, cmd *cobra.Command, dockerCli command.Cli, opt
 	var serverConnErr error
 	if needsServerInfo(opts.format, info) {
 		serverConnErr = addServerInfo(ctx, dockerCli, opts.format, &info)
+		if serverConnErr == nil {
+			// Update client API version after it was negotiated.
+			info.ClientInfo.APIVersion = dockerCli.CurrentVersion()
+		}
 	}
 
 	if opts.format == "" {
 		info.UserName = dockerCli.ConfigFile().AuthConfigs[registry.IndexServer].Username
-		info.ClientInfo.APIVersion = dockerCli.CurrentVersion()
 		return errors.Join(prettyPrintInfo(dockerCli, info), serverConnErr)
 	}
 

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -91,6 +91,7 @@ type clientVersion struct {
 func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
 	v := clientVersion{
 		Version:           version.Version,
+		APIVersion:        api.DefaultVersion,
 		DefaultAPIVersion: api.DefaultVersion,
 		GoVersion:         runtime.Version(),
 		GitCommit:         version.GitCommit,


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4506
- relates to https://github.com/docker/cli/pull/4505


### cli/command/system/runInfo: set negotiated API version when available

The current logic was ignoring (e.g.) `--format=json` formats, and was
only setting the negotiated API version if no format was specified.

While we do want to avoid calling the API if possible, we do already
check if the given template requires a server connection, so let's
move updating the API version to that block.


### cli/command/system/newClientVersion: initialize with default API version

Set the APIVersion and DefaultAPIVersion fields to the default version,
as that's the version the client assumes without making a API connection
to do version negotiation.

:warning: One change worth mentioning is that this means that the API version will
differ, depending on the format:

If no server information is fetched:

    docker info --format='{{ json .ClientInfo }}' | jq .ApiVersion
    "1.44"

If server information is fetched:

    docker info --format='{{ json .}}' | jq .ClientInfo.ApiVersion
    "1.43"

An alternative could be to leave the ApiVersion field empty if no
negotiation took place.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

