### PR TITLE
Add OomScoreAdj to "docker service create" and "docker compose"

### DIFF
--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -68,6 +68,8 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagSysCtl, "version", []string{"1.40"})
 	flags.Var(&opts.ulimits, flagUlimit, "Ulimit options")
 	flags.SetAnnotation(flagUlimit, "version", []string{"1.41"})
+	flags.Int64Var(&opts.oomScoreAdj, flagOomScoreAdj, 0, "Tune host's OOM preferences (-1000 to 1000) ")
+	flags.SetAnnotation(flagOomScoreAdj, "version", []string{"1.46"})
 
 	flags.Var(cliopts.NewListOptsRef(&opts.resources.resGenericResources, ValidateSingleGenericResource), "generic-resource", "User defined resources")
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.32"})

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -529,6 +529,7 @@ type serviceOptions struct {
 	capAdd          opts.ListOpts
 	capDrop         opts.ListOpts
 	ulimits         opts.UlimitOpt
+	oomScoreAdj     int64
 
 	resources resourceOptions
 	stopGrace opts.DurationOpt
@@ -747,6 +748,7 @@ func (options *serviceOptions) ToService(ctx context.Context, apiClient client.N
 				CapabilityAdd:   capAdd,
 				CapabilityDrop:  capDrop,
 				Ulimits:         options.ulimits.GetList(),
+				OomScoreAdj:     options.oomScoreAdj,
 			},
 			Networks:      networks,
 			Resources:     resources,
@@ -1043,6 +1045,7 @@ const (
 	flagUlimit                  = "ulimit"
 	flagUlimitAdd               = "ulimit-add"
 	flagUlimitRemove            = "ulimit-rm"
+	flagOomScoreAdj             = "oom-score-adj"
 )
 
 func validateAPIVersion(c swarm.ServiceSpec, serverAPIVersion string) error {

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -108,6 +108,8 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagUlimitAdd, "version", []string{"1.41"})
 	flags.Var(newListOptsVar(), flagUlimitRemove, "Remove a ulimit option")
 	flags.SetAnnotation(flagUlimitRemove, "version", []string{"1.41"})
+	flags.Int64Var(&options.oomScoreAdj, flagOomScoreAdj, 0, "Tune host's OOM preferences (-1000 to 1000) ")
+	flags.SetAnnotation(flagOomScoreAdj, "version", []string{"1.46"})
 
 	// Add needs parsing, Remove only needs the key
 	flags.Var(newListOptsVar(), flagGenericResourcesRemove, "Remove a Generic resource")
@@ -365,6 +367,10 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 		taskResources().Reservations = spec.TaskTemplate.Resources.Reservations
 		updateInt64Value(flagReserveCPU, &task.Resources.Reservations.NanoCPUs)
 		updateInt64Value(flagReserveMemory, &task.Resources.Reservations.MemoryBytes)
+	}
+
+	if anyChanged(flags, flagOomScoreAdj) {
+		updateInt64(flagOomScoreAdj, &task.ContainerSpec.OomScoreAdj)
 	}
 
 	if err := addGenericResources(flags, task); err != nil {

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -148,6 +148,7 @@ func Service(
 				CapabilityAdd:   capAdd,
 				CapabilityDrop:  capDrop,
 				Ulimits:         convertUlimits(service.Ulimits),
+				OomScoreAdj:     service.OomScoreAdj,
 			},
 			LogDriver:     logDriver,
 			Resources:     resources,

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -29,6 +29,7 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	servicePath("ulimits", interp.PathMatchAll, "hard"):              toInt,
 	servicePath("ulimits", interp.PathMatchAll, "soft"):              toInt,
 	servicePath("privileged"):                                        toBoolean,
+	servicePath("oom_score_adj"):                                     toInt,
 	servicePath("read_only"):                                         toBoolean,
 	servicePath("stdin_open"):                                        toBoolean,
 	servicePath("tty"):                                               toBoolean,

--- a/cli/compose/schema/data/config_schema_v3.13.json
+++ b/cli/compose/schema/data/config_schema_v3.13.json
@@ -287,6 +287,7 @@
             }
           }
         },
+        "oom_score_adj": {"type": "integer"},
         "user": {"type": "string"},
         "userns_mode": {"type": "string"},
         "volumes": {

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -207,6 +207,7 @@ type ServiceConfig struct {
 	Tty             bool                             `mapstructure:"tty" yaml:"tty,omitempty" json:"tty,omitempty"`
 	Ulimits         map[string]*UlimitsConfig        `yaml:",omitempty" json:"ulimits,omitempty"`
 	User            string                           `yaml:",omitempty" json:"user,omitempty"`
+	OomScoreAdj     int64                            `yaml:",omitempty" json:"oom_score_adj,omitempty"`
 	UserNSMode      string                           `mapstructure:"userns_mode" yaml:"userns_mode,omitempty" json:"userns_mode,omitempty"`
 	Volumes         []ServiceVolumeConfig            `yaml:",omitempty" json:"volumes,omitempty"`
 	WorkingDir      string                           `mapstructure:"working_dir" yaml:"working_dir,omitempty" json:"working_dir,omitempty"`

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -46,6 +46,7 @@ Create a new service
 | [`--network`](#network)                             | `network`         |              | Network attachments                                                                                 |
 | `--no-healthcheck`                                  | `bool`            |              | Disable any container-specified HEALTHCHECK                                                         |
 | `--no-resolve-image`                                | `bool`            |              | Do not query the registry to resolve image digest and supported platforms                           |
+| `--oom-score-adj`                                   | `int64`           | `0`          | Tune host's OOM preferences (-1000 to 1000)                                                         |
 | [`--placement-pref`](#placement-pref)               | `pref`            |              | Add a placement preference                                                                          |
 | [`-p`](#publish), [`--publish`](#publish)           | `port`            |              | Publish a port as a node port                                                                       |
 | `-q`, `--quiet`                                     | `bool`            |              | Suppress progress output                                                                            |

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -59,6 +59,7 @@ Update a service
 | `--network-rm`                                | `list`            |         | Remove a network                                                                                    |
 | `--no-healthcheck`                            | `bool`            |         | Disable any container-specified HEALTHCHECK                                                         |
 | `--no-resolve-image`                          | `bool`            |         | Do not query the registry to resolve image digest and supported platforms                           |
+| `--oom-score-adj`                             | `int64`           | `0`     | Tune host's OOM preferences (-1000 to 1000)                                                         |
 | `--placement-pref-add`                        | `pref`            |         | Add a placement preference                                                                          |
 | `--placement-pref-rm`                         | `pref`            |         | Remove a placement preference                                                                       |
 | [`--publish-add`](#publish-add)               | `port`            |         | Add or update a published port                                                                      |


### PR DESCRIPTION
- [x] depends on https://github.com/moby/moby/pull/47950
- [x] depends on https://github.com/docker/cli/pull/5169
- [x] depends on https://github.com/docker/cli/pull/5170

**- What I did**
I added oom-score-adj flag to docker service create and docker service update

**- How I did it**
By modifying container service to accept the option as well as adding a flag to the CLI

**- How to test it**
Compile this PR and copy the CLI binary to a running moby dev shell using  https://github.com/moby/moby/pull/47950



**- Description for the changelog**

```markdown changelog

Add OOMScoreAdj to docker service create and docker compose
```

