### PR TITLE
Fix errors encountered by CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,16 +44,6 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           git checkout HEAD^2
-      - 
-        name: Update Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.21'
-      -
-        name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: go
       # CodeQL 2.16.4's auto-build added support for multi-module repositories,
       # and is trying to be smart by searching for modules in every directory,
       # including vendor directories. If no module is found, it's creating one
@@ -64,6 +54,16 @@ jobs:
         run: |
           ln -s vendor.mod go.mod
           ln -s vendor.sum go.sum
+      -
+        name: Update Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      -
+        name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
       -
         name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/vendor.mod
+++ b/vendor.mod
@@ -4,7 +4,7 @@ module github.com/docker/cli
 // There is no 'go.mod' file, as that would imply opting in for all the rules
 // around SemVer, which this repo cannot abide by as it uses CalVer.
 
-go 1.21
+go 1.21.0
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
### gha: CodeQL: move go.mod/go.sum symlink earlier to help caching

actions/setup-go was trying to use caching, and produced a warning
because it expects a `go.mod` / `go.sum`;

    Run actions/setup-go@v5
      with:
        go-version: 1.21
        check-latest: false
        token: ***
        cache: true
      env:
        DISABLE_WARN_OUTSIDE_CONTAINER: 1
    Setup go version spec 1.21
    Found in cache @ /opt/hostedtoolcache/go/1.21.9/x64
    Added go to the path
    Successfully set up Go version 1.21
    /opt/hostedtoolcache/go/1.21.9/x64/bin/go env GOMODCACHE
    /opt/hostedtoolcache/go/1.21.9/x64/bin/go env GOCACHE
    /home/runner/go/pkg/mod
    /home/runner/.cache/go-build
    Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/cli/cli. Supported file pattern: go.sum
    go version go1.21.9 linux/amd64

While our regular builds would use a containerised flow, CodeQL's autobuild
does not, and also doesn't seem to use our vendor directory (?) so for this
one it's probably fine to let it use some caching.



### go.mod: use SemVer format for go version to assist CodeQL AutoBuild

CodeQL AutoBuild started to produce errors if the `go.mod` does not use
SemVer for the go version; https://github.com/github/codeql/blob/3a2b0a2feba58c05706c88b5589cacf6094f7f9d/go/extractor/diagnostics/diagnostics.go#L512-L525

Let's give it one.