### PR TITLE
[24.0 backport] Fix setting ServerAddress property in NativeStore

### DIFF
--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -51,6 +51,7 @@ func (c *nativeStore) Get(serverAddress string) (types.AuthConfig, error) {
 	auth.Username = creds.Username
 	auth.IdentityToken = creds.IdentityToken
 	auth.Password = creds.Password
+	auth.ServerAddress = creds.ServerAddress
 
 	return auth, nil
 }
@@ -76,6 +77,9 @@ func (c *nativeStore) GetAll() (map[string]types.AuthConfig, error) {
 		ac.Username = creds.Username
 		ac.Password = creds.Password
 		ac.IdentityToken = creds.IdentityToken
+		if ac.ServerAddress == "" {
+			ac.ServerAddress = creds.ServerAddress
+		}
 		authConfigs[registry] = ac
 	}
 

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -145,9 +145,10 @@ func TestNativeStoreGet(t *testing.T) {
 	assert.NilError(t, err)
 
 	expected := types.AuthConfig{
-		Username: "foo",
-		Password: "bar",
-		Email:    "foo@example.com",
+		Username:      "foo",
+		Password:      "bar",
+		Email:         "foo@example.com",
+		ServerAddress: validServerAddress,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
 }
@@ -169,6 +170,7 @@ func TestNativeStoreGetIdentityToken(t *testing.T) {
 	expected := types.AuthConfig{
 		IdentityToken: "abcd1234",
 		Email:         "foo@example2.com",
+		ServerAddress: validServerAddress2,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/4655
- fixes https://github.com/docker/cli/issues/4653


This will return the ServerAddress property when using the NativeStore. This happens when you use docker credential helpers, not the credential store.

The reason this fix is needed is because it needs to be propagated properly down towards `moby/moby` project in the following logic:

```golang
func authorizationCredsFromAuthConfig(authConfig registrytypes.AuthConfig) docker.AuthorizerOpt {
	cfgHost := registry.ConvertToHostname(authConfig.ServerAddress)
	if cfgHost == "" || cfgHost == registry.IndexHostname {
		cfgHost = registry.DefaultRegistryHost
	}

	return docker.WithAuthCreds(func(host string) (string, string, error) {
		if cfgHost != host {
			logrus.WithFields(logrus.Fields{
				"host":    host,
				"cfgHost": cfgHost,
			}).Warn("Host doesn't match")
			return "", "", nil
		}
		if authConfig.IdentityToken != "" {
			return "", authConfig.IdentityToken, nil
		}
		return authConfig.Username, authConfig.Password, nil
	})
}
```
This logic resides in the following file :
`daemon/containerd/resolver.go` .

In the case when using the containerd storage feature when setting the `cfgHost` variable from the `authConfig.ServerAddress` it will always be empty. Since it will never be returned from the NativeStore currently. Therefore Docker Hub images will work fine, but anything else will fail since the `cfgHost` will always be the `registry.DefaultRegistryHost`.


(cherry picked from commit b24e7f85a488da13dc2d5be87acdaab2652634bb)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

