### PR TITLE
Mention checkpoint filesystem limitations

### DIFF
--- a/docs/reference/commandline/checkpoint.md
+++ b/docs/reference/commandline/checkpoint.md
@@ -110,3 +110,6 @@ Error response from daemon: Cannot checkpoint container c1: rpc error: code = 2 
 $ cat /var/lib/docker/containers/eb62ebdbf237ce1a8736d2ae3c7d88601fc0a50235b0ba767b559a1f3c5a600b/checkpoints/checkpoint1/criu.work/dump.log
 Error (mount.c:740): mnt: 126:./dev/console doesn't have a proper root mount
 ```
+
+Checkpoints don't include any changes to the container's filesystem. This is
+a [known limitation of CRIU](https://criu.org/Filesystem_C/R).


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

I found it confusing that docker checkpoint doesn't checkpoint the container's filesystem. Therefore, I updated the docs for this command to mention that changes to the filesystem don't get checkpointed.

**- How I did it**

N/A

**- How to verify it**

N/A

**- Description for the changelog**

Updated the `docker checkpoint` docs to mention that the command doesn't checkpoint filesystem changes.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![platypus-young-picture-id1220729124-1](https://github.com/docker/cli/assets/8731922/27585ee4-d22f-4058-8e09-06702901fdc8)


