### PR TITLE
cli/config/configfile(autoRemove): New config.json option.

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -104,7 +104,9 @@ func runRun(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, ro
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
-	copts.autoRemove = dockerCli.ConfigFile().AutoRemove
+    if !flags.Changed("rm") {
+   	copts.autoRemove = dockerCli.ConfigFile().AutoRemove
+   }
 	containerCfg, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
 	// just in case the parse does not exit
 	if err != nil {

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -104,6 +104,7 @@ func runRun(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, ro
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
+	copts.autoRemove = dockerCli.ConfigFile().AutoRemove
 	containerCfg, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
 	// just in case the parse does not exit
 	if err != nil {

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -41,6 +41,7 @@ type ConfigFile struct {
 	CLIPluginsExtraDirs  []string                     `json:"cliPluginsExtraDirs,omitempty"`
 	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
 	Aliases              map[string]string            `json:"aliases,omitempty"`
+	AutoRemove           bool                         `json:"autoRemove,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings


### PR DESCRIPTION
Allow user to set `"autoRemove": true` in their `~/.docker/config.json` to have `--rm=true` be set by default for `docker run -it <containter> -- sh` commands.

**- What I did**

I surfaced an option in the `~/.docker/config.json` to always have `--rm=true` when running containers, so that my container list doesn't get cluttered.  It's called `"autoRemove": true` to match the code, but that's perhaps not the best name.

Fixes #4763.

**- How I did it**

I added a field in the ConfigFile struct, and used it in the `container run` command.

**- How to verify it**

I ran the binary with and without `"autoRemove": true` in the `config.json` file, and observed that the flag was set correctly, both with "printf debugging" and observing my stopped containers list.

**- Description for the changelog**

* Added `autoRemove` boolean option to `config.json`, so that `--rm` is implicit with running `docker run ...`.

**- A picture of a cute animal**

![image](https://github.com/docker/cli/assets/423357/6bfe0904-35df-4786-a369-7dc8151dc963)
(Canada Goose from https://commons.wikimedia.org/wiki/File:Canada_goose_gosling_-_natures_pics.jpg)

