### PR TITLE
[26.1 backport] Centralize init of Meter/TracerProviders

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -273,6 +273,11 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption)
 			return ResolveDefaultContext(cli.options, cli.contextStoreConfig)
 		},
 	}
+
+	// TODO(krissetto): pass ctx to the funcs instead of using this
+	cli.createGlobalMeterProvider(cli.baseCtx)
+	cli.createGlobalTracerProvider(cli.baseCtx)
+
 	return nil
 }
 

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -307,9 +307,13 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		return err
 	}
 
-	mp := dockerCli.MeterProvider(ctx)
-	defer mp.Shutdown(ctx)
-	otel.SetMeterProvider(mp)
+	mp := dockerCli.MeterProvider()
+	if mp, ok := mp.(command.MeterProvider); ok {
+		defer mp.Shutdown(ctx)
+	} else {
+		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
+	}
+
 	dockerCli.InstrumentCobraCommands(cmd, mp)
 
 	var envs []string


### PR DESCRIPTION
backports https://github.com/docker/cli/pull/5067