### PR TITLE
fix/Add hostname check in registry URL on login

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -96,6 +97,16 @@ func verifyloginOptions(dockerCli command.Cli, opts *loginOptions) error {
 
 		opts.password = strings.TrimSuffix(string(contents), "\n")
 		opts.password = strings.TrimSuffix(opts.password, "\r")
+	}
+
+	if opts.serverAddress != "" {
+		u, err := url.Parse(opts.serverAddress)
+		if err != nil {
+			return errors.Errorf("Invalid server address: %s", opts.serverAddress)
+		}
+		if u.Host == "" {
+			return errors.Errorf("Server address must include a hostname: %s", opts.serverAddress)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**- What I did:** To address the issue related to potential credential leakage when specifying a registry URL without a hostname, I added validation checks for the registry URL's validity and the presence of a hostname when passing the registry address in the CLI.

**- How I did it:** As fixing the bug on the server side seemed unfeasible due to the data formation for client-side authentication, which results in passing an empty hostname string and attempting login to the default address with private credentials, I incorporated corresponding checks into the code.

**- How to verify it:** You can verify it by using the command `docker login http:///path`, which should output the following message: "Server address must include a hostname: ''".

**- Description for the changelog:**
```markdown changelog
Added validation checks for the registry URL's validity and the presence of a hostname when passing the registry address in the CLI to prevent potential credential leakage. [GitHub issue #47795](https://github.com/moby/moby/issues/47795)
```

**- Link to the relevant code snippet in Moby:** [Moby Code - registry/service.go#L55](https://github.com/moby/moby/blob/master/registry/service.go#L55)
