### PR TITLE
docs: fix invalid daemon.json examples

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -1038,7 +1038,7 @@ The following is a full example of the allowed configuration options on Linux:
   "cgroup-parent": "",
   "containerd": "/run/containerd/containerd.sock",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-address-pools": [
@@ -1079,7 +1079,7 @@ The following is a full example of the allowed configuration options on Linux:
   "proxies": {
     "http-proxy": "http://proxy.example.com:80",
     "https-proxy": "https://proxy.example.com:443",
-    "no-proxy": "*.test.example.com,.example.org",
+    "no-proxy": "*.test.example.com,.example.org"
   },
   "icc": false,
   "init": false,
@@ -1170,7 +1170,7 @@ The following is a full example of the allowed configuration options on Windows:
   "bridge": "",
   "containerd": "\\\\.\\pipe\\containerd-containerd",
   "containerd-namespace": "docker",
-  "containerd-plugin-namespace": "docker-plugins",
+  "containerd-plugins-namespace": "docker-plugins",
   "data-root": "",
   "debug": true,
   "default-network-opts": {},


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Fix incorrect config option `containerd-plugin-namespace` -> `containerd-plugins-namespace`
- Remove trailing comma in array

addresses:

- https://github.com/docker/docs/issues/19397
- https://github.com/docker/docs/issues/19398

replaces https://github.com/docker/docs/pull/19450

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

