### PR TITLE
Fix hang when container fails to start

### DIFF
--- a/cli/command/container/utils.go
+++ b/cli/command/container/utils.go
@@ -36,6 +36,7 @@ func waitExitOrRemoved(ctx context.Context, apiClient client.APIClient, containe
 
 	statusC := make(chan int)
 	go func() {
+		defer close(statusC)
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

fixes https://github.com/docker/cli/issues/5053

When running a container, if it fails to start, we immediately cancel the context used for `waitExitOrRemoved` and, if running the container with `--rm`, wait on the channel:

https://github.com/docker/cli/blob/870ad7f4b9910341f30dd2632db4375858455d8a/cli/command/container/run.go#L196-L205

However, in https://github.com/docker/cli/commit/840016ea0504fb1c616a3af2f8d48bd16a7400f4, we added the following line https://github.com/docker/cli/blob/647ccf34334f76b7cc668f485143af4e11403c20/cli/command/container/utils.go#L40-L41

but in this case, we return from the goroutine without notifying the caller, which causes the caller to hang.

**- How I did it**

We should not be cancelling the context used to wait on the container exit/removal in this case, and it's only happening by accident due to this line, which is there for other reasons https://github.com/docker/cli/blob/05cba3f7b97c73d49675a3e5adb1118fe0c79867/cli/command/container/run.go#L196-L199

So I used a new context for the `waitExitOrRemoved` call.

Also, close the returned channel to unblock any caller when we hit this branch, and added another `close` to a case down where we added another return without notifying the caller.

**- How to verify it**

Reproduce such as:
```bash
#!/bin/bash
while :; do
	docker run --rm --entrypoint invalidcommand alpine param
done
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix issue where the CLI process would sometimes hang when a container failed to start.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/docker/cli/assets/70572044/4536726c-ce70-40e8-9d6e-fc471d4cec6b)
