### PR TITLE
cli/command/container: TestSplitCpArg: cleaner skip

### DIFF
--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -14,7 +14,6 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/fs"
-	"gotest.tools/v3/skip"
 )
 
 func TestRunCopyWithInvalidArguments(t *testing.T) {
@@ -151,7 +150,7 @@ func TestSplitCpArg(t *testing.T) {
 	}{
 		{
 			doc:          "absolute path with colon",
-			os:           "linux",
+			os:           "unix",
 			path:         "/abs/path:withcolon",
 			expectedPath: "/abs/path:withcolon",
 		},
@@ -181,7 +180,12 @@ func TestSplitCpArg(t *testing.T) {
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
-			skip.If(t, tc.os == "windows" && runtime.GOOS != "windows" || tc.os == "linux" && runtime.GOOS == "windows")
+			if tc.os == "windows" && runtime.GOOS != "windows" {
+				t.Skip("skipping windows test on non-windows platform")
+			}
+			if tc.os == "unix" && runtime.GOOS == "windows" {
+				t.Skip("skipping unix test on windows")
+			}
 
 			ctr, path := splitCpArg(tc.path)
 			assert.Check(t, is.Equal(tc.expectedContainer, ctr))


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5224#discussion_r1665426727

Trying to make the logic slightly clearer, and adding a custom message for the skip,

Before this:

    === RUN   TestSplitCpArg/absolute_path_with_drive
        cp_test.go:184: tc.os == "windows" && runtime.GOOS != "windows" || tc.os == "linux" && runtime.GOOS == "windows"

After this:

    === RUN   TestSplitCpArg/absolute_path_with_drive
        cp_test.go:184: skipping windows test on non-windows platform


