### PR TITLE
[25.0 backport] docs: update link targets

### DIFF
--- a/docs/extend/config.md
+++ b/docs/extend/config.md
@@ -55,11 +55,11 @@ the registry.
 
 - `entrypoint` string array
 
-   Entrypoint of the plugin, see [`ENTRYPOINT`](https://docs.docker.com/engine/reference/builder/#entrypoint)
+   Entrypoint of the plugin, see [`ENTRYPOINT`](https://docs.docker.com/reference/dockerfile/#entrypoint)
 
 - `workdir` string
 
-   Working directory of the plugin, see [`WORKDIR`](https://docs.docker.com/engine/reference/builder/#workdir)
+   Working directory of the plugin, see [`WORKDIR`](https://docs.docker.com/reference/dockerfile/#workdir)
 
 - `network` PluginNetwork
 

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -104,7 +104,7 @@ Enable the authorization plugin with a dedicated command line flag in the
 `--authorization-plugin=PLUGIN_ID` format. The flag supplies a `PLUGIN_ID`
 value. This value can be the plugin’s socket or a path to a specification file.
 Authorization plugins can be loaded without restarting the daemon. Refer
-to the [`dockerd` documentation](../reference/commandline/dockerd.md#configuration-reload-behavior) for more information.
+to the [`dockerd` documentation](https://docs.docker.com/reference/cli/dockerd/#configuration-reload-behavior) for more information.
 
 ```console
 $ dockerd --authorization-plugin=plugin1 --authorization-plugin=plugin2,...

--- a/docs/reference/commandline/builder_build.md
+++ b/docs/reference/commandline/builder_build.md
@@ -47,4 +47,4 @@ Build an image from a Dockerfile
 
 ## Description
 
-See [docker build](build.md) for more information.
+See [docker build](image_build.md) for more information.

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -11,7 +11,7 @@ aliases:
 ---
 
 The base command for the Docker CLI is `docker`. For information about the
-available flags and subcommands, refer to the [CLI reference](docker.md)
+available flags and subcommands, refer to the [CLI reference](https://docs.docker.com/reference/cli/docker/)
 
 Depending on your Docker system configuration, you may be required to preface
 each `docker` command with `sudo`. To avoid having to use `sudo` with the
@@ -26,20 +26,20 @@ the [installation](https://docs.docker.com/install/) instructions for your opera
 The following list of environment variables are supported by the `docker` command
 line:
 
-| Variable                      | Description                                                                                                                                                                                                                                                  |
-| :---------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `DOCKER_API_VERSION`          | Override the negotiated API version to use for debugging (e.g. `1.19`)                                                                                                                                                                                       |
-| `DOCKER_CERT_PATH`            | Location of your authentication keys. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md)                                                                                                                                  |
-| `DOCKER_CONFIG`               | The location of your client configuration files.                                                                                                                                                                                                             |
-| `DOCKER_CONTENT_TRUST_SERVER` | The URL of the Notary server to use. Defaults to the same URL as the registry.                                                                                                                                                                               |
-| `DOCKER_CONTENT_TRUST`        | When set Docker uses notary to sign and verify images. Equates to `--disable-content-trust=false` for build, create, pull, push, run.                                                                                                                        |
-| `DOCKER_CONTEXT`              | Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)                                                                                                                                      |
-| `DOCKER_DEFAULT_PLATFORM`     | Default platform for commands that take the `--platform` flag.                                                                                                                                                                                               |
-| `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release. |
-| `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                                                                                                                                                 |
-| `DOCKER_TLS`                  | Enable TLS for connections made by the `docker` CLI (equivalent of the `--tls` command-line option). Set to a non-empty value to enable TLS. Note that TLS is enabled automatically if any of the other TLS options are set.                                 |
-| `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](dockerd.md)                                                                                                                      |
-| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`) when [building](image_build.md) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`).                                                  |
+| Variable                      | Description                                                                                                                                                                                                                                                       |
+| :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DOCKER_API_VERSION`          | Override the negotiated API version to use for debugging (e.g. `1.19`)                                                                                                                                                                                            |
+| `DOCKER_CERT_PATH`            | Location of your authentication keys. This variable is used both by the `docker` CLI and the [`dockerd` daemon](https://docs.docker.com/reference/cli/dockerd/)                                                                                                   |
+| `DOCKER_CONFIG`               | The location of your client configuration files.                                                                                                                                                                                                                  |
+| `DOCKER_CONTENT_TRUST_SERVER` | The URL of the Notary server to use. Defaults to the same URL as the registry.                                                                                                                                                                                    |
+| `DOCKER_CONTENT_TRUST`        | When set Docker uses notary to sign and verify images. Equates to `--disable-content-trust=false` for build, create, pull, push, run.                                                                                                                             |
+| `DOCKER_CONTEXT`              | Name of the `docker context` to use (overrides `DOCKER_HOST` env var and default context set with `docker context use`)                                                                                                                                           |
+| `DOCKER_DEFAULT_PLATFORM`     | Default platform for commands that take the `--platform` flag.                                                                                                                                                                                                    |
+| `DOCKER_HIDE_LEGACY_COMMANDS` | When set, Docker hides "legacy" top-level commands (such as `docker rm`, and `docker pull`) in `docker help` output, and only `Management commands` per object-type (e.g., `docker container`) are printed. This may become the default in a future release.      |
+| `DOCKER_HOST`                 | Daemon socket to connect to.                                                                                                                                                                                                                                      |
+| `DOCKER_TLS`                  | Enable TLS for connections made by the `docker` CLI (equivalent of the `--tls` command-line option). Set to a non-empty value to enable TLS. Note that TLS is enabled automatically if any of the other TLS options are set.                                      |
+| `DOCKER_TLS_VERIFY`           | When set Docker uses TLS and verifies the remote. This variable is used both by the `docker` CLI and the [`dockerd` daemon](https://docs.docker.com/reference/cli/dockerd/)                                                                                       |
+| `BUILDKIT_PROGRESS`           | Set type of progress output (`auto`, `plain`, `tty`, `rawjson`) when [building](https://docs.docker.com/reference/cli/docker/image/build/) with [BuildKit backend](https://docs.docker.com/build/buildkit/). Use plain to show container output (default `auto`). |
 
 Because Docker is developed using Go, you can also use any environment
 variables used by the Go runtime. In particular, you may find these useful:
@@ -115,20 +115,20 @@ different location.
 These fields lets you customize the default output format for some commands
 if no `--format` flag is provided.
 
-| Property               | Description                                                                                                                                                         |
-| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `configFormat`         | Custom default format for `docker config ls` output. See [`docker config ls`](config_ls.md#format) for a list of supported formatting directives.                   |
-| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. See [`docker images`](image_ls.md#format) for a list of supported formatting directives.      |
-| `networksFormat`       | Custom default format for `docker network ls` output. See [`docker network ls`](network_ls.md#format) for a list of supported formatting directives.                |
-| `nodesFormat`          | Custom default format for `docker node ls` output. See [`docker node ls`](node_ls.md#format) for a list of supported formatting directives.                         |
-| `pluginsFormat`        | Custom default format for `docker plugin ls` output. See [`docker plugin ls`](plugin_ls.md#format) for a list of supported formatting directives.                   |
-| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. See [`docker ps`](container_ls.md#format) for a list of supported formatting directives.      |
-| `secretFormat`         | Custom default format for `docker secret ls` output. See [`docker secret ls`](secret_ls.md#format) for a list of supported formatting directives.                   |
-| `serviceInspectFormat` | Custom default format for `docker service inspect` output. See [`docker service inspect`](service_inspect.md#format) for a list of supported formatting directives. |
-| `servicesFormat`       | Custom default format for `docker service ls` output. See [`docker service ls`](service_ls.md#format) for a list of supported formatting directives.                |
-| `statsFormat`          | Custom default format for `docker stats` output. See [`docker stats`](container_stats.md#format) for a list of supported formatting directives.                     |
-| `tasksFormat`          | Custom default format for `docker stack ps` output. See [`docker stack ps`](stack_ps.md#format) for a list of supported formatting directives.                      |
-| `volumesFormat`        | Custom default format for `docker volume ls` output. See [`docker volume ls`](volume_ls.md#format) for a list of supported formatting directives.                   |
+| Property               | Description                                                                                                                                                                                                    |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `configFormat`         | Custom default format for `docker config ls` output. See [`docker config ls`](https://docs.docker.com/reference/cli/docker/config/ls/#format) for a list of supported formatting directives.                   |
+| `imagesFormat`         | Custom default format for `docker images` / `docker image ls` output. See [`docker images`](https://docs.docker.com/reference/cli/docker/image/ls/#format) for a list of supported formatting directives.      |
+| `networksFormat`       | Custom default format for `docker network ls` output. See [`docker network ls`](https://docs.docker.com/reference/cli/docker/network/ls/#format) for a list of supported formatting directives.                |
+| `nodesFormat`          | Custom default format for `docker node ls` output. See [`docker node ls`](https://docs.docker.com/reference/cli/docker/node/ls/#format) for a list of supported formatting directives.                         |
+| `pluginsFormat`        | Custom default format for `docker plugin ls` output. See [`docker plugin ls`](https://docs.docker.com/reference/cli/docker/plugin/ls/#format) for a list of supported formatting directives.                   |
+| `psFormat`             | Custom default format for `docker ps` / `docker container ps` output. See [`docker ps`](https://docs.docker.com/reference/cli/docker/container/ls/#format) for a list of supported formatting directives.      |
+| `secretFormat`         | Custom default format for `docker secret ls` output. See [`docker secret ls`](https://docs.docker.com/reference/cli/docker/secret/ls/#format) for a list of supported formatting directives.                   |
+| `serviceInspectFormat` | Custom default format for `docker service inspect` output. See [`docker service inspect`](https://docs.docker.com/reference/cli/docker/service/inspect/#format) for a list of supported formatting directives. |
+| `servicesFormat`       | Custom default format for `docker service ls` output. See [`docker service ls`](https://docs.docker.com/reference/cli/docker/service/ls/#format) for a list of supported formatting directives.                |
+| `statsFormat`          | Custom default format for `docker stats` output. See [`docker stats`](https://docs.docker.com/reference/cli/docker/container/stats/#format) for a list of supported formatting directives.                     |
+| `tasksFormat`          | Custom default format for `docker stack ps` output. See [`docker stack ps`](https://docs.docker.com/reference/cli/docker/stack/ps/#format) for a list of supported formatting directives.                      |
+| `volumesFormat`        | Custom default format for `docker volume ls` output. See [`docker volume ls`](https://docs.docker.com/reference/cli/docker/volume/ls/#format) for a list of supported formatting directives.                   |
 
 ### Custom HTTP headers
 
@@ -144,14 +144,14 @@ credential store. When this property is set, `docker login` will attempt to
 store credentials in the binary specified by `docker-credential-<value>` which
 is visible on `$PATH`. If this property isn't set, credentials are stored
 in the `auths` property of the CLI configuration file. For more information,
-see the [**Credential stores** section in the `docker login` documentation](login.md#credential-stores)
+see the [**Credential stores** section in the `docker login` documentation](https://docs.docker.com/reference/cli/docker/login/#credential-stores)
 
 The property `credHelpers` specifies a set of credential helpers to use
 preferentially over `credsStore` or `auths` when storing and retrieving
 credentials for specific registries. If this property is set, the binary
 `docker-credential-<value>` will be used when storing or retrieving credentials
 for a specific registry. For more information, see the
-[**Credential helpers** section in the `docker login` documentation](login.md#credential-helpers)
+[**Credential helpers** section in the `docker login` documentation](https://docs.docker.com/reference/cli/docker/login/#credential-helpers)
 
 ### Automatic proxy configuration for containers
 
@@ -299,12 +299,12 @@ commands use the following default sockets:
 - `npipe:////./pipe/docker_engine` on Windows
 
 To achieve a similar effect without having to specify the `-H` flag for every
-command, you could also [create a context](context_create.md),
+command, you could also [create a context](https://docs.docker.com/reference/cli/docker/context/create/),
 or alternatively, use the
 [`DOCKER_HOST` environment variable](#environment-variables).
 
 For more information about the `-H` flag, see
-[Daemon socket option](dockerd.md#daemon-socket-option).
+[Daemon socket option](https://docs.docker.com/reference/cli/dockerd/#daemon-socket-option).
 
 #### Using TCP sockets
 

--- a/docs/reference/commandline/container_attach.md
+++ b/docs/reference/commandline/container_attach.md
@@ -164,4 +164,4 @@ the following:
 
 These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
 sequences. To configure a different configuration default key sequence for all
-containers, see [**Configuration file** section](cli.md#configuration-files).
+containers, see [**Configuration file** section](https://docs.docker.com/engine/reference/commandline/cli/#configuration-files).

--- a/docs/reference/commandline/container_cp.md
+++ b/docs/reference/commandline/container_cp.md
@@ -112,7 +112,7 @@ $ docker cp CONTAINER:/var/logs/app.log - | tar x -O | grep "ERROR"
 ### Corner cases
 
 It isn't possible to copy certain system files such as resources under
-`/proc`, `/sys`, `/dev`, [tmpfs](run.md#tmpfs), and mounts created by
+`/proc`, `/sys`, `/dev`, [tmpfs](container_run.md#tmpfs), and mounts created by
 the user in the container. However, you can still copy such files by manually
 running `tar` in `docker exec`. Both of the following examples do the same thing
 in different ways (consider `SRC_PATH` and `DEST_PATH` are directories):

--- a/docs/reference/commandline/container_create.md
+++ b/docs/reference/commandline/container_create.md
@@ -131,8 +131,8 @@ so that it's ready to start when you need it. The initial status of the
 new container is `created`.
 
 The `docker create` command shares most of its options with the `docker run`
-command (which performs a `docker create` before starting it). Refer to the
-[`docker run` command](run.md) section and the [Docker run reference](../run.md)
+command (which performs a `docker create` before starting it).
+Refer to the [`docker run` CLI reference](container_run.md)
 for details on the available flags and options.
 
 ## Examples

--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -787,7 +787,7 @@ the following:
 
 These `a`, `ctrl-a`, `X`, or `ctrl-\\` values are all examples of valid key
 sequences. To configure a different configuration default key sequence for all
-containers, see [**Configuration file** section](cli.md#configuration-files).
+containers, see [**Configuration file** section](https://docs.docker.com/engine/reference/commandline/cli/#configuration-files).
 
 ### <a name="device"></a> Add host device to container (--device)
 
@@ -888,7 +888,7 @@ This starts an `ubuntu` container with access to the specified CDI device,
   on the system running the daemon, in one of the configured CDI specification
   directories.
 - The CDI feature has been enabled on the daemon side, see [Enable CDI
-  devices](dockerd.md#enable-cdi-devices).
+  devices](https://docs.docker.com/reference/cli/dockerd/#enable-cdi-devices).
 
 ### <a name="attach"></a> Attach to STDIN/STDOUT/STDERR (-a, --attach)
 
@@ -1306,7 +1306,7 @@ container to exit. This signal can be a signal name in the format `SIG<NAME>`,
 for instance `SIGKILL`, or an unsigned number that matches a position in the
 kernel's syscall table, for instance `9`.
 
-The default value is defined by [`STOPSIGNAL`](https://docs.docker.com/engine/reference/builder/#stopsignal)
+The default value is defined by [`STOPSIGNAL`](https://docs.docker.com/reference/dockerfile/#stopsignal)
 in the image, or `SIGTERM` if the image has no `STOPSIGNAL` defined.
 
 ### <a name="security-opt"></a> Optional security options (--security-opt)

--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -50,7 +50,7 @@ Build an image from a Dockerfile
 The `docker build` command builds Docker images from a Dockerfile and a
 "context". A build's context is the set of files located in the specified
 `PATH` or `URL`. The build process can refer to any of the files in the
-context. For example, your build can use a [*COPY*](https://docs.docker.com/engine/reference/builder/#copy)
+context. For example, your build can use a [*COPY*](https://docs.docker.com/reference/dockerfile/#copy)
 instruction to reference a file in the context.
 
 The `URL` parameter can refer to three kinds of resources: Git repositories,
@@ -144,7 +144,7 @@ In most cases, it's best to put each Dockerfile in an empty directory. Then,
 add to that directory only the files needed for building the Dockerfile. To
 increase the build's performance, you can exclude files and directories by
 adding a `.dockerignore` file to that directory as well. For information on
-creating one, see the [.dockerignore file](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
+creating one, see the [.dockerignore file](https://docs.docker.com/reference/dockerfile/#dockerignore-file).
 
 If the Docker client loses connection to the daemon, it cancels the build.
 This happens if you interrupt the Docker client with `CTRL-c` or if the Docker
@@ -172,7 +172,7 @@ $ echo $?
 
 See also:
 
-[*Dockerfile Reference*](https://docs.docker.com/engine/reference/builder/).
+[*Dockerfile Reference*](https://docs.docker.com/reference/dockerfile/).
 
 ## Examples
 
@@ -213,7 +213,7 @@ where to find the files for the "context" of the build on the Docker daemon.
 Remember that the daemon could be running on a remote machine and that no
 parsing of the Dockerfile happens at the client side (where you're running
 `docker build`). That means that all the files at `PATH` are sent, not just
-the ones listed to [`ADD`](https://docs.docker.com/engine/reference/builder/#add)
+the ones listed to [`ADD`](https://docs.docker.com/reference/dockerfile/#add)
 in the Dockerfile.
 
 The transfer of context from the local machine to the Docker daemon is what the
@@ -302,7 +302,7 @@ Successfully built 99cc1ad10469
 This example shows the use of the `.dockerignore` file to exclude the `.git`
 directory from the context. You can see its effect in the changed size of the
 uploaded context. The builder reference contains detailed information on
-[creating a .dockerignore file](https://docs.docker.com/engine/reference/builder/#dockerignore-file).
+[creating a .dockerignore file](https://docs.docker.com/reference/dockerfile/#dockerignore-file).
 
 When using the [BuildKit backend](https://docs.docker.com/build/buildkit/),
 `docker build` searches for a `.dockerignore` file relative to the Dockerfile
@@ -384,12 +384,12 @@ the command line.
 ### <a name="cgroup-parent"></a> Use a custom parent cgroup (--cgroup-parent)
 
 When you run `docker build` with the `--cgroup-parent` option, the daemon runs the containers
-used in the build with the [corresponding `docker run` flag](../run.md#specify-custom-cgroups).
+used in the build with the [corresponding `docker run` flag](container_run.md#cgroup-parent).
 
 ### <a name="ulimit"></a> Set ulimits in container (--ulimit)
 
 Using the `--ulimit` option with `docker build` causes the daemon to start each build step's
-container using those [`--ulimit` flag values](run.md#ulimit).
+container using those [`--ulimit` flag values](container_run.md#ulimit).
 
 ### <a name="build-arg"></a> Set build-time variables (--build-arg)
 
@@ -415,7 +415,7 @@ Using this flag doesn't alter the output you see when the build process echoes t
 Dockerfile.
 
 For detailed information on using `ARG` and `ENV` instructions, see the
-[Dockerfile reference](https://docs.docker.com/engine/reference/builder/).
+[Dockerfile reference](https://docs.docker.com/reference/dockerfile/).
 
 You can also use the `--build-arg` flag without a value, in which case the daemon
 propagates the value from the local environment into the Docker container it's building:
@@ -425,7 +425,7 @@ $ export HTTP_PROXY=http://10.20.30.2:1234
 $ docker build --build-arg HTTP_PROXY .
 ```
 
-This example is similar to how `docker run -e` works. Refer to the [`docker run` documentation](run.md#env)
+This example is similar to how `docker run -e` works. Refer to the [`docker run` documentation](container_run.md#env)
 for more information.
 
 ### <a name="security-opt"></a> Optional security options (--security-opt)
@@ -553,7 +553,7 @@ $ docker build -o - . > out.tar
 
 The `--output` option exports all files from the target stage. A common pattern
 for exporting only specific files is to do multi-stage builds and to copy the
-desired files to a new scratch stage with [`COPY --from`](https://docs.docker.com/engine/reference/builder/#copy).
+desired files to a new scratch stage with [`COPY --from`](https://docs.docker.com/reference/dockerfile/#copy).
 
 The example, the `Dockerfile` below uses a separate stage to collect the
 build artifacts for exporting:
@@ -642,7 +642,7 @@ Available options for the networking mode are:
 - `none`: Run with no network access.
 - `host`: Run in the host’s network environment.
 
-Find more details in the [Dockerfile documentation](https://docs.docker.com/engine/reference/builder/#run---network).
+Find more details in the [Dockerfile documentation](https://docs.docker.com/reference/dockerfile/#run---network).
 
 ### <a name="squash"></a> Squash an image's layers (--squash) (experimental)
 

--- a/docs/reference/commandline/image_pull.md
+++ b/docs/reference/commandline/image_pull.md
@@ -34,7 +34,7 @@ use `docker pull`.
 
 If you are behind an HTTP proxy server, for example in corporate settings,
 before open a connect to registry, you may need to configure the Docker
-daemon's proxy settings, refer to the [dockerd command-line reference](dockerd.md#proxy-configuration)
+daemon's proxy settings, refer to the [dockerd command-line reference](https://docs.docker.com/reference/cli/dockerd/#proxy-configuration)
 for details.
 
 ### Concurrent downloads
@@ -42,7 +42,7 @@ for details.
 By default the Docker daemon will pull three layers of an image at a time.
 If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
 this via the `--max-concurrent-downloads` daemon option. See the
-[daemon documentation](dockerd.md) for more details.
+[daemon documentation](https://docs.docker.com/reference/cli/dockerd/) for more details.
 
 ## Examples
 
@@ -184,7 +184,7 @@ Registry credentials are managed by [docker login](login.md).
 
 Docker uses the `https://` protocol to communicate with a registry, unless the
 registry is allowed to be accessed over an insecure connection. Refer to the
-[insecure registries](dockerd.md#insecure-registries) section for more information.
+[insecure registries](https://docs.docker.com/reference/cli/dockerd/#insecure-registries) section for more information.
 
 
 ### <a name="all-tags"></a> Pull a repository with multiple images (-a, --all-tags)

--- a/docs/reference/commandline/image_push.md
+++ b/docs/reference/commandline/image_push.md
@@ -40,7 +40,7 @@ Registry credentials are managed by [docker login](login.md).
 By default the Docker daemon will push five layers of an image at a time.
 If you are on a low bandwidth connection this may cause timeout issues and you may want to lower
 this via the `--max-concurrent-uploads` daemon option. See the
-[daemon documentation](dockerd.md) for more details.
+[daemon documentation](https://docs.docker.com/reference/cli/dockerd/) for more details.
 
 ## Examples
 

--- a/docs/reference/commandline/image_tag.md
+++ b/docs/reference/commandline/image_tag.md
@@ -43,8 +43,7 @@ underscores, periods, and hyphens. It can't start with a period or hyphen and
 must be no longer than 128 characters. If you don't specify a tag, the command uses `latest` by default.
 
 You can group your images together using names and tags, and then
-[push](https://docs.docker.com/engine/reference/commandline/push) them to a
-registry.
+[push](image_push.md) them to a registry.
 
 ## Examples
 

--- a/docs/reference/commandline/index.md
+++ b/docs/reference/commandline/index.md
@@ -10,11 +10,11 @@ identifier: "smn_cli_guide"
 This section contains reference information on using Docker's command line
 client. Each command has a reference page along with samples. If you are
 unfamiliar with the command line, you should start by reading about how to [Use
-the Docker command line](cli.md).
+the Docker command line](https://docs.docker.com/engine/reference/commandline/cli/).
 
 You start the Docker daemon with the command line. How you start the daemon
 affects your Docker containers. For that reason you should also make sure to
-read the [`dockerd`](dockerd.md) reference page.
+read the [`dockerd`](https://docs.docker.com/reference/cli/dockerd/) reference page.
 
 ## Commands by object
 
@@ -22,7 +22,7 @@ read the [`dockerd`](dockerd.md) reference page.
 
 | Command                           | Description                                          |
 | :-------------------------------- | :--------------------------------------------------- |
-| [dockerd](dockerd.md)             | Launch the Docker daemon                             |
+| [dockerd](../dockerd.md)          | Launch the Docker daemon                             |
 | [inspect](inspect.md)             | Return low-level information on a container or image |
 | [system events](system_events.md) | Get real-time events from the server                 |
 | [system info](system_info.md)     | Display system-wide information                      |

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -78,7 +78,7 @@ ID                         HOSTNAME       STATUS  AVAILABILITY  MANAGER STATUS
 
 The `label` filter matches nodes based on engine labels and on the presence of a
 `label` alone or a `label` and a value. Engine labels are configured in
-the [daemon configuration](dockerd.md#daemon-configuration-file). To filter on
+the [daemon configuration](https://docs.docker.com/reference/cli/dockerd/#daemon-configuration-file). To filter on
 Swarm `node` labels, use [`node.label` instead](#nodelabel).
 
 The following filter matches nodes with the `foo` label regardless of its value.

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -56,7 +56,7 @@ $ docker node update --label-add type=queue worker1
 
 The labels you set for nodes using `docker node update` apply only to the node
 entity within the swarm. Do not confuse them with the docker daemon labels for
-[dockerd](dockerd.md).
+[dockerd](https://docs.docker.com/reference/cli/dockerd/).
 
 For more information about labels, refer to [apply custom
 metadata](https://docs.docker.com/engine/userguide/labels-custom-metadata/).

--- a/docs/reference/commandline/plugin_create.md
+++ b/docs/reference/commandline/plugin_create.md
@@ -15,7 +15,7 @@ Create a plugin from a rootfs and configuration. Plugin data directory must cont
 ## Description
 
 Creates a plugin. Before creating the plugin, prepare the plugin's root
-filesystem as well as the [config.json](../../extend/config.md).
+filesystem as well as the [config.json](https://docs.docker.com/engine/extend/config/).
 
 ## Examples
 

--- a/docs/reference/commandline/plugin_inspect.md
+++ b/docs/reference/commandline/plugin_inspect.md
@@ -21,7 +21,7 @@ in a JSON array.
 
 ### Inspect a plugin
 
-The following example example inspects the `tiborvass/sample-volume-plugin` plugin:
+The following example inspects the `tiborvass/sample-volume-plugin` plugin:
 
 ```console
 $ docker plugin inspect tiborvass/sample-volume-plugin:latest

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -349,7 +349,7 @@ volumes in a service:
     <td>
       <p>The type of mount, can be either <tt>volume</tt>, <tt>bind</tt>, <tt>tmpfs</tt>, or <tt>npipe</tt>. Defaults to <tt>volume</tt> if no type is specified.</p>
       <ul>
-        <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/engine/reference/commandline/volume_create/">managed volume</a>
+        <li><tt>volume</tt>: mounts a <a href="https://docs.docker.com/reference/cli/docker/volume/create/">managed volume</a>
         into the container.</li> <li><tt>bind</tt>:
         bind-mounts a directory or file from the host into the container.</li>
         <li><tt>tmpfs</tt>: mount a tmpfs in the container</li>

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -133,21 +133,21 @@ to [the `daemon.json` file](#daemon-configuration-file).
 
 The following list of environment variables are supported by the `dockerd` daemon.
 Some of these environment variables are supported both by the Docker Daemon and
-the `docker` CLI. Refer to [Environment variables](cli.md#environment-variables)
+the `docker` CLI. Refer to [Environment variables](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables)
 in the CLI section to learn about environment variables supported by the
 `docker` CLI.
 
-| Variable            | Description                                                                                                                                                                       |
-|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DOCKER_CERT_PATH`  | Location of your authentication keys. This variable is used both by the [`docker` CLI](cli.md) and the `dockerd` daemon.                                                          |
-| `DOCKER_DRIVER`     | The storage driver to use.                                                                                                                                                        |
-| `DOCKER_RAMDISK`    | If set this disables `pivot_root`.                                                                                                                                                |
-| `DOCKER_TLS_VERIFY` | When set Docker uses TLS and verifies the remote. This variable is used both by the  [`docker` CLI](cli.md) and the `dockerd` daemon.                                             |
-| `DOCKER_TMPDIR`     | Location for temporary files created by the daemon.                                                                                                                               |
-| `HTTP_PROXY`        | Proxy URL for HTTP requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                      |
-| `HTTPS_PROXY`       | Proxy URL for HTTPS requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                     |
-| `MOBY_DISABLE_PIGZ` | Disables the use of [`unpigz`](https://linux.die.net/man/1/pigz) to  decompress layers in parallel when pulling images, even if it is installed.                                  |
-| `NO_PROXY`          | Comma-separated values specifying hosts that should be excluded from proxying. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details. |
+| Variable            | Description                                                                                                                                                                             |
+| :------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DOCKER_CERT_PATH`  | Location of your authentication keys. This variable is used both by the [`docker` CLI](https://docs.docker.com/engine/reference/commandline/cli/) and the `dockerd` daemon.             |
+| `DOCKER_DRIVER`     | The storage driver to use.                                                                                                                                                              |
+| `DOCKER_RAMDISK`    | If set this disables `pivot_root`.                                                                                                                                                      |
+| `DOCKER_TLS_VERIFY` | When set Docker uses TLS and verifies the remote. This variable is used both by the [`docker` CLI](https://docs.docker.com/engine/reference/commandline/cli/) and the `dockerd` daemon. |
+| `DOCKER_TMPDIR`     | Location for temporary files created by the daemon.                                                                                                                                     |
+| `HTTP_PROXY`        | Proxy URL for HTTP requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                            |
+| `HTTPS_PROXY`       | Proxy URL for HTTPS requests unless overridden by NoProxy. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.                           |
+| `MOBY_DISABLE_PIGZ` | Disables the use of [`unpigz`](https://linux.die.net/man/1/pigz) to decompress layers in parallel when pulling images, even if it is installed.                                         |
+| `NO_PROXY`          | Comma-separated values specifying hosts that should be excluded from proxying. See the [Go specification](https://pkg.go.dev/golang.org/x/net/http/httpproxy#Config) for details.       |
 
 ## Examples
 
@@ -795,7 +795,7 @@ Any `--ulimit` options passed to `docker run` override the daemon defaults.
 
 Be careful setting `nproc` with the `ulimit` flag, as `nproc` is designed by Linux to
 set the maximum number of processes available to a user, not to a container.
-For details, see [`docker run` reference](run.md#ulimit).
+For details, see [`docker run` reference](https://docs.docker.com/reference/cli/docker/container/run/#ulimit).
 
 ### Access authorization
 
@@ -819,7 +819,7 @@ If you have multiple plugins installed, each plugin, in order, must
 allow the request for it to complete.
 
 For information about how to create an authorization plugin, refer to the
-[authorization plugin](../../extend/plugins_authorization.md) section.
+[authorization plugin](https://docs.docker.com/engine/extend/plugins_authorization/) section.
 
 ### Daemon user namespace options
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,7 +14,7 @@ keywords: "Engine"
 
 # Engine reference
 
-* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
+* [Dockerfile reference](https://docs.docker.com/reference/dockerfile/)
 * [Docker run reference](run.md)
 * [Command line reference](commandline/index.md)
 * [API Reference](https://docs.docker.com/engine/api/)

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -114,13 +114,13 @@ $ docker attach 0246aa4d1448
 For more information about `docker run` flags related to foreground and
 background modes, see:
 
-- [`docker run --detach`](commandline/container_run.md#detach): run container in background
-- [`docker run --attach`](commandline/container_run.md#attach): attach to `stdin`, `stdout`, and `stderr`
-- [`docker run --tty`](commandline/container_run.md#tty): allocate a pseudo-tty
-- [`docker run --interactive`](commandline/container_run.md#interactive): keep `stdin` open even if not attached
+- [`docker run --detach`](https://docs.docker.com/reference/cli/docker/container/run/#detach): run container in background
+- [`docker run --attach`](https://docs.docker.com/reference/cli/docker/container/run/#attach): attach to `stdin`, `stdout`, and `stderr`
+- [`docker run --tty`](https://docs.docker.com/reference/cli/docker/container/run/#tty): allocate a pseudo-tty
+- [`docker run --interactive`](https://docs.docker.com/reference/cli/docker/container/run/#interactive): keep `stdin` open even if not attached
 
 For more information about re-attaching to a background container, see
-[`docker attach`](commandline/container_attach.md).
+[`docker attach`](https://docs.docker.com/reference/cli/docker/container/attach/).
 
 ## Container identification
 
@@ -135,7 +135,7 @@ You can identify a container in three ways:
 The UUID identifier is a random ID assigned to the container by the daemon.
 
 The daemon generates a random string name for containers automatically. You can
-also defined a custom name using [the `--name` flag](./commandline/container_run.md#name).
+also defined a custom name using [the `--name` flag](https://docs.docker.com/reference/cli/docker/container/run/#name).
 Defining a `name` can be a handy way to add meaning to a container. If you
 specify a `name`, you can use it when referring to the container in a
 user-defined network. This works for both background and foreground Docker
@@ -966,7 +966,7 @@ use of facilities allowed by the capabilities, so you should not have to adjust 
 
 ## Overriding image defaults
 
-When you build an image from a [Dockerfile](https://docs.docker.com/engine/reference/builder/),
+When you build an image from a [Dockerfile](https://docs.docker.com/reference/dockerfile/),
 or when committing it, you can set a number of default parameters that take
 effect when the image starts up as a container. When you run an image, you can
 override those defaults using flags for the `docker run` command.

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-: "${CLI_DOCS_TOOL_VERSION=v0.5.1}"
+: "${CLI_DOCS_TOOL_VERSION=v0.7.0}"
 
 export GO111MODULE=auto
 


### PR DESCRIPTION
**- What I did**

backport of #4866

- **deps: update cli-docs-tool version (v0.7.0)**
- **docs: update url scheme for reference docs**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

