### PR TITLE
[25.0 backport] docker stack: allow '=' separator in extra_hosts

### DIFF
--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1302,12 +1302,14 @@ services:
     extra_hosts:
       "zulu": "162.242.195.82"
       "alpha": "50.31.209.229"
+      "beta": "[fd20:f8a7:6e5b::2]"
       "host.docker.internal": "host-gateway"
 `)
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
 		"alpha:50.31.209.229",
+		"beta:fd20:f8a7:6e5b::2",
 		"host.docker.internal:host-gateway",
 		"zulu:162.242.195.82",
 	}
@@ -1324,16 +1326,25 @@ services:
     image: busybox
     extra_hosts:
       - "zulu:162.242.195.82"
+      - "whiskey=162.242.195.83"
       - "alpha:50.31.209.229"
       - "zulu:ff02::1"
-      - "host.docker.internal:host-gateway"
+      - "whiskey=ff02::2"
+      - "foxtrot=[ff02::3]"
+      - "bravo:[ff02::4]"
+      - "host.docker.internal=host-gateway"
+      - "noaddress"
 `)
 	assert.NilError(t, err)
 
 	expected := types.HostsList{
 		"zulu:162.242.195.82",
+		"whiskey:162.242.195.83",
 		"alpha:50.31.209.229",
 		"zulu:ff02::1",
+		"whiskey:ff02::2",
+		"foxtrot:ff02::3",
+		"bravo:ff02::4",
 		"host.docker.internal:host-gateway",
 	}
 


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/4860

**- What I did**

The compose file format allows `=` as a separator in extra hosts, and `docker compose config` uses it instead of `:`.

Accept either separator in `docker stack deploy`, converting to `:` for the engine's API.

Also, remove brackets from IP addresses, as they're allowed by the compose file (although not generated by `docker compose config`).

Fixes #4859

**- How I did it**

Similar to changes in the CLI's `--add-hosts`, buildx and compose - check for an `=` separator first, then try `:`, and strip the brackets.

**- How to verify it**

As described in #4859 - plus updated unit tests.

**- Description for the changelog**

Accept '=' separators and '[ipv6]' in compose files for 'docker stack deploy'.