### PR TITLE
man/docker-build.1: typo in parameter variable: CID => IID

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -11,7 +11,7 @@ docker-build - Build an image from a Dockerfile
 [**-c**|**--cpu-shares**[=*0*]]
 [**--cgroup-parent**[=*CGROUP-PARENT*]]
 [**--help**]
-[**--iidfile**[=*CIDFILE*]]
+[**--iidfile**[=*IIDFILE*]]
 [**-f**|**--file**[=*PATH/Dockerfile*]]
 [**-squash**] *Experimental*
 [**--force-rm**]


### PR DESCRIPTION
--iidfile logically specifies the IIDFILE and not the CIDFILE (use --cidfile from docker-run.1.md for specifying a cidfile).

checks:

* typo not included in other open pull requests (as far as i could see)
* as per CONTRIBUTING.md no typo is too small not to be pull-requested..


**- Description for the changelog**

man/docker-build.1: fix typo
