### PR TITLE
Add tests for increased coverage.

### DIFF
--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -16,6 +16,16 @@ func TestNamespaceScope(t *testing.T) {
 	assert.Check(t, is.Equal("foo_bar", scoped))
 }
 
+func TestNamespaceDescope(t *testing.T) {
+	descoped := Namespace{name: "foo"}.Descope("foo_bar")
+	assert.Check(t, is.Equal("bar", descoped))
+}
+
+func TestNamespaceName(t *testing.T) {
+	namespaceName := Namespace{name: "foo"}.Name()
+	assert.Check(t, is.Equal("foo", namespaceName))
+}
+
 func TestAddStackLabel(t *testing.T) {
 	labels := map[string]string{
 		"something": "labeled",

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -61,6 +61,15 @@ func TestConvertEnvironment(t *testing.T) {
 	assert.Check(t, is.DeepEqual([]string{"foo=bar", "key=value"}, env))
 }
 
+func TestConvertEnvironmentWhenNilValueExists(t *testing.T) {
+	source := map[string]*string{
+		"key":            strPtr("value"),
+		"keyWithNoValue": nil,
+	}
+	env := convertEnvironment(source)
+	assert.Check(t, is.DeepEqual([]string{"key=value", "keyWithNoValue"}, env))
+}
+
 func TestConvertExtraHosts(t *testing.T) {
 	source := composetypes.HostsList{
 		"zulu:127.0.0.2",

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -9,6 +9,55 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 )
 
+func TestVolumesWithMultipleServiceVolumeConfigs(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	serviceVolumes := []composetypes.ServiceVolumeConfig{
+		{
+			Type:   "volume",
+			Target: "/foo",
+		},
+		{
+			Type:   "volume",
+			Target: "/foo/bar",
+		},
+	}
+
+	expected := []mount.Mount{
+		{
+			Type:   "volume",
+			Target: "/foo",
+		},
+		{
+			Type:   "volume",
+			Target: "/foo/bar",
+		},
+	}
+
+	mnt, err := Volumes(serviceVolumes, volumes{}, namespace)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, mnt))
+}
+
+func TestVolumesWithMultipleServiceVolumeConfigsWithUndefinedVolumeConfig(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	serviceVolumes := []composetypes.ServiceVolumeConfig{
+		{
+			Type:   "volume",
+			Source: "foo",
+			Target: "/foo",
+		},
+		{
+			Type:   "volume",
+			Target: "/foo/bar",
+		},
+	}
+
+	_, err := Volumes(serviceVolumes, volumes{}, namespace)
+	assert.Error(t, err, "undefined volume \"foo\"")
+}
+
 func TestConvertVolumeToMountAnonymousVolume(t *testing.T) {
 	config := composetypes.ServiceVolumeConfig{
 		Type:   "volume",
@@ -104,6 +153,49 @@ func TestConvertVolumeToMountConflictingOptionsTmpfsInBind(t *testing.T) {
 	assert.Error(t, err, "tmpfs options are incompatible with type bind")
 }
 
+func TestConvertVolumeToMountConflictingOptionsClusterInVolume(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:    "volume",
+		Target:  "/target",
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type volume")
+}
+
+func TestConvertVolumeToMountConflictingOptionsClusterInBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "bind",
+		Source: "/foo",
+		Target: "/target",
+		Bind: &composetypes.ServiceVolumeBind{
+			Propagation: "slave",
+		},
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type bind")
+}
+
+func TestConvertVolumeToMountConflictingOptionsClusterInTmpfs(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "tmpfs",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type tmpfs")
+}
+
 func TestConvertVolumeToMountConflictingOptionsBindInTmpfs(t *testing.T) {
 	namespace := NewNamespace("foo")
 
@@ -130,6 +222,50 @@ func TestConvertVolumeToMountConflictingOptionsVolumeInTmpfs(t *testing.T) {
 	}
 	_, err := convertVolumeToMount(config, volumes{}, namespace)
 	assert.Error(t, err, "volume options are incompatible with type tmpfs")
+}
+
+func TestHandleNpipeToMountAnonymousNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "invalid npipe source, source cannot be empty")
+}
+
+func TestHandleNpipeToMountConflictingOptionsTmpfsInNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Source: "/foo",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "tmpfs options are incompatible with type npipe")
+}
+
+func TestHandleNpipeToMountConflictingOptionsVolumeInNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Source: "/foo",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "volume options are incompatible with type npipe")
 }
 
 func TestConvertVolumeToMountNamedVolume(t *testing.T) {
@@ -344,6 +480,27 @@ func TestConvertTmpfsToMountVolumeWithSource(t *testing.T) {
 	assert.Error(t, err, "invalid tmpfs source, source must be empty")
 }
 
+func TestHandleNpipeToMountBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+	expected := mount.Mount{
+		Type:        mount.TypeNamedPipe,
+		Source:      "/bar",
+		Target:      "/foo",
+		ReadOnly:    true,
+		BindOptions: &mount.BindOptions{Propagation: mount.PropagationShared},
+	}
+	config := composetypes.ServiceVolumeConfig{
+		Type:     "npipe",
+		Source:   "/bar",
+		Target:   "/foo",
+		ReadOnly: true,
+		Bind:     &composetypes.ServiceVolumeBind{Propagation: "shared"},
+	}
+	mnt, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, mnt))
+}
+
 func TestConvertVolumeToMountAnonymousNpipe(t *testing.T) {
 	config := composetypes.ServiceVolumeConfig{
 		Type:   "npipe",
@@ -426,4 +583,99 @@ func TestConvertVolumeMountClusterGroup(t *testing.T) {
 	mnt, err := convertVolumeToMount(config, stackVolumes, NewNamespace("foo"))
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(expected, mnt))
+}
+
+func TestHandleClusterToMountAnonymousCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "invalid cluster source, source cannot be empty")
+}
+
+func TestHandleClusterToMountConflictingOptionsTmpfsInCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "/foo",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "tmpfs options are incompatible with type cluster")
+}
+
+func TestHandleClusterToMountConflictingOptionsVolumeInCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "/foo",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "volume options are incompatible with type cluster")
+}
+
+func TestHandleClusterToMountWithUndefinedVolumeConfig(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "foo",
+		Target: "/srv",
+	}
+
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "undefined volume \"foo\"")
+}
+
+func TestHandleClusterToMountWithVolumeConfigName(t *testing.T) {
+	stackVolumes := volumes{
+		"foo": composetypes.VolumeConfig{
+			Name: "bar",
+		},
+	}
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "foo",
+		Target: "/srv",
+	}
+
+	expected := mount.Mount{
+		Type:           mount.TypeCluster,
+		Source:         "bar",
+		Target:         "/srv",
+		ClusterOptions: &mount.ClusterOptions{},
+	}
+
+	mnt, err := convertVolumeToMount(config, stackVolumes, NewNamespace("foo"))
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, mnt))
+}
+
+func TestHandleClusterToMountBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+	config := composetypes.ServiceVolumeConfig{
+		Type:     "cluster",
+		Source:   "/bar",
+		Target:   "/foo",
+		ReadOnly: true,
+		Bind:     &composetypes.ServiceVolumeBind{Propagation: "shared"},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "bind options are incompatible with type cluster")
 }

--- a/opts/network_test.go
+++ b/opts/network_test.go
@@ -135,3 +135,18 @@ func TestNetworkOptAdvancedSyntaxInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkOptStringNetOptString(t *testing.T) {
+	networkOpt := &NetworkOpt{}
+	result := networkOpt.String()
+	assert.Check(t, is.Equal("", result))
+	if result != "" {
+		t.Errorf("Expected an empty string, got %s", result)
+	}
+}
+
+func TestNetworkOptTypeNetOptType(t *testing.T) {
+	networkOpt := &NetworkOpt{}
+	result := networkOpt.Type()
+	assert.Check(t, is.Equal("network", result))
+}

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -465,3 +465,18 @@ func TestParseLink(t *testing.T) {
 		t.Fatalf("Expected error 'bad format for links: link:alias:wrong' but got: %v", err)
 	}
 }
+
+func TestGetAllOrEmptyReturnsNilOrValue(t *testing.T) {
+	opts := NewListOpts(nil)
+	assert.Check(t, is.DeepEqual(opts.GetAllOrEmpty(), []string{}))
+	opts.Set("foo")
+	assert.Check(t, is.DeepEqual(opts.GetAllOrEmpty(), []string{"foo"}))
+}
+
+func TestParseCPUsReturnZeroOnInvalidValues(t *testing.T) {
+	resValue, _ := ParseCPUs("foo")
+	var z1 int64 = 0
+	assert.Equal(t, z1, resValue)
+	resValue, _ = ParseCPUs("1e-32")
+	assert.Equal(t, z1, resValue)
+}


### PR DESCRIPTION
**- What I did**

Increased test coverage of `cli/compose/convert/volume.go` to 100%.

Fixed typo in `cli/compose/template/template_test.go` to reach the intended branch test in `extractVariables` func
It checks for `Strings.Contains` func checks for `:?` and not `?:`

Added tests of Descope and Name methods for Namespace in `cli/compose/convert/compose_test.go`.

Added test of convertEnvironment in case of nil value in `cli/compose/convert/service_test.go`.

Added tests for `capitalizeFirst` func in `cli/command/utils_test.go`.

Added tests of String and Type methods for NetworkOpt in `opts/network_test.go`.

Added test for GetAllOrEmpty method and for ParseCPUs in `opts/opts_test.go`.

**- How I did it**

We started by checking the [Code coverage](https://app.codecov.io/gh/docker) to see where testing was lacking and added test as we saw fit in order to increase the test coverage.

**- How to verify it**

Check difference as reported by codecov bot when triggered.

Verify it by running first running `make dev` and `make test` to check that all test passes and afterwards running the following commands to check that the test coverage has increaed:

```bash
$ go test -coverprofile=coverage.out ./...
$ go tool cover -html=coverage.out -o coverage.html
```

or 

`make test-coverage`

**- Description for the changelog**

Add various test cases for increased test coverage.

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/docker/cli/assets/64321057/f553b1f2-f0ee-4bb3-9340-f30bff3c7d90)
