### PR TITLE
cli/command: remove dot-imports and unhandled errors, and fix TestSwarmUpdate

### DIFF
--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -50,23 +50,23 @@ func TestConfigList(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configListFunc: func(_ context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
-				*Config(ConfigID("ID-1-foo"),
-					ConfigName("1-foo"),
-					ConfigVersion(swarm.Version{Index: 10}),
-					ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
-					ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Config(builders.ConfigID("ID-1-foo"),
+					builders.ConfigName("1-foo"),
+					builders.ConfigVersion(swarm.Version{Index: 10}),
+					builders.ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
-				*Config(ConfigID("ID-10-foo"),
-					ConfigName("10-foo"),
-					ConfigVersion(swarm.Version{Index: 11}),
-					ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
-					ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Config(builders.ConfigID("ID-10-foo"),
+					builders.ConfigName("10-foo"),
+					builders.ConfigVersion(swarm.Version{Index: 11}),
+					builders.ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
-				*Config(ConfigID("ID-2-foo"),
-					ConfigName("2-foo"),
-					ConfigVersion(swarm.Version{Index: 11}),
-					ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
-					ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Config(builders.ConfigID("ID-2-foo"),
+					builders.ConfigName("2-foo"),
+					builders.ConfigVersion(swarm.Version{Index: 11}),
+					builders.ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
 			}, nil
 		},
@@ -80,15 +80,15 @@ func TestConfigListWithQuietOption(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configListFunc: func(_ context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
-				*Config(ConfigID("ID-foo"), ConfigName("foo")),
-				*Config(ConfigID("ID-bar"), ConfigName("bar"), ConfigLabels(map[string]string{
+				*builders.Config(builders.ConfigID("ID-foo"), builders.ConfigName("foo")),
+				*builders.Config(builders.ConfigID("ID-bar"), builders.ConfigName("bar"), builders.ConfigLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
 		},
 	})
 	cmd := newConfigListCommand(cli)
-	cmd.Flags().Set("quiet", "true")
+	assert.Check(t, cmd.Flags().Set("quiet", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "config-list-with-quiet-option.golden")
 }
@@ -97,8 +97,8 @@ func TestConfigListWithConfigFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configListFunc: func(_ context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
-				*Config(ConfigID("ID-foo"), ConfigName("foo")),
-				*Config(ConfigID("ID-bar"), ConfigName("bar"), ConfigLabels(map[string]string{
+				*builders.Config(builders.ConfigID("ID-foo"), builders.ConfigName("foo")),
+				*builders.Config(builders.ConfigID("ID-bar"), builders.ConfigName("bar"), builders.ConfigLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
@@ -116,15 +116,15 @@ func TestConfigListWithFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configListFunc: func(_ context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
 			return []swarm.Config{
-				*Config(ConfigID("ID-foo"), ConfigName("foo")),
-				*Config(ConfigID("ID-bar"), ConfigName("bar"), ConfigLabels(map[string]string{
+				*builders.Config(builders.ConfigID("ID-foo"), builders.ConfigName("foo")),
+				*builders.Config(builders.ConfigID("ID-bar"), builders.ConfigName("bar"), builders.ConfigLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
 		},
 	})
 	cmd := newConfigListCommand(cli)
-	cmd.Flags().Set("format", "{{ .Name }} {{ .Labels }}")
+	assert.Check(t, cmd.Flags().Set("format", "{{ .Name }} {{ .Labels }}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "config-list-with-format.golden")
 }
@@ -135,24 +135,24 @@ func TestConfigListWithFilter(t *testing.T) {
 			assert.Check(t, is.Equal("foo", options.Filters.Get("name")[0]))
 			assert.Check(t, is.Equal("lbl1=Label-bar", options.Filters.Get("label")[0]))
 			return []swarm.Config{
-				*Config(ConfigID("ID-foo"),
-					ConfigName("foo"),
-					ConfigVersion(swarm.Version{Index: 10}),
-					ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
-					ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Config(builders.ConfigID("ID-foo"),
+					builders.ConfigName("foo"),
+					builders.ConfigVersion(swarm.Version{Index: 10}),
+					builders.ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
-				*Config(ConfigID("ID-bar"),
-					ConfigName("bar"),
-					ConfigVersion(swarm.Version{Index: 11}),
-					ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
-					ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Config(builders.ConfigID("ID-bar"),
+					builders.ConfigName("bar"),
+					builders.ConfigVersion(swarm.Version{Index: 11}),
+					builders.ConfigCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.ConfigUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
 			}, nil
 		},
 	})
 	cmd := newConfigListCommand(cli)
-	cmd.Flags().Set("filter", "name=foo")
-	cmd.Flags().Set("filter", "label=lbl1=Label-bar")
+	assert.Check(t, cmd.Flags().Set("filter", "name=foo"))
+	assert.Check(t, cmd.Flags().Set("filter", "label=lbl1=Label-bar"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "config-list-with-filter.golden")
 }

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -160,7 +160,7 @@ func TestContainerListErrors(t *testing.T) {
 		)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -171,11 +171,11 @@ func TestContainerListWithoutFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1"),
-				*Container("c2", WithName("foo")),
-				*Container("c3", WithPort(80, 80, TCP), WithPort(81, 81, TCP), WithPort(82, 82, TCP)),
-				*Container("c4", WithPort(81, 81, UDP)),
-				*Container("c5", WithPort(82, 82, IP("8.8.8.8"), TCP)),
+				*builders.Container("c1"),
+				*builders.Container("c2", builders.WithName("foo")),
+				*builders.Container("c3", builders.WithPort(80, 80, builders.TCP), builders.WithPort(81, 81, builders.TCP), builders.WithPort(82, 82, builders.TCP)),
+				*builders.Container("c4", builders.WithPort(81, 81, builders.UDP)),
+				*builders.Container("c5", builders.WithPort(82, 82, builders.IP("8.8.8.8"), builders.TCP)),
 			}, nil
 		},
 	})
@@ -188,13 +188,13 @@ func TestContainerListNoTrunc(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1"),
-				*Container("c2", WithName("foo/bar")),
+				*builders.Container("c1"),
+				*builders.Container("c2", builders.WithName("foo/bar")),
 			}, nil
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("no-trunc", "true")
+	assert.Check(t, cmd.Flags().Set("no-trunc", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-without-format-no-trunc.golden")
 }
@@ -204,13 +204,13 @@ func TestContainerListNamesMultipleTime(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1"),
-				*Container("c2", WithName("foo/bar")),
+				*builders.Container("c1"),
+				*builders.Container("c2", builders.WithName("foo/bar")),
 			}, nil
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", "{{.Names}} {{.Names}}")
+	assert.Check(t, cmd.Flags().Set("format", "{{.Names}} {{.Names}}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-name-name.golden")
 }
@@ -220,13 +220,13 @@ func TestContainerListFormatTemplateWithArg(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1", WithLabel("some.label", "value")),
-				*Container("c2", WithName("foo/bar"), WithLabel("foo", "bar")),
+				*builders.Container("c1", builders.WithLabel("some.label", "value")),
+				*builders.Container("c2", builders.WithName("foo/bar"), builders.WithLabel("foo", "bar")),
 			}, nil
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", `{{.Names}} {{.Label "some.label"}}`)
+	assert.Check(t, cmd.Flags().Set("format", `{{.Names}} {{.Label "some.label"}}`))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-with-arg.golden")
 }
@@ -275,9 +275,9 @@ func TestContainerListFormatSizeSetsOption(t *testing.T) {
 				},
 			})
 			cmd := newListCommand(cli)
-			cmd.Flags().Set("format", tc.format)
+			assert.Check(t, cmd.Flags().Set("format", tc.format))
 			if tc.sizeFlag != "" {
-				cmd.Flags().Set("size", tc.sizeFlag)
+				assert.Check(t, cmd.Flags().Set("size", tc.sizeFlag))
 			}
 			assert.NilError(t, cmd.Execute())
 		})
@@ -288,8 +288,8 @@ func TestContainerListWithConfigFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1", WithLabel("some.label", "value"), WithSize(10700000)),
-				*Container("c2", WithName("foo/bar"), WithLabel("foo", "bar"), WithSize(3200000)),
+				*builders.Container("c1", builders.WithLabel("some.label", "value"), builders.WithSize(10700000)),
+				*builders.Container("c2", builders.WithName("foo/bar"), builders.WithLabel("foo", "bar"), builders.WithSize(3200000)),
 			}, nil
 		},
 	})
@@ -305,8 +305,8 @@ func TestContainerListWithFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerListFunc: func(_ container.ListOptions) ([]types.Container, error) {
 			return []types.Container{
-				*Container("c1", WithLabel("some.label", "value")),
-				*Container("c2", WithName("foo/bar"), WithLabel("foo", "bar")),
+				*builders.Container("c1", builders.WithLabel("some.label", "value")),
+				*builders.Container("c2", builders.WithName("foo/bar"), builders.WithLabel("foo", "bar")),
 			}, nil
 		},
 	})

--- a/cli/command/idresolver/idresolver_test.go
+++ b/cli/command/idresolver/idresolver_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -50,7 +50,7 @@ func TestResolveWithCache(t *testing.T) {
 	cli := &fakeClient{
 		nodeInspectFunc: func(nodeID string) (swarm.Node, []byte, error) {
 			inspectCounter++
-			return *Node(NodeName("node-foo")), []byte{}, nil
+			return *builders.Node(builders.NodeName("node-foo")), []byte{}, nil
 		},
 	}
 
@@ -82,14 +82,14 @@ func TestResolveNode(t *testing.T) {
 		{
 			nodeID: "nodeID",
 			nodeInspectFunc: func(string) (swarm.Node, []byte, error) {
-				return *Node(NodeName("node-foo")), []byte{}, nil
+				return *builders.Node(builders.NodeName("node-foo")), []byte{}, nil
 			},
 			expectedID: "node-foo",
 		},
 		{
 			nodeID: "nodeID",
 			nodeInspectFunc: func(string) (swarm.Node, []byte, error) {
-				return *Node(NodeName(""), Hostname("node-hostname")), []byte{}, nil
+				return *builders.Node(builders.NodeName(""), builders.Hostname("node-hostname")), []byte{}, nil
 			},
 			expectedID: "node-hostname",
 		},
@@ -124,7 +124,7 @@ func TestResolveService(t *testing.T) {
 		{
 			serviceID: "serviceID",
 			serviceInspectFunc: func(string) (swarm.Service, []byte, error) {
-				return *Service(ServiceName("service-foo")), []byte{}, nil
+				return *builders.Service(builders.ServiceName("service-foo")), []byte{}, nil
 			},
 			expectedID: "service-foo",
 		},

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders"
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/google/go-cmp/cmp"
@@ -59,10 +59,10 @@ func TestNetworkList(t *testing.T) {
 				}
 				assert.Check(t, is.DeepEqual(expectedOpts, options, cmp.AllowUnexported(filters.Args{})))
 
-				return []types.NetworkResource{*NetworkResource(NetworkResourceID("123454321"),
-					NetworkResourceName("network_1"),
-					NetworkResourceDriver("09.7.01"),
-					NetworkResourceScope("global"))}, nil
+				return []types.NetworkResource{*builders.NetworkResource(builders.NetworkResourceID("123454321"),
+					builders.NetworkResourceName("network_1"),
+					builders.NetworkResourceDriver("09.7.01"),
+					builders.NetworkResourceScope("global"))}, nil
 			},
 		},
 		{
@@ -73,9 +73,9 @@ func TestNetworkList(t *testing.T) {
 			golden: "network-list-sort.golden",
 			networkListFunc: func(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 				return []types.NetworkResource{
-					*NetworkResource(NetworkResourceName("network-2-foo")),
-					*NetworkResource(NetworkResourceName("network-1-foo")),
-					*NetworkResource(NetworkResourceName("network-10-foo")),
+					*builders.NetworkResource(builders.NetworkResourceName("network-2-foo")),
+					*builders.NetworkResource(builders.NetworkResourceName("network-1-foo")),
+					*builders.NetworkResource(builders.NetworkResourceName("network-10-foo")),
 				}, nil
 			},
 		},
@@ -86,7 +86,7 @@ func TestNetworkList(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{networkListFunc: tc.networkListFunc})
 			cmd := newListCommand(cli)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.Check(t, cmd.Flags().Set(key, value))
 			}
 			assert.NilError(t, cmd.Execute())
 			golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package functions
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -52,7 +52,7 @@ func TestNodeDemoteNoChange(t *testing.T) {
 	cmd := newDemoteCommand(
 		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleWorker {
@@ -69,7 +69,7 @@ func TestNodeDemoteMultipleNode(t *testing.T) {
 	cmd := newDemoteCommand(
 		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleWorker {

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package functions
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
 	"github.com/pkg/errors"
@@ -71,7 +71,7 @@ func TestNodeInspectErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -86,7 +86,7 @@ func TestNodeInspectPretty(t *testing.T) {
 		{
 			name: "simple",
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(NodeLabels(map[string]string{
+				return *builders.Node(builders.NodeLabels(map[string]string{
 					"lbl1": "value1",
 				})), []byte{}, nil
 			},
@@ -94,13 +94,13 @@ func TestNodeInspectPretty(t *testing.T) {
 		{
 			name: "manager",
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 		},
 		{
 			name: "manager-leader",
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager(Leader())), []byte{}, nil
+				return *builders.Node(builders.Manager(builders.Leader())), []byte{}, nil
 			},
 		},
 	}
@@ -110,7 +110,7 @@ func TestNodeInspectPretty(t *testing.T) {
 		})
 		cmd := newInspectCommand(cli)
 		cmd.SetArgs([]string{"nodeID"})
-		cmd.Flags().Set("pretty", "true")
+		assert.Check(t, cmd.Flags().Set("pretty", "true"))
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("node-inspect-pretty.%s.golden", tc.name))
 	}

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
 	"github.com/pkg/errors"
@@ -56,9 +56,9 @@ func TestNodeList(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
-				*Node(NodeID("nodeID1"), Hostname("node-2-foo"), Manager(Leader()), EngineVersion(".")),
-				*Node(NodeID("nodeID2"), Hostname("node-10-foo"), Manager(), EngineVersion("18.03.0-ce")),
-				*Node(NodeID("nodeID3"), Hostname("node-1-foo")),
+				*builders.Node(builders.NodeID("nodeID1"), builders.Hostname("node-2-foo"), builders.Manager(builders.Leader()), builders.EngineVersion(".")),
+				*builders.Node(builders.NodeID("nodeID2"), builders.Hostname("node-10-foo"), builders.Manager(), builders.EngineVersion("18.03.0-ce")),
+				*builders.Node(builders.NodeID("nodeID3"), builders.Hostname("node-1-foo")),
 			}, nil
 		},
 		infoFunc: func() (system.Info, error) {
@@ -79,12 +79,12 @@ func TestNodeListQuietShouldOnlyPrintIDs(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
-				*Node(NodeID("nodeID1")),
+				*builders.Node(builders.NodeID("nodeID1")),
 			}, nil
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("quiet", "true")
+	assert.Check(t, cmd.Flags().Set("quiet", "true"))
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Equal(cli.OutBuffer().String(), "nodeID1\n"))
 }
@@ -93,9 +93,9 @@ func TestNodeListDefaultFormatFromConfig(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
-				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),
-				*Node(NodeID("nodeID2"), Hostname("nodeHostname2"), Manager()),
-				*Node(NodeID("nodeID3"), Hostname("nodeHostname3")),
+				*builders.Node(builders.NodeID("nodeID1"), builders.Hostname("nodeHostname1"), builders.Manager(builders.Leader())),
+				*builders.Node(builders.NodeID("nodeID2"), builders.Hostname("nodeHostname2"), builders.Manager()),
+				*builders.Node(builders.NodeID("nodeID3"), builders.Hostname("nodeHostname3")),
 			}, nil
 		},
 		infoFunc: func() (system.Info, error) {
@@ -118,8 +118,8 @@ func TestNodeListFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		nodeListFunc: func() ([]swarm.Node, error) {
 			return []swarm.Node{
-				*Node(NodeID("nodeID1"), Hostname("nodeHostname1"), Manager(Leader())),
-				*Node(NodeID("nodeID2"), Hostname("nodeHostname2"), Manager()),
+				*builders.Node(builders.NodeID("nodeID1"), builders.Hostname("nodeHostname1"), builders.Manager(builders.Leader())),
+				*builders.Node(builders.NodeID("nodeID2"), builders.Hostname("nodeHostname2"), builders.Manager()),
 			}, nil
 		},
 		infoFunc: func() (system.Info, error) {
@@ -134,7 +134,7 @@ func TestNodeListFormat(t *testing.T) {
 		NodesFormat: "{{.ID}}: {{.Hostname}} {{.Status}}/{{.ManagerStatus}}",
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", "{{.Hostname}}: {{.ManagerStatus}}")
+	assert.Check(t, cmd.Flags().Set("format", "{{.Hostname}}: {{.ManagerStatus}}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "node-list-format-flag.golden")
 }

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -52,7 +52,7 @@ func TestNodePromoteNoChange(t *testing.T) {
 	cmd := newPromoteCommand(
 		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {
@@ -69,7 +69,7 @@ func TestNodePromoteMultipleNode(t *testing.T) {
 	cmd := newPromoteCommand(
 		test.NewFakeCli(&fakeClient{
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
@@ -58,7 +58,7 @@ func TestNodePsErrors(t *testing.T) {
 		cmd := newPsCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.Error(t, cmd.Execute(), tc.expectedError)
@@ -80,11 +80,11 @@ func TestNodePs(t *testing.T) {
 			name: "simple",
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 				return []swarm.Task{
-					*Task(WithStatus(Timestamp(time.Now().Add(-2*time.Hour)), PortStatus([]swarm.PortConfig{
+					*builders.Task(builders.WithStatus(builders.Timestamp(time.Now().Add(-2*time.Hour)), builders.PortStatus([]swarm.PortConfig{
 						{
 							TargetPort:    80,
 							PublishedPort: 80,
@@ -108,16 +108,16 @@ func TestNodePs(t *testing.T) {
 			name: "with-errors",
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 				return []swarm.Task{
-					*Task(TaskID("taskID1"), TaskServiceID("failure"),
-						WithStatus(Timestamp(time.Now().Add(-2*time.Hour)), StatusErr("a task error"))),
-					*Task(TaskID("taskID2"), TaskServiceID("failure"),
-						WithStatus(Timestamp(time.Now().Add(-3*time.Hour)), StatusErr("a task error"))),
-					*Task(TaskID("taskID3"), TaskServiceID("failure"),
-						WithStatus(Timestamp(time.Now().Add(-4*time.Hour)), StatusErr("a task error"))),
+					*builders.Task(builders.TaskID("taskID1"), builders.TaskServiceID("failure"),
+						builders.WithStatus(builders.Timestamp(time.Now().Add(-2*time.Hour)), builders.StatusErr("a task error"))),
+					*builders.Task(builders.TaskID("taskID2"), builders.TaskServiceID("failure"),
+						builders.WithStatus(builders.Timestamp(time.Now().Add(-3*time.Hour)), builders.StatusErr("a task error"))),
+					*builders.Task(builders.TaskID("taskID3"), builders.TaskServiceID("failure"),
+						builders.WithStatus(builders.Timestamp(time.Now().Add(-4*time.Hour)), builders.StatusErr("a task error"))),
 				}, nil
 			},
 			serviceInspectFunc: func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
@@ -143,7 +143,7 @@ func TestNodePs(t *testing.T) {
 		cmd := newPsCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("node-ps.%s.golden", tc.name))

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -43,7 +43,7 @@ func TestNodeUpdateErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(NodeLabels(map[string]string{
+				return *builders.Node(builders.NodeLabels(map[string]string{
 					"key": "value",
 				})), []byte{}, nil
 			},
@@ -61,7 +61,7 @@ func TestNodeUpdateErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -81,7 +81,7 @@ func TestNodeUpdate(t *testing.T) {
 				"role": "manager",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {
@@ -96,7 +96,7 @@ func TestNodeUpdate(t *testing.T) {
 				"availability": "drain",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Availability != swarm.NodeAvailabilityDrain {
@@ -111,7 +111,7 @@ func TestNodeUpdate(t *testing.T) {
 				"label-add": "lbl",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if _, present := node.Annotations.Labels["lbl"]; !present {
@@ -126,7 +126,7 @@ func TestNodeUpdate(t *testing.T) {
 				"label-add": "key=value",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(), []byte{}, nil
+				return *builders.Node(), []byte{}, nil
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if value, present := node.Annotations.Labels["key"]; !present || value != "value" {
@@ -141,7 +141,7 @@ func TestNodeUpdate(t *testing.T) {
 				"label-rm": "key",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(NodeLabels(map[string]string{
+				return *builders.Node(builders.NodeLabels(map[string]string{
 					"key": "value",
 				})), []byte{}, nil
 			},
@@ -161,7 +161,7 @@ func TestNodeUpdate(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		assert.NilError(t, cmd.Execute())
 	}

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/docker/cli/cli/command" // Prevents a circular import with "github.com/docker/cli/internal/test"
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types/registry"
@@ -63,11 +63,11 @@ func TestGetDefaultAuthConfig(t *testing.T) {
 	}
 	cfg := configfile.New("filename")
 	for _, authconfig := range testAuthConfigs {
-		cfg.GetCredentialsStore(authconfig.ServerAddress).Store(configtypes.AuthConfig(authconfig))
+		assert.Check(t, cfg.GetCredentialsStore(authconfig.ServerAddress).Store(configtypes.AuthConfig(authconfig)))
 	}
 	for _, tc := range testCases {
 		serverAddress := tc.inputServerAddress
-		authconfig, err := GetDefaultAuthConfig(cfg, tc.checkCredStore, serverAddress, serverAddress == "https://index.docker.io/v1/")
+		authconfig, err := command.GetDefaultAuthConfig(cfg, tc.checkCredStore, serverAddress, serverAddress == "https://index.docker.io/v1/")
 		if tc.expectedErr != "" {
 			assert.Check(t, err != nil)
 			assert.Check(t, is.Equal(tc.expectedErr, err.Error()))
@@ -86,7 +86,8 @@ func TestGetDefaultAuthConfig_HelperError(t *testing.T) {
 	expectedAuthConfig := registry.AuthConfig{
 		ServerAddress: serverAddress,
 	}
-	authconfig, err := GetDefaultAuthConfig(cfg, true, serverAddress, serverAddress == "https://index.docker.io/v1/")
+	const isDefaultRegistry = false // registry is not "https://index.docker.io/v1/"
+	authconfig, err := command.GetDefaultAuthConfig(cfg, true, serverAddress, isDefaultRegistry)
 	assert.Check(t, is.DeepEqual(expectedAuthConfig, authconfig))
 	assert.Check(t, is.ErrorContains(err, "docker-credential-fake-does-not-exist"))
 }

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -50,25 +50,25 @@ func TestSecretList(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretListFunc: func(_ context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
-				*Secret(SecretID("ID-1-foo"),
-					SecretName("1-foo"),
-					SecretVersion(swarm.Version{Index: 10}),
-					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
-					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Secret(builders.SecretID("ID-1-foo"),
+					builders.SecretName("1-foo"),
+					builders.SecretVersion(swarm.Version{Index: 10}),
+					builders.SecretCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
-				*Secret(SecretID("ID-10-foo"),
-					SecretName("10-foo"),
-					SecretVersion(swarm.Version{Index: 11}),
-					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
-					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
-					SecretDriver("driver"),
+				*builders.Secret(builders.SecretID("ID-10-foo"),
+					builders.SecretName("10-foo"),
+					builders.SecretVersion(swarm.Version{Index: 11}),
+					builders.SecretCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+					builders.SecretDriver("driver"),
 				),
-				*Secret(SecretID("ID-2-foo"),
-					SecretName("2-foo"),
-					SecretVersion(swarm.Version{Index: 11}),
-					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
-					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
-					SecretDriver("driver"),
+				*builders.Secret(builders.SecretID("ID-2-foo"),
+					builders.SecretName("2-foo"),
+					builders.SecretVersion(swarm.Version{Index: 11}),
+					builders.SecretCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+					builders.SecretDriver("driver"),
 				),
 			}, nil
 		},
@@ -82,15 +82,15 @@ func TestSecretListWithQuietOption(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretListFunc: func(_ context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
-				*Secret(SecretID("ID-foo"), SecretName("foo")),
-				*Secret(SecretID("ID-bar"), SecretName("bar"), SecretLabels(map[string]string{
+				*builders.Secret(builders.SecretID("ID-foo"), builders.SecretName("foo")),
+				*builders.Secret(builders.SecretID("ID-bar"), builders.SecretName("bar"), builders.SecretLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
 		},
 	})
 	cmd := newSecretListCommand(cli)
-	cmd.Flags().Set("quiet", "true")
+	assert.Check(t, cmd.Flags().Set("quiet", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "secret-list-with-quiet-option.golden")
 }
@@ -99,8 +99,8 @@ func TestSecretListWithConfigFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretListFunc: func(_ context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
-				*Secret(SecretID("ID-foo"), SecretName("foo")),
-				*Secret(SecretID("ID-bar"), SecretName("bar"), SecretLabels(map[string]string{
+				*builders.Secret(builders.SecretID("ID-foo"), builders.SecretName("foo")),
+				*builders.Secret(builders.SecretID("ID-bar"), builders.SecretName("bar"), builders.SecretLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
@@ -118,15 +118,15 @@ func TestSecretListWithFormat(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretListFunc: func(_ context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
 			return []swarm.Secret{
-				*Secret(SecretID("ID-foo"), SecretName("foo")),
-				*Secret(SecretID("ID-bar"), SecretName("bar"), SecretLabels(map[string]string{
+				*builders.Secret(builders.SecretID("ID-foo"), builders.SecretName("foo")),
+				*builders.Secret(builders.SecretID("ID-bar"), builders.SecretName("bar"), builders.SecretLabels(map[string]string{
 					"label": "label-bar",
 				})),
 			}, nil
 		},
 	})
 	cmd := newSecretListCommand(cli)
-	cmd.Flags().Set("format", "{{ .Name }} {{ .Labels }}")
+	assert.Check(t, cmd.Flags().Set("format", "{{ .Name }} {{ .Labels }}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "secret-list-with-format.golden")
 }
@@ -137,24 +137,24 @@ func TestSecretListWithFilter(t *testing.T) {
 			assert.Check(t, is.Equal("foo", options.Filters.Get("name")[0]), "foo")
 			assert.Check(t, is.Equal("lbl1=Label-bar", options.Filters.Get("label")[0]))
 			return []swarm.Secret{
-				*Secret(SecretID("ID-foo"),
-					SecretName("foo"),
-					SecretVersion(swarm.Version{Index: 10}),
-					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
-					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Secret(builders.SecretID("ID-foo"),
+					builders.SecretName("foo"),
+					builders.SecretVersion(swarm.Version{Index: 10}),
+					builders.SecretCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
-				*Secret(SecretID("ID-bar"),
-					SecretName("bar"),
-					SecretVersion(swarm.Version{Index: 11}),
-					SecretCreatedAt(time.Now().Add(-2*time.Hour)),
-					SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
+				*builders.Secret(builders.SecretID("ID-bar"),
+					builders.SecretName("bar"),
+					builders.SecretVersion(swarm.Version{Index: 11}),
+					builders.SecretCreatedAt(time.Now().Add(-2*time.Hour)),
+					builders.SecretUpdatedAt(time.Now().Add(-1*time.Hour)),
 				),
 			}, nil
 		},
 	})
 	cmd := newSecretListCommand(cli)
-	cmd.Flags().Set("filter", "name=foo")
-	cmd.Flags().Set("filter", "label=lbl1=Label-bar")
+	assert.Check(t, cmd.Flags().Set("filter", "name=foo"))
+	assert.Check(t, cmd.Flags().Set("filter", "label=lbl1=Label-bar"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "secret-list-with-filter.golden")
 }

--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -3,7 +3,7 @@ package service
 import (
 	"context"
 
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
@@ -40,7 +40,7 @@ func (f *fakeClient) ServiceInspectWithRaw(ctx context.Context, serviceID string
 		return f.serviceInspectWithRawFunc(ctx, serviceID, options)
 	}
 
-	return *Service(ServiceID(serviceID)), []byte{}, nil
+	return *builders.Service(builders.ServiceID(serviceID)), []byte{}, nil
 }
 
 func (f *fakeClient) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
@@ -74,5 +74,5 @@ func (f *fakeClient) NetworkInspect(ctx context.Context, networkID string, optio
 }
 
 func newService(id string, name string) swarm.Service {
-	return *Service(ServiceID(id), ServiceName(name))
+	return *builders.Service(builders.ServiceID(id), builders.ServiceName(name))
 }

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	// Import builders to get the builder function as package function
-	. "github.com/docker/cli/internal/test/builders"
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
@@ -30,7 +29,7 @@ func TestServiceListOrder(t *testing.T) {
 	})
 	cmd := newListCommand(cli)
 	cmd.SetArgs([]string{})
-	cmd.Flags().Set("format", "{{.Name}}")
+	assert.Check(t, cmd.Flags().Set("format", "{{.Name}}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "service-list-sort.golden")
 }
@@ -248,21 +247,21 @@ func generateServices(t *testing.T, opts clusterOpts) []swarm.Service {
 	}
 
 	return []swarm.Service{
-		*Service(
-			ServiceID("replicated"),
-			ServiceName("01-replicated-service"),
-			ReplicatedService(opts.desiredTasks),
-			ServiceStatus(opts.desiredTasks, opts.runningTasks),
+		*builders.Service(
+			builders.ServiceID("replicated"),
+			builders.ServiceName("01-replicated-service"),
+			builders.ReplicatedService(opts.desiredTasks),
+			builders.ServiceStatus(opts.desiredTasks, opts.runningTasks),
 		),
-		*Service(
-			ServiceID("global"),
-			ServiceName("02-global-service"),
-			GlobalService(),
-			ServiceStatus(opts.activeNodes, globalTasks),
+		*builders.Service(
+			builders.ServiceID("global"),
+			builders.ServiceName("02-global-service"),
+			builders.GlobalService(),
+			builders.ServiceStatus(opts.activeNodes, globalTasks),
 		),
-		*Service(
-			ServiceID("none-id"),
-			ServiceName("03-none-service"),
+		*builders.Service(
+			builders.ServiceID("none-id"),
+			builders.ServiceName("03-none-service"),
 		),
 	}
 }

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -38,7 +38,7 @@ func TestListErrors(t *testing.T) {
 		},
 		{
 			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
-				return []swarm.Service{*Service()}, nil
+				return []swarm.Service{*builders.Service()}, nil
 			},
 			expectedError: "cannot get label",
 		},
@@ -51,7 +51,7 @@ func TestListErrors(t *testing.T) {
 		cmd.SetArgs(tc.args)
 		cmd.SetOut(io.Discard)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
 	}
@@ -101,8 +101,8 @@ func TestStackList(t *testing.T) {
 			var services []swarm.Service
 			for _, name := range tc.serviceNames {
 				services = append(services,
-					*Service(
-						ServiceLabels(map[string]string{
+					*builders.Service(
+						builders.ServiceLabels(map[string]string{
 							"com.docker.stack.namespace": name,
 						}),
 					),
@@ -115,7 +115,7 @@ func TestStackList(t *testing.T) {
 			})
 			cmd := newListCommand(cli)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.Check(t, cmd.Flags().Set(key, value))
 			}
 			assert.NilError(t, cmd.Execute())
 			golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -76,7 +76,7 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithQuietOption",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(TaskID("id-foo"))}, nil
+				return []swarm.Task{*builders.Task(builders.TaskID("id-foo"))}, nil
 			},
 			args: []string{"foo"},
 			flags: map[string]string{
@@ -87,7 +87,7 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithNoTruncOption",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(TaskID("xn4cypcov06f2w8gsbaf2lst3"))}, nil
+				return []swarm.Task{*builders.Task(builders.TaskID("xn4cypcov06f2w8gsbaf2lst3"))}, nil
 			},
 			args: []string{"foo"},
 			flags: map[string]string{
@@ -99,12 +99,12 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithNoResolveOption",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(
-					TaskNodeID("id-node-foo"),
+				return []swarm.Task{*builders.Task(
+					builders.TaskNodeID("id-node-foo"),
 				)}, nil
 			},
 			nodeInspectWithRaw: func(ref string) (swarm.Node, []byte, error) {
-				return *Node(NodeName("node-name-bar")), nil, nil
+				return *builders.Node(builders.NodeName("node-name-bar")), nil, nil
 			},
 			args: []string{"foo"},
 			flags: map[string]string{
@@ -116,7 +116,7 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithFormat",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
+				return []swarm.Task{*builders.Task(builders.TaskServiceID("service-id-foo"))}, nil
 			},
 			args: []string{"foo"},
 			flags: map[string]string{
@@ -127,7 +127,7 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithConfigFormat",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(TaskServiceID("service-id-foo"))}, nil
+				return []swarm.Task{*builders.Task(builders.TaskServiceID("service-id-foo"))}, nil
 			},
 			config: configfile.ConfigFile{
 				TasksFormat: "{{ .Name }}",
@@ -138,17 +138,17 @@ func TestStackPs(t *testing.T) {
 		{
 			doc: "WithoutFormat",
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{*Task(
-					TaskID("id-foo"),
-					TaskServiceID("service-id-foo"),
-					TaskNodeID("id-node"),
-					WithTaskSpec(TaskImage("myimage:mytag")),
-					TaskDesiredState(swarm.TaskStateReady),
-					WithStatus(TaskState(swarm.TaskStateFailed), Timestamp(time.Now().Add(-2*time.Hour))),
+				return []swarm.Task{*builders.Task(
+					builders.TaskID("id-foo"),
+					builders.TaskServiceID("service-id-foo"),
+					builders.TaskNodeID("id-node"),
+					builders.WithTaskSpec(builders.TaskImage("myimage:mytag")),
+					builders.TaskDesiredState(swarm.TaskStateReady),
+					builders.WithStatus(builders.TaskState(swarm.TaskStateFailed), builders.Timestamp(time.Now().Add(-2*time.Hour))),
 				)}, nil
 			},
 			nodeInspectWithRaw: func(ref string) (swarm.Node, []byte, error) {
-				return *Node(NodeName("node-name-bar")), nil, nil
+				return *builders.Node(builders.NodeName("node-name-bar")), nil, nil
 			},
 			args:   []string{"foo"},
 			golden: "stack-ps-without-format.golden",
@@ -166,7 +166,7 @@ func TestStackPs(t *testing.T) {
 			cmd := newPsCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.Check(t, cmd.Flags().Set(key, value))
 			}
 			cmd.SetOut(io.Discard)
 

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
 	"github.com/pkg/errors"
@@ -96,7 +96,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 		cmd := newJoinTokenCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -123,10 +123,10 @@ func TestSwarmJoinToken(t *testing.T) {
 				}, nil
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 		},
 		{
@@ -140,10 +140,10 @@ func TestSwarmJoinToken(t *testing.T) {
 				}, nil
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 		},
 		{
@@ -160,10 +160,10 @@ func TestSwarmJoinToken(t *testing.T) {
 				}, nil
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 		},
 		{
@@ -173,10 +173,10 @@ func TestSwarmJoinToken(t *testing.T) {
 				flagQuiet: "true",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 		},
 		{
@@ -186,10 +186,10 @@ func TestSwarmJoinToken(t *testing.T) {
 				flagQuiet: "true",
 			},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return *Node(Manager()), []byte{}, nil
+				return *builders.Node(builders.Manager()), []byte{}, nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 		},
 	}
@@ -202,7 +202,7 @@ func TestSwarmJoinToken(t *testing.T) {
 		cmd := newJoinTokenCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("jointoken-%s.golden", tc.name))

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -45,7 +45,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 			expectedError: "cannot rotate because autolock is not turned on",
 		},
@@ -55,7 +55,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(Autolock()), nil
+				return *builders.Swarm(builders.Autolock()), nil
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
 				return errors.Errorf("error updating the swarm")
@@ -88,7 +88,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -129,7 +129,7 @@ func TestSwarmUnlockKey(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(Autolock()), nil
+				return *builders.Swarm(builders.Autolock()), nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
 				return types.SwarmUnlockKeyResponse{
@@ -144,7 +144,7 @@ func TestSwarmUnlockKey(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(Autolock()), nil
+				return *builders.Swarm(builders.Autolock()), nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
 				return types.SwarmUnlockKeyResponse{
@@ -162,7 +162,7 @@ func TestSwarmUnlockKey(t *testing.T) {
 		cmd := newUnlockKeyCommand(cli)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("unlockkeys-%s.golden", tc.name))

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -56,7 +56,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 				flagAutolock: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
 				return types.SwarmUnlockKeyResponse{}, errors.Errorf("error getting unlock key")
@@ -73,7 +73,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 			}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -81,7 +81,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 }
 
 func TestSwarmUpdate(t *testing.T) {
-	swarmInfo := Swarm()
+	swarmInfo := builders.Swarm()
 	swarmInfo.ClusterInfo.TLSInfo.TrustRoot = "trustroot"
 
 	testCases := []struct {
@@ -155,7 +155,7 @@ func TestSwarmUpdate(t *testing.T) {
 				return nil
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return *Swarm(), nil
+				return *builders.Swarm(), nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
 				return types.SwarmUnlockKeyResponse{

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/pkg/errors"
@@ -59,7 +59,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 		)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
@@ -80,14 +80,14 @@ func TestVolumeInspectWithoutFormat(t *testing.T) {
 				if volumeID != "foo" {
 					return volume.Volume{}, errors.Errorf("Invalid volumeID, expected %s, got %s", "foo", volumeID)
 				}
-				return *Volume(), nil
+				return *builders.Volume(), nil
 			},
 		},
 		{
 			name: "multiple-volume-with-labels",
 			args: []string{"foo", "bar"},
 			volumeInspectFunc: func(volumeID string) (volume.Volume, error) {
-				return *Volume(VolumeName(volumeID), VolumeLabels(map[string]string{
+				return *builders.Volume(builders.VolumeName(volumeID), builders.VolumeLabels(map[string]string{
 					"foo": "bar",
 				})), nil
 			},
@@ -106,7 +106,7 @@ func TestVolumeInspectWithoutFormat(t *testing.T) {
 
 func TestVolumeInspectWithFormat(t *testing.T) {
 	volumeInspectFunc := func(volumeID string) (volume.Volume, error) {
-		return *Volume(VolumeLabels(map[string]string{
+		return *builders.Volume(builders.VolumeLabels(map[string]string{
 			"foo": "bar",
 		})), nil
 	}
@@ -135,7 +135,7 @@ func TestVolumeInspectWithFormat(t *testing.T) {
 		})
 		cmd := newInspectCommand(cli)
 		cmd.SetArgs(tc.args)
-		cmd.Flags().Set("format", tc.format)
+		assert.Check(t, cmd.Flags().Set("format", tc.format))
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("volume-inspect-with-format.%s.golden", tc.name))
 	}

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/test"
-	. "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/pkg/errors"
@@ -40,7 +40,7 @@ func TestVolumeListErrors(t *testing.T) {
 		)
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.Check(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
@@ -53,9 +53,9 @@ func TestVolumeListWithoutFormat(t *testing.T) {
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
 				Volumes: []*volume.Volume{
-					Volume(),
-					Volume(VolumeName("foo"), VolumeDriver("bar")),
-					Volume(VolumeName("baz"), VolumeLabels(map[string]string{
+					builders.Volume(),
+					builders.Volume(builders.VolumeName("foo"), builders.VolumeDriver("bar")),
+					builders.Volume(builders.VolumeName("baz"), builders.VolumeLabels(map[string]string{
 						"foo": "bar",
 					})),
 				},
@@ -72,9 +72,9 @@ func TestVolumeListWithConfigFormat(t *testing.T) {
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
 				Volumes: []*volume.Volume{
-					Volume(),
-					Volume(VolumeName("foo"), VolumeDriver("bar")),
-					Volume(VolumeName("baz"), VolumeLabels(map[string]string{
+					builders.Volume(),
+					builders.Volume(builders.VolumeName("foo"), builders.VolumeDriver("bar")),
+					builders.Volume(builders.VolumeName("baz"), builders.VolumeLabels(map[string]string{
 						"foo": "bar",
 					})),
 				},
@@ -94,9 +94,9 @@ func TestVolumeListWithFormat(t *testing.T) {
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
 				Volumes: []*volume.Volume{
-					Volume(),
-					Volume(VolumeName("foo"), VolumeDriver("bar")),
-					Volume(VolumeName("baz"), VolumeLabels(map[string]string{
+					builders.Volume(),
+					builders.Volume(builders.VolumeName("foo"), builders.VolumeDriver("bar")),
+					builders.Volume(builders.VolumeName("baz"), builders.VolumeLabels(map[string]string{
 						"foo": "bar",
 					})),
 				},
@@ -104,7 +104,7 @@ func TestVolumeListWithFormat(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", "{{ .Name }} {{ .Driver }} {{ .Labels }}")
+	assert.Check(t, cmd.Flags().Set("format", "{{ .Name }} {{ .Driver }} {{ .Labels }}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-with-format.golden")
 }
@@ -114,15 +114,15 @@ func TestVolumeListSortOrder(t *testing.T) {
 		volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
 			return volume.ListResponse{
 				Volumes: []*volume.Volume{
-					Volume(VolumeName("volume-2-foo")),
-					Volume(VolumeName("volume-10-foo")),
-					Volume(VolumeName("volume-1-foo")),
+					builders.Volume(builders.VolumeName("volume-2-foo")),
+					builders.Volume(builders.VolumeName("volume-10-foo")),
+					builders.Volume(builders.VolumeName("volume-1-foo")),
 				},
 			}, nil
 		},
 	})
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("format", "{{ .Name }}")
+	assert.Check(t, cmd.Flags().Set("format", "{{ .Name }}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-list-sort.golden")
 }
@@ -223,14 +223,14 @@ func TestClusterVolumeList(t *testing.T) {
 							},
 						},
 					},
-					Volume(VolumeName("volume-local-1")),
+					builders.Volume(builders.VolumeName("volume-local-1")),
 				},
 			}, nil
 		},
 	})
 
 	cmd := newListCommand(cli)
-	cmd.Flags().Set("cluster", "true")
+	assert.Check(t, cmd.Flags().Set("cluster", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "volume-cluster-volume-list.golden")
 }


### PR DESCRIPTION
### swarm: TestSwarmUpdate: remove non-existing "--quiet" flag

The `docker swarm update` copmmand does not have a `--quiet` flag, but this
test was trying to set it.

    docker swarm update --help
    
    Usage:  docker swarm update [OPTIONS]
    
    Update the swarm
    
    Options:
          --autolock                        Change manager autolocking setting (true|false)
          --cert-expiry duration            Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
          --dispatcher-heartbeat duration   Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
          --external-ca external-ca         Specifications of one or more certificate signing endpoints
          --max-snapshots uint              Number of additional Raft snapshots to retain
          --snapshot-interval uint          Number of log entries between Raft snapshots (default 10000)
          --task-history-limit int          Task history retention limit (default 5)

The test didn't catch this issue, because errors when setting the flag were
not handled, so also adding error-handling;

    === Failed
    === FAIL: cli/command/swarm TestSwarmUpdate (0.00s)
        update_test.go:177: assertion failed: error is not nil: no such flag -quiet


### cli/command: remove dot-imports and unhandled errors

Please the linters in preparation of updating golangci-lint;

- remove dot-imports
- add some checks for unhandled errors
- replace some fixed-value variables for consts

    cli/command/image/build/context.go:238:17: G107: Potential HTTP request made with variable url (gosec)
        if resp, err = http.Get(url); err != nil {
                       ^
    cli/command/idresolver/idresolver_test.go:7:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/registry_test.go:7:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/cli/command" // Prevents a circular import with "github.com/docker/cli/internal/test"
        ^
    cli/command/task/print_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/swarm/update_test.go:10:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/swarm/unlock_key_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/swarm/join_token_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/node/list_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/node/promote_test.go:8:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/node/demote_test.go:8:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package functions
        ^
    cli/command/node/ps_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/node/update_test.go:8:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/node/inspect_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package functions
        ^
    cli/command/secret/ls_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/secret/inspect_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/volume/inspect_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/volume/list_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/config/inspect_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/config/ls_test.go:11:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/network/list_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders"
        ^
    cli/command/container/list_test.go:10:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/service/list_test.go:12:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders"
        ^
    cli/command/service/client_test.go:6:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/stack/list_test.go:8:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/stack/services_test.go:9:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^
    cli/command/stack/ps_test.go:10:2: dot-imports: should not use dot imports (revive)
        . "github.com/docker/cli/internal/test/builders" // Import builders to get the builder function as package function
        ^

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

