### PR TITLE
cli/config: add GetFeature, SetFeature for ConfigFile

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -351,3 +351,26 @@ func (configFile *ConfigFile) SetPluginConfig(pluginname, option, value string) 
 		delete(configFile.Plugins, pluginname)
 	}
 }
+
+// GetFeature retrieves the given key from the config features map.
+func (configFile *ConfigFile) GetFeature(key string) (string, bool) {
+	if configFile.Features == nil {
+		return "", false
+	}
+	v, ok := configFile.Features[key]
+	return v, ok
+}
+
+// SetFeature sets the key to the given value in the config features map.
+// If the features field is nil, it initializes a new map.
+// Passing a value of "" will remove the key-value pair from the map.
+func (configFile *ConfigFile) SetFeature(key, value string) {
+	if configFile.Features == nil {
+		configFile.Features = make(map[string]string)
+	}
+	if value != "" {
+		configFile.Features[key] = value
+	} else {
+		delete(configFile.Features, key)
+	}
+}

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -602,3 +602,57 @@ func TestPluginConfig(t *testing.T) {
 	assert.NilError(t, err)
 	golden.Assert(t, string(cfg), "plugin-config-2.golden")
 }
+
+func TestSetFeature(t *testing.T) {
+	t.Run("new feature", func(t *testing.T) {
+		configFile := &ConfigFile{}
+
+		configFile.SetFeature("foo", "bar")
+
+		assert.Equal(t, "bar", configFile.Features["foo"])
+	})
+
+	t.Run("update key", func(t *testing.T) {
+		configFile := &ConfigFile{}
+
+		configFile.SetFeature("foo", "bar")
+		assert.Equal(t, "bar", configFile.Features["foo"])
+
+		configFile.SetFeature("foo", "baz")
+		assert.Equal(t, "baz", configFile.Features["foo"])
+	})
+
+	t.Run("remove feature", func(t *testing.T) {
+		configFile := &ConfigFile{}
+
+		configFile.SetFeature("foo", "bar")
+		assert.Equal(t, "bar", configFile.Features["foo"])
+
+		configFile.SetFeature("foo", "")
+		_, exists := configFile.Features["foo"]
+		assert.Check(t, !exists)
+	})
+}
+
+func TestGetFeature(t *testing.T) {
+	t.Run("feature exists", func(t *testing.T) {
+		configFile := &ConfigFile{}
+		configFile.Features = map[string]string{
+			"foo": "bar",
+		}
+
+		f, ok := configFile.GetFeature("foo")
+
+		assert.Check(t, ok)
+		assert.Equal(t, "bar", f)
+	})
+
+	t.Run("missing feature", func(t *testing.T) {
+		configFile := &ConfigFile{}
+
+		f, ok := configFile.GetFeature("baz")
+
+		assert.Check(t, !ok)
+		assert.Equal(t, "", f)
+	})
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add exported functions to get/set values from `ConfigFile.Features` map introduced in https://github.com/docker/cli/commit/c5016c6d5ba4d8c6a4e258a926d46fe420b476f2.

**- How I did it**

Carefully.

**- How to verify it**

```console
go test -v -count=1 -run=Test.etFeature ./cli/config/...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/70572044/a5e4ba05-aacc-4d14-b3ae-187d27a7662c)

