### PR TITLE
[24.0 backport] cli/registry: fix client.pullManifestList not de-referencing manifest, and remove "v1" check

### DIFF
--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -243,11 +243,6 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 
 	confirmedTLSRegistries := make(map[string]bool)
 	for _, endpoint := range endpoints {
-		if endpoint.Version == registry.APIVersion1 {
-			logrus.Debugf("skipping v1 endpoint %s", endpoint.URL)
-			continue
-		}
-
 		if endpoint.URL.Scheme != "https" {
 			if _, confirmedTLS := confirmedTLSRegistries[endpoint.URL.Host]; confirmedTLS {
 				logrus.Debugf("skipping non-TLS endpoint %s for host/port that appears to use TLS", endpoint.URL)

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -202,7 +202,8 @@ func pullManifestList(ctx context.Context, ref reference.Named, repo distributio
 		}
 
 		// Replace platform from config
-		imageManifest.Descriptor.Platform = types.OCIPlatform(&manifestDescriptor.Platform)
+		p := manifestDescriptor.Platform
+		imageManifest.Descriptor.Platform = types.OCIPlatform(&p)
 
 		infos = append(infos, imageManifest)
 	}


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4540

---

### cli/registry: fix client.pullManifestList not de-referencing manifest

Kudos to gosec;

    cli/registry/client/fetcher.go:205:57: G601: Implicit memory aliasing in for loop. (gosec)
            imageManifest.Descriptor.Platform = types.OCIPlatform(&manifestDescriptor.Platform)
                                                                  ^

### cli/registry: client.iterateEndpoints: remove check for APIVersion1

registryService.LookupPullEndpoints uses lookupV2Endpoints
https://github.com/moby/moby/blob/v24.0.5/registry/service.go#L137-L142

which, as the name indicates, only returns V2 endpoints;
https://github.com/moby/moby/blob/v24.0.5/registry/service_v2.go#L10-L80


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


