### PR TITLE
cli: make initializing the global meter- and tracing providers optional

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -45,6 +45,7 @@ func RunPlugin(dockerCli *command.DockerCli, plugin *cobra.Command, meta manager
 			if os.Getenv("DOCKER_CLI_PLUGIN_USE_DIAL_STDIO") != "" {
 				opts = append(opts, withPluginClientConn(plugin.Name()))
 			}
+			opts = append(opts, command.WithEnableGlobalMeterProvider(), command.WithEnableGlobalTracerProvider())
 			err = tcmd.Initialize(opts...)
 			ogRunE := cmd.RunE
 			if ogRunE == nil {

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -92,6 +92,8 @@ type DockerCli struct {
 	// this may be replaced by explicitly passing a context to functions that
 	// need it.
 	baseCtx context.Context
+
+	enableGlobalMeter, enableGlobalTracer bool
 }
 
 // DefaultVersion returns api.defaultVersion.
@@ -284,8 +286,12 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption)
 	}
 
 	// TODO(krissetto): pass ctx to the funcs instead of using this
-	cli.createGlobalMeterProvider(cli.baseCtx)
-	cli.createGlobalTracerProvider(cli.baseCtx)
+	if cli.enableGlobalMeter {
+		cli.createGlobalMeterProvider(cli.baseCtx)
+	}
+	if cli.enableGlobalTracer {
+		cli.createGlobalTracerProvider(cli.baseCtx)
+	}
 
 	return nil
 }

--- a/cli/command/telemetry_options.go
+++ b/cli/command/telemetry_options.go
@@ -1,0 +1,25 @@
+package command
+
+// WithEnableGlobalMeterProvider configures the DockerCli to create a new
+// MeterProvider from the initialized DockerCli struct, and set it as
+// the global meter provider.
+//
+// WARNING: For internal use, don't depend on this.
+func WithEnableGlobalMeterProvider() CLIOption {
+	return func(cli *DockerCli) error {
+		cli.enableGlobalMeter = true
+		return nil
+	}
+}
+
+// WithEnableGlobalTracerProvider configures the DockerCli to create a new
+// TracerProvider from the initialized DockerCli struct, and set it as
+// the global tracer provider.
+//
+// WARNING: For internal use, don't depend on this.
+func WithEnableGlobalTracerProvider() CLIOption {
+	return func(cli *DockerCli) error {
+		cli.enableGlobalTracer = true
+		return nil
+	}
+}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -354,7 +354,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		return err
 	}
 
-	if err := tcmd.Initialize(); err != nil {
+	if err := tcmd.Initialize(command.WithEnableGlobalMeterProvider(), command.WithEnableGlobalTracerProvider()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/commit/02537eac596a6e1bab435c8d2445603990445678 / https://github.com/docker/cli/pull/5067

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add WithEnableGlobalMeterProvider and WithEnableGlobalTracerProvider options
```

**- A picture of a cute animal (not mandatory but encouraged)**

