### PR TITLE
docs/deprecated: update "oom-score-adjust" status for daemon

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -53,7 +53,7 @@ The table below provides an overview of the current status of deprecated feature
 | Deprecated | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
 | Deprecated | [IsAutomated field, and "is-automated" filter on docker search](#isautomated-field-and-is-automated-filter-on-docker-search)       | v25.0      | v26.0  |
 | Removed    | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
-| Deprecated | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
+| Removed    | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
 | Removed    | [Buildkit build information](#buildkit-build-information)                                                                          | v23.0      | v24.0  |
 | Deprecated | [Legacy builder for Linux images](#legacy-builder-for-linux-images)                                                                | v23.0      | -      |
 | Deprecated | [Legacy builder fallback](#legacy-builder-fallback)                                                                                | v23.0      | -      |
@@ -153,7 +153,7 @@ after upgrading.
 ### OOM-score adjust for the daemon
 
 **Deprecated in Release: v24.0**
-**Target For Removal In Release: v25.0**
+**Removed in Release: v25.0**
 
 The `oom-score-adjust` option was added to prevent the daemon from being
 OOM-killed before other processes. This option was mostly added as a


### PR DESCRIPTION
- relates to https://github.com/moby/moby/commit/fb96b94ed00aa4f200dc03642bc46d4289eb6860 / https://github.com/moby/moby/pull/45484
- relates to https://github.com/moby/moby/commit/5a922dc162bbe0a03450165da4e6aceca55073d4 / https://github.com/moby/moby/pull/45315



Using this option on the daemon will now produce an error (flag will be removed entirely in v26.0).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

