### PR TITLE
Fix OTLP env var overriding

### DIFF
--- a/cli/command/telemetry_docker.go
+++ b/cli/command/telemetry_docker.go
@@ -41,23 +41,19 @@ func dockerExporterOTLPEndpoint(cli Cli) (endpoint string, secure bool) {
 		otelCfg = m[otelContextFieldName]
 	}
 
-	if otelCfg == nil {
-		return "", false
+	if otelCfg != nil {
+		otelMap, ok := otelCfg.(map[string]any)
+		if !ok {
+			otel.Handle(errors.Errorf(
+				"unexpected type for field %q: %T (expected: %T)",
+				otelContextFieldName,
+				otelCfg,
+				otelMap,
+			))
+		}
+		// keys from https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/
+		endpoint, _ = otelMap[otelExporterOTLPEndpoint].(string)
 	}
-
-	otelMap, ok := otelCfg.(map[string]any)
-	if !ok {
-		otel.Handle(errors.Errorf(
-			"unexpected type for field %q: %T (expected: %T)",
-			otelContextFieldName,
-			otelCfg,
-			otelMap,
-		))
-		return "", false
-	}
-
-	// keys from https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/
-	endpoint, _ = otelMap[otelExporterOTLPEndpoint].(string)
 
 	// Override with env var value if it exists AND IS SET
 	// (ignore otel defaults for this override when the key exists but is empty)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the OTLP endpoint overriding via env var

**- How I did it**
Made sure to check for the override even when otel configuration bits are missing from the context metadata, instead of returning early

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

