### PR TITLE
cli-plugins/manager: add GoDoc for getPluginDirs, defaultSystemPluginDirs

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -49,6 +49,16 @@ func IsNotFound(err error) bool {
 	return ok
 }
 
+// getPluginDirs returns the platform-specific locations to search for plugins
+// in order of preference.
+//
+// Plugin-discovery is performed in the following order of preference:
+//
+// 1. The "cli-plugins" directory inside the CLIs [config.Path] (usually "~/.docker/cli-plugins").
+// 2. Additional plugin directories as configured through [ConfigFile.CLIPluginsExtraDirs].
+// 3. Platform-specific defaultSystemPluginDirs.
+//
+// [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
 func getPluginDirs(cfg *configfile.ConfigFile) ([]string, error) {
 	var pluginDirs []string
 

--- a/cli-plugins/manager/manager_unix.go
+++ b/cli-plugins/manager/manager_unix.go
@@ -2,7 +2,19 @@
 
 package manager
 
+// defaultSystemPluginDirs are the platform-specific locations to search
+// for plugins in order of preference.
+//
+// Plugin-discovery is performed in the following order of preference:
+//
+// 1. The "cli-plugins" directory inside the CLIs config-directory (usually "~/.docker/cli-plugins").
+// 2. Additional plugin directories as configured through [ConfigFile.CLIPluginsExtraDirs].
+// 3. Platform-specific defaultSystemPluginDirs (as defined below).
+//
+// [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
 var defaultSystemPluginDirs = []string{
-	"/usr/local/lib/docker/cli-plugins", "/usr/local/libexec/docker/cli-plugins",
-	"/usr/lib/docker/cli-plugins", "/usr/libexec/docker/cli-plugins",
+	"/usr/local/lib/docker/cli-plugins",
+	"/usr/local/libexec/docker/cli-plugins",
+	"/usr/lib/docker/cli-plugins",
+	"/usr/libexec/docker/cli-plugins",
 }

--- a/cli-plugins/manager/manager_windows.go
+++ b/cli-plugins/manager/manager_windows.go
@@ -5,6 +5,16 @@ import (
 	"path/filepath"
 )
 
+// defaultSystemPluginDirs are the platform-specific locations to search
+// for plugins in order of preference.
+//
+// Plugin-discovery is performed in the following order of preference:
+//
+// 1. The "cli-plugins" directory inside the CLIs config-directory (usually "~/.docker/cli-plugins").
+// 2. Additional plugin directories as configured through [ConfigFile.CLIPluginsExtraDirs].
+// 3. Platform-specific defaultSystemPluginDirs (as defined below).
+//
+// [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
 var defaultSystemPluginDirs = []string{
 	filepath.Join(os.Getenv("ProgramData"), "Docker", "cli-plugins"),
 	filepath.Join(os.Getenv("ProgramFiles"), "Docker", "cli-plugins"),


### PR DESCRIPTION
Add some documentation about their purpose, and document order of preference when resolving plugins.


**- A picture of a cute animal (not mandatory but encouraged)**

