### PR TITLE
scripts/vendor: remove -compat=1.19

### DIFF
--- a/scripts/vendor
+++ b/scripts/vendor
@@ -23,7 +23,7 @@ EOL
 }
 
 update() {
-  (set -x ; go mod tidy -compat=1.19 -modfile=vendor.mod; go mod vendor -modfile=vendor.mod)
+  (set -x ; go mod tidy -modfile=vendor.mod; go mod vendor -modfile=vendor.mod)
 }
 
 validate() {


### PR DESCRIPTION
We originally added this -compat to keep a consistent format of the vendor.mod files for cases where there were differences between go versions.

I don't think we really need this anymore, so let's remove.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

