### PR TITLE
plugins: run plugin with new process group ID

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -232,6 +232,7 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		configureOSSpecificCommand(cmd)
 
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, ReexecEnvvar+"="+os.Args[0])

--- a/cli-plugins/manager/manager_unix.go
+++ b/cli-plugins/manager/manager_unix.go
@@ -2,7 +2,21 @@
 
 package manager
 
+import (
+	"os/exec"
+	"syscall"
+)
+
 var defaultSystemPluginDirs = []string{
 	"/usr/local/lib/docker/cli-plugins", "/usr/local/libexec/docker/cli-plugins",
 	"/usr/lib/docker/cli-plugins", "/usr/libexec/docker/cli-plugins",
+}
+
+func configureOSSpecificCommand(cmd *exec.Cmd) {
+	// Spawn the plugin process in a new process group, so that signals are not forwarded by the OS.
+	// The foreground process group is e.g. sent a SIGINT when Ctrl-C is input to the TTY, but we
+	// implement our own job control for the plugin.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 }

--- a/cli-plugins/manager/manager_windows.go
+++ b/cli-plugins/manager/manager_windows.go
@@ -2,10 +2,15 @@ package manager
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
 var defaultSystemPluginDirs = []string{
 	filepath.Join(os.Getenv("ProgramData"), "Docker", "cli-plugins"),
 	filepath.Join(os.Getenv("ProgramFiles"), "Docker", "cli-plugins"),
+}
+
+func configureOSSpecificCommand(cmd *exec.Cmd) {
+	// no-op
 }


### PR DESCRIPTION
Changes were made in https://github.com/docker/cli/pull/4599 to provide a mechanism for the CLI to notify running plugin processes that they should exit, in order to improve the general CLI/plugin UX. The current implementation boils down to:
1. The CLI creates a socket
2. The CLI executes the plugin
3. The plugin connects to the socket
4. (When) the CLI receives a termination signal, it uses the socket to notify the plugin that it should exit
5. The plugin's gets notified via the socket, and cancels it's `cmd.Context`, which then gets handled appropriately

This change works in most cases and fixes the issue it sets out to solve (see: https://github.com/docker/compose/pull/11292) however, in the case where the user has a TTY attached and the plugin is not already handling received signals, steps 4+ changes:
4. (When) the CLI receives a termination signal, before it can use the socket to notify the plugin that it should exit, the plugin process also receives a signal due to sharing the pgid with the CLI

Since we now have a proper "job control" mechanism, we can simplify the scenarios by executing the plugins with their own process group id, thereby removing the "double notification" issue and making it so that plugins can handle the same whether attached to a TTY or not.

In order to make this change "plugin-binary" backwards-compatible, in the case that a plugin does not connect to the socket, the CLI passes the signal to the plugin process.

-------------------

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Execute plugins with their own process group id. If a(n older) plugin does not connect to the CLI socket, pass received signals onto the plugin process, so as to preserve compatibility with older plugin binaries.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![IMG_2069](https://github.com/docker/cli/assets/70572044/afed2e02-5100-4135-a17a-3baa8cfb9315)

