### PR TITLE
plugins/hooks: Don't show empty hook messages

### DIFF
--- a/cli-plugins/manager/hooks.go
+++ b/cli-plugins/manager/hooks.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli-plugins/hooks"
 	"github.com/docker/cli/cli/command"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -100,9 +101,33 @@ func invokeAndCollectHooks(ctx context.Context, dockerCli command.Cli, rootCmd, 
 		if err != nil {
 			continue
 		}
-		nextSteps = append(nextSteps, processedHook...)
+
+		var appended bool
+		nextSteps, appended = appendNextSteps(nextSteps, processedHook)
+		if !appended {
+			logrus.Debugf("Plugin %s responded with an empty hook message %q. Ignoring.", pluginName, string(hookReturn))
+		}
 	}
 	return nextSteps
+}
+
+// appendNextSteps appends the processed hook output to the nextSteps slice.
+// If the processed hook output is empty, it is not appended.
+// Empty lines are not stripped if there's at least one non-empty line.
+func appendNextSteps(nextSteps []string, processed []string) ([]string, bool) {
+	empty := true
+	for _, l := range processed {
+		if strings.TrimSpace(l) != "" {
+			empty = false
+			break
+		}
+	}
+
+	if empty {
+		return nextSteps, false
+	}
+
+	return append(nextSteps, processed...), true
 }
 
 // pluginMatch takes a plugin configuration and a string representing the

--- a/cli-plugins/manager/hooks_test.go
+++ b/cli-plugins/manager/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestGetNaiveFlags(t *testing.T) {
@@ -106,5 +107,37 @@ func TestPluginMatch(t *testing.T) {
 		match, ok := pluginMatch(tc.pluginConfig, tc.commandString)
 		assert.Equal(t, ok, tc.expectedOk)
 		assert.Equal(t, match, tc.expectedMatch)
+	}
+}
+
+func TestAppendNextSteps(t *testing.T) {
+	testCases := []struct {
+		processed   []string
+		expectedOut []string
+	}{
+		{
+			processed:   []string{},
+			expectedOut: []string{},
+		},
+		{
+			processed:   []string{"", ""},
+			expectedOut: []string{},
+		},
+		{
+			processed:   []string{"Some hint", "", "Some other hint"},
+			expectedOut: []string{"Some hint", "", "Some other hint"},
+		},
+		{
+			processed:   []string{"Hint 1", "Hint 2"},
+			expectedOut: []string{"Hint 1", "Hint 2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			got, appended := appendNextSteps([]string{}, tc.processed)
+			assert.Check(t, is.DeepEqual(got, tc.expectedOut))
+			assert.Check(t, is.Equal(appended, len(got) > 0))
+		})
 	}
 }


### PR DESCRIPTION
**- What I did**
Don't show `Next steps:` with no messages at all when plugin returns an unitialized value of `HookMessage` (zero-initialization sets its type to NextSteps and empty template).

**- How to verify it**
Unit test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Don't show empty hints when plugins returns an empty hook message.
```

**- A picture of a cute animal (not mandatory but encouraged)**

