### PR TITLE
[26.1 backport] Add OTel instrumentation to CLI plugins

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -314,7 +314,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
 	}
 
-	dockerCli.InstrumentCobraCommands(cmd, mp)
+	dockerCli.InstrumentCobraCommands(ctx, cmd)
 
 	var envs []string
 	args, os.Args, envs, err = processAliases(dockerCli, cmd, args, os.Args)


### PR DESCRIPTION
Backports https://github.com/docker/cli/pull/5051