### PR TITLE
force TestNewHistoryCommandSuccess to use UTC timezone

### DIFF
--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
-	"gotest.tools/v3/skip"
 )
 
 func TestNewHistoryCommandErrors(t *testing.T) {
@@ -43,16 +42,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 }
 
-func notUTCTimezone() bool {
-	if _, offset := time.Now().Zone(); offset != 0 {
-		return true
-	}
-	return false
-}
-
 func TestNewHistoryCommandSuccess(t *testing.T) {
-	skip.If(t, notUTCTimezone, "expected output requires UTC timezone")
-
 	testCases := []struct {
 		name             string
 		args             []string
@@ -65,6 +55,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 				return []image.HistoryResponseItem{{
 					ID:      "1234567890123456789",
 					Created: time.Now().Unix(),
+					Comment: "none",
 				}}, nil
 			},
 		},
@@ -98,6 +89,9 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			// Set to UTC timezone as timestamps in output are
+			// printed in the current timezone
+			t.Setenv("TZ", "UTC")
 			cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
 			cmd := NewHistoryCommand(cli)
 			cmd.SetOut(io.Discard)

--- a/cli/command/image/testdata/history-command-success.simple.golden
+++ b/cli/command/image/testdata/history-command-success.simple.golden
@@ -1,2 +1,2 @@
 IMAGE          CREATED                  CREATED BY   SIZE      COMMENT
-123456789012   Less than a second ago                0B        
+123456789012   Less than a second ago                0B        none


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/3781
- fixes https://github.com/docker/cli/pull/3779#discussion_r974281026


This test was skipped if the host was not using UTC timezone, because the output of timestamps would be different, causing the test to fail.

This patch overrides the TZ env-var to make the test use UTC, so that we don't have to skip the test.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

