### PR TITLE
docstring: typo: settings -> setting

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -43,7 +43,7 @@
 #   "yes" - Show names and ids
 #
 # You can tailor completion for the "events", "history", "inspect", "run",
-# "rmi" and "save" commands by settings the following environment
+# "rmi" and "save" commands by setting the following environment
 # variables:
 #
 # DOCKER_COMPLETION_SHOW_IMAGE_IDS


### PR DESCRIPTION
```markdown changelog
docstring: typo: replace 'settings' with 'setting' to make subject and verb agree
```