### PR TITLE
push: Don't default to `DOCKER_DEFAULT_PLATFORM`, improve message

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -84,7 +84,7 @@ func RunPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error
 
 		printNote(dockerCli, `Selecting a single platform will only push one matching image manifest from a multi-platform image index.
 This means that any other components attached to the multi-platform image index (like Buildkit attestations) won't be pushed.
-If you want to only push a single platform image while preserving the attestations, please use 'docker convert\n'
+If you want to push a whole multi-platform image, make sure all image content is present and remove the --platform flag.
 `)
 	}
 

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
@@ -58,7 +57,11 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tags of an image to the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 	command.AddTrustSigningFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
-	flags.StringVar(&opts.platform, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"),
+
+	// Don't default to DOCKER_DEFAULT_PLATFORM env variable, always default to
+	// pushing the image as-is. This also avoids forcing the platform selection
+	// on older APIs which don't support it.
+	flags.StringVar(&opts.platform, "platform", "",
 		`Push a platform-specific manifest as a single-platform image to the registry.
 'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)`)
 	flags.SetAnnotation("platform", "version", []string{"1.46"})

--- a/docs/reference/commandline/image_push.md
+++ b/docs/reference/commandline/image_push.md
@@ -9,12 +9,12 @@ Upload an image to a registry
 
 ### Options
 
-| Name                                         | Type     | Default | Description                                                                                                                                 |
-|:---------------------------------------------|:---------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------|
-| [`-a`](#all-tags), [`--all-tags`](#all-tags) | `bool`   |         | Push all tags of an image to the repository                                                                                                 |
-| `--disable-content-trust`                    | `bool`   | `true`  | Skip image signing                                                                                                                          |
-| `--platform`                                 | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
-| `-q`, `--quiet`                              | `bool`   |         | Suppress verbose output                                                                                                                     |
+| Name                                         | Type     | Default | Description                                                                                                                                                                                                                                          |
+|:---------------------------------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`-a`](#all-tags), [`--all-tags`](#all-tags) | `bool`   |         | Push all tags of an image to the repository                                                                                                                                                                                                          |
+| `--disable-content-trust`                    | `bool`   | `true`  | Skip image signing                                                                                                                                                                                                                                   |
+| `--platform`                                 | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>Image index won't be pushed, meaning that other manifests, including attestations won't be preserved.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
+| `-q`, `--quiet`                              | `bool`   |         | Suppress verbose output                                                                                                                                                                                                                              |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -9,12 +9,12 @@ Upload an image to a registry
 
 ### Options
 
-| Name                      | Type     | Default | Description                                                                                                                                 |
-|:--------------------------|:---------|:--------|:--------------------------------------------------------------------------------------------------------------------------------------------|
-| `-a`, `--all-tags`        | `bool`   |         | Push all tags of an image to the repository                                                                                                 |
-| `--disable-content-trust` | `bool`   | `true`  | Skip image signing                                                                                                                          |
-| `--platform`              | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
-| `-q`, `--quiet`           | `bool`   |         | Suppress verbose output                                                                                                                     |
+| Name                      | Type     | Default | Description                                                                                                                                                                                                                                          |
+|:--------------------------|:---------|:--------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-a`, `--all-tags`        | `bool`   |         | Push all tags of an image to the repository                                                                                                                                                                                                          |
+| `--disable-content-trust` | `bool`   | `true`  | Skip image signing                                                                                                                                                                                                                                   |
+| `--platform`              | `string` |         | Push a platform-specific manifest as a single-platform image to the registry.<br>Image index won't be pushed, meaning that other manifests, including attestations won't be preserved.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64) |
+| `-q`, `--quiet`           | `bool`   |         | Suppress verbose output                                                                                                                                                                                                                              |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/issues/5242

Don't default the value of `--platform` flag to `DOCKER_DEFAULT_PLATFORM` environment variable and adjust the note.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
containerd integration: Fix `docker push` defaulting the `--platform` flag to a value of `DOCKER_DEFAULT_PLATFORM` environment variable on unsupported API versions.
```

**- A picture of a cute animal (not mandatory but encouraged)**

