### PR TITLE
cli/command/container: remove deprecated NewStartOptions

### DIFF
--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -28,13 +28,6 @@ type StartOptions struct {
 	Containers []string
 }
 
-// NewStartOptions creates a new StartOptions.
-//
-// Deprecated: create a new [StartOptions] directly.
-func NewStartOptions() StartOptions {
-	return StartOptions{}
-}
-
 // NewStartCommand creates a new cobra.Command for `docker start`
 func NewStartCommand(dockerCli command.Cli) *cobra.Command {
 	var opts StartOptions


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/4447
- https://github.com/docker/compose/pull/10828
- https://github.com/docker/cli/pull/3436

This function was deprecated in 298bddcc233af9e29f2fe9014c3c211712d5f633 for v25.0, and unused. This patch removes the function.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```
cli/command/container: remove deprecated `NewStartOptions()`
```


**- A picture of a cute animal (not mandatory but encouraged)**

