### PR TITLE
Set CGO_ENABLED=1 on riscv64

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -48,7 +48,7 @@ if [ -z "$CGO_ENABLED" ]; then
     case "$(go env GOOS)" in
         linux)
             case "$(go env GOARCH)" in
-                amd64|arm64|arm|s390x)
+                amd64|arm64|arm|s390x|riscv64)
                     CGO_ENABLED=1
                 ;;
                 *)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Set CGO_ENABLED=1 on riscv64
CGO works fine on riscv64 thus should be enabled.
Avoid build error https://github.com/golang/go/issues/64875

**- How I did it**

Add riscv64 case in `scripts/build/.variables`

**- How to verify it**

[Arch Linux PKGBUILD](https://gitlab.archlinux.org/archlinux/packaging/packages/docker/-/blob/1-25.0.3-1/PKGBUILD?ref_type=tags) doesn't build on riscv64, as it uses `-buildmode=pie` and `scripts/build/.variables` sets `CGO_ENABLED=0` before the PR.
With this PR, it builds fine.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Set CGO_ENABLED=1 on riscv64

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/docker/cli/assets/13995937/dad22566-ef3c-443a-86f2-30c03e461023)

