### PR TITLE
4600-cli/command: adding `docker volumes` alias

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -41,6 +41,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		registry.NewSearchCommand(dockerCli),
 		system.NewVersionCommand(dockerCli),
 		system.NewInfoCommand(dockerCli),
+		volume.NewVolumesCommand(dockerCli),
 
 		// management commands
 		builder.NewBuilderCommand(dockerCli),

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -26,16 +26,20 @@ type listOptions struct {
 	filter  opts.FilterOpt
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+// NewVolumesCommand creates a new `docker volumes` command
+func NewVolumesCommand(dockerCli command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
-		Use:     "ls [OPTIONS]",
-		Aliases: []string{"list"},
+		Use:     "volumes [OPTIONS]",
 		Short:   "List volumes",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(dockerCli, options)
+		},
+		Annotations: map[string]string{
+			"category-top": "13",
+			"aliases":      "docker volume ls, docker volume list, docker volumes",
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
@@ -49,6 +53,13 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("cluster", "swarm", []string{"manager"})
 
 	return cmd
+}
+
+func newListCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := *NewVolumesCommand(dockerCli)
+	cmd.Aliases = []string{"list"}
+	cmd.Use = "ls [OPTIONS]"
+	return &cmd
 }
 
 func runList(dockerCli command.Cli, options listOptions) error {

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -14,8 +14,9 @@ import (
 	"gotest.tools/v3/golden"
 )
 
-func TestVolumeListErrors(t *testing.T) {
+func TestNewVolumesCommandErrors(t *testing.T) {
 	testCases := []struct {
+		name           string
 		args           []string
 		flags          map[string]string
 		volumeListFunc func(filter filters.Args) (volume.ListResponse, error)
@@ -33,7 +34,7 @@ func TestVolumeListErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := newListCommand(
+		cmd := NewVolumesCommand(
 			test.NewFakeCli(&fakeClient{
 				volumeListFunc: tc.volumeListFunc,
 			}),
@@ -48,7 +49,7 @@ func TestVolumeListErrors(t *testing.T) {
 	}
 }
 
-func TestVolumeListWithoutFormat(t *testing.T) {
+func TestNewVolumesCommandWithoutFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
@@ -62,12 +63,12 @@ func TestVolumeListWithoutFormat(t *testing.T) {
 			}, nil
 		},
 	})
-	cmd := newListCommand(cli)
+	cmd := NewVolumesCommand(cli)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-without-format.golden")
 }
 
-func TestVolumeListWithConfigFormat(t *testing.T) {
+func TestNewVolumesCommandWithConfigFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
@@ -84,12 +85,12 @@ func TestVolumeListWithConfigFormat(t *testing.T) {
 	cli.SetConfigFile(&configfile.ConfigFile{
 		VolumesFormat: "{{ .Name }} {{ .Driver }} {{ .Labels }}",
 	})
-	cmd := newListCommand(cli)
+	cmd := NewVolumesCommand(cli)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-with-config-format.golden")
 }
 
-func TestVolumeListWithFormat(t *testing.T) {
+func TestNewVolumesCommandWithFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
@@ -103,13 +104,13 @@ func TestVolumeListWithFormat(t *testing.T) {
 			}, nil
 		},
 	})
-	cmd := newListCommand(cli)
+	cmd := NewVolumesCommand(cli)
 	cmd.Flags().Set("format", "{{ .Name }} {{ .Driver }} {{ .Labels }}")
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-with-format.golden")
 }
 
-func TestVolumeListSortOrder(t *testing.T) {
+func TestNewVolumesCommandSortOrder(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
@@ -121,13 +122,13 @@ func TestVolumeListSortOrder(t *testing.T) {
 			}, nil
 		},
 	})
-	cmd := newListCommand(cli)
+	cmd := NewVolumesCommand(cli)
 	cmd.Flags().Set("format", "{{ .Name }}")
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-sort.golden")
 }
 
-func TestClusterVolumeList(t *testing.T) {
+func TestClusterNewVolumesCommand(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
@@ -229,7 +230,7 @@ func TestClusterVolumeList(t *testing.T) {
 		},
 	})
 
-	cmd := newListCommand(cli)
+	cmd := NewVolumesCommand(cli)
 	cmd.Flags().Set("cluster", "true")
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-cluster-volume-list.golden")


### PR DESCRIPTION
**- What I did**
I've added a new command / alias for the `docker volume ls`, being `docker volumes`

**- How I did it**
By altering the existing files and doing a very similar job to what the `docker images` does, just with the volume instead

**- How to verify it**
Running `docker volumes` on the command line

**- Description for the changelog**
Added a new alias for the `docker volume ls` command: `docker volumes`

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/docker/cli/assets/2676755/3b78ce4f-3cde-4186-8e41-0a1793808be0)

**- Side notes**
This is my first PR here, please be kind, and sorry in advance :)

