### PR TITLE
feat: force lf line endings by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
 Dockerfile* linguist-language=Dockerfile
 vendor.mod linguist-language=Go-Module
 vendor.sum linguist-language=Go-Checksums
+*.bat text eol=crlf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,6 @@ jobs:
 #          - windows-2022 # FIXME: some tests are failing on the Windows runner, as well as on Appveyor since June 24, 2018: https://ci.appveyor.com/project/docker/cli/history
     steps:
       -
-        name: Prepare git
-        if: matrix.os == 'windows-latest'
-        run: |
-          git config --system core.autocrlf false
-          git config --system core.eol lf
-      -
         name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**


On Windows machines users' might install git using the default "Checkout Windows-style, commit Unix-style line endings".
![image](https://github.com/docker/cli/assets/18033717/1fe6f031-ccfa-4981-8c87-5bd26e4daea7)

Or

```console
git config --global core.autocrlf true
```

This will prevent the user from building the CLI due to bash scripts inside the `scripts/*` directory to automatically be perceived with the `CRLF` line ending. The error is ambiguous as to suggest a file is missing - however, it is due to bash scripts having incorrect line endings.
 
```console
$ docker buildx bake

=> ERROR [build 2/2] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=type=tmp  1.8s ------                                                                                                                         

> [build 2/2] RUN --mount=type=bind,target=.,ro     --mount=type=cache,target=/root/.cache     --mount=type=tmpfs,target=cli/winresources     xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     
xx-verify $([ "static" = "static" ] && echo "--static") /out/docker:                                                                                                        
': No such file or directory                                                                                                 

 ------                                                                                                                        
Dockerfile:64                                                                                                                 
--------------------                                                                                                            
63 |     COPY --link --from=goversioninfo /out/goversioninfo /usr/bin/goversioninfo                                           
64 | >>> RUN --mount=type=bind,target=.,ro \                                                                                  
65 | >>>     --mount=type=cache,target=/root/.cache \                                                                         
66 | >>>     --mount=type=tmpfs,target=cli/winresources \                                                                     
67 | >>>     # override the default behavior of go with xx-go                                                                 
68 | >>>     xx-go --wrap && \                                                                                                
69 | >>>     # export GOCACHE=$(go env GOCACHE)/$(xx-info)$([ -f /etc/alpine-release ] && echo "alpine") && \                 
70 | >>>     TARGET=/out ./scripts/build/binary && \                                                                          
71 | >>>     xx-verify $([ "$GO_LINKMODE" = "static" ] && echo "--static") /out/docker                                        
72 |                                                                                                                        --------------------                                                                                                          ERROR: failed to solve: process "/bin/sh -c xx-go --wrap &&     TARGET=/out ./scripts/build/binary &&     
xx-verify $([ \"$GO_LINKMODE\" = \"static\" ] && echo \"--static\") /out/docker" 
did not complete successfully: exit code: 127
 ```

**- How I did it**

Added `* text=auto eol=lf` to `.gitattributes` to force git to by default treat files in the repository with the `lf` line ending.

**- How to verify it**

Checkout the repository on Windows and with `git config --global core.autocrlf true` then open any of the script files in an editor, the editor should tell you the line endings are `LF`. You should also be able to see inside WSL, running `file scripts/build/binary` should print `... ASCII text executable`. 

If there's something about it containing `CRLF` then it means it's incorrect.  

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

