### PR TITLE
plugin: drop explicit unlink

### DIFF
--- a/cli-plugins/socket/socket_abstract.go
+++ b/cli-plugins/socket/socket_abstract.go
@@ -2,19 +2,8 @@
 
 package socket
 
-import (
-	"net"
-)
-
-func listen(socketname string) (*net.UnixListener, error) {
-	// Create an abstract socket -- this socket can be opened by name, but is
-	// not present in the filesystem.
-	return net.ListenUnix("unix", &net.UnixAddr{
-		Name: "@" + socketname,
-		Net:  "unix",
-	})
-}
-
-func unlink(listener *net.UnixListener) {
-	// Do nothing; the socket is not present in the filesystem.
+func socketName(basename string) string {
+	// Address of an abstract socket -- this socket can be opened by name,
+	// but is not present in the filesystem.
+	return "@" + basename
 }

--- a/cli-plugins/socket/socket_noabstract.go
+++ b/cli-plugins/socket/socket_noabstract.go
@@ -3,23 +3,12 @@
 package socket
 
 import (
-	"net"
 	"os"
 	"path/filepath"
-	"syscall"
 )
 
-func listen(socketname string) (*net.UnixListener, error) {
-	// Because abstract sockets are unavailable, we create a socket in the
-	// system temporary directory instead.
-	return net.ListenUnix("unix", &net.UnixAddr{
-		Name: filepath.Join(os.TempDir(), socketname),
-		Net:  "unix",
-	})
-}
-
-func unlink(listener *net.UnixListener) {
-	// unlink(2) is best effort here; if it fails, we may 'leak' a socket
-	// into the filesystem, but this is unlikely and overall harmless.
-	_ = syscall.Unlink(listener.Addr().String())
+func socketName(basename string) string {
+	// Because abstract sockets are unavailable, use a socket path in the
+	// system temporary directory.
+	return filepath.Join(os.TempDir(), basename)
 }


### PR DESCRIPTION
Go's `net` package [will unlink][1] for us, as long as we used listen to create the Unix socket.

Go will even skip the unlink when the socket appears to be abstract (start with a NUL, represented by an @), though we must be cautious to only create sockets with an abstract address on platforms that actually support it -- this caused [several][2] [bugs][3] before.

  [1]: https://pkg.go.dev/net#UnixListener.SetUnlinkOnClose
  [2]: https://github.com/docker/cli/pull/4783
  [3]: https://github.com/docker/cli/pull/4863
