### PR TITLE
prune: fix build cache prune warning

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -125,7 +125,7 @@ func confirmationMessage(dockerCli command.Cli, options pruneOptions) string {
 		if options.all {
 			warnings = append(warnings, "all build cache")
 		} else {
-			warnings = append(warnings, "all dangling build cache")
+			warnings = append(warnings, "unused build cache")
 		}
 	}
 

--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -36,7 +36,7 @@ func TestPrunePromptFilters(t *testing.T) {
   - all stopped containers
   - all networks not used by at least one container
   - all dangling images
-  - all dangling build cache
+  - unused build cache
 
   Items to be pruned will be filtered with:
   - label!=foo=bar

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -29,7 +29,7 @@ WARNING! This will remove:
         - all stopped containers
         - all networks not used by at least one container
         - all dangling images
-        - all build cache
+        - unused build cache
 Are you sure you want to continue? [y/N] y
 
 Deleted Containers:


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Rephrase the warn message fr build cache prune to mention shared refs instead of dangling

- relates to docker/docs#18790

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

