### PR TITLE
socket: return from loop after EOF

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -65,6 +65,7 @@ func ConnectAndWait(cb func()) {
 			_, err := conn.Read(b)
 			if errors.Is(err, io.EOF) {
 				cb()
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
After a plugin receives the termination request via socket and closes the context, it atm goes into a tight loop that never returns.