### PR TITLE
Add documentation for CDI support

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -672,7 +672,7 @@ the container exits**, you can add the `--rm` flag:
 > ```console
 > $ docker run --rm -v /foo -v awesome:/bar busybox top
 > ```
-> 
+>
 > the volume for `/foo` will be removed, but the volume for `/bar` will not.
 > Volumes inherited via `--volumes-from` will be removed with the same logic: if
 > the original volume was specified with a name it will **not** be removed.
@@ -1256,6 +1256,8 @@ container nearly all the same access to the host as processes running outside
 containers on the host. Additional information about running with `--privileged`
 is available on the [Docker Blog](https://www.docker.com/blog/docker-can-now-run-within-docker/).
 
+### Linux device nodes
+
 If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that
 will be accessible within the container.
@@ -1282,6 +1284,20 @@ $ docker run --device=/dev/sda:/dev/xvdc:w --rm -it ubuntu fdisk  /dev/xvdc
 $ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
 fdisk: unable to open /dev/xvdc: Operation not permitted
 ```
+
+### Container Device Interface (CDI) devices
+
+In addition to supporting Linux device nodes, Docker also allows for CDI devices -- identified by fully-qualified device names -- to be requested using the `--device` command line argument as follows:
+
+```console
+$ docker run --device=vendor.com/class=device-name --rm -it ubuntu
+```
+
+This will start a container based of the `ubuntu` image with access to the specified CDI device, `vendor.com/class=device-name`.
+
+Note that this assumes that the CDI specification for the requested device is available on the system. Furthermore, this is an experimental feature and as such does not represent a stable API.
+
+### Linux capabilities
 
 In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
@@ -1418,7 +1434,7 @@ container's logging driver. The following options are supported:
 | `fluentd`    | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                           |
 | `awslogs`    | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs.                               |
 | `splunk`     | Splunk logging driver for Docker. Writes log messages to `splunk` using Event Http Collector.                                  |
-| `etwlogs`    | Event Tracing for Windows (ETW) events. Writes log messages as Event Tracing for Windows (ETW) events. Only Windows platforms. |                                                  
+| `etwlogs`    | Event Tracing for Windows (ETW) events. Writes log messages as Event Tracing for Windows (ETW) events. Only Windows platforms. |
 | `gcplogs`    | Google Cloud Platform (GCP) Logging. Writes log messages to Google Cloud Platform (GCP) Logging.                               |
 | `logentries` | Rapid7 Logentries. Writes log messages to Rapid7 Logentries.                                                                   |
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added documentation on the use of the Container Device Interface to request devices through the `docker run` command. The following PRs are relevant:
* Initial `experimental` feature implementaton in Daemon: https://github.com/moby/moby/pull/45134
* Addition of Info output in the Daemon: https://github.com/moby/moby/pull/46004
* Initial CLI support: https://github.com/docker/cli/pull/4084
* Addition of Info output in the CLI: https://github.com/docker/cli/pull/4510

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Added documentation on requesting CDI devices in `docker run`

**- A picture of a cute animal (not mandatory but encouraged)**

### TODO:
- [x] Document devices through run
- [ ] Document CDI spec dirs
- [ ] Document info command
- [ ] Document usage in `docker compose`
- [ ] Add note to `--gpus` flag

Related
- https://docs.docker.com/config/containers/resource_constraints/#gpu
- https://docs.docker.com/compose/gpu-support/
