### PR TITLE
docs: update redirect metadata for hugo

### DIFF
--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -1,5 +1,5 @@
 ---
-redirect_from:
+aliases:
 - "/engine/extend/plugins/"
 description: "How to add additional functionality to Docker with plugins extensions"
 keywords: "Examples, Usage, plugins, docker, documentation, user guide"

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -1,7 +1,7 @@
 ---
 description: "How to create authorization plugins to manage access control to your Docker daemon."
 keywords: "security, authorization, authentication, docker, documentation, plugin, extend"
-redirect_from:
+aliases:
 - "/engine/extend/authorization/"
 ---
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -2,7 +2,7 @@
 title: "Use the Docker command line"
 description: "Docker's CLI command description and usage"
 keywords: "Docker, Docker documentation, CLI, command line, config.json, CLI configuration file"
-redirect_from:
+aliases:
   - /reference/commandline/cli/
   - /engine/reference/commandline/engine/
   - /engine/reference/commandline/engine_activate/

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -2,7 +2,7 @@
 title: "dockerd"
 description: "The daemon command description and usage"
 keywords: "container, daemon, runtime"
-redirect_from:
+aliases:
 - /engine/reference/commandline/daemon/
 ---
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1,7 +1,7 @@
 ---
 description: "Configure containers at runtime"
 keywords: "docker, run, configure, runtime"
-redirect_from:
+aliases:
 - /reference/run/
 ---
 


### PR DESCRIPTION
docs.docker.com switched from Jekyll to Hugo, which uses "aliases" instead of "redirect_from".

**- A picture of a cute animal (not mandatory but encouraged)**

