### PR TITLE
Fix typo in dockerd reference documentation

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -205,7 +205,7 @@ find examples of using Systemd socket activation with Docker and Systemd in the
 You can configure the Docker daemon to listen to multiple sockets at the same
 time using multiple `-H` options:
 
-The example below runs the daemon listenin on the default unix socket, and
+The example below runs the daemon listening on the default unix socket, and
 on 2 specific IP addresses on this host:
 
 ```console


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
    - Fixed a typo in the docker daemon reference docs

**- How I did it**
- Using https://github.dev

**- How to verify it**
- See files changed diff

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed a typo in the docker daemon reference documentation

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/docker/cli/assets/79593869/89617f3e-21cd-4354-b363-b4fb66f7feeb)
> _Lily, goblin of the legs_