### PR TITLE
Fix extremely minor typo in docker-run man page

### DIFF
--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -761,10 +761,10 @@ The `Z` option tells Docker to label the content with a private unshared label.
 Only the current container can use a private volume.
 
 By default bind mounted volumes are `private`. That means any mounts done
-inside container will not be visible on host and vice-a-versa. One can change
+inside container will not be visible on host and vice versa. One can change
 this behavior by specifying a volume mount propagation property. Making a
 volume `shared` mounts done under that volume inside container will be
-visible on host and vice-a-versa. Making a volume `slave` enables only one
+visible on host and vice versa. Making a volume `slave` enables only one
 way mount propagation and that is mounts done on host under that volume
 will be visible inside container but not the other way around.
 


### PR DESCRIPTION
The latin phrase "vice versa" can be pronounced "vice-a-versa", but should not be rendered as such.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed an extremely minor typo in the docker-run man page.

**- How I did it**

Made a 6 character edit to the docker-run markdown documentation page.

**- How to verify it**

First, check out the definition of [vice versa](https://dictionary.cambridge.org/dictionary/english/vice-versa). Then note the definition of [vice-a-versa](https://www.wordnik.com/words/vice-a-versa) indicates that it is a "phonetic alternate spelling". This irks the extremely pedantic as the original latin phrase can be kept intact.

Now, while my one semester of college linguistics taught me that there is no "right" way to pronounce something, and that the fluidity of language is not only to be expected, but should not have a moral value ascribed to it, I think that if the original phrase is both remembered and widely used, we should defer to that.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fixed an extremely minor typo in the docker-run man page.

**- A picture of a cute animal (not mandatory but encouraged)**

```
  .
 ..^____/
`-. ___ )
  ||  ||
```
