### PR TITLE
[24.0 backport] docs: remove "{% raw %}" / "{% endraw %}" Jekyl (liquid) leftovers

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -821,9 +821,7 @@ Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` a
 `fluentd-tag` have been deprecated in favor of the generic `tag` option.
 
 ```console
-{% raw %}
 $ docker --log-driver=syslog --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"
-{% endraw %}
 ```
 
 

--- a/docs/extend/plugins_graphdriver.md
+++ b/docs/extend/plugins_graphdriver.md
@@ -311,9 +311,7 @@ and `Parent`. `Parent` may be an empty string, in which case there is no parent.
 **Response**:
 
 ```
-{% raw %}
 {{ TAR STREAM }}
-{% endraw %}
 ```
 
 ### /GraphDriver.Changes
@@ -357,9 +355,7 @@ Respond with a non-empty string error if an error occurred.
 **Request**:
 
 ```
-{% raw %}
 {{ TAR STREAM }}
-{% endraw %}
 ```
 
 Extract the changeset from the given diff into the layer with the specified `ID`

--- a/docs/extend/plugins_logging.md
+++ b/docs/extend/plugins_logging.md
@@ -213,7 +213,7 @@ to determine what set of logs to read.
 **Response**:
 
 ```
-{% raw %}{{ log stream }}{% endraw %}
+{{ log stream }}
 ```
 
 The response should be the encoded log message using the same format as the

--- a/docs/extend/plugins_services.md
+++ b/docs/extend/plugins_services.md
@@ -69,10 +69,8 @@ node1 is the manager and node2 is the worker.
 4. Observe the task getting scheduled in node 2:
 
     ```console
-    {% raw %}
     $ docker ps --format '{{.ID}}\t {{.Status}} {{.Names}} {{.Command}}'
     83fc1e842599     Up 2 days my-service.1.9jn59qzn7nbc3m0zt1hij12xs "top"
-    {% endraw %}
     ```
 
 ### Network plugins

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -156,7 +156,7 @@ By default, the Docker command line stores its configuration files in a
 directory called `.docker` within your `$HOME` directory.
 
 Docker manages most of the files in the configuration directory
-and you should not modify them. However, you *can* modify the
+and you should not modify them. However, you can modify the
 `config.json` file to control certain aspects of how the `docker`
 command behaves.
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -313,7 +313,6 @@ Following is a sample `config.json` file to illustrate the format used for
 various fields:
 
 ```json
-{% raw %}
 {
   "HttpHeaders": {
     "MyHeader": "MyValue"
@@ -356,7 +355,6 @@ various fields:
     }
   }
 }
-{% endraw %}
 ```
 
 ### Experimental features

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -570,19 +570,15 @@ for a container can be obtained via [`docker inspect`](commandline/inspect.md). 
 for container "my-container";
 
 ```console
-{% raw %}
 $ docker inspect -f "{{ .RestartCount }}" my-container
 # 2
-{% endraw %}
 ```
 
 Or, to get the last time the container was (re)started;
 
 ```console
-{% raw %}
 $ docker inspect -f "{{ .State.StartedAt }}" my-container
 # 2015-03-04T23:47:07.691840179Z
-{% endraw %}
 ```
 
 Combining `--restart` (restart policy) with the `--rm` (clean up) flag results
@@ -1646,7 +1642,6 @@ Similarly the operator can set the **HOSTNAME** (Linux) or **COMPUTERNAME** (Win
 Example:
 
 ```console
-{% raw %}
 $ docker run --name=test -d \
     --health-cmd='stat /etc/passwd || exit 1' \
     --health-interval=2s \
@@ -1691,7 +1686,6 @@ $ sleep 2; docker inspect --format='{{json .State.Health}}' test
     }
   ]
 }
-{% endraw %}
 ```
 
 The health status is also displayed in the `docker ps` output.


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4681
- addresses https://github.com/docker/docs/issues/18236
- addresses https://github.com/docker/docs/issues/18585



**- A picture of a cute animal (not mandatory but encouraged)**

