### PR TITLE
hooks: pass command execution error to plugins

### DIFF
--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -105,11 +105,8 @@ func newPlugin(c Candidate, cmds []*cobra.Command) (Plugin, error) {
 
 // RunHook executes the plugin's hooks command
 // and returns its unprocessed output.
-func (p *Plugin) RunHook(cmdName string, flags map[string]string) ([]byte, error) {
-	hDataBytes, err := json.Marshal(HookPluginData{
-		RootCmd: cmdName,
-		Flags:   flags,
-	})
+func (p *Plugin) RunHook(hookData HookPluginData) ([]byte, error) {
+	hDataBytes, err := json.Marshal(hookData)
 	if err != nil {
 		return nil, wrapAsPluginError(err, "failed to marshall hook data")
 	}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -357,7 +357,11 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 	// If the command is being executed in an interactive terminal
 	// and hook are enabled, run the plugin hooks.
 	if dockerCli.HooksEnabled() && dockerCli.Out().IsTerminal() && subCommand != nil {
-		pluginmanager.RunCLICommandHooks(dockerCli, cmd, subCommand)
+		var errMessage string
+		if err != nil {
+			errMessage = err.Error()
+		}
+		pluginmanager.RunCLICommandHooks(dockerCli, cmd, subCommand, errMessage)
 	}
 
 	return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Added a field to `HookPluginData` to hold the error message (if applicable) that resulted from the execution for which the hook is being invoked.

This is only available for CLI command executions.

**- How to verify it**

**- A picture of a cute animal (not mandatory but encouraged)**

