### PR TITLE
[25.0 backport] Fixed typo in bash completion functions

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1146,6 +1146,7 @@ __docker_complete_plugin() {
 	local path=$1
 	local completionCommand="__completeNoDesc"
 	local resultArray=($path $completionCommand)
+	local current="$cur"
 	for value in "${words[@]:2}"; do
 		if [ -z "$value" ]; then
 			resultArray+=( "''" )


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/4876


Fix for issue #4874