### PR TITLE
[27.1 backport] gha: check-pr-branch: verify major version only

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -53,10 +53,16 @@ jobs:
       # Backports or PR that target a release branch directly should mention the target branch in the title, for example:
       # [X.Y backport] Some change that needs backporting to X.Y
       # [X.Y] Change directly targeting the X.Y branch
-      - name: Get branch from PR title
-        id: title_branch
-        run: echo "$PR_TITLE" | sed -n 's/^\[\([0-9]*\.[0-9]*\)[^]]*\].*/branch=\1/p' >> $GITHUB_OUTPUT
-
       - name: Check release branch
-        if: github.event.pull_request.base.ref != steps.title_branch.outputs.branch && !(github.event.pull_request.base.ref == 'master' && steps.title_branch.outputs.branch == '')
-        run: echo "::error::PR title suggests targetting the ${{ steps.title_branch.outputs.branch }} branch, but is opened against ${{ github.event.pull_request.base.ref }}" && exit 1
+        id: title_branch
+        run: |
+          # get the intended major version prefix ("[27.1 backport]" -> "27.") from the PR title.
+          [[ "$PR_TITLE" =~ ^\[([0-9]*\.)[^]]*\] ]] && branch="${BASH_REMATCH[1]}"
+
+          # get major version prefix from the release branch ("27.x -> "27.")
+          [[ "$GITHUB_BASE_REF" =~ ^([0-9]*\.) ]] && target_branch="${BASH_REMATCH[1]}" || target_branch="$GITHUB_BASE_REF"
+
+          if [[ "$target_branch" != "$branch" ]] && ! [[ "$GITHUB_BASE_REF" == "master" && "$branch" == "" ]]; then
+              echo "::error::PR is opened against the $GITHUB_BASE_REF branch, but its title suggests otherwise."
+              exit 1
+          fi


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5262

We'll be using release branches for minor version updates, so instead of (e.g.) a 27.0 branch, we'll be using 27.x and continue using the branch for minor version updates.

This patch changes the validation step to only compare against the major version.

(cherry picked from commit 45f769d9b41bf4c9643e4c9eb6c9b2a1c80888be)
