### PR TITLE
adding -c option for docker run/build in manpages

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -8,7 +8,7 @@ docker-build - Build an image from a Dockerfile
 [**--add-host**[=*[]*]]
 [**--build-arg**[=*[]*]]
 [**--cache-from**[=*[]*]]
-[**--cpu-shares**[=*0*]]
+[**-c**|**--cpu-shares**[=*0*]]
 [**--cgroup-parent**[=*CGROUP-PARENT*]]
 [**--help**]
 [**--iidfile**[=*CIDFILE*]]
@@ -153,7 +153,7 @@ In Linux, default is **bridge**.
   Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you omit the unit, the system uses bytes.
   If you omit the size entirely, the system uses `64m`.
 
-**--cpu-shares** *0*
+**-c**, **--cpu-shares** *0*
   CPU shares (relative weight).
 
   By default, all containers get the same proportion of CPU cycles.
@@ -166,7 +166,7 @@ In Linux, default is **bridge**.
   You can change this proportion by adjusting the container's CPU share
   weighting relative to the weighting of all other running containers.
 
-  To modify the proportion from the default of 1024, use the **--cpu-shares**
+  To modify the proportion from the default of 1024, use the **-c** or **--cpu-shares**
   flag to set the weighting to 2 or higher.
 
       Container   CPU share    Flag

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -10,7 +10,7 @@ docker-run - Create and run a new container from an image
 [**--annotation**[=*[]*]]
 [**--blkio-weight**[=*[BLKIO-WEIGHT]*]]
 [**--blkio-weight-device**[=*[]*]]
-[**--cpu-shares**[=*0*]]
+[**-c**|**--cpu-shares**[=*0*]]
 [**--cap-add**[=*[]*]]
 [**--cap-drop**[=*[]*]]
 [**--cgroupns**[=*[]*]]
@@ -137,14 +137,14 @@ option can be set multiple times.
 **--blkio-weight-device**=[]
    Block IO weight (relative device weight, format: `DEVICE_NAME:WEIGHT`).
 
-**--cpu-shares**=*0*
+**-c**, **--cpu-shares**=*0*
    CPU shares (relative weight)
 
    By default, all containers get the same proportion of CPU cycles. This proportion
 can be modified by changing the container's CPU share weighting relative
 to the weighting of all other running containers.
 
-To modify the proportion from the default of 1024, use the **--cpu-shares**
+To modify the proportion from the default of 1024, use the **-c** or **--cpu-shares**
 flag to set the weighting to 2 or higher.
 
 The proportion will only apply when CPU-intensive processes are running.


### PR DESCRIPTION
fixes #4521 (-c flag is not described in man page)

**- What I did**
Added the "-c" option to  man pages for consistency with documentation and implementation 

**- How I did it**

**- How to verify it**
man docker run

**- Description for the changelog**
Fixing inconsistent run/build option (-c) in man pages

**- A picture of a cute animal (not mandatory but encouraged)**

