### PR TITLE
replace dockerfile/dockerignore with patternmatcher/ignorefile

### DIFF
--- a/cli/command/image/build/dockerignore.go
+++ b/cli/command/image/build/dockerignore.go
@@ -1,11 +1,12 @@
 package build
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/moby/patternmatcher"
+	"github.com/moby/patternmatcher/ignorefile"
 )
 
 // ReadDockerignore reads the .dockerignore file in the context directory and
@@ -22,7 +23,11 @@ func ReadDockerignore(contextDir string) ([]string, error) {
 	}
 	defer f.Close()
 
-	return dockerignore.ReadAll(f)
+	patterns, err := ignorefile.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading .dockerignore: %w", err)
+	}
+	return patterns, nil
 }
 
 // TrimBuildFilesFromExcludes removes the named Dockerfile and .dockerignore from

--- a/vendor.mod
+++ b/vendor.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.14
 	github.com/mitchellh/mapstructure v1.3.2
 	github.com/moby/buildkit v0.11.6
-	github.com/moby/patternmatcher v0.5.0
+	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/swarmkit/v2 v2.0.0-20230713153928-bc71908479e5
 	github.com/moby/sys/sequential v0.5.0
 	github.com/moby/sys/signal v0.7.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -154,8 +154,8 @@ github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYG
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/buildkit v0.11.6 h1:VYNdoKk5TVxN7k4RvZgdeM4GOyRvIi4Z8MXOY7xvyUs=
 github.com/moby/buildkit v0.11.6/go.mod h1:GCqKfHhz+pddzfgaR7WmHVEE3nKKZMMDPpK8mh3ZLv4=
-github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
-github.com/moby/patternmatcher v0.5.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/swarmkit/v2 v2.0.0-20230713153928-bc71908479e5 h1:o6x+wIX1vKD0kJlEqe8M9TLIe0SK8lnGcA6XoJtaFqg=
 github.com/moby/swarmkit/v2 v2.0.0-20230713153928-bc71908479e5/go.mod h1:XUMlwIIC+wrwBDMUjxEvk5Z8FPoIPM8LdBw7w/Zu1rg=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=

--- a/vendor/github.com/moby/patternmatcher/ignorefile/ignorefile.go
+++ b/vendor/github.com/moby/patternmatcher/ignorefile/ignorefile.go
@@ -1,4 +1,4 @@
-package dockerignore
+package ignorefile
 
 import (
 	"bufio"
@@ -6,23 +6,31 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
-// ReadAll reads a .dockerignore file and returns the list of file patterns
-// to ignore. Note this will trim whitespace from each line as well
-// as use GO's "clean" func to get the shortest/cleanest path for each.
+// ReadAll reads an ignore file from a reader and returns the list of file
+// patterns to ignore, applying the following rules:
+//
+//   - An UTF8 BOM header (if present) is stripped.
+//   - Lines starting with "#" are considered comments and are skipped.
+//
+// For remaining lines:
+//
+//   - Leading and trailing whitespace is removed from each ignore pattern.
+//   - It uses [filepath.Clean] to get the shortest/cleanest path for
+//     ignore patterns.
+//   - Leading forward-slashes ("/") are removed from ignore patterns,
+//     so "/some/path" and "some/path" are considered equivalent.
 func ReadAll(reader io.Reader) ([]string, error) {
 	if reader == nil {
 		return nil, nil
 	}
 
-	scanner := bufio.NewScanner(reader)
 	var excludes []string
 	currentLine := 0
-
 	utf8bom := []byte{0xEF, 0xBB, 0xBF}
+
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		scannedBytes := scanner.Bytes()
 		// We trim UTF8 BOM
@@ -59,7 +67,7 @@ func ReadAll(reader io.Reader) ([]string, error) {
 		excludes = append(excludes, pattern)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, errors.Wrap(err, "error reading .dockerignore")
+		return nil, err
 	}
 	return excludes, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,11 +167,11 @@ github.com/miekg/pkcs11
 github.com/mitchellh/mapstructure
 # github.com/moby/buildkit v0.11.6
 ## explicit; go 1.18
-github.com/moby/buildkit/frontend/dockerfile/dockerignore
 github.com/moby/buildkit/util/appcontext
 # github.com/moby/patternmatcher v0.6.0
 ## explicit; go 1.19
 github.com/moby/patternmatcher
+github.com/moby/patternmatcher/ignorefile
 # github.com/moby/swarmkit/v2 v2.0.0-20230713153928-bc71908479e5
 ## explicit; go 1.18
 github.com/moby/swarmkit/v2/api

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -169,7 +169,7 @@ github.com/mitchellh/mapstructure
 ## explicit; go 1.18
 github.com/moby/buildkit/frontend/dockerfile/dockerignore
 github.com/moby/buildkit/util/appcontext
-# github.com/moby/patternmatcher v0.5.0
+# github.com/moby/patternmatcher v0.6.0
 ## explicit; go 1.19
 github.com/moby/patternmatcher
 # github.com/moby/swarmkit/v2 v2.0.0-20230713153928-bc71908479e5


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4457

### vendor: github.com/moby/patternmatcher v0.6.0

- integrate frontend/dockerfile/dockerignore from buildkit

full diff: https://github.com/moby/patternmatcher/compare/v0.5.0...v0.6.0


### replace dockerfile/dockerignore for patternmatcher/ignorefile

The BuildKit dockerignore package was migrated to the patternmatcher
repository / module. This patch updates our uses of the BuildKit package
with its new location.

A small local change was made to keep the format of the existing error message,
because the "ignorefile" package is slightly more agnostic in that respect
and doesn't include ".dockerignore" in the error message.





**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

