### PR TITLE
cli/push: Add `platform` switch 

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -12,11 +13,13 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/docker/api/types/auxprogress"
 	"github.com/docker/docker/api/types/image"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/moby/term"
+	"github.com/morikuni/aec"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -62,6 +65,8 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 // RunPush performs a push against the engine based on the specified options
+//
+//nolint:gocyclo
 func RunPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error {
 	var platform *ocispec.Platform
 	if opts.platform != "" {
@@ -74,9 +79,8 @@ func RunPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error
 
 		printNote(dockerCli, `Selecting a single platform will only push one matching image manifest from a multi-platform image index.
 This means that any other components attached to the multi-platform image index (like Buildkit attestations) won't be pushed.
-If you want to only push a single platform image while preserving the attestations, please build an image with only that platform and push it instead.
-Example: echo "FROM %s" | docker build - --platform %s -t <NEW-TAG>
-`, opts.remote, opts.platform)
+If you want to only push a single platform image while preserving the attestations, please use 'docker convert\n'
+`)
 	}
 
 	ref, err := reference.ParseNormalizedNamed(opts.remote)
@@ -117,6 +121,13 @@ Example: echo "FROM %s" | docker build - --platform %s -t <NEW-TAG>
 		return err
 	}
 
+	defer func() {
+		for _, note := range notes {
+			fmt.Fprintln(dockerCli.Err(), "")
+			printNote(dockerCli, note)
+		}
+	}()
+
 	defer responseBody.Close()
 	if !opts.untrusted {
 		// TODO PushTrustedReference currently doesn't respect `--quiet`
@@ -124,20 +135,51 @@ Example: echo "FROM %s" | docker build - --platform %s -t <NEW-TAG>
 	}
 
 	if opts.quiet {
-		err = jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(io.Discard), nil)
+		err = jsonmessage.DisplayJSONMessagesToStream(responseBody, streams.NewOut(io.Discard), handleAux(dockerCli))
 		if err == nil {
 			fmt.Fprintln(dockerCli.Out(), ref.String())
 		}
 		return err
 	}
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), handleAux(dockerCli))
+}
+
+var notes []string
+
+func handleAux(dockerCli command.Cli) func(jm jsonmessage.JSONMessage) {
+	return func(jm jsonmessage.JSONMessage) {
+		b := []byte(*jm.Aux)
+
+		var stripped auxprogress.ManifestPushedInsteadOfIndex
+		err := json.Unmarshal(b, &stripped)
+		if err == nil && stripped.ManifestPushedInsteadOfIndex {
+			note := fmt.Sprintf("Not all multiplatform-content is present and only the available single-platform image was pushed\n%s -> %s",
+				aec.RedF.Apply(stripped.OriginalIndex.Digest.String()),
+				aec.GreenF.Apply(stripped.SelectedManifest.Digest.String()),
+			)
+			notes = append(notes, note)
+		}
+
+		var missing auxprogress.ContentMissing
+		err = json.Unmarshal(b, &missing)
+		if err == nil && missing.ContentMissing {
+			note := `You're trying to push a manifest list/index which 
+				references multiple platform specific manifests, but not all of them are available locally
+				or available to the remote repository.
+
+				Make sure you have all the referenced content and try again.
+
+				You can also push only a single platform specific manifest directly by specifying the platform you want to push with the --platform flag.`
+			notes = append(notes, note)
+		}
+	}
 }
 
 func printNote(dockerCli command.Cli, format string, args ...any) {
 	if _, isTTY := term.GetFdInfo(dockerCli.Err()); isTTY {
-		_, _ = fmt.Fprint(dockerCli.Err(), "\x1b[1;37m\x1b[1;46m[ NOTE ]\x1b[0m\x1b[0m ")
+		_, _ = fmt.Fprint(dockerCli.Err(), aec.WhiteF.Apply(aec.CyanB.Apply("[ NOTE ]"))+" ")
 	} else {
 		_, _ = fmt.Fprint(dockerCli.Err(), "[ NOTE ] ")
 	}
-	_, _ = fmt.Fprintf(dockerCli.Err(), format+"\n\n", args...)
+	_, _ = fmt.Fprintf(dockerCli.Err(), aec.Bold.Apply(format)+"\n", args...)
 }

--- a/docs/reference/commandline/image_push.md
+++ b/docs/reference/commandline/image_push.md
@@ -9,11 +9,12 @@ Upload an image to a registry
 
 ### Options
 
-| Name                                         | Type   | Default | Description                                 |
-|:---------------------------------------------|:-------|:--------|:--------------------------------------------|
-| [`-a`](#all-tags), [`--all-tags`](#all-tags) |        |         | Push all tags of an image to the repository |
-| `--disable-content-trust`                    | `bool` | `true`  | Skip image signing                          |
-| `-q`, `--quiet`                              |        |         | Suppress verbose output                     |
+| Name                                         | Type     | Default | Description                                                                                                                                 |
+|:---------------------------------------------|:---------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------|
+| [`-a`](#all-tags), [`--all-tags`](#all-tags) |          |         | Push all tags of an image to the repository                                                                                                 |
+| `--disable-content-trust`                    | `bool`   | `true`  | Skip image signing                                                                                                                          |
+| `--platform`                                 | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
+| `-q`, `--quiet`                              |          |         | Suppress verbose output                                                                                                                     |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -9,11 +9,12 @@ Upload an image to a registry
 
 ### Options
 
-| Name                      | Type   | Default | Description                                 |
-|:--------------------------|:-------|:--------|:--------------------------------------------|
-| `-a`, `--all-tags`        |        |         | Push all tags of an image to the repository |
-| `--disable-content-trust` | `bool` | `true`  | Skip image signing                          |
-| `-q`, `--quiet`           |        |         | Suppress verbose output                     |
+| Name                      | Type     | Default | Description                                                                                                                                 |
+|:--------------------------|:---------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------|
+| `-a`, `--all-tags`        |          |         | Push all tags of an image to the repository                                                                                                 |
+| `--disable-content-trust` | `bool`   | `true`  | Skip image signing                                                                                                                          |
+| `--platform`              | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
+| `-q`, `--quiet`           |          |         | Suppress verbose output                                                                                                                     |
 
 
 <!---MARKER_GEN_END-->

--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v26.1.1-0.20240610145149-a736d0701c41+incompatible // master (v27.0.0-dev)
+	github.com/docker/docker v26.1.1-0.20240610201418-9d9488468fe2+incompatible // master (v27.0.0-dev)
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -59,8 +59,8 @@ github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.1-0.20240610145149-a736d0701c41+incompatible h1:Kraon288jb3POkrmM5w6Xo979z2rrCtFzHycAjafRes=
-github.com/docker/docker v26.1.1-0.20240610145149-a736d0701c41+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.1-0.20240610201418-9d9488468fe2+incompatible h1:k63BdhjySkwvmdeofOsBElcuVrWaDBrI7FQgnyoVnnM=
+github.com/docker/docker v26.1.1-0.20240610201418-9d9488468fe2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -1368,7 +1368,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always empty and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always empty. It must not be used, and will be removed in API v1.47.
         type: "string"
         example: ""
       Domainname:
@@ -1377,7 +1378,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always empty and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always empty. It must not be used, and will be removed in API v1.47.
         type: "string"
         example: ""
       User:
@@ -1390,7 +1392,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1400,7 +1403,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1410,7 +1414,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1436,7 +1441,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1446,7 +1452,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1456,7 +1463,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always false and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always false. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1492,7 +1500,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always empty and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always empty. It must not be used, and will be removed in API v1.47.
         type: "string"
         default: ""
         example: ""
@@ -1530,7 +1539,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always omitted and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always omitted. It must not be used, and will be removed in API v1.47.
         type: "boolean"
         default: false
         example: false
@@ -1541,7 +1551,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Deprecated**: this field is deprecated in API v1.44 and up. It is always omitted.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always omitted. It must not be used, and will be removed in API v1.47.
         type: "string"
         default: ""
         example: ""
@@ -1574,7 +1585,8 @@ definitions:
 
           <p><br /></p>
 
-          > **Note**: this field is always omitted and must not be used.
+          > **Deprecated**: this field is not part of the image specification and is
+          > always omitted. It must not be used, and will be removed in API v1.47.
         type: "integer"
         default: 10
         x-nullable: true
@@ -2115,6 +2127,7 @@ definitions:
             format: "dateTime"
             example: "2022-02-28T14:40:02.623929178Z"
             x-nullable: true
+
   ImageSummary:
     type: "object"
     x-go-name: "Summary"
@@ -9023,6 +9036,11 @@ paths:
             details.
           type: "string"
           required: true
+        - name: "platform"
+          in: "query"
+          description: "Select a platform-specific manifest to be pushed. OCI platform (JSON encoded)"
+          type: "string"
+          x-nullable: true
       tags: ["Image"]
   /images/{name}/tag:
     post:

--- a/vendor/github.com/docker/docker/api/types/auxprogress/push.go
+++ b/vendor/github.com/docker/docker/api/types/auxprogress/push.go
@@ -1,0 +1,26 @@
+package auxprogress
+
+import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ManifestPushedInsteadOfIndex is a note that is sent when a manifest is pushed
+// instead of an index.  It is sent when the pushed image is an multi-platform
+// index, but the whole index couldn't be pushed.
+type ManifestPushedInsteadOfIndex struct {
+	ManifestPushedInsteadOfIndex bool `json:"manifestPushedInsteadOfIndex"` // Always true
+
+	// OriginalIndex is the descriptor of the original image index.
+	OriginalIndex ocispec.Descriptor `json:"originalIndex"`
+
+	// SelectedManifest is the descriptor of the manifest that was pushed instead.
+	SelectedManifest ocispec.Descriptor `json:"selectedManifest"`
+}
+
+// ContentMissing is a note that is sent when push fails because the content is missing.
+type ContentMissing struct {
+	ContentMissing bool `json:"contentMissing"` // Always true
+
+	// Desc is the descriptor of the root object that was attempted to be pushed.
+	Desc ocispec.Descriptor `json:"desc"`
+}

--- a/vendor/github.com/docker/docker/api/types/image/opts.go
+++ b/vendor/github.com/docker/docker/api/types/image/opts.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types/filters"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImportSource holds source information for ImageImport
@@ -43,7 +44,23 @@ type PullOptions struct {
 }
 
 // PushOptions holds information to push images.
-type PushOptions PullOptions
+type PushOptions struct {
+	All          bool
+	RegistryAuth string // RegistryAuth is the base64 encoded credentials for the registry
+
+	// PrivilegeFunc is a function that clients can supply to retry operations
+	// after getting an authorization error. This function returns the registry
+	// authentication header value in base64 encoded format, or an error if the
+	// privilege request fails.
+	//
+	// Also see [github.com/docker/docker/api/types.RequestPrivilegeFunc].
+	PrivilegeFunc func(context.Context) (string, error)
+
+	// Platform is an optional field that selects a specific platform to push
+	// when the image is a multi-platform image.
+	// Using this will only push a single platform-specific manifest.
+	Platform *ocispec.Platform `json:",omitempty"`
+}
 
 // ListOptions holds parameters to list images with.
 type ListOptions struct {

--- a/vendor/github.com/docker/docker/client/image_push.go
+++ b/vendor/github.com/docker/docker/client/image_push.go
@@ -2,7 +2,9 @@ package client // import "github.com/docker/docker/client"
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -34,6 +36,20 @@ func (cli *Client) ImagePush(ctx context.Context, image string, options image.Pu
 		if tagged, ok := ref.(reference.Tagged); ok {
 			query.Set("tag", tagged.Tag())
 		}
+	}
+
+	if options.Platform != nil {
+		if err := cli.NewVersionError(ctx, "1.46", "platform"); err != nil {
+			return nil, err
+		}
+
+		p := *options.Platform
+		pJson, err := json.Marshal(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid platform: %v", err)
+		}
+
+		query.Set("platform", string(pJson))
 	}
 
 	resp, err := cli.tryImagePush(ctx, name, query, options.RegistryAuth)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,6 +60,7 @@ github.com/docker/distribution/uuid
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types
+github.com/docker/docker/api/types/auxprogress
 github.com/docker/docker/api/types/blkiodev
 github.com/docker/docker/api/types/checkpoint
 github.com/docker/docker/api/types/container

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v26.1.1-0.20240610145149-a736d0701c41+incompatible
+# github.com/docker/docker v26.1.1-0.20240610201418-9d9488468fe2+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- needs: https://github.com/moby/moby/pull/47679

**- What I did**
Added a `platform` switch to `docker image push`.

**- How I did it**

**- How to verify it**
```bash
$ docker pull --platform linux/arm64 busybox
$ docker tag busybox myimage
$ docker push --platform linux/arm64 myimage
```

**- Description for the changelog**
```markdown changelog
containerd image store: Add `--platform` switch to `docker image push`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

