### PR TITLE
plugins: cleanup sockets when done

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"runtime"
 	"sync"
+
+	"github.com/sirupsen/logrus"
 )
 
 // EnvKey represents the well-known environment variable used to pass the
@@ -30,6 +32,7 @@ func NewPluginServer(h func(net.Conn)) (*PluginServer, error) {
 	if err != nil {
 		return nil, err
 	}
+	logrus.Trace("Plugin server listening on ", l.Addr())
 
 	if h == nil {
 		h = func(net.Conn) {}
@@ -92,6 +95,7 @@ func (pl *PluginServer) Addr() net.Addr {
 //
 // The error value is that of the underlying [net.Listner.Close] call.
 func (pl *PluginServer) Close() error {
+	logrus.Trace("Closing plugin server")
 	// Close connections first to ensure the connections get io.EOF instead
 	// of a connection reset.
 	pl.closeAllConns()
@@ -106,6 +110,10 @@ func (pl *PluginServer) Close() error {
 func (pl *PluginServer) closeAllConns() {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
+
+	if pl.closed {
+		return
+	}
 
 	// Prevent new connections from being accepted.
 	pl.closed = true

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -245,6 +245,11 @@ func tryPluginRun(ctx context.Context, dockerCli command.Cli, cmd *cobra.Command
 	if err == nil {
 		plugincmd.Env = append(plugincmd.Env, socket.EnvKey+"="+srv.Addr().String())
 	}
+	defer func() {
+		// Close the server when plugin execution is over, so that in case
+		// it's still open, any sockets on the filesystem are cleaned up.
+		_ = srv.Close()
+	}()
 
 	// Set additional environment variables specified by the caller.
 	plugincmd.Env = append(plugincmd.Env, envs...)


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4963

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Since 509123f935e6fcb2cedf0df7bd8585a346082969, we've been leaking sockets in the filesystem on platforms where abstract sockets aren't supported.

That change relied on Go to cleanup our sockets for us, which Go will happily do as long as we make sure to close the listener, which we weren't previously doing unless to signal the plugin to terminate.

**- How I did it**

This change adds a deferred call to `PluginServer.Close()`, which makes sure we close the plugin server at the end of the plugin execution, so that we never exit without cleaning up.

**- How to verify it**

Execute a plugin command with debug logging enabled (e.g. `docker -D compose convert`) and look for the added debug log. Also check `$TMPDIR` for leaked sockets.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

![Screenshot 2024-06-11 at 21 32 13](https://github.com/docker/cli/assets/70572044/482f544a-27f7-45a3-bf75-bfffddad22a0)
