### PR TITLE
[26.1 backport] cli/command: more go1.19 ("predeclared any")

### DIFF
--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package context
 
 import (


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5131

(cherry picked from commit d0057db3ac5de21111ac21ffdb1de006f1632204)


**- A picture of a cute animal (not mandatory but encouraged)**

