### PR TITLE
cli/registry: fix client.pullManifestList not de-referencing manifest

### DIFF
--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -202,7 +202,8 @@ func pullManifestList(ctx context.Context, ref reference.Named, repo distributio
 		}
 
 		// Replace platform from config
-		imageManifest.Descriptor.Platform = types.OCIPlatform(&manifestDescriptor.Platform)
+		p := manifestDescriptor.Platform
+		imageManifest.Descriptor.Platform = types.OCIPlatform(&p)
 
 		infos = append(infos, imageManifest)
 	}


### PR DESCRIPTION
Kudos to gosec;

    cli/registry/client/fetcher.go:205:57: G601: Implicit memory aliasing in for loop. (gosec)
            imageManifest.Descriptor.Platform = types.OCIPlatform(&manifestDescriptor.Platform)
                                                                  ^

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

