### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # GitHub code owners
 # See https://github.com/blog/2392-introducing-code-owners
 
-cli/command/stack/**        @silvin-lubecki
-contrib/completion/bash/**  @albers
-contrib/completion/zsh/**   @sdurrheimer
-docs/**                     @thaJeztah
+cli/command/stack/**        @silvin-lubecki @docker/runtime-owners
+contrib/completion/bash/**  @albers @docker/runtime-owners
+docs/**                     @thaJeztah @docker/runtime-owners


### PR DESCRIPTION
Keep pinging desired individuals for certain changes, but allow others to keep reviewing in accordance with org Branch Protection rules 

(note: runtime-owners team has notifications disabled)
