### PR TITLE
docs/deprecated.md: add missing versions for  "-g / --graph" and devicemapper removal to table

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -76,7 +76,7 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [Support for the `overlay2.override_kernel_check` storage option](#support-for-the-overlay2override_kernel_check-storage-option)   | v19.03     | v24.0  |
 | Removed    | [AuFS storage driver](#aufs-storage-driver)                                                                                        | v19.03     | v24.0  |
 | Removed    | [Legacy "overlay" storage driver](#legacy-overlay-storage-driver)                                                                  | v18.09     | v24.0  |
-| Disabled   | [Device mapper storage driver](#device-mapper-storage-driver)                                                                      | v18.09     | -      |
+| Removed    | [Device mapper storage driver](#device-mapper-storage-driver)                                                                      | v18.09     | v25.0  |
 | Removed    | [Use of reserved namespaces in engine labels](#use-of-reserved-namespaces-in-engine-labels)                                        | v18.06     | v20.10 |
 | Removed    | [`--disable-legacy-registry` override daemon option](#--disable-legacy-registry-override-daemon-option)                            | v17.12     | v19.03 |
 | Removed    | [Interacting with V1 registries](#interacting-with-v1-registries)                                                                  | v17.06     | v17.12 |

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -81,7 +81,7 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`--disable-legacy-registry` override daemon option](#--disable-legacy-registry-override-daemon-option)                            | v17.12     | v19.03 |
 | Removed    | [Interacting with V1 registries](#interacting-with-v1-registries)                                                                  | v17.06     | v17.12 |
 | Removed    | [Asynchronous `service create` and `service update` as default](#asynchronous-service-create-and-service-update-as-default)        | v17.05     | v17.10 |
-| Removed    | [`-g` and `--graph` flags on `dockerd`](#-g-and---graph-flags-on-dockerd)                                                          | v17.05     | -      |
+| Removed    | [`-g` and `--graph` flags on `dockerd`](#-g-and---graph-flags-on-dockerd)                                                          | v17.05     | v23.0  |
 | Deprecated | [Top-level network properties in NetworkSettings](#top-level-network-properties-in-networksettings)                                | v1.13      | v17.12 |
 | Removed    | [`filter` param for `/images/json` endpoint](#filter-param-for-imagesjson-endpoint)                                                | v1.13      | v20.10 |
 | Removed    | [`repository:shortid` image references](#repositoryshortid-image-references)                                                       | v1.13      | v17.12 |


### PR DESCRIPTION
### docs/deprecate.md: add version for devicemapper removal to table

- relates to https://github.com/docker/cli/pull/4307

commit 5d6612798a195b30edf4244ff06f18e80b1167d5 updated the deprecation
status for devicemapper to "removed", but forgot to update the status
in the table.


### docs/deprecated.md: add version for "-g" / "--graph" removal

relates to:

- https://github.com/docker/cli/pull/3739
- https://github.com/moby/moby/pull/28696
- https://github.com/moby/moby/pull/43981


commit 304c100ed250756a64009605d7b5fc7674441934 updated the deprecation
status for these options, but forgot to update the status in the table.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

