### PR TITLE
Dockerfile: build gotestsum and goversioninfo without cgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,13 @@ FROM build-base-${BASE_VARIANT} AS goversioninfo
 ARG GOVERSIONINFO_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    GOBIN=/out GO111MODULE=on go install "github.com/josephspurrier/goversioninfo/cmd/goversioninfo@${GOVERSIONINFO_VERSION}"
+    GOBIN=/out GO111MODULE=on CGO_ENABLED=0 go install "github.com/josephspurrier/goversioninfo/cmd/goversioninfo@${GOVERSIONINFO_VERSION}"
 
 FROM build-base-${BASE_VARIANT} AS gotestsum
 ARG GOTESTSUM_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    GOBIN=/out GO111MODULE=on go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
+    GOBIN=/out GO111MODULE=on CGO_ENABLED=0 go install "gotest.tools/gotestsum@${GOTESTSUM_VERSION}" \
     && /out/gotestsum --version
 
 FROM build-${BASE_VARIANT} AS build


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4354

It's not needed to build these binaries. The Dockerfile.dev image already
has CGO_ENABLED=0 as default in the golang image, so does not need updates.


**- A picture of a cute animal (not mandatory but encouraged)**

