### PR TITLE
[24.0 backport] docs/man: fix -name flag with single hyphen

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -678,7 +678,7 @@ any number of minor numbers (added as new devices appear), add the
 following rule:
 
 ```console
-$ docker run -d --device-cgroup-rule='c 42:* rmw' -name my-container my-image
+$ docker run -d --device-cgroup-rule='c 42:* rmw' --name my-container my-image
 ```
 
 Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`

--- a/man/src/container/create-example.md
+++ b/man/src/container/create-example.md
@@ -25,7 +25,7 @@ any number of minor number (added as new devices appear), the
 following rule would be added:
 
 ```console
-$ docker create --device-cgroup-rule='c 42:* rmw' -name my-container my-image
+$ docker create --device-cgroup-rule='c 42:* rmw' --name my-container my-image
 ```
 
 Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4679
- addresses https://github.com/docker/docs/issues/18655

(cherry picked from commit 174cbb588f05091fbb30fe1942145a6bcebbb71d)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

