### PR TITLE
cli/command/registry: fix link to credential stores

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -20,7 +20,7 @@ import (
 
 const unencryptedWarning = `WARNING! Your password will be stored unencrypted in %s.
 Configure a credential helper to remove this warning. See
-https://docs.docker.com/engine/reference/commandline/login/#credentials-store
+https://docs.docker.com/engine/reference/commandline/login/#credential-stores
 `
 
 type loginOptions struct {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix a dead link

**- How I did it**

**- How to verify it**
Click the link ;)

**- Description for the changelog**
Fix link in unencryptedWarning
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix the link to the credential stores in the unencrypted credentials warning
```

**- A picture of a cute animal (not mandatory but encouraged)**

