### PR TITLE
[27.1 backport] gha: update to macOS 13, add macOS 14 arm64 (Apple Silicon M1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13  # macOS 13 on Intel
+          - macos-14  # macOS 14 on arm64 (Apple Silicon M1)
 #          - windows-2022 # FIXME: some tests are failing on the Windows runner, as well as on Appveyor since June 24, 2018: https://ci.appveyor.com/project/docker/cli/history
     steps:
       -


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5268

(cherry picked from commit 9617e8d0ce8ef7d38bd2291eb7ba0da1a05fabc5)

