### PR TITLE
ci/e2e: Run e2e for 24.0 and 25.0 engine

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,11 +28,9 @@ jobs:
           - alpine
           - debian
         engine-version:
-#          - 20.10-dind # FIXME: Fails on 20.10
-          - stable-dind # TODO: Use 20.10-dind, stable-dind is deprecated
-        include:
-          - target: non-experimental
-            engine-version: 19.03-dind
+          - 24.0-dind
+          - 25.0-dind
+
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Move away from `stable-dind` which is Docker 19(!).

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

