### PR TITLE
feat: relative parent paths on bind mount src

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -375,7 +375,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 			if parsed.Type == string(mounttypes.TypeBind) {
 				if hostPart, targetPath, ok := strings.Cut(bind, ":"); ok {
-					if strings.HasPrefix(hostPart, "."+string(filepath.Separator)) || hostPart == "." {
+					if !filepath.IsAbs(hostPart) && strings.HasPrefix(hostPart, ".") {
 						if absHostPart, err := filepath.Abs(hostPart); err == nil {
 							hostPart = absHostPart
 						}

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -100,7 +100,7 @@ func (m *MountOpt) Set(value string) error {
 			mount.Type = mounttypes.Type(strings.ToLower(val))
 		case "source", "src":
 			mount.Source = val
-			if strings.HasPrefix(val, "."+string(filepath.Separator)) || val == "." {
+			if !filepath.IsAbs(val) && strings.HasPrefix(val, ".") {
 				if abs, err := filepath.Abs(val); err == nil {
 					mount.Source = abs
 				}

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -39,10 +39,21 @@ func TestMountRelative(t *testing.T) {
 			name: "Current path",
 			path: ".",
 			bind: "type=bind,source=.,target=/target",
-		}, {
+		},
+		{
 			name: "Current path with slash",
 			path: "./",
 			bind: "type=bind,source=./,target=/target",
+		},
+		{
+			name: "Parent path with slash",
+			path: "../",
+			bind: "type=bind,source=../,target=/target",
+		},
+		{
+			name: "Parent path",
+			path: "..",
+			bind: "type=bind,source=..,target=/target",
 		},
 	} {
 		t.Run(testcase.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
This is a follow-up PR of https://github.com/docker/cli/pull/3469

**- What I did**
The `source` value of `-v/--volume/--mount` is validated, if **not** absolute **and** contains the `.` prefix the value is converted to an absolute path. This prefix (`.`) is always required for `source` since the `-v/--volume/--mount` flags also support setting named volumes.
 
**- How I did it**

**- How to verify it**
- CI tests
- `docker run --rm -v ../:/test busybox ls -l /test`
- `docker run --rm --mount type=bind,source=../,target=/test busybox ls -l /test`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
```markdown changelog
Add support for relative parent paths (`../`) on bind mount sources when using `docker run/create` with `-v/--volume` or `--mount type=bind` options.
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/docker/cli/assets/18033717/e5c1dc49-b1ed-4f79-9075-23f6681513e5)

