### PR TITLE
fix: flaky prompt termination on reader close test

### DIFF
--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -197,13 +197,11 @@ func TestPromptForConfirmation(t *testing.T) {
 			promptReader, promptWriter = io.Pipe()
 
 			wroteHook := make(chan struct{}, 1)
-			defer close(wroteHook)
 			promptOut := test.NewWriterWithHook(bufioWriter, func(p []byte) {
 				wroteHook <- struct{}{}
 			})
 
 			result := make(chan promptResult, 1)
-			defer close(result)
 			go func() {
 				r, err := command.PromptForConfirmation(ctx, promptReader, promptOut, "")
 				result <- promptResult{r, err}
@@ -216,7 +214,7 @@ func TestPromptForConfirmation(t *testing.T) {
 			assert.NilError(t, bufioWriter.Flush())
 			assert.Equal(t, strings.TrimSpace(buf.String()), "Are you sure you want to proceed? [y/N]")
 
-			resultCtx, resultCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			resultCtx, resultCancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer resultCancel()
 
 			tc.f(t, resultCtx, result)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes https://github.com/docker/cli/issues/4948

**- What I did**
Increase the context timeout from 100ms to 500ms. Removed the manual close on the result channels to prevent panics on test failures.

**- How I did it**

**- How to verify it**

```shell
$ go test -v -run=TestPromptForConfirmation/case=reader_closed -count=1000 ./cli/command/utils_test.go

=== RUN   TestPromptForConfirmation/case=reader_closed
--- PASS: TestPromptForConfirmation (0.00s)
    --- PASS: TestPromptForConfirmation/case=reader_closed (0.00s)
PASS
ok  	command-line-arguments	0.263s
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix TestPromptForConfirmation flakiness

**- A picture of a cute animal (not mandatory but encouraged)**

