### PR TITLE
[24.0 backport] docs/reference: run.md: remove stray whitespace and update cli-docs-tool to v0.6.0

### DIFF
--- a/docs/reference/commandline/system.md
+++ b/docs/reference/commandline/system.md
@@ -5,13 +5,12 @@ Manage Docker
 
 ### Subcommands
 
-| Name                                 | Description                                                                      |
-|:-------------------------------------|:---------------------------------------------------------------------------------|
-| [`df`](system_df.md)                 | Show docker disk usage                                                           |
-| [`dial-stdio`](system_dial-stdio.md) | Proxy the stdio stream to the daemon connection. Should not be invoked manually. |
-| [`events`](system_events.md)         | Get real time events from the server                                             |
-| [`info`](system_info.md)             | Display system-wide information                                                  |
-| [`prune`](system_prune.md)           | Remove unused data                                                               |
+| Name                         | Description                          |
+|:-----------------------------|:-------------------------------------|
+| [`df`](system_df.md)         | Show docker disk usage               |
+| [`events`](system_events.md) | Get real time events from the server |
+| [`info`](system_info.md)     | Display system-wide information      |
+| [`prune`](system_prune.md)   | Remove unused data                   |
 
 
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -672,7 +672,7 @@ the container exits**, you can add the `--rm` flag:
 > ```console
 > $ docker run --rm -v /foo -v awesome:/bar busybox top
 > ```
-> 
+>
 > the volume for `/foo` will be removed, but the volume for `/bar` will not.
 > Volumes inherited via `--volumes-from` will be removed with the same logic: if
 > the original volume was specified with a name it will **not** be removed.
@@ -1418,7 +1418,7 @@ container's logging driver. The following options are supported:
 | `fluentd`    | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                           |
 | `awslogs`    | Amazon CloudWatch Logs logging driver for Docker. Writes log messages to Amazon CloudWatch Logs.                               |
 | `splunk`     | Splunk logging driver for Docker. Writes log messages to `splunk` using Event Http Collector.                                  |
-| `etwlogs`    | Event Tracing for Windows (ETW) events. Writes log messages as Event Tracing for Windows (ETW) events. Only Windows platforms. |                                                  
+| `etwlogs`    | Event Tracing for Windows (ETW) events. Writes log messages as Event Tracing for Windows (ETW) events. Only Windows platforms. |
 | `gcplogs`    | Google Cloud Platform (GCP) Logging. Writes log messages to Google Cloud Platform (GCP) Logging.                               |
 | `logentries` | Rapid7 Logentries. Writes log messages to Rapid7 Logentries.                                                                   |
 

--- a/scripts/docs/generate-md.sh
+++ b/scripts/docs/generate-md.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-: "${CLI_DOCS_TOOL_VERSION=v0.5.1}"
+: "${CLI_DOCS_TOOL_VERSION=v0.6.0}"
 
 export GO111MODULE=auto
 


### PR DESCRIPTION
backport of 

- https://github.com/docker/cli/pull/4536
- https://github.com/docker/cli/pull/4531

(cherry picked from commit 3d2aac6a0d51374dfb6edbfeaec13a39156a9de8)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

