### PR TITLE
make runAttach public and allow passing context

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -52,7 +52,7 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.Container = args[0]
 			options.Command = args[1:]
-			return RunExec(dockerCli, options)
+			return RunExec(context.Background(), dockerCli, options)
 		},
 		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(container types.Container) bool {
 			return container.State != "paused"
@@ -96,13 +96,12 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 // RunExec executes an `exec` command
-func RunExec(dockerCli command.Cli, options ExecOptions) error {
+func RunExec(ctx context.Context, dockerCli command.Cli, options ExecOptions) error {
 	execConfig, err := parseExec(options, dockerCli.ConfigFile())
 	if err != nil {
 		return err
 	}
 
-	ctx := context.Background()
 	client := dockerCli.Client()
 
 	// We need to check the tty _before_ we do the ContainerExecCreate, because

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -195,7 +195,7 @@ func TestRunExec(t *testing.T) {
 		t.Run(testcase.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&testcase.client)
 
-			err := RunExec(cli, testcase.options)
+			err := RunExec(context.Background(), cli, testcase.options)
 			if testcase.expectedError != "" {
 				assert.ErrorContains(t, err, testcase.expectedError)
 			} else {

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -169,8 +169,7 @@ func TestRunExec(t *testing.T) {
 		{
 			doc: "successful detach",
 			options: withDefaultOpts(ExecOptions{
-				Container: "thecontainer",
-				Detach:    true,
+				Detach: true,
 			}),
 			client: fakeClient{execCreateFunc: execCreateWithID},
 		},
@@ -195,7 +194,7 @@ func TestRunExec(t *testing.T) {
 		t.Run(testcase.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&testcase.client)
 
-			err := RunExec(context.Background(), cli, testcase.options)
+			err := RunExec(context.Background(), cli, "thecontainer", testcase.options)
 			if testcase.expectedError != "" {
 				assert.ErrorContains(t, err, testcase.expectedError)
 			} else {


### PR DESCRIPTION
**- What I did**
make `runAttach` a public method to be used by docker compose (enforce alignment and avoid code duplication)
introduce `runXXWithContext` to pass current context

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**

