### PR TITLE
[25.0 backport] socket: return from loop after EOF

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -65,6 +65,7 @@ func ConnectAndWait(cb func()) {
 			_, err := conn.Read(b)
 			if errors.Is(err, io.EOF) {
 				cb()
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/4805
- introduced in https://github.com/docker/cli/commit/1554ac3b5f38147301c518c60da16f3f80c1717b / https://github.com/docker/cli/pull/4599



(cherry picked from commit 8cd3b00420a3c4e8c731f2f0c117e3d3fe0b4e32)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

