### PR TITLE
docs/deprecated: update status for graphdriver-plugins

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -152,6 +152,7 @@ part of the underlying image's Config, and deprecated:
 ### Graphdriver plugins (experimental)
 
 **Deprecated in Release: v27.0**
+**Disabled by default in Release: v27.0**
 **Target For Removal In Release: v28.0**
 
 [Graphdriver plugins](https://github.com/docker/cli/blob/v26.1.4/docs/extend/plugins_graphdriver.md)
@@ -160,8 +161,14 @@ storage drivers for storing images and containers. This feature was not
 maintained since its inception, and will no longer be supported in upcoming
 releases.
 
-Users of this feature are recommended to instead configure the Docker Engine
-to use the [containerd image store](https://docs.docker.com/storage/containerd/),
+Support for graphdriver plugins is disabled by default in v27.0, and will be
+removed v28.0. An `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` environment variable
+is provided in v27.0 to re-enable the feature. This environment variable must
+be set to a non-empty value in the daemon's environment.
+
+The `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` environment variable, along with
+support for graphdriver plugins, will be removed in v28.0. Users of this feature
+are recommended to instead configure the Docker Engine to use the [containerd image store](https://docs.docker.com/storage/containerd/)
 and a custom [snapshotter](https://github.com/containerd/containerd/tree/v1.7.18/docs/snapshotters)
 
 ### API CORS headers
@@ -700,7 +707,7 @@ An environment variable (`DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE`) is
 added in Docker v26.0 that allows re-enabling support for these image formats
 in the daemon. This environment variable must be set to a non-empty value in
 the daemon's environment (for example, through a [systemd override file](https://docs.docker.com/config/daemon/systemd/)).
-Support for the `DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE` environment-variable
+Support for the `DOCKER_ENABLE_DEPRECATED_PULL_SCHEMA_1_IMAGE` environment variable
 will be removed in Docker v27.0 after which this functionality is removed permanently.
 
 ### `docker engine` subcommands


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5172
- relates to https://github.com/moby/moby/pull/48050


Add a mention of the feature being disabled by default, and the DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS env-var.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Document DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS env-var
```

**- A picture of a cute animal (not mandatory but encouraged)**

