### PR TITLE
[27.0 backport] re-introduced support for port numbers in docker registry URL

### DIFF
--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -74,7 +74,10 @@ func ConvertToHostname(maybeURL string) string {
 	if strings.Contains(stripped, "://") {
 		u, err := url.Parse(stripped)
 		if err == nil && u.Hostname() != "" {
-			return u.Hostname()
+			if u.Port() == "" {
+				return u.Hostname()
+			}
+			return u.Hostname() + ":" + u.Port()
 		}
 	}
 	hostName, _, _ := strings.Cut(stripped, "/")

--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -167,6 +167,23 @@ func TestConvertToHostname(t *testing.T) {
 			input:    "ftp://example.com",
 			expected: "example.com",
 		},
+		// should support non-standard port in registry url
+		{
+			input:    "example.com:6555",
+			expected: "example.com:6555",
+		},
+		{
+			input:    "http://example.com:6555",
+			expected: "example.com:6555",
+		},
+		{
+			input:    "https://example.com:6555",
+			expected: "example.com:6555",
+		},
+		{
+			input:    "https://example.com:6555/v2/",
+			expected: "example.com:6555",
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5195

**- What I did**
* this is a fix for a regression introduced by https://github.com/docker/cli/pull/3599
* re-introduced support for port numbers in docker registry URL
* fixes https://github.com/docker/cli/issues/5194

**- How to verify it**
* added new test cases and ran `docker buildx bake test`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix a regression that caused port numbers to be ignored when parsing a Docker registry URL.
```

**- A picture of a cute animal (not mandatory but encouraged)**

