### PR TITLE
feat: wire ctx into plugin hooks

### DIFF
--- a/cli-plugins/manager/hooks.go
+++ b/cli-plugins/manager/hooks.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -27,29 +28,36 @@ type HookPluginData struct {
 // a main CLI command was executed. It calls the hook subcommand for all
 // present CLI plugins that declare support for hooks in their metadata and
 // parses/prints their responses.
-func RunCLICommandHooks(dockerCli command.Cli, rootCmd, subCommand *cobra.Command, cmdErrorMessage string) {
+func RunCLICommandHooks(ctx context.Context, dockerCli command.Cli, rootCmd, subCommand *cobra.Command, cmdErrorMessage string) {
 	commandName := strings.TrimPrefix(subCommand.CommandPath(), rootCmd.Name()+" ")
 	flags := getCommandFlags(subCommand)
 
-	runHooks(dockerCli, rootCmd, subCommand, commandName, flags, cmdErrorMessage)
+	runHooks(ctx, dockerCli, rootCmd, subCommand, commandName, flags, cmdErrorMessage)
 }
 
 // RunPluginHooks is the entrypoint for the hooks execution flow
 // after a plugin command was just executed by the CLI.
-func RunPluginHooks(dockerCli command.Cli, rootCmd, subCommand *cobra.Command, args []string) {
+func RunPluginHooks(ctx context.Context, dockerCli command.Cli, rootCmd, subCommand *cobra.Command, args []string) {
 	commandName := strings.Join(args, " ")
 	flags := getNaiveFlags(args)
 
-	runHooks(dockerCli, rootCmd, subCommand, commandName, flags, "")
+	runHooks(ctx, dockerCli, rootCmd, subCommand, commandName, flags, "")
 }
 
-func runHooks(dockerCli command.Cli, rootCmd, subCommand *cobra.Command, invokedCommand string, flags map[string]string, cmdErrorMessage string) {
-	nextSteps := invokeAndCollectHooks(dockerCli, rootCmd, subCommand, invokedCommand, flags, cmdErrorMessage)
+func runHooks(ctx context.Context, dockerCli command.Cli, rootCmd, subCommand *cobra.Command, invokedCommand string, flags map[string]string, cmdErrorMessage string) {
+	nextSteps := invokeAndCollectHooks(ctx, dockerCli, rootCmd, subCommand, invokedCommand, flags, cmdErrorMessage)
 
 	hooks.PrintNextSteps(dockerCli.Err(), nextSteps)
 }
 
-func invokeAndCollectHooks(dockerCli command.Cli, rootCmd, subCmd *cobra.Command, subCmdStr string, flags map[string]string, cmdErrorMessage string) []string {
+func invokeAndCollectHooks(ctx context.Context, dockerCli command.Cli, rootCmd, subCmd *cobra.Command, subCmdStr string, flags map[string]string, cmdErrorMessage string) []string {
+	// check if the context was cancelled before invoking hooks
+	select {
+	case <-ctx.Done():
+		return nil
+	default:
+	}
+
 	pluginsCfg := dockerCli.ConfigFile().Plugins
 	if pluginsCfg == nil {
 		return nil
@@ -67,7 +75,7 @@ func invokeAndCollectHooks(dockerCli command.Cli, rootCmd, subCmd *cobra.Command
 			continue
 		}
 
-		hookReturn, err := p.RunHook(HookPluginData{
+		hookReturn, err := p.RunHook(ctx, HookPluginData{
 			RootCmd:      match,
 			Flags:        flags,
 			CommandError: cmdErrorMessage,

--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -105,13 +106,13 @@ func newPlugin(c Candidate, cmds []*cobra.Command) (Plugin, error) {
 
 // RunHook executes the plugin's hooks command
 // and returns its unprocessed output.
-func (p *Plugin) RunHook(hookData HookPluginData) ([]byte, error) {
+func (p *Plugin) RunHook(ctx context.Context, hookData HookPluginData) ([]byte, error) {
 	hDataBytes, err := json.Marshal(hookData)
 	if err != nil {
 		return nil, wrapAsPluginError(err, "failed to marshall hook data")
 	}
 
-	pCmd := exec.Command(p.Path, p.Name, HookSubcommandName, string(hDataBytes))
+	pCmd := exec.CommandContext(ctx, p.Path, p.Name, HookSubcommandName, string(hDataBytes))
 	pCmd.Env = os.Environ()
 	pCmd.Env = append(pCmd.Env, ReexecEnvvar+"="+os.Args[0])
 	hookCmdOutput, err := pCmd.Output()

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -337,7 +337,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 			err := tryPluginRun(dockerCli, cmd, args[0], envs)
 			if err == nil {
 				if dockerCli.HooksEnabled() && dockerCli.Out().IsTerminal() && ccmd != nil {
-					pluginmanager.RunPluginHooks(dockerCli, cmd, ccmd, args)
+					pluginmanager.RunPluginHooks(ctx, dockerCli, cmd, ccmd, args)
 				}
 				return nil
 			}
@@ -362,7 +362,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		if err != nil {
 			errMessage = err.Error()
 		}
-		pluginmanager.RunCLICommandHooks(dockerCli, cmd, subCommand, errMessage)
+		pluginmanager.RunCLICommandHooks(ctx, dockerCli, cmd, subCommand, errMessage)
 	}
 
 	return err


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

In the spirit of wiring up `context.Context` for graceful exit and early termination of tasks, I have done some more wiring up of `ctx` inside the plugin hooks. This allows early returns for when the `ctx` is cancelled so that hooks aren't printed as well as cancelling the execution of the plugin through `exec.CommandContext`.

**- What I did**
Allow early cancellation of plugin hooks through `context.Context` and plugin execution cancellation through `exec.CommandContext`.

**- How I did it**
Wired up `ctx` inside the `RunCLICommandHooks` and `RunPluginHooks`.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

