### PR TITLE
command: include default otel error handler for the cli

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -12,15 +12,17 @@ import (
 	"github.com/docker/cli/cli-plugins/socket"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/connhelper"
+	"github.com/docker/cli/cli/debug"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 )
 
 // PersistentPreRunE must be called by any plugin command (or
 // subcommand) which uses the cobra `PersistentPreRun*` hook. Plugins
 // which do not make use of `PersistentPreRun*` do not need to call
 // this (although it remains safe to do so). Plugins are recommended
-// to use `PersistenPreRunE` to enable the error to be
+// to use `PersistentPreRunE` to enable the error to be
 // returned. Should not be called outside of a command's
 // PersistentPreRunE hook and must not be run unless Run has been
 // called.
@@ -66,6 +68,8 @@ func RunPlugin(dockerCli *command.DockerCli, plugin *cobra.Command, meta manager
 
 // Run is the top-level entry point to the CLI plugin framework. It should be called from your plugin's `main()` function.
 func Run(makeCmd func(command.Cli) *cobra.Command, meta manager.Metadata) {
+	otel.SetErrorHandler(debug.OTELErrorHandler)
+
 	dockerCli, err := command.NewDockerCli()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cli/debug/debug.go
+++ b/cli/debug/debug.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
 )
 
 // Enable sets the DEBUG env var to true
@@ -24,3 +25,13 @@ func Disable() {
 func IsEnabled() bool {
 	return os.Getenv("DEBUG") != ""
 }
+
+// OTELErrorHandler is an error handler for OTEL that
+// uses the CLI debug package to log messages when an error
+// occurs.
+//
+// The default is to log to the debug level which is only
+// enabled when debugging is enabled.
+var OTELErrorHandler otel.ErrorHandler = otel.ErrorHandlerFunc(func(err error) {
+	logrus.WithError(err).Debug("otel error")
+})

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/cli-plugins/socket"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
+	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	platformsignals "github.com/docker/cli/cmd/docker/internal/signals"
@@ -33,6 +34,7 @@ func main() {
 		os.Exit(1)
 	}
 	logrus.SetOutput(dockerCli.Err())
+	otel.SetErrorHandler(debug.OTELErrorHandler)
 
 	if err := runDocker(ctx, dockerCli); err != nil {
 		if sterr, ok := err.(cli.StatusError); ok {


### PR DESCRIPTION
**- What I did**

This adds a default otel error handler for the cli in the debug package.
It uses logrus to log the error on the debug level and should work out
of the box with the `--debug` flag and `DEBUG` environment variable.

**- How I did it**

Created a function for handling the error that logs the message to `logrus` and registered it with this type: https://pkg.go.dev/go.opentelemetry.io/otel#ErrorHandlerFunc

**- How to verify it**

```
$ DOCKER_CLI_OTEL_EXPORTER_OTLP_ENDPOINT=://blah docker --debug info
DEBU[0000] otel error                                    error="docker otel endpoint is invalid: parse \"://blah\": missing protocol scheme"
```

Without this change, the output is:

```
2024/04/01 09:51:53 docker otel endpoint is invalid: parse "://blah": missing protocol scheme
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Include otel-related errors in debug logs.

**- A picture of a cute animal (not mandatory but encouraged)**
