### PR TITLE
cli/command/image: add go:build tag to prevent downgrading go version

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.19
+
 package image
 
 import (


### PR DESCRIPTION
- using the check from https://github.com/docker/cli/pull/4723

Before this:

```bash
make shell
make -C ./internal/gocompat/
...

GO111MODULE=on go test -v
# github.com/docker/cli/cli/command/image
../../cli/command/image/push.go:177:62: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)
FAIL	gocompat [build failed]
make: *** [Makefile:3: verify] Error 1
make: Leaving directory '/go/src/github.com/docker/cli/internal/gocompat'
```

After this patch:

```bash
make shell
make -C ./internal/gocompat/
...

GO111MODULE=on go test -v
=== RUN   TestModuleCompatibllity
    main_test.go:133: all packages have the correct go version specified through //go:build
--- PASS: TestModuleCompatibllity (0.00s)
PASS
ok  	gocompat	0.007s
make: Leaving directory '/go/src/github.com/docker/cli/internal/gocompat'
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix a compile error when using the CLI code as a go module
```

**- A picture of a cute animal (not mandatory but encouraged)**

