### PR TITLE
install bash-completion in dev container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,16 @@ mod-outdated: ## check outdated dependencies
 authors: ## generate AUTHORS file from git history
 	scripts/docs/generate-authors.sh
 
+.PHONY: completion
+completion: binary
+completion: /etc/bash_completion.d/docker
+completion: ## generate and install the completion scripts
+
+.PHONY: /etc/bash_completion.d/docker
+/etc/bash_completion.d/docker: ## generate and install the bash-completion script
+	mkdir -p /etc/bash_completion.d
+	docker completion bash > /etc/bash_completion.d/docker
+
 .PHONY: manpages
 manpages: ## generate man pages from go source and markdown
 	scripts/docs/generate-man.sh

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM golang AS dev
 RUN  apk add --no-cache \
     bash \
+    bash-completion \
     build-base \
     ca-certificates \
     coreutils \
@@ -44,7 +45,8 @@ RUN  apk add --no-cache \
     nano
 
 RUN echo -e "\nYou are now in a development container. Run '\e\033[1mmake help\e\033[0m' to learn about\navailable make targets.\n" > /etc/motd \
- && echo -e "cat /etc/motd\nPS1=\"\e[0;32m\u@docker-cli-dev\\$ \e[0m\"" >> /root/.bashrc
+ && echo -e "cat /etc/motd\nPS1=\"\e[0;32m\u@docker-cli-dev\\$ \e[0m\"" >> /root/.bashrc \
+ && echo -e "source /etc/bash/bash_completion.sh" >> /root/.bashrc
 CMD bash
 ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENV PATH=$PATH:/go/src/github.com/docker/cli/build


### PR DESCRIPTION
### Dockerfile.dev: install bash-completion in dev container

It's not initialized, because there's no `docker` command installed
by default, but at least this makes sure that the basics are present
for testing.

### Makefile: add completion target

Add a "completion" target to install the generated completion
scripts inside the dev-container. As generating this script
depends on the docker binary, it calls "make binary" first.

**- A picture of a cute animal (not mandatory but encouraged)**

