### PR TITLE
[26.1 backport] plugins/hooks: Don't show empty hook messages

### DIFF
--- a/cli-plugins/manager/hooks_test.go
+++ b/cli-plugins/manager/hooks_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestGetNaiveFlags(t *testing.T) {
@@ -106,5 +107,37 @@ func TestPluginMatch(t *testing.T) {
 		match, ok := pluginMatch(tc.pluginConfig, tc.commandString)
 		assert.Equal(t, ok, tc.expectedOk)
 		assert.Equal(t, match, tc.expectedMatch)
+	}
+}
+
+func TestAppendNextSteps(t *testing.T) {
+	testCases := []struct {
+		processed   []string
+		expectedOut []string
+	}{
+		{
+			processed:   []string{},
+			expectedOut: []string{},
+		},
+		{
+			processed:   []string{"", ""},
+			expectedOut: []string{},
+		},
+		{
+			processed:   []string{"Some hint", "", "Some other hint"},
+			expectedOut: []string{"Some hint", "", "Some other hint"},
+		},
+		{
+			processed:   []string{"Hint 1", "Hint 2"},
+			expectedOut: []string{"Hint 1", "Hint 2"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			got, appended := appendNextSteps([]string{}, tc.processed)
+			assert.Check(t, is.DeepEqual(got, tc.expectedOut))
+			assert.Check(t, is.Equal(appended, len(got) > 0))
+		})
 	}
 }


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5078

**- What I did**
Don't show `Next steps:` with no messages at all when plugin returns an unitialized value of `HookMessage` (zero-initialization sets its type to NextSteps and empty template).

**- How to verify it**
Unit test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Don't show empty hints when plugins returns an empty hook message.
```

**- A picture of a cute animal (not mandatory but encouraged)**

