### PR TITLE
[25.0] vendor: github.com/docker/docker v25.0.2

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v25.0.0+incompatible
+	github.com/docker/docker v25.0.1+incompatible
 	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v25.0.1+incompatible
+	github.com/docker/docker v25.0.2+incompatible
 	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -54,8 +54,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.0+incompatible h1:g9b6wZTblhMgzOT2tspESstfw6ySZ9kdm94BLDKaZac=
-github.com/docker/docker v25.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.1+incompatible h1:k5TYd5rIVQRSqcTwCID+cyVA0yRg86+Pcrz1ls0/frA=
+github.com/docker/docker v25.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.1 h1:j/eKUktUltBtMzKqmfLB0PAgqYyMHOp5vfsD1807oKo=
 github.com/docker/docker-credential-helpers v0.8.1/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor.sum
+++ b/vendor.sum
@@ -54,8 +54,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v25.0.1+incompatible h1:k5TYd5rIVQRSqcTwCID+cyVA0yRg86+Pcrz1ls0/frA=
-github.com/docker/docker v25.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v25.0.2+incompatible h1:/OaKeauroa10K4Nqavw4zlhcDq/WBcPMc5DbjOGgozY=
+github.com/docker/docker v25.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.1 h1:j/eKUktUltBtMzKqmfLB0PAgqYyMHOp5vfsD1807oKo=
 github.com/docker/docker-credential-helpers v0.8.1/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/builder/remotecontext/urlutil/urlutil.go
+++ b/vendor/github.com/docker/docker/builder/remotecontext/urlutil/urlutil.go
@@ -12,7 +12,7 @@ import (
 
 // urlPathWithFragmentSuffix matches fragments to use as Git reference and build
 // context from the Git repository. See IsGitURL for details.
-var urlPathWithFragmentSuffix = regexp.MustCompile(".git(?:#.+)?$")
+var urlPathWithFragmentSuffix = regexp.MustCompile(`\.git(?:#.+)?$`)
 
 // IsURL returns true if the provided str is an HTTP(S) URL by checking if it
 // has a http:// or https:// scheme. No validation is performed to verify if the

--- a/vendor/github.com/docker/docker/pkg/system/xattrs.go
+++ b/vendor/github.com/docker/docker/pkg/system/xattrs.go
@@ -1,0 +1,18 @@
+package system // import "github.com/docker/docker/pkg/system"
+
+type XattrError struct {
+	Op   string
+	Attr string
+	Path string
+	Err  error
+}
+
+func (e *XattrError) Error() string { return e.Op + " " + e.Attr + " " + e.Path + ": " + e.Err.Error() }
+
+func (e *XattrError) Unwrap() error { return e.Err }
+
+// Timeout reports whether this error represents a timeout.
+func (e *XattrError) Timeout() bool {
+	t, ok := e.Err.(interface{ Timeout() bool })
+	return ok && t.Timeout()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v25.0.1+incompatible
+# github.com/docker/docker v25.0.2+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v25.0.0+incompatible
+# github.com/docker/docker v25.0.1+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- backport of https://github.com/docker/cli/pull/4820
- and updating to v25.0.2;

### vendor: github.com/docker/docker v25.0.1

relevant changes:

- Fix isGitURL regular expression https://github.com/moby/moby/pull/47136 / https://github.com/moby/moby/pull/47109
- pkg/system: return even richer xattr errors https://github.com/moby/moby/pull/47178 / https://github.com/moby/moby/pull/47174


full diff: https://github.com/moby/moby/compare/v25.0.0...v25.0.1


### vendor: github.com/docker/docker v25.0.2

full diff: https://github.com/docker/docker/compare/v25.0.1...v25.0.2



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

