### PR TITLE
vendor: github.com/docker/docker v26.0.0-rc2

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v26.0.0-rc1.0.20240307174919-f4c696eef17d+incompatible // 26.0.0-rc2
+	github.com/docker/docker v26.0.0-rc2+incompatible // 26.0.0-rc2
 	github.com/docker/docker-credential-helpers v0.8.1
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -54,8 +54,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.0.0-rc1.0.20240307174919-f4c696eef17d+incompatible h1:3KKLLQTG8GiV/4+OMpBuXm35zK75vbzwUxbp7AZuxdA=
-github.com/docker/docker v26.0.0-rc1.0.20240307174919-f4c696eef17d+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.0.0-rc2+incompatible h1:EgOKh0HdpXSSmV7dvxqySuLU2qNEySrv+LxFixZ0/jM=
+github.com/docker/docker v26.0.0-rc2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.1 h1:j/eKUktUltBtMzKqmfLB0PAgqYyMHOp5vfsD1807oKo=
 github.com/docker/docker-credential-helpers v0.8.1/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v26.0.0-rc1.0.20240307174919-f4c696eef17d+incompatible
+# github.com/docker/docker v26.0.0-rc2+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
no changes in vendored files

full diff: https://github.com/docker/docker/compare/f4c696eef17d...v26.0.0-rc2

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>