### PR TITLE
Enable completion for some 'image' sub commands

### DIFF
--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
@@ -31,6 +32,7 @@ func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
 			opts.image = args[0]
 			return runHistory(cmd.Context(), dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 		Annotations: map[string]string{
 			"aliases": "docker image history, docker history",
 		},

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.refs = args
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
@@ -29,6 +30,7 @@ func NewRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), dockerCli, opts, args)
 		},
+		ValidArgsFunction: completion.ImageNames(dockerCli),
 		Annotations: map[string]string{
 			"aliases": "docker image rm, docker image remove, docker rmi",
 		},


### PR DESCRIPTION
**- What I did**
This pull request enables shell completion for these commands:
- `docker image rm` (and its aliases `docker image remove` and `docker rmi`)
- `docker image history`
- `docker image inspect`

**- How I did it**
I have added a `ValidArgsFunction` to each of the relevant commands.

**- How to verify it**
I ran `make dev` to enter a development shell, and then `make && ./build/docker __completeNoDesc image rm ""` (and similar for the other commands being modified) to verify expected output (both before & after making code changes).

I also ran `make test` which reported success.

**- Description for the changelog**
```markdown changelog
Enable shell completion for `docker image rm`, `docker image history`, and `docker image inspect`.
```

This change fixes https://github.com/docker/cli/issues/4588.

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://images.unsplash.com/photo-1597382389726-fbe8c7a6905e?w=450)