### PR TITLE
cli/compose/loader: use golden.Assert() for readability

### DIFF
--- a/cli/compose/loader/types_test.go
+++ b/cli/compose/loader/types_test.go
@@ -17,7 +17,7 @@ func TestMarshallConfig(t *testing.T) {
 
 	actual, err := yaml.Marshal(cfg)
 	assert.NilError(t, err)
-	golden.AssertBytes(t, actual, "full-example.yaml.golden")
+	golden.Assert(t, string(actual), "full-example.yaml.golden")
 
 	// Make sure the expected can be parsed.
 	yamlData, err := os.ReadFile("testdata/full-example.yaml.golden")
@@ -34,7 +34,7 @@ func TestJSONMarshallConfig(t *testing.T) {
 	cfg := fullExampleConfig(workingDir, homeDir)
 	actual, err := json.MarshalIndent(cfg, "", "  ")
 	assert.NilError(t, err)
-	golden.AssertBytes(t, actual, "full-example.json.golden")
+	golden.Assert(t, string(actual), "full-example.json.golden")
 
 	jsonData, err := os.ReadFile("testdata/full-example.json.golden")
 	assert.NilError(t, err)


### PR DESCRIPTION
golden.AssertBytes prints the failure as a bytes-array, which makes it not human-readable; let's compare strings instead.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

