### PR TITLE
[25.0 backport] docs: update host-gateway-ip to use daemon.json instead of cli flag

### DIFF
--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -849,7 +849,9 @@ flag for the dockerd command line interface, or the `host-gateway-ip` key in
 the daemon configuration file.
 
 ```console
-$ dockerd --host-gateway-ip 192.0.2.0
+$ cat > /etc/docker/daemon.json
+{ "host-gateway-ip": "192.0.2.0" }
+$ sudo systemctl restart docker
 $ docker run -it --add-host host.docker.internal:host-gateway \
   busybox ping host.docker.internal 
 PING host.docker.internal (192.0.2.0): 56 data bytes
@@ -1072,6 +1074,7 @@ The following is a full example of the allowed configuration options on Linux:
   "fixed-cidr": "",
   "fixed-cidr-v6": "",
   "group": "",
+  "host-gateway-ip": "",
   "hosts": [],
   "proxies": {
     "http-proxy": "http://proxy.example.com:80",
@@ -1181,6 +1184,7 @@ The following is a full example of the allowed configuration options on Windows:
   "features": {},
   "fixed-cidr": "",
   "group": "",
+  "host-gateway-ip": "",
   "hosts": [],
   "insecure-registries": [],
   "labels": [],


### PR DESCRIPTION
- Backport of https://github.com/docker/cli/pull/4818

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Changes the host-gateway-ip example to use daemon.json config instead of cli flag.

- relates to https://github.com/docker/buildx/issues/2201#issuecomment-1906003593

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

