### PR TITLE
cli/command/stack: fix faulty sort for sorting stacks

### DIFF
--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -56,8 +56,7 @@ func format(out io.Writer, opts options.List, stacks []*formatter.Stack) error {
 		Format: fmt,
 	}
 	sort.Slice(stacks, func(i, j int) bool {
-		return sortorder.NaturalLess(stacks[i].Name, stacks[j].Name) ||
-			!sortorder.NaturalLess(stacks[j].Name, stacks[i].Name)
+		return sortorder.NaturalLess(stacks[i].Name, stacks[j].Name)
 	})
 	return formatter.StackWrite(stackCtx, stacks)
 }


### PR DESCRIPTION
This code was updated in 7b9580df518bd0c3c859279d7423872625404f6b (https://github.com/docker/cli/pull/3139), which removed support for using kubernetes as orchestrator, but in doing so made this `sort.Slice` (probably) not do what it was expected to do ':)

```diff
index 412cc2e5ee86..861ae1be2fb9 100644
@@ -75,8 +54,7 @@ func format(dockerCli command.Cli, opts options.List, orchestrator command.Orche
 	}
 	sort.Slice(stacks, func(i, j int) bool {
 		return sortorder.NaturalLess(stacks[i].Name, stacks[j].Name) ||
-			!sortorder.NaturalLess(stacks[j].Name, stacks[i].Name) &&
-				sortorder.NaturalLess(stacks[j].Namespace, stacks[i].Namespace)
+			!sortorder.NaturalLess(stacks[j].Name, stacks[i].Name)
 	})
 	return formatter.StackWrite(stackCtx, stacks)
 }
```

The extra condition was added in 84241cc393a36848076c2d3bd61fa023858fb16b (https://github.com/docker/cli/pull/1031) to support multiple namespaces. This patch removes it, bringing it back to the state it was before that commit.


**- A picture of a cute animal (not mandatory but encouraged)**

