### PR TITLE
cmd/docker: registerCompletionFuncForGlobalFlags: take store.Store as argument

### DIFF
--- a/cmd/docker/completions.go
+++ b/cmd/docker/completions.go
@@ -1,27 +1,34 @@
 package main
 
 import (
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/spf13/cobra"
 )
 
-func registerCompletionFuncForGlobalFlags(dockerCli *command.DockerCli, cmd *cobra.Command) {
-	cmd.RegisterFlagCompletionFunc(
+func registerCompletionFuncForGlobalFlags(contextStore store.Store, cmd *cobra.Command) error {
+	err := cmd.RegisterFlagCompletionFunc(
 		"context",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			names, err := store.Names(dockerCli.ContextStore())
+			names, err := store.Names(contextStore)
 			if err != nil {
 				return nil, cobra.ShellCompDirectiveError
 			}
 			return names, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
-	cmd.RegisterFlagCompletionFunc(
+	if err != nil {
+		return err
+	}
+	err = cmd.RegisterFlagCompletionFunc(
 		"log-level",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			values := []string{"debug", "info", "warn", "error", "fatal"}
 			return values, cobra.ShellCompDirectiveNoFileComp
 		},
 	)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -59,7 +59,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	cmd.SetErr(dockerCli.Err())
 
 	opts, helpCmd = cli.SetupRootCommand(cmd)
-	registerCompletionFuncForGlobalFlags(dockerCli, cmd)
+	_ = registerCompletionFuncForGlobalFlags(dockerCli.ContextStore(), cmd)
 	cmd.Flags().BoolP("version", "v", false, "Print version information and quit")
 	setFlagErrorFunc(dockerCli, cmd)
 


### PR DESCRIPTION
Update this function to accept a smaller interface, as it doesn't need all of "CLI". Also return errors encountered during its operation (although the caller currently has no error return on its own).

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

