### PR TITLE
network create: make --ipv6 optional

### DIFF
--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -23,7 +23,7 @@ type createOptions struct {
 	driverOpts opts.MapOpts
 	labels     opts.ListOpts
 	internal   bool
-	ipv6       bool
+	ipv6       *bool
 	attachable bool
 	ingress    bool
 	configOnly bool
@@ -38,6 +38,7 @@ type createOptions struct {
 }
 
 func newCreateCommand(dockerCli command.Cli) *cobra.Command {
+	var ipv6 bool
 	options := createOptions{
 		driverOpts: *opts.NewMapOpts(nil, nil),
 		labels:     opts.NewListOpts(opts.ValidateLabel),
@@ -51,6 +52,11 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.name = args[0]
+
+			if cmd.Flag("ipv6").Changed {
+				options.ipv6 = &ipv6
+			}
+
 			return runCreate(cmd.Context(), dockerCli, options)
 		},
 		ValidArgsFunction: completion.NoComplete,
@@ -61,7 +67,7 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.driverOpts, "opt", "o", "Set driver specific options")
 	flags.Var(&options.labels, "label", "Set metadata on a network")
 	flags.BoolVar(&options.internal, "internal", false, "Restrict external access to the network")
-	flags.BoolVar(&options.ipv6, "ipv6", false, "Enable IPv6 networking")
+	flags.BoolVar(&ipv6, "ipv6", false, "Enable or disable IPv6 networking")
 	flags.BoolVar(&options.attachable, "attachable", false, "Enable manual container attachment")
 	flags.SetAnnotation("attachable", "version", []string{"1.25"})
 	flags.BoolVar(&options.ingress, "ingress", false, "Create swarm routing-mesh network")
@@ -107,7 +113,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, options createOptions
 			Options: options.ipamOpt.GetAll(),
 		},
 		Internal:   options.internal,
-		EnableIPv6: &options.ipv6,
+		EnableIPv6: options.ipv6,
 		Attachable: options.attachable,
 		Ingress:    options.ingress,
 		Scope:      options.scope,

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -107,7 +107,7 @@ func runCreate(ctx context.Context, dockerCli command.Cli, options createOptions
 			Options: options.ipamOpt.GetAll(),
 		},
 		Internal:   options.internal,
-		EnableIPv6: options.ipv6,
+		EnableIPv6: &options.ipv6,
 		Attachable: options.attachable,
 		Ingress:    options.ingress,
 		Scope:      options.scope,

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -18,7 +18,7 @@ Create a network
 | `--ip-range`              | `stringSlice` |           | Allocate container ip from a sub-range                  |
 | `--ipam-driver`           | `string`      | `default` | IP Address Management Driver                            |
 | `--ipam-opt`              | `map`         | `map[]`   | Set IPAM driver specific options                        |
-| `--ipv6`                  |               |           | Enable IPv6 networking                                  |
+| `--ipv6`                  |               |           | Enable or disable IPv6 networking                       |
 | `--label`                 | `list`        |           | Set metadata on a network                               |
 | `-o`, `--opt`             | `map`         | `map[]`   | Set driver specific options                             |
 | `--scope`                 | `string`      |           | Control the network's scope                             |
@@ -170,7 +170,7 @@ flags used for the docker0 bridge:
 | `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
 | `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
 | `--internal` | -              | Restrict external access to the network    |
-| `--ipv6`     | `--ipv6`       | Enable IPv6 networking                     |
+| `--ipv6`     | `--ipv6`       | Enable or disable IPv6 networking          |
 | `--subnet`   | `--bip`        | Subnet for network                         |
 
 For example, let's use `-o` or `--opt` options to specify an IP address binding

--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.5.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible // master (v27.0.0-dev)
+	github.com/docker/docker v26.1.1-0.20240606182029-00f18ef7a455+incompatible // master (v27.0.0-dev)
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -59,8 +59,8 @@ github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible h1:8g5smywu5/OBvcewEvwznUkqjraD7/9CWre2y2tCTGY=
-github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.1-0.20240606182029-00f18ef7a455+incompatible h1:6OR7f7LuvJU27W400ctN0mxeAGDnPc0Fg2IGQhltKb0=
+github.com/docker/docker v26.1.1-0.20240606182029-00f18ef7a455+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -430,7 +430,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool                     `json:",omitempty"`
 	Driver         string                   // Driver is the driver-name used to create the network (e.g. `bridge`, `overlay`)
 	Scope          string                   // Scope describes the level at which the network exists (e.g. `swarm` for cluster-wide or `local` for machine level).
-	EnableIPv6     bool                     // EnableIPv6 represents whether to enable IPv6.
+	EnableIPv6     *bool                    `json:",omitempty"` // EnableIPv6 represents whether to enable IPv6.
 	IPAM           *network.IPAM            // IPAM is the network's IP Address Management.
 	Internal       bool                     // Internal represents if the network is used internal only.
 	Attachable     bool                     // Attachable represents if the global scope is manually attachable by regular containers from workers in swarm mode.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v26.1.1-0.20240605134824-c6aaabc9fc82+incompatible
+# github.com/docker/docker v26.1.1-0.20240606182029-00f18ef7a455+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
**- What I did**

The API field `EnableIPv6` was marked as optional in our Swagger docs, and its default value in the Go client came from that field being a bool, thus defaulting to its zero value. That's not the case anymore.

This field is now a `*bool` as to let daemon's config define the default value. IPv6 can still be enabled / disabled by explicitly specifying the `--ipv6` flag when doing `docker network create`.

**- How to verify it**

Start a daemon from moby/moby master branch:

```console
$ ./build/docker-darwin-arm64 network create testnet
$ docker network inspect --format='{{ (index .IPAM.Config) }}' testnet
[{172.20.0.0/16  172.20.0.1 map[]}]

$ ./build/docker-darwin-arm64 network create --ipv6 testnetv6
$ docker network inspect --format='{{ (index .IPAM.Config) }}' testnetv6
[{172.19.0.0/16  172.19.0.1 map[]} {fdbc:8ec0:bb64::/64  fdbc:8ec0:bb64::1/64 map[]}]
```

Then restart the daemon with `--default-network-opt=bridge=com.docker.network.enable_ipv6=true`:

```console
$ ./build/docker-darwin-arm64 network create testnetv6
$ docker network inspect --format='{{ (index .IPAM.Config) }}' testnetv6
[{172.20.0.0/16  172.20.0.1 map[]} {fd8c:5815:be1a::/64  fd8c:5815:be1a::1/64 map[]}]

$ ./build/docker-darwin-arm64 network create --ipv6=false testnet
$ docker network inspect --format='{{ (index .IPAM.Config) }}' testnet
[{172.19.0.0/16  172.19.0.1 map[]}]
```

**- A picture of a cute animal (not mandatory but encouraged)**

