### PR TITLE
formatters(image): prevent image size from displaying scientific notation

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -248,7 +248,7 @@ func (c *imageContext) CreatedAt() string {
 }
 
 func (c *imageContext) Size() string {
-	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
+	return units.HumanSize(float64(c.i.Size))
 }
 
 func (c *imageContext) Containers() string {

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -41,6 +41,11 @@ func TestImageContext(t *testing.T) {
 			call:     ctx.Size,
 		},
 		{
+			imageCtx: imageContext{i: types.ImageSummary{Size: 999900000}, trunc: true},
+			expValue: "999.9MB",
+			call:     ctx.Size,
+		},
+		{
 			imageCtx: imageContext{i: image.Summary{Created: unix}, trunc: true},
 			expValue: time.Unix(unix, 0).String(), call: ctx.CreatedAt,
 		},


### PR DESCRIPTION
fixes #3091 
dupe #4459

**- What I did**

`HumanSizeWithPrecision` (which was configured to 3 significant digits) was replaced with `HumanSize` (which defaults to 4) in order to prevent scientific notation from appearing under certain edge cases. This is a known bug (docker/go-units#44) in the affected dependency.

In practical terms, adjusting the precision from 3 to 4 should cause no issues with users' current expectations and usage of the cli.

**- How to verify it**

Regression tests implemented to prevent future breakage.

**- Description for the changelog**

```markdown changelog
formatters(image): prevent image size from displaying scientific notation under edge cases
```