### PR TITLE
gha/e2e: Update latest version to 27.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,9 +28,8 @@ jobs:
           - alpine
           - debian
         engine-version:
-          - 27-rc # testing
-          - 26.1  # latest
-          - 25.0  # latest - 1
+          - 27.0  # latest
+          - 26.1  # latest - 1
           - 23.0  # mirantis lts
           # TODO(krissetto) 19.03 needs a look, doesn't work ubuntu 22.04 (cgroup errors). 
           # we could have a separate job that tests it against ubuntu 20.04


### PR DESCRIPTION
27.0 is out - update the latest version used for e2e and drop the 25.0
