### PR TITLE
Support custom SSH config file for SSH connection

### DIFF
--- a/cli/connhelper/ssh/ssh.go
+++ b/cli/connhelper/ssh/ssh.go
@@ -34,23 +34,25 @@ func ParseURL(daemonURL string) (*Spec, error) {
 	if u.RawQuery != "" {
 		return nil, errors.Errorf("extra query after the host: %q", u.RawQuery)
 	}
-	if u.Fragment != "" {
-		return nil, errors.Errorf("extra fragment after the host: %q", u.Fragment)
-	}
+	sp.SSHConfig = u.Fragment
 	return &sp, err
 }
 
 // Spec of SSH URL
 type Spec struct {
-	User string
-	Host string
-	Port string
-	Path string
+	User      string
+	Host      string
+	Port      string
+	Path      string
+	SSHConfig string
 }
 
 // Args returns args except "ssh" itself combined with optional additional command args
 func (sp *Spec) Args(add ...string) []string {
 	var args []string
+	if sp.SSHConfig != "" {
+		args = append(args, "-F", sp.SSHConfig)
+	}
 	if sp.User != "" {
 		args = append(args, "-l", sp.User)
 	}

--- a/cli/connhelper/ssh/ssh_test.go
+++ b/cli/connhelper/ssh/ssh_test.go
@@ -28,6 +28,13 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			url: "ssh://foo#/path/to/ssh_config",
+			expectedArgs: []string{
+				"-F", "/path/to/ssh_config",
+				"--", "foo",
+			},
+		},
+		{
 			url:           "ssh://me:passw0rd@foo",
 			expectedError: "plain-text password is not supported",
 		},
@@ -40,10 +47,6 @@ func TestParseURL(t *testing.T) {
 		{
 			url:           "ssh://foo?bar",
 			expectedError: `extra query after the host: "bar"`,
-		},
-		{
-			url:           "ssh://foo#bar",
-			expectedError: `extra fragment after the host: "bar"`,
 		},
 		{
 			url:           "ssh://",

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -336,6 +336,14 @@ component to the end of the SSH address.
 $ docker -H ssh://user@192.168.64.5/var/run/docker.sock ps
 ```
 
+In addition, you can optionally specify an SSH config file by appending a
+fragment component to the end of the SSH address (that is, behind a hash `#`).
+The given file path is passed to SSH using the `ssh -F` option.
+
+```console
+$ docker -H ssh://user@192.168.64.5#/path/to/ssh_config ps
+```
+
 ### Display help text
 
 To list the help on any command just execute the command, followed by the

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -247,6 +247,7 @@ precedence over `HTTP_PROXY`.
 The Docker client supports connecting to a remote daemon via SSH:
 
 ```console
+$ docker -H ssh://me@example.com:22/var/run/docker.sock#/path/to/ssh_config ps
 $ docker -H ssh://me@example.com:22/var/run/docker.sock ps
 $ docker -H ssh://me@example.com:22 ps
 $ docker -H ssh://me@example.com ps


### PR DESCRIPTION
SSH Docker host connections support specifying an SSH username, hostname, port, and socket path with `ssh://…`. Furthermore, the default user SSH config file located at `~/.ssh/config` is respected.

However, it would be useful to specify a path to a custom SSH config on the CLI. Use cases are per-project SSH configs or SSH configs generated on the fly (e.g., by `vagrant ssh-config`).

**- What I did**

With this commit, a path to a custom SSH config can be specified as part of the SSH Docker host URL.

This closes #1301. Related issues: #1463, #2539.

**- How I did it**

An SSH config file can be specified by appending a URL fragment component to the end of the SSH address (that is, behind a hash `#`). The given file path is passed to SSH using the `ssh -F` option. Example:

```
$ docker --host ssh://user@192.168.64.5#/path/to/ssh_config ps
```

**- How to verify it**

Set up:

```console
$ docker buildx bake

$ cat <<EOF >Vagrantfile
Vagrant.configure("2") do |config|
  config.vm.box = "bento/ubuntu-24.04"
  config.vm.provision "docker"
end
EOF

$ vagrant up

$ vagrant ssh-config --host my-host >my_ssh_config
```

Test:

```console
$ build/docker --host 'ssh://my-host#my_ssh_config' run -dit nginx

$ build/docker --host 'ssh://my-host#my_ssh_config' ps
CONTAINER ID   IMAGE     COMMAND                  CREATED         STATUS         PORTS     NAMES
856870d88719   nginx     "/docker-entrypoint.…"   5 seconds ago   Up 3 seconds   80/tcp    serene_mcclintock

$ build/docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
```

Tear down:

```console
$ vagrant destroy

$ rm -fr .vagrant/ my_ssh_config Vagrantfile
```

**- Description for the changelog**

```markdown changelog
Support custom SSH config file for SSH Docker host connections using URL of the form `ssh://host#/path/to/ssh_config`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

![custom_ssh_config](https://github.com/docker/cli/assets/8361681/3bf84444-d1bd-4e6b-a6db-ddc9e294ff96)