### PR TITLE
TestParseWithMacAddress: check endpoint-scoped MacAddress field

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -290,9 +290,14 @@ func TestParseWithMacAddress(t *testing.T) {
 	if _, _, _, err := parseRun([]string{invalidMacAddress, "img", "cmd"}); err != nil && err.Error() != "invalidMacAddress is not a valid mac address" {
 		t.Fatalf("Expected an error with %v mac-address, got %v", invalidMacAddress, err)
 	}
-	if config, _, _ := mustParse(t, validMacAddress); config.MacAddress != "92:d0:c6:0a:29:33" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+	config, hostConfig, nwConfig := mustParse(t, validMacAddress)
+	if config.MacAddress != "92:d0:c6:0a:29:33" { //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
 		t.Fatalf("Expected the config to have '92:d0:c6:0a:29:33' as container-wide MacAddress, got '%v'",
 			config.MacAddress) //nolint:staticcheck // ignore SA1019: field is deprecated, but still used on API < v1.44.
+	}
+	defaultNw := hostConfig.NetworkMode.NetworkName()
+	if nwConfig.EndpointsConfig[defaultNw].MacAddress != "92:d0:c6:0a:29:33" {
+		t.Fatalf("Expected the default endpoint to have the MacAddress '92:d0:c6:0a:29:33' set, got '%v'", nwConfig.EndpointsConfig[defaultNw].MacAddress)
 	}
 }
 


### PR DESCRIPTION
- Supersedes / Closes https://github.com/docker/cli/pull/4645
- relates to https://github.com/moby/moby/pull/45905

This is a follow-up of https://github.com/docker/cli/pull/4419. That PR leveraged the fact that EndpointSettings.MacAddress is already available, although not used by the CreateNetwork endpoint.

TestParseWithMacAddress was testing whether the container-wide MacAddress field is set, and we still need to test that to ensure backward compatibility. But we now also need to test whether the endpoint-specific MacAddress is set.