### PR TITLE
[25.0 backport] Require changelog in 25.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,13 @@ Please provide the following information:
 **- Description for the changelog**
 <!--
 Write a short (one line) summary that describes the changes in this
-pull request for inclusion in the changelog:
+pull request for inclusion in the changelog.
+It must be placed inside the below triple backticks section:
 -->
+```markdown changelog
 
+
+```
 
 **- A picture of a cute animal (not mandatory but encouraged)**
 

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,46 @@
+name: validate-pr
+
+on:
+  pull_request:
+    types: [opened, edited, labeled, unlabeled]
+
+jobs:
+  check-area-label:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Missing `area/` label
+        if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
+        run: |
+          echo "Every PR with an \`impact/*\` label should also have an \`area/*\` label"
+          exit 1
+      - name: OK
+        run: exit 0
+
+  check-changelog:
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/')
+    runs-on: ubuntu-20.04
+    env:
+      PR_BODY: |
+        ${{ github.event.pull_request.body }}
+    steps:
+      - name: Check changelog description
+        run: |
+          # Extract the `markdown changelog` note code block
+          block=$(echo -n "$PR_BODY" | tr -d '\r' | awk '/^```markdown changelog$/{flag=1;next}/^```$/{flag=0}flag')
+
+          # Strip empty lines
+          desc=$(echo "$block" |  awk NF)
+
+          if [ -z "$desc" ]; then
+            echo "Changelog section is empty. Please provide a description for the changelog."
+            exit 1
+          fi
+
+          len=$(echo -n "$desc" | wc -c)
+          if [[ $len -le 6 ]]; then
+            echo "Description looks too short: $desc"
+            exit 1
+          fi
+
+          echo "This PR will be included in the release notes with the following note:"
+          echo "$desc"

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -44,3 +44,19 @@ jobs:
 
           echo "This PR will be included in the release notes with the following note:"
           echo "$desc"
+
+  check-pr-branch:
+    runs-on: ubuntu-20.04
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      # Backports or PR that target a release branch directly should mention the target branch in the title, for example:
+      # [X.Y backport] Some change that needs backporting to X.Y
+      # [X.Y] Change directly targeting the X.Y branch
+      - name: Get branch from PR title
+        id: title_branch
+        run: echo "$PR_TITLE" | sed -n 's/^\[\([0-9]*\.[0-9]*\)[^]]*\].*/branch=\1/p' >> $GITHUB_OUTPUT
+
+      - name: Check release branch
+        if: github.event.pull_request.base.ref != steps.title_branch.outputs.branch && !(github.event.pull_request.base.ref == 'master' && steps.title_branch.outputs.branch == '')
+        run: echo "::error::PR title suggests targetting the ${{ steps.title_branch.outputs.branch }} branch, but is opened against ${{ github.event.pull_request.base.ref }}" && exit 1

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Missing `area/` label
         if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
         run: |
-          echo "Every PR with an \`impact/*\` label should also have an \`area/*\` label"
+          echo "::error::Every PR with an 'impact/*' label should also have an 'area/*' label"
           exit 1
       - name: OK
         run: exit 0
@@ -32,13 +32,13 @@ jobs:
           desc=$(echo "$block" |  awk NF)
 
           if [ -z "$desc" ]; then
-            echo "Changelog section is empty. Please provide a description for the changelog."
+            echo "::error::Changelog section is empty. Please provide a description for the changelog."
             exit 1
           fi
 
           len=$(echo -n "$desc" | wc -c)
           if [[ $len -le 6 ]]; then
-            echo "Description looks too short: $desc"
+            echo "::error::Description looks too short: $desc"
             exit 1
           fi
 


### PR DESCRIPTION
**- What I did**
Backports https://github.com/docker/cli/pull/4981 to 25.0

**- How I did it**
```
git cherry-pick -xsS 745704d7b4ec55c93b84db5372e0369850434207
git cherry-pick -xsS f92fcdef1b5f801c2fe359eee1833473caeabb5a
git cherry-pick -xsS c3243a8cc3da6bafc9e363d3d09550e558cd529f
```

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Require impactful changes to include a changelog entry and area label
```

**- A picture of a cute animal (not mandatory but encouraged)**

