### PR TITLE
cli/config/credentials: ConvertToHostname: handle IP-addresses

### DIFF
--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"net"
 	"net/url"
 	"strings"
 
@@ -77,7 +78,7 @@ func ConvertToHostname(maybeURL string) string {
 			if u.Port() == "" {
 				return u.Hostname()
 			}
-			return u.Hostname() + ":" + u.Port()
+			return net.JoinHostPort(u.Hostname(), u.Port())
 		}
 	}
 	hostName, _, _ := strings.Cut(stripped, "/")

--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -138,6 +138,19 @@ func TestFileStoreErase(t *testing.T) {
 func TestConvertToHostname(t *testing.T) {
 	tests := []struct{ input, expected string }{
 		{
+			input:    "127.0.0.1",
+			expected: "127.0.0.1",
+		},
+		{
+			input:    "::1",
+			expected: "::1",
+		},
+		{
+			// FIXME(thaJeztah): this should be normalized to "::1" if there's no port (or vice-versa, as long as we're consistent)
+			input:    "[::1]",
+			expected: "[::1]",
+		},
+		{
 			input:    "example.com",
 			expected: "example.com",
 		},
@@ -169,8 +182,33 @@ func TestConvertToHostname(t *testing.T) {
 		},
 		// should support non-standard port in registry url
 		{
+			input:    "127.0.0.1:6556",
+			expected: "127.0.0.1:6556",
+		},
+		{
+			// FIXME(thaJeztah): this should be normalized to "[::1]:6556"
+			input:    "::1:6556",
+			expected: "::1:6556",
+		},
+		{
+			input:    "[::1]:6556",
+			expected: "[::1]:6556",
+		},
+		{
 			input:    "example.com:6555",
 			expected: "example.com:6555",
+		},
+		{
+			input:    "https://127.0.0.1:6555/v2/",
+			expected: "127.0.0.1:6555",
+		},
+		{
+			input:    "https://::1:6555/v2/",
+			expected: "[::1]:6555",
+		},
+		{
+			input:    "https://[::1]:6555/v2/",
+			expected: "[::1]:6555",
 		},
 		{
 			input:    "http://example.com:6555",


### PR DESCRIPTION
**- What I did**
- follow-up to https://github.com/docker/cli/pull/5195
- addresses another regression in https://github.com/docker/cli/pull/3599
- fixes https://github.com/docker/cli/issues/5194

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix handling of IPv6 addresses with custom ports on docker login
```

**- A picture of a cute animal (not mandatory but encouraged)**

