### PR TITLE
Uniform output of volume prune cmd with other prune cmds

### DIFF
--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -73,13 +73,15 @@ func TestVolumePruneSuccess(t *testing.T) {
 	testCases := []struct {
 		name            string
 		args            []string
+		input           string
 		volumePruneFunc func(args filters.Args) (types.VolumesPruneReport, error)
 	}{
 		{
-			name: "all",
-			args: []string{"--all"},
+			name:  "all",
+			args:  []string{"--all"},
+			input: "y",
 			volumePruneFunc: func(pruneFilter filters.Args) (types.VolumesPruneReport, error) {
-				assert.Check(t, is.Equal([]string{"true"}, pruneFilter.Get("all")))
+				assert.Check(t, is.DeepEqual([]string{"true"}, pruneFilter.Get("all")))
 				return types.VolumesPruneReport{}, nil
 			},
 		},
@@ -91,10 +93,11 @@ func TestVolumePruneSuccess(t *testing.T) {
 			},
 		},
 		{
-			name: "label-filter",
-			args: []string{"--filter", "label=foobar"},
+			name:  "label-filter",
+			args:  []string{"--filter", "label=foobar"},
+			input: "y",
 			volumePruneFunc: func(pruneFilter filters.Args) (types.VolumesPruneReport, error) {
-				assert.Check(t, is.Equal([]string{"foobar"}, pruneFilter.Get("label")))
+				assert.Check(t, is.DeepEqual([]string{"foobar"}, pruneFilter.Get("label")))
 				return types.VolumesPruneReport{}, nil
 			},
 		},
@@ -104,6 +107,9 @@ func TestVolumePruneSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{volumePruneFunc: tc.volumePruneFunc})
 			cmd := NewPruneCommand(cli)
+			if tc.input != "" {
+				cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(tc.input))))
+			}
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()

--- a/cli/command/volume/testdata/volume-prune-no.golden
+++ b/cli/command/volume/testdata/volume-prune-no.golden
@@ -1,2 +1,2 @@
 WARNING! This will remove anonymous local volumes not used by at least one container.
-Are you sure you want to continue? [y/N] Total reclaimed space: 0B
+Are you sure you want to continue? [y/N] 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**  

Make the `docker volume prune` cmd out uniform with the other `prune` commands in case of user cancellation at the confirmation prompt.   

Basically, don't show the `Total reclaimed space: 0 ` text when the user says "n" or simply presses ENTER at the confirmation prompt.

Closes #4851 

**- How I did it**
- Return error when user refuses at confirmation prompt
- Avoid sending space freed msg if user cancelled
- Fixed unit tests assertions and logic, some "success" tests were actually going through the failure path, and we were none the wiser :)

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![photo_5913688840516780494_y](https://github.com/docker/cli/assets/47751006/afd6bd2f-9f41-4f3f-95de-af90ba9d079c)

