### PR TITLE
docs: fix typo in "network create" docs

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -61,7 +61,7 @@ to access the network stack of a swarm service.
 
 The `--attachable` option used in the example above disables this restriction,
 and allows for both swarm services and manually started containers to attach to
-the oerlay network.
+the overlay network.
 
 Network names must be unique. The Docker daemon attempts to identify naming
 conflicts but this is not guaranteed. It is the user's responsibility to avoid

--- a/man/src/network/create.md
+++ b/man/src/network/create.md
@@ -30,7 +30,7 @@ to access the network stack of a swarm service.
 
 The `--attachable` option used in the example above disables this restriction,
 and allows for both swarm services and manually started containers to attach to
-the oerlay network.
+the overlay network.
 
 Network names must be unique. The Docker daemon attempts to identify naming
 conflicts but this is not guaranteed. It is the user's responsibility to avoid


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/18488, which updated this typo in the generated docs


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

