### PR TITLE
cli: make cli.StatusError slightly prettier

### DIFF
--- a/cli/command/network/remove_test.go
+++ b/cli/command/network/remove_test.go
@@ -90,7 +90,7 @@ func TestNetworkRemoveForce(t *testing.T) {
 				assert.NilError(t, err)
 			} else {
 				assert.Check(t, is.Contains(fakeCli.ErrBuffer().String(), tc.expectedErr))
-				assert.ErrorContains(t, err, "Code: 1")
+				assert.ErrorContains(t, err, "exit status 1")
 			}
 		})
 	}

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -444,7 +444,7 @@ func TestFormatInfo(t *testing.T) {
 		{
 			doc:           "syntax",
 			template:      "{{}",
-			expectedError: `Status: template parsing error: template: :1: unexpected "}" in command, Code: 64`,
+			expectedError: `template parsing error: template: :1: unexpected "}" in command`,
 		},
 		{
 			doc:           "syntax",

--- a/cli/error.go
+++ b/cli/error.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -28,6 +28,12 @@ type StatusError struct {
 	StatusCode int
 }
 
+// Error formats the error for printing. If a custom Status is provided,
+// it is returned as-is, otherwise it generates a generic error-message
+// based on the StatusCode.
 func (e StatusError) Error() string {
-	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
+	if e.Status == "" {
+		return "exit status " + strconv.Itoa(e.StatusCode)
+	}
+	return e.Status
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5229#issuecomment-2209343234


This error didn't do a great job at formatting. If a StatusError was produced without a Status message, it would print a very non-informative error, with information missing.

Let's update the output:

- If a status-message is provided; print just that (after all the status code is something that can be found from the shell, e.g. through `echo $?` in Bash).
- If no status-message is provided: print a message more similar to Go's `exec.ExecError`, which uses `os.rocessState.String()` (see [1]).

Before this patch, an error without custom status would print:

    Status: , Code: 2

After this patch:

    exit status 2

In situations where a custom error-message is provided, the error-message
is print as-is, whereas before this patch, the message got combined with
the `Status:` and `Code:`, which resulted in some odd output.

Before this patch:

    docker volume --no-such-flag
    Status: unknown flag: --no-such-flag
    See 'docker volume --help'.
    
    Usage:  docker volume COMMAND
    
    Manage volumes
    
    Commands:
      create      Create a volume
      inspect     Display detailed information on one or more volumes
      ls          List volumes
      prune       Remove unused local volumes
      rm          Remove one or more volumes
      update      Update a volume (cluster volumes only)
    
    Run 'docker volume COMMAND --help' for more information on a command.
    , Code: 125

With this patch, the error is shown as-is;

    docker volume --no-such-flag
    unknown flag: --no-such-flag
    See 'docker volume --help'.
    
    Usage:  docker volume COMMAND
    
    Manage volumes
    
    Commands:
      create      Create a volume
      inspect     Display detailed information on one or more volumes
      ls          List volumes
      prune       Remove unused local volumes
      rm          Remove one or more volumes
      update      Update a volume (cluster volumes only)
    
    Run 'docker volume COMMAND --help' for more information on a command.

While the exit-code is no longer printed, it's still properly handled;

    echo $?
    125

[1]: https://github.com/golang/go/blob/82c14346d89ec0eeca114f9ca0e88516b2cda454/src/os/exec_posix.go#L107-L135


**- A picture of a cute animal (not mandatory but encouraged)**

