### PR TITLE
plugins/hooks: run hooks when exit code != 0

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -353,9 +353,6 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 	// which remain.
 	cmd.SetArgs(args)
 	err = cmd.Execute()
-	if err != nil {
-		return err
-	}
 
 	// If the command is being executed in an interactive terminal,
 	// run the plugin hooks (but don't throw an error if something misbehaves)
@@ -363,7 +360,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		_ = pluginmanager.RunPluginHooks(dockerCli, cmd, subCommand, "", args)
 	}
 
-	return nil
+	return err
 }
 
 type versionDetails interface {


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR changes the hooks flow so that hooks are still invoked after the command execution returned an error/non-zero exit code.

I ran into this with `docker exec -it [] sh`, since I was exiting with CTRL+D after doing things inside a container and depending on the exit code my hooks wouldn't get invoked, which isn't desired.

In the future, this might also be interesting to allow plugins to run hooks after an error so they can offer error-state recovery suggestions, although this would require additional work to give the plugin more information about the failed execution.

**- How to verify it**

Try hooks after a non-zero exit code `docker exec`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/70572044/60db744f-f9e2-4dad-8071-160951c9a887)


