### PR TITLE
vendor: github.com/docker/docker c6aaabc9fc82 (master / v27.0.0-dev)

### DIFF
--- a/cli/command/network/client_test.go
+++ b/cli/command/network/client_test.go
@@ -15,9 +15,9 @@ type fakeClient struct {
 	networkConnectFunc    func(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	networkDisconnectFunc func(ctx context.Context, networkID, container string, force bool) error
 	networkRemoveFunc     func(ctx context.Context, networkID string) error
-	networkListFunc       func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error)
+	networkListFunc       func(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 	networkPruneFunc      func(ctx context.Context, pruneFilters filters.Args) (types.NetworksPruneReport, error)
-	networkInspectFunc    func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, []byte, error)
+	networkInspectFunc    func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, []byte, error)
 }
 
 func (c *fakeClient) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (network.CreateResponse, error) {
@@ -41,11 +41,11 @@ func (c *fakeClient) NetworkDisconnect(ctx context.Context, networkID, container
 	return nil
 }
 
-func (c *fakeClient) NetworkList(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
+func (c *fakeClient) NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
 	if c.networkListFunc != nil {
 		return c.networkListFunc(ctx, options)
 	}
-	return []types.NetworkResource{}, nil
+	return []network.Inspect{}, nil
 }
 
 func (c *fakeClient) NetworkRemove(ctx context.Context, networkID string) error {
@@ -55,11 +55,11 @@ func (c *fakeClient) NetworkRemove(ctx context.Context, networkID string) error 
 	return nil
 }
 
-func (c *fakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, opts network.InspectOptions) (types.NetworkResource, []byte, error) {
+func (c *fakeClient) NetworkInspectWithRaw(ctx context.Context, networkID string, opts network.InspectOptions) (network.Inspect, []byte, error) {
 	if c.networkInspectFunc != nil {
 		return c.networkInspectFunc(ctx, networkID, opts)
 	}
-	return types.NetworkResource{}, nil, nil
+	return network.Inspect{}, nil, nil
 }
 
 func (c *fakeClient) NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error) {

--- a/cli/command/network/formatter.go
+++ b/cli/command/network/formatter.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stringid"
 )
 
@@ -35,10 +35,10 @@ func NewFormat(source string, quiet bool) formatter.Format {
 }
 
 // FormatWrite writes the context
-func FormatWrite(ctx formatter.Context, networks []types.NetworkResource) error {
+func FormatWrite(ctx formatter.Context, networks []network.Summary) error {
 	render := func(format func(subContext formatter.SubContext) error) error {
-		for _, network := range networks {
-			networkCtx := &networkContext{trunc: ctx.Trunc, n: network}
+		for _, nw := range networks {
+			networkCtx := &networkContext{trunc: ctx.Trunc, n: nw}
 			if err := format(networkCtx); err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func FormatWrite(ctx formatter.Context, networks []types.NetworkResource) error 
 type networkContext struct {
 	formatter.HeaderContext
 	trunc bool
-	n     types.NetworkResource
+	n     network.Summary
 }
 
 func (c *networkContext) MarshalJSON() ([]byte, error) {

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/internal/test"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stringid"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -29,36 +29,36 @@ func TestNetworkContext(t *testing.T) {
 		call       func() string
 	}{
 		{networkContext{
-			n:     types.NetworkResource{ID: networkID},
+			n:     network.Summary{ID: networkID},
 			trunc: false,
 		}, networkID, ctx.ID},
 		{networkContext{
-			n:     types.NetworkResource{ID: networkID},
+			n:     network.Summary{ID: networkID},
 			trunc: true,
 		}, stringid.TruncateID(networkID), ctx.ID},
 		{networkContext{
-			n: types.NetworkResource{Name: "network_name"},
+			n: network.Summary{Name: "network_name"},
 		}, "network_name", ctx.Name},
 		{networkContext{
-			n: types.NetworkResource{Driver: "driver_name"},
+			n: network.Summary{Driver: "driver_name"},
 		}, "driver_name", ctx.Driver},
 		{networkContext{
-			n: types.NetworkResource{EnableIPv6: true},
+			n: network.Summary{EnableIPv6: true},
 		}, "true", ctx.IPv6},
 		{networkContext{
-			n: types.NetworkResource{EnableIPv6: false},
+			n: network.Summary{EnableIPv6: false},
 		}, "false", ctx.IPv6},
 		{networkContext{
-			n: types.NetworkResource{Internal: true},
+			n: network.Summary{Internal: true},
 		}, "true", ctx.Internal},
 		{networkContext{
-			n: types.NetworkResource{Internal: false},
+			n: network.Summary{Internal: false},
 		}, "false", ctx.Internal},
 		{networkContext{
-			n: types.NetworkResource{},
+			n: network.Summary{},
 		}, "", ctx.Labels},
 		{networkContext{
-			n: types.NetworkResource{Labels: map[string]string{"label1": "value1", "label2": "value2"}},
+			n: network.Summary{Labels: map[string]string{"label1": "value1", "label2": "value2"}},
 		}, "label1=value1,label2=value2", ctx.Labels},
 	}
 
@@ -155,7 +155,7 @@ foobar_bar 2017-01-01 00:00:00 +0000 UTC
 	timestamp1, _ := time.Parse("2006-01-02", "2016-01-01")
 	timestamp2, _ := time.Parse("2006-01-02", "2017-01-01")
 
-	networks := []types.NetworkResource{
+	networks := []network.Summary{
 		{ID: "networkID1", Name: "foobar_baz", Driver: "foo", Scope: "local", Created: timestamp1},
 		{ID: "networkID2", Name: "foobar_bar", Driver: "bar", Scope: "local", Created: timestamp2},
 	}
@@ -176,7 +176,7 @@ foobar_bar 2017-01-01 00:00:00 +0000 UTC
 }
 
 func TestNetworkContextWriteJSON(t *testing.T) {
-	networks := []types.NetworkResource{
+	networks := []network.Summary{
 		{ID: "networkID1", Name: "foobar_baz"},
 		{ID: "networkID2", Name: "foobar_bar"},
 	}
@@ -200,7 +200,7 @@ func TestNetworkContextWriteJSON(t *testing.T) {
 }
 
 func TestNetworkContextWriteJSONField(t *testing.T) {
-	networks := []types.NetworkResource{
+	networks := []network.Summary{
 		{ID: "networkID1", Name: "foobar_baz"},
 		{ID: "networkID2", Name: "foobar_bar"},
 	}

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/builders"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/google/go-cmp/cmp"
@@ -19,12 +18,12 @@ import (
 
 func TestNetworkListErrors(t *testing.T) {
 	testCases := []struct {
-		networkListFunc func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error)
+		networkListFunc func(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 		expectedError   string
 	}{
 		{
-			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
-				return []types.NetworkResource{}, errors.Errorf("error creating network")
+			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
+				return []network.Summary{}, errors.Errorf("error creating network")
 			},
 			expectedError: "error creating network",
 		},
@@ -44,7 +43,7 @@ func TestNetworkListErrors(t *testing.T) {
 func TestNetworkList(t *testing.T) {
 	testCases := []struct {
 		doc             string
-		networkListFunc func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error)
+		networkListFunc func(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 		flags           map[string]string
 		golden          string
 	}{
@@ -54,13 +53,13 @@ func TestNetworkList(t *testing.T) {
 				"filter": "image.name=ubuntu",
 			},
 			golden: "network-list.golden",
-			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
+			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
 				expectedOpts := network.ListOptions{
 					Filters: filters.NewArgs(filters.Arg("image.name", "ubuntu")),
 				}
 				assert.Check(t, is.DeepEqual(expectedOpts, options, cmp.AllowUnexported(filters.Args{})))
 
-				return []types.NetworkResource{*builders.NetworkResource(builders.NetworkResourceID("123454321"),
+				return []network.Summary{*builders.NetworkResource(builders.NetworkResourceID("123454321"),
 					builders.NetworkResourceName("network_1"),
 					builders.NetworkResourceDriver("09.7.01"),
 					builders.NetworkResourceScope("global"))}, nil
@@ -72,8 +71,8 @@ func TestNetworkList(t *testing.T) {
 				"format": "{{ .Name }}",
 			},
 			golden: "network-list-sort.golden",
-			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
-				return []types.NetworkResource{
+			networkListFunc: func(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
+				return []network.Summary{
 					*builders.NetworkResource(builders.NetworkResourceName("network-2-foo")),
 					*builders.NetworkResource(builders.NetworkResourceName("network-1-foo")),
 					*builders.NetworkResource(builders.NetworkResourceName("network-10-foo")),

--- a/cli/command/network/remove_test.go
+++ b/cli/command/network/remove_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
@@ -105,8 +104,8 @@ func TestNetworkRemovePromptTermination(t *testing.T) {
 		networkRemoveFunc: func(ctx context.Context, networkID string) error {
 			return errors.New("fakeClient networkRemoveFunc should not be called")
 		},
-		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, []byte, error) {
-			return types.NetworkResource{
+		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, []byte, error) {
+			return network.Inspect{
 				ID:      "existing-network",
 				Name:    "existing-network",
 				Ingress: true,

--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -18,7 +18,7 @@ type fakeClient struct {
 	serviceListFunc           func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)
 	taskListFunc              func(context.Context, types.TaskListOptions) ([]swarm.Task, error)
 	infoFunc                  func(ctx context.Context) (system.Info, error)
-	networkInspectFunc        func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error)
+	networkInspectFunc        func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error)
 	nodeListFunc              func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
 }
 
@@ -67,11 +67,11 @@ func (f *fakeClient) Info(ctx context.Context) (system.Info, error) {
 	return f.infoFunc(ctx)
 }
 
-func (f *fakeClient) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error) {
+func (f *fakeClient) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 	if f.networkInspectFunc != nil {
 		return f.networkInspectFunc(ctx, networkID, options)
 	}
-	return types.NetworkResource{}, nil
+	return network.Inspect{}, nil
 }
 
 func newService(id string, name string) swarm.Service {

--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -10,9 +10,9 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/inspect"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	mounttypes "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/stringid"
 	units "github.com/docker/go-units"
@@ -208,9 +208,9 @@ func NewFormat(source string) formatter.Format {
 
 func resolveNetworks(service swarm.Service, getNetwork inspect.GetRefFunc) map[string]string {
 	networkNames := make(map[string]string)
-	for _, network := range service.Spec.TaskTemplate.Networks {
-		if resolved, _, err := getNetwork(network.Target); err == nil {
-			if resolvedNetwork, ok := resolved.(types.NetworkResource); ok {
+	for _, nw := range service.Spec.TaskTemplate.Networks {
+		if resolved, _, err := getNetwork(nw.Target); err == nil {
+			if resolvedNetwork, ok := resolved.(network.Summary); ok {
 				networkNames[resolvedNetwork.ID] = resolvedNetwork.Name
 			}
 		}

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -136,7 +136,7 @@ func formatServiceInspect(t *testing.T, format formatter.Format, now time.Time) 
 			return s, nil, nil
 		},
 		func(ref string) (any, []byte, error) {
-			return types.NetworkResource{
+			return network.Inspect{
 				ID:   "5vpyomhb6ievnk0i0o60gcnei",
 				Name: "mynetwork",
 			}, nil, nil

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/docker/cli/opts"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
@@ -186,20 +185,20 @@ func TestResourceOptionsToResourceRequirements(t *testing.T) {
 }
 
 func TestToServiceNetwork(t *testing.T) {
-	nws := []types.NetworkResource{
+	nws := []network.Inspect{
 		{Name: "aaa-network", ID: "id555"},
 		{Name: "mmm-network", ID: "id999"},
 		{Name: "zzz-network", ID: "id111"},
 	}
 
 	client := &fakeClient{
-		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error) {
+		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 			for _, nw := range nws {
 				if nw.ID == networkID || nw.Name == networkID {
 					return nw, nil
 				}
 			}
-			return types.NetworkResource{}, fmt.Errorf("network not found: %s", networkID)
+			return network.Inspect{}, fmt.Errorf("network not found: %s", networkID)
 		},
 	}
 

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -847,20 +847,20 @@ func TestRemoveGenericResources(t *testing.T) {
 
 func TestUpdateNetworks(t *testing.T) {
 	ctx := context.Background()
-	nws := []types.NetworkResource{
+	nws := []network.Summary{
 		{Name: "aaa-network", ID: "id555"},
 		{Name: "mmm-network", ID: "id999"},
 		{Name: "zzz-network", ID: "id111"},
 	}
 
 	client := &fakeClient{
-		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error) {
+		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 			for _, nw := range nws {
 				if nw.ID == networkID || nw.Name == networkID {
 					return nw, nil
 				}
 			}
-			return types.NetworkResource{}, fmt.Errorf("network not found: %s", networkID)
+			return network.Inspect{}, fmt.Errorf("network not found: %s", networkID)
 		},
 	}
 

--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -29,7 +29,7 @@ type fakeClient struct {
 	removedConfigs  []string
 
 	serviceListFunc    func(options types.ServiceListOptions) ([]swarm.Service, error)
-	networkListFunc    func(options network.ListOptions) ([]types.NetworkResource, error)
+	networkListFunc    func(options network.ListOptions) ([]network.Summary, error)
 	secretListFunc     func(options types.SecretListOptions) ([]swarm.Secret, error)
 	configListFunc     func(options types.ConfigListOptions) ([]swarm.Config, error)
 	nodeListFunc       func(options types.NodeListOptions) ([]swarm.Node, error)
@@ -70,13 +70,13 @@ func (cli *fakeClient) ServiceList(_ context.Context, options types.ServiceListO
 	return servicesList, nil
 }
 
-func (cli *fakeClient) NetworkList(_ context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
+func (cli *fakeClient) NetworkList(_ context.Context, options network.ListOptions) ([]network.Summary, error) {
 	if cli.networkListFunc != nil {
 		return cli.networkListFunc(options)
 	}
 
 	namespace := namespaceFromFilters(options.Filters)
-	networksList := []types.NetworkResource{}
+	networksList := []network.Summary{}
 	for _, name := range cli.networks {
 		if belongToNamespace(name, namespace) {
 			networksList = append(networksList, networkFromName(name))
@@ -200,8 +200,8 @@ func serviceFromName(name string) swarm.Service {
 	}
 }
 
-func networkFromName(name string) types.NetworkResource {
-	return types.NetworkResource{
+func networkFromName(name string) network.Summary {
+	return network.Summary{
 		ID:   "ID-" + name,
 		Name: name,
 	}

--- a/cli/command/stack/swarm/client_test.go
+++ b/cli/command/stack/swarm/client_test.go
@@ -29,7 +29,7 @@ type fakeClient struct {
 	removedConfigs  []string
 
 	serviceListFunc    func(options types.ServiceListOptions) ([]swarm.Service, error)
-	networkListFunc    func(options network.ListOptions) ([]types.NetworkResource, error)
+	networkListFunc    func(options network.ListOptions) ([]network.Summary, error)
 	secretListFunc     func(options types.SecretListOptions) ([]swarm.Secret, error)
 	configListFunc     func(options types.ConfigListOptions) ([]swarm.Config, error)
 	nodeListFunc       func(options types.NodeListOptions) ([]swarm.Node, error)
@@ -70,13 +70,13 @@ func (cli *fakeClient) ServiceList(_ context.Context, options types.ServiceListO
 	return servicesList, nil
 }
 
-func (cli *fakeClient) NetworkList(_ context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
+func (cli *fakeClient) NetworkList(_ context.Context, options network.ListOptions) ([]network.Summary, error) {
 	if cli.networkListFunc != nil {
 		return cli.networkListFunc(options)
 	}
 
 	namespace := namespaceFromFilters(options.Filters)
-	networksList := []types.NetworkResource{}
+	networksList := []network.Summary{}
 	for _, name := range cli.networks {
 		if belongToNamespace(name, namespace) {
 			networksList = append(networksList, networkFromName(name))
@@ -189,8 +189,8 @@ func serviceFromName(name string) swarm.Service {
 	}
 }
 
-func networkFromName(name string) types.NetworkResource {
-	return types.NetworkResource{
+func networkFromName(name string) network.Summary {
+	return network.Summary{
 		ID:   "ID-" + name,
 		Name: name,
 	}

--- a/cli/command/stack/swarm/common.go
+++ b/cli/command/stack/swarm/common.go
@@ -34,7 +34,7 @@ func getStackServices(ctx context.Context, apiclient client.APIClient, namespace
 	return apiclient.ServiceList(ctx, types.ServiceListOptions{Filters: getStackFilter(namespace)})
 }
 
-func getStackNetworks(ctx context.Context, apiclient client.APIClient, namespace string) ([]types.NetworkResource, error) {
+func getStackNetworks(ctx context.Context, apiclient client.APIClient, namespace string) ([]network.Summary, error) {
 	return apiclient.NetworkList(ctx, network.ListOptions{Filters: getStackFilter(namespace)})
 }
 

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -165,7 +165,7 @@ func createNetworks(ctx context.Context, dockerCli command.Cli, namespace conver
 		return err
 	}
 
-	existingNetworkMap := make(map[string]types.NetworkResource)
+	existingNetworkMap := make(map[string]network.Summary)
 	for _, nw := range existingNetworks {
 		existingNetworkMap[nw.Name] = nw
 	}

--- a/cli/command/stack/swarm/deploy_composefile_test.go
+++ b/cli/command/stack/swarm/deploy_composefile_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test/network"
-	"github.com/docker/docker/api/types"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
@@ -19,7 +18,7 @@ func (n notFound) NotFound() {}
 
 func TestValidateExternalNetworks(t *testing.T) {
 	testcases := []struct {
-		inspectResponse types.NetworkResource
+		inspectResponse networktypes.Inspect
 		inspectError    error
 		expectedMsg     string
 		network         string
@@ -45,13 +44,13 @@ func TestValidateExternalNetworks(t *testing.T) {
 		},
 		{
 			network:         "user",
-			inspectResponse: types.NetworkResource{Scope: "swarm"},
+			inspectResponse: networktypes.Inspect{Scope: "swarm"},
 		},
 	}
 
 	for _, testcase := range testcases {
 		fakeClient := &network.FakeClient{
-			NetworkInspectFunc: func(_ context.Context, _ string, _ networktypes.InspectOptions) (types.NetworkResource, error) {
+			NetworkInspectFunc: func(_ context.Context, _ string, _ networktypes.InspectOptions) (networktypes.Inspect, error) {
 				return testcase.inspectResponse, testcase.inspectError
 			},
 		}

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack/options"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
 	apiclient "github.com/docker/docker/client"
@@ -102,14 +102,14 @@ func removeServices(
 func removeNetworks(
 	ctx context.Context,
 	dockerCli command.Cli,
-	networks []types.NetworkResource,
+	networks []network.Summary,
 ) bool {
 	var hasError bool
-	for _, network := range networks {
-		fmt.Fprintf(dockerCli.Out(), "Removing network %s\n", network.Name)
-		if err := dockerCli.Client().NetworkRemove(ctx, network.ID); err != nil {
+	for _, nw := range networks {
+		fmt.Fprintf(dockerCli.Out(), "Removing network %s\n", nw.Name)
+		if err := dockerCli.Client().NetworkRemove(ctx, nw.ID); err != nil {
 			hasError = true
-			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", network.ID, err)
+			fmt.Fprintf(dockerCli.Err(), "Failed to remove network %s: %s", nw.ID, err)
 		}
 	}
 	return hasError

--- a/internal/test/builders/network.go
+++ b/internal/test/builders/network.go
@@ -1,14 +1,14 @@
 package builders
 
 import (
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 )
 
 // NetworkResource creates a network resource with default values.
 // Any number of networkResource function builder can be pass to modify the existing value.
 // feel free to add another builder func if you need to override another value
-func NetworkResource(builders ...func(resource *types.NetworkResource)) *types.NetworkResource {
-	resource := &types.NetworkResource{}
+func NetworkResource(builders ...func(resource *network.Summary)) *network.Summary {
+	resource := &network.Summary{}
 
 	for _, builder := range builders {
 		builder(resource)
@@ -17,29 +17,29 @@ func NetworkResource(builders ...func(resource *types.NetworkResource)) *types.N
 }
 
 // NetworkResourceName sets the name of the resource network
-func NetworkResourceName(name string) func(networkResource *types.NetworkResource) {
-	return func(networkResource *types.NetworkResource) {
+func NetworkResourceName(name string) func(networkResource *network.Summary) {
+	return func(networkResource *network.Summary) {
 		networkResource.Name = name
 	}
 }
 
 // NetworkResourceID sets the ID of the resource network
-func NetworkResourceID(id string) func(networkResource *types.NetworkResource) {
-	return func(networkResource *types.NetworkResource) {
+func NetworkResourceID(id string) func(networkResource *network.Summary) {
+	return func(networkResource *network.Summary) {
 		networkResource.ID = id
 	}
 }
 
 // NetworkResourceDriver sets the driver of the resource network
-func NetworkResourceDriver(name string) func(networkResource *types.NetworkResource) {
-	return func(networkResource *types.NetworkResource) {
+func NetworkResourceDriver(name string) func(networkResource *network.Summary) {
+	return func(networkResource *network.Summary) {
 		networkResource.Driver = name
 	}
 }
 
 // NetworkResourceScope sets the Scope of the resource network
-func NetworkResourceScope(scope string) func(networkResource *types.NetworkResource) {
-	return func(networkResource *types.NetworkResource) {
+func NetworkResourceScope(scope string) func(networkResource *network.Summary) {
+	return func(networkResource *network.Summary) {
 		networkResource.Scope = scope
 	}
 }

--- a/internal/test/network/client.go
+++ b/internal/test/network/client.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 )
@@ -11,13 +10,13 @@ import (
 // FakeClient is a fake NetworkAPIClient
 type FakeClient struct {
 	client.NetworkAPIClient
-	NetworkInspectFunc func(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error)
+	NetworkInspectFunc func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error)
 }
 
 // NetworkInspect fakes inspecting a network
-func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error) {
+func (c *FakeClient) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 	if c.NetworkInspectFunc != nil {
 		return c.NetworkInspectFunc(ctx, networkID, options)
 	}
-	return types.NetworkResource{}, nil
+	return network.Inspect{}, nil
 }

--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v26.1.1-0.20240603220541-cd3804655a25+incompatible // master (v27.0.0-dev)
+	github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible // master (v27.0.0-dev)
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -59,8 +59,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.1-0.20240603220541-cd3804655a25+incompatible h1:mzBHld522snTZ7BoMQiw0RXTdraVMr380QGZzGsPRqI=
-github.com/docker/docker v26.1.1-0.20240603220541-cd3804655a25+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible h1:8g5smywu5/OBvcewEvwznUkqjraD7/9CWre2y2tCTGY=
+github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/types/network/network.go
+++ b/vendor/github.com/docker/docker/api/types/network/network.go
@@ -1,6 +1,8 @@
 package network // import "github.com/docker/docker/api/types/network"
 
 import (
+	"time"
+
 	"github.com/docker/docker/api/types/filters"
 )
 
@@ -41,6 +43,32 @@ type DisconnectOptions struct {
 	Container string
 	Force     bool
 }
+
+// Inspect is the body of the "get network" http response message.
+type Inspect struct {
+	Name       string                      // Name is the name of the network
+	ID         string                      `json:"Id"` // ID uniquely identifies a network on a single machine
+	Created    time.Time                   // Created is the time the network created
+	Scope      string                      // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
+	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
+	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
+	IPAM       IPAM                        // IPAM is the network's IP Address Management
+	Internal   bool                        // Internal represents if the network is used internal only
+	Attachable bool                        // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
+	Ingress    bool                        // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
+	ConfigFrom ConfigReference             // ConfigFrom specifies the source which will provide the configuration for this network.
+	ConfigOnly bool                        // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
+	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
+	Options    map[string]string           // Options holds the network specific options to use for when creating the network
+	Labels     map[string]string           // Labels holds metadata specific to the network being created
+	Peers      []PeerInfo                  `json:",omitempty"` // List of peer nodes for an overlay network
+	Services   map[string]ServiceInfo      `json:",omitempty"`
+}
+
+// Summary is used as response when listing networks. It currently is an alias
+// for [Inspect], but may diverge in the future, as not all information may
+// be included when listing networks.
+type Summary = Inspect
 
 // Address represents an IP address
 type Address struct {

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -423,27 +423,6 @@ type MountPoint struct {
 	Propagation mount.Propagation
 }
 
-// NetworkResource is the body of the "get network" http response message
-type NetworkResource struct {
-	Name       string                              // Name is the requested name of the network
-	ID         string                              `json:"Id"` // ID uniquely identifies a network on a single machine
-	Created    time.Time                           // Created is the time the network created
-	Scope      string                              // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level)
-	Driver     string                              // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
-	EnableIPv6 bool                                // EnableIPv6 represents whether to enable IPv6
-	IPAM       network.IPAM                        // IPAM is the network's IP Address Management
-	Internal   bool                                // Internal represents if the network is used internal only
-	Attachable bool                                // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.
-	Ingress    bool                                // Ingress indicates the network is providing the routing-mesh for the swarm cluster.
-	ConfigFrom network.ConfigReference             // ConfigFrom specifies the source which will provide the configuration for this network.
-	ConfigOnly bool                                // ConfigOnly networks are place-holder networks for network configurations to be used by other networks. ConfigOnly networks cannot be used directly to run containers or services.
-	Containers map[string]network.EndpointResource // Containers contains endpoints belonging to the network
-	Options    map[string]string                   // Options holds the network specific options to use for when creating the network
-	Labels     map[string]string                   // Labels holds metadata specific to the network being created
-	Peers      []network.PeerInfo                  `json:",omitempty"` // List of peer nodes for an overlay network
-	Services   map[string]network.ServiceInfo      `json:",omitempty"`
-}
-
 // NetworkCreate is the expected body of the "create network" http request message
 type NetworkCreate struct {
 	// Deprecated: CheckDuplicate is deprecated since API v1.44, but it defaults to true when sent by the client

--- a/vendor/github.com/docker/docker/api/types/types_deprecated.go
+++ b/vendor/github.com/docker/docker/api/types/types_deprecated.go
@@ -1,39 +1,8 @@
 package types
 
 import (
-	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 )
-
-// ImageImportOptions holds information to import images from the client host.
-//
-// Deprecated: use [image.ImportOptions].
-type ImageImportOptions = image.ImportOptions
-
-// ImageCreateOptions holds information to create images.
-//
-// Deprecated: use [image.CreateOptions].
-type ImageCreateOptions = image.CreateOptions
-
-// ImagePullOptions holds information to pull images.
-//
-// Deprecated: use [image.PullOptions].
-type ImagePullOptions = image.PullOptions
-
-// ImagePushOptions holds information to push images.
-//
-// Deprecated: use [image.PushOptions].
-type ImagePushOptions = image.PushOptions
-
-// ImageListOptions holds parameters to list images with.
-//
-// Deprecated: use [image.ListOptions].
-type ImageListOptions = image.ListOptions
-
-// ImageRemoveOptions holds parameters to remove images.
-//
-// Deprecated: use [image.RemoveOptions].
-type ImageRemoveOptions = image.RemoveOptions
 
 // NetworkListOptions holds parameters to filter the list of networks with.
 //
@@ -64,3 +33,8 @@ type NetworkDisconnect = network.DisconnectOptions
 //
 // Deprecated: use [network.EndpointResource].
 type EndpointResource = network.EndpointResource
+
+// NetworkResource is the body of the "get network" http response message/
+//
+// Deprecated: use [network.Inspect] or [network.Summary] (for list operations).
+type NetworkResource = network.Inspect

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -110,9 +110,9 @@ type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, network, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (network.CreateResponse, error)
 	NetworkDisconnect(ctx context.Context, network, container string, force bool) error
-	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (types.NetworkResource, error)
-	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (types.NetworkResource, []byte, error)
-	NetworkList(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error)
+	NetworkInspect(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, error)
+	NetworkInspectWithRaw(ctx context.Context, network string, options network.InspectOptions) (network.Inspect, []byte, error)
+	NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error)
 	NetworkRemove(ctx context.Context, network string) error
 	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error)
 }

--- a/vendor/github.com/docker/docker/client/network_inspect.go
+++ b/vendor/github.com/docker/docker/client/network_inspect.go
@@ -7,20 +7,19 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 )
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
-func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, error) {
+func (cli *Client) NetworkInspect(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID, options)
 	return networkResource, err
 }
 
 // NetworkInspectWithRaw returns the information for a specific network configured in the docker host and its raw representation.
-func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options network.InspectOptions) (types.NetworkResource, []byte, error) {
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, []byte, error) {
 	if networkID == "" {
-		return types.NetworkResource{}, nil, objectNotFoundError{object: "network", id: networkID}
+		return network.Inspect{}, nil, objectNotFoundError{object: "network", id: networkID}
 	}
 	query := url.Values{}
 	if options.Verbose {
@@ -33,15 +32,15 @@ func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string, 
 	resp, err := cli.get(ctx, "/networks/"+networkID, query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
-		return types.NetworkResource{}, nil, err
+		return network.Inspect{}, nil, err
 	}
 
 	raw, err := io.ReadAll(resp.body)
 	if err != nil {
-		return types.NetworkResource{}, nil, err
+		return network.Inspect{}, nil, err
 	}
 
-	var nw types.NetworkResource
+	var nw network.Inspect
 	err = json.NewDecoder(bytes.NewReader(raw)).Decode(&nw)
 	return nw, raw, err
 }

--- a/vendor/github.com/docker/docker/client/network_list.go
+++ b/vendor/github.com/docker/docker/client/network_list.go
@@ -5,13 +5,12 @@ import (
 	"encoding/json"
 	"net/url"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 )
 
 // NetworkList returns the list of networks configured in the docker host.
-func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions) ([]types.NetworkResource, error) {
+func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
 		//nolint:staticcheck // ignore SA1019 for old code
@@ -22,7 +21,7 @@ func (cli *Client) NetworkList(ctx context.Context, options network.ListOptions)
 
 		query.Set("filters", filterJSON)
 	}
-	var networkResources []types.NetworkResource
+	var networkResources []network.Summary
 	resp, err := cli.get(ctx, "/networks", query, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v26.1.1-0.20240603220541-cd3804655a25+incompatible
+# github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- api: move more network-related types to api/types/network https://github.com/moby/moby/pull/47882

full diff: https://github.com/docker/docker/compare/cd3804655a252117742a2987df15630a61ce334e...c6aaabc9fc8201496379ab12bf4c9386000cb21d

**- A picture of a cute animal (not mandatory but encouraged)**

