### PR TITLE
vendor: github.com/fvbommel/sortorder v1.1.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -16,7 +16,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
-	github.com/fvbommel/sortorder v1.0.2
+	github.com/fvbommel/sortorder v1.1.0
 	github.com/go-viper/mapstructure/v2 v2.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.6.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -80,8 +80,8 @@ github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fvbommel/sortorder v1.0.2 h1:mV4o8B2hKboCdkJm+a7uX/SIpZob4JzUpc5GGnM45eo=
-github.com/fvbommel/sortorder v1.0.2/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
+github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/vendor/github.com/fvbommel/sortorder/README.md
+++ b/vendor/github.com/fvbommel/sortorder/README.md
@@ -3,3 +3,7 @@
     import "github.com/fvbommel/sortorder"
 
 Sort orders and comparison functions.
+
+Case-insensitive sort orders are in the `casefolded` sub-package
+because it pulls in the Unicode tables in the standard library,
+which can add significantly to the size of binaries.

--- a/vendor/github.com/fvbommel/sortorder/natsort.go
+++ b/vendor/github.com/fvbommel/sortorder/natsort.go
@@ -4,7 +4,7 @@ package sortorder
 // means that e.g. "abc2" < "abc12".
 //
 // Non-digit sequences and numbers are compared separately. The former are
-// compared bytewise, while the latter are compared numerically (except that
+// compared bytewise, while digits are compared numerically (except that
 // the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
 //
 // Limitation: only ASCII digits (0-9) are considered.
@@ -14,13 +14,13 @@ func (n Natural) Len() int           { return len(n) }
 func (n Natural) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
 func (n Natural) Less(i, j int) bool { return NaturalLess(n[i], n[j]) }
 
-func isdigit(b byte) bool { return '0' <= b && b <= '9' }
+func isDigit(b byte) bool { return '0' <= b && b <= '9' }
 
 // NaturalLess compares two strings using natural ordering. This means that e.g.
 // "abc2" < "abc12".
 //
 // Non-digit sequences and numbers are compared separately. The former are
-// compared bytewise, while the latter are compared numerically (except that
+// compared bytewise, while digits are compared numerically (except that
 // the number of leading zeros is used as a tie-breaker, so e.g. "2" < "02")
 //
 // Limitation: only ASCII digits (0-9) are considered.
@@ -28,7 +28,7 @@ func NaturalLess(str1, str2 string) bool {
 	idx1, idx2 := 0, 0
 	for idx1 < len(str1) && idx2 < len(str2) {
 		c1, c2 := str1[idx1], str2[idx2]
-		dig1, dig2 := isdigit(c1), isdigit(c2)
+		dig1, dig2 := isDigit(c1), isDigit(c2)
 		switch {
 		case dig1 != dig2: // Digits before other characters.
 			return dig1 // True if LHS is a digit, false if the RHS is one.
@@ -48,16 +48,16 @@ func NaturalLess(str1, str2 string) bool {
 			}
 			// Eat all digits.
 			nonZero1, nonZero2 := idx1, idx2
-			for ; idx1 < len(str1) && isdigit(str1[idx1]); idx1++ {
+			for ; idx1 < len(str1) && isDigit(str1[idx1]); idx1++ {
 			}
-			for ; idx2 < len(str2) && isdigit(str2[idx2]); idx2++ {
+			for ; idx2 < len(str2) && isDigit(str2[idx2]); idx2++ {
 			}
 			// If lengths of numbers with non-zero prefix differ, the shorter
 			// one is less.
 			if len1, len2 := idx1-nonZero1, idx2-nonZero2; len1 != len2 {
 				return len1 < len2
 			}
-			// If they're equal, string comparison is correct.
+			// If they're equally long, string comparison is correct.
 			if nr1, nr2 := str1[nonZero1:idx1], str2[nonZero2:idx2]; nr1 != nr2 {
 				return nr1 < nr2
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/docker/go-units
 # github.com/felixge/httpsnoop v1.0.4
 ## explicit; go 1.13
 github.com/felixge/httpsnoop
-# github.com/fvbommel/sortorder v1.0.2
+# github.com/fvbommel/sortorder v1.1.0
 ## explicit; go 1.13
 github.com/fvbommel/sortorder
 # github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
- Add a case-folding version of Natural sort order This can be used to perform case-insensitive comparisons and sorting. It's been placed in a separate sub-package because it requires the Unicode tables in the standard library, which can add significantly to binary size.

full diff: https://github.com/fvbommel/sortorder/compare/v1.0.2...v1.1.0

