### PR TITLE
[23.0 backport] Stop slowing bash init by caching plugins path slowly

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1142,7 +1142,10 @@ __docker_complete_user_group() {
 	fi
 }
 
-DOCKER_PLUGINS_PATH=$(docker info --format '{{range .ClientInfo.Plugins}}{{.Path}}:{{end}}')
+__docker_plugins_path() {
+	local docker_plugins_path=$(docker info --format '{{range .ClientInfo.Plugins}}{{.Path}}:{{end}}')
+	echo "${docker_plugins_path//:/ }"
+}
 
 __docker_complete_plugin() {
 	local path=$1
@@ -5503,7 +5506,7 @@ _docker() {
 	# Create completion functions for all registered plugins
 	local known_plugin_commands=()
 	local plugin_name=""
-	for plugin_path in ${DOCKER_PLUGINS_PATH//:/ }; do
+	for plugin_path in $(__docker_plugins_path); do
 		plugin_name=$(basename "$plugin_path" | sed 's/ *$//')
 		plugin_name=${plugin_name#docker-}
 		plugin_name=${plugin_name%%.*}


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4505
- fixes https://github.com/docker/cli/issues/3889


Fixes issue #3889 by only loading docker plugins path when needed: if it is fast enough than it shouldn't be a problem to do this on demand; OTOH if it is slow then we shouldn't do this during *every* bash session initialization, regardless if docker completion will be needed or not.


(cherry picked from commit 1da67be9caf37a4f0b297cfd41da3ab41c2bd2c7)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

