### PR TITLE
images: print hint when invoking "docker images" with ambiguous argument

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -68,12 +68,10 @@ func runImages(ctx context.Context, dockerCli command.Cli, options imagesOptions
 		filters.Add("reference", options.matchName)
 	}
 
-	listOptions := image.ListOptions{
+	images, err := dockerCli.Client().ImageList(ctx, image.ListOptions{
 		All:     options.all,
 		Filters: filters,
-	}
-
-	images, err := dockerCli.Client().ImageList(ctx, listOptions)
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -24,7 +24,7 @@ type imagesOptions struct {
 }
 
 // NewImagesCommand creates a new `docker images` command
-func NewImagesCommand(dockerCli command.Cli) *cobra.Command {
+func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
 	options := imagesOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -35,7 +35,7 @@ func NewImagesCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 0 {
 				options.matchName = args[0]
 			}
-			return runImages(cmd.Context(), dockerCli, options)
+			return runImages(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"category-top": "7",
@@ -55,20 +55,20 @@ func NewImagesCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
-	cmd := *NewImagesCommand(dockerCli)
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
+	cmd := *NewImagesCommand(dockerCLI)
 	cmd.Aliases = []string{"list"}
 	cmd.Use = "ls [OPTIONS] [REPOSITORY[:TAG]]"
 	return &cmd
 }
 
-func runImages(ctx context.Context, dockerCli command.Cli, options imagesOptions) error {
+func runImages(ctx context.Context, dockerCLI command.Cli, options imagesOptions) error {
 	filters := options.filter.Value()
 	if options.matchName != "" {
 		filters.Add("reference", options.matchName)
 	}
 
-	images, err := dockerCli.Client().ImageList(ctx, image.ListOptions{
+	images, err := dockerCLI.Client().ImageList(ctx, image.ListOptions{
 		All:     options.all,
 		Filters: filters,
 	})
@@ -78,8 +78,8 @@ func runImages(ctx context.Context, dockerCli command.Cli, options imagesOptions
 
 	format := options.format
 	if len(format) == 0 {
-		if len(dockerCli.ConfigFile().ImagesFormat) > 0 && !options.quiet {
-			format = dockerCli.ConfigFile().ImagesFormat
+		if len(dockerCLI.ConfigFile().ImagesFormat) > 0 && !options.quiet {
+			format = dockerCLI.ConfigFile().ImagesFormat
 		} else {
 			format = formatter.TableFormatKey
 		}
@@ -87,7 +87,7 @@ func runImages(ctx context.Context, dockerCli command.Cli, options imagesOptions
 
 	imageCtx := formatter.ImageContext{
 		Context: formatter.Context{
-			Output: dockerCli.Out(),
+			Output: dockerCLI.Out(),
 			Format: formatter.NewImageFormat(format, options.quiet, options.showDigests),
 			Trunc:  !options.noTrunc,
 		},

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -95,3 +95,17 @@ func TestNewListCommandAlias(t *testing.T) {
 	assert.Check(t, cmd.HasAlias("list"))
 	assert.Check(t, !cmd.HasAlias("other"))
 }
+
+func TestNewListCommandAmbiguous(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{})
+	cmd := NewImagesCommand(cli)
+	cmd.SetOut(io.Discard)
+
+	// Set the Use field to mimic that the command was called as "docker images",
+	// not "docker image ls".
+	cmd.Use = "images"
+	cmd.SetArgs([]string{"ls"})
+	err := cmd.Execute()
+	assert.NilError(t, err)
+	golden.Assert(t, cli.ErrBuffer().String(), "list-command-ambiguous.golden")
+}

--- a/cli/command/image/testdata/list-command-ambiguous.golden
+++ b/cli/command/image/testdata/list-command-ambiguous.golden
@@ -1,0 +1,2 @@
+
+No images found matching "ls": did you mean "docker image ls"?


### PR DESCRIPTION
- addresses / closes https://github.com/docker/cli/issues/887
- addresses / closes https://github.com/docker/cli/issues/4591
- related https://github.com/docker/cli/pull/4601
- related https://github.com/docker/cli/issues/4600
- related https://github.com/docker/cli/pull/3758



### cli/command/images: runImages: inline intermediate var

### cli/command/images: runImages: use proper camel-case for dockerCLI


### images: print hint when invoking "docker images" with ambiguous argument

The `docker images` top-level subcommand predates the `docker <object> <verb>`
convention (e.g. `docker image ls`), but accepts a positional argument to
search/filter images by name (globbing). It's common for users to accidentally
mistake these commands, and to use (e.g.) `docker images ls`, expecting
to see all images, but ending up with an empty list because no image named
"ls" was found.

Disallowing these search-terms would be a breaking change, but we can print
and informational message to help the users correct their mistake.


Before this patch:

    docker images ls
    REPOSITORY   TAG       IMAGE ID   CREATED   SIZE

With this patch applied:

    docker images ls
    REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
    
    No images found matching "ls": did you mean "docker image ls"?


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

```
print hint when invoking "docker images" with ambiguous argument
```

