### PR TITLE
[24.0 backport] cli/registry/client: set actions when authn with token

### DIFF
--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
 	distributionclient "github.com/docker/distribution/registry/client"
@@ -77,6 +78,7 @@ func (c *client) MountBlob(ctx context.Context, sourceRef reference.Canonical, t
 	if err != nil {
 		return err
 	}
+	repoEndpoint.actions = trust.ActionsPushAndPull
 	repo, err := c.getRepositoryForReference(ctx, targetRef, repoEndpoint)
 	if err != nil {
 		return err
@@ -102,6 +104,7 @@ func (c *client) PutManifest(ctx context.Context, ref reference.Named, manifest 
 		return digest.Digest(""), err
 	}
 
+	repoEndpoint.actions = trust.ActionsPushAndPull
 	repo, err := c.getRepositoryForReference(ctx, ref, repoEndpoint)
 	if err != nil {
 		return digest.Digest(""), err
@@ -151,7 +154,9 @@ func (c *client) getHTTPTransportForRepoEndpoint(ctx context.Context, repoEndpoi
 		c.authConfigResolver(ctx, repoEndpoint.info.Index),
 		repoEndpoint.endpoint,
 		repoEndpoint.Name(),
-		c.userAgent)
+		c.userAgent,
+		repoEndpoint.actions,
+	)
 	return httpTransport, errors.Wrap(err, "failed to configure transport")
 }
 


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4511
- fixes https://github.com/docker/cli/issues/4345
- fixes https://github.com/moby/moby/issues/45726


When using a personal access token, Docker Hub produces an error if actions are requested beyond the token's allowed actions. This resulted in errors when using a PAT with limited permissions to do a "docker manifest inspect".

This patch sets actions to "pull" only by default, and requests "push" action for requests that need it.

To verify:

- create a PAT with limited access (read-only)
- log in with your username and the PAT as password

Before this patch:

    docker manifest inspect ubuntu:latest
    Get "https://registry-1.docker.io/v2/library/ubuntu/manifests/latest": unauthorized: access token has insufficient scopes

With this patch applied:

    docker manifest inspect ubuntu:latest
    {
       "schemaVersion": 2,
       "mediaType": "application/vnd.oci.image.index.v1+json",
       "manifests": [
          {
             "mediaType": "application/vnd.oci.image.manifest.v1+json",
             "size": 424,
             "digest": "sha256:56887c5194fddd8db7e36ced1c16b3569d89f74c801dc8a5adbf48236fb34564",
             "platform": {
                "architecture": "amd64",
                "os": "linux"
             }
          },
          {
             "mediaType": "application/vnd.oci.image.manifest.v1+json",
             "size": 424,
             "digest": "sha256:c835a4f2a632bc91a2b494e871549f0dd83f2966c780e66435774e77e048ddf0",
             "platform": {
                "architecture": "arm",
                "os": "linux",
                "variant": "v7"
             }
          }
       ]
    }


(cherry picked from commit d2047b954e63b1a6219c4d8891c357bfea9df5cc)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

