### PR TITLE
docs: Add zstd as supported in load command

### DIFF
--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -20,7 +20,7 @@ Load an image from a tar archive or STDIN
 ## Description
 
 Load an image or repository from a tar archive (even if compressed with gzip,
-bzip2, or xz) from a file or STDIN. It restores both images and tags.
+bzip2, xz or zstd) from a file or STDIN. It restores both images and tags.
 
 ## Examples
 


### PR DESCRIPTION
**- What I did**
As far as I can tell, zstd is now supported  in the `load` command.
[The PR that adds support for it](https://github.com/moby/moby/pull/41759).

**- How I did it**

**- How to verify it**
I checked the zstd support with:
```shell
docker pull hello-world
docker save hello-world | zstd | ssh <remote_host> docker load
```
And the remote was able to run the hello-world  container successfully.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

