### PR TITLE
cli-plugins/socket: remove use of deprecated distribution uuid package

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -1,12 +1,12 @@
 package socket
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net"
 	"os"
-
-	"github.com/docker/distribution/uuid"
 )
 
 // EnvKey represents the well-known environment variable used to pass the plugin being
@@ -17,7 +17,7 @@ const EnvKey = "DOCKER_CLI_PLUGIN_SOCKET"
 // and update the conn pointer, and returns the listener for the socket (which the caller
 // is responsible for closing when it's no longer needed).
 func SetupConn(conn **net.UnixConn) (*net.UnixListener, error) {
-	listener, err := listen("docker_cli_" + uuid.Generate().String())
+	listener, err := listen("docker_cli_" + randomID())
 	if err != nil {
 		return nil, err
 	}
@@ -25,6 +25,14 @@ func SetupConn(conn **net.UnixConn) (*net.UnixListener, error) {
 	accept(listener, conn)
 
 	return listener, nil
+}
+
+func randomID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(err) // This shouldn't happen
+	}
+	return hex.EncodeToString(b)
 }
 
 func accept(listener *net.UnixListener, conn **net.UnixConn) {


### PR DESCRIPTION
relates to:

- https://github.com/distribution/distribution/pull/4129
- https://github.com/distribution/distribution/pull/4132
- https://github.com/distribution/distribution/pull/4157



### cli-plugins/socket: remove use of deprecated distribution uuid package


The "github.com/docker/distribution" module moved to the distribution
org ("github.com/docker/distribution/v3"), and the new module deprecated
and removed the uuid package in favor of Google's UUID package.

While we still depend on the old module through packages and as an indirect
dependency, we may want to try avoid using it.

This patch replaces the use for the socket package, and replaces it for a
local utility, taking the same approach as `stringid.GenerateRandomID()`,
which should be random enough for this purpose.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

