### PR TITLE
mount: bind-recursive: remove boolean convenience values

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -442,13 +442,13 @@ The following options can only be used for bind mounts (`type=bind`):
       A value is one of:<br />
       <br />
       <ul>
-        <li><<tt>enabled</tt>,  <tt>true</tt>  or <tt>1</tt>: Enables recursive bind-mount.
+        <li><<tt>enabled</tt>: Enables recursive bind-mount.
         Read-only mounts are made recursively read-only if kernel is v5.12 or later.
         Otherwise they are not made recursively read-only.</li>
-        <li><<tt>disabled</tt>, <tt>false</tt> or <tt>0</tt>: Disables recursive bind-mount.</li>
-        <li><<tt>writable</tt>:                               Enables recursive bind-mount.
+        <li><<tt>disabled</tt>: Disables recursive bind-mount.</li>
+        <li><<tt>writable</tt>: Enables recursive bind-mount.
         Read-only mounts are not made recursively read-only.</li>
-        <li><<tt>readonly</tt>:                               Enables recursive bind-mount.
+        <li><<tt>readonly</tt>: Enables recursive bind-mount.
         Read-only mounts are made recursively read-only if kernel is v5.12 or later.
         Otherwise the Engine raises an error.</li>
       </ul>

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -116,16 +116,7 @@ func (m *MountOpt) Set(value string) error {
 			}
 			logrus.Warn("bind-nonrecursive is deprecated, use bind-recursive=disabled instead")
 		case "bind-recursive":
-			valS := val
-			// Allow boolean as an alias to "enabled" or "disabled"
-			if b, err := strconv.ParseBool(valS); err == nil {
-				if b {
-					valS = "enabled"
-				} else {
-					valS = "disabled"
-				}
-			}
-			switch valS {
+			switch val {
 			case "enabled": // read-only mounts are recursively read-only if Engine >= v25 && kernel >= v5.12, otherwise writable
 				// NOP
 			case "disabled": // alias of bind-nonrecursive=true


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4316
- relates to https://github.com/docker/cli/pull/4606
- relates to https://github.com/docker/docs/pull/18669#discussion_r1401764837
- updates fc6976db45e24cc2baff50d806402ae2a8468a13 / https://github.com/docker/cli/pull/4316
- updates 74bace156ccfcee69c3c0ac84806ed488adb69e0 / https://github.com/docker/cli/pull/4606

Commit fc6976db45e24cc2baff50d806402ae2a8468a13 (https://github.com/docker/cli/pull/4316) introduced support for the `bind-recursive` option on `--mount`, and deprecated the `bind-nonrecursive` option.  Unlike `bind-nonrecursive` boolean, the `bind-recursive` option accepts a string value with multiple options.

For convenience, the `bind-recursive` option also was made to accept boolean values (true/false, 1/0). However, as the option works as the _reverse_ of `bind-nonrecursive` (`bind-nonrecursive=true` === `bind-recursive=false`), the new option won't be a "drop-in" replacement, and having more options to choose from may only be adding more complexity / cognitive overload.

This patch removes support for boolean values; if we see a need to add support for boolean values in future, it would be trivial to add back this functionality.


**- A picture of a cute animal (not mandatory but encouraged)**

