### PR TITLE
otel: capture exit code as int64

### DIFF
--- a/cli/command/telemetry_utils.go
+++ b/cli/command/telemetry_utils.go
@@ -3,7 +3,6 @@ package command
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -110,7 +109,7 @@ func attributesFromError(err error) []attribute.KeyValue {
 		}
 		attrs = append(attrs, attribute.String("command.error.type", otelErrorType(err)))
 	}
-	attrs = append(attrs, attribute.String("command.status.code", strconv.Itoa(exitCode)))
+	attrs = append(attrs, attribute.Int("command.status.code", exitCode))
 
 	return attrs
 }

--- a/cli/command/telemetry_utils_test.go
+++ b/cli/command/telemetry_utils_test.go
@@ -159,7 +159,7 @@ func TestAttributesFromError(t *testing.T) {
 			testName: "no error",
 			err:      nil,
 			expected: []attribute.KeyValue{
-				attribute.String("command.status.code", "0"),
+				attribute.Int("command.status.code", 0),
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestAttributesFromError(t *testing.T) {
 			err:      statusError{StatusCode: 127},
 			expected: []attribute.KeyValue{
 				attribute.String("command.error.type", "generic"),
-				attribute.String("command.status.code", "127"),
+				attribute.Int("command.status.code", 127),
 			},
 		},
 		{
@@ -175,7 +175,7 @@ func TestAttributesFromError(t *testing.T) {
 			err:      context.Canceled,
 			expected: []attribute.KeyValue{
 				attribute.String("command.error.type", "canceled"),
-				attribute.String("command.status.code", "1"),
+				attribute.Int("command.status.code", 1),
 			},
 		},
 	} {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Capture exit code as int64 (it used to be a string!)

**- How I did it**

By changing characters in source files!

**- How to verify it**

Run the relevant tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

