### PR TITLE
docs: fix incorrect heading levels in docker run reference

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -293,7 +293,7 @@ You may wish to share the UTS namespace with the host if you would like the
 hostname of the container to change as the hostname of the host changes. A more
 advanced use case would be changing the host's hostname from a container.
 
-## <a name="ipc"></a> IPC settings (--ipc)
+### <a name="ipc"></a> IPC settings (--ipc)
 
 ```text
 --ipc="MODE"  : Set the IPC mode for the container
@@ -934,7 +934,7 @@ $ docker run --rm -i busybox echo "foo bar baz" \
 rab
 ```
 
-## <a name="init"></a> Specify an init process
+### <a name="init"></a> Specify an init process
 
 You can use the `--init` flag to indicate that an init process should be used as
 the PID 1 in the container. Specifying an init process ensures the usual
@@ -981,7 +981,7 @@ You can use the `-t` flag without `-i` flag. This still allocates a pseudo-TTY
 to the container, but with no way of writing to `STDIN`. The only time this
 might be useful is if the output of the container requires a TTY environment.
 
-## <a name="cgroup-parent"></a> Specify custom cgroups
+### <a name="cgroup-parent"></a> Specify custom cgroups
 
 Using the `--cgroup-parent` flag, you can pass a specific cgroup to run a
 container in. This allows you to create and manage cgroups on their own. You can
@@ -1194,7 +1194,7 @@ The `--add-host` flag also accepts a `:` separator, for example:
 $ docker run --add-host=my-hostname:8.8.8.8 --rm -it alpine
 ```
 
-## <a name="log-driver"></a> Logging drivers (--log-driver)
+### <a name="log-driver"></a> Logging drivers (--log-driver)
 
 The container can have a different logging driver than the Docker daemon. Use
 the `--log-driver=<DRIVER>` with the `docker run` command to configure the


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed incorrect h2-level headings to h3 in the examples section.

The h2 levels break the cli-docs-tool yaml generation.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

