### PR TITLE
improve passing context

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -36,13 +36,7 @@ func RunPlugin(dockerCli *command.DockerCli, plugin *cobra.Command, meta manager
 	PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		var err error
 		persistentPreRunOnce.Do(func() {
-			cmdContext := cmd.Context()
-			// TODO: revisit and make sure this check makes sense
-			// see: https://github.com/docker/cli/pull/4599#discussion_r1422487271
-			if cmdContext == nil {
-				cmdContext = context.TODO()
-			}
-			ctx, cancel := context.WithCancel(cmdContext)
+			ctx, cancel := context.WithCancel(cmd.Context())
 			cmd.SetContext(ctx)
 			// Set up the context to cancel based on signalling via CLI socket.
 			socket.ConnectAndWait(cancel)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -29,6 +29,7 @@ import (
 
 func main() {
 	ctx := context.Background()
+
 	dockerCli, err := command.NewDockerCli(command.WithBaseContext(ctx))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -352,7 +353,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 	// We've parsed global args already, so reset args to those
 	// which remain.
 	cmd.SetArgs(args)
-	err = cmd.Execute()
+	err = cmd.ExecuteContext(ctx)
 
 	// If the command is being executed in an interactive terminal
 	// and hook are enabled, run the plugin hooks.

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -15,8 +16,10 @@ import (
 
 func TestClientDebugEnabled(t *testing.T) {
 	defer debug.Disable()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-	cli, err := command.NewDockerCli()
+	cli, err := command.NewDockerCli(command.WithBaseContext(ctx))
 	assert.NilError(t, err)
 	tcmd := newDockerCommand(cli)
 	tcmd.SetFlag("debug", "true")
@@ -39,7 +42,13 @@ func runCliCommand(t *testing.T, r io.ReadCloser, w io.Writer, args ...string) e
 	if w == nil {
 		w = io.Discard
 	}
-	cli, err := command.NewDockerCli(command.WithInputStream(r), command.WithCombinedStreams(w))
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	cli, err := command.NewDockerCli(
+		command.WithBaseContext(ctx),
+		command.WithInputStream(r),
+		command.WithCombinedStreams(w))
 	assert.NilError(t, err)
 	tcmd := newDockerCommand(cli)
 

--- a/docs/generate/generate.go
+++ b/docs/generate/generate.go
@@ -37,6 +37,7 @@ func gen(opts *options) error {
 		Use:   "docker [OPTIONS] COMMAND [ARG...]",
 		Short: "The base command for the Docker CLI.",
 	}
+
 	clientOpts, _ := cli.SetupRootCommand(cmd)
 	if err := dockerCLI.Initialize(clientOpts); err != nil {
 		return err

--- a/e2e/cli-plugins/plugins/nopersistentprerun/main.go
+++ b/e2e/cli-plugins/plugins/nopersistentprerun/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
-		cmd := &cobra.Command{
+		return &cobra.Command{
 			Use:   "nopersistentprerun",
 			Short: "Testing without PersistentPreRun hooks",
 			// PersistentPreRunE: Not specified, we need to test that it works in the absence of an explicit call
@@ -25,7 +25,6 @@ func main() {
 				return nil
 			},
 		}
-		return cmd
 	},
 		manager.Metadata{
 			SchemaVersion: "0.1.0",


### PR DESCRIPTION
Relates to OTEL changes and graceful exit changes

See below PRs
- https://github.com/docker/cli/pull/4698
- https://github.com/docker/cli/pull/4993

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Create a base context in the main function and use it as the base context in cobra commands. This allows context cancellation throughout the CLI. 

**- A picture of a cute animal (not mandatory but encouraged)**

