### PR TITLE
update flag-description for --cgroup-parent

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -126,7 +126,7 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Int64Var(&options.cpuQuota, "cpu-quota", 0, "Limit the CPU CFS (Completely Fair Scheduler) quota")
 	flags.StringVar(&options.cpuSetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flags.StringVar(&options.cpuSetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
-	flags.StringVar(&options.cgroupParent, "cgroup-parent", "", "Optional parent cgroup for the container")
+	flags.StringVar(&options.cgroupParent, "cgroup-parent", "", `Set the parent cgroup for the "RUN" instructions during build`)
 	flags.StringVar(&options.isolation, "isolation", "", "Container isolation technology")
 	flags.Var(&options.labels, "label", "Set metadata for an image")
 	flags.BoolVar(&options.noCache, "no-cache", false, "Do not use cache when building the image")

--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -14,7 +14,7 @@ Build an image from a Dockerfile
 | [`--add-host`](#add-host)           | `list`        |           | Add a custom host-to-IP mapping (`host:ip`)                       |
 | [`--build-arg`](#build-arg)         | `list`        |           | Set build-time variables                                          |
 | [`--cache-from`](#cache-from)       | `stringSlice` |           | Images to consider as cache sources                               |
-| [`--cgroup-parent`](#cgroup-parent) | `string`      |           | Optional parent cgroup for the container                          |
+| [`--cgroup-parent`](#cgroup-parent) | `string`      |           | Set the parent cgroup for the `RUN` instructions during build     |
 | `--compress`                        |               |           | Compress the build context using gzip                             |
 | `--cpu-period`                      | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) period              |
 | `--cpu-quota`                       | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) quota               |

--- a/docs/reference/commandline/builder_build.md
+++ b/docs/reference/commandline/builder_build.md
@@ -14,7 +14,7 @@ Build an image from a Dockerfile
 | `--add-host`              | `list`        |           | Add a custom host-to-IP mapping (`host:ip`)                       |
 | `--build-arg`             | `list`        |           | Set build-time variables                                          |
 | `--cache-from`            | `stringSlice` |           | Images to consider as cache sources                               |
-| `--cgroup-parent`         | `string`      |           | Optional parent cgroup for the container                          |
+| `--cgroup-parent`         | `string`      |           | Set the parent cgroup for the `RUN` instructions during build     |
 | `--compress`              |               |           | Compress the build context using gzip                             |
 | `--cpu-period`            | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) period              |
 | `--cpu-quota`             | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) quota               |

--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -14,7 +14,7 @@ Build an image from a Dockerfile
 | `--add-host`              | `list`        |           | Add a custom host-to-IP mapping (`host:ip`)                       |
 | `--build-arg`             | `list`        |           | Set build-time variables                                          |
 | `--cache-from`            | `stringSlice` |           | Images to consider as cache sources                               |
-| `--cgroup-parent`         | `string`      |           | Optional parent cgroup for the container                          |
+| `--cgroup-parent`         | `string`      |           | Set the parent cgroup for the `RUN` instructions during build     |
 | `--compress`              |               |           | Compress the build context using gzip                             |
 | `--cpu-period`            | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) period              |
 | `--cpu-quota`             | `int64`       | `0`       | Limit the CPU CFS (Completely Fair Scheduler) quota               |


### PR DESCRIPTION
relates to:

- https://github.com/docker/buildx/pull/1905
- https://github.com/moby/moby/issues/34469#issuecomment-362042644



This attempts to make it clearer that the --cgroup-parent option is only used for the containers used during build. Instead of mentioning "build container", I opted for using "RUN instructions" (to match the --network description), although this may not be ideal (as it assumes the "Dockerfile" front-end, which of course may not be the case).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

