### PR TITLE
cleanup: don't use pkg/errors

### DIFF
--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // pluginError is set as Plugin.Err by NewPlugin if the plugin
@@ -36,13 +36,13 @@ func (e *pluginError) MarshalText() (text []byte, err error) {
 }
 
 // wrapAsPluginError wraps an error in a pluginError with an
-// additional message, analogous to errors.Wrapf.
+// additional message, analogous to wrapped error.
 func wrapAsPluginError(err error, msg string) error {
-	return &pluginError{cause: errors.Wrap(err, msg)}
+	return &pluginError{cause: fmt.Errorf(msg+": %w", err)}
 }
 
 // NewPluginError creates a new pluginError, analogous to
 // errors.Errorf.
 func NewPluginError(msg string, args ...any) error {
-	return &pluginError{cause: errors.Errorf(msg, args...)}
+	return &pluginError{cause: fmt.Errorf(msg, args...)}
 }

--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -2,11 +2,12 @@ package manager
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -41,14 +42,14 @@ func newPlugin(c Candidate, cmds []*cobra.Command) (Plugin, error) {
 	// which would fail here, so there are all real errors.
 	fullname := filepath.Base(path)
 	if fullname == "." {
-		return Plugin{}, errors.Errorf("unable to determine basename of plugin candidate %q", path)
+		return Plugin{}, fmt.Errorf("unable to determine basename of plugin candidate %q", path)
 	}
 	var err error
 	if fullname, err = trimExeSuffix(fullname); err != nil {
-		return Plugin{}, errors.Wrapf(err, "plugin candidate %q", path)
+		return Plugin{}, fmt.Errorf("plugin candidate %q: %w", path, err)
 	}
 	if !strings.HasPrefix(fullname, NamePrefix) {
-		return Plugin{}, errors.Errorf("plugin candidate %q: does not have %q prefix", path, NamePrefix)
+		return Plugin{}, fmt.Errorf("plugin candidate %q: does not have %q prefix", path, NamePrefix)
 	}
 
 	p := Plugin{

--- a/cli-plugins/manager/suffix_windows.go
+++ b/cli-plugins/manager/suffix_windows.go
@@ -1,10 +1,9 @@
 package manager
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // This is made slightly more complex due to needing to be case insensitive.

--- a/cli-plugins/manager/suffix_windows.go
+++ b/cli-plugins/manager/suffix_windows.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -10,12 +10,12 @@ import (
 func trimExeSuffix(s string) (string, error) {
 	ext := filepath.Ext(s)
 	if ext == "" {
-		return "", errors.Errorf("path %q lacks required file extension", s)
+		return "", fmt.Errorf("path %q lacks required file extension", s)
 	}
 
 	exe := ".exe"
 	if !strings.EqualFold(ext, exe) {
-		return "", errors.Errorf("path %q lacks required %q suffix", s, exe)
+		return "", fmt.Errorf("path %q lacks required %q suffix", s, exe)
 	}
 	return strings.TrimSuffix(s, ext), nil
 }

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fvbommel/sortorder"
 	"github.com/moby/term"
 	"github.com/morikuni/aec"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -218,7 +217,7 @@ var helpCommand = &cobra.Command{
 	RunE: func(c *cobra.Command, args []string) error {
 		cmd, args, e := c.Root().Find(args)
 		if cmd == nil || e != nil || len(args) > 0 {
-			return errors.Errorf("unknown help topic: %v", strings.Join(args, " "))
+			return fmt.Errorf("unknown help topic: %v", strings.Join(args, " "))
 		}
 		helpFunc := cmd.HelpFunc()
 		helpFunc(cmd, args)

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -1,13 +1,13 @@
 package checkpoint
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/checkpoint"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/checkpoint/create_test.go
+++ b/cli/command/checkpoint/create_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -29,7 +29,7 @@ func TestCheckpointCreateErrors(t *testing.T) {
 		{
 			args: []string{"foo", "bar"},
 			checkpointCreateFunc: func(container string, options checkpoint.CreateOptions) error {
-				return errors.Errorf("error creating checkpoint for container foo")
+				return fmt.Errorf("error creating checkpoint for container foo")
 			},
 			expectedError: "error creating checkpoint for container foo",
 		},

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -1,12 +1,12 @@
 package checkpoint
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/checkpoint"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/checkpoint/list_test.go
+++ b/cli/command/checkpoint/list_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -29,7 +29,7 @@ func TestCheckpointListErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			checkpointListFunc: func(container string, options checkpoint.ListOptions) ([]checkpoint.Summary, error) {
-				return []checkpoint.Summary{}, errors.Errorf("error getting checkpoints for container foo")
+				return []checkpoint.Summary{}, fmt.Errorf("error getting checkpoints for container foo")
 			},
 			expectedError: "error getting checkpoints for container foo",
 		},

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -1,7 +1,7 @@
 package checkpoint
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -28,7 +28,7 @@ func TestCheckpointRemoveErrors(t *testing.T) {
 		{
 			args: []string{"foo", "bar"},
 			checkpointDeleteFunc: func(container string, options checkpoint.DeleteOptions) error {
-				return errors.Errorf("error deleting checkpoint")
+				return fmt.Errorf("error deleting checkpoint")
 			},
 			expectedError: "error deleting checkpoint",
 		},

--- a/cli/command/checkpoint/remove_test.go
+++ b/cli/command/checkpoint/remove_test.go
@@ -1,12 +1,12 @@
 package checkpoint
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/checkpoint"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -30,7 +31,6 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	notaryclient "github.com/theupdateframework/notary/client"
 )
@@ -165,7 +165,7 @@ func (cli *DockerCli) BuildKitEnabled() (bool, error) {
 	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
-			return false, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+			return false, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w", err)
 		}
 		return enabled, nil
 	}
@@ -254,7 +254,7 @@ func NewAPIClientFromFlags(opts *cliflags.ClientOptions, configFile *configfile.
 	}
 	endpoint, err := resolveDockerEndpoint(contextStore, resolveContextName(opts, configFile))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to resolve docker endpoint")
+		return nil, fmt.Errorf("unable to resolve docker endpoint: %w", err)
 	}
 	return newAPIClientFromEndpoint(endpoint, configFile)
 }
@@ -436,7 +436,7 @@ func (cli *DockerCli) initialize() error {
 	cli.init.Do(func() {
 		cli.dockerEndpoint, cli.initErr = cli.getDockerEndPoint()
 		if cli.initErr != nil {
-			cli.initErr = errors.Wrap(cli.initErr, "unable to resolve docker endpoint")
+			cli.initErr = fmt.Errorf("unable to resolve docker endpoint: %w", cli.initErr)
 			return
 		}
 		if cli.client == nil {

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 )

--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/moby/sys/sequential"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -64,7 +63,7 @@ func RunConfigCreate(dockerCli command.Cli, options CreateOptions) error {
 
 	configData, err := io.ReadAll(in)
 	if err != nil {
-		return errors.Errorf("Error reading content from %q: %v", options.File, err)
+		return fmt.Errorf("Error reading content from %q: %v", options.File, err)
 	}
 
 	spec := swarm.ConfigSpec{

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,7 +37,7 @@ func TestConfigCreateErrors(t *testing.T) {
 		{
 			args: []string{"name", filepath.Join("testdata", configDataFile)},
 			configCreateFunc: func(_ context.Context, configSpec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
-				return types.ConfigCreateResponse{}, errors.Errorf("error creating config")
+				return types.ConfigCreateResponse{}, fmt.Errorf("error creating config")
 			},
 			expectedError: "error creating config",
 		},
@@ -60,7 +60,7 @@ func TestConfigCreateWithName(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configCreateFunc: func(_ context.Context, spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 			if spec.Name != name {
-				return types.ConfigCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+				return types.ConfigCreateResponse{}, fmt.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
 			actual = spec.Data
@@ -99,7 +99,7 @@ func TestConfigCreateWithLabels(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configCreateFunc: func(_ context.Context, spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 			if !reflect.DeepEqual(spec, expected) {
-				return types.ConfigCreateResponse{}, errors.Errorf("expected %+v, got %+v", expected, spec)
+				return types.ConfigCreateResponse{}, fmt.Errorf("expected %+v, got %+v", expected, spec)
 			}
 
 			return types.ConfigCreateResponse{
@@ -125,11 +125,11 @@ func TestConfigCreateWithTemplatingDriver(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		configCreateFunc: func(_ context.Context, spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
 			if spec.Name != name {
-				return types.ConfigCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+				return types.ConfigCreateResponse{}, fmt.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
 			if spec.Templating.Name != expectedDriver.Name {
-				return types.ConfigCreateResponse{}, errors.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
+				return types.ConfigCreateResponse{}, fmt.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
 			}
 
 			return types.ConfigCreateResponse{

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/config/inspect_test.go
+++ b/cli/command/config/inspect_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -28,7 +27,7 @@ func TestConfigInspectErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			configInspectFunc: func(_ context.Context, configID string) (swarm.Config, []byte, error) {
-				return swarm.Config{}, nil, errors.Errorf("error while inspecting the config")
+				return swarm.Config{}, nil, fmt.Errorf("error while inspecting the config")
 			},
 			expectedError: "error while inspecting the config",
 		},
@@ -45,7 +44,7 @@ func TestConfigInspectErrors(t *testing.T) {
 				if configID == "foo" {
 					return *builders.Config(builders.ConfigName("foo")), nil, nil
 				}
-				return swarm.Config{}, nil, errors.Errorf("error while inspecting the config")
+				return swarm.Config{}, nil, fmt.Errorf("error while inspecting the config")
 			},
 			expectedError: "error while inspecting the config",
 		},
@@ -76,7 +75,7 @@ func TestConfigInspectWithoutFormat(t *testing.T) {
 			args: []string{"foo"},
 			configInspectFunc: func(_ context.Context, name string) (swarm.Config, []byte, error) {
 				if name != "foo" {
-					return swarm.Config{}, nil, errors.Errorf("Invalid name, expected %s, got %s", "foo", name)
+					return swarm.Config{}, nil, fmt.Errorf("Invalid name, expected %s, got %s", "foo", name)
 				}
 				return *builders.Config(builders.ConfigID("ID-foo"), builders.ConfigName("foo")), nil, nil
 			},

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/config/ls_test.go
+++ b/cli/command/config/ls_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -29,7 +29,7 @@ func TestConfigListErrors(t *testing.T) {
 		},
 		{
 			configListFunc: func(_ context.Context, options types.ConfigListOptions) ([]swarm.Config, error) {
-				return []swarm.Config{}, errors.Errorf("error listing configs")
+				return []swarm.Config{}, fmt.Errorf("error listing configs")
 			},
 			expectedError: "error listing configs",
 		},

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +50,7 @@ func RunConfigRemove(dockerCli command.Cli, opts RemoveOptions) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -24,7 +24,7 @@ func TestConfigRemoveErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			configRemoveFunc: func(name string) error {
-				return errors.Errorf("error removing config")
+				return fmt.Errorf("error removing config")
 			},
 			expectedError: "error removing config",
 		},
@@ -65,7 +65,7 @@ func TestConfigRemoveContinueAfterError(t *testing.T) {
 		configRemoveFunc: func(name string) error {
 			removedConfigs = append(removedConfigs, name)
 			if name == "foo" {
-				return errors.Errorf("error removing config: %s", name)
+				return fmt.Errorf("error removing config: %s", name)
 			}
 			return nil
 		},

--- a/cli/command/config/remove_test.go
+++ b/cli/command/config/remove_test.go
@@ -1,12 +1,12 @@
 package config
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/moby/sys/signal"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -25,7 +24,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 			args:          []string{"5cb5bb5e4a3b"},
 			expectedError: "something went wrong",
 			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
-				return types.ContainerJSON{}, errors.Errorf("something went wrong")
+				return types.ContainerJSON{}, fmt.Errorf("something went wrong")
 			},
 		},
 		{

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -3,6 +3,7 @@ package container
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	units "github.com/docker/go-units"
 	"github.com/morikuni/aec"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -333,7 +333,7 @@ func copyToContainer(ctx context.Context, dockerCli command.Cli, copyConfig cpCo
 
 	// Validate the destination path
 	if err := command.ValidateOutputPathFileMode(dstStat.Mode); err != nil {
-		return errors.Wrapf(err, `destination "%s:%s" must be a directory or a regular file`, copyConfig.container, dstPath)
+		return fmt.Errorf("destination \"%s:%s\" must be a directory or a regular file: %w", copyConfig.container, dstPath, err)
 	}
 
 	// Ignore any error and assume that the parent directory of the destination
@@ -356,7 +356,7 @@ func copyToContainer(ctx context.Context, dockerCli command.Cli, copyConfig cpCo
 		content = os.Stdin
 		resolvedDstPath = dstInfo.Path
 		if !dstInfo.IsDir {
-			return errors.Errorf("destination \"%s:%s\" must be a directory", copyConfig.container, dstPath)
+			return fmt.Errorf("destination \"%s:%s\" must be a directory", copyConfig.container, dstPath)
 		}
 	} else {
 		// Prepare source copy info.

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -21,7 +21,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/jsonmessage"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -151,7 +150,7 @@ func (cid *cidFile) Close() error {
 		return nil
 	}
 	if err := os.Remove(cid.path); err != nil {
-		return errors.Wrapf(err, "failed to remove the CID file '%s'", cid.path)
+		return fmt.Errorf("failed to remove the CID file '%s': %w", cid.path, err)
 	}
 
 	return nil
@@ -162,7 +161,7 @@ func (cid *cidFile) Write(id string) error {
 		return nil
 	}
 	if _, err := cid.file.Write([]byte(id)); err != nil {
-		return errors.Wrap(err, "failed to write the container ID to the file")
+		return fmt.Errorf("failed to write the container ID to the file: %w", err)
 	}
 	cid.written = true
 	return nil
@@ -173,12 +172,12 @@ func newCIDFile(path string) (*cidFile, error) {
 		return &cidFile{}, nil
 	}
 	if _, err := os.Stat(path); err == nil {
-		return nil, errors.Errorf("container ID file found, make sure the other container isn't running or delete %s", path)
+		return nil, fmt.Errorf("container ID file found, make sure the other container isn't running or delete %s", path)
 	}
 
 	f, err := os.Create(path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create the container ID file")
+		return nil, fmt.Errorf("failed to create the container ID file: %w", err)
 	}
 
 	return &cidFile{path: path, file: f}, nil
@@ -239,7 +238,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	if options.platform != "" && versions.GreaterThanOrEqualTo(dockerCli.Client().ClientVersion(), "1.41") {
 		p, err := platforms.Parse(options.platform)
 		if err != nil {
-			return "", errors.Wrap(err, "error parsing specified platform")
+			return "", fmt.Errorf("error parsing specified platform: %w", err)
 		}
 		platform = &p
 	}

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -2,12 +2,12 @@ package container
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	apiclient "github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -257,7 +258,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 			args:          []string{"5cb5bb5e4a3b", "-t", "-i", "bash"},
 			expectedError: "something went wrong",
 			containerInspectFunc: func(containerID string) (types.ContainerJSON, error) {
-				return types.ContainerJSON{}, errors.Errorf("something went wrong")
+				return types.ContainerJSON{}, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/fs"

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -2,12 +2,13 @@ package container
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +48,7 @@ func runExport(dockerCli command.Cli, opts exportOptions) error {
 	}
 
 	if err := command.ValidateOutputPath(opts.output); err != nil {
-		return errors.Wrap(err, "failed to export container")
+		return fmt.Errorf("failed to export container: %w", err)
 	}
 
 	clnt := dockerCli.Client()

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/docker/cli/cli"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +84,7 @@ func buildContainerListOptions(options *psOptions) (*container.ListOptions, erro
 	if len(options.format) > 0 {
 		tmpl, err := templates.NewParse("", options.format)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse template")
+			return nil, fmt.Errorf("failed to parse template: %w", err)
 		}
 
 		optionsProcessor := formatter.NewContainerContext()
@@ -92,7 +92,7 @@ func buildContainerListOptions(options *psOptions) (*container.ListOptions, erro
 		// This shouldn't error out but swallowing the error makes it harder
 		// to track down if preProcessor issues come up.
 		if err := tmpl.Execute(io.Discard, optionsProcessor); err != nil {
-			return nil, errors.Wrap(err, "failed to execute template")
+			return nil, fmt.Errorf("failed to execute template: %w", err)
 		}
 
 		// if `size` was not explicitly set to false (with `--size=false`)

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -3,6 +3,7 @@ package container
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -22,7 +23,6 @@ import (
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/nat"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	cdi "tags.cncf.io/container-device-interface/pkg/parser"
@@ -331,7 +331,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	// Validate the input mac address
 	if copts.macAddress != "" {
 		if _, err := opts.ValidateMACAddress(copts.macAddress); err != nil {
-			return nil, errors.Errorf("%s is not a valid mac address", copts.macAddress)
+			return nil, fmt.Errorf("%s is not a valid mac address", copts.macAddress)
 		}
 	}
 	if copts.stdin {
@@ -347,7 +347,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 	swappiness := copts.swappiness
 	if swappiness != -1 && (swappiness < 0 || swappiness > 100) {
-		return nil, errors.Errorf("invalid value: %d. Valid memory swappiness range is 0-100", swappiness)
+		return nil, fmt.Errorf("invalid value: %d. Valid memory swappiness range is 0-100", swappiness)
 	}
 
 	mounts := copts.mounts.Value()
@@ -429,7 +429,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	// Merge in exposed ports to the map of published ports
 	for _, e := range copts.expose.GetAll() {
 		if strings.Contains(e, ":") {
-			return nil, errors.Errorf("invalid port format for --expose: %s", e)
+			return nil, fmt.Errorf("invalid port format for --expose: %s", e)
 		}
 		// support two formats for expose, original format <portnum>/[<proto>]
 		// or <startport-endport>/[<proto>]
@@ -438,7 +438,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		// if expose a port, the start and end port are the same
 		start, end, err := nat.ParsePortRange(port)
 		if err != nil {
-			return nil, errors.Errorf("invalid range format for --expose: %s, error: %s", e, err)
+			return nil, fmt.Errorf("invalid range format for --expose: %s, error: %s", e, err)
 		}
 		for i := start; i <= end; i++ {
 			p, err := nat.NewPort(proto, strconv.FormatUint(i, 10))
@@ -492,22 +492,22 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 	pidMode := container.PidMode(copts.pidMode)
 	if !pidMode.Valid() {
-		return nil, errors.Errorf("--pid: invalid PID mode")
+		return nil, fmt.Errorf("--pid: invalid PID mode")
 	}
 
 	utsMode := container.UTSMode(copts.utsMode)
 	if !utsMode.Valid() {
-		return nil, errors.Errorf("--uts: invalid UTS mode")
+		return nil, fmt.Errorf("--uts: invalid UTS mode")
 	}
 
 	usernsMode := container.UsernsMode(copts.usernsMode)
 	if !usernsMode.Valid() {
-		return nil, errors.Errorf("--userns: invalid USER mode")
+		return nil, fmt.Errorf("--userns: invalid USER mode")
 	}
 
 	cgroupnsMode := container.CgroupnsMode(copts.cgroupnsMode)
 	if !cgroupnsMode.Valid() {
-		return nil, errors.Errorf("--cgroupns: invalid CGROUP mode")
+		return nil, fmt.Errorf("--cgroupns: invalid CGROUP mode")
 	}
 
 	restartPolicy, err := opts.ParseRestartPolicy(copts.restartPolicy)
@@ -542,7 +542,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 		copts.healthStartInterval != 0
 	if copts.noHealthcheck {
 		if haveHealthSettings {
-			return nil, errors.Errorf("--no-healthcheck conflicts with --health-* options")
+			return nil, fmt.Errorf("--no-healthcheck conflicts with --health-* options")
 		}
 		healthConfig = &container.HealthConfig{Test: strslice.StrSlice{"NONE"}}
 	} else if haveHealthSettings {
@@ -551,13 +551,13 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 			probe = []string{"CMD-SHELL", copts.healthCmd}
 		}
 		if copts.healthInterval < 0 {
-			return nil, errors.Errorf("--health-interval cannot be negative")
+			return nil, fmt.Errorf("--health-interval cannot be negative")
 		}
 		if copts.healthTimeout < 0 {
-			return nil, errors.Errorf("--health-timeout cannot be negative")
+			return nil, fmt.Errorf("--health-timeout cannot be negative")
 		}
 		if copts.healthRetries < 0 {
-			return nil, errors.Errorf("--health-retries cannot be negative")
+			return nil, fmt.Errorf("--health-retries cannot be negative")
 		}
 		if copts.healthStartPeriod < 0 {
 			return nil, fmt.Errorf("--health-start-period cannot be negative")
@@ -690,7 +690,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	}
 
 	if copts.autoRemove && !hostConfig.RestartPolicy.IsNone() {
-		return nil, errors.Errorf("Conflicting options: --restart and --rm")
+		return nil, fmt.Errorf("Conflicting options: --restart and --rm")
 	}
 
 	// only set this value if the user provided the flag, else it should default to nil
@@ -774,7 +774,7 @@ func parseNetworkOpts(copts *containerOptions) (map[string]*networktypes.Endpoin
 			return nil, err
 		}
 		if _, ok := endpoints[n.Target]; ok {
-			return nil, errdefs.InvalidParameter(errors.Errorf("network %q is specified multiple times", n.Target))
+			return nil, errdefs.InvalidParameter(fmt.Errorf("network %q is specified multiple times", n.Target))
 		}
 
 		// For backward compatibility: if no custom options are provided for the network,
@@ -868,7 +868,7 @@ func parseNetworkAttachmentOpt(ep opts.NetworkAttachmentOpts) (*networktypes.End
 	}
 	if ep.MacAddress != "" {
 		if _, err := opts.ValidateMACAddress(ep.MacAddress); err != nil {
-			return nil, errors.Errorf("%s is not a valid mac address", ep.MacAddress)
+			return nil, fmt.Errorf("%s is not a valid mac address", ep.MacAddress)
 		}
 		epConfig.MacAddress = ep.MacAddress
 	}
@@ -883,7 +883,7 @@ func convertToStandardNotation(ports []string) ([]string, error) {
 			for _, param := range strings.Split(publish, ",") {
 				k, v, ok := strings.Cut(param, "=")
 				if !ok || k == "" {
-					return optsList, errors.Errorf("invalid publish opts format (should be name=value but got '%s')", param)
+					return optsList, fmt.Errorf("invalid publish opts format (should be name=value but got '%s')", param)
 				}
 				params[k] = v
 			}
@@ -898,7 +898,7 @@ func convertToStandardNotation(ports []string) ([]string, error) {
 func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]string, error) {
 	loggingOptsMap := opts.ConvertKVStringsToMap(loggingOpts)
 	if loggingDriver == "none" && len(loggingOpts) > 0 {
-		return map[string]string{}, errors.Errorf("invalid logging opts for driver %s", loggingDriver)
+		return map[string]string{}, fmt.Errorf("invalid logging opts for driver %s", loggingDriver)
 	}
 	return loggingOptsMap, nil
 }
@@ -912,16 +912,16 @@ func parseSecurityOpts(securityOpts []string) ([]string, error) {
 		}
 		if (!ok || v == "") && k != "no-new-privileges" {
 			// "no-new-privileges" is the only option that does not require a value.
-			return securityOpts, errors.Errorf("Invalid --security-opt: %q", opt)
+			return securityOpts, fmt.Errorf("Invalid --security-opt: %q", opt)
 		}
 		if k == "seccomp" && v != "unconfined" {
 			f, err := os.ReadFile(v)
 			if err != nil {
-				return securityOpts, errors.Errorf("opening seccomp profile (%s) failed: %v", v, err)
+				return securityOpts, fmt.Errorf("opening seccomp profile (%s) failed: %v", v, err)
 			}
 			b := bytes.NewBuffer(nil)
 			if err := json.Compact(b, f); err != nil {
-				return securityOpts, errors.Errorf("compacting json for seccomp profile (%s) failed: %v", v, err)
+				return securityOpts, fmt.Errorf("compacting json for seccomp profile (%s) failed: %v", v, err)
 			}
 			securityOpts[key] = fmt.Sprintf("seccomp=%s", b.Bytes())
 		}
@@ -955,7 +955,7 @@ func parseStorageOpts(storageOpts []string) (map[string]string, error) {
 	for _, option := range storageOpts {
 		k, v, ok := strings.Cut(option, "=")
 		if !ok {
-			return nil, errors.Errorf("invalid storage option")
+			return nil, fmt.Errorf("invalid storage option")
 		}
 		m[k] = v
 	}
@@ -970,7 +970,7 @@ func parseDevice(device, serverOS string) (container.DeviceMapping, error) {
 	case "windows":
 		return parseWindowsDevice(device)
 	}
-	return container.DeviceMapping{}, errors.Errorf("unknown server OS: %s", serverOS)
+	return container.DeviceMapping{}, fmt.Errorf("unknown server OS: %s", serverOS)
 }
 
 // parseLinuxDevice parses a device mapping string to a container.DeviceMapping struct
@@ -994,7 +994,7 @@ func parseLinuxDevice(device string) (container.DeviceMapping, error) {
 	case 1:
 		src = arr[0]
 	default:
-		return container.DeviceMapping{}, errors.Errorf("invalid device specification: %s", device)
+		return container.DeviceMapping{}, fmt.Errorf("invalid device specification: %s", device)
 	}
 
 	if dst == "" {
@@ -1024,7 +1024,7 @@ func validateDeviceCgroupRule(val string) (string, error) {
 		return val, nil
 	}
 
-	return val, errors.Errorf("invalid device cgroup format '%s'", val)
+	return val, fmt.Errorf("invalid device cgroup format '%s'", val)
 }
 
 // validDeviceMode checks if the mode for device is valid or not.
@@ -1056,7 +1056,7 @@ func validateDevice(val string, serverOS string) (string, error) {
 		// Windows does validation entirely server-side
 		return val, nil
 	}
-	return "", errors.Errorf("unknown server OS: %s", serverOS)
+	return "", fmt.Errorf("unknown server OS: %s", serverOS)
 }
 
 // validateLinuxPath is the implementation of validateDevice knowing that the
@@ -1071,12 +1071,12 @@ func validateLinuxPath(val string, validator func(string) bool) (string, error) 
 	var mode string
 
 	if strings.Count(val, ":") > 2 {
-		return val, errors.Errorf("bad format for path: %s", val)
+		return val, fmt.Errorf("bad format for path: %s", val)
 	}
 
 	split := strings.SplitN(val, ":", 3)
 	if split[0] == "" {
-		return val, errors.Errorf("bad format for path: %s", val)
+		return val, fmt.Errorf("bad format for path: %s", val)
 	}
 	switch len(split) {
 	case 1:
@@ -1095,13 +1095,13 @@ func validateLinuxPath(val string, validator func(string) bool) (string, error) 
 		containerPath = split[1]
 		mode = split[2]
 		if isValid := validator(split[2]); !isValid {
-			return val, errors.Errorf("bad mode specified: %s", mode)
+			return val, fmt.Errorf("bad mode specified: %s", mode)
 		}
 		val = fmt.Sprintf("%s:%s:%s", split[0], containerPath, mode)
 	}
 
 	if !path.IsAbs(containerPath) {
-		return val, errors.Errorf("%s is not an absolute path", containerPath)
+		return val, fmt.Errorf("%s is not an absolute path", containerPath)
 	}
 	return val, nil
 }
@@ -1114,7 +1114,7 @@ func validateAttach(val string) (string, error) {
 			return s, nil
 		}
 	}
-	return val, errors.Errorf("valid streams are STDIN, STDOUT and STDERR")
+	return val, fmt.Errorf("valid streams are STDIN, STDOUT and STDERR")
 }
 
 func validateAPIVersion(c *containerConfig, serverAPIVersion string) error {

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -280,7 +279,7 @@ func compareRandomizedStrings(a, b, c, d string) error {
 	if a == d && b == c {
 		return nil
 	}
-	return errors.Errorf("strings don't match")
+	return fmt.Errorf("strings don't match")
 }
 
 // Simple parse with MacAddress validation

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/go-connections/nat"
 	"github.com/fvbommel/sortorder"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -67,11 +66,11 @@ func runPort(dockerCli command.Cli, opts *portOptions) error {
 			proto = "tcp"
 		}
 		if _, err = strconv.ParseUint(port, 10, 16); err != nil {
-			return errors.Wrapf(err, "Error: invalid port (%s)", port)
+			return fmt.Errorf("Error: invalid port (%s): %w", port, err)
 		}
 		frontends, exists := c.NetworkSettings.Ports[nat.Port(port+"/"+proto)]
 		if !exists || frontends == nil {
-			return errors.Errorf("Error: No public port '%s' published for %s", opts.port, opts.container)
+			return fmt.Errorf("Error: No public port '%s' published for %s", opts.port, opts.container)
 		}
 		for _, frontend := range frontends {
 			out = append(out, net.JoinHostPort(frontend.HostIP, frontend.HostPort))

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +50,7 @@ func runRename(dockerCli command.Cli, opts *renameOptions) error {
 
 	if err := dockerCli.Client().ContainerRename(ctx, oldName, newName); err != nil {
 		fmt.Fprintln(dockerCli.Err(), err)
-		return errors.Errorf("Error: failed to rename container named %s", oldName)
+		return fmt.Errorf("Error: failed to rename container named %s", oldName)
 	}
 	return nil
 }

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/sys/signal"
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/sys/signal"
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -210,7 +210,7 @@ func startContainersWithoutAttachments(ctx context.Context, dockerCli command.Cl
 	}
 
 	if len(failedContainers) > 0 {
-		return errors.Errorf("Error: failed to start containers: %s", strings.Join(failedContainers, ", "))
+		return fmt.Errorf("Error: failed to start containers: %s", strings.Join(failedContainers, ", "))
 	}
 	return nil
 }

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/stats_helpers.go
+++ b/cli/command/container/stats_helpers.go
@@ -3,13 +3,13 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"sync"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/tty_test.go
+++ b/cli/command/container/tty_test.go
@@ -2,7 +2,7 @@ package container
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +16,7 @@ import (
 func TestInitTtySizeErrors(t *testing.T) {
 	expectedError := "failed to resize tty, using default size\n"
 	fakeContainerExecResizeFunc := func(id string, options container.ResizeOptions) error {
-		return errors.Errorf("Error response from daemon: no such exec")
+		return fmt.Errorf("Error response from daemon: no such exec")
 	}
 	fakeResizeTtyFunc := func(ctx context.Context, cli command.Cli, id string, isExec bool) error {
 		height, width := uint(1024), uint(768)

--- a/cli/command/container/tty_test.go
+++ b/cli/command/container/tty_test.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	containertypes "github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -2,13 +2,13 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +84,7 @@ func createNewContext(contextStore store.ReaderWriter, o *CreateOptions) error {
 	}
 	dockerEP, dockerTLS, err := getDockerEndpointMetadataAndTLS(contextStore, o.Docker)
 	if err != nil {
-		return errors.Wrap(err, "unable to create docker endpoint config")
+		return fmt.Errorf("unable to create docker endpoint config: %w", err)
 	}
 	contextMetadata := store.Metadata{
 		Endpoints: map[string]any{
@@ -116,9 +116,9 @@ func checkContextNameForCreation(s store.Reader, name string) error {
 	}
 	if _, err := s.GetMetadata(name); !errdefs.IsNotFound(err) {
 		if err != nil {
-			return errors.Wrap(err, "error while getting existing contexts")
+			return fmt.Errorf("error while getting existing contexts: %w", err)
 		}
-		return errors.Errorf("context %q already exists", name)
+		return fmt.Errorf("context %q already exists", name)
 	}
 	return nil
 }

--- a/cli/command/context/remove.go
+++ b/cli/command/context/remove.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -54,7 +54,7 @@ func RunRemove(dockerCli command.Cli, opts RemoveOptions, names []string) error 
 func doRemove(dockerCli command.Cli, name string, isCurrent, force bool) error {
 	if isCurrent {
 		if !force {
-			return errors.Errorf("context %q is in use, set -f flag to force remove", name)
+			return fmt.Errorf("context %q is in use, set -f flag to force remove", name)
 		}
 		// fallback to DOCKER_HOST
 		cfg := dockerCli.ConfigFile()
@@ -77,7 +77,7 @@ func checkContextExists(dockerCli command.Cli, name string) error {
 	contextDir := dockerCli.ContextStore().GetStorageInfo(name).MetadataPath
 	_, err := os.Stat(contextDir)
 	if os.IsNotExist(err) {
-		return errdefs.NotFound(errors.Errorf("context %q does not exist", name))
+		return errdefs.NotFound(fmt.Errorf("context %q does not exist", name))
 	}
 	// Ignore other errors; if relevant, they will produce an error when
 	// performing the actual delete.

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -1,14 +1,14 @@
 package context
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestRemove(t *testing.T) {
@@ -19,7 +19,7 @@ func TestRemove(t *testing.T) {
 	_, err := cli.ContextStore().GetMetadata("current")
 	assert.NilError(t, err)
 	_, err = cli.ContextStore().GetMetadata("other")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errors.Is(err, os.ErrNotExist))
 }
 
 func TestRemoveNotAContext(t *testing.T) {

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +75,7 @@ func RunUpdate(dockerCLI command.Cli, o *UpdateOptions) error {
 	if o.Docker != nil {
 		dockerEP, dockerTLS, err := getDockerEndpointMetadataAndTLS(s, o.Docker)
 		if err != nil {
-			return errors.Wrap(err, "unable to create docker endpoint config")
+			return fmt.Errorf("unable to create docker endpoint config: %w", err)
 		}
 		c.Endpoints[docker.DockerEndpoint] = dockerEP
 		tlsDataToReset[docker.DockerEndpoint] = dockerTLS

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/flags"
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -47,7 +46,7 @@ func TestUse(t *testing.T) {
 func TestUseNoExist(t *testing.T) {
 	cli := makeFakeCli(t)
 	err := newUseCommand(cli).RunE(nil, []string{"test"})
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errors.Is(err, os.ErrNotExist))
 }
 
 // TestUseDefaultWithoutConfigFile verifies that the CLI does not create

--- a/cli/command/defaultcontextstore.go
+++ b/cli/command/defaultcontextstore.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -183,7 +185,7 @@ func (s *ContextStoreWithDefault) GetTLSData(contextName, endpointName, fileName
 			return nil, err
 		}
 		if defaultContext.TLS.Endpoints[endpointName].Files[fileName] == nil {
-			return nil, errdefs.NotFound(errors.Errorf("TLS data for %s/%s/%s does not exist", DefaultContextName, endpointName, fileName))
+			return nil, errdefs.NotFound(fmt.Errorf("TLS data for %s/%s/%s does not exist", DefaultContextName, endpointName, fileName))
 		}
 		return defaultContext.TLS.Endpoints[endpointName].Files[fileName], nil
 	}

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"crypto/rand"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -171,5 +173,5 @@ func TestErrTLSDataError(t *testing.T) {
 	meta := testDefaultMetadata()
 	s := testStore(t, meta, store.ContextTLSData{})
 	_, err := s.GetTLSData("default", "noop", "noop")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errors.Is(err, os.ErrNotExist))
 }

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -2,13 +2,13 @@ package formatter
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"text/template"
 
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	"github.com/docker/cli/templates"
-	"github.com/pkg/errors"
 )
 
 // Format keys used to specify certain kinds of output formats
@@ -73,7 +73,7 @@ func (c *Context) preFormat() {
 func (c *Context) parseFormat() (*template.Template, error) {
 	tmpl, err := templates.Parse(c.finalFormat)
 	if err != nil {
-		return tmpl, errors.Wrap(err, "template parsing error")
+		return tmpl, fmt.Errorf("template parsing error: %w", err)
 	}
 	return tmpl, err
 }
@@ -94,7 +94,7 @@ func (c *Context) postFormat(tmpl *template.Template, subContext SubContext) {
 
 func (c *Context) contextFormat(tmpl *template.Template, subContext SubContext) error {
 	if err := tmpl.Execute(c.buffer, subContext); err != nil {
-		return errors.Wrap(err, "template parsing error")
+		return fmt.Errorf("template parsing error: %w", err)
 	}
 	if c.Format.IsTable() && c.header != nil {
 		c.header = subContext.FullHeader()

--- a/cli/command/formatter/reflect.go
+++ b/cli/command/formatter/reflect.go
@@ -2,10 +2,9 @@ package formatter
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"unicode"
-
-	"github.com/pkg/errors"
 )
 
 // MarshalJSON marshals x into json
@@ -22,14 +21,14 @@ func MarshalJSON(x any) ([]byte, error) {
 func marshalMap(x any) (map[string]any, error) {
 	val := reflect.ValueOf(x)
 	if val.Kind() != reflect.Ptr {
-		return nil, errors.Errorf("expected a pointer to a struct, got %v", val.Kind())
+		return nil, fmt.Errorf("expected a pointer to a struct, got %v", val.Kind())
 	}
 	if val.IsNil() {
-		return nil, errors.Errorf("expected a pointer to a struct, got nil pointer")
+		return nil, fmt.Errorf("expected a pointer to a struct, got nil pointer")
 	}
 	valElem := val.Elem()
 	if valElem.Kind() != reflect.Struct {
-		return nil, errors.Errorf("expected a pointer to a struct, got a pointer to %v", valElem.Kind())
+		return nil, fmt.Errorf("expected a pointer to a struct, got a pointer to %v", valElem.Kind())
 	}
 	typ := val.Type()
 	m := make(map[string]any)
@@ -51,7 +50,7 @@ var unmarshallableNames = map[string]struct{}{"FullHeader": {}}
 // It returns ("", nil, nil) for valid but non-marshallable parameter. (e.g. "unexportedFunc()")
 func marshalForMethod(typ reflect.Method, val reflect.Value) (string, any, error) {
 	if val.Kind() != reflect.Func {
-		return "", nil, errors.Errorf("expected func, got %v", val.Kind())
+		return "", nil, fmt.Errorf("expected func, got %v", val.Kind())
 	}
 	name, numIn, numOut := typ.Name, val.Type().NumIn(), val.Type().NumOut()
 	_, blackListed := unmarshallableNames[name]

--- a/cli/command/idresolver/idresolver.go
+++ b/cli/command/idresolver/idresolver.go
@@ -2,11 +2,11 @@ package idresolver
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 )
 
 // IDResolver provides ID to Name resolution.
@@ -48,7 +48,7 @@ func (r *IDResolver) get(ctx context.Context, t any, id string) (string, error) 
 		}
 		return service.Spec.Annotations.Name, nil
 	default:
-		return "", errors.Errorf("unsupported type")
+		return "", fmt.Errorf("unsupported type")
 	}
 }
 

--- a/cli/command/idresolver/idresolver_test.go
+++ b/cli/command/idresolver/idresolver_test.go
@@ -2,7 +2,7 @@ package idresolver
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/docker/cli/internal/test/builders"
@@ -14,7 +14,7 @@ import (
 func TestResolveError(t *testing.T) {
 	cli := &fakeClient{
 		nodeInspectFunc: func(nodeID string) (swarm.Node, []byte, error) {
-			return swarm.Node{}, []byte{}, errors.Errorf("error inspecting node")
+			return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting node")
 		},
 	}
 
@@ -75,7 +75,7 @@ func TestResolveNode(t *testing.T) {
 		{
 			nodeID: "nodeID",
 			nodeInspectFunc: func(string) (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting node")
 			},
 			expectedID: "nodeID",
 		},
@@ -117,7 +117,7 @@ func TestResolveService(t *testing.T) {
 		{
 			serviceID: "serviceID",
 			serviceInspectFunc: func(string) (swarm.Service, []byte, error) {
-				return swarm.Service{}, []byte{}, errors.Errorf("error inspecting service")
+				return swarm.Service{}, []byte{}, fmt.Errorf("error inspecting service")
 			},
 			expectedID: "serviceID",
 		},

--- a/cli/command/idresolver/idresolver_test.go
+++ b/cli/command/idresolver/idresolver_test.go
@@ -2,11 +2,11 @@ package idresolver
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/image"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -30,7 +29,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 			args:          []string{"image:tag"},
 			expectedError: "something went wrong",
 			imageHistoryFunc: func(img string) ([]image.HistoryResponseItem, error) {
-				return []image.HistoryResponseItem{{}}, errors.Errorf("something went wrong")
+				return []image.HistoryResponseItem{{}}, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -29,7 +29,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 			args:          []string{"testdata/import-command-success.input.txt"},
 			expectedError: "something went wrong",
 			imageImportFunc: func(source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error) {
-				return nil, errors.Errorf("something went wrong")
+				return nil, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -1,13 +1,13 @@
 package image
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -31,7 +30,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 			name:          "failed-list",
 			expectedError: "something went wrong",
 			imageListFunc: func(options types.ImageListOptions) ([]image.Summary, error) {
-				return []image.Summary{}, errors.Errorf("something went wrong")
+				return []image.Summary{}, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/docker/cli/cli"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/sys/sequential"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +59,7 @@ func runLoad(dockerCli command.Cli, opts loadOptions) error {
 	// To avoid getting stuck, verify that a tar file is given either in
 	// the input flag or through stdin and if not display an error message and exit.
 	if opts.input == "" && dockerCli.In().IsTerminal() {
-		return errors.Errorf("requested load from stdin, but stdin is empty")
+		return fmt.Errorf("requested load from stdin, but stdin is empty")
 	}
 
 	if !dockerCli.Out().IsTerminal() {

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,7 +34,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 			name:          "pull-error",
 			expectedError: "something went wrong",
 			imageLoadFunc: func(input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
-				return types.ImageLoadResponse{}, errors.Errorf("something went wrong")
+				return types.ImageLoadResponse{}, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -8,7 +9,6 @@ import (
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -32,7 +31,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 			args:          []string{"--force"},
 			expectedError: "something went wrong",
 			imagesPruneFunc: func(pruneFilter filters.Args) (types.ImagesPruneReport, error) {
-				return types.ImagesPruneReport{}, errors.Errorf("something went wrong")
+				return types.ImagesPruneReport{}, fmt.Errorf("something went wrong")
 			},
 		},
 	}

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/trust"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -14,7 +15,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -1,13 +1,13 @@
 package image
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -33,7 +33,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 			args:          []string{"image:repo"},
 			expectedError: "Failed to push",
 			imagePushFunc: func(ref string, options types.ImagePushOptions) (io.ReadCloser, error) {
-				return io.NopCloser(strings.NewReader("")), errors.Errorf("Failed to push")
+				return io.NopCloser(strings.NewReader("")), fmt.Errorf("Failed to push")
 			},
 		},
 	}

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/image"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -48,7 +47,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 			expectedError: "error removing image",
 			imageRemoveFunc: func(img string, options types.ImageRemoveOptions) ([]image.DeleteResponse, error) {
 				assert.Check(t, is.Equal("image1", img))
-				return []image.DeleteResponse{}, errors.Errorf("error removing image")
+				return []image.DeleteResponse{}, fmt.Errorf("error removing image")
 			},
 		},
 		{
@@ -58,7 +57,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 			imageRemoveFunc: func(img string, options types.ImageRemoveOptions) ([]image.DeleteResponse, error) {
 				assert.Check(t, !options.Force)
 				assert.Check(t, options.PruneChildren)
-				return []image.DeleteResponse{}, errors.Errorf("error removing image")
+				return []image.DeleteResponse{}, fmt.Errorf("error removing image")
 			},
 		},
 	}

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -2,12 +2,13 @@ package image
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,7 @@ func RunSave(dockerCli command.Cli, opts saveOptions) error {
 	}
 
 	if err := command.ValidateOutputPath(opts.output); err != nil {
-		return errors.Wrap(err, "failed to save image")
+		return fmt.Errorf("failed to save image: %w", err)
 	}
 
 	responseBody, err := dockerCli.Client().ImageSave(context.Background(), opts.images)

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -1,13 +1,13 @@
 package image
 
 import (
+	"errors"
 	"io"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -1,7 +1,7 @@
 package image
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -37,7 +37,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 			isTerminal:    false,
 			expectedError: "error saving image",
 			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
-				return io.NopCloser(strings.NewReader("")), errors.Errorf("error saving image")
+				return io.NopCloser(strings.NewReader("")), fmt.Errorf("error saving image")
 			},
 		},
 		{

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -50,7 +50,7 @@ func NewTemplateInspectorFromString(out io.Writer, tmplStr string) (Inspector, e
 
 	tmpl, err := templates.Parse(tmplStr)
 	if err != nil {
-		return nil, fmt.Errorf("template parsing error: %s", err)
+		return nil, fmt.Errorf("template parsing error: %w", err)
 	}
 	return NewTemplateInspector(out, tmpl), nil
 }
@@ -100,7 +100,7 @@ func (i *TemplateInspector) Inspect(typedElement any, rawElement []byte) error {
 	buffer := new(bytes.Buffer)
 	if err := i.tmpl.Execute(buffer, typedElement); err != nil {
 		if rawElement == nil {
-			return fmt.Errorf("template parsing error: %v", err)
+			return fmt.Errorf("template parsing error: %w", err)
 		}
 		return i.tryRawInspectFallback(rawElement)
 	}
@@ -119,12 +119,12 @@ func (i *TemplateInspector) tryRawInspectFallback(rawElement []byte) error {
 	dec.UseNumber()
 
 	if rawErr := dec.Decode(&raw); rawErr != nil {
-		return fmt.Errorf("unable to read inspect data: %v", rawErr)
+		return fmt.Errorf("unable to read inspect data: %w", rawErr)
 	}
 
 	tmplMissingKey := i.tmpl.Option("missingkey=error")
 	if rawErr := tmplMissingKey.Execute(buffer, raw); rawErr != nil {
-		return fmt.Errorf("template parsing error: %v", rawErr)
+		return fmt.Errorf("template parsing error: %w", rawErr)
 	}
 
 	i.buffer.Write(buffer.Bytes())

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -3,13 +3,13 @@ package inspect
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"text/template"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/templates"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -50,7 +50,7 @@ func NewTemplateInspectorFromString(out io.Writer, tmplStr string) (Inspector, e
 
 	tmpl, err := templates.Parse(tmplStr)
 	if err != nil {
-		return nil, errors.Errorf("template parsing error: %s", err)
+		return nil, fmt.Errorf("template parsing error: %s", err)
 	}
 	return NewTemplateInspector(out, tmpl), nil
 }
@@ -100,7 +100,7 @@ func (i *TemplateInspector) Inspect(typedElement any, rawElement []byte) error {
 	buffer := new(bytes.Buffer)
 	if err := i.tmpl.Execute(buffer, typedElement); err != nil {
 		if rawElement == nil {
-			return errors.Errorf("template parsing error: %v", err)
+			return fmt.Errorf("template parsing error: %v", err)
 		}
 		return i.tryRawInspectFallback(rawElement)
 	}
@@ -119,12 +119,12 @@ func (i *TemplateInspector) tryRawInspectFallback(rawElement []byte) error {
 	dec.UseNumber()
 
 	if rawErr := dec.Decode(&raw); rawErr != nil {
-		return errors.Errorf("unable to read inspect data: %v", rawErr)
+		return fmt.Errorf("unable to read inspect data: %v", rawErr)
 	}
 
 	tmplMissingKey := i.tmpl.Option("missingkey=error")
 	if rawErr := tmplMissingKey.Execute(buffer, raw); rawErr != nil {
-		return errors.Errorf("template parsing error: %v", rawErr)
+		return fmt.Errorf("template parsing error: %v", rawErr)
 	}
 
 	i.buffer.Write(buffer.Bytes())

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -49,11 +49,11 @@ func newAnnotateCommand(dockerCli command.Cli) *cobra.Command {
 func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
 	targetRef, err := normalizeReference(opts.target)
 	if err != nil {
-		return fmt.Errorf("annotate: error parsing name for manifest list %s: %w: %w", opts.target, err)
+		return fmt.Errorf("annotate: error parsing name for manifest list %s: %w", opts.target, err)
 	}
 	imgRef, err := normalizeReference(opts.image)
 	if err != nil {
-		return fmt.Errorf("annotate: error parsing name for manifest %s: %w: %w", opts.image, err)
+		return fmt.Errorf("annotate: error parsing name for manifest %s: %w", opts.image, err)
 	}
 
 	manifestStore := dockerCli.ManifestStore()

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/store"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -50,11 +49,11 @@ func newAnnotateCommand(dockerCli command.Cli) *cobra.Command {
 func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
 	targetRef, err := normalizeReference(opts.target)
 	if err != nil {
-		return errors.Wrapf(err, "annotate: error parsing name for manifest list %s", opts.target)
+		return fmt.Errorf("annotate: error parsing name for manifest list %s: %w: %w", opts.target, err)
 	}
 	imgRef, err := normalizeReference(opts.image)
 	if err != nil {
-		return errors.Wrapf(err, "annotate: error parsing name for manifest %s", opts.image)
+		return fmt.Errorf("annotate: error parsing name for manifest %s: %w: %w", opts.image, err)
 	}
 
 	manifestStore := dockerCli.ManifestStore()
@@ -87,7 +86,7 @@ func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
 	}
 
 	if !isValidOSArch(imageManifest.Descriptor.Platform.OS, imageManifest.Descriptor.Platform.Architecture) {
-		return errors.Errorf("manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
+		return fmt.Errorf("manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
 	}
 	return manifestStore.Save(targetRef, imgRef, imageManifest)
 }

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -39,12 +38,12 @@ func createManifestList(dockerCli command.Cli, args []string, opts createOpts) e
 	newRef := args[0]
 	targetRef, err := normalizeReference(newRef)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing name for manifest list %s", newRef)
+		return fmt.Errorf("error parsing name for manifest list %s: %w: %w", newRef, err)
 	}
 
 	_, err = registry.ParseRepositoryInfo(targetRef)
 	if err != nil {
-		return errors.Wrapf(err, "error parsing repository name for manifest list %s", newRef)
+		return fmt.Errorf("error parsing repository name for manifest list %s: %w: %w", newRef, err)
 	}
 
 	manifestStore := dockerCli.ManifestStore()
@@ -55,7 +54,7 @@ func createManifestList(dockerCli command.Cli, args []string, opts createOpts) e
 	case err != nil:
 		return err
 	case !opts.amend:
-		return errors.Errorf("refusing to amend an existing manifest list with no --amend flag")
+		return fmt.Errorf("refusing to amend an existing manifest list with no --amend flag")
 	}
 
 	ctx := context.Background()

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -38,12 +38,12 @@ func createManifestList(dockerCli command.Cli, args []string, opts createOpts) e
 	newRef := args[0]
 	targetRef, err := normalizeReference(newRef)
 	if err != nil {
-		return fmt.Errorf("error parsing name for manifest list %s: %w: %w", newRef, err)
+		return fmt.Errorf("error parsing name for manifest list %s: %w", newRef, err)
 	}
 
 	_, err = registry.ParseRepositoryInfo(targetRef)
 	if err != nil {
-		return fmt.Errorf("error parsing repository name for manifest list %s: %w: %w", newRef, err)
+		return fmt.Errorf("error parsing repository name for manifest list %s: %w", newRef, err)
 	}
 
 	manifestStore := dockerCli.ManifestStore()

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -99,10 +99,10 @@ func TestManifestCreateNoManifest(t *testing.T) {
 	cli.SetManifestStore(manifestStore)
 	cli.SetRegistryClient(&fakeRegistryClient{
 		getManifestFunc: func(_ context.Context, ref reference.Named) (manifesttypes.ImageManifest, error) {
-			return manifesttypes.ImageManifest{}, errors.Errorf("No such image: %v", ref)
+			return manifesttypes.ImageManifest{}, fmt.Errorf("No such image: %v", ref)
 		},
 		getManifestListFunc: func(ctx context.Context, ref reference.Named) ([]manifesttypes.ImageManifest, error) {
-			return nil, errors.Errorf("No such manifest: %s", ref)
+			return nil, fmt.Errorf("No such manifest: %s", ref)
 		},
 	})
 

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/manifest/store"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -123,7 +123,7 @@ func printManifestList(dockerCli command.Cli, namedRef reference.Named, list []t
 		for _, img := range list {
 			mfd, err := buildManifestDescriptor(targetRepo, img)
 			if err != nil {
-				return fmt.Errorf("failed to assemble ManifestDescriptor: %w: %w", err)
+				return fmt.Errorf("failed to assemble ManifestDescriptor: %w", err)
 			}
 			manifests = append(manifests, mfd)
 		}

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -124,7 +123,7 @@ func printManifestList(dockerCli command.Cli, namedRef reference.Named, list []t
 		for _, img := range list {
 			mfd, err := buildManifestDescriptor(targetRepo, img)
 			if err != nil {
-				return errors.Wrap(err, "failed to assemble ManifestDescriptor")
+				return fmt.Errorf("failed to assemble ManifestDescriptor: %w: %w", err)
 			}
 			manifests = append(manifests, mfd)
 		}

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/manifest/inspect_test.go
+++ b/cli/command/manifest/inspect_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -85,7 +86,7 @@ func TestInspectCommandNotFound(t *testing.T) {
 			return types.ImageManifest{}, errors.New("missing")
 		},
 		getManifestListFunc: func(ctx context.Context, ref reference.Named) ([]types.ImageManifest, error) {
-			return nil, errors.Errorf("No such manifest: %s", ref)
+			return nil, fmt.Errorf("No such manifest: %s", ref)
 		},
 	})
 

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -182,7 +182,7 @@ func buildManifestDescriptor(targetRepo *registry.RepositoryInfo, imageManifest 
 	}
 
 	if err = manifest.Descriptor.Digest.Validate(); err != nil {
-		return manifestlist.ManifestDescriptor{}, fmt.Errorf("digest parse of image %q failed: %w: %w", imageManifest.Ref, err)
+		return manifestlist.ManifestDescriptor{}, fmt.Errorf("digest parse of image %q failed: %w", imageManifest.Ref, err)
 	}
 
 	return manifest, nil

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -16,7 +16,6 @@ import (
 	"github.com/docker/distribution/manifest/ocischema"
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +73,7 @@ func runPush(dockerCli command.Cli, opts pushOpts) error {
 		return err
 	}
 	if len(manifests) == 0 {
-		return errors.Errorf("%s not found", targetRef)
+		return fmt.Errorf("%s not found", targetRef)
 	}
 
 	req, err := buildPushRequest(manifests, targetRef, opts.insecure)
@@ -145,8 +144,7 @@ func buildManifestList(manifests []types.ImageManifest, targetRef reference.Name
 		if imageManifest.Descriptor.Platform == nil ||
 			imageManifest.Descriptor.Platform.Architecture == "" ||
 			imageManifest.Descriptor.Platform.OS == "" {
-			return nil, errors.Errorf(
-				"manifest %s must have an OS and Architecture to be pushed to a registry", imageManifest.Ref)
+			return nil, fmt.Errorf("manifest %s must have an OS and Architecture to be pushed to a registry", imageManifest.Ref)
 		}
 		descriptor, err := buildManifestDescriptor(targetRepoInfo, imageManifest)
 		if err != nil {
@@ -167,7 +165,7 @@ func buildManifestDescriptor(targetRepo *registry.RepositoryInfo, imageManifest 
 	manifestRepoHostname := reference.Domain(repoInfo.Name)
 	targetRepoHostname := reference.Domain(targetRepo.Name)
 	if manifestRepoHostname != targetRepoHostname {
-		return manifestlist.ManifestDescriptor{}, errors.Errorf("cannot use source images from a different registry than the target image: %s != %s", manifestRepoHostname, targetRepoHostname)
+		return manifestlist.ManifestDescriptor{}, fmt.Errorf("cannot use source images from a different registry than the target image: %s != %s", manifestRepoHostname, targetRepoHostname)
 	}
 
 	manifest := manifestlist.ManifestDescriptor{
@@ -184,8 +182,7 @@ func buildManifestDescriptor(targetRepo *registry.RepositoryInfo, imageManifest 
 	}
 
 	if err = manifest.Descriptor.Digest.Validate(); err != nil {
-		return manifestlist.ManifestDescriptor{}, errors.Wrapf(err,
-			"digest parse of image %q failed", imageManifest.Ref)
+		return manifestlist.ManifestDescriptor{}, fmt.Errorf("digest parse of image %q failed: %w: %w", imageManifest.Ref, err)
 	}
 
 	return manifest, nil
@@ -237,7 +234,7 @@ func buildPutManifestRequest(imageManifest types.ImageManifest, targetRef refere
 
 		dig := imageManifest.Descriptor.Digest
 		if dig2 := dig.Algorithm().FromBytes(dt); dig != dig2 {
-			return mountRequest{}, errors.Errorf("internal digest mismatch for %s: expected %s, got %s", imageManifest.Ref, dig, dig2)
+			return mountRequest{}, fmt.Errorf("internal digest mismatch for %s: expected %s, got %s", imageManifest.Ref, dig, dig2)
 		}
 
 		var manifest schema2.DeserializedManifest
@@ -256,7 +253,7 @@ func buildPutManifestRequest(imageManifest types.ImageManifest, targetRef refere
 
 		dig := imageManifest.Descriptor.Digest
 		if dig2 := dig.Algorithm().FromBytes(dt); dig != dig2 {
-			return mountRequest{}, errors.Errorf("internal digest mismatch for %s: expected %s, got %s", imageManifest.Ref, dig, dig2)
+			return mountRequest{}, fmt.Errorf("internal digest mismatch for %s: expected %s, got %s", imageManifest.Ref, dig, dig2)
 		}
 
 		var manifest ocischema.DeserializedManifest

--- a/cli/command/manifest/push_test.go
+++ b/cli/command/manifest/push_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -19,7 +20,7 @@ func newFakeRegistryClient() *fakeRegistryClient {
 			return manifesttypes.ImageManifest{}, errors.New("")
 		},
 		getManifestListFunc: func(_ context.Context, _ reference.Named) ([]manifesttypes.ImageManifest, error) {
-			return nil, errors.Errorf("")
+			return nil, fmt.Errorf("")
 		},
 	}
 }

--- a/cli/command/manifest/push_test.go
+++ b/cli/command/manifest/push_test.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/manifest/store"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/manifest/rm.go
+++ b/cli/command/manifest/rm.go
@@ -1,11 +1,11 @@
 package manifest
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -24,7 +24,7 @@ func TestNetworkConnectErrors(t *testing.T) {
 		{
 			args: []string{"toto", "titi"},
 			networkConnectFunc: func(ctx context.Context, networkID, container string, config *network.EndpointSettings) error {
-				return errors.Errorf("error connecting network")
+				return fmt.Errorf("error connecting network")
 			},
 			expectedError: "error connecting network",
 		},

--- a/cli/command/network/connect_test.go
+++ b/cli/command/network/connect_test.go
@@ -2,12 +2,12 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/network"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -229,7 +229,7 @@ func subnetMatches(subnet, data string) (bool, error) {
 
 	_, s, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return false, fmt.Errorf("invalid subnet: %w: %w", err)
+		return false, fmt.Errorf("invalid subnet: %w", err)
 	}
 
 	if strings.Contains(data, "/") {

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -131,7 +130,7 @@ func runCreate(dockerCli command.Cli, options createOptions) error {
 //nolint:gocyclo
 func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]string) ([]network.IPAMConfig, error) {
 	if len(subnets) < len(ranges) || len(subnets) < len(gateways) {
-		return nil, errors.Errorf("every ip-range or gateway must have a corresponding subnet")
+		return nil, fmt.Errorf("every ip-range or gateway must have a corresponding subnet")
 	}
 	iData := map[string]*network.IPAMConfig{}
 
@@ -147,7 +146,7 @@ func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]str
 				return nil, err
 			}
 			if ok1 || ok2 {
-				return nil, errors.Errorf("multiple overlapping subnet configuration is not supported")
+				return nil, fmt.Errorf("multiple overlapping subnet configuration is not supported")
 			}
 		}
 		iData[s] = &network.IPAMConfig{Subnet: s, AuxAddress: map[string]string{}}
@@ -165,14 +164,14 @@ func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]str
 				continue
 			}
 			if iData[s].IPRange != "" {
-				return nil, errors.Errorf("cannot configure multiple ranges (%s, %s) on the same subnet (%s)", r, iData[s].IPRange, s)
+				return nil, fmt.Errorf("cannot configure multiple ranges (%s, %s) on the same subnet (%s)", r, iData[s].IPRange, s)
 			}
 			d := iData[s]
 			d.IPRange = r
 			match = true
 		}
 		if !match {
-			return nil, errors.Errorf("no matching subnet for range %s", r)
+			return nil, fmt.Errorf("no matching subnet for range %s", r)
 		}
 	}
 
@@ -188,14 +187,14 @@ func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]str
 				continue
 			}
 			if iData[s].Gateway != "" {
-				return nil, errors.Errorf("cannot configure multiple gateways (%s, %s) for the same subnet (%s)", g, iData[s].Gateway, s)
+				return nil, fmt.Errorf("cannot configure multiple gateways (%s, %s) for the same subnet (%s)", g, iData[s].Gateway, s)
 			}
 			d := iData[s]
 			d.Gateway = g
 			match = true
 		}
 		if !match {
-			return nil, errors.Errorf("no matching subnet for gateway %s", g)
+			return nil, fmt.Errorf("no matching subnet for gateway %s", g)
 		}
 	}
 
@@ -214,7 +213,7 @@ func consolidateIpam(subnets, ranges, gateways []string, auxaddrs map[string]str
 			match = true
 		}
 		if !match {
-			return nil, errors.Errorf("no matching subnet for aux-address %s", aa)
+			return nil, fmt.Errorf("no matching subnet for aux-address %s", aa)
 		}
 	}
 
@@ -230,7 +229,7 @@ func subnetMatches(subnet, data string) (bool, error) {
 
 	_, s, err := net.ParseCIDR(subnet)
 	if err != nil {
-		return false, errors.Wrap(err, "invalid subnet")
+		return false, fmt.Errorf("invalid subnet: %w: %w", err)
 	}
 
 	if strings.Contains(data, "/") {

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -27,7 +27,7 @@ func TestNetworkCreateErrors(t *testing.T) {
 		{
 			args: []string{"toto"},
 			networkCreateFunc: func(ctx context.Context, name string, createBody types.NetworkCreate) (types.NetworkCreateResponse, error) {
-				return types.NetworkCreateResponse{}, errors.Errorf("error creating network")
+				return types.NetworkCreateResponse{}, fmt.Errorf("error creating network")
 			},
 			expectedError: "error creating network",
 		},

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -2,11 +2,11 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/network/disconnect_test.go
+++ b/cli/command/network/disconnect_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -22,7 +22,7 @@ func TestNetworkDisconnectErrors(t *testing.T) {
 		{
 			args: []string{"toto", "titi"},
 			networkDisconnectFunc: func(ctx context.Context, networkID, container string, force bool) error {
-				return errors.Errorf("error disconnecting network")
+				return fmt.Errorf("error disconnecting network")
 			},
 			expectedError: "error disconnecting network",
 		},

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestNetworkListErrors(t *testing.T) {
 	}{
 		{
 			networkListFunc: func(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
-				return []types.NetworkResource{}, errors.Errorf("error creating network")
+				return []types.NetworkResource{}, fmt.Errorf("error creating network")
 			},
 			expectedError: "error creating network",
 		},

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/network/remove_test.go
+++ b/cli/command/network/remove_test.go
@@ -2,12 +2,12 @@ package network
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -1,13 +1,13 @@
 package node
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/node/demote_test.go
+++ b/cli/command/node/demote_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -24,14 +24,14 @@ func TestNodeDemoteErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			expectedError: "error inspecting the node",
 		},
 		{
 			args: []string{"nodeID"},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
-				return errors.Errorf("error updating the node")
+				return fmt.Errorf("error updating the node")
 			},
 			expectedError: "error updating the node",
 		},
@@ -56,7 +56,7 @@ func TestNodeDemoteNoChange(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleWorker {
-					return errors.Errorf("expected role worker, got %s", node.Role)
+					return fmt.Errorf("expected role worker, got %s", node.Role)
 				}
 				return nil
 			},
@@ -73,7 +73,7 @@ func TestNodeDemoteMultipleNode(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleWorker {
-					return errors.Errorf("expected role worker, got %s", node.Role)
+					return fmt.Errorf("expected role worker, got %s", node.Role)
 				}
 				return nil
 			},

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -28,24 +27,24 @@ func TestNodeInspectErrors(t *testing.T) {
 		{
 			args: []string{"self"},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error inspecting the node",
 		},
 		{
 			args: []string{"self"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			infoFunc: func() (system.Info, error) {
 				return system.Info{Swarm: swarm.Info{NodeID: "abc"}}, nil
@@ -58,7 +57,7 @@ func TestNodeInspectErrors(t *testing.T) {
 				"pretty": "true",
 			},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/node/list_test.go
+++ b/cli/command/node/list_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -23,7 +23,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 	}{
 		{
 			nodeListFunc: func() ([]swarm.Node, error) {
-				return []swarm.Node{}, errors.Errorf("error listing nodes")
+				return []swarm.Node{}, fmt.Errorf("error listing nodes")
 			},
 			expectedError: "error listing nodes",
 		},
@@ -36,7 +36,7 @@ func TestNodeListErrorOnAPIFailure(t *testing.T) {
 				}, nil
 			},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -1,13 +1,13 @@
 package node
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/node/promote_test.go
+++ b/cli/command/node/promote_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -24,14 +24,14 @@ func TestNodePromoteErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			expectedError: "error inspecting the node",
 		},
 		{
 			args: []string{"nodeID"},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
-				return errors.Errorf("error updating the node")
+				return fmt.Errorf("error updating the node")
 			},
 			expectedError: "error updating the node",
 		},
@@ -56,7 +56,7 @@ func TestNodePromoteNoChange(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {
-					return errors.Errorf("expected role manager, got %s", node.Role)
+					return fmt.Errorf("expected role manager, got %s", node.Role)
 				}
 				return nil
 			},
@@ -73,7 +73,7 @@ func TestNodePromoteMultipleNode(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {
-					return errors.Errorf("expected role manager, got %s", node.Role)
+					return fmt.Errorf("expected role manager, got %s", node.Role)
 				}
 				return nil
 			},

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -99,7 +99,7 @@ func runPs(dockerCli command.Cli, options psOptions) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -29,21 +28,21 @@ func TestNodePsErrors(t *testing.T) {
 	}{
 		{
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			expectedError: "error inspecting the node",
 		},
 		{
 			args: []string{"nodeID"},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return []swarm.Task{}, errors.Errorf("error returning the task list")
+				return []swarm.Task{}, fmt.Errorf("error returning the task list")
 			},
 			expectedError: "error returning the task list",
 		},

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +48,7 @@ func runRemove(dockerCli command.Cli, args []string, opts removeOptions) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/cli/command/node/remove_test.go
+++ b/cli/command/node/remove_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -21,7 +21,7 @@ func TestNodeRemoveErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			nodeRemoveFunc: func() error {
-				return errors.Errorf("error removing the node")
+				return fmt.Errorf("error removing the node")
 			},
 			expectedError: "error removing the node",
 		},

--- a/cli/command/node/remove_test.go
+++ b/cli/command/node/remove_test.go
@@ -1,11 +1,11 @@
 package node
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -2,13 +2,13 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -101,7 +101,7 @@ func mergeNodeUpdate(flags *pflag.FlagSet) func(*swarm.Node) error {
 			for _, k := range keys {
 				// if a key doesn't exist, fail the command explicitly
 				if _, exists := spec.Annotations.Labels[k]; !exists {
-					return errors.Errorf("key %s doesn't exist in node's labels", k)
+					return fmt.Errorf("key %s doesn't exist in node's labels", k)
 				}
 				delete(spec.Annotations.Labels, k)
 			}

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -1,13 +1,13 @@
 package node
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/node/update_test.go
+++ b/cli/command/node/update_test.go
@@ -1,7 +1,7 @@
 package node
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -29,14 +29,14 @@ func TestNodeUpdateErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			expectedError: "error inspecting the node",
 		},
 		{
 			args: []string{"nodeID"},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
-				return errors.Errorf("error updating the node")
+				return fmt.Errorf("error updating the node")
 			},
 			expectedError: "error updating the node",
 		},
@@ -85,7 +85,7 @@ func TestNodeUpdate(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Role != swarm.NodeRoleManager {
-					return errors.Errorf("expected role manager, got %s", node.Role)
+					return fmt.Errorf("expected role manager, got %s", node.Role)
 				}
 				return nil
 			},
@@ -100,7 +100,7 @@ func TestNodeUpdate(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if node.Availability != swarm.NodeAvailabilityDrain {
-					return errors.Errorf("expected drain availability, got %s", node.Availability)
+					return fmt.Errorf("expected drain availability, got %s", node.Availability)
 				}
 				return nil
 			},
@@ -115,7 +115,7 @@ func TestNodeUpdate(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if _, present := node.Annotations.Labels["lbl"]; !present {
-					return errors.Errorf("expected 'lbl' label, got %v", node.Annotations.Labels)
+					return fmt.Errorf("expected 'lbl' label, got %v", node.Annotations.Labels)
 				}
 				return nil
 			},
@@ -130,7 +130,7 @@ func TestNodeUpdate(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if value, present := node.Annotations.Labels["key"]; !present || value != "value" {
-					return errors.Errorf("expected 'key' label to be 'value', got %v", node.Annotations.Labels)
+					return fmt.Errorf("expected 'key' label to be 'value', got %v", node.Annotations.Labels)
 				}
 				return nil
 			},
@@ -147,7 +147,7 @@ func TestNodeUpdate(t *testing.T) {
 			},
 			nodeUpdateFunc: func(nodeID string, version swarm.Version, node swarm.NodeSpec) error {
 				if len(node.Annotations.Labels) > 0 {
-					return errors.Errorf("expected no labels, got %v", node.Annotations.Labels)
+					return fmt.Errorf("expected no labels, got %v", node.Annotations.Labels)
 				}
 				return nil
 			},

--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/archive"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +51,7 @@ func validateContextDir(contextDir string) (string, error) {
 	}
 
 	if !stat.IsDir() {
-		return "", errors.Errorf("context must be a directory")
+		return "", fmt.Errorf("context must be a directory")
 	}
 
 	return absContextDir, nil

--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func newEnableCommand(dockerCli command.Cli) *cobra.Command {
 func runEnable(dockerCli command.Cli, opts *enableOpts) error {
 	name := opts.name
 	if opts.timeout < 0 {
-		return errors.Errorf("negative timeout %d is invalid", opts.timeout)
+		return fmt.Errorf("negative timeout %d is invalid", opts.timeout)
 	}
 
 	if err := dockerCli.Client().PluginEnable(context.Background(), name, types.PluginEnableOptions{Timeout: opts.timeout}); err != nil {

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -76,7 +76,7 @@ func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOpti
 		ref = reference.TagNameOnly(ref)
 		nt, ok := ref.(reference.NamedTagged)
 		if !ok {
-			return types.PluginInstallOptions{}, errors.Errorf("invalid name: %s", ref.String())
+			return types.PluginInstallOptions{}, fmt.Errorf("invalid name: %s", ref.String())
 		}
 
 		trusted, err := image.TrustedReference(ctx, dockerCli, nt)
@@ -112,7 +112,7 @@ func runInstall(dockerCli command.Cli, opts pluginOptions) error {
 			return err
 		}
 		if _, ok := aref.(reference.Canonical); ok {
-			return errors.Errorf("invalid name: %s", opts.localName)
+			return fmt.Errorf("invalid name: %s", opts.localName)
 		}
 		localName = reference.FamiliarString(reference.TagNameOnly(aref))
 	}

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +44,7 @@ func runPush(dockerCli command.Cli, opts pushOptions) error {
 		return err
 	}
 	if _, ok := named.(reference.Canonical); ok {
-		return errors.Errorf("invalid name: %s", opts.name)
+		return fmt.Errorf("invalid name: %s", opts.name)
 	}
 
 	named = reference.TagNameOnly(named)

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -39,11 +39,11 @@ func runUpgrade(dockerCli command.Cli, opts pluginOptions) error {
 	ctx := context.Background()
 	p, _, err := dockerCli.Client().PluginInspectWithRaw(ctx, opts.localName)
 	if err != nil {
-		return errors.Errorf("error reading plugin data: %v", err)
+		return fmt.Errorf("error reading plugin data: %v", err)
 	}
 
 	if p.Enabled {
-		return errors.Errorf("the plugin must be disabled before upgrading")
+		return fmt.Errorf("the plugin must be disabled before upgrading")
 	}
 
 	opts.localName = p.Name
@@ -52,13 +52,13 @@ func runUpgrade(dockerCli command.Cli, opts pluginOptions) error {
 	}
 	remote, err := reference.ParseNormalizedNamed(opts.remote)
 	if err != nil {
-		return errors.Wrap(err, "error parsing remote upgrade image reference")
+		return fmt.Errorf("error parsing remote upgrade image reference: %w", err)
 	}
 	remote = reference.TagNameOnly(remote)
 
 	old, err := reference.ParseNormalizedNamed(p.PluginReference)
 	if err != nil {
-		return errors.Wrap(err, "error parsing current image reference")
+		return fmt.Errorf("error parsing current image reference: %w", err)
 	}
 	old = reference.TagNameOnly(old)
 

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -17,7 +17,6 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
 	"github.com/moby/term"
-	"github.com/pkg/errors"
 )
 
 const patSuggest = "You can log in with your password or a Personal Access " +
@@ -102,7 +101,7 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 	// will hit this if you attempt docker login from mintty where stdin
 	// is a pipe, not a character based console.
 	if flPassword == "" && !cli.In().IsTerminal() {
-		return errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
+		return fmt.Errorf("Error: Cannot perform an interactive login from a non TTY device")
 	}
 
 	authconfig.Username = strings.TrimSpace(authconfig.Username)
@@ -127,7 +126,7 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 		}
 	}
 	if flUser == "" {
-		return errors.Errorf("Error: Non-null Username Required")
+		return fmt.Errorf("Error: Non-null Username Required")
 	}
 	if flPassword == "" {
 		oldState, err := term.SaveState(cli.In().FD())
@@ -145,7 +144,7 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 		}
 		fmt.Fprint(cli.Out(), "\n")
 		if flPassword == "" {
-			return errors.Errorf("Error: Password Required")
+			return fmt.Errorf("Error: Password Required")
 		}
 	}
 
@@ -161,7 +160,7 @@ func ConfigureAuth(cli Cli, flUser, flPassword string, authconfig *registrytypes
 func readInput(in io.Reader) (string, error) {
 	line, _, err := bufio.NewReader(in).ReadLine()
 	if err != nil {
-		return "", errors.Wrap(err, "error while reading input")
+		return "", fmt.Errorf("error while reading input: %w", err)
 	}
 	return strings.TrimSpace(string(line)), nil
 }

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -154,7 +154,7 @@ func runLogin(dockerCli command.Cli, opts loginOptions) error { //nolint:gocyclo
 	}
 
 	if err := creds.Store(configtypes.AuthConfig(authConfig)); err != nil {
-		return errors.Errorf("Error saving credentials: %v", err)
+		return fmt.Errorf("Error saving credentials: %v", err)
 	}
 
 	if response.Status != "" {

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/moby/sys/sequential"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -54,12 +53,12 @@ func runSecretCreate(dockerCli command.Cli, options createOptions) error {
 	ctx := context.Background()
 
 	if options.driver != "" && options.file != "" {
-		return errors.Errorf("When using secret driver secret data must be empty")
+		return fmt.Errorf("When using secret driver secret data must be empty")
 	}
 
 	secretData, err := readSecretData(dockerCli.In(), options.file)
 	if err != nil {
-		return errors.Errorf("Error reading content from %q: %v", options.file, err)
+		return fmt.Errorf("Error reading content from %q: %v", options.file, err)
 	}
 	spec := swarm.SecretSpec{
 		Annotations: swarm.Annotations{

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -36,7 +36,7 @@ func TestSecretCreateErrors(t *testing.T) {
 		{
 			args: []string{"name", filepath.Join("testdata", secretDataFile)},
 			secretCreateFunc: func(_ context.Context, secretSpec swarm.SecretSpec) (types.SecretCreateResponse, error) {
-				return types.SecretCreateResponse{}, errors.Errorf("error creating secret")
+				return types.SecretCreateResponse{}, fmt.Errorf("error creating secret")
 			},
 			expectedError: "error creating secret",
 		},
@@ -69,7 +69,7 @@ func TestSecretCreateWithName(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if !reflect.DeepEqual(spec, expected) {
-				return types.SecretCreateResponse{}, errors.Errorf("expected %+v, got %+v", expected, spec)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected %+v, got %+v", expected, spec)
 			}
 			return types.SecretCreateResponse{
 				ID: "ID-" + spec.Name,
@@ -92,11 +92,11 @@ func TestSecretCreateWithDriver(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if spec.Name != name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
 			if spec.Driver.Name != expectedDriver.Name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
 			}
 
 			return types.SecretCreateResponse{
@@ -121,11 +121,11 @@ func TestSecretCreateWithTemplatingDriver(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if spec.Name != name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
 			if spec.Templating.Name != expectedDriver.Name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected driver %v, got %v", expectedDriver, spec.Labels)
 			}
 
 			return types.SecretCreateResponse{
@@ -151,11 +151,11 @@ func TestSecretCreateWithLabels(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
 			if spec.Name != name {
-				return types.SecretCreateResponse{}, errors.Errorf("expected name %q, got %q", name, spec.Name)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected name %q, got %q", name, spec.Name)
 			}
 
 			if !reflect.DeepEqual(spec.Labels, expectedLabels) {
-				return types.SecretCreateResponse{}, errors.Errorf("expected labels %v, got %v", expectedLabels, spec.Labels)
+				return types.SecretCreateResponse{}, fmt.Errorf("expected labels %v, got %v", expectedLabels, spec.Labels)
 			}
 
 			return types.SecretCreateResponse{

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -2,7 +2,6 @@ package secret
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -28,7 +27,7 @@ func TestSecretInspectErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			secretInspectFunc: func(_ context.Context, secretID string) (swarm.Secret, []byte, error) {
-				return swarm.Secret{}, nil, errors.Errorf("error while inspecting the secret")
+				return swarm.Secret{}, nil, fmt.Errorf("error while inspecting the secret")
 			},
 			expectedError: "error while inspecting the secret",
 		},
@@ -45,7 +44,7 @@ func TestSecretInspectErrors(t *testing.T) {
 				if secretID == "foo" {
 					return *builders.Secret(builders.SecretName("foo")), nil, nil
 				}
-				return swarm.Secret{}, nil, errors.Errorf("error while inspecting the secret")
+				return swarm.Secret{}, nil, fmt.Errorf("error while inspecting the secret")
 			},
 			expectedError: "error while inspecting the secret",
 		},
@@ -76,7 +75,7 @@ func TestSecretInspectWithoutFormat(t *testing.T) {
 			args: []string{"foo"},
 			secretInspectFunc: func(_ context.Context, name string) (swarm.Secret, []byte, error) {
 				if name != "foo" {
-					return swarm.Secret{}, nil, errors.Errorf("Invalid name, expected %s, got %s", "foo", name)
+					return swarm.Secret{}, nil, fmt.Errorf("Invalid name, expected %s, got %s", "foo", name)
 				}
 				return *builders.Secret(builders.SecretID("ID-foo"), builders.SecretName("foo")), nil, nil
 			},

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/secret/ls_test.go
+++ b/cli/command/secret/ls_test.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -29,7 +29,7 @@ func TestSecretListErrors(t *testing.T) {
 		},
 		{
 			secretListFunc: func(_ context.Context, options types.SecretListOptions) ([]swarm.Secret, error) {
-				return []swarm.Secret{}, errors.Errorf("error listing secrets")
+				return []swarm.Secret{}, fmt.Errorf("error listing secrets")
 			},
 			expectedError: "error listing secrets",
 		},

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +48,7 @@ func runSecretRemove(dockerCli command.Cli, opts removeOptions) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 
 	return nil

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -25,7 +25,7 @@ func TestSecretRemoveErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			secretRemoveFunc: func(_ context.Context, name string) error {
-				return errors.Errorf("error removing secret")
+				return fmt.Errorf("error removing secret")
 			},
 			expectedError: "error removing secret",
 		},
@@ -66,7 +66,7 @@ func TestSecretRemoveContinueAfterError(t *testing.T) {
 		secretRemoveFunc: func(_ context.Context, name string) error {
 			removedSecrets = append(removedSecrets, name)
 			if name == "foo" {
-				return errors.Errorf("error removing secret: %s", name)
+				return fmt.Errorf("error removing secret: %s", name)
 			}
 			return nil
 		},

--- a/cli/command/secret/remove_test.go
+++ b/cli/command/secret/remove_test.go
@@ -2,12 +2,12 @@ package secret
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -17,7 +17,6 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	units "github.com/docker/go-units"
 	"github.com/fvbommel/sortorder"
-	"github.com/pkg/errors"
 )
 
 const serviceInspectPrettyTemplate formatter.Format = `
@@ -231,7 +230,7 @@ func InspectFormatWrite(ctx formatter.Context, refs []string, getRef, getNetwork
 			}
 			service, ok := serviceI.(swarm.Service)
 			if !ok {
-				return errors.Errorf("got wrong object to inspect")
+				return fmt.Errorf("got wrong object to inspect")
 			}
 			if err := format(&serviceInspectContext{Service: service, networkNames: resolveNetworks(service, getNetwork)}); err != nil {
 				return err

--- a/cli/command/service/generic_resource_opts.go
+++ b/cli/command/service/generic_resource_opts.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/docker/docker/api/types/swarm"
 	swarmapi "github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/genericresource"
@@ -37,7 +35,7 @@ func ParseGenericResources(value []string) ([]swarm.GenericResource, error) {
 
 	resources, err := genericresource.Parse(value)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid generic resource specification")
+		return nil, fmt.Errorf("invalid generic resource specification: %w", err)
 	}
 
 	swarmResources := genericResourcesFromGRPC(resources)

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -10,7 +11,6 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +31,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.refs = args
 
 			if opts.pretty && len(opts.format) > 0 {
-				return errors.Errorf("--format is incompatible with human friendly format")
+				return fmt.Errorf("--format is incompatible with human friendly format")
 			}
 			return runInspect(dockerCli, opts)
 		},
@@ -60,7 +60,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 		if err == nil || !errdefs.IsNotFound(err) {
 			return service, nil, err
 		}
-		return nil, nil, errors.Errorf("Error: no such service: %s", ref)
+		return nil, nil, fmt.Errorf("Error: no such service: %s", ref)
 	}
 
 	getNetwork := func(ref string) (any, []byte, error) {
@@ -68,7 +68,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 		if err == nil || !errdefs.IsNotFound(err) {
 			return network, nil, err
 		}
-		return nil, nil, errors.Errorf("Error: no such network: %s", ref)
+		return nil, nil, fmt.Errorf("Error: no such network: %s", ref)
 	}
 
 	f := opts.format
@@ -82,7 +82,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 	// check if the user is trying to apply a template to the pretty format, which
 	// is not supported
 	if strings.HasPrefix(f, "pretty") && f != "pretty" {
-		return errors.Errorf("Cannot supply extra formatting options to the pretty template")
+		return fmt.Errorf("Cannot supply extra formatting options to the pretty template")
 	}
 
 	serviceCtx := formatter.Context{

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -257,7 +257,7 @@ func (lw *logWriter) Write(buf []byte) (int, error) {
 	// break up the log line into parts.
 	parts := bytes.SplitN(buf, []byte(" "), numParts)
 	if len(parts) != numParts {
-		return 0, errors.Errorf("invalid context in log message: %v", string(buf))
+		return 0, fmt.Errorf("invalid context in log message: %v", string(buf))
 	}
 	// parse the details out
 	details, err := logs.ParseLogDetails(string(parts[detailsIndex]))
@@ -322,19 +322,19 @@ func (lw *logWriter) Write(buf []byte) (int, error) {
 func (lw *logWriter) parseContext(details map[string]string) (logContext, error) {
 	nodeID, ok := details["com.docker.swarm.node.id"]
 	if !ok {
-		return logContext{}, errors.Errorf("missing node id in details: %v", details)
+		return logContext{}, fmt.Errorf("missing node id in details: %v", details)
 	}
 	delete(details, "com.docker.swarm.node.id")
 
 	serviceID, ok := details["com.docker.swarm.service.id"]
 	if !ok {
-		return logContext{}, errors.Errorf("missing service id in details: %v", details)
+		return logContext{}, fmt.Errorf("missing service id in details: %v", details)
 	}
 	delete(details, "com.docker.swarm.service.id")
 
 	taskID, ok := details["com.docker.swarm.task.id"]
 	if !ok {
-		return logContext{}, errors.Errorf("missing task id in details: %s", details)
+		return logContext{}, fmt.Errorf("missing task id in details: %s", details)
 	}
 	delete(details, "com.docker.swarm.task.id")
 

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -18,7 +19,6 @@ import (
 	"github.com/google/shlex"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/defaults"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -98,7 +98,7 @@ func (o *placementPrefOpts) Set(value string) error {
 		return errors.New(`placement preference must be of the format "<strategy>=<arg>"`)
 	}
 	if strategy != "spread" {
-		return errors.Errorf("unsupported placement preference %s (only spread is supported)", strategy)
+		return fmt.Errorf("unsupported placement preference %s (only spread is supported)", strategy)
 	}
 
 	o.prefs = append(o.prefs, swarm.PlacementPreference{
@@ -443,7 +443,7 @@ func (o *healthCheckOptions) toHealthConfig() (*container.HealthConfig, error) {
 		o.retries != 0
 	if o.noHealthcheck {
 		if haveHealthSettings {
-			return nil, errors.Errorf("--%s conflicts with --health-* options", flagNoHealthcheck)
+			return nil, fmt.Errorf("--%s conflicts with --health-* options", flagNoHealthcheck)
 		}
 		healthConfig = &container.HealthConfig{Test: []string{"NONE"}}
 	} else if haveHealthSettings {
@@ -580,7 +580,7 @@ func (options *serviceOptions) ToServiceMode() (swarm.ServiceMode, error) {
 	switch options.mode {
 	case "global":
 		if options.replicas.Value() != nil {
-			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
+			return serviceMode, fmt.Errorf("replicas can only be used with replicated or replicated-job mode")
 		}
 
 		if options.maxReplicas > 0 {
@@ -616,11 +616,11 @@ func (options *serviceOptions) ToServiceMode() (swarm.ServiceMode, error) {
 			return serviceMode, errors.New("max-concurrent can only be used with replicated-job mode")
 		}
 		if options.replicas.Value() != nil {
-			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
+			return serviceMode, fmt.Errorf("replicas can only be used with replicated or replicated-job mode")
 		}
 		serviceMode.GlobalJob = &swarm.GlobalJob{}
 	default:
-		return serviceMode, errors.Errorf("Unknown mode: %s, only replicated and global supported", options.mode)
+		return serviceMode, fmt.Errorf("Unknown mode: %s, only replicated and global supported", options.mode)
 	}
 	return serviceMode, nil
 }
@@ -688,7 +688,7 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 	// flags are not set, then the values will be nil. If they are non-nil,
 	// then return an error.
 	if (serviceMode.ReplicatedJob != nil || serviceMode.GlobalJob != nil) && (updateConfig != nil || rollbackConfig != nil) {
-		return service, errors.Errorf("update and rollback configuration is not supported for jobs")
+		return service, fmt.Errorf("update and rollback configuration is not supported for jobs")
 	}
 
 	networks := convertNetworks(options.networks)

--- a/cli/command/service/parse.go
+++ b/cli/command/service/parse.go
@@ -2,12 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	swarmtypes "github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 )
 
 // ParseSecrets retrieves the secrets with the requested names and fills
@@ -22,7 +22,7 @@ func ParseSecrets(apiClient client.SecretAPIClient, requestedSecrets []*swarmtyp
 
 	for _, secret := range requestedSecrets {
 		if _, exists := secretRefs[secret.File.Name]; exists {
-			return nil, errors.Errorf("duplicate secret target for %s not allowed", secret.SecretName)
+			return nil, fmt.Errorf("duplicate secret target for %s not allowed", secret.SecretName)
 		}
 		secretRef := new(swarmtypes.SecretReference)
 		*secretRef = *secret
@@ -51,7 +51,7 @@ func ParseSecrets(apiClient client.SecretAPIClient, requestedSecrets []*swarmtyp
 	for _, ref := range secretRefs {
 		id, ok := foundSecrets[ref.SecretName]
 		if !ok {
-			return nil, errors.Errorf("secret not found: %s", ref.SecretName)
+			return nil, fmt.Errorf("secret not found: %s", ref.SecretName)
 		}
 
 		// set the id for the ref to properly assign in swarm
@@ -101,7 +101,7 @@ func ParseConfigs(apiClient client.ConfigAPIClient, requestedConfigs []*swarmtyp
 		}
 
 		if _, exists := configRefs[config.File.Name]; exists {
-			return nil, errors.Errorf("duplicate config target for %s not allowed", config.ConfigName)
+			return nil, fmt.Errorf("duplicate config target for %s not allowed", config.ConfigName)
 		}
 
 		configRefs[config.File.Name] = configRef
@@ -132,7 +132,7 @@ func ParseConfigs(apiClient client.ConfigAPIClient, requestedConfigs []*swarmtyp
 	for _, ref := range configRefs {
 		id, ok := foundConfigs[ref.ConfigName]
 		if !ok {
-			return nil, errors.Errorf("config not found: %s", ref.ConfigName)
+			return nil, fmt.Errorf("config not found: %s", ref.ConfigName)
 		}
 
 		// set the id for the ref to properly assign in swarm
@@ -147,7 +147,7 @@ func ParseConfigs(apiClient client.ConfigAPIClient, requestedConfigs []*swarmtyp
 	for _, ref := range runtimeRefs {
 		id, ok := foundConfigs[ref.ConfigName]
 		if !ok {
-			return nil, errors.Errorf("config not found: %s", ref.ConfigName)
+			return nil, fmt.Errorf("config not found: %s", ref.ConfigName)
 		}
 
 		ref.ConfigID = id

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +43,7 @@ func runRemove(dockerCli command.Cli, sids []string) error {
 		fmt.Fprintf(dockerCli.Out(), "%s\n", sid)
 	}
 	if len(errs) > 0 {
-		return errors.Errorf(strings.Join(errs, "\n"))
+		return fmt.Errorf(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -44,13 +43,7 @@ func scaleArgs(cmd *cobra.Command, args []string) error {
 	}
 	for _, arg := range args {
 		if k, v, ok := strings.Cut(arg, "="); !ok || k == "" || v == "" {
-			return errors.Errorf(
-				"Invalid scale specifier '%s'.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-				arg,
-				cmd.CommandPath(),
-				cmd.UseLine(),
-				cmd.Short,
-			)
+			return fmt.Errorf("Invalid scale specifier '%s'.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", arg, cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 		}
 	}
 	return nil
@@ -91,7 +84,7 @@ func runScale(dockerCli command.Cli, options *scaleOptions, args []string) error
 	if len(errs) == 0 {
 		return nil
 	}
-	return errors.Errorf(strings.Join(errs, "\n"))
+	return fmt.Errorf(strings.Join(errs, "\n"))
 }
 
 func runServiceScale(ctx context.Context, dockerCli command.Cli, serviceID string, scale uint64) error {
@@ -109,7 +102,7 @@ func runServiceScale(ctx context.Context, dockerCli command.Cli, serviceID strin
 	case serviceMode.ReplicatedJob != nil:
 		serviceMode.ReplicatedJob.TotalCompletions = &scale
 	default:
-		return errors.Errorf("scale can only be used with replicated or replicated-job mode")
+		return fmt.Errorf("scale can only be used with replicated or replicated-job mode")
 	}
 
 	response, err := client.ServiceUpdate(ctx, service.ID, service.Version, service.Spec, types.ServiceUpdateOptions{})

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/docker/client"
 	units "github.com/docker/go-units"
 	"github.com/moby/swarmkit/v2/api/defaults"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -169,7 +169,7 @@ func runUpdate(dockerCli command.Cli, flags *pflag.FlagSet, options *serviceOpti
 			clientSideRollback = true
 			spec = service.PreviousSpec
 			if spec == nil {
-				return errors.Errorf("service does not have a previous specification to roll back to")
+				return fmt.Errorf("service does not have a previous specification to roll back to")
 			}
 		} else {
 			serverSideRollback = true
@@ -922,7 +922,7 @@ func updateMounts(flags *pflag.FlagSet, mounts *[]mounttypes.Mount) error {
 		values := flags.Lookup(flagMountAdd).Value.(*opts.MountOpt).Value()
 		for _, mount := range values {
 			if _, ok := mountsByTarget[mount.Target]; ok {
-				return errors.Errorf("duplicate mount target")
+				return fmt.Errorf("duplicate mount target")
 			}
 			mountsByTarget[mount.Target] = mount
 		}
@@ -1118,7 +1118,7 @@ func updateReplicas(flags *pflag.FlagSet, serviceMode *swarm.ServiceMode) error 
 	}
 
 	if serviceMode == nil || serviceMode.Replicated == nil {
-		return errors.Errorf("replicas can only be used with replicated mode")
+		return fmt.Errorf("replicas can only be used with replicated mode")
 	}
 	serviceMode.Replicated.Replicas = flags.Lookup(flagReplicas).Value.(*Uint64Opt).Value()
 	return nil
@@ -1258,7 +1258,7 @@ func updateHealthcheck(flags *pflag.FlagSet, containerSpec *swarm.ContainerSpec)
 			}
 			return nil
 		}
-		return errors.Errorf("--%s conflicts with --health-* options", flagNoHealthcheck)
+		return fmt.Errorf("--%s conflicts with --health-* options", flagNoHealthcheck)
 	}
 	if len(containerSpec.Healthcheck.Test) > 0 && containerSpec.Healthcheck.Test[0] == "NONE" {
 		containerSpec.Healthcheck.Test = nil
@@ -1329,7 +1329,7 @@ func updateNetworks(ctx context.Context, apiClient client.NetworkAPIClient, flag
 				return err
 			}
 			if _, exists := existingNetworks[nwID]; exists {
-				return errors.Errorf("service is already attached to network %s", network.Target)
+				return fmt.Errorf("service is already attached to network %s", network.Target)
 			}
 			network.Target = nwID
 			newNetworks = append(newNetworks, network)

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -32,7 +32,7 @@ func TestListErrors(t *testing.T) {
 		},
 		{
 			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
-				return []swarm.Service{}, errors.Errorf("error getting services")
+				return []swarm.Service{}, fmt.Errorf("error getting services")
 			},
 			expectedError: "error getting services",
 		},

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/cli/cli/compose/loader"
 	"github.com/docker/cli/cli/compose/schema"
 	composetypes "github.com/docker/cli/cli/compose/types"
-	"github.com/pkg/errors"
 )
 
 // LoadComposefile parse the composefile specified in the cli and returns its Config and version.
@@ -29,7 +29,7 @@ func LoadComposefile(dockerCli command.Cli, opts options.Deploy) (*composetypes.
 	if err != nil {
 		if fpe, ok := err.(*loader.ForbiddenPropertiesError); ok {
 			// this error is intentionally formatted multi-line
-			return nil, errors.Errorf("Compose file contains unsupported options:\n\n%s\n", propertyWarnings(fpe.Properties))
+			return nil, fmt.Errorf("Compose file contains unsupported options:\n\n%s\n", propertyWarnings(fpe.Properties))
 		}
 
 		return nil, err
@@ -119,7 +119,7 @@ func buildEnvironment(env []string) (map[string]string, error) {
 
 		k, v, ok := strings.Cut(s, "=")
 		if !ok || k == "" {
-			return result, errors.Errorf("unexpected environment variable '%s'", s)
+			return result, fmt.Errorf("unexpected environment variable '%s'", s)
 		}
 		// value may be set, but empty if "s" is like "K=", not "K".
 		result[k] = v

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -33,7 +33,7 @@ func TestStackPsErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return nil, errors.Errorf("error getting tasks")
+				return nil, fmt.Errorf("error getting tasks")
 			},
 			expectedError: "error getting tasks",
 		},

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -1,6 +1,7 @@
 package stack
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestStackServicesErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			serviceListFunc: func(options types.ServiceListOptions) ([]swarm.Service, error) {
-				return nil, errors.Errorf("error getting services")
+				return nil, fmt.Errorf("error getting services")
 			},
 			expectedError: "error getting services",
 		},
@@ -37,7 +37,7 @@ func TestStackServicesErrors(t *testing.T) {
 				return []swarm.Service{*builders.Service(builders.GlobalService())}, nil
 			},
 			nodeListFunc: func(options types.NodeListOptions) ([]swarm.Node, error) {
-				return nil, errors.Errorf("error getting nodes")
+				return nil, fmt.Errorf("error getting nodes")
 			},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
 				return []swarm.Task{*builders.Task()}, nil
@@ -50,7 +50,7 @@ func TestStackServicesErrors(t *testing.T) {
 				return []swarm.Service{*builders.Service(builders.GlobalService())}, nil
 			},
 			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
-				return nil, errors.Errorf("error getting tasks")
+				return nil, fmt.Errorf("error getting tasks")
 			},
 			expectedError: "error getting tasks",
 		},

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli/command"
@@ -10,7 +11,6 @@ import (
 	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/pkg/errors"
 )
 
 // Resolve image constants
@@ -43,7 +43,7 @@ func validateResolveImageFlag(opts *options.Deploy) error {
 	case ResolveImageAlways, ResolveImageChanged, ResolveImageNever:
 		return nil
 	default:
-		return errors.Errorf("Invalid option %s for flag --resolve-image", opts.ResolveImage)
+		return fmt.Errorf("Invalid option %s for flag --resolve-image", opts.ResolveImage)
 	}
 }
 

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -105,13 +105,13 @@ func createSecrets(ctx context.Context, dockerCli command.Cli, secrets []swarm.S
 		case err == nil:
 			// secret already exists, then we update that
 			if err := client.SecretUpdate(ctx, secret.ID, secret.Meta.Version, secretSpec); err != nil {
-				return fmt.Errorf("failed to update secret %s: %w: %w", secretSpec.Name, err)
+				return fmt.Errorf("failed to update secret %s: %w", secretSpec.Name, err)
 			}
 		case errdefs.IsNotFound(err):
 			// secret does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating secret %s\n", secretSpec.Name)
 			if _, err := client.SecretCreate(ctx, secretSpec); err != nil {
-				return fmt.Errorf("failed to create secret %s: %w: %w", secretSpec.Name, err)
+				return fmt.Errorf("failed to create secret %s: %w", secretSpec.Name, err)
 			}
 		default:
 			return err
@@ -129,13 +129,13 @@ func createConfigs(ctx context.Context, dockerCli command.Cli, configs []swarm.C
 		case err == nil:
 			// config already exists, then we update that
 			if err := client.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
-				return fmt.Errorf("failed to update config %s: %w: %w", configSpec.Name, err)
+				return fmt.Errorf("failed to update config %s: %w", configSpec.Name, err)
 			}
 		case errdefs.IsNotFound(err):
 			// config does not exist, then we create a new one.
 			fmt.Fprintf(dockerCli.Out(), "Creating config %s\n", configSpec.Name)
 			if _, err := client.ConfigCreate(ctx, configSpec); err != nil {
-				return fmt.Errorf("failed to create config %s: %w: %w", configSpec.Name, err)
+				return fmt.Errorf("failed to create config %s: %w", configSpec.Name, err)
 			}
 		default:
 			return err
@@ -168,7 +168,7 @@ func createNetworks(ctx context.Context, dockerCli command.Cli, namespace conver
 
 		fmt.Fprintf(dockerCli.Out(), "Creating network %s\n", name)
 		if _, err := client.NetworkCreate(ctx, name, createOpts); err != nil {
-			return fmt.Errorf("failed to create network %s: %w: %w", name, err)
+			return fmt.Errorf("failed to create network %s: %w", name, err)
 		}
 	}
 	return nil
@@ -240,7 +240,7 @@ func deployServices(ctx context.Context, dockerCli command.Cli, services map[str
 
 			response, err := apiClient.ServiceUpdate(ctx, service.ID, service.Version, serviceSpec, updateOpts)
 			if err != nil {
-				return fmt.Errorf("failed to update service %s: %w: %w", name, err)
+				return fmt.Errorf("failed to update service %s: %w", name, err)
 			}
 
 			for _, warning := range response.Warnings {
@@ -257,7 +257,7 @@ func deployServices(ctx context.Context, dockerCli command.Cli, services map[str
 			}
 
 			if _, err := apiClient.ServiceCreate(ctx, serviceSpec, createOpts); err != nil {
-				return fmt.Errorf("failed to create service %s: %w: %w", name, err)
+				return fmt.Errorf("failed to create service %s: %w", name, err)
 			}
 		}
 	}

--- a/cli/command/stack/swarm/deploy_composefile_test.go
+++ b/cli/command/stack/swarm/deploy_composefile_test.go
@@ -2,11 +2,11 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/docker/cli/internal/test/network"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/stack/swarm/list.go
+++ b/cli/command/stack/swarm/list.go
@@ -2,12 +2,12 @@ package swarm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack/formatter"
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 )
 
 // GetStacks lists the swarm stacks.
@@ -23,8 +23,7 @@ func GetStacks(dockerCli command.Cli) ([]*formatter.Stack, error) {
 		labels := service.Spec.Labels
 		name, ok := labels[convert.LabelNamespace]
 		if !ok {
-			return nil, errors.Errorf("cannot get label %s for service %s",
-				convert.LabelNamespace, service.ID)
+			return nil, fmt.Errorf("cannot get label %s for service %s", convert.LabelNamespace, service.ID)
 		}
 		ztack, ok := m[name]
 		if !ok {

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/pkg/errors"
 )
 
 // RunRemove is the swarm implementation of docker stack remove
@@ -63,7 +62,7 @@ func RunRemove(dockerCli command.Cli, opts options.Remove) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf(strings.Join(errs, "\n"))
+		return fmt.Errorf(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/command/swarm/progress"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -90,7 +90,7 @@ func runInit(dockerCli command.Cli, flags *pflag.FlagSet, opts initOptions) erro
 		case swarm.NodeAvailabilityActive, swarm.NodeAvailabilityPause, swarm.NodeAvailabilityDrain:
 			req.Availability = availability
 		default:
-			return errors.Errorf("invalid availability %q, only active, pause and drain are supported", opts.availability)
+			return fmt.Errorf("invalid availability %q, only active, pause and drain are supported", opts.availability)
 		}
 	}
 
@@ -113,7 +113,7 @@ func runInit(dockerCli command.Cli, flags *pflag.FlagSet, opts initOptions) erro
 	if req.AutoLockManagers {
 		unlockKeyResp, err := client.SwarmGetUnlockKey(ctx)
 		if err != nil {
-			return errors.Wrap(err, "could not fetch unlock key")
+			return fmt.Errorf("could not fetch unlock key: %w", err)
 		}
 		printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
 	}

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -26,28 +25,28 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 		{
 			name: "init-failed",
 			swarmInitFunc: func() (string, error) {
-				return "", errors.Errorf("error initializing the swarm")
+				return "", fmt.Errorf("error initializing the swarm")
 			},
 			expectedError: "error initializing the swarm",
 		},
 		{
 			name: "init-failed-with-ip-choice",
 			swarmInitFunc: func() (string, error) {
-				return "", errors.Errorf("could not choose an IP address to advertise")
+				return "", fmt.Errorf("could not choose an IP address to advertise")
 			},
 			expectedError: "could not choose an IP address to advertise - specify one with --advertise-addr",
 		},
 		{
 			name: "swarm-inspect-after-init-failed",
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return swarm.Swarm{}, errors.Errorf("error inspecting the swarm")
+				return swarm.Swarm{}, fmt.Errorf("error inspecting the swarm")
 			},
 			expectedError: "error inspecting the swarm",
 		},
 		{
 			name: "node-inspect-after-init-failed",
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting the node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting the node")
 			},
 			expectedError: "error inspecting the node",
 		},
@@ -57,7 +56,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 				flagAutolock: "true",
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
-				return types.SwarmUnlockKeyResponse{}, errors.Errorf("error getting swarm unlock key")
+				return types.SwarmUnlockKeyResponse{}, fmt.Errorf("error getting swarm unlock key")
 			},
 			expectedError: "could not fetch unlock key: error getting swarm unlock key",
 		},

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -69,7 +68,7 @@ func runJoin(dockerCli command.Cli, flags *pflag.FlagSet, opts joinOptions) erro
 		case swarm.NodeAvailabilityActive, swarm.NodeAvailabilityPause, swarm.NodeAvailabilityDrain:
 			req.Availability = availability
 		default:
-			return errors.Errorf("invalid availability %q, only active, pause and drain are supported", opts.availability)
+			return fmt.Errorf("invalid availability %q, only active, pause and drain are supported", opts.availability)
 		}
 	}
 

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ func TestSwarmJoinErrors(t *testing.T) {
 			name: "join-failed",
 			args: []string{"remote"},
 			swarmJoinFunc: func() error {
-				return errors.Errorf("error joining the swarm")
+				return fmt.Errorf("error joining the swarm")
 			},
 			expectedError: "error joining the swarm",
 		},
@@ -42,7 +42,7 @@ func TestSwarmJoinErrors(t *testing.T) {
 			name: "join-failed-on-init",
 			args: []string{"remote"},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -2,12 +2,12 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -43,7 +42,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 			name: "swarm-inspect-failed",
 			args: []string{"worker"},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return swarm.Swarm{}, errors.Errorf("error inspecting the swarm")
+				return swarm.Swarm{}, fmt.Errorf("error inspecting the swarm")
 			},
 			expectedError: "error inspecting the swarm",
 		},
@@ -54,7 +53,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return swarm.Swarm{}, errors.Errorf("error inspecting the swarm")
+				return swarm.Swarm{}, fmt.Errorf("error inspecting the swarm")
 			},
 			expectedError: "error inspecting the swarm",
 		},
@@ -65,7 +64,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
-				return errors.Errorf("error updating the swarm")
+				return fmt.Errorf("error updating the swarm")
 			},
 			expectedError: "error updating the swarm",
 		},
@@ -73,7 +72,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 			name: "node-inspect-failed",
 			args: []string{"worker"},
 			nodeInspectFunc: func() (swarm.Node, []byte, error) {
-				return swarm.Node{}, []byte{}, errors.Errorf("error inspecting node")
+				return swarm.Node{}, []byte{}, fmt.Errorf("error inspecting node")
 			},
 			expectedError: "error inspecting node",
 		},
@@ -81,7 +80,7 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 			name: "info-failed",
 			args: []string{"worker"},
 			infoFunc: func() (system.Info, error) {
-				return system.Info{}, errors.Errorf("error asking for node info")
+				return system.Info{}, fmt.Errorf("error asking for node info")
 			},
 			expectedError: "error asking for node info",
 		},

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -1,12 +1,12 @@
 package swarm
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -26,7 +26,7 @@ func TestSwarmLeaveErrors(t *testing.T) {
 		{
 			name: "leave-failed",
 			swarmLeaveFunc: func() error {
-				return errors.Errorf("error leaving the swarm")
+				return fmt.Errorf("error leaving the swarm")
 			},
 			expectedError: "error leaving the swarm",
 		},

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"encoding/csv"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -177,7 +177,7 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 	for _, field := range fields {
 		key, value, ok := strings.Cut(field, "=")
 		if !ok {
-			return nil, errors.Errorf("invalid field '%s' must be a key=value pair", field)
+			return nil, fmt.Errorf("invalid field '%s' must be a key=value pair", field)
 		}
 
 		// TODO(thaJeztah): these options should not be case-insensitive.
@@ -187,7 +187,7 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 			if strings.ToLower(value) == string(swarm.ExternalCAProtocolCFSSL) {
 				externalCA.Protocol = swarm.ExternalCAProtocolCFSSL
 			} else {
-				return nil, errors.Errorf("unrecognized external CA protocol %s", value)
+				return nil, fmt.Errorf("unrecognized external CA protocol %s", value)
 			}
 		case "url":
 			hasURL = true
@@ -195,7 +195,7 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 		case "cacert":
 			cacontents, err := os.ReadFile(value)
 			if err != nil {
-				return nil, errors.Wrap(err, "unable to read CA cert for external CA")
+				return nil, fmt.Errorf("unable to read CA cert for external CA: %w", err)
 			}
 			if pemBlock, _ := pem.Decode(cacontents); pemBlock == nil {
 				return nil, errors.New("CA cert for external CA must be in PEM format")

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +69,7 @@ func runUnlockKey(dockerCli command.Cli, opts unlockKeyOptions) error {
 
 	unlockKeyResp, err := client.SwarmGetUnlockKey(ctx)
 	if err != nil {
-		return errors.Wrap(err, "could not fetch unlock key")
+		return fmt.Errorf("could not fetch unlock key: %w", err)
 	}
 
 	if unlockKeyResp.UnlockKey == "" {

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -35,7 +34,7 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 				flagRotate: "true",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return swarm.Swarm{}, errors.Errorf("error inspecting the swarm")
+				return swarm.Swarm{}, fmt.Errorf("error inspecting the swarm")
 			},
 			expectedError: "error inspecting the swarm",
 		},
@@ -58,14 +57,14 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 				return *builders.Swarm(builders.Autolock()), nil
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
-				return errors.Errorf("error updating the swarm")
+				return fmt.Errorf("error updating the swarm")
 			},
 			expectedError: "error updating the swarm",
 		},
 		{
 			name: "swarm-get-unlock-key-failed",
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
-				return types.SwarmUnlockKeyResponse{}, errors.Errorf("error getting unlock key")
+				return types.SwarmUnlockKeyResponse{}, fmt.Errorf("error getting unlock key")
 			},
 			expectedError: "error getting unlock key",
 		},

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -1,7 +1,7 @@
 package swarm
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -58,7 +58,7 @@ func TestSwarmUnlockErrors(t *testing.T) {
 				}, nil
 			},
 			swarmUnlockFunc: func(req swarm.UnlockRequest) error {
-				return errors.Errorf("error unlocking the swarm")
+				return fmt.Errorf("error unlocking the swarm")
 			},
 			expectedError: "error unlocking the swarm",
 		},
@@ -87,7 +87,7 @@ func TestSwarmUnlock(t *testing.T) {
 		},
 		swarmUnlockFunc: func(req swarm.UnlockRequest) error {
 			if req.UnlockKey != input {
-				return errors.Errorf("Invalid unlock key")
+				return fmt.Errorf("Invalid unlock key")
 			}
 			return nil
 		},

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -68,7 +67,7 @@ func runUpdate(dockerCli command.Cli, flags *pflag.FlagSet, opts swarmOptions) e
 	if curAutoLock && !prevAutoLock {
 		unlockKeyResp, err := client.SwarmGetUnlockKey(ctx)
 		if err != nil {
-			return errors.Wrap(err, "could not fetch unlock key")
+			return fmt.Errorf("could not fetch unlock key: %w", err)
 		}
 		printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
 	}

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -36,7 +35,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 				flagTaskHistoryLimit: "10",
 			},
 			swarmInspectFunc: func() (swarm.Swarm, error) {
-				return swarm.Swarm{}, errors.Errorf("error inspecting the swarm")
+				return swarm.Swarm{}, fmt.Errorf("error inspecting the swarm")
 			},
 			expectedError: "error inspecting the swarm",
 		},
@@ -46,7 +45,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 				flagTaskHistoryLimit: "10",
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
-				return errors.Errorf("error updating the swarm")
+				return fmt.Errorf("error updating the swarm")
 			},
 			expectedError: "error updating the swarm",
 		},
@@ -59,7 +58,7 @@ func TestSwarmUpdateErrors(t *testing.T) {
 				return *builders.Swarm(), nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
-				return types.SwarmUnlockKeyResponse{}, errors.Errorf("error getting unlock key")
+				return types.SwarmUnlockKeyResponse{}, fmt.Errorf("error getting unlock key")
 			},
 			expectedError: "error getting unlock key",
 		},
@@ -111,33 +110,33 @@ func TestSwarmUpdate(t *testing.T) {
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
 				if *swarm.Orchestration.TaskHistoryRetentionLimit != 10 {
-					return errors.Errorf("historyLimit not correctly set")
+					return fmt.Errorf("historyLimit not correctly set")
 				}
 				heartbeatDuration, err := time.ParseDuration("10s")
 				if err != nil {
 					return err
 				}
 				if swarm.Dispatcher.HeartbeatPeriod != heartbeatDuration {
-					return errors.Errorf("heartbeatPeriodLimit not correctly set")
+					return fmt.Errorf("heartbeatPeriodLimit not correctly set")
 				}
 				certExpiryDuration, err := time.ParseDuration("20s")
 				if err != nil {
 					return err
 				}
 				if swarm.CAConfig.NodeCertExpiry != certExpiryDuration {
-					return errors.Errorf("certExpiry not correctly set")
+					return fmt.Errorf("certExpiry not correctly set")
 				}
 				if len(swarm.CAConfig.ExternalCAs) != 1 || swarm.CAConfig.ExternalCAs[0].CACert != "trustroot" {
-					return errors.Errorf("externalCA not correctly set")
+					return fmt.Errorf("externalCA not correctly set")
 				}
 				if *swarm.Raft.KeepOldSnapshots != 10 {
-					return errors.Errorf("keepOldSnapshots not correctly set")
+					return fmt.Errorf("keepOldSnapshots not correctly set")
 				}
 				if swarm.Raft.SnapshotInterval != 100 {
-					return errors.Errorf("snapshotInterval not correctly set")
+					return fmt.Errorf("snapshotInterval not correctly set")
 				}
 				if !swarm.EncryptionConfig.AutoLockManagers {
-					return errors.Errorf("autolock not correctly set")
+					return fmt.Errorf("autolock not correctly set")
 				}
 				return nil
 			},
@@ -150,7 +149,7 @@ func TestSwarmUpdate(t *testing.T) {
 			},
 			swarmUpdateFunc: func(swarm swarm.Spec, flags swarm.UpdateFlags) error {
 				if *swarm.Orchestration.TaskHistoryRetentionLimit != 10 {
-					return errors.Errorf("historyLimit not correctly set")
+					return fmt.Errorf("historyLimit not correctly set")
 				}
 				return nil
 			},

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -2,13 +2,14 @@ package system
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +35,7 @@ func runDialStdio(dockerCli command.Cli) error {
 	dialer := dockerCli.Client().Dialer()
 	conn, err := dialer(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to open the raw stream connection")
+		return fmt.Errorf("failed to open the raw stream connection: %w", err)
 	}
 	defer conn.Close()
 
@@ -80,7 +81,7 @@ func copier(to halfWriteCloser, from halfReadCloser, debugDescription string) er
 		}
 	}()
 	if _, err := io.Copy(to, from); err != nil {
-		return errors.Wrapf(err, "error while Copy (%s)", debugDescription)
+		return fmt.Errorf("error while Copy (%s): %w", debugDescription, err)
 	}
 	return nil
 }

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -11,7 +11,6 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +49,7 @@ func runInspect(dockerCli command.Cli, opts inspectOptions) error {
 	case "", "container", "image", "node", "network", "service", "volume", "task", "plugin", "secret":
 		elementSearcher = inspectAll(context.Background(), dockerCli, opts.size, opts.inspectType)
 	default:
-		return errors.Errorf("%q is not a valid value for --type", opts.inspectType)
+		return fmt.Errorf("%q is not a valid value for --type", opts.inspectType)
 	}
 	return inspect.Inspect(dockerCli.Out(), opts.ids, opts.format, elementSearcher)
 }
@@ -208,7 +207,7 @@ func inspectAll(ctx context.Context, dockerCli command.Cli, getSize bool, typeCo
 			}
 			return v, raw, err
 		}
-		return nil, nil, errors.Errorf("Error: No such object: %s", ref)
+		return nil, nil, fmt.Errorf("Error: No such object: %s", ref)
 	}
 }
 

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sort"
 	"strconv"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tonistiigi/go-rosetta"
 )
@@ -211,7 +211,7 @@ func newVersionTemplate(templateFormat string) (*template.Template, error) {
 	tmpl := templates.New("version").Funcs(template.FuncMap{"getDetailsOrder": getDetailsOrder})
 	tmpl, err := tmpl.Parse(templateFormat)
 
-	return tmpl, errors.Wrap(err, "template parsing error")
+	return tmpl, fmt.Errorf("template parsing error: %w", err)
 }
 
 func getDetailsOrder(v types.ComponentVersion) []string {

--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/trust"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/trustmanager"
@@ -88,7 +87,7 @@ func validateAndGenerateKey(streams command.Streams, keyName string, workingDir 
 	pubPEM, err := generateKeyAndOutputPubPEM(keyName, privKeyFileStore)
 	if err != nil {
 		fmt.Fprint(streams.Out(), err.Error())
-		return errors.Wrapf(err, "failed to generate key for %s", keyName)
+		return fmt.Errorf("failed to generate key for %s: %w", keyName, err)
 	}
 
 	// Output the public key to a file in the CWD or specified dir
@@ -126,7 +125,7 @@ func writePubKeyPEMToDir(pubPEM pem.Block, keyName, workingDir string) (string, 
 	pubFileName := strings.Join([]string{keyName, "pub"}, ".")
 	pubFilePath := filepath.Join(workingDir, pubFileName)
 	if err := os.WriteFile(pubFilePath, pem.EncodeToMemory(&pubPEM), notary.PrivNoExecPerms); err != nil {
-		return "", errors.Wrapf(err, "failed to write public key to %s", pubFilePath)
+		return "", fmt.Errorf("failed to write public key to %s: %w", pubFilePath, err)
 	}
 	return pubFilePath, nil
 }

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/trust"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/storage"
@@ -60,10 +59,10 @@ func loadPrivKey(streams command.Streams, keyPath string, options keyLoadOptions
 	passRet := trust.GetPassphraseRetriever(streams.In(), streams.Out())
 	keyBytes, err := getPrivKeyBytesFromPath(keyPath)
 	if err != nil {
-		return errors.Wrapf(err, "refusing to load key from %s", keyPath)
+		return fmt.Errorf("refusing to load key from %s: %w", keyPath, err)
 	}
 	if err := loadPrivKeyBytesToStore(keyBytes, privKeyImporters, keyPath, options.keyName, passRet); err != nil {
-		return errors.Wrapf(err, "error importing key from %s", keyPath)
+		return fmt.Errorf("error importing key from %s: %w", keyPath, err)
 	}
 	fmt.Fprintf(streams.Out(), "Successfully imported key from %s\n", keyPath)
 	return nil
@@ -95,7 +94,7 @@ func loadPrivKeyBytesToStore(privKeyBytes []byte, privKeyImporters []trustmanage
 		return fmt.Errorf("provided file %s is not a supported private key - to add a signer's public key use docker trust signer add", keyPath)
 	}
 	if privKeyBytes, err = decodePrivKeyIfNecessary(privKeyBytes, passRet); err != nil {
-		return errors.Wrapf(err, "cannot load key from provided file %s", keyPath)
+		return fmt.Errorf("cannot load key from provided file %s: %w", keyPath, err)
 	}
 	// Make a reader, rewind the file pointer
 	return trustmanager.ImportKeys(bytes.NewReader(privKeyBytes), privKeyImporters, keyName, "", passRet)

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -9,7 +9,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
@@ -62,7 +61,7 @@ func revokeTrust(dockerCLI command.Cli, remote string, options revokeOptions) er
 	}
 	defer clearChangeList(notaryRepo)
 	if err := revokeSignature(notaryRepo, tag); err != nil {
-		return errors.Wrapf(err, "could not remove signature for %s", remote)
+		return fmt.Errorf("could not remove signature for %s: %w", remote, err)
 	}
 	fmt.Fprintf(dockerCLI.Out(), "Successfully deleted signature for %s\n", remote)
 	return nil

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	apiclient "github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
@@ -124,7 +124,7 @@ func signAndPublishToTarget(out io.Writer, imgRefAndAuth trust.ImageRefAndAuth, 
 		err = notaryRepo.Publish()
 	}
 	if err != nil {
-		return errors.Wrapf(err, "failed to sign %s:%s", imgRefAndAuth.RepoInfo().Name.Name(), tag)
+		return fmt.Errorf("failed to sign %s:%s: %w", imgRefAndAuth.RepoInfo().Name.Name(), tag, err)
 	}
 	fmt.Fprintf(out, "Successfully signed %s:%s\n", imgRefAndAuth.RepoInfo().Name.Name(), tag)
 	return nil
@@ -209,7 +209,7 @@ func initNotaryRepoWithSigners(notaryRepo client.Repository, newSigner data.Role
 		return err
 	}
 	if err := addStagedSigner(notaryRepo, newSigner, []data.PublicKey{signerKey}); err != nil {
-		return errors.Wrapf(err, "could not add signer to repo: %s", strings.TrimPrefix(newSigner.String(), "targets/"))
+		return fmt.Errorf("could not add signer to repo: %s: %w", strings.TrimPrefix(newSigner.String(), "targets/"), err)
 	}
 
 	return notaryRepo.Publish()

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/theupdateframework/notary/client"
 	"github.com/theupdateframework/notary/tuf/data"
@@ -49,7 +49,7 @@ func removeSigner(dockerCLI command.Cli, options signerRemoveOptions) error {
 		}
 	}
 	if len(errRepos) > 0 {
-		return errors.Errorf("error removing signer from: %s", strings.Join(errRepos, ", "))
+		return fmt.Errorf("error removing signer from: %s", strings.Join(errRepos, ", "))
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func removeSingleSigner(dockerCLI command.Cli, repoName, signerName string, forc
 
 	signerDelegation := data.RoleName("targets/" + signerName)
 	if signerDelegation == releasesRoleTUFName {
-		return false, errors.Errorf("releases is a reserved keyword and cannot be removed")
+		return false, fmt.Errorf("releases is a reserved keyword and cannot be removed")
 	}
 	notaryRepo, err := dockerCLI.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
@@ -95,7 +95,7 @@ func removeSingleSigner(dockerCLI command.Cli, repoName, signerName string, forc
 	}
 	delegationRoles, err := notaryRepo.GetDelegationRoles()
 	if err != nil {
-		return false, errors.Wrapf(err, "error retrieving signers for %s", repoName)
+		return false, fmt.Errorf("error retrieving signers for %s: %w", repoName, err)
 	}
 	var role data.Role
 	for _, delRole := range delegationRoles {
@@ -105,7 +105,7 @@ func removeSingleSigner(dockerCLI command.Cli, repoName, signerName string, forc
 		}
 	}
 	if role.Name == "" {
-		return false, errors.Errorf("no signer %s for repository %s", signerName, repoName)
+		return false, fmt.Errorf("no signer %s for repository %s", signerName, repoName)
 	}
 	allRoles, err := notaryRepo.ListRoles()
 	if err != nil {

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,6 @@ import (
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/moby/sys/sequential"
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
 
@@ -134,7 +134,7 @@ func ValidateOutputPath(path string) error {
 	dir := filepath.Dir(filepath.Clean(path))
 	if dir != "" && dir != "." {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			return errors.Errorf("invalid output path: directory %q does not exist", dir)
+			return fmt.Errorf("invalid output path: directory %q does not exist", dir)
 		}
 	}
 	// check whether `path` points to a regular file
@@ -149,7 +149,7 @@ func ValidateOutputPath(path string) error {
 		}
 
 		if err := ValidateOutputPathFileMode(fileInfo.Mode()); err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("invalid output path: %q must be a directory or a regular file", path))
+			return fmt.Errorf("invalid output path: %q must be a directory or a regular file: %w", path, err)
 		}
 	}
 	return nil
@@ -202,11 +202,11 @@ func StringSliceReplaceAt(s, find, replace []string, requireIndex int) ([]string
 func ValidateMountWithAPIVersion(m mounttypes.Mount, serverAPIVersion string) error {
 	if m.BindOptions != nil {
 		if m.BindOptions.NonRecursive && versions.LessThan(serverAPIVersion, "1.40") {
-			return errors.Errorf("bind-recursive=disabled requires API v1.40 or later")
+			return fmt.Errorf("bind-recursive=disabled requires API v1.40 or later")
 		}
 		// ReadOnlyNonRecursive can be safely ignored when API < 1.44
 		if m.BindOptions.ReadOnlyForceRecursive && versions.LessThan(serverAPIVersion, "1.44") {
-			return errors.Errorf("bind-recursive=readonly requires API v1.44 or later")
+			return fmt.Errorf("bind-recursive=readonly requires API v1.44 or later")
 		}
 	}
 	return nil

--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -1,11 +1,11 @@
 package command
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -52,7 +51,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 1 {
 				if options.name != "" {
-					return errors.Errorf("conflicting options: either specify --name or provide positional arg, not both")
+					return fmt.Errorf("conflicting options: either specify --name or provide positional arg, not both")
 				}
 				options.name = args[0]
 			}

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"sort"
@@ -34,7 +35,7 @@ func TestVolumeCreateErrors(t *testing.T) {
 		},
 		{
 			volumeCreateFunc: func(createBody volume.CreateOptions) (volume.Volume, error) {
-				return volume.Volume{}, errors.Errorf("error creating volume")
+				return volume.Volume{}, fmt.Errorf("error creating volume")
 			},
 			expectedError: "error creating volume",
 		},
@@ -60,7 +61,7 @@ func TestVolumeCreateWithName(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeCreateFunc: func(body volume.CreateOptions) (volume.Volume, error) {
 			if body.Name != name {
-				return volume.Volume{}, errors.Errorf("expected name %q, got %q", name, body.Name)
+				return volume.Volume{}, fmt.Errorf("expected name %q, got %q", name, body.Name)
 			}
 			return volume.Volume{
 				Name: body.Name,
@@ -99,16 +100,16 @@ func TestVolumeCreateWithFlags(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		volumeCreateFunc: func(body volume.CreateOptions) (volume.Volume, error) {
 			if body.Name != "" {
-				return volume.Volume{}, errors.Errorf("expected empty name, got %q", body.Name)
+				return volume.Volume{}, fmt.Errorf("expected empty name, got %q", body.Name)
 			}
 			if body.Driver != expectedDriver {
-				return volume.Volume{}, errors.Errorf("expected driver %q, got %q", expectedDriver, body.Driver)
+				return volume.Volume{}, fmt.Errorf("expected driver %q, got %q", expectedDriver, body.Driver)
 			}
 			if !reflect.DeepEqual(body.DriverOpts, expectedOpts) {
-				return volume.Volume{}, errors.Errorf("expected drivers opts %v, got %v", expectedOpts, body.DriverOpts)
+				return volume.Volume{}, fmt.Errorf("expected drivers opts %v, got %v", expectedOpts, body.DriverOpts)
 			}
 			if !reflect.DeepEqual(body.Labels, expectedLabels) {
-				return volume.Volume{}, errors.Errorf("expected labels %v, got %v", expectedLabels, body.Labels)
+				return volume.Volume{}, fmt.Errorf("expected labels %v, got %v", expectedLabels, body.Labels)
 			}
 			return volume.Volume{
 				Name: name,

--- a/cli/command/volume/create_test.go
+++ b/cli/command/volume/create_test.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"io"
 	"reflect"
 	"sort"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -27,7 +26,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 		{
 			args: []string{"foo"},
 			volumeInspectFunc: func(volumeID string) (volume.Volume, error) {
-				return volume.Volume{}, errors.Errorf("error while inspecting the volume")
+				return volume.Volume{}, fmt.Errorf("error while inspecting the volume")
 			},
 			expectedError: "error while inspecting the volume",
 		},
@@ -46,7 +45,7 @@ func TestVolumeInspectErrors(t *testing.T) {
 						Name: "foo",
 					}, nil
 				}
-				return volume.Volume{}, errors.Errorf("error while inspecting the volume")
+				return volume.Volume{}, fmt.Errorf("error while inspecting the volume")
 			},
 			expectedError: "error while inspecting the volume",
 		},
@@ -78,7 +77,7 @@ func TestVolumeInspectWithoutFormat(t *testing.T) {
 			args: []string{"foo"},
 			volumeInspectFunc: func(volumeID string) (volume.Volume, error) {
 				if volumeID != "foo" {
-					return volume.Volume{}, errors.Errorf("Invalid volumeID, expected %s, got %s", "foo", volumeID)
+					return volume.Volume{}, fmt.Errorf("Invalid volumeID, expected %s, got %s", "foo", volumeID)
 				}
 				return *builders.Volume(), nil
 			},

--- a/cli/command/volume/inspect_test.go
+++ b/cli/command/volume/inspect_test.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -1,7 +1,7 @@
 package volume
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestVolumeListErrors(t *testing.T) {
 		},
 		{
 			volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {
-				return volume.ListResponse{}, errors.Errorf("error listing volumes")
+				return volume.ListResponse{}, fmt.Errorf("error listing volumes")
 			},
 			expectedError: "error listing volumes",
 		},

--- a/cli/command/volume/list_test.go
+++ b/cli/command/volume/list_test.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/golden"
 )

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -2,6 +2,7 @@ package volume
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	units "github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -37,7 +36,7 @@ func TestVolumePruneErrors(t *testing.T) {
 				"force": "true",
 			},
 			volumePruneFunc: func(args filters.Args) (types.VolumesPruneReport, error) {
-				return types.VolumesPruneReport{}, errors.Errorf("error pruning volumes")
+				return types.VolumesPruneReport{}, fmt.Errorf("error pruning volumes")
 			},
 			expectedError: "error pruning volumes",
 		},

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -1,6 +1,7 @@
 package volume
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"runtime"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"

--- a/cli/command/volume/remove.go
+++ b/cli/command/volume/remove.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +55,7 @@ func runRemove(dockerCli command.Cli, opts *removeOptions) error {
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf("%s", strings.Join(errs, "\n"))
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -1,11 +1,11 @@
 package volume
 
 import (
+	"errors"
 	"io"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 )
 

--- a/cli/command/volume/remove_test.go
+++ b/cli/command/volume/remove_test.go
@@ -1,7 +1,7 @@
 package volume
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -21,7 +21,7 @@ func TestVolumeRemoveErrors(t *testing.T) {
 		{
 			args: []string{"nodeID"},
 			volumeRemoveFunc: func(volumeID string, force bool) error {
-				return errors.Errorf("error removing the volume")
+				return fmt.Errorf("error removing the volume")
 			},
 			expectedError: "error removing the volume",
 		},

--- a/cli/command/volume/update.go
+++ b/cli/command/volume/update.go
@@ -2,12 +2,12 @@ package volume
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/volume"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -33,16 +33,16 @@ func Services(
 	for _, service := range config.Services {
 		secrets, err := convertServiceSecrets(apiClient, namespace, service.Secrets, config.Secrets)
 		if err != nil {
-			return nil, errors.Wrapf(err, "service %s", service.Name)
+			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
 		}
 		configs, err := convertServiceConfigObjs(apiClient, namespace, service, config.Configs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "service %s", service.Name)
+			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
 		}
 
 		serviceSpec, err := Service(apiClient.ClientVersion(), namespace, service, config.Networks, config.Volumes, secrets, configs)
 		if err != nil {
-			return nil, errors.Wrapf(err, "service %s", service.Name)
+			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
 		}
 		result[service.Name] = serviceSpec
 	}
@@ -210,7 +210,7 @@ func convertServiceNetworks(
 	for networkName, network := range networks {
 		networkConfig, ok := networkConfigs[networkName]
 		if !ok && networkName != defaultNetwork {
-			return nil, errors.Errorf("undefined network %q", networkName)
+			return nil, fmt.Errorf("undefined network %q", networkName)
 		}
 		var aliases []string
 		if network != nil {
@@ -250,7 +250,7 @@ func convertServiceSecrets(
 	lookup := func(key string) (composetypes.FileObjectConfig, error) {
 		secretSpec, exists := secretSpecs[key]
 		if !exists {
-			return composetypes.FileObjectConfig{}, errors.Errorf("undefined secret %q", key)
+			return composetypes.FileObjectConfig{}, fmt.Errorf("undefined secret %q", key)
 		}
 		return composetypes.FileObjectConfig(secretSpec), nil
 	}
@@ -294,7 +294,7 @@ func convertServiceConfigObjs(
 	lookup := func(key string) (composetypes.FileObjectConfig, error) {
 		configSpec, exists := configSpecs[key]
 		if !exists {
-			return composetypes.FileObjectConfig{}, errors.Errorf("undefined config %q", key)
+			return composetypes.FileObjectConfig{}, fmt.Errorf("undefined config %q", key)
 		}
 		return composetypes.FileObjectConfig(configSpec), nil
 	}
@@ -435,7 +435,7 @@ func convertHealthcheck(healthcheck *composetypes.HealthCheckConfig) (*container
 	)
 	if healthcheck.Disable {
 		if len(healthcheck.Test) != 0 {
-			return nil, errors.Errorf("test and disable can't be set at the same time")
+			return nil, fmt.Errorf("test and disable can't be set at the same time")
 		}
 		return &container.HealthConfig{
 			Test: []string{"NONE"},
@@ -487,7 +487,7 @@ func convertRestartPolicy(restart string, source *composetypes.RestartPolicy) (*
 				MaxAttempts: &attempts,
 			}, nil
 		default:
-			return nil, errors.Errorf("unknown restart policy: %s", restart)
+			return nil, fmt.Errorf("unknown restart policy: %s", restart)
 		}
 	}
 
@@ -611,12 +611,12 @@ func convertDeployMode(mode string, replicas *uint64) (swarm.ServiceMode, error)
 	switch mode {
 	case "global-job":
 		if replicas != nil {
-			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
+			return serviceMode, fmt.Errorf("replicas can only be used with replicated or replicated-job mode")
 		}
 		serviceMode.GlobalJob = &swarm.GlobalJob{}
 	case "global":
 		if replicas != nil {
-			return serviceMode, errors.Errorf("replicas can only be used with replicated or replicated-job mode")
+			return serviceMode, fmt.Errorf("replicas can only be used with replicated or replicated-job mode")
 		}
 		serviceMode.Global = &swarm.GlobalService{}
 	case "replicated-job":
@@ -627,7 +627,7 @@ func convertDeployMode(mode string, replicas *uint64) (swarm.ServiceMode, error)
 	case "replicated", "":
 		serviceMode.Replicated = &swarm.ReplicatedService{Replicas: replicas}
 	default:
-		return serviceMode, errors.Errorf("Unknown mode: %s", mode)
+		return serviceMode, fmt.Errorf("Unknown mode: %s", mode)
 	}
 	return serviceMode, nil
 }
@@ -660,9 +660,9 @@ func convertCredentialSpec(namespace Namespace, spec composetypes.CredentialSpec
 	case l == 0:
 		return nil, nil
 	case l == 2:
-		return nil, errors.Errorf("invalid credential spec: cannot specify both %s and %s", o[0], o[1])
+		return nil, fmt.Errorf("invalid credential spec: cannot specify both %s and %s", o[0], o[1])
 	case l > 2:
-		return nil, errors.Errorf("invalid credential spec: cannot specify both %s, and %s", strings.Join(o[:l-1], ", "), o[l-1])
+		return nil, fmt.Errorf("invalid credential spec: cannot specify both %s, and %s", strings.Join(o[:l-1], ", "), o[l-1])
 	}
 	swarmCredSpec := swarm.CredentialSpec(spec)
 	// if we're using a swarm Config for the credential spec, over-write it
@@ -681,7 +681,7 @@ func convertCredentialSpec(namespace Namespace, spec composetypes.CredentialSpec
 				return &swarmCredSpec, nil
 			}
 		}
-		return nil, errors.Errorf("invalid credential spec: spec specifies config %v, but no such config can be found", swarmCredSpec.Config)
+		return nil, fmt.Errorf("invalid credential spec: spec specifies config %v, but no such config can be found", swarmCredSpec.Config)
 	}
 	return &swarmCredSpec, nil
 }

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -33,16 +33,16 @@ func Services(
 	for _, service := range config.Services {
 		secrets, err := convertServiceSecrets(apiClient, namespace, service.Secrets, config.Secrets)
 		if err != nil {
-			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
+			return nil, fmt.Errorf("service %s: %w", service.Name, err)
 		}
 		configs, err := convertServiceConfigObjs(apiClient, namespace, service, config.Configs)
 		if err != nil {
-			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
+			return nil, fmt.Errorf("service %s: %w", service.Name, err)
 		}
 
 		serviceSpec, err := Service(apiClient.ClientVersion(), namespace, service, config.Networks, config.Volumes, secrets, configs)
 		if err != nil {
-			return nil, fmt.Errorf("service %s: %w: %w", service.Name, err)
+			return nil, fmt.Errorf("service %s: %w", service.Name, err)
 		}
 		result[service.Name] = serviceSpec
 	}

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -1,11 +1,12 @@
 package convert
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/pkg/errors"
 )
 
 type volumes map[string]composetypes.VolumeConfig
@@ -56,7 +57,7 @@ func handleVolumeToMount(
 
 	stackVolume, exists := stackVolumes[volume.Source]
 	if !exists {
-		return mount.Mount{}, errors.Errorf("undefined volume %q", volume.Source)
+		return mount.Mount{}, fmt.Errorf("undefined volume %q", volume.Source)
 	}
 
 	result.Source = namespace.Scope(volume.Source)
@@ -180,7 +181,7 @@ func handleClusterToMount(
 		// external volumes with a given group exist.
 		stackVolume, exists := stackVolumes[volume.Source]
 		if !exists {
-			return mount.Mount{}, errors.Errorf("undefined volume %q", volume.Source)
+			return mount.Mount{}, fmt.Errorf("undefined volume %q", volume.Source)
 		}
 
 		// if the volume is not specified with a group source, we may namespace

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -1,11 +1,11 @@
 package interpolation
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/docker/cli/cli/compose/template"
-	"github.com/pkg/errors"
 )
 
 // Options supported by Interpolate
@@ -64,7 +64,7 @@ func recursiveInterpolate(value any, path Path, opts Options) (any, error) {
 			return newValue, nil
 		}
 		casted, err := caster(newValue)
-		return casted, newPathError(path, errors.Wrap(err, "failed to cast to expected type"))
+		return casted, newPathError(path, fmt.Errorf("failed to cast to expected type: %w", err))
 
 	case map[string]any:
 		out := map[string]any{}
@@ -98,11 +98,9 @@ func newPathError(path Path, err error) error {
 	case nil:
 		return nil
 	case *template.InvalidTemplateError:
-		return errors.Errorf(
-			"invalid interpolation format for %s: %#v; you may need to escape any $ with another $",
-			path, err.Template)
+		return fmt.Errorf("invalid interpolation format for %s: %#v; you may need to escape any $ with another $", path, err.Template)
 	default:
-		return errors.Wrapf(err, "error while interpolating %s", path)
+		return fmt.Errorf("error while interpolating %s: %w", path, err)
 	}
 }
 

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -1,11 +1,11 @@
 package loader
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
 	interp "github.com/docker/cli/cli/compose/interpolation"
-	"github.com/pkg/errors"
 )
 
 var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
@@ -63,7 +63,7 @@ func toBoolean(value string) (any, error) {
 	case "n", "no", "false", "off":
 		return false, nil
 	default:
-		return nil, errors.Errorf("invalid boolean: %s", value)
+		return nil, fmt.Errorf("invalid boolean: %s", value)
 	}
 }
 

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -20,7 +21,6 @@ import (
 	units "github.com/docker/go-units"
 	"github.com/google/shlex"
 	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -52,7 +52,7 @@ func ParseYAML(source []byte) (map[string]any, error) {
 	}
 	cfgMap, ok := cfg.(map[any]any)
 	if !ok {
-		return nil, errors.Errorf("top-level object must be a mapping")
+		return nil, fmt.Errorf("top-level object must be a mapping")
 	}
 	converted, err := convertToStringKeysRecursive(cfgMap, "")
 	if err != nil {
@@ -64,7 +64,7 @@ func ParseYAML(source []byte) (map[string]any, error) {
 // Load reads a ConfigDetails and returns a fully loaded configuration
 func Load(configDetails types.ConfigDetails, opt ...func(*Options)) (*types.Config, error) {
 	if len(configDetails.ConfigFiles) < 1 {
-		return nil, errors.Errorf("No files specified")
+		return nil, fmt.Errorf("No files specified")
 	}
 
 	options := &Options{
@@ -89,7 +89,7 @@ func Load(configDetails types.ConfigDetails, opt ...func(*Options)) (*types.Conf
 			configDetails.Version = version
 		}
 		if configDetails.Version != version {
-			return nil, errors.Errorf("version mismatched between two composefiles : %v and %v", configDetails.Version, version)
+			return nil, fmt.Errorf("version mismatched between two composefiles : %v and %v", configDetails.Version, version)
 		}
 
 		if err := validateForbidden(configDict); err != nil {
@@ -389,7 +389,7 @@ func formatInvalidKeyError(keyPrefix string, key any) error {
 	} else {
 		location = "in " + keyPrefix
 	}
-	return errors.Errorf("non-string key %s: %#v", location, key)
+	return fmt.Errorf("non-string key %s: %#v", location, key)
 }
 
 // LoadServices produces a ServiceConfig map from a compose file Dict
@@ -534,7 +534,7 @@ func transformUlimits(data any) (any, error) {
 		ulimit.Hard = value["hard"].(int)
 		return ulimit, nil
 	default:
-		return data, errors.Errorf("invalid type %T for ulimits", value)
+		return data, fmt.Errorf("invalid type %T for ulimits", value)
 	}
 }
 
@@ -553,7 +553,7 @@ func LoadNetworks(source map[string]any, version string) (map[string]types.Netwo
 		switch {
 		case network.External.Name != "":
 			if network.Name != "" {
-				return nil, errors.Errorf("network %s: network.external.name and network.name conflict; only use network.name", name)
+				return nil, fmt.Errorf("network %s: network.external.name and network.name conflict; only use network.name", name)
 			}
 			if versions.GreaterThanOrEqualTo(version, "3.5") {
 				logrus.Warnf("network %s: network.external.name is deprecated in favor of network.name", name)
@@ -570,9 +570,7 @@ func LoadNetworks(source map[string]any, version string) (map[string]types.Netwo
 }
 
 func externalVolumeError(volume, key string) error {
-	return errors.Errorf(
-		"conflicting parameters \"external\" and %q specified for volume %q",
-		key, volume)
+	return fmt.Errorf("conflicting parameters \"external\" and %q specified for volume %q", key, volume)
 }
 
 // LoadVolumes produces a VolumeConfig map from a compose file Dict
@@ -596,7 +594,7 @@ func LoadVolumes(source map[string]any, version string) (map[string]types.Volume
 			return nil, externalVolumeError(name, "labels")
 		case volume.External.Name != "":
 			if volume.Name != "" {
-				return nil, errors.Errorf("volume %s: volume.external.name and volume.name conflict; only use volume.name", name)
+				return nil, fmt.Errorf("volume %s: volume.external.name and volume.name conflict; only use volume.name", name)
 			}
 			if versions.GreaterThanOrEqualTo(version, "3.4") {
 				logrus.Warnf("volume %s: volume.external.name is deprecated in favor of volume.name", name)
@@ -657,7 +655,7 @@ func loadFileObjectConfig(name string, objType string, obj types.FileObjectConfi
 		// handle deprecated external.name
 		if obj.External.Name != "" {
 			if obj.Name != "" {
-				return obj, errors.Errorf("%[1]s %[2]s: %[1]s.external.name and %[1]s.name conflict; only use %[1]s.name", objType, name)
+				return obj, fmt.Errorf("%[1]s %[2]s: %[1]s.external.name and %[1]s.name conflict; only use %[1]s.name", objType, name)
 			}
 			if versions.GreaterThanOrEqualTo(details.Version, "3.5") {
 				logrus.Warnf("%[1]s %[2]s: %[1]s.external.name is deprecated in favor of %[1]s.name", objType, name)
@@ -670,7 +668,7 @@ func loadFileObjectConfig(name string, objType string, obj types.FileObjectConfi
 		// if not "external: true"
 	case obj.Driver != "":
 		if obj.File != "" {
-			return obj, errors.Errorf("%[1]s %[2]s: %[1]s.driver and %[1]s.file conflict; only use %[1]s.driver", objType, name)
+			return obj, fmt.Errorf("%[1]s %[2]s: %[1]s.driver and %[1]s.file conflict; only use %[1]s.driver", objType, name)
 		}
 	default:
 		obj.File = absPath(details.WorkingDir, obj.File)
@@ -693,7 +691,7 @@ var transformMapStringString TransformerFunc = func(data any) (any, error) {
 	case map[string]string:
 		return value, nil
 	default:
-		return data, errors.Errorf("invalid type %T for map[string]string", value)
+		return data, fmt.Errorf("invalid type %T for map[string]string", value)
 	}
 }
 
@@ -704,7 +702,7 @@ var transformExternal TransformerFunc = func(data any) (any, error) {
 	case map[string]any:
 		return map[string]any{"external": true, "name": value["name"]}, nil
 	default:
-		return data, errors.Errorf("invalid type %T for external", value)
+		return data, fmt.Errorf("invalid type %T for external", value)
 	}
 }
 
@@ -732,12 +730,12 @@ var transformServicePort TransformerFunc = func(data any) (any, error) {
 			case map[string]any:
 				ports = append(ports, value)
 			default:
-				return data, errors.Errorf("invalid type %T for port", value)
+				return data, fmt.Errorf("invalid type %T for port", value)
 			}
 		}
 		return ports, nil
 	default:
-		return data, errors.Errorf("invalid type %T for port", entries)
+		return data, fmt.Errorf("invalid type %T for port", entries)
 	}
 }
 
@@ -748,7 +746,7 @@ var transformStringSourceMap TransformerFunc = func(data any) (any, error) {
 	case map[string]any:
 		return data, nil
 	default:
-		return data, errors.Errorf("invalid type %T for secret", value)
+		return data, fmt.Errorf("invalid type %T for secret", value)
 	}
 }
 
@@ -759,7 +757,7 @@ var transformBuildConfig TransformerFunc = func(data any) (any, error) {
 	case map[string]any:
 		return data, nil
 	default:
-		return data, errors.Errorf("invalid type %T for service build", value)
+		return data, fmt.Errorf("invalid type %T for service build", value)
 	}
 }
 
@@ -770,7 +768,7 @@ var transformServiceVolumeConfig TransformerFunc = func(data any) (any, error) {
 	case map[string]any:
 		return data, nil
 	default:
-		return data, errors.Errorf("invalid type %T for service volume", value)
+		return data, fmt.Errorf("invalid type %T for service volume", value)
 	}
 }
 
@@ -801,7 +799,7 @@ var transformStringList TransformerFunc = func(data any) (any, error) {
 	case []any:
 		return value, nil
 	default:
-		return data, errors.Errorf("invalid type %T for string list", value)
+		return data, fmt.Errorf("invalid type %T for string list", value)
 	}
 }
 
@@ -824,7 +822,7 @@ func transformListOrMapping(listOrMapping any, sep string, allowNil bool) any {
 	case []any:
 		return listOrMapping
 	}
-	panic(errors.Errorf("expected a map or a list, got %T: %#v", listOrMapping, listOrMapping))
+	panic(fmt.Errorf("expected a map or a list, got %T: %#v", listOrMapping, listOrMapping))
 }
 
 func transformMappingOrList(mappingOrList any, sep string, allowNil bool) any {
@@ -846,7 +844,7 @@ func transformMappingOrList(mappingOrList any, sep string, allowNil bool) any {
 		}
 		return result
 	}
-	panic(errors.Errorf("expected a map or a list, got %T: %#v", mappingOrList, mappingOrList))
+	panic(fmt.Errorf("expected a map or a list, got %T: %#v", mappingOrList, mappingOrList))
 }
 
 var transformShellCommand TransformerFunc = func(value any) (any, error) {
@@ -863,7 +861,7 @@ var transformHealthCheckTest TransformerFunc = func(data any) (any, error) {
 	case []any:
 		return value, nil
 	default:
-		return value, errors.Errorf("invalid type %T for healthcheck.test", value)
+		return value, fmt.Errorf("invalid type %T for healthcheck.test", value)
 	}
 }
 
@@ -874,7 +872,7 @@ var transformSize TransformerFunc = func(value any) (any, error) {
 	case string:
 		return units.RAMInBytes(value)
 	}
-	panic(errors.Errorf("invalid type for size %T", value))
+	panic(fmt.Errorf("invalid type for size %T", value))
 }
 
 var transformStringToDuration TransformerFunc = func(value any) (any, error) {
@@ -886,7 +884,7 @@ var transformStringToDuration TransformerFunc = func(value any) (any, error) {
 		}
 		return types.Duration(d), nil
 	default:
-		return value, errors.Errorf("invalid type %T for duration", value)
+		return value, fmt.Errorf("invalid type %T for duration", value)
 	}
 }
 

--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -1,12 +1,12 @@
 package loader
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 
 	"dario.cat/mergo"
 	"github.com/docker/cli/cli/compose/types"
-	"github.com/pkg/errors"
 )
 
 type specials struct {
@@ -26,23 +26,23 @@ func merge(configs []*types.Config) (*types.Config, error) {
 		var err error
 		base.Services, err = mergeServices(base.Services, override.Services)
 		if err != nil {
-			return base, errors.Wrapf(err, "cannot merge services from %s", override.Filename)
+			return base, fmt.Errorf("cannot merge services from %s: %w", override.Filename, err)
 		}
 		base.Volumes, err = mergeVolumes(base.Volumes, override.Volumes)
 		if err != nil {
-			return base, errors.Wrapf(err, "cannot merge volumes from %s", override.Filename)
+			return base, fmt.Errorf("cannot merge volumes from %s: %w", override.Filename, err)
 		}
 		base.Networks, err = mergeNetworks(base.Networks, override.Networks)
 		if err != nil {
-			return base, errors.Wrapf(err, "cannot merge networks from %s", override.Filename)
+			return base, fmt.Errorf("cannot merge networks from %s: %w", override.Filename, err)
 		}
 		base.Secrets, err = mergeSecrets(base.Secrets, override.Secrets)
 		if err != nil {
-			return base, errors.Wrapf(err, "cannot merge secrets from %s", override.Filename)
+			return base, fmt.Errorf("cannot merge secrets from %s: %w", override.Filename, err)
 		}
 		base.Configs, err = mergeConfigs(base.Configs, override.Configs)
 		if err != nil {
-			return base, errors.Wrapf(err, "cannot merge configs from %s", override.Filename)
+			return base, fmt.Errorf("cannot merge configs from %s: %w", override.Filename, err)
 		}
 	}
 	return base, nil
@@ -68,7 +68,7 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 		overrideService := overrideService
 		if baseService, ok := baseServices[name]; ok {
 			if err := mergo.Merge(&baseService, &overrideService, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(specials)); err != nil {
-				return base, errors.Wrapf(err, "cannot merge service %s", name)
+				return base, fmt.Errorf("cannot merge service %s: %w", name, err)
 			}
 			baseServices[name] = baseService
 			continue
@@ -86,7 +86,7 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 func toServiceSecretConfigsMap(s any) (map[any]any, error) {
 	secrets, ok := s.([]types.ServiceSecretConfig)
 	if !ok {
-		return nil, errors.Errorf("not a serviceSecretConfig: %v", s)
+		return nil, fmt.Errorf("not a serviceSecretConfig: %v", s)
 	}
 	m := map[any]any{}
 	for _, secret := range secrets {
@@ -98,7 +98,7 @@ func toServiceSecretConfigsMap(s any) (map[any]any, error) {
 func toServiceConfigObjConfigsMap(s any) (map[any]any, error) {
 	secrets, ok := s.([]types.ServiceConfigObjConfig)
 	if !ok {
-		return nil, errors.Errorf("not a serviceSecretConfig: %v", s)
+		return nil, fmt.Errorf("not a serviceSecretConfig: %v", s)
 	}
 	m := map[any]any{}
 	for _, secret := range secrets {
@@ -110,7 +110,7 @@ func toServiceConfigObjConfigsMap(s any) (map[any]any, error) {
 func toServicePortConfigsMap(s any) (map[any]any, error) {
 	ports, ok := s.([]types.ServicePortConfig)
 	if !ok {
-		return nil, errors.Errorf("not a servicePortConfig slice: %v", s)
+		return nil, fmt.Errorf("not a servicePortConfig slice: %v", s)
 	}
 	m := map[any]any{}
 	for _, p := range ports {
@@ -122,7 +122,7 @@ func toServicePortConfigsMap(s any) (map[any]any, error) {
 func toServiceVolumeConfigsMap(s any) (map[any]any, error) {
 	volumes, ok := s.([]types.ServiceVolumeConfig)
 	if !ok {
-		return nil, errors.Errorf("not a serviceVolumeConfig slice: %v", s)
+		return nil, fmt.Errorf("not a serviceVolumeConfig slice: %v", s)
 	}
 	m := map[any]any{}
 	for _, v := range volumes {
@@ -209,7 +209,7 @@ func mergeSlice(tomap tomapFn, writeValue writeValueFromMapFn) func(dst, src ref
 func sliceToMap(tomap tomapFn, v reflect.Value) (map[any]any, error) {
 	// check if valid
 	if !v.IsValid() {
-		return nil, errors.Errorf("invalid value : %+v", v)
+		return nil, fmt.Errorf("invalid value : %+v", v)
 	}
 	return tomap(v.Interface())
 }

--- a/cli/compose/loader/volume.go
+++ b/cli/compose/loader/volume.go
@@ -1,13 +1,14 @@
 package loader
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
 	"github.com/docker/cli/cli/compose/types"
 	"github.com/docker/docker/api/types/mount"
-	"github.com/pkg/errors"
 )
 
 const endOfSpec = rune(0)
@@ -33,7 +34,7 @@ func ParseVolume(spec string) (types.ServiceVolumeConfig, error) {
 		case char == ':' || char == endOfSpec:
 			if err := populateFieldFromBuffer(char, buffer, &volume); err != nil {
 				populateType(&volume)
-				return volume, errors.Wrapf(err, "invalid spec: %s", spec)
+				return volume, fmt.Errorf("invalid spec: %s: %w", spec, err)
 			}
 			buffer = []rune{}
 		default:

--- a/cli/compose/schema/schema.go
+++ b/cli/compose/schema/schema.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -67,7 +66,7 @@ func Validate(config map[string]any, version string) error {
 	version = normalizeVersion(version)
 	schemaData, err := schemas.ReadFile("data/config_schema_v" + version + ".json")
 	if err != nil {
-		return errors.Errorf("unsupported Compose file version: %s", version)
+		return fmt.Errorf("unsupported Compose file version: %s", version)
 	}
 
 	schemaLoader := gojsonschema.NewStringLoader(string(schemaData))

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/pkg/homedir"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -69,7 +68,7 @@ func SetDir(dir string) {
 func Path(p ...string) (string, error) {
 	path := filepath.Join(append([]string{Dir()}, p...)...)
 	if !strings.HasPrefix(path, Dir()+string(filepath.Separator)) {
-		return "", errors.Errorf("path %q is outside of root config directory %q", path, Dir())
+		return "", fmt.Errorf("path %q is outside of root config directory %q", path, Dir())
 	}
 	return path, nil
 }
@@ -112,7 +111,7 @@ func load(configDir string) (*configfile.ConfigFile, error) {
 	defer file.Close()
 	err = configFile.LoadFromReader(file)
 	if err != nil {
-		err = errors.Wrap(err, filename)
+		err = fmt.Errorf(filename+": %w", err)
 	}
 	return configFile, err
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -3,6 +3,8 @@ package configfile
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,7 +12,6 @@ import (
 
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -137,7 +138,7 @@ func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {
 // Save encodes and writes out all the authorization information
 func (configFile *ConfigFile) Save() (retErr error) {
 	if configFile.Filename == "" {
-		return errors.Errorf("Can't save config with empty filename")
+		return fmt.Errorf("Can't save config with empty filename")
 	}
 
 	dir := filepath.Dir(configFile.Filename)
@@ -163,7 +164,7 @@ func (configFile *ConfigFile) Save() (retErr error) {
 	}
 
 	if err := temp.Close(); err != nil {
-		return errors.Wrap(err, "error closing temp file")
+		return fmt.Errorf("error closing temp file: %w", err)
 	}
 
 	// Handle situation where the configfile is a symlink
@@ -241,11 +242,11 @@ func decodeAuth(authStr string) (string, string, error) {
 		return "", "", err
 	}
 	if n > decLen {
-		return "", "", errors.Errorf("Something went wrong decoding auth config")
+		return "", "", fmt.Errorf("Something went wrong decoding auth config")
 	}
 	userName, password, ok := strings.Cut(string(decoded), ":")
 	if !ok || userName == "" {
-		return "", "", errors.Errorf("Invalid auth configuration file")
+		return "", "", fmt.Errorf("Invalid auth configuration file")
 	}
 	return userName, strings.Trim(password, "\x00"), nil
 }

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -2,7 +2,6 @@ package credentials
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -22,7 +21,7 @@ const (
 	missingCredsAddress  = "https://missing.docker.io/v1"
 )
 
-var errCommandExited = errors.Errorf("exited 1")
+var errCommandExited = fmt.Errorf("exited 1")
 
 // mockCommand simulates interactions between the docker client and a remote
 // credentials helper.

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )

--- a/cli/connhelper/commandconn/commandconn.go
+++ b/cli/connhelper/commandconn/commandconn.go
@@ -28,7 +28,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -139,7 +138,7 @@ func (c *commandConn) handleEOF(err error) error {
 			c.stderrMu.Lock()
 			stderr := c.stderr.String()
 			c.stderrMu.Unlock()
-			return errors.Errorf("command %v did not exit after %v: stderr=%q", c.cmd.Args, err, stderr)
+			return fmt.Errorf("command %v did not exit after %v: stderr=%q", c.cmd.Args, err, stderr)
 		}
 	}
 
@@ -149,7 +148,7 @@ func (c *commandConn) handleEOF(err error) error {
 	c.stderrMu.Lock()
 	stderr := c.stderr.String()
 	c.stderrMu.Unlock()
-	return errors.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%s", c.cmd.Args, werr, stderr)
+	return fmt.Errorf("command %v has exited with %v, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=%s", c.cmd.Args, werr, stderr)
 }
 
 func ignorableCloseError(err error) bool {

--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -3,13 +3,13 @@ package connhelper
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
 
 	"github.com/docker/cli/cli/connhelper/commandconn"
 	"github.com/docker/cli/cli/connhelper/ssh"
-	"github.com/pkg/errors"
 )
 
 // ConnectionHelper allows to connect to a remote host with custom stream provider binary.
@@ -43,7 +43,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 	if u.Scheme == "ssh" {
 		sp, err := ssh.ParseURL(daemonURL)
 		if err != nil {
-			return nil, errors.Wrap(err, "ssh host connection is not valid")
+			return nil, fmt.Errorf("ssh host connection is not valid: %w", err)
 		}
 		return &ConnectionHelper{
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -2,9 +2,9 @@
 package ssh
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
-
-	"github.com/pkg/errors"
 )
 
 // ParseURL parses URL
@@ -14,7 +14,7 @@ func ParseURL(daemonURL string) (*Spec, error) {
 		return nil, err
 	}
 	if u.Scheme != "ssh" {
-		return nil, errors.Errorf("expected scheme ssh, got %q", u.Scheme)
+		return nil, fmt.Errorf("expected scheme ssh, got %q", u.Scheme)
 	}
 
 	var sp Spec
@@ -27,15 +27,15 @@ func ParseURL(daemonURL string) (*Spec, error) {
 	}
 	sp.Host = u.Hostname()
 	if sp.Host == "" {
-		return nil, errors.Errorf("no host specified")
+		return nil, fmt.Errorf("no host specified")
 	}
 	sp.Port = u.Port()
 	sp.Path = u.Path
 	if u.RawQuery != "" {
-		return nil, errors.Errorf("extra query after the host: %q", u.RawQuery)
+		return nil, fmt.Errorf("extra query after the host: %q", u.RawQuery)
 	}
 	if u.Fragment != "" {
-		return nil, errors.Errorf("extra fragment after the host: %q", u.Fragment)
+		return nil, fmt.Errorf("extra fragment after the host: %q", u.Fragment)
 	}
 	return &sp, err
 }

--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -13,7 +15,6 @@ import (
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
-	"github.com/pkg/errors"
 )
 
 // EndpointMeta is a typed wrapper around a context-store generic endpoint describing
@@ -67,7 +68,7 @@ func (ep *Endpoint) tlsConfig() (*tls.Config, error) {
 
 		x509cert, err := tls.X509KeyPair(ep.TLSData.Cert, keyBytes)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to retrieve context tls info")
+			return nil, fmt.Errorf("failed to retrieve context tls info: %w", err)
 		}
 		tlsOpts = append(tlsOpts, func(cfg *tls.Config) {
 			cfg.Certificates = []tls.Certificate{x509cert}
@@ -143,7 +144,7 @@ func EndpointFromContext(metadata store.Metadata) (EndpointMeta, error) {
 	}
 	typed, ok := ep.(EndpointMeta)
 	if !ok {
-		return EndpointMeta{}, errors.Errorf("endpoint %q is not of type EndpointMeta", DockerEndpoint)
+		return EndpointMeta{}, fmt.Errorf("endpoint %q is not of type EndpointMeta", DockerEndpoint)
 	}
 	return typed, nil
 }

--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/fvbommel/sortorder"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -61,7 +61,7 @@ func parseTypedOrMap(payload []byte, getter TypeGetter) (any, error) {
 func (s *metadataStore) get(name string) (Metadata, error) {
 	m, err := s.getByID(contextdirOf(name))
 	if err != nil {
-		return m, errors.Wrapf(err, "context %q", name)
+		return m, fmt.Errorf("context %q: %w", name, err)
 	}
 	return m, nil
 }
@@ -71,7 +71,7 @@ func (s *metadataStore) getByID(id contextdir) (Metadata, error) {
 	bytes, err := os.ReadFile(fileName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return Metadata{}, errdefs.NotFound(errors.Wrap(err, "context not found"))
+			return Metadata{}, errdefs.NotFound(fmt.Errorf("context not found: %w", err))
 		}
 		return Metadata{}, err
 	}
@@ -96,7 +96,7 @@ func (s *metadataStore) getByID(id contextdir) (Metadata, error) {
 
 func (s *metadataStore) remove(name string) error {
 	if err := os.RemoveAll(s.contextDir(contextdirOf(name))); err != nil {
-		return errors.Wrapf(err, "failed to remove metadata")
+		return fmt.Errorf("failed to remove metadata: %w", err)
 	}
 	return nil
 }
@@ -116,7 +116,7 @@ func (s *metadataStore) list() ([]Metadata, error) {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			return nil, errors.Wrap(err, "failed to read metadata")
+			return nil, fmt.Errorf("failed to read metadata: %w", err)
 		}
 		res = append(res, c)
 	}

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,9 +15,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 type endpoint struct {
@@ -104,7 +103,7 @@ func TestRemove(t *testing.T) {
 	}))
 	assert.NilError(t, s.Remove("source"))
 	_, err = s.GetMetadata("source")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errors.Is(err, os.ErrNotExist))
 	f, err := s.ListTLSFiles("source")
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(f))
@@ -119,7 +118,7 @@ func TestListEmptyStore(t *testing.T) {
 func TestErrHasCorrectContext(t *testing.T) {
 	_, err := New(t.TempDir(), testCfg).GetMetadata("no-exists")
 	assert.ErrorContains(t, err, "no-exists")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errors.Is(err, os.ErrNotExist))
 }
 
 func TestDetectImportContentType(t *testing.T) {

--- a/cli/context/store/tlsstore.go
+++ b/cli/context/store/tlsstore.go
@@ -1,12 +1,12 @@
 package store
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/pkg/errors"
 )
 
 const tlsDir = "tls"
@@ -39,9 +39,9 @@ func (s *tlsStore) getData(name, endpointName, filename string) ([]byte, error) 
 	data, err := os.ReadFile(filepath.Join(s.endpointDir(name, endpointName), filename))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, errdefs.NotFound(errors.Errorf("TLS data for %s/%s/%s does not exist", name, endpointName, filename))
+			return nil, errdefs.NotFound(fmt.Errorf("TLS data for %s/%s/%s does not exist", name, endpointName, filename))
 		}
-		return nil, errors.Wrapf(err, "failed to read TLS data for endpoint %s", endpointName)
+		return nil, fmt.Errorf("failed to read TLS data for endpoint %s: %w", endpointName, err)
 	}
 	return data, nil
 }
@@ -49,14 +49,14 @@ func (s *tlsStore) getData(name, endpointName, filename string) ([]byte, error) 
 // remove deletes all TLS data for the given context.
 func (s *tlsStore) remove(name string) error {
 	if err := os.RemoveAll(s.contextDir(name)); err != nil {
-		return errors.Wrapf(err, "failed to remove TLS data")
+		return fmt.Errorf("failed to remove TLS data: %w", err)
 	}
 	return nil
 }
 
 func (s *tlsStore) removeEndpoint(name, endpointName string) error {
 	if err := os.RemoveAll(s.endpointDir(name, endpointName)); err != nil {
-		return errors.Wrapf(err, "failed to remove TLS data for endpoint %s", endpointName)
+		return fmt.Errorf("failed to remove TLS data for endpoint %s: %w", endpointName, err)
 	}
 	return nil
 }
@@ -68,7 +68,7 @@ func (s *tlsStore) listContextData(name string) (map[string]EndpointFiles, error
 		if os.IsNotExist(err) {
 			return map[string]EndpointFiles{}, nil
 		}
-		return nil, errors.Wrapf(err, "failed to list TLS files for context %s", name)
+		return nil, fmt.Errorf("failed to list TLS files for context %s: %w", name, err)
 	}
 	r := make(map[string]EndpointFiles)
 	for _, epFS := range epFSs {
@@ -78,7 +78,7 @@ func (s *tlsStore) listContextData(name string) (map[string]EndpointFiles, error
 				continue
 			}
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to list TLS files for endpoint %s", epFS.Name())
+				return nil, fmt.Errorf("failed to list TLS files for endpoint %s: %w", epFS.Name(), err)
 			}
 			var files EndpointFiles
 			for _, fs := range fss {

--- a/cli/context/tlsdata.go
+++ b/cli/context/tlsdata.go
@@ -1,10 +1,10 @@
 package context
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/docker/cli/cli/context/store"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -45,14 +45,14 @@ func (data *TLSData) ToStoreTLSData() *store.EndpointTLSData {
 func LoadTLSData(s store.Reader, contextName, endpointName string) (*TLSData, error) {
 	tlsFiles, err := s.ListTLSFiles(contextName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve TLS files for context %q", contextName)
+		return nil, fmt.Errorf("failed to retrieve TLS files for context %q: %w", contextName, err)
 	}
 	if epTLSFiles, ok := tlsFiles[endpointName]; ok {
 		var tlsData TLSData
 		for _, f := range epTLSFiles {
 			data, err := s.GetTLSData(contextName, endpointName, f)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to retrieve TLS data (%s) for context %q", f, contextName)
+				return nil, fmt.Errorf("failed to retrieve TLS data (%s) for context %q: %w", f, contextName, err)
 			}
 			switch f {
 			case caKey:

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // Store manages local storage of image distribution manifests
@@ -73,7 +72,7 @@ func (s *fsStore) getFromFilename(ref reference.Reference, filename string) (typ
 			return types.ImageManifest{}, err
 		}
 		if dgst := digest.FromBytes(raw); dgst != manifestInfo.Digest {
-			return types.ImageManifest{}, errors.Errorf("invalid manifest file %v: image manifest digest mismatch (%v != %v)", filename, manifestInfo.Digest, dgst)
+			return types.ImageManifest{}, fmt.Errorf("invalid manifest file %v: image manifest digest mismatch (%v != %v)", filename, manifestInfo.Digest, dgst)
 		}
 		manifestInfo.ImageManifest.Descriptor = ocispec.Descriptor{
 			Digest:    manifestInfo.Digest,

--- a/cli/manifest/types/types.go
+++ b/cli/manifest/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/distribution/reference"
 	"github.com/docker/distribution"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/distribution/manifest/schema2"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ImageManifest contains info to output for a manifest object.
@@ -82,7 +82,7 @@ func (i ImageManifest) Payload() (string, []byte, error) {
 	case i.OCIManifest != nil:
 		return i.OCIManifest.Payload()
 	default:
-		return "", nil, errors.Errorf("%s has no payload", i.Ref)
+		return "", nil, fmt.Errorf("%s has no payload", i.Ref)
 	}
 }
 
@@ -141,7 +141,7 @@ type SerializableNamed struct {
 func (s *SerializableNamed) UnmarshalJSON(b []byte) error {
 	var raw string
 	if err := json.Unmarshal(b, &raw); err != nil {
-		return errors.Wrapf(err, "invalid named reference bytes: %s", b)
+		return fmt.Errorf("invalid named reference bytes: %s: %w", b, err)
 	}
 	var err error
 	s.Named, err = reference.ParseNamed(raw)

--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
-	"github.com/pkg/errors"
 )
 
 type repositoryEndpoint struct {
@@ -94,7 +93,7 @@ func getHTTPTransport(authConfig registrytypes.AuthConfig, endpoint registry.API
 	authTransport := transport.NewTransport(base, modifiers...)
 	challengeManager, err := registry.PingV2Registry(endpoint.URL, authTransport)
 	if err != nil {
-		return nil, errors.Wrap(err, "error pinging v2 registry")
+		return nil, fmt.Errorf("error pinging v2 registry: %w", err)
 	}
 	if authConfig.RegistryToken != "" {
 		passThruTokenHandler := &existingTokenHandler{token: authConfig.RegistryToken}

--- a/cli/required.go
+++ b/cli/required.go
@@ -1,9 +1,9 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +14,10 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	if cmd.HasSubCommands() {
-		return errors.Errorf("\n" + strings.TrimRight(cmd.UsageString(), "\n"))
+		return fmt.Errorf("\n" + strings.TrimRight(cmd.UsageString(), "\n"))
 	}
 
-	return errors.Errorf(
-		"%q accepts no arguments.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-		cmd.CommandPath(),
-		cmd.CommandPath(),
-		cmd.UseLine(),
-		cmd.Short,
-	)
+	return fmt.Errorf("%q accepts no arguments.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", cmd.CommandPath(), cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 }
 
 // RequiresMinArgs returns an error if there is not at least min args
@@ -32,15 +26,7 @@ func RequiresMinArgs(min int) cobra.PositionalArgs {
 		if len(args) >= min {
 			return nil
 		}
-		return errors.Errorf(
-			"%q requires at least %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-			cmd.CommandPath(),
-			min,
-			pluralize("argument", min),
-			cmd.CommandPath(),
-			cmd.UseLine(),
-			cmd.Short,
-		)
+		return fmt.Errorf("%q requires at least %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", cmd.CommandPath(), min, pluralize("argument", min), cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 	}
 }
 
@@ -50,15 +36,7 @@ func RequiresMaxArgs(max int) cobra.PositionalArgs {
 		if len(args) <= max {
 			return nil
 		}
-		return errors.Errorf(
-			"%q requires at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-			cmd.CommandPath(),
-			max,
-			pluralize("argument", max),
-			cmd.CommandPath(),
-			cmd.UseLine(),
-			cmd.Short,
-		)
+		return fmt.Errorf("%q requires at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", cmd.CommandPath(), max, pluralize("argument", max), cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 	}
 }
 
@@ -68,16 +46,7 @@ func RequiresRangeArgs(min int, max int) cobra.PositionalArgs {
 		if len(args) >= min && len(args) <= max {
 			return nil
 		}
-		return errors.Errorf(
-			"%q requires at least %d and at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-			cmd.CommandPath(),
-			min,
-			max,
-			pluralize("argument", max),
-			cmd.CommandPath(),
-			cmd.UseLine(),
-			cmd.Short,
-		)
+		return fmt.Errorf("%q requires at least %d and at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", cmd.CommandPath(), min, max, pluralize("argument", max), cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 	}
 }
 
@@ -87,15 +56,7 @@ func ExactArgs(number int) cobra.PositionalArgs {
 		if len(args) == number {
 			return nil
 		}
-		return errors.Errorf(
-			"%q requires exactly %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
-			cmd.CommandPath(),
-			number,
-			pluralize("argument", number),
-			cmd.CommandPath(),
-			cmd.UseLine(),
-			cmd.Short,
-		)
+		return fmt.Errorf("%q requires exactly %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s", cmd.CommandPath(), number, pluralize("argument", number), cmd.CommandPath(), cmd.UseLine(), cmd.Short)
 	}
 }
 

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -3,6 +3,7 @@ package trust
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/client"
@@ -66,7 +66,7 @@ func Server(index *registrytypes.IndexInfo) (string, error) {
 	if s := os.Getenv("DOCKER_CONTENT_TRUST_SERVER"); s != "" {
 		urlObj, err := url.Parse(s)
 		if err != nil || urlObj.Scheme != "https" {
-			return "", errors.Errorf("valid https URL required for trust server, got %s", s)
+			return "", fmt.Errorf("valid https URL required for trust server, got %s", s)
 		}
 
 		return s, nil
@@ -214,27 +214,27 @@ func NotaryError(repoName string, err error) error {
 	switch err.(type) {
 	case *json.SyntaxError:
 		logrus.Debugf("Notary syntax error: %s", err)
-		return errors.Errorf("Error: no trust data available for remote repository %s. Try running notary server and setting DOCKER_CONTENT_TRUST_SERVER to its HTTPS address?", repoName)
+		return fmt.Errorf("Error: no trust data available for remote repository %s. Try running notary server and setting DOCKER_CONTENT_TRUST_SERVER to its HTTPS address?", repoName)
 	case signed.ErrExpired:
-		return errors.Errorf("Error: remote repository %s out-of-date: %v", repoName, err)
+		return fmt.Errorf("Error: remote repository %s out-of-date: %v", repoName, err)
 	case trustmanager.ErrKeyNotFound:
-		return errors.Errorf("Error: signing keys for remote repository %s not found: %v", repoName, err)
+		return fmt.Errorf("Error: signing keys for remote repository %s not found: %v", repoName, err)
 	case storage.NetworkError:
-		return errors.Errorf("Error: error contacting notary server: %v", err)
+		return fmt.Errorf("Error: error contacting notary server: %v", err)
 	case storage.ErrMetaNotFound:
-		return errors.Errorf("Error: trust data missing for remote repository %s or remote repository not found: %v", repoName, err)
+		return fmt.Errorf("Error: trust data missing for remote repository %s or remote repository not found: %v", repoName, err)
 	case trustpinning.ErrRootRotationFail, trustpinning.ErrValidationFail, signed.ErrInvalidKeyType:
-		return errors.Errorf("Warning: potential malicious behavior - trust data mismatch for remote repository %s: %v", repoName, err)
+		return fmt.Errorf("Warning: potential malicious behavior - trust data mismatch for remote repository %s: %v", repoName, err)
 	case signed.ErrNoKeys:
-		return errors.Errorf("Error: could not find signing keys for remote repository %s, or could not decrypt signing key: %v", repoName, err)
+		return fmt.Errorf("Error: could not find signing keys for remote repository %s, or could not decrypt signing key: %v", repoName, err)
 	case signed.ErrLowVersion:
-		return errors.Errorf("Warning: potential malicious behavior - trust data version is lower than expected for remote repository %s: %v", repoName, err)
+		return fmt.Errorf("Warning: potential malicious behavior - trust data version is lower than expected for remote repository %s: %v", repoName, err)
 	case signed.ErrRoleThreshold:
-		return errors.Errorf("Warning: potential malicious behavior - trust data has insufficient signatures for remote repository %s: %v", repoName, err)
+		return fmt.Errorf("Warning: potential malicious behavior - trust data has insufficient signatures for remote repository %s: %v", repoName, err)
 	case client.ErrRepositoryNotExist:
-		return errors.Errorf("Error: remote trust data does not exist for %s: %v", repoName, err)
+		return fmt.Errorf("Error: remote trust data does not exist for %s: %v", repoName, err)
 	case signed.ErrInsufficientSignatures:
-		return errors.Errorf("Error: could not produce valid signature for %s.  If Yubikey was used, was touch input provided?: %v", repoName, err)
+		return fmt.Errorf("Error: could not produce valid signature for %s.  If Yubikey was used, was touch input provided?: %v", repoName, err)
 	}
 
 	return err
@@ -281,7 +281,7 @@ func GetSignableRoles(repo client.Repository, target *client.Target) ([]data.Rol
 	}
 
 	if len(signableRoles) == 0 {
-		return signableRoles, errors.Errorf("no valid signing keys for delegation roles")
+		return signableRoles, fmt.Errorf("no valid signing keys for delegation roles")
 	}
 
 	return signableRoles, nil

--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -26,11 +26,11 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 
 	for k, v := range aliasMap {
 		if _, ok := allowedAliases[k]; !ok {
-			return args, osArgs, envs, errors.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
+			return args, osArgs, envs, fmt.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
 		}
 		if c, _, err := cmd.Find(strings.Split(v, " ")); err == nil {
 			if !pluginmanager.IsPluginCommand(c) {
-				return args, osArgs, envs, errors.Errorf("not allowed to alias with builtin %q as target", v)
+				return args, osArgs, envs, fmt.Errorf("not allowed to alias with builtin %q as target", v)
 			}
 		}
 		aliases = append(aliases, [2][]string{{k}, {v}})

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -49,7 +49,7 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
-			return args, osargs, nil, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w: %w", err)
+			return args, osargs, nil, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w", err)
 		}
 		if !enabled {
 			buildKitDisabled = true

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -49,7 +49,7 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
-			return args, osargs, nil, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+			return args, osargs, nil, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w: %w", err)
 		}
 		if !enabled {
 			buildKitDisabled = true

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/cli/cmd/docker/internal/appcontext"
 	"github.com/docker/docker/api/types/versions"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -104,7 +104,7 @@ func setupHelpCommand(dockerCli command.Cli, rootCmd, helpCmd *cobra.Command) {
 				return helpcmd.Run()
 			}
 			if !pluginmanager.IsNotFound(err) {
-				return errors.Errorf("unknown help topic: %v", strings.Join(args, " "))
+				return fmt.Errorf("unknown help topic: %v", strings.Join(args, " "))
 			}
 		}
 		if origRunE != nil {

--- a/docs/generate/generate.go
+++ b/docs/generate/generate.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/docs/generate/generate.go
+++ b/docs/generate/generate.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 
@@ -64,7 +65,7 @@ func gen(opts *options) error {
 				return err
 			}
 		default:
-			return errors.Errorf("unknown format %q", format)
+			return fmt.Errorf("unknown format %q", format)
 		}
 	}
 

--- a/e2e/plugin/trust_test.go
+++ b/e2e/plugin/trust_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/e2e/internal/fixtures"
 	"github.com/docker/cli/internal/test/environment"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 	"gotest.tools/v3/icmd"

--- a/e2e/plugin/trust_test.go
+++ b/e2e/plugin/trust_test.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -109,7 +108,7 @@ func ensureBasicPluginBin() (string, error) {
 	cmd := exec.Command(goBin, "build", "-o", installPath, "./basic")
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return "", errors.Wrapf(err, "error building basic plugin bin: %s", string(out))
+		return "", fmt.Errorf("error building basic plugin bin: %s: %w", string(out), err)
 	}
 	return installPath, nil
 }

--- a/internal/test/environment/testenv.go
+++ b/internal/test/environment/testenv.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"

--- a/internal/test/output/output.go
+++ b/internal/test/output/output.go
@@ -1,10 +1,9 @@
 package output
 
 import (
+	"fmt"
 	"strings"
 	"testing"
-
-	"github.com/pkg/errors"
 )
 
 // Assert checks output lines at specified locations
@@ -30,7 +29,7 @@ func Prefix(expected string) func(string) error {
 		if strings.HasPrefix(actual, expected) {
 			return nil
 		}
-		return errors.Errorf("expected %q to start with %q", actual, expected)
+		return fmt.Errorf("expected %q to start with %q", actual, expected)
 	}
 }
 
@@ -40,7 +39,7 @@ func Suffix(expected string) func(string) error {
 		if strings.HasSuffix(actual, expected) {
 			return nil
 		}
-		return errors.Errorf("expected %q to end with %q", actual, expected)
+		return fmt.Errorf("expected %q to end with %q", actual, expected)
 	}
 }
 
@@ -50,7 +49,7 @@ func Contains(expected string) func(string) error {
 		if strings.Contains(actual, expected) {
 			return nil
 		}
-		return errors.Errorf("expected %q to contain %q", actual, expected)
+		return fmt.Errorf("expected %q to contain %q", actual, expected)
 	}
 }
 
@@ -60,6 +59,6 @@ func Equals(expected string) func(string) error {
 		if expected == actual {
 			return nil
 		}
-		return errors.Errorf("got %q, expected %q", actual, expected)
+		return fmt.Errorf("got %q, expected %q", actual, expected)
 	}
 }

--- a/opts/duration.go
+++ b/opts/duration.go
@@ -1,9 +1,8 @@
 package opts
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // PositiveDurationOpt is an option type for time.Duration that uses a pointer.
@@ -20,7 +19,7 @@ func (d *PositiveDurationOpt) Set(s string) error {
 		return err
 	}
 	if *d.DurationOpt.value < 0 {
-		return errors.Errorf("duration cannot be negative")
+		return fmt.Errorf("duration cannot be negative")
 	}
 	return nil
 }

--- a/opts/env.go
+++ b/opts/env.go
@@ -1,10 +1,9 @@
 package opts
 
 import (
+	"errors"
 	"os"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ValidateEnv validates an environment variable and returns it.

--- a/opts/gpus.go
+++ b/opts/gpus.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/pkg/errors"
 )
 
 // GpuOpts is a Value type for parsing mounts
@@ -20,7 +19,7 @@ func parseCount(s string) (int, error) {
 		return -1, nil
 	}
 	i, err := strconv.Atoi(s)
-	return i, errors.Wrap(err, "count must be an integer")
+	return i, fmt.Errorf("count must be an integer: %w", err)
 }
 
 // Set a new mount value
@@ -69,7 +68,7 @@ func (o *GpuOpts) Set(value string) error {
 			r := csv.NewReader(strings.NewReader(val))
 			optFields, err := r.Read()
 			if err != nil {
-				return errors.Wrap(err, "failed to read gpu options")
+				return fmt.Errorf("failed to read gpu options: %w", err)
 			}
 			req.Options = ConvertKVStringsToMap(optFields)
 		default:

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api/types/filters"
 	units "github.com/docker/go-units"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/service/logs/parse_logs.go
+++ b/service/logs/parse_logs.go
@@ -3,10 +3,9 @@
 package logs
 
 import (
+	"errors"
 	"net/url"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ParseLogDetails parses a string of key value pairs in the form

--- a/vendor.mod
+++ b/vendor.mod
@@ -30,7 +30,6 @@ require (
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/vendor.sum
+++ b/vendor.sum
@@ -197,10 +197,10 @@ github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/
 github.com/opencontainers/image-spec v1.1.0-rc5/go.mod h1:X4pATf0uXsnn3g5aiGIsVnJBR4mxhKzfwmvK/B2NTm8=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
**- What I did**

Replaced uses of `github.com/pkg/errors` in this repo.

That package has been archived for 2 years, after `fmt.Errorf` added support for wrapping errors with `%w` in Go 1.13, more than 3 years ago.

There are still indirect dependencies on `pkg/errors` via github.com/docker/docker -- I can try to clean those up as well, if you're interested.

**- How I did it**

Mostly I ran this: https://github.com/zchee/go-analyzer/tree/main/pkgerrors

```
pkgerrors -fix ./...
```

In order to get that to work though, I first needed to find cases where `errors.Wrap` was called like `errors.Wrap(err, msg)` (where `msg` is an identifier and not a const string expression) or `errors.Wrap(err, foo())` (where `foo` is a method call and not a const string expression).

After that I replaced any remaining `errors.Is` calls to use Go's stdlib `errors.Is`, which now works with the `%w` added by the analyzer

**- How to verify it**

Thorough code review and reliance on tests

**- Description for the changelog**

Remove use of deprecated/archived module github.com/pkg/errors


**TODO** (if you're interested in proceeding)

- [ ] fix lint findings now that `fmt.Errorf` with capitalized message trips the linter
- [ ] do github.com/docker/docker too