### PR TITLE
[23.0 backport] gha: update to use macos-12 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
+          - macos-12
 #          - windows-2022 # FIXME: some tests are failing on the Windows runner, as well as on Appveyor since June 24, 2018: https://ci.appveyor.com/project/docker/cli/history
     steps:
       -


### PR DESCRIPTION
**- What I did**
Backports #4794 to 23.0

**- How I did it**
```
git cherry-pick -xsS f722e07c62f2caec0c1f9a0363ace1991d11ef4b
```

**- How to verify it**
CI must be successful

**- Description for the changelog**
```markdown changelog
Update macOS runners in CI to macOS 12 
```

**- A picture of a cute animal (not mandatory but encouraged)**

