### PR TITLE
Permit '=' separator and '[ipv6]' in --add-host

### DIFF
--- a/docs/reference/commandline/build.md
+++ b/docs/reference/commandline/build.md
@@ -454,12 +454,12 @@ Specifying the `--isolation` flag without a value is the same as setting `--isol
 
 ### <a name="add-host"></a> Add entries to container hosts file (--add-host)
 
-You can add other hosts into a container's `/etc/hosts` file by using one or
-more `--add-host` flags. This example adds a static address for a host named
-`docker`:
+You can add other hosts into a build container's `/etc/hosts` file by using one
+or more `--add-host` flags. This example adds static addresses for hosts named
+`my-hostname` and `my_hostname_v6`:
 
 ```console
-$ docker build --add-host docker:10.180.0.1 .
+$ docker build --add-host my_hostname=8.8.8.8 --add-host my_hostname_v6=2001:4860:4860::8888 .
 ```
 
 If you need your build to connect to services running on the host, you can use
@@ -467,7 +467,15 @@ the special `host-gateway` value for `--add-host`. In the following example,
 build containers resolve `host.docker.internal` to the host's gateway IP.
 
 ```console
-$ docker build --add-host host.docker.internal:host-gateway .
+$ docker build --add-host host.docker.internal=host-gateway .
+```
+
+You can wrap an IPv6 address in square brackets.
+`=` and `:` are both valid separators.
+Both formats in the following example are valid:
+
+```console
+$ docker build --add-host my-hostname:10.180.0.1 --add-host my-hostname_v6=[2001:4860:4860::8888] .
 ```
 
 ### <a name="target"></a> Specifying target build stage (--target)

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -746,20 +746,26 @@ section of the Docker run reference page.
 
 You can add other hosts into a container's `/etc/hosts` file by using one or
 more `--add-host` flags. This example adds a static address for a host named
-`docker`:
+`my-hostname`:
 
 ```console
-$ docker run --add-host=docker:93.184.216.34 --rm -it alpine
+$ docker run --add-host=my-hostname=8.8.8.8 --rm -it alpine
 
-/ # ping docker
-PING docker (93.184.216.34): 56 data bytes
-64 bytes from 93.184.216.34: seq=0 ttl=37 time=93.052 ms
-64 bytes from 93.184.216.34: seq=1 ttl=37 time=92.467 ms
-64 bytes from 93.184.216.34: seq=2 ttl=37 time=92.252 ms
+/ # ping my-hostname
+PING my-hostname (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: seq=0 ttl=37 time=93.052 ms
+64 bytes from 8.8.8.8: seq=1 ttl=37 time=92.467 ms
+64 bytes from 8.8.8.8: seq=2 ttl=37 time=92.252 ms
 ^C
---- docker ping statistics ---
+--- my-hostname ping statistics ---
 4 packets transmitted, 4 packets received, 0% packet loss
 round-trip min/avg/max = 92.209/92.495/93.052 ms
+```
+
+You can wrap an IPv6 address in square brackets:
+
+```console
+$ docker run --add-host my-hostname=[2001:db8::33] --rm -it alpine
 ```
 
 The `--add-host` flag supports a special `host-gateway` value that resolves to
@@ -779,9 +785,15 @@ $ echo "hello from host!" > ./hello
 $ python3 -m http.server 8000
 Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 $ docker run \
-  --add-host host.docker.internal:host-gateway \
+  --add-host host.docker.internal=host-gateway \
   curlimages/curl -s host.docker.internal:8000/hello
 hello from host!
+```
+
+The `--add-host` flag also accepts a `:` separator, for example:
+
+```console
+$ docker run --add-host=my-hostname:8.8.8.8 --rm -it alpine
 ```
 
 ### <a name="ulimit"></a> Set ulimits in container (--ulimit)

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -78,10 +78,10 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
    layers in tact, and one for the squashed version.
 
 **--add-host** []
-   Add a custom host-to-IP mapping (host:ip)
+   Add a custom host-to-IP mapping (host=ip, or host:ip)
 
-   Add a line to /etc/hosts. The format is hostname:ip.  The **--add-host**
-option can be set multiple times.
+   Add a line to /etc/hosts. The format is hostname=ip, or hostname:ip.
+   The **--add-host** option can be set multiple times.
 
 **--build-arg** *variable*
    name and value of a **buildarg**.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -121,10 +121,10 @@ executables expect) and pass along signals. The **-a** option can be set for
 each of stdin, stdout, and stderr.
 
 **--add-host**=[]
-   Add a custom host-to-IP mapping (host:ip)
+   Add a custom host-to-IP mapping (host=ip, or host:ip)
 
