### PR TITLE
fix: concurrency safe `net.UnixConn`

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"time"
 )
 
 // EnvKey represents the well-known environment variable used to pass the plugin being
@@ -44,21 +45,32 @@ func randomID() string {
 func accept(listener *net.UnixListener) <-chan *net.UnixConn {
 	connChan := make(chan *net.UnixConn, 1)
 
-	go func(connChan chan<- *net.UnixConn) {
-		for {
+	go func() {
+		const maxRetries = 10
+		const waitBetweenRetries = 100 * time.Millisecond
+
+		var conn *net.UnixConn
+		var err error
+
+		// retry accepting a connection if there was an error
+		for i := 0; i < maxRetries; i++ {
 			// this is a blocking call and will wait
 			// until a new connection is accepted
-			c, err := listener.AcceptUnix()
+			// or until the timout is reached
+			conn, err = listener.AcceptUnix()
 
-			// perform any platform-specific actions on accept (e.g. unlink non-abstract sockets)
-			onAccept(listener)
-			// retry accepting a connection if there was an error
 			if err != nil {
+				time.Sleep(waitBetweenRetries)
 				continue
 			}
-			connChan <- c
+			break
 		}
-	}(connChan)
+		// perform any platform-specific actions on accept (e.g. unlink non-abstract sockets)
+		onAccept(listener)
+		connChan <- conn
+		// close the channel to signal we won't accept any more connections
+		close(connChan)
+	}()
 
 	return connChan
 }

--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"time"
 )
 
 // EnvKey represents the well-known environment variable used to pass the plugin being
@@ -46,25 +45,11 @@ func accept(listener *net.UnixListener) <-chan *net.UnixConn {
 	connChan := make(chan *net.UnixConn, 1)
 
 	go func() {
-		const maxRetries = 10
-		const waitBetweenRetries = 100 * time.Millisecond
+		// this is a blocking call and will wait
+		// until a new connection is accepted
+		// or until the timout is reached
+		conn, _ := listener.AcceptUnix()
 
-		var conn *net.UnixConn
-		var err error
-
-		// retry accepting a connection if there was an error
-		for i := 0; i < maxRetries; i++ {
-			// this is a blocking call and will wait
-			// until a new connection is accepted
-			// or until the timout is reached
-			conn, err = listener.AcceptUnix()
-
-			if err != nil {
-				time.Sleep(waitBetweenRetries)
-				continue
-			}
-			break
-		}
 		// perform any platform-specific actions on accept (e.g. unlink non-abstract sockets)
 		onAccept(listener)
 		connChan <- conn

--- a/cli-plugins/socket/socket_darwin.go
+++ b/cli-plugins/socket/socket_darwin.go
@@ -14,6 +14,6 @@ func listen(socketname string) (*net.UnixListener, error) {
 	})
 }
 
-func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
+func onAccept(listener *net.UnixListener) {
 	syscall.Unlink(listener.Addr().String())
 }

--- a/cli-plugins/socket/socket_nodarwin.go
+++ b/cli-plugins/socket/socket_nodarwin.go
@@ -13,7 +13,7 @@ func listen(socketname string) (*net.UnixListener, error) {
 	})
 }
 
-func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
+func onAccept(listener *net.UnixListener) {
 	// do nothing
 	// while on darwin and OpenBSD we would unlink here;
 	// on non-darwin the socket is abstract and not present on the filesystem

--- a/cli-plugins/socket/socket_openbsd.go
+++ b/cli-plugins/socket/socket_openbsd.go
@@ -14,6 +14,6 @@ func listen(socketname string) (*net.UnixListener, error) {
 	})
 }
 
-func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
+func onAccept(listener *net.UnixListener) {
 	syscall.Unlink(listener.Addr().String())
 }

--- a/cli-plugins/socket/socket_test.go
+++ b/cli-plugins/socket/socket_test.go
@@ -27,22 +27,6 @@ func TestSetupConn(t *testing.T) {
 		pollConnNotNil(t, conn)
 	})
 
