### PR TITLE
e2e: update to use compose v2, and don't depend on distro-packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ARG XX_VERSION=1.2.1
 ARG GOVERSIONINFO_VERSION=v1.3.0
 ARG GOTESTSUM_VERSION=v1.10.0
 ARG BUILDX_VERSION=0.11.2
+ARG COMPOSE_VERSION=v2.22.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
@@ -98,15 +99,13 @@ RUN --mount=ro --mount=type=cache,target=/root/.cache \
     TARGET=/out ./scripts/build/plugins e2e/cli-plugins/plugins/*
 
 FROM build-base-alpine AS e2e-base-alpine
-RUN apk add --no-cache build-base curl docker-compose openssl openssh-client
+RUN apk add --no-cache build-base curl openssl openssh-client
 
 FROM build-base-bullseye AS e2e-base-bullseye
 RUN apt-get update && apt-get install -y build-essential curl openssl openssh-client
-ARG COMPOSE_VERSION=1.29.2
-RUN curl -fsSL https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose
 
-FROM docker/buildx-bin:${BUILDX_VERSION} AS buildx
+FROM docker/buildx-bin:${BUILDX_VERSION}   AS buildx
+FROM docker/compose-bin:${COMPOSE_VERSION} AS compose
 
 FROM e2e-base-${BASE_VARIANT} AS e2e
 ARG NOTARY_VERSION=v0.6.1
@@ -116,7 +115,8 @@ RUN echo 'notary.cert' >> /etc/ca-certificates.conf && update-ca-certificates
 COPY --link --from=gotestsum /out/gotestsum /usr/bin/gotestsum
 COPY --link --from=build /out ./build/
 COPY --link --from=build-plugins /out ./build/
-COPY --link --from=buildx /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --link --from=buildx  /buildx         /usr/libexec/docker/cli-plugins/docker-buildx
+COPY --link --from=compose /docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 COPY --link . .
 ENV DOCKER_BUILDKIT=1
 ENV PATH=/go/src/github.com/docker/cli/build:$PATH

--- a/e2e/compose-env.connhelper-ssh.yaml
+++ b/e2e/compose-env.connhelper-ssh.yaml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   engine:
       build:

--- a/e2e/compose-env.experimental.yaml
+++ b/e2e/compose-env.experimental.yaml
@@ -1,6 +1,3 @@
-version: '2.1'
-
 services:
   engine:
       command: ["--insecure-registry=registry:5000", "--experimental"]
-

--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   registry:
     image: 'registry:2'
@@ -25,4 +23,3 @@ services:
       ports:
         - 4444:4443
       command: ['notary-server', '-config=/fixtures/notary-config.json']
-

--- a/scripts/test/e2e/run
+++ b/scripts/test/e2e/run
@@ -26,13 +26,13 @@ setup() {
         export TEST_CONNHELPER_SSH_ID_RSA_PUB
         file="${file}:./e2e/compose-env.connhelper-ssh.yaml"
     fi
-    COMPOSE_PROJECT_NAME=$project COMPOSE_FILE=$file docker-compose up --build -d >&2
+    COMPOSE_PROJECT_NAME=$project COMPOSE_FILE=$file docker compose up --build -d >&2
 
     local network="${project}_default"
     # TODO: only run if inside a container
     docker network connect "$network" "$(hostname)"
 
-    engine_ip="$(container_ip "${project}_engine_1" "$network")"
+    engine_ip="$(container_ip "${project}-engine-1" "$network")"
     engine_host="tcp://$engine_ip:2375"
     if [ "${TEST_CONNHELPER:-}" = "ssh" ];then
         engine_host="ssh://penguin@${engine_ip}"
@@ -54,7 +54,7 @@ cleanup() {
     local project=$1
     local network="${project}_default"
     docker network disconnect "$network" "$(hostname)"
-    COMPOSE_PROJECT_NAME=$1 COMPOSE_FILE=$2 docker-compose down -v --rmi local >&2
+    COMPOSE_PROJECT_NAME=$1 COMPOSE_FILE=$2 docker compose down -v --rmi local >&2
 }
 
 runtests() {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4354

We were depending on alpine's package repository to install compose, but for debian we used compose's GitHub releases. Depending on distro packages means that we don't know when updates will happen, and versions may diverge because of that; for example, alpine 3.18 updated to compose v2;

On alpine 3.17:

    make -f docker.Makefile build-e2e-image
    docker run --rm docker-cli-e2e docker-compose --version
    docker-compose version 1.29.2, build unknown

On alpine 3.18:

    make -f docker.Makefile build-e2e-image
    docker run --rm docker-cli-e2e docker-compose --version
    Docker Compose version v2.17.3

This caused our e2e script to fail, as it made assumptions about the name format created by compose, which changed from underscores to hyphens in v2;

    Container cliendtoendsuite-engine-1  Running
    Error: No such object: cliendtoendsuite_engine_1

This patch:

- updates the Dockerfile to install compose from the compose-bin image
- adjusts the e2e script for the new naming scheme format
- removes the version field from the compose-files used in e2e, as they are no longer used by compose.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

