### PR TITLE
cli/config/credentials: move warning to fileStore

### DIFF
--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -1,8 +1,10 @@
 package credentials
 
 import (
+	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/docker/cli/cli/config/types"
@@ -52,19 +54,33 @@ func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
 	return c.file.GetAuthConfigs(), nil
 }
 
+// unencryptedWarning warns the user when using an insecure credential storage.
+// After a deprecation period, user will get prompted if stdin and stderr are a terminal.
+// Otherwise, we'll assume they want it (sadly), because people may have been scripting
+// insecure logins and we don't want to break them. Maybe they'll see the warning in their
+// logs and fix things.
+const unencryptedWarning = `
+WARNING! Your credentials are stored unencrypted in '%s'.
+Configure a credential helper to remove this warning. See
+https://docs.docker.com/go/credential-store/
+`
+
 // Store saves the given credentials in the file store.
 func (c *fileStore) Store(authConfig types.AuthConfig) error {
 	authConfigs := c.file.GetAuthConfigs()
 	authConfigs[authConfig.ServerAddress] = authConfig
-	return c.file.Save()
-}
+	if err := c.file.Save(); err != nil {
+		return err
+	}
 
-func (c *fileStore) GetFilename() string {
-	return c.file.GetFilename()
-}
+	if authConfig.Password != "" {
+		// Display a warning if we're storing the users password (not a token).
+		//
+		// FIXME(thaJeztah): make output configurable instead of hardcoding to os.Stderr
+		_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf(unencryptedWarning, c.file.GetFilename()))
+	}
 
-func (c *fileStore) IsFileStore() bool {
-	return true
+	return nil
 }
 
 // ConvertToHostname converts a registry url which has http|https prepended


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/5258
- relates to https://github.com/docker/cli/pull/5244#discussion_r1682633124


### cli/config/credentials: move warning to fileStore

The fileStore itself is aware that it's insecure, so we can make it
responsible for printing the warning. It's not "perfect", as we use
`os.Stderr` unconditionally (not `dockerCli.Err()`), but probably won't
make a difference in _most_ cases.



**- A picture of a cute animal (not mandatory but encouraged)**

