### PR TITLE
context list: temporarily add ContextType to JSON output

### DIFF
--- a/cli/command/context/testdata/list-json.golden
+++ b/cli/command/context/testdata/list-json.golden
@@ -1,5 +1,5 @@
-{"Current":false,"Description":"description of context1","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context1"}
-{"Current":false,"Description":"description of context2","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context2"}
-{"Current":false,"Description":"description of context3","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context3"}
-{"Current":true,"Description":"description of current","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"current"}
-{"Current":false,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","Error":"","Name":"default"}
+{"Name":"context1","Description":"description of context1","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"aci"}
+{"Name":"context2","Description":"description of context2","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"ecs"}
+{"Name":"context3","Description":"description of context3","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"moby"}
+{"Name":"current","Description":"description of current","DockerEndpoint":"https://someswarmserver.example.com","Current":true,"Error":"","ContextType":"moby"}
+{"Name":"default","Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","Current":false,"Error":"","ContextType":"moby"}

--- a/cli/command/formatter/context.go
+++ b/cli/command/formatter/context.go
@@ -1,5 +1,7 @@
 package formatter
 
+import "encoding/json"
+
 const (
 	// ClientContextTableFormat is the default client context format.
 	ClientContextTableFormat = "table {{.Name}}{{if .Current}} *{{end}}\t{{.Description}}\t{{.DockerEndpoint}}\t{{.Error}}"
@@ -28,6 +30,13 @@ type ClientContext struct {
 	DockerEndpoint string
 	Current        bool
 	Error          string
+
+	// ContextType is a temporary field for compatibility with
+	// Visual Studio, which depends on this from the "cloud integration"
+	// wrapper.
+	//
+	// Deprecated: this type is only for backward-compatibility. Do not use.
+	ContextType string `json:"ContextType,omitempty"`
 }
 
 // ClientContextWrite writes formatted contexts using the Context
@@ -60,6 +69,13 @@ func newClientContextContext() *clientContextContext {
 }
 
 func (c *clientContextContext) MarshalJSON() ([]byte, error) {
+	if c.c.ContextType != "" {
+		// We only have ContextType set for plain "json" or "{{json .}}" formatting,
+		// so we should be able to just use the default json.Marshal with no
+		// special handling.
+		return json.Marshal(c.c)
+	}
+	// FIXME(thaJeztah): why do we need a special marshal function here?
 	return MarshalJSON(c)
 }
 


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/cli/pull/5097

Docker Desktop currently ships with the "cloud integration" wrapper, which outputs an additional ContextType field in the JSON output.

While this field is non-standard, it made its way into Visual Studio's Docker integration, which uses this to exclude "aci" and "eci" context types that are not supported by Visual Studio.

This patch;

- conditionally adds a ContextType field to the JSON output
- but ONLY when using the default "{{json .}}" or "json" formats (which are the formats used by Visual Studio)
- if the context is a "aci" or "eci" context, that type is preserved, otherwise the default "moby" type is used.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add a temporary `ContextType` field to the JSON output of "docker context ls" for backward-compatibility with Visual Studio.
```

**- A picture of a cute animal (not mandatory but encouraged)**

