### PR TITLE
cli-plugins: don't use abstract sockets on macOS

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -1,0 +1,77 @@
+package socket
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+
+	"github.com/docker/distribution/uuid"
+)
+
+// EnvKey represents the well-known environment variable used to pass the plugin being
+// executed the socket name it should listen on to coordinate with the host CLI.
+const EnvKey = "DOCKER_CLI_PLUGIN_SOCKET"
+
+// SetupConn sets up a Unix socket listener, establishes a goroutine to handle connections
+// and update the conn pointer, and returns the environment variable to pass to the plugin.
+func SetupConn(conn **net.UnixConn) (string, error) {
+	listener, err := listen()
+	if err != nil {
+		return "", err
+	}
+
+	accept(listener, conn)
+
+	return EnvKey + "=" + listener.Addr().String(), nil
+}
+
+func listen() (*net.UnixListener, error) {
+	return net.ListenUnix("unix", &net.UnixAddr{
+		Name: "@docker_cli_" + uuid.Generate().String(),
+		Net:  "unix",
+	})
+}
+
+func accept(listener *net.UnixListener, conn **net.UnixConn) {
+	defer listener.Close()
+
+	go func() {
+		for {
+			// ignore error here, if we failed to accept a connection,
+			// conn is nil and we fallback to previous behavior
+			*conn, _ = listener.AcceptUnix()
+		}
+	}()
+}
+
+// ConnectAndWait connects to the socket passed via well-known env var,
+// if present, and attempts to read from it until it receives an EOF, at which
+// point cb is called.
+func ConnectAndWait(cb func()) {
+	socketAddr, ok := os.LookupEnv(EnvKey)
+	if !ok {
+		// if a plugin compiled against a more recent version of docker/cli
+		// is executed by an older CLI binary, ignore missing environment
+		// variable and behave as usual
+		return
+	}
+	addr, err := net.ResolveUnixAddr("unix", socketAddr)
+	if err != nil {
+		return
+	}
+	conn, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return
+	}
+
+	go func() {
+		b := make([]byte, 1)
+		for {
+			_, err := conn.Read(b)
+			if errors.Is(err, io.EOF) {
+				cb()
+			}
+		}
+	}()
+}

--- a/cli-plugins/socket/socket_darwin.go
+++ b/cli-plugins/socket/socket_darwin.go
@@ -1,0 +1,19 @@
+package socket
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func listen(socketname string) (*net.UnixListener, error) {
+	return net.ListenUnix("unix", &net.UnixAddr{
+		Name: filepath.Join(os.TempDir(), socketname),
+		Net:  "unix",
+	})
+}
+
+func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
+	syscall.Unlink(listener.Addr().String())
+}

--- a/cli-plugins/socket/socket_nodarwin.go
+++ b/cli-plugins/socket/socket_nodarwin.go
@@ -1,0 +1,19 @@
+//go:build !darwin
+
+package socket
+
+import (
+	"net"
+)
+
+func listen(socketname string) (*net.UnixListener, error) {
+	return net.ListenUnix("unix", &net.UnixAddr{
+		Name: "@" + socketname,
+		Net:  "unix",
+	})
+}
+
+func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
+	// do nothing
+	// while on darwin we would unlink here; on non-darwin the socket is abstract and not present on the filesystem
+}


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/4780

macOS does not support abstract sockets, and as such the current implementation is problematic since the sockets are created in the current working directory, which alters build contexts and can break builds if bind-mounted.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

