### PR TITLE
[23.0 backport] Fix codeql 2.16 in 23.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,16 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: go
+      # CodeQL 2.16.4's auto-build added support for multi-module repositories,
+      # and is trying to be smart by searching for modules in every directory,
+      # including vendor directories. If no module is found, it's creating one
+      # which is ... not what we want, so let's give it a "go.mod".
+      # see: https://github.com/docker/cli/pull/4944#issuecomment-2002034698
+      -
+        name: Create go.mod
+        run: |
+          ln -s vendor.mod go.mod
+          ln -s vendor.sum go.sum
       -
         name: Autobuild
         uses: github/codeql-action/autobuild@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   codeql:
     runs-on: ubuntu-20.04
+    env:
+      DISABLE_WARN_OUTSIDE_CONTAINER: '1'
+    
     steps:
       -
         name: Checkout


### PR DESCRIPTION
**- What I did**
Backports https://github.com/docker/cli/pull/4947 to 23.0

**- How I did it**
```
git cherry-pick -xsS 24186d8008ecbd5e00b09185cd42ac88aac6f701
git cherry-pick -xsS b120b96ac705f585652ae8a63bff748b4c500252
```

**- How to verify it**
CodeQL workflow must be successful

**- Description for the changelog**
```markdown changelog
Fix CodeQL 2.16 autobuild in CI
```

**- A picture of a cute animal (not mandatory but encouraged)**

