### PR TITLE
Output valid json for docker ps --format='{{json .}}'

### DIFF
--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -63,6 +63,7 @@ func (c *Context) preFormat() {
 		c.finalFormat = c.finalFormat[len(TableFormatKey):]
 	case c.Format.IsJSON():
 		c.finalFormat = JSONFormat
+		c.buffer.WriteString("[")
 	}
 
 	c.finalFormat = strings.Trim(c.finalFormat, " ")
@@ -88,6 +89,12 @@ func (c *Context) postFormat(tmpl *template.Template, subContext SubContext) {
 		c.buffer.WriteTo(t)
 		t.Flush()
 	} else {
+		if c.Format.IsJSON() {
+			if c.buffer.Len() > 1 {
+				c.buffer.Truncate(c.buffer.Len() - 2)
+			}
+			c.buffer.WriteString("]\n")
+		}
 		c.buffer.WriteTo(c.Output)
 	}
 }
@@ -98,6 +105,9 @@ func (c *Context) contextFormat(tmpl *template.Template, subContext SubContext) 
 	}
 	if c.Format.IsTable() && c.header != nil {
 		c.header = subContext.FullHeader()
+	}
+	if c.Format.IsJSON() {
+		c.buffer.WriteString(",")
 	}
 	c.buffer.WriteString("\n")
 	return nil

--- a/cli/command/formatter/formatter_test.go
+++ b/cli/command/formatter/formatter_test.go
@@ -38,7 +38,7 @@ func TestContext(t *testing.T) {
 		{
 			name:   "json format",
 			format: JSONFormatKey,
-			expected: `{"Name":"test"}
+			expected: `[{"Name":"test"}]
 `,
 		},
 		{
@@ -65,4 +65,19 @@ test
 			assert.Equal(t, buf.String(), tc.expected)
 		})
 	}
+}
+
+func TestContextWithFormatJSONAndNoContainers(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	ctx := Context{
+		Format: Format(JSONFormatKey),
+		Output: buf,
+	}
+	subContext := fakeSubContext{}
+	subFormat := func(f func(sub SubContext) error) error {
+		return nil
+	}
+	err := ctx.Write(&subContext, subFormat)
+	assert.NilError(t, err)
+	assert.Equal(t, buf.String(), "[]\n")
 }


### PR DESCRIPTION
Attempt to fix https://github.com/moby/moby/issues/46906

**- What I did**
Extended [formatter.go](https://github.com/docker/cli/blob/master/cli/command/formatter/formatter.go) to output valid json array

**- How I did it**
Modified built-in functions in the [formatter.go](https://github.com/docker/cli/blob/master/cli/command/formatter/formatter.go)  to add required prefix and suffix to generate valid json array.

**- How to verify it**
1. Must have multiple docker containers in any state
2. Run `docker ps -a --format='{{json .}}'`

**- Description for the changelog**
- Output valid json for `docker ps --format={{json .}}`


