### PR TITLE
[27.0 backport] fix: container stream should not be terminated by ctx

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -119,6 +119,8 @@ func runRun(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, ro
 
 //nolint:gocyclo
 func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOptions, copts *containerOptions, containerCfg *containerConfig) error {
+	ctx = context.WithoutCancel(ctx)
+
 	config := containerCfg.Config
 	stdout, stderr := dockerCli.Out(), dockerCli.Err()
 	apiClient := dockerCli.Client()
@@ -181,7 +183,7 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		// ctx should not be cancellable here, as this would kill the stream to the container
 		// and we want to keep the stream open until the process in the container exits or until
 		// the user forcefully terminates the CLI.
-		closeFn, err := attachContainer(context.WithoutCancel(ctx), dockerCli, containerID, &errCh, config, container.AttachOptions{
+		closeFn, err := attachContainer(ctx, dockerCli, containerID, &errCh, config, container.AttachOptions{
 			Stream:     true,
 			Stdin:      config.AttachStdin,
 			Stdout:     config.AttachStdout,

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -178,7 +178,10 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 			detachKeys = runOpts.detachKeys
 		}
 
-		closeFn, err := attachContainer(ctx, dockerCli, containerID, &errCh, config, container.AttachOptions{
+		// ctx should not be cancellable here, as this would kill the stream to the container
+		// and we want to keep the stream open until the process in the container exits or until
+		// the user forcefully terminates the CLI.
+		closeFn, err := attachContainer(context.WithoutCancel(ctx), dockerCli, containerID, &errCh, config, container.AttachOptions{
 			Stream:     true,
 			Stdin:      config.AttachStdin,
 			Stdout:     config.AttachStdout,

--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -1,8 +1,10 @@
 package container
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/poll"
 	"gotest.tools/v3/skip"
 )
 
@@ -220,4 +223,27 @@ func TestMountSubvolume(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestProcessTermination(t *testing.T) {
+	var out bytes.Buffer
+	cmd := icmd.Command("docker", "run", "--rm", "-i", fixtures.AlpineImage,
+		"sh", "-c", "echo 'starting trap'; trap 'echo got signal; exit 0;' TERM; while true; do sleep 10; done")
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	result := icmd.StartCmd(cmd).Assert(t, icmd.Success)
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		if strings.Contains(result.Stdout(), "starting trap") {
+			return poll.Success()
+		}
+		return poll.Continue("waiting for process to trap signal")
+	}, poll.WithDelay(1*time.Second), poll.WithTimeout(5*time.Second))
+
+	assert.NilError(t, result.Cmd.Process.Signal(syscall.SIGTERM))
+
+	icmd.WaitOnCmd(time.Second*10, result).Assert(t, icmd.Expected{
+		ExitCode: 0,
+	})
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->
- backports: https://github.com/docker/cli/pull/5247
- fixes: https://github.com/docker/cli/issues/5241

**- What I did**
Prevent the hijacked stream from exiting on main `ctx` cancellation. When the user sends a termination signal to the CLI while attached to a container, the signal should be forwarded to the container and handled by the process inside the container. The CLI should wait for the container to gracefully exit. 

If the user wishes to exit without waiting, sending more termination requests will still forcefully exit the CLI. 

**- How I did it**

**- How to verify it**

handle_sigterm.sh
```sh
#!/bin/sh

# Function to handle SIGTERM
handle_sigterm() {
    echo "Received SIGTERM, exiting..."
    exit 0
}

trap 'handle_sigterm' TERM

while true; do
    echo "Waiting for sigterm"
    sleep 10
done
```

```console
⋊> ~/G/cli on hotfix-sigterm-container ◦ build/docker run -i \                                                    
                                                      -v $HOME/Downloads/:/home:ro \
                                                      alpine:latest \
                                                      /home/handle_sigterm.sh
Waiting for sigterm
Waiting for sigterm
Received SIGTERM, exiting...
```

```console
⋊> ~ ps -ef | grep "handle_sigterm.sh" | grep "docker run"
benehiko  279458  277233  1 17:48 pts/5    00:00:00 build/docker run -i -v /home/benehiko/Downloads/:/home:ro alpine:latest /home/handle_sigterm.sh
⋊> ~ kill -15 279458 
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
sending a termination request to the CLI while attached to a container, will wait for the container to exit before closing the stream.

```

**- A picture of a cute animal (not mandatory but encouraged)**
