### PR TITLE
cli/config: improve handling of errors

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -84,8 +84,10 @@ func LoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
 	return &configFile, err
 }
 
-// Load reads the configuration files in the given directory, and sets up
-// the auth config information and returns values.
+// Load reads the configuration file ([ConfigFileName]) from the given directory.
+// If no directory is given, it uses the default [Dir]. A [*configfile.ConfigFile]
+// is returned containing the contents of the configuration file, or a default
+// struct if no configfile exists in the given location.
 func Load(configDir string) (*configfile.ConfigFile, error) {
 	if configDir == "" {
 		configDir = Dir()
@@ -118,7 +120,16 @@ func load(configDir string) (*configfile.ConfigFile, error) {
 }
 
 // LoadDefaultConfigFile attempts to load the default config file and returns
-// an initialized ConfigFile struct if none is found.
+// a reference to the ConfigFile struct. If none is found or when failing to load
+// the configuration file, it initializes a default ConfigFile struct. If no
+// credentials-store is set in the configuration file, it attempts to discover
+// the default store to use for the current platform.
+//
+// Important: LoadDefaultConfigFile prints a warning to stderr when failing to
+// load the configuration file, but otherwise ignores errors. Consumers should
+// consider using [Load] (and [credentials.DetectDefaultStore]) to detect errors
+// when updating the configuration file, to prevent discarding a (malformed)
+// configuration file.
 func LoadDefaultConfigFile(stderr io.Writer) *configfile.ConfigFile {
 	configFile, err := load(Dir())
 	if err != nil {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -352,6 +352,7 @@ func TestLoadDefaultConfigFile(t *testing.T) {
 	expected.PsFormat = "format"
 
 	assert.Check(t, is.DeepEqual(expected, configFile))
+	assert.Check(t, is.Equal(buffer.String(), ""))
 }
 
 func TestConfigPath(t *testing.T) {

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/config/credentials"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/skip"
 )
 
 func setupConfigDir(t *testing.T) string {
@@ -67,6 +69,19 @@ func TestLoadDanglingSymlink(t *testing.T) {
 	fi, err := os.Lstat(cfgFile)
 	assert.NilError(t, err)
 	assert.Equal(t, fi.Mode()&os.ModeSymlink, os.ModeSymlink, "expected %v to be a symlink", cfgFile)
+}
+
+func TestLoadNoPermissions(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		skip.If(t, os.Getuid() == 0, "cannot test permission denied when running as root")
+	}
+	cfgDir := t.TempDir()
+	cfgFile := filepath.Join(cfgDir, ConfigFileName)
+	err := os.WriteFile(cfgFile, []byte(`{}`), os.FileMode(0o000))
+	assert.NilError(t, err)
+
+	_, err = Load(cfgDir)
+	assert.ErrorIs(t, err, os.ErrPermission)
 }
 
 func TestSaveFileToDirs(t *testing.T) {
@@ -345,14 +360,31 @@ func TestLoadDefaultConfigFile(t *testing.T) {
 	err := os.WriteFile(filename, content, 0o644)
 	assert.NilError(t, err)
 
-	configFile := LoadDefaultConfigFile(buffer)
-	credStore := credentials.DetectDefaultStore("")
-	expected := configfile.New(filename)
-	expected.CredentialsStore = credStore
-	expected.PsFormat = "format"
+	t.Run("success", func(t *testing.T) {
+		configFile := LoadDefaultConfigFile(buffer)
+		credStore := credentials.DetectDefaultStore("")
+		expected := configfile.New(filename)
+		expected.CredentialsStore = credStore
+		expected.PsFormat = "format"
 
-	assert.Check(t, is.DeepEqual(expected, configFile))
-	assert.Check(t, is.Equal(buffer.String(), ""))
+		assert.Check(t, is.DeepEqual(expected, configFile))
+		assert.Check(t, is.Equal(buffer.String(), ""))
+	})
+
+	t.Run("permission error", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			skip.If(t, os.Getuid() == 0, "cannot test permission denied when running as root")
+		}
+		err = os.Chmod(filename, 0o000)
+		assert.NilError(t, err)
+
+		buffer.Reset()
+		_ = LoadDefaultConfigFile(buffer)
+		warnings := buffer.String()
+
+		assert.Check(t, is.Contains(warnings, "WARNING:"))
+		assert.Check(t, is.Contains(warnings, os.ErrPermission.Error()))
+	})
 }
 
 func TestConfigPath(t *testing.T) {


### PR DESCRIPTION
Improving some parts of how we handle failures when loading the CLI configuration file. This relates to https://github.com/docker/cli/issues/5075, but does not yet fix that issue (only handling some additional errors);

- https://github.com/docker/cli/issues/5075

Changes in this PR should not likely cause a change in behavior (so could be included in a patch release); follow-up changes are still needed to handle various scenarios where we should hard-fail, but there's many different related code-paths, so this still needs work.

### cli/config: Load(): improve GoDoc

### cli/config: add test for dangling symlink for config-file

This may need further discussion, but we currently handle dangling
symlinks gracefully, so let's add a test for this, and verify that
we don't replace symlinks with a file.

### cli/config: TestLoadDefaultConfigFile: check that no warnings are printed

Loading the config should print no warnings on a successful load.

### cli/config: do not discard permission errors when loading config-file

When attempting to load a config-file that exists, but is not accessible for
the current user, we should not discard the error.

This patch makes sure that the error is returned by Load(), but does not yet
change LoadDefaultConfigFile, as this requires a change in signature.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Print a warning when the CLI does not have permissions to read the configuration file.
```

**- A picture of a cute animal (not mandatory but encouraged)**