-   Add a line to /etc/hosts. The format is hostname:ip.  The **--add-host**
-option can be set multiple times.
+   Add a line to /etc/hosts. The format is hostname=ip, or hostname:ip.
+   The **--add-host** option can be set multiple times.
 
 **--annotation**=[]
    Add an annotation to the container (passed through to the OCI runtime).

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -2,8 +2,10 @@ package opts
 
 import (
 	"fmt"
-	"strings"
 	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestParseHost(t *testing.T) {
@@ -146,32 +148,152 @@ func TestParseInvalidUnixAddrInvalid(t *testing.T) {
 }
 
 func TestValidateExtraHosts(t *testing.T) {
-	valid := []string{
-		`myhost:192.168.0.1`,
-		`thathost:10.0.2.1`,
-		`anipv6host:2003:ab34:e::1`,
-		`ipv6local:::1`,
-		`host.docker.internal:host-gateway`,
+	tests := []struct {
+		doc         string
+		input       string
+		expectedOut string // Expect output==input if not set.
+		expectedErr string // Expect success if not set.
+	}{
+		{
+			doc:   "IPv4, colon sep",
+			input: `myhost:192.168.0.1`,
+		},
+		{
+			doc:         "IPv4, eq sep",
+			input:       `myhost=192.168.0.1`,
+			expectedOut: `myhost:192.168.0.1`,
+		},
+		{
+			doc:         "Weird but permitted, IPv4 with brackets",
+			input:       `myhost=[192.168.0.1]`,
+			expectedOut: `myhost:192.168.0.1`,
+		},
+		{
+			doc:   "Host and domain",
+			input: `host.and.domain.invalid:10.0.2.1`,
+		},
+		{
+			doc:   "IPv6, colon sep",
+			input: `anipv6host:2003:ab34:e::1`,
+		},
+		{
+			doc:         "IPv6, colon sep, brackets",
+			input:       `anipv6host:[2003:ab34:e::1]`,
+			expectedOut: `anipv6host:2003:ab34:e::1`,
+		},
+		{
+			doc:         "IPv6, eq sep, brackets",
+			input:       `anipv6host=[2003:ab34:e::1]`,
+			expectedOut: `anipv6host:2003:ab34:e::1`,
+		},
+		{
+			doc:   "IPv6 localhost, colon sep",
+			input: `ipv6local:::1`,
+		},
+		{
+			doc:         "IPv6 localhost, eq sep",
+			input:       `ipv6local=::1`,
+			expectedOut: `ipv6local:::1`,
+		},
+		{
+			doc:         "IPv6 localhost, eq sep, brackets",
+			input:       `ipv6local=[::1]`,
+			expectedOut: `ipv6local:::1`,
+		},
+		{
+			doc:   "IPv6 localhost, non-canonical, colon sep",
+			input: `ipv6local:0:0:0:0:0:0:0:1`,
+		},
+		{
+			doc:         "IPv6 localhost, non-canonical, eq sep",
+			input:       `ipv6local=0:0:0:0:0:0:0:1`,
+			expectedOut: `ipv6local:0:0:0:0:0:0:0:1`,
+		},
+		{
+			doc:         "IPv6 localhost, non-canonical, eq sep, brackets",
+			input:       `ipv6local=[0:0:0:0:0:0:0:1]`,
+			expectedOut: `ipv6local:0:0:0:0:0:0:0:1`,
+		},
+		{
+			doc:   "host-gateway special case, colon sep",
+			input: `host.docker.internal:host-gateway`,
+		},
+		{
+			doc:         "host-gateway special case, eq sep",
+			input:       `host.docker.internal=host-gateway`,
+			expectedOut: `host.docker.internal:host-gateway`,
+		},
+		{
+			doc:         "Bad address, colon sep",
+			input:       `myhost:192.notanipaddress.1`,
+			expectedErr: `invalid IP address in add-host: "192.notanipaddress.1"`,
+		},
+		{
+			doc:         "Bad address, eq sep",
+			input:       `myhost=192.notanipaddress.1`,
+			expectedErr: `invalid IP address in add-host: "192.notanipaddress.1"`,
+		},
+		{
+			doc:         "No sep",
+			input:       `thathost-nosemicolon10.0.0.1`,
+			expectedErr: `bad format for add-host: "thathost-nosemicolon10.0.0.1"`,
+		},
+		{
+			doc:         "Bad IPv6",
+			input:       `anipv6host:::::1`,
+			expectedErr: `invalid IP address in add-host: "::::1"`,
+		},
+		{
+			doc:         "Bad IPv6, trailing colons",
+			input:       `ipv6local:::0::`,
+			expectedErr: `invalid IP address in add-host: "::0::"`,
+		},
+		{
+			doc:         "Bad IPv6, missing close bracket",
+			input:       `ipv6addr=[::1`,
+			expectedErr: `invalid IP address in add-host: "[::1"`,
+		},
+		{
+			doc:         "Bad IPv6, missing open bracket",
+			input:       `ipv6addr=::1]`,
+			expectedErr: `invalid IP address in add-host: "::1]"`,
+		},
+		{
+			doc:         "Missing address, colon sep",
+			input:       `myhost.invalid:`,
+			expectedErr: `invalid IP address in add-host: ""`,
+		},
+		{
+			doc:         "Missing address, eq sep",
+			input:       `myhost.invalid=`,
+			expectedErr: `invalid IP address in add-host: ""`,
+		},
+		{
+			doc:         "IPv6 localhost, bad name",
+			input:       `:=::1`,
+			expectedErr: `bad format for add-host: ":=::1"`,
+		},
+		{
+			doc:         "No input",
+			input:       ``,
+			expectedErr: `bad format for add-host: ""`,
+		},
 	}
 
-	invalid := map[string]string{
-		`myhost:192.notanipaddress.1`:  `invalid IP`,
-		`thathost-nosemicolon10.0.0.1`: `bad format`,
-		`anipv6host:::::1`:             `invalid IP`,
-		`ipv6local:::0::`:              `invalid IP`,
-	}
-
-	for _, extrahost := range valid {
-		if _, err := ValidateExtraHost(extrahost); err != nil {
-			t.Fatalf("ValidateExtraHost(`"+extrahost+"`) should succeed: error %v", err)
+	for _, tc := range tests {
+		tc := tc
+		if tc.expectedOut == "" {
+			tc.expectedOut = tc.input
 		}
-	}
-
-	for extraHost, expectedError := range invalid {
-		if _, err := ValidateExtraHost(extraHost); err == nil {
-			t.Fatalf("ValidateExtraHost(`%q`) should have failed validation", extraHost)
-		} else if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("ValidateExtraHost(`%q`) error should contain %q", extraHost, expectedError)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			actualOut, actualErr := ValidateExtraHost(tc.input)
+			if tc.expectedErr == "" {
+				assert.Check(t, is.Equal(tc.expectedOut, actualOut))
+				assert.NilError(t, actualErr)
+			} else {
+				assert.Check(t, actualOut == "")
+				assert.Check(t, is.Error(actualErr, tc.expectedErr))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #4648

**- What I did**

Make it easier to specify IPv6 addresses in the '--add-host' option by permitting 'host=ip' in addition to 'host:ip', and allowing square brackets around the address.

For example:

    --add-host=hostname:127.0.0.1
    --add-host=hostname:::1
    --add-host=hostname=::1
    --add-host=hostname:[::1]

**- How I did it**

To avoid compatibility problems, the CLI will replace an '=' separator with ':', and strip brackets, before sending the request to the API.

**- How to verify it**

New unit tests pass.

The `docker run` command sets up a `/etc/hosts` entry as expected when using '=' and brackets ...

```
# /usr/local/cli/cli/build/docker run -ti --add-host thishost=[::1] alpine sh
/ # cat /etc/hosts
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
::1     thishost
172.18.0.2      43c134b9fad0
```

But `docker inspect` still shows the option with a ':' separator and no brackets ...

```
# /usr/local/cli/cli/build/docker inspect 43 -f '{{ .HostConfig.ExtraHosts }}'
[thishost:::1]
```

The same formats work for legacy `docker build`, `buildx` needs a separate change ...

```
root@6b6f43dcb70f:/go/src/github.com/docker/docker/a# cat Dockerfile
FROM alpine:latest
RUN ping -c1 something
RUN ping -c1 somethingv6

root@6b6f43dcb70f:/go/src/github.com/docker/docker/a# DOCKER_BUILDKIT=0 /usr/local/cli/cli/build/docker build --no-cache --add-host=something=8.8.8.8 --add-host somethingv6=[::1] .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  3.072kB
Step 1/3 : FROM alpine:latest
 ---> 3cc203321400
Step 2/3 : RUN ping -c1 something
 ---> Running in e4bbbe9f65d4
PING something (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: seq=0 ttl=62 time=16.070 ms

--- something ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 16.070/16.070/16.070 ms
 ---> Removed intermediate container e4bbbe9f65d4
 ---> 13397ec9bb56
Step 3/3 : RUN ping -c1 somethingv6
 ---> Running in 39453415243e
PING somethingv6 (::1): 56 data bytes
64 bytes from ::1: seq=0 ttl=64 time=0.024 ms

--- somethingv6 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.024/0.024/0.024 ms
 ---> Removed intermediate container 39453415243e
 ---> e968e3d10d73
Successfully built e968e3d10d73
```

**- Description for the changelog**

Permit '=' separator and '[ipv6]' in --add-host