### PR TITLE
temporarily revert ci: Add bin-image workflow 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  VERSION: ${{ github.ref }}
-
 on:
   workflow_dispatch:
   push:
@@ -88,50 +85,6 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: /tmp/out/*
           if-no-files-found: error
-
-  bin-image:
-    runs-on: ubuntu-20.04
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'docker/cli' }}
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: dockereng/cli-bin
-          tags: |
-            type=semver,pattern={{version}}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=sha
-      -
-        name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_CLIBIN_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_CLIBIN_TOKEN }}
-      -
-        name: Build and push image
-        uses: docker/bake-action@v4
-        with:
-          files: |
-            ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
-          targets: bin-image-cross
-          push: ${{ github.event_name != 'pull_request' }}
-          set: |
-            *.cache-from=type=gha,scope=bin-image
-            *.cache-to=type=gha,scope=bin-image,mode=max
 
   prepare-plugins:
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,4 +124,4 @@ FROM scratch AS plugins
 COPY --from=build-plugins /out .
 
 FROM scratch AS binary
-COPY --from=build /out/docker /docker
+COPY --from=build /out .

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -165,26 +165,3 @@ target "e2e-gencerts" {
     dockerfile = "./e2e/testdata/Dockerfile.gencerts"
     output = ["./e2e/testdata"]
 }
-
-target "docker-metadata-action" {
-  tags = ["cli-bin:local"]
-}
-
-target "bin-image" {
-  inherits = ["binary", "docker-metadata-action"]
-  output = ["type=docker"]
-}
-
-target "bin-image-cross" {
-  inherits = ["bin-image"]
-  output = ["type=image"]
-  platforms = [
-    "linux/amd64",
-    "linux/arm/v6",
-    "linux/arm/v7",
-    "linux/arm64",
-    "linux/ppc64le",
-    "linux/s390x",
-    "windows/amd64"
-  ]
-}


### PR DESCRIPTION
- partial revert of https://github.com/docker/cli/pull/4752


Looks like 6ad07f2a4b6a1e6fb77cb94820def43ea894c4af caused the docker-ce-packaging scripts to fail; https://github.com/docker/cli/pull/4752/commits/6ad07f2a4b6a1e6fb77cb94820def43ea894c4af#r1450359984


```
dest=$PWD/build/mac; cd /home/ubuntu/workspace/release-packaging_ce-nightly/packaging/src/github.com/docker/cli/build && for platform in *; do \
	arch=$(echo $platform | cut -d_ -f2); \
	mkdir -p $dest/$arch/docker; \
	cp $platform/docker-darwin-* $dest/$arch/docker/docker && \
	tar -C $dest/$arch -c -z -f $dest/$arch/docker-25.0.0-rc.2.tgz docker; \
done
cp: cannot stat 'darwin_amd64/docker-darwin-*': No such file or directory
cp: cannot stat 'darwin_arm64/docker-darwin-*': No such file or directory
```




**- A picture of a cute animal (not mandatory but encouraged)**

