### PR TITLE
vendor: github.com/docker/docker ec4bac431c88 (v27.0.0-dev)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -12,7 +12,7 @@ require (
 	github.com/creack/pty v1.1.21
 	github.com/distribution/reference v0.6.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v27.0.0-rc.1.0.20240614193652-ba69bd9c1e48+incompatible
+	github.com/docker/docker v27.0.0-rc.1.0.20240616165053-ec4bac431c88+incompatible
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -59,8 +59,8 @@ github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.0.0-rc.1.0.20240614193652-ba69bd9c1e48+incompatible h1:JxgzfWA95FczoLD0JMlZjTXVQz3f/bpT5Kt5wvN/yQY=
-github.com/docker/docker v27.0.0-rc.1.0.20240614193652-ba69bd9c1e48+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.0.0-rc.1.0.20240616165053-ec4bac431c88+incompatible h1:8oA6C1+SM3iyWmXHgRzPWyImgpNkspJbmePZb+yHk20=
+github.com/docker/docker v27.0.0-rc.1.0.20240616165053-ec4bac431c88+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/api/swagger.yaml
+++ b/vendor/github.com/docker/docker/api/swagger.yaml
@@ -442,6 +442,24 @@ definitions:
           Mode:
             description: "The permission mode for the tmpfs mount in an integer."
             type: "integer"
+          Options:
+            description: |
+              The options to be passed to the tmpfs mount. An array of arrays.
+              Flag options should be provided as 1-length arrays. Other types
+              should be provided as as 2-length arrays, where the first item is
+              the key and the second the value.
+            type: "array"
+            properties:
+              items:
+                type: "array"
+                items:
+                  type: "array"
+                  minItems: 1
+                  maxItems: 2
+                  items:
+                    type: "string"
+            example:
+              [["noexec"]]
 
   RestartPolicy:
     description: |

--- a/vendor/github.com/docker/docker/api/types/mount/mount.go
+++ b/vendor/github.com/docker/docker/api/types/mount/mount.go
@@ -119,7 +119,11 @@ type TmpfsOptions struct {
 	SizeBytes int64 `json:",omitempty"`
 	// Mode of the tmpfs upon creation
 	Mode os.FileMode `json:",omitempty"`
-
+	// Options to be passed to the tmpfs mount. An array of arrays. Flag
+	// options should be provided as 1-length arrays. Other types should be
+	// provided as 2-length arrays, where the first item is the key and the
+	// second the value.
+	Options [][]string `json:",omitempty"`
 	// TODO(stevvooe): There are several more tmpfs flags, specified in the
 	// daemon, that are accepted. Only the most basic are added for now.
 	//

--- a/vendor/github.com/docker/docker/pkg/archive/archive.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive.go
@@ -541,8 +541,10 @@ func newTarAppender(idMapping idtools.IdentityMapping, writer io.Writer, chownOp
 }
 
 // CanonicalTarNameForPath canonicalizes relativePath to a POSIX-style path using
-// forward slashes. It is an alias for filepath.ToSlash, which is a no-op on
+// forward slashes. It is an alias for [filepath.ToSlash], which is a no-op on
 // Linux and Unix.
+//
+// Deprecated: use [filepath.ToSlash]. This function will be removed in the next release.
 func CanonicalTarNameForPath(relativePath string) string {
 	return filepath.ToSlash(relativePath)
 }
@@ -1452,6 +1454,8 @@ func cmdStream(cmd *exec.Cmd, input io.Reader) (io.ReadCloser, error) {
 // NewTempArchive reads the content of src into a temporary file, and returns the contents
 // of that file as an archive. The archive can only be read once - as soon as reading completes,
 // the file will be deleted.
+//
+// Deprecated: NewTempArchive is only used in tests and will be removed in the next release.
 func NewTempArchive(src io.Reader, dir string) (*TempArchive, error) {
 	f, err := os.CreateTemp(dir, "")
 	if err != nil {
@@ -1473,6 +1477,8 @@ func NewTempArchive(src io.Reader, dir string) (*TempArchive, error) {
 
 // TempArchive is a temporary archive. The archive can only be read once - as soon as reading completes,
 // the file will be deleted.
+//
+// Deprecated: TempArchive is only used in tests and will be removed in the next release.
 type TempArchive struct {
 	*os.File
 	Size   int64 // Pre-computed from Stat().Size() as a convenience

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v27.0.0-rc.1.0.20240614193652-ba69bd9c1e48+incompatible
+# github.com/docker/docker v27.0.0-rc.1.0.20240616165053-ec4bac431c88+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
full diff: https://github.com/docker/docker/compare/ba69bd9c1e48...ec4bac431c88

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>