### PR TITLE
cli/command/container: parseSecurityOpts: fix --security-opt seccomp=builtin

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -1274,17 +1274,18 @@ in the image, or `SIGTERM` if the image has no `STOPSIGNAL` defined.
 
 ### <a name="security-opt"></a> Optional security options (--security-opt)
 
-| Option                                    | Description                                                               |
-|:------------------------------------------|:--------------------------------------------------------------------------|
-| `--security-opt="label=user:USER"`        | Set the label user for the container                                      |
-| `--security-opt="label=role:ROLE"`        | Set the label role for the container                                      |
-| `--security-opt="label=type:TYPE"`        | Set the label type for the container                                      |
-| `--security-opt="label=level:LEVEL"`      | Set the label level for the container                                     |
-| `--security-opt="label=disable"`          | Turn off label confinement for the container                              |
-| `--security-opt="apparmor=PROFILE"`       | Set the apparmor profile to be applied to the container                   |
-| `--security-opt="no-new-privileges=true"` | Disable container processes from gaining new privileges                   |
-| `--security-opt="seccomp=unconfined"`     | Turn off seccomp confinement for the container                            |
-| `--security-opt="seccomp=profile.json"`   | White-listed syscalls seccomp Json file to be used as a seccomp filter    |
+| Option                                    | Description                                                                                                                                                                                                      |
+|:------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--security-opt="label=user:USER"`        | Set the label user for the container                                                                                                                                                                             |
+| `--security-opt="label=role:ROLE"`        | Set the label role for the container                                                                                                                                                                             |
+| `--security-opt="label=type:TYPE"`        | Set the label type for the container                                                                                                                                                                             |
+| `--security-opt="label=level:LEVEL"`      | Set the label level for the container                                                                                                                                                                            |
+| `--security-opt="label=disable"`          | Turn off label confinement for the container                                                                                                                                                                     |
+| `--security-opt="apparmor=PROFILE"`       | Set the apparmor profile to be applied to the container                                                                                                                                                          |
+| `--security-opt="no-new-privileges=true"` | Disable container processes from gaining new privileges                                                                                                                                                          |
+| `--security-opt="seccomp=unconfined"`     | Turn off seccomp confinement for the container                                                                                                                                                                   |
+| `--security-opt="seccomp=builtin"`        | Use the default (built-in) seccomp profile for the container. This can be used to enable seccomp for a container running on a daemon with a custom default profile set, or with seccomp disabled ("unconfined"). |
+| `--security-opt="seccomp=profile.json"`   | White-listed syscalls seccomp Json file to be used as a seccomp filter                                                                                                                                           |
 
 The `--security-opt` flag lets you override the default labeling scheme for a
 container. Specifying the level in the following command allows you to share


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/42481

Docker v23.0 and up allow the daemon to be configured to have seccomp disabled by default (using the "unconfined" profile as default), and introduced a new "builtin" profile-name for the default (see [moby@f8795ed364586acd][1] and [mnoby@ac449d6b5ad29a50][2]).

However, the CLI had no special handling for the "builtin" profile, which resulted in it trying to load it as a file, which would fail;

    docker run -it --rm --security-opt seccomp=builtin busybox
    docker: opening seccomp profile (builtin) failed: open builtin: no such file or directory.
    See 'docker run --help'.

This patch adds a special case for the "builtin" profile, to allow using the default profile on daemons with seccomp disabled (unconfined) by default.

[1]: https://github.com/moby/moby/commit/f8795ed364586acd93f72e206a409e7e0e27edcc
[2]: https://github.com/moby/moby/commit/ac449d6b5ad29a5086824729ce54eec6b0cc8545

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

