### PR TITLE
cli-bin/windows: Add .exe extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,8 +123,14 @@ COPY --link . .
 FROM scratch AS plugins
 COPY --from=build-plugins /out .
 
-FROM scratch AS bin-image
+FROM scratch AS bin-image-linux
 COPY --from=build /out/docker /docker
+FROM scratch AS bin-image-darwin
+COPY --from=build /out/docker /docker
+FROM scratch AS bin-image-windows
+COPY --from=build /out/docker /docker.exe
+
+FROM bin-image-${TARGETOS} AS bin-image
 
 FROM scratch AS binary
 COPY --from=build /out .


### PR DESCRIPTION
Before this commit, the CLI binary in `dockereng/cli-bin` image was named `docker` regardless of platform.

Change the binary name to `docker.exe` in Windows images.