### PR TITLE
hooks: set expected environment when executing

### DIFF
--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"encoding/json"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -113,7 +114,10 @@ func (p *Plugin) RunHook(cmdName string, flags map[string]string) ([]byte, error
 		return nil, wrapAsPluginError(err, "failed to marshall hook data")
 	}
 
-	hookCmdOutput, err := exec.Command(p.Path, p.Name, HookSubcommandName, string(hDataBytes)).Output()
+	pCmd := exec.Command(p.Path, p.Name, HookSubcommandName, string(hDataBytes))
+	pCmd.Env = os.Environ()
+	pCmd.Env = append(pCmd.Env, ReexecEnvvar+"="+os.Args[0])
+	hookCmdOutput, err := pCmd.Output()
 	if err != nil {
 		return nil, wrapAsPluginError(err, "failed to execute plugin hook subcommand")
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

During normal plugin execution (from the CLI), the CLI configures the plugin command it's about to execute in order to pass all environment variables on, as well as to set the `ReexecEnvVar` env var that informs the plugin about how it was executed, and which plugins rely on to check whether they are being run standalone or not.

https://github.com/docker/cli/blob/50117590567998307eba377295a1ec24e214ccc7/cli-plugins/manager/manager.go#L243-L244

This commit adds the same behavior to hook invocations, which is necessary for some plugins to know that they are not running standalone so that they expose their root command at the correct level.


**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/70572044/04b613f6-6672-430b-b9dc-c55b3ab96569)

