### PR TITLE
testenv: Add DaemonAPIVersion helper

### DIFF
--- a/internal/test/environment/testenv.go
+++ b/internal/test/environment/testenv.go
@@ -108,3 +108,14 @@ func SkipIfNotPlatform(t *testing.T, platform string) {
 	daemonPlatform := strings.TrimSpace(result.Stdout())
 	skip.If(t, daemonPlatform != platform, "running against a non %s daemon", platform)
 }
+
+// DaemonAPIVersion returns the negotiated daemon API version.
+func DaemonAPIVersion(t *testing.T) string {
+	t.Helper()
+	// Use Client.APIVersion instead of Server.APIVersion.
+	// The latter is the maximum version that the server supports
+	// while the Client.APIVersion contains the negotiated version.
+	result := icmd.RunCmd(icmd.Command("docker", "version", "--format", "{{.Client.APIVersion}}"))
+	result.Assert(t, icmd.Expected{Err: icmd.None})
+	return strings.TrimSpace(result.Stdout())
+}


### PR DESCRIPTION
- extracted from: https://github.com/docker/cli/pull/4331

Allow tests to check the negotiated API version used by the client.

Can be used to skip tests based on API versions, for example:
```go
    skip.If(t, versions.LessThan(environment.DaemonAPIVersion(t), "1.44"))
```

will skip the test if the API version is older than 1.44

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

