### PR TITLE
vendor: github.com/docker/docker 7bc56c53657d (v25.0.0-dev)

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
+| Deprecated | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
 | Deprecated | [IsAutomated field, and "is-automated" filter on docker search](#isautomated-field--and-is--automated-filter-on-docker-search)     | v25.0      | -      |
 | Removed    | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
 | Deprecated | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
@@ -108,6 +109,21 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13  |
 | Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12  |
 
+
+### Container short ID in network Aliases field
+
+**Deprecated in Release: v25.0**
+**Target For Remove In Release: v26.0**
+
+The `Aliases` field returned by `docker inspect` contains the container short
+ID once the container is started. This behavior is deprecated in v25.0 but
+kept until the next release, v26.0. Starting with that version, the `Aliases`
+field will only contain the aliases set through the `docker container create`
+and `docker run` flag `--network-alias`.
+
+A new field `DNSNames` containing the container name (if one was specified),
+the hostname, the network aliases, as well as the container short ID, has been
+introduced in v25.0 and should be used instead of the `Aliases` field.
 
 ### IsAutomated field, and "is-automated" filter on docker search
 

--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.18
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v25.0.0-beta.2.0.20231219173513-388216fc45ab+incompatible // master (v25.0.0-dev)
+	github.com/docker/docker v25.0.0-beta.2.0.20231220185316-7bc56c53657d+incompatible // master (v25.0.0-dev)
 	github.com/docker/docker-credential-helpers v0.8.0
 	github.com/docker/go-connections v0.4.1-0.20231110212414-fa09c952e3ea
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -54,8 +54,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.0-beta.2.0.20231219173513-388216fc45ab+incompatible h1:ChEUgFlWcTpckX7kRdO3wCBwIWS7CeJJ3J+H4ZGWqxM=
-github.com/docker/docker v25.0.0-beta.2.0.20231219173513-388216fc45ab+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.0-beta.2.0.20231220185316-7bc56c53657d+incompatible h1:oxPwtc72PEsdGe/DPTwoK84N+S2lePCrIhARYPVYjqM=
+github.com/docker/docker v25.0.0-beta.2.0.20231220185316-7bc56c53657d+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.0 h1:YQFtbBQb4VrpoPxhFuzEBPQ9E16qz5SpHLS+uswaCp8=
 github.com/docker/docker-credential-helpers v0.8.0/go.mod h1:UGFXcuoQ5TxPiB54nHOZ32AWRqQdECoh/Mg0AlEYb40=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -2530,6 +2530,21 @@ definitions:
         example:
           com.example.some-label: "some-value"
           com.example.some-other-label: "some-other-value"
+      DNSNames:
+        description: |
+          List of all DNS names an endpoint has on a specific network. This
+          list is based on the container name, network aliases, container short
+          ID, and hostname.
+
+          These DNS names are non-fully qualified but can contain several dots.
+          You can get fully qualified DNS names by appending `.<network-name>`.
+          For instance, if container name is `my.ctr` and the network is named
+          `testnet`, `DNSNames` will contain `my.ctr` and the FQDN will be
+          `my.ctr.testnet`.
+        type: array
+        items:
+          type: string
+        example: ["foobar", "server_x", "server_y", "my.ctr"]
 
   EndpointIPAMConfig:
     description: |

--- a/vendor/github.com/docker/docker/api/types/network/endpoint.go
+++ b/vendor/github.com/docker/docker/api/types/network/endpoint.go
@@ -13,7 +13,7 @@ type EndpointSettings struct {
 	// Configurations
 	IPAMConfig *EndpointIPAMConfig
 	Links      []string
-	Aliases    []string
+	Aliases    []string // Aliases holds the list of extra, user-specified DNS names for this endpoint.
 	MacAddress string
 	// Operational data
 	NetworkID           string
@@ -25,6 +25,9 @@ type EndpointSettings struct {
 	GlobalIPv6Address   string
 	GlobalIPv6PrefixLen int
 	DriverOpts          map[string]string
+	// DNSNames holds all the (non fully qualified) DNS names associated to this endpoint. First entry is used to
+	// generate PTR records.
+	DNSNames []string
 }
 
 // Copy makes a deep copy of `EndpointSettings`
@@ -43,6 +46,12 @@ func (es *EndpointSettings) Copy() *EndpointSettings {
 		aliases := make([]string, 0, len(es.Aliases))
 		epCopy.Aliases = append(aliases, es.Aliases...)
 	}
+
+	if len(es.DNSNames) > 0 {
+		epCopy.DNSNames = make([]string, len(es.DNSNames))
+		copy(epCopy.DNSNames, es.DNSNames)
+	}
+
 	return &epCopy
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v25.0.0-beta.2.0.20231219173513-388216fc45ab+incompatible
+# github.com/docker/docker v25.0.0-beta.2.0.20231220185316-7bc56c53657d+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
**- What I did**

1. vendor: github.com/docker/docker 7bc56c53657d (v25.0.0-dev) ;
2. Add a deprecation note about the short cid in the Aliases field ;

