### PR TITLE
[25.0 backport] Avoid keeping @docker_cli_[UUID] files

### DIFF
--- a/cli-plugins/socket/socket_openbsd.go
+++ b/cli-plugins/socket/socket_openbsd.go
@@ -1,20 +1,19 @@
-//go:build !darwin && !openbsd
-
 package socket
 
 import (
 	"net"
+	"os"
+	"path/filepath"
+	"syscall"
 )
 
 func listen(socketname string) (*net.UnixListener, error) {
 	return net.ListenUnix("unix", &net.UnixAddr{
-		Name: "@" + socketname,
+		Name: filepath.Join(os.TempDir(), socketname),
 		Net:  "unix",
 	})
 }
 
 func onAccept(conn *net.UnixConn, listener *net.UnixListener) {
-	// do nothing
-	// while on darwin and OpenBSD we would unlink here;
-	// on non-darwin the socket is abstract and not present on the filesystem
+	syscall.Unlink(listener.Addr().String())
 }


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/4862

Seems that OpenBSD behaves like darwin and requires to unlink all socket, after it was used.

Tested on OpenBSD 7.4


(cherry picked from commit 2c214241fa2eb3b44d15d7aad587168d3bd70b48)