### PR TITLE
Add a description of '--internal' to the docs

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -184,6 +184,12 @@ $ docker network create \
 
 ### <a name="internal"></a> Network internal mode (--internal)
 
+Containers on an internal network may communicate between each other, but not
+with any other network, as no default route is configured and firewall rules
+are set up to drop all traffic to or from other networks. Communication with
+the gateway IP  address (and thus appropriately configured host services) is
+possible, and the host may communicate with any container IP directly.
+
 By default, when you connect a container to an `overlay` network, Docker also
 connects a bridge network to it to provide external connectivity. If you want
 to create an externally isolated `overlay` network, you can specify the

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -162,7 +162,8 @@ equivalent Docker daemon flags used for docker0 bridge:
 | `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
-network driver, again with their approximate equivalents to `docker daemon`.
+network driver, again with their approximate equivalents to Docker daemon
+flags used for the docker0 bridge:
 
 | Argument     | Equivalent     | Description                                |
 |--------------|----------------|--------------------------------------------|


### PR DESCRIPTION
**- What I did**

Add a description of a --internal network (written by @neersighted) to the CLI docs - as they currently only mention overlay networks.

(Also, while I was there, update the description for the table listing 'network create' options, to make it consistent with the table listing 'bridge' options.)

**- How I did it**

**- How to verify it**

**- Description for the changelog**

Added a description of --internal networks to the docs.

**- A picture of a cute animal (not mandatory but encouraged)**

