### PR TITLE
change back nolint -> nosec

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -234,7 +234,8 @@ func GetContextFromURL(out io.Writer, remoteURL, dockerfileName string) (io.Read
 // getWithStatusError does an http.Get() and returns an error if the
 // status code is 4xx or 5xx.
 func getWithStatusError(url string) (resp *http.Response, err error) {
-	if resp, err = http.Get(url); err != nil { //nolint:gosec // Ignore G107: Potential HTTP request made with variable url
+	//#nosec G107 -- Ignore G107: Potential HTTP request made with variable url
+	if resp, err = http.Get(url); err != nil {
 		return nil, err
 	}
 	if resp.StatusCode < http.StatusBadRequest {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4620

commit 9e1f8d646e15b2626e56960e9505ad281937dc30 changed this to a "nolint" comment due to a regression in GoSec. That regression was fixed, so we can go back to use the more fine-grained "nosec" comment.


**- A picture of a cute animal (not mandatory but encouraged)**

