### PR TITLE
correctly handle configuration file saving when it is a relative symlink

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -169,10 +169,16 @@ func (configFile *ConfigFile) Save() (retErr error) {
 		return errors.Wrap(err, "error closing temp file")
 	}
 
-	// Handle situation where the configfile is a symlink
+	// Handle situation where the configfile is a symlink, and allow for dangling symlinks
 	cfgFile := configFile.Filename
-	if f, err := os.Readlink(cfgFile); err == nil {
+	if f, err := filepath.EvalSymlinks(cfgFile); err == nil {
 		cfgFile = f
+	} else if os.IsNotExist(err) {
+		// extract the path from the error if the configfile does not exist or is a dangling symlink
+		var pathError *os.PathError
+		if errors.As(err, &pathError) {
+			cfgFile = pathError.Path
+		}
 	}
 
 	// Try copying the current config file (if any) ownership and permissions

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -538,6 +538,34 @@ func TestSaveWithSymlink(t *testing.T) {
 	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
 }
 
+func TestSaveWithRelativeSymlink(t *testing.T) {
+	dir := fs.NewDir(t, t.Name(), fs.WithFile("real-config.json", `{}`))
+	defer dir.Remove()
+
+	symLink := dir.Join("config.json")
+	relativeRealFile := "real-config.json"
+	realFile := dir.Join(relativeRealFile)
+	err := os.Symlink(relativeRealFile, symLink)
+	assert.NilError(t, err)
+
+	configFile := New(symLink)
+
+	err = configFile.Save()
+	assert.NilError(t, err)
+
+	fi, err := os.Lstat(symLink)
+	assert.NilError(t, err)
+	assert.Assert(t, fi.Mode()&os.ModeSymlink != 0, "expected %s to be a symlink", symLink)
+
+	cfg, err := os.ReadFile(symLink)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
+
+	cfg, err = os.ReadFile(realFile)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(string(cfg), "{\n	\"auths\": {}\n}"))
+}
+
 func TestPluginConfig(t *testing.T) {
 	configFile := New("test-plugin")
 	defer os.Remove("test-plugin")


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->
fixes: #5281 

**- What I did**
Correctly hand the cases with config file being a relative symlink.

**- How I did it**
Check whether the result path of `os.Readlink(cfgFile)` is a relative path, if so, get the absolute path of it.

**- How to verify it**
```bash
mkdir ~/.docker
echo '{}' > ~/.docker/config-company.json
ln -sf config-company.json ~/.docker/config.json   # create a relative symlink
docker login -u <user>
grep auths ~/.docker/config.json && echo OK || echo Failed
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix an issue where the CLI would not correctly save the configuration file (`~/.docker/config.json`) if it was a relative symbolic link.
```

**- A picture of a cute animal (not mandatory but encouraged)**

