### PR TITLE
WIP: test/cli: Use APIClient instead of Client

### DIFF
--- a/cli/command/builder/client_test.go
+++ b/cli/command/builder/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	builderPruneFunc func(ctx context.Context, opts types.BuildCachePruneOptions) (*types.BuildCachePruneReport, error)
 }
 

--- a/cli/command/checkpoint/client_test.go
+++ b/cli/command/checkpoint/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	checkpointCreateFunc func(container string, options checkpoint.CreateOptions) error
 	checkpointDeleteFunc func(container string, options checkpoint.DeleteOptions) error
 	checkpointListFunc   func(container string, options checkpoint.ListOptions) ([]checkpoint.Summary, error)

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -100,7 +100,7 @@ func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 }
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	pingFunc   func() (types.Ping, error)
 	version    string
 	negotiated bool

--- a/cli/command/config/client_test.go
+++ b/cli/command/config/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	configCreateFunc  func(context.Context, swarm.ConfigSpec) (types.ConfigCreateResponse, error)
 	configInspectFunc func(context.Context, string) (swarm.Config, []byte, error)
 	configListFunc    func(context.Context, types.ConfigListOptions) ([]swarm.Config, error)

--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	inspectFunc         func(string) (types.ContainerJSON, error)
 	execInspectFunc     func(execID string) (container.ExecInspect, error)
 	execCreateFunc      func(containerID string, options container.ExecOptions) (types.IDResponse, error)

--- a/cli/command/idresolver/client_test.go
+++ b/cli/command/idresolver/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	nodeInspectFunc    func(string) (swarm.Node, []byte, error)
 	serviceInspectFunc func(string) (swarm.Service, []byte, error)
 }

--- a/cli/command/image/client_test.go
+++ b/cli/command/image/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	imageTagFunc     func(string, string) error
 	imageSaveFunc    func(images []string) (io.ReadCloser, error)
 	imageRemoveFunc  func(image string, options image.RemoveOptions) ([]image.DeleteResponse, error)

--- a/cli/command/network/client_test.go
+++ b/cli/command/network/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	networkCreateFunc     func(ctx context.Context, name string, options network.CreateOptions) (network.CreateResponse, error)
 	networkConnectFunc    func(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	networkDisconnectFunc func(ctx context.Context, networkID, container string, force bool) error

--- a/cli/command/node/client_test.go
+++ b/cli/command/node/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	infoFunc           func() (system.Info, error)
 	nodeInspectFunc    func() (swarm.Node, []byte, error)
 	nodeListFunc       func() ([]swarm.Node, error)

--- a/cli/command/plugin/client_test.go
+++ b/cli/command/plugin/client_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	pluginCreateFunc  func(createContext io.Reader, createOptions types.PluginCreateOptions) error
 	pluginDisableFunc func(name string, disableOptions types.PluginDisableOptions) error
 	pluginEnableFunc  func(name string, options types.PluginEnableOptions) error

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 }
 
 func (c fakeClient) Info(context.Context) (system.Info, error) {

--- a/cli/command/secret/client_test.go
+++ b/cli/command/secret/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	secretCreateFunc  func(context.Context, swarm.SecretSpec) (types.SecretCreateResponse, error)
 	secretInspectFunc func(context.Context, string) (swarm.Secret, []byte, error)
 	secretListFunc    func(context.Context, types.SecretListOptions) ([]swarm.Secret, error)

--- a/cli/command/service/client_test.go
+++ b/cli/command/service/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	serviceInspectWithRawFunc func(ctx context.Context, serviceID string, options types.ServiceInspectOptions) (swarm.Service, []byte, error)
 	serviceUpdateFunc         func(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (swarm.ServiceUpdateResponse, error)
 	serviceListFunc           func(context.Context, types.ServiceListOptions) ([]swarm.Service, error)

--- a/cli/command/stack/client_test.go
+++ b/cli/command/stack/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 
 	version string
 

--- a/cli/command/stack/swarm/client_test.go
+++ b/cli/command/stack/swarm/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 
 	version string
 

--- a/cli/command/swarm/client_test.go
+++ b/cli/command/swarm/client_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	infoFunc              func() (system.Info, error)
 	swarmInitFunc         func() (string, error)
 	swarmInspectFunc      func() (swarm.Swarm, error)

--- a/cli/command/system/client_test.go
+++ b/cli/command/system/client_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 
 	version            string
 	serverVersion      func(ctx context.Context) (types.Version, error)

--- a/cli/command/trust/inspect_pretty_test.go
+++ b/cli/command/trust/inspect_pretty_test.go
@@ -26,7 +26,7 @@ import (
 // TODO(n4ss): remove common tests with the regular inspect command
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 }
 
 func (c *fakeClient) Info(context.Context) (system.Info, error) {

--- a/cli/command/volume/client_test.go
+++ b/cli/command/volume/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	volumeCreateFunc  func(volume.CreateOptions) (volume.Volume, error)
 	volumeInspectFunc func(volumeID string) (volume.Volume, error)
 	volumeListFunc    func(filter filters.Args) (volume.ListResponse, error)

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -615,7 +615,7 @@ func TestConvertServiceConfigs(t *testing.T) {
 }
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 	secretListFunc func(types.SecretListOptions) ([]swarm.Secret, error)
 	configListFunc func(types.ConfigListOptions) ([]swarm.Config, error)
 }

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -125,7 +125,7 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 }
 
 type fakeClient struct {
-	client.Client
+	client.APIClient
 }
 
 func (c *fakeClient) Ping(_ context.Context) (types.Ping, error) {


### PR DESCRIPTION
Embed APIClient interface in `fakeClient` instead of the `Client` struct to satisfy the interface.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

