### PR TITLE
ci: Add bin-image workflow (2nd approach)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  VERSION: ${{ github.ref }}
+
 on:
   workflow_dispatch:
   push:
@@ -85,6 +88,50 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: /tmp/out/*
           if-no-files-found: error
+
+  bin-image:
+    runs-on: ubuntu-20.04
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'docker/cli' }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dockereng/cli-bin
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_CLIBIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_CLIBIN_TOKEN }}
+      -
+        name: Build and push image
+        uses: docker/bake-action@v4
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: bin-image-cross
+          push: ${{ github.event_name != 'pull_request' }}
+          set: |
+            *.cache-from=type=gha,scope=bin-image
+            *.cache-to=type=gha,scope=bin-image,mode=max
 
   prepare-plugins:
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,5 +123,8 @@ COPY --link . .
 FROM scratch AS plugins
 COPY --from=build-plugins /out .
 
+FROM scratch AS bin-image
+COPY --from=build /out/docker /docker
+
 FROM scratch AS binary
 COPY --from=build /out .

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -165,3 +165,27 @@ target "e2e-gencerts" {
     dockerfile = "./e2e/testdata/Dockerfile.gencerts"
     output = ["./e2e/testdata"]
 }
+
+target "docker-metadata-action" {
+  tags = ["cli-bin:local"]
+}
+
+target "bin-image" {
+  inherits = ["binary", "docker-metadata-action"]
+  target = "bin-image"
+  output = ["type=docker"]
+}
+
+target "bin-image-cross" {
+  inherits = ["bin-image"]
+  output = ["type=image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x",
+    "windows/amd64"
+  ]
+}


### PR DESCRIPTION
- follow up to: https://github.com/docker/cli/pull/4752
- follow up to: https://github.com/docker/cli/pull/4785

Same as https://github.com/docker/cli/pull/4752 except it has a separate build target instead of altering the original `binary` target.