### PR TITLE
[24.0 Backport] docs: add default-network-opt daemon option 

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -46,6 +46,7 @@ Options:
       --default-gateway ip                    Container default gateway IPv4 address
       --default-gateway-v6 ip                 Container default gateway IPv6 address
       --default-ipc-mode string               Default mode for containers ipc ("shareable" | "private") (default "private")
+      --default-network-opt mapmap            Default network options (default map[])
       --default-runtime string                Default OCI runtime for containers (default "runc")
       --default-shm-size bytes                Default shm size for containers (default 64MiB)
       --default-ulimit ulimit                 Default ulimits for containers (default [])
@@ -1449,6 +1450,7 @@ This is a full example of the allowed configuration options on Linux:
   "default-cgroupns-mode": "private",
   "default-gateway": "",
   "default-gateway-v6": "",
+  "default-network-opts": {},
   "default-runtime": "runc",
   "default-shm-size": "64M",
   "default-ulimits": {
@@ -1566,6 +1568,7 @@ This is a full example of the allowed configuration options on Windows:
   "containerd-plugin-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
+  "default-network-opts": {},
   "default-runtime": "",
   "default-ulimits": {},
   "dns": [],
@@ -1710,4 +1713,51 @@ $ sudo dockerd \
         --bridge=none \
         --data-root=/var/lib/docker-bootstrap \
         --exec-root=/var/run/docker-bootstrap
+```
+
+### Default network options
+
+The `default-network-opts` key in the `daemon.json` configuration file, and the
+equivalent `--default-network-opt` CLI flag, let you specify default values for
+driver network driver options for new networks.
+
+The following example shows how to configure options for the `bridge` driver
+using the `daemon.json` file.
+
+```json
+{
+  "default-network-opts": {
+    "bridge": {
+      "com.docker.network.bridge.host_binding_ipv4": "127.0.0.1",
+      "com.docker.network.bridge.mtu": "1234"
+    }
+  }
+}
+```
+
+This example uses the `bridge` network driver. Refer to the
+[bridge network driver page](https://docs.docker.com/network/drivers/bridge/#options)
+for an overview of available driver options.
+
+After changing the configuration and restarting the daemon, new networks that
+you create use these option configurations as defaults.
+
+```console
+$ docker network create mynet
+$ docker network inspect mynet --format "{{json .Options}}"
+{"com.docker.network.bridge.host_binding_ipv4":"127.0.0.1","com.docker.network.bridge.mtu":"1234"}
+```
+
+Note that changing this daemon configuration doesn't affect pre-existing
+networks.
+
+Using the `--default-network-opt` CLI flag is useful for testing and debugging
+purposes, but you should prefer using the `daemon.json` file for persistent
+daemon configuration. The CLI flag expects a value with the following format:
+`driver=opt=value`, for example:
+
+```console
+$ sudo dockerd \
+  --default-network-opt bridge=com.docker.network.bridge.host_binding_ipv4=127.0.0.1 \
+  --default-network-opt bridge=com.docker.network.bridge.mtu=1234
 ```

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -20,6 +20,7 @@ dockerd - Enable daemon mode
 [**--default-gateway**[=*DEFAULT-GATEWAY*]]
 [**--default-gateway-v6**[=*DEFAULT-GATEWAY-V6*]]
 [**--default-address-pool**[=*DEFAULT-ADDRESS-POOL*]]
+[**--default-network-opt**[=*DRIVER=OPT=VALUE*]]
 [**--default-runtime**[=*runc*]]
 [**--default-ipc-mode**=*MODE*]
 [**--default-shm-size**[=*64MiB*]]
@@ -185,6 +186,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   Default address pool from which IPAM driver selects a subnet for the networks.
   Example: base=172.30.0.0/16,size=24 will set the default
   address pools for the selected scope networks to {172.30.[0-255].0/24}
+
+**--default-network-opt**=*DRIVER=OPT=VALUE*
+  Default network driver options
 
 **--default-runtime**=*"runtime"*
   Set default runtime if there're more than one specified by **--add-runtime**.


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

backport of docker/cli#4635