-	t.Run("allows reconnects", func(t *testing.T) {
-		listener, _, err := SetupConn()
-		assert.NilError(t, err)
-		assert.Check(t, listener != nil, "returned nil listener but no error")
-		addr, err := net.ResolveUnixAddr("unix", listener.Addr().String())
-		assert.NilError(t, err, "failed to resolve listener address")
-
-		otherConn, err := net.DialUnix("unix", nil, addr)
-		assert.NilError(t, err, "failed to dial returned listener")
-
-		otherConn.Close()
-
-		_, err = net.DialUnix("unix", nil, addr)
-		assert.NilError(t, err, "failed to redial listener")
-	})
-
 	t.Run("does not leak sockets to local directory", func(t *testing.T) {
 		listener, _, err := SetupConn()
 		assert.NilError(t, err)

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/docker/cli/cli"
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
@@ -255,8 +254,7 @@ func tryPluginRun(dockerCli command.Cli, cmd *cobra.Command, subcommand string, 
 						_, _ = fmt.Fprintf(dockerCli.Err(), "failed to signal plugin to close: %v\n", err)
 					}
 				}
-			// timeout here if for some reason the channel is still open and not populated.
-			case <-time.After(1 * time.Millisecond):
+			default:
 				// fallthrough and continue with the loop.
 			}
 			retries++


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Create a `*net.UnixConn` receive-only channel, forcing the consumer to wait for the `listener.AcceptUnix()` to return a new connection before it can be used. We don't actually use the returned connection much outside of the tests, only when the CLI receives a Termination signal.

The race condition seemed to also only affect tests that were accessing the `net.UnixConn` instance before it was set or maybe even while it was being set. Since there was no proper mechanism for waiting for the connection to be set, we ended up with race conditions.

See below for some go code explaining this.

```go
var conn *net.UnixConn
// sets up an inifinte loop in the background
listener, err := SetupConn(&conn)

// poll the conn for non nill 
pollConnNotNil(t, conn) // <-- can succeed or fail here

// closes the connection
conn.Close() // <-- can succeed or fail here
```

```go
// Close closes the connection.
func (c *conn) Close() error {
	if !c.ok() {
		return syscall.EINVAL
	}
	err := c.fd.Close() // <--- fails
	if err != nil {
		err = &OpError{Op: "close", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
	}
	return err
}
```

```shell
go test -v -race .
---
WARNING: DATA RACE
Read at 0x00c00013322c by goroutine 16:
  internal/poll.(*FD).Close()
      /usr/lib/go/src/internal/poll/fd_unix.go:112 +0x98
  net.(*netFD).Close()
      /usr/lib/go/src/net/fd_posix.go:37 +0x3d
  net.(*conn).Close()
      /usr/lib/go/src/net/net.go:203 +0x6a
  github.com/docker/cli/cli-plugins/socket.TestConnectAndWait.func1()
      /home/benehiko/go/src/github.com/docker/cli/cli-plugins/socket/socket_test.go:107 +0x2dd
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/lib/go/src/testing/testing.go:1648 +0x44
```

**- How I did it**
Return a receive-only channel containing the `net.UnixConn` instance.

**- How to verify it**
CI should not fail on tests:
```shell
--- FAIL: TestSetupConn (0.00s)
    --- FAIL: TestSetupConn/allows_reconnects (0.00s)
--- FAIL: TestConnectAndWait (0.00s)
    --- FAIL: TestConnectAndWait/connect_goroutine_exits_after_EOF (0.00s)
```

Locally I cannot find a race condition for these test anymore:
```shell
⋊> ~/g/s/g/d/c/c/socket on fix-socket-concurrency ⨯ go test -v -race ./...  11:55:12
=== RUN   TestSetupConn
=== RUN   TestSetupConn/updates_conn_when_connected
=== RUN   TestSetupConn/allows_reconnects
=== RUN   TestSetupConn/does_not_leak_sockets_to_local_directory
--- PASS: TestSetupConn (0.00s)
    --- PASS: TestSetupConn/updates_conn_when_connected (0.00s)
    --- PASS: TestSetupConn/allows_reconnects (0.00s)
    --- PASS: TestSetupConn/does_not_leak_sockets_to_local_directory (0.00s)
=== RUN   TestConnectAndWait
=== RUN   TestConnectAndWait/calls_cancel_func_on_EOF
=== RUN   TestConnectAndWait/connect_goroutine_exits_after_EOF
--- PASS: TestConnectAndWait (0.00s)
    --- PASS: TestConnectAndWait/calls_cancel_func_on_EOF (0.00s)
    --- PASS: TestConnectAndWait/connect_goroutine_exits_after_EOF (0.00s)
PASS
ok  	github.com/docker/cli/cli-plugins/socket	1.019s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
The `socket.go` implementation introduced race conditions on the `net.UnixConn` instance passed on to the `SetupConn` function which is now resolved.

**- A picture of a cute animal (not mandatory but encouraged)**

![kitten-cat-cute-kitten-kitty-97c7d2448f0682f1f578c0b9f57aacab](https://github.com/docker/cli/assets/18033717/72d2af5d-9f22-4571-b6cb-80aa82faaba9)
(https://www.pickpik.com/kitten-cat-cute-kitten-kitty-cute-cat-curious-135563)