### PR TITLE
Feature option 'windows-dns-proxy'

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -1236,6 +1236,12 @@ The list of feature options include:
   snapshotters instead of the classic storage drivers for storing image and
   container data. For more information, see
   [containerd storage](https://docs.docker.com/storage/containerd/).
+- `windows-dns-proxy`: when set to `true`, the daemon's internal DNS resolver
+  will forward requests to external servers. Without this, most applications
+  running in the container will still be able to use secondary DNS servers
+  configured in the container itself, but `nslookup` won't be able to resolve
+  external names. The current default is `false`, it will change to `true` in
+  a future release. This option is only allowed on Windows.
 
 #### Configuration reload behavior
 

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -1243,6 +1243,9 @@ The list of feature options include:
   external names. The current default is `false`, it will change to `true` in
   a future release. This option is only allowed on Windows.
 
+  > **Warning**
+  > The `windows-dns-proxy` feature flag will be removed in a future release.
+
 #### Configuration reload behavior
 
 Some options can be reconfigured when the daemon is running without requiring


### PR DESCRIPTION
**- What I did**

- related to https://github.com/moby/moby/pull/47584

Document feature option 'windows-dns-proxy', which can be used to enable or disable forwarding of DNS requests from the daemon's internal resolver to external servers.

The default is `false`, for release 26.1 - and the plan is to change it to `true` in 27.0.

**- How I did it**
n/a

**- How to verify it**
n/a

**- Description for the changelog**
Document feature option 'windows-dns-proxy'.
