### PR TITLE
cli-plugins: PluginRunCommand: use cmd.Environ instead of os.Environ

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -240,8 +240,7 @@ func PluginRunCommand(dockerCli command.Cli, name string, rootcmd *cobra.Command
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
-		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, ReexecEnvvar+"="+os.Args[0])
+		cmd.Env = append(cmd.Environ(), ReexecEnvvar+"="+os.Args[0])
 		cmd.Env = appendPluginResourceAttributesEnvvar(cmd.Env, rootcmd, plugin)
 
 		return cmd, nil


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/5027


Commit 50117590567998307eba377295a1ec24e214ccc7 implemented a fix that caused the current environment to be discarded, using `os.Environ()`. On Windows, `os.Environ()` may produce an incorrect value for `PWD`, for which a new function was added in go1.19;

- https://tip.golang.org/doc/go1.19#osexecpkgosexec
- https://go-review.googlesource.com/c/go/+/401340
- https://github.com/golang/go/issues/50599

Replace the use of `os.Environ()` with `cmd.Environ()` to address that.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

