### PR TITLE
[25.0 backport] Fix codeql 2.16 in 25.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,16 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: go
+      # CodeQL 2.16.4's auto-build added support for multi-module repositories,
+      # and is trying to be smart by searching for modules in every directory,
+      # including vendor directories. If no module is found, it's creating one
+      # which is ... not what we want, so let's give it a "go.mod".
+      # see: https://github.com/docker/cli/pull/4944#issuecomment-2002034698
+      -
+        name: Create go.mod
+        run: |
+          ln -s vendor.mod go.mod
+          ln -s vendor.sum go.sum
       -
         name: Autobuild
         uses: github/codeql-action/autobuild@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,8 @@ jobs:
   codeql:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360
+    env:
+      DISABLE_WARN_OUTSIDE_CONTAINER: '1'
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
**- What I did**
Backports https://github.com/docker/cli/pull/4947 to 25.0

**- How I did it**
```
git cherry-pick -xsS 24186d8008ecbd5e00b09185cd42ac88aac6f701
git cherry-pick -xsS b120b96ac705f585652ae8a63bff748b4c500252
```

**- How to verify it**
CI must be successful

**- Description for the changelog**
```markdown changelog
Fix CodeQL 2.16 autobuild in CI
```

**- A picture of a cute animal (not mandatory but encouraged)**

