### PR TITLE
Correct typos in comments in the `cli/` folder

### DIFF
--- a/cli/command/formatter/tabwriter/tabwriter.go
+++ b/cli/command/formatter/tabwriter/tabwriter.go
@@ -106,7 +106,7 @@ type Writer struct {
 	cell    cell     // current incomplete cell; cell.width is up to buf[pos] excluding ignored sections
 	endChar byte     // terminating char of escaped sequence (Escape for escapes, '>', ';' for HTML tags/entities, or 0)
 	lines   [][]cell // list of lines; each line is a list of cells
-	widths  []int    // list of column widths in runes - re-used during formatting
+	widths  []int    // list of column widths in runes - reused during formatting
 }
 
 // addLine adds a new line.
@@ -115,7 +115,7 @@ type Writer struct {
 func (b *Writer) addLine(flushed bool) {
 	// Grow slice instead of appending,
 	// as that gives us an opportunity
-	// to re-use an existing []cell.
+	// to reuse an existing []cell.
 	if n := len(b.lines) + 1; n <= cap(b.lines) {
 		b.lines = b.lines[:n]
 		b.lines[n-1] = b.lines[n-1][:0]
@@ -159,7 +159,7 @@ func (b *Writer) reset() {
 // - the sizes and widths of processed text are kept in the lines list
 //   which contains a list of cells for each line
 // - the widths list is a temporary list with current widths used during
-//   formatting; it is kept in Writer because it's re-used
+//   formatting; it is kept in Writer because it's reused
 //
 //                    |<---------- size ---------->|
 //                    |                            |

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -131,7 +131,7 @@ func (s *ShlexOpt) Set(value string) error {
 	return nil
 }
 
-// Type returns the tyep of the value
+// Type returns the type of the value
 func (s *ShlexOpt) Type() string {
 	return "command"
 }

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -832,7 +832,7 @@ func (u *globalJobProgressUpdater) writeOverallProgress(complete int) {
 	// total progress.
 	u.progressOut.WriteProgress(progress.Progress{
 		// see (*replicatedJobProgressUpdater).writeOverallProgress for an
-		// explanation fo the advanced fmt use in this function.
+		// explanation of the advanced fmt use in this function.
 		ID: "job progress",
 		Action: fmt.Sprintf(
 			"%*d out of %d complete", u.progressDigits, complete, u.total,

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -281,7 +281,7 @@ func convertServiceSecrets(
 
 // convertServiceConfigObjs takes an API client, a namespace, a ServiceConfig,
 // and a set of compose Config specs, and creates the swarm ConfigReferences
-// required by the serivce. Unlike convertServiceSecrets, this takes the whole
+// required by the service. Unlike convertServiceSecrets, this takes the whole
 // ServiceConfig, because some Configs may be needed as a result of other
 // fields (like CredentialSpecs).
 //

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -48,7 +48,7 @@ type Mapping func(string) (string, bool)
 // the substitution and an error.
 type SubstituteFunc func(string, Mapping) (string, bool, error)
 
-// SubstituteWith subsitute variables in the string with their values.
+// SubstituteWith substitutes variables in the string with their values.
 // It accepts additional substitute function.
 func SubstituteWith(template string, mapping Mapping, pattern *regexp.Regexp, subsFuncs ...SubstituteFunc) (string, error) {
 	var err error

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -14,7 +14,7 @@ type NamedTypeGetter struct {
 	typeGetter TypeGetter
 }
 
-// EndpointTypeGetter returns a NamedTypeGetter with the spcecified name and getter
+// EndpointTypeGetter returns a NamedTypeGetter with the specified name and getter
 func EndpointTypeGetter(name string, getter TypeGetter) NamedTypeGetter {
 	return NamedTypeGetter{
 		name:       name,


### PR DESCRIPTION
**- What I did**

Corrected all typos I found in the `cli/` folder.

**- How I did it**

Ran [Codespell](https://github.com/codespell-project/codespell) on this repository and manually corrected valid misspellings flagged.

**- How to verify it**

`N/A`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Corrected typos in comments in the `cli/` folder.
```
