### PR TITLE
Updated engine versions used in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,8 +28,8 @@ jobs:
           - alpine
           - debian
         engine-version:
-          - 25.0  # latest
-          - 24.0  # latest - 1
+          - 26.1  # latest
+          - 25.0  # latest - 1
           - 23.0  # mirantis lts
           # TODO(krissetto) 19.03 needs a look, doesn't work ubuntu 22.04 (cgroup errors). 
           # we could have a separate job that tests it against ubuntu 20.04

--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -4,7 +4,7 @@ services:
     image: 'registry:2'
 
   engine:
-      image: 'docker:${ENGINE_VERSION:-25.0}-dind'
+      image: 'docker:${ENGINE_VERSION:-26.1}-dind'
       privileged: true
       command: ['--insecure-registry=registry:5000']
       environment:

--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -2,7 +2,7 @@
 
 # ENGINE_VERSION is the version of the (docker-in-docker) Docker Engine to
 # test against.
-ARG ENGINE_VERSION=25.0
+ARG ENGINE_VERSION=26.1
 
 FROM docker:${ENGINE_VERSION}-dind
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Updated engine versions used in e2e tests

**- How I did it**
Added `26.1`, removed `24.0`

**- How to verify it**
If tests are green, all should be good

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Update engine versions used in e2e tests
```

**- A picture of a cute animal (not mandatory but encouraged)**


![](https://www.liveonegoodlife.com/wp-content/uploads/2021/05/word-image-7-1506x1536.jpeg)
