### PR TITLE
Add a deprecation warning about --link on default nw

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -50,6 +50,7 @@ The table below provides an overview of the current status of deprecated feature
 
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
+| Deprecated | [Links on the default bridge network](#links-on-the-default-bridge-network)                                                        | v26.0      | -      |
 | Deprecated | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
 | Deprecated | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
 | Deprecated | [IsAutomated field, and "is-automated" filter on docker search](#isautomated-field-and-is-automated-filter-on-docker-search)       | v25.0      | v26.0  |
@@ -109,6 +110,18 @@ The table below provides an overview of the current status of deprecated feature
 | Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09 |
 | Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13  |
 | Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12  |
+
+### Links on the default bridge network
+
+**Deprecated in Release: v26.0**
+**Target for Removal In Release: v28.0**
+
+The `--link` option on `docker create` and `docker run`, when used with no
+`--network` specified, is deprecated in v26.0 and will be removed in a future
+release. Custom networks should be used instead.
+
+Note that, the `--link` option is still supported when a non-default network
+is used.
 
 ### Deprecate legacy API versions
 


### PR DESCRIPTION
Related to:

- https://github.com/moby/moby/pull/47427

**- What I did**

Update the "Deprecated Engine Features" doc page.