### PR TITLE
docs/deprecated: mark logentries log-driver for removal

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -51,6 +51,7 @@ The table below provides an overview of the current status of deprecated feature
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
 | Deprecated | [IsAutomated field, and "is-automated" filter on docker search](#isautomated-field--and-is--automated-filter-on-docker-search)     | v25.0      | -      |
+| Deprecated | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
 | Deprecated | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
 | Removed    | [Buildkit build information](#buildkit-build-information)                                                                          | v23.0      | v24.0  |
 | Deprecated | [Legacy builder for Linux images](#legacy-builder-for-linux-images)                                                                | v23.0      | -      |
@@ -121,6 +122,15 @@ results.
 The `AUTOMATED` column has been removed from the default `docker search`
 and `docker image search` output in v25.0, and the corresponding `IsAutomated`
 templating option will be removed in v26.0.
+
+### Logentries logging driver
+
+**Deprecated in Release: v24.0**
+**Target For Removal In Release: v25.0**
+
+The logentries service SaaS was shut down on November 15, 2022, rendering
+this logging driver non-functional. Users should no longer use this logging
+driver, and the driver will be removed in Docker 25.0.
 
 ### OOM-score adjust for the daemon
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/46925
- https://github.com/moby/moby/pull/46926


The service has been discontinued on November 15, 2022:

> Dear Logentries user,
>
> We have identified you as the owner of, or collaborator of, a Logentries
> account.
>
> The Logentries service will be discontinued on November 15th, 2022. This
> means that your Logentries account access will be removed and all your
> log data will be permanently deleted on this date.
>
> Next Steps
> If you are interested in an alternative Rapid7 log management solution,
> InsightOps will be available for purchase through December 16th, 2022.
> Please note, there is no support to migrate your existing Logentries
> account to InsightOps.
>
> Thank you for being a valued user of Logentries.
>
> Thank you,
> Rapid7 Customer Success


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

