### PR TITLE
fix: terminology from "symbol link" to "symbolic link"

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -159,7 +159,7 @@ func NewCopyCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symbol link in SRC_PATH")
+	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symbolic link in SRC_PATH")
 	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Archive mode (copy all uid/gid information)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached")
 	return cmd
@@ -227,7 +227,7 @@ func copyFromContainer(ctx context.Context, dockerCli command.Cli, copyConfig cp
 	}
 
 	client := dockerCli.Client()
-	// if client requests to follow symbol link, then must decide target file to be copied
+	// if client requests to follow symbolic link, then must decide target file to be copied
 	var rebaseName string
 	if copyConfig.followLink {
 		srcStat, err := client.ContainerStatPath(ctx, copyConfig.container, srcPath)


### PR DESCRIPTION
Corrected the terminology from "symbol link" to "symbolic link" in the following instances for clarity and accuracy:

1. In the flags definition: Changed "Always follow symbol link in SRC_PATH" to "Always follow symbolic link in SRC_PATH"

2. In the client request comment: Changed "if client requests to follow symbol link, then must decide target file to be copied" to "if client requests to follow symbolic link, then must decide target file to be copied"

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Corrected the terminology from "symbol link" to "symbolic link" in two instances within the code.


**- How I did it**

Updated the flag description in the code and the corresponding comment to replace "symbol link" with "symbolic link" to ensure proper terminology is used.


**- How to verify it**

Review the changes in the relevant files to confirm that "symbol link" has been replaced with "symbolic link". Additionally, ensure that the functionality related to symbolic links operates as expected.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Corrected terminology from "symbol link" to "symbolic link" in flag descriptions and comments.
```

**- A picture of a cute animal (not mandatory but encouraged)**

