### PR TITLE
builder: correct the command path for docker build

### DIFF
--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -69,7 +69,7 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	}
 
 	// is this a build that should be forwarded to the builder?
-	fwargs, fwosargs, alias, forwarded := forwardBuilder(builderAlias, args, osargs)
+	fwargs, fwosargs, fwcmdpath, forwarded := forwardBuilder(builderAlias, args, osargs)
 	if !forwarded {
 		return args, osargs, nil, nil
 	}
@@ -117,33 +117,37 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	}
 
 	// overwrite the command path for this plugin using the alias name.
-	cmd.Annotations[pluginmanager.CommandAnnotationPluginCommandPath] = fmt.Sprintf("%s %s", cmd.CommandPath(), alias)
+	cmd.Annotations[pluginmanager.CommandAnnotationPluginCommandPath] = strings.Join(append([]string{cmd.CommandPath()}, fwcmdpath...), " ")
 
 	return fwargs, fwosargs, envs, nil
 }
 
-func forwardBuilder(alias string, args, osargs []string) ([]string, []string, string, bool) {
-	aliases := [][2][]string{
+func forwardBuilder(alias string, args, osargs []string) ([]string, []string, []string, bool) {
+	aliases := [][3][]string{
 		{
 			{"builder"},
 			{alias},
+			{"builder"},
 		},
 		{
 			{"build"},
 			{alias, "build"},
+			{},
 		},
 		{
 			{"image", "build"},
 			{alias, "build"},
+			{"image"},
 		},
 	}
 	for _, al := range aliases {
 		if fwargs, changed := command.StringSliceReplaceAt(args, al[0], al[1], 0); changed {
 			fwosargs, _ := command.StringSliceReplaceAt(osargs, al[0], al[1], -1)
-			return fwargs, fwosargs, al[0][0], true
+			fwcmdpath := al[2]
+			return fwargs, fwosargs, fwcmdpath, true
 		}
 	}
-	return args, osargs, "", false
+	return args, osargs, nil, false
 }
 
 // hasBuilderName checks if a builder name is defined in args or env vars


### PR DESCRIPTION
**- What I did**

The command path sent for `docker build` should be `docker` rather than `docker build` to be consistent with the other command paths.

* `docker buildx build` has a command path of `docker buildx`
* `docker builder build` has a command path of `docker builder`
* `docker image build` has a command path of `docker image`

The reason this gets set to `docker buildx` rather than `docker buildx build` is because the `build` portion of the command path is processed by the plugin. So the command path only contains the portions of the command path that were processed by this tool.

Since the `build` of `docker build` gets forwarded to `buildx`, it is not included in the command path.

**- How I did it**

Modified the process for how the command path gets set.

**- How to verify it**

Inside of buildkit, you can do `hack/compose -f hack/composefiles/extensions/buildx.yaml up -d --build`. Then do `docker logs -f buildkit-otel-collector-1`.

Compile master of `buildx` to a location where the docker cli can find it. Compile this change. Run `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 BUILDX_EXPERIMENTAL=true docker build ...` and look a the debug output.
