### PR TITLE
docs: remove unnecessary -itd from examples

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -729,7 +729,7 @@ to the `my-net` network.
 
 ```console
 $ docker network create my-net
-$ docker run -itd --network=my-net busybox
+$ docker run --network=my-net nginx
 ```
 
 You can also choose the IP addresses for the container with `--ip` and `--ip6`
@@ -738,7 +738,7 @@ static IP to containers, you must specify subnet block for the network.
 
 ```console
 $ docker network create --subnet 192.0.2.0/24 my-net
-$ docker run -itd --network=my-net --ip=192.0.2.69 busybox
+$ docker run --network=my-net --ip=192.0.2.69 nginx
 ```
 
 To connect the container to more than one network, repeat the `--network` option.
@@ -746,7 +746,7 @@ To connect the container to more than one network, repeat the `--network` option
 ```console
 $ docker network create --subnet 192.0.2.0/24 my-net1
 $ docker network create --subnet 192.0.3.0/24 my-net2
-$ docker run -itd --network=my-net1 --network=my-net2 busybox
+$ docker run --network=my-net1 --network=my-net2 nginx
 ```
 
 To specify options when connecting to more than one network, use the extended syntax
@@ -766,7 +766,7 @@ for the `--network` flag. Comma-separated options that can be specified in the e
 ```console
 $ docker network create --subnet 192.0.2.0/24 my-net1
 $ docker network create --subnet 192.0.3.0/24 my-net2
-$ docker run -itd --network=name=my-net1,ip=192.0.2.42 --network=name=my-net2,ip=192.0.3.42 busybox
+$ docker run --network=name=my-net1,ip=192.0.2.42 --network=name=my-net2,ip=192.0.3.42 nginx
 ```
 
 `sysctl` settings that start with `net.ipv4.`, `net.ipv6.` or `net.mpls.` can be
@@ -781,7 +781,7 @@ assigns the IPv4 address `192.0.2.42`.
 
 ```console
 $ docker network create --subnet 192.0.2.0/24 my-net
-$ docker run -itd --network=name=my-net,\"driver-opt=com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\",ip=192.0.2.42 busybox
+$ docker run --network=name=my-net,\"driver-opt=com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\",ip=192.0.2.42 nginx
 ```
 
 > **Note**

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -37,7 +37,7 @@ You can also use the `docker run --network=<network-name>` option to start a
 container and immediately connect it to a network.
 
 ```console
-$ docker run -itd --network=multi-host-network busybox
+$ docker run --network=multi-host-network nginx
 ```
 
 ### <a name="ip"></a> Specify the IP address a container will use on a given network (--ip)

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -84,10 +84,10 @@ for more information about different endpoint modes.
 ### Connect containers
 
 When you start a container, use the `--network` flag to connect it to a network.
-This example adds the `busybox` container to the `mynet` network:
+This example adds the `nginx` container to the `mynet` network:
 
 ```console
-$ docker run -itd --network=mynet busybox
+$ docker run --network=mynet nginx
 ```
 
 If you want to add a container to a network after the container is already

--- a/docs/reference/commandline/network_inspect.md
+++ b/docs/reference/commandline/network_inspect.md
@@ -25,10 +25,10 @@ all results in a JSON object.
 Connect two containers to the default `bridge` network:
 
 ```console
-$ sudo docker run -itd --name=container1 busybox
+$ sudo docker run -d --name=container1 nginx
 f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27
 
-$ sudo docker run -itd --name=container2 busybox
+$ sudo docker run -d --name=container2 nginx
 bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
 ```
 

--- a/man/src/network/connect.md
+++ b/man/src/network/connect.md
@@ -9,7 +9,7 @@ $ docker network connect multi-host-network container1
 You can also use the `docker run --network=<network-name>` option to start a container and immediately connect it to a network.
 
 ```console
-$ docker run -itd --network=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 busybox
+$ docker run --network=multi-host-network --ip 172.20.88.22 --ip6 2001:db8::8822 nginx
 ```
 
 You can pause, restart, and stop containers that are connected to a network.

--- a/man/src/network/create.md
+++ b/man/src/network/create.md
@@ -51,10 +51,10 @@ for more information about different endpoint modes.
 ## Connect containers
 
 When you start a container, use the `--network` flag to connect it to a network.
-This example adds the `busybox` container to the `mynet` network:
+This example adds the `nginx` container to the `mynet` network:
 
 ```console
-$ docker run -itd --network=mynet busybox
+$ docker run -d --network=mynet nginx
 ```
 
 If you want to add a container to a network after the container is already

--- a/man/src/network/inspect.md
+++ b/man/src/network/inspect.md
@@ -1,10 +1,10 @@
 Returns information about one or more networks. By default, this command renders all results in a JSON object. For example, if you connect two containers to the default `bridge` network:
 
 ```console
-$ sudo docker run -itd --name=container1 busybox
+$ sudo docker run -d --name=container1 nginx
 f2870c98fd504370fb86e59f32cd0753b1ac9b69b7d80566ffc7192a82b3ed27
 
-$ sudo docker run -itd --name=container2 busybox
+$ sudo docker run -d --name=container2 nginx
 bda12f8922785d1f160be70736f26c1e331ab8aaf8ed8d56728508f2e2fd4727
 ```
 


### PR DESCRIPTION
**- What I did**

The -itd options, probably used to keep the tty container running in the
background, is not necessary for these examples. Updated the examples to
remove the unnecessary flags. Also, changed the example image from
busybox to nginx.

Relates to:

- docker/docs#19699

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

