### PR TITLE
Correct typos in `docs/` and `man/`

### DIFF
--- a/docs/reference/commandline/volume_create.md
+++ b/docs/reference/commandline/volume_create.md
@@ -57,7 +57,7 @@ A volume named  "hello"  already exists with the "some-other" driver. Choose a d
 ```
 
 If you specify a volume name already in use on the current driver, Docker
-assumes you want to re-use the existing volume and doesn't return an error.
+assumes you want to reuse the existing volume and doesn't return an error.
 
 ### <a name="opt"></a> Driver-specific options (-o, --opt)
 

--- a/man/Dockerfile.5.md
+++ b/man/Dockerfile.5.md
@@ -48,7 +48,7 @@ A Dockerfile is similar to a Makefile.
   to a new image if necessary, before finally outputting the ID of the new
   image. The Docker daemon automatically cleans up the context it is given.
 
-  Docker re-uses intermediate images whenever possible. This significantly
+  Docker reuses intermediate images whenever possible. This significantly
   accelerates the *docker build* process.
 
 # FORMAT


### PR DESCRIPTION
**- What I did**

Corrected all typos I found in the `docs/` and `man/` folders.

**- How I did it**

Ran [Codespell](https://github.com/codespell-project/codespell) on this repository and manually corrected valid misspellings flagged.

**- How to verify it**

`N/A`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Corrected typos in comments in the `docs/` and `man/` folders.
```
