### PR TITLE
Remove dead url reference.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,7 @@ anybody starts working on it.
 
 We are always thrilled to receive pull requests. We do our best to process them
 quickly. If your pull request is not accepted on the first try,
-don't get discouraged! Our contributor's guide explains [the review process we
-use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contribution/).
+don't get discouraged!
 
 ### Talking to other Docker users and contributors
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I removed a sentence with a dead url.

**- How I did it**
By just deleting it, i would have preferred to fix the reference, but there doesn't seem to be a review process anymore in the official docs.

**- How to verify it**
Just by trying to access https://docs.docker.com/opensource/workflow/make-a-contribution/
I even searched for the old reference in the wayback machine but nothing similar is present in the current docs.

**- Description for the changelog**
Removed sentence containing invalid URL from contributing guidelines.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**
![308a8eed88f530fbcb366436c937c1a8](https://github.com/docker/cli/assets/62723360/3d5754ee-b1b8-401d-871d-2d0890257c62)

