### PR TITLE
bake: Add `windows/arm64` target to bin-image-cross

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -186,6 +186,7 @@ target "bin-image-cross" {
     "linux/arm64",
     "linux/ppc64le",
     "linux/s390x",
-    "windows/amd64"
+    "windows/amd64",
+    "windows/arm64"
   ]
 }


### PR DESCRIPTION
Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>