### PR TITLE
Fix:CLI returns "unknown flag" error when you misspell a command and pass a flag

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -116,6 +116,15 @@ func setFlagErrorFunc(dockerCli command.Cli, cmd *cobra.Command) {
 	// is called.
 	flagErrorFunc := cmd.FlagErrorFunc()
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		// When TraverseChildren is set to true on a parent command,
+		// Cobra will parse flags before looking for the appropriate command to run.
+		// First check the command exists before raising a flag error
+		args := os.Args[1:]
+		commandExists := findCommand(cmd, args)
+
+		if !commandExists {
+			return fmt.Errorf("docker: '%s' is not a docker command.\nSee 'docker --help'", args[0])
+		}
 		if err := pluginmanager.AddPluginCommandStubs(dockerCli, cmd.Root()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Set the DisableFlagParsing value to true in cmd/docker to pass commands as arguements.


**- What I did**
Reproduced the bug #4550 and identified a solution. 

**- How I did it**
Set `DisableFlagParsing` to `true` in cmd/docker/docker.go.  

[cobra documentation](https://pkg.go.dev/github.com/spf13/cobra#section-readme)
`DisableFlagParsing disables the flag parsing.
If this is true all flags will be passed to the command as arguments.`

**- How to verify it**
Ran the following commands to verify the issue had been resolved and to check for any introduced issues. 

```
docker iamges --filter
```
returns 
```
docker: 'iamges' is not a docker command.
See 'docker --help'
```

I also ran a few other commands to check the output. 

An invalid command with an invalid flag.
```
docker iamges --filterr
```
Returns 
```
docker: 'iamges' is not a docker command.
See 'docker --help'
```

Check an existing command with a flag and value in the flag still functions as expected. 
```
docker ps --filter status="running"
```
Returns 
```
CONTAINER ID   IMAGE            COMMAND             CREATED       STATUS       PORTS     NAMES
9440fe53b574   docker-cli-dev   "/bin/sh -c bash"   2 hours ago   Up 2 hours             nifty_franklin
```

Check that valid command with an invalid flag returns the flag help. 
```
docker images --filterrr
```
Returns 
```
unknown flag: --filterrr
See 'docker images --help'.
```

Check valid command with valid flag but no arguement for the flag 
```
docker ps --filter
```
Returns 
```
flag needs an argument: --filter
See 'docker ps --help'.
```

**- Description for the changelog**

When [TraverseChildren](https://pkg.go.dev/github.com/spf13/cobra#Command.TraverseChildren) is set to true in cobra, flags will be parsed before looking for the appropriate command to run which was causing the unexpected flag errors for commands that do not exist. 
I don't see simply TraverseChildren to `true` as an option - from what I can see it looks as though its intentionally been set to true to chain commands/flags. 

The change I have made checks that the command exists and returns an invalid docker command error if it does not before the flag error is returned. 


closes #4550



edit: Update with new PR changes. 



