### PR TITLE
#4935 - Fixed broken links to style guide and building documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,8 @@ submitting a pull request.
 Update the documentation when creating or modifying features. Test your
 documentation changes for clarity, concision, and correctness, as well as a
 clean documentation build. See our contributors guide for [our style
-guide](https://docs.docker.com/opensource/doc-style) and instructions on [building
-the documentation](https://docs.docker.com/opensource/project/test-and-docs/#build-and-test-the-documentation).
+guide](https://docs.docker.com/contribute/style/grammar/) and instructions on [building
+the documentation](https://github.com/docker/docs/blob/main/CONTRIBUTING.md).
 
 Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #4935.

**- What I did**
```
Changed what "our style guide" and "building the documentation" direct to in CONTRIBUTING.md.
```
**- Description for the changelog**
<!--
-->
```markdown changelog
In CONTRIBUTING.md, "our style guide" and "building the documentation" don't direct to broken links.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/39168493/058dfb71-41b7-4843-a651-cd69294dd5b2)
