### PR TITLE
cli/command: remove deprecated DockerCliOption, InitializeOpt

### DIFF
--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -11,18 +11,10 @@ import (
 	"github.com/moby/term"
 )
 
-// CLIOption applies a modification on a DockerCli.
+// CLIOption is a functional argument to apply options to a [DockerCli]. These
+// options can be passed to [NewDockerCli] to initialize a new CLI, or
+// applied with [DockerCli.Initialize] or [DockerCli.Apply].
 type CLIOption func(cli *DockerCli) error
-
-// DockerCliOption applies a modification on a DockerCli.
-//
-// Deprecated: use [CLIOption] instead.
-type DockerCliOption = CLIOption
-
-// InitializeOpt is the type of the functional options passed to DockerCli.Initialize
-//
-// Deprecated: use [CLIOption] instead.
-type InitializeOpt = CLIOption
 
 // WithStandardStreams sets a cli in, out and err streams with the standard streams.
 func WithStandardStreams() CLIOption {


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4387

These types were deprecated in 7af509c7f12e2a541aedb9f26ec3e498c64eee8f (v25.0), in favor of CLIOption, and are no longer used.

This patch removes the deprecated type-aliases, and while updating, also improves the documentation for the CLIOption type.

With this patch:

<img width="1155" alt="Screenshot 2024-01-20 at 21 37 36" src="https://github.com/docker/cli/assets/1804568/a9b8c601-8247-4543-9fca-aa09061d8e8c">


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
cli/command: remove deprecated 1DockerCliOption`, `InitializeOpt`
```


**- A picture of a cute animal (not mandatory but encouraged)**

