### PR TITLE
docs: refresh image versions in examples

### DIFF
--- a/docs/reference/commandline/container_attach.md
+++ b/docs/reference/commandline/container_attach.md
@@ -97,7 +97,7 @@ CONTAINER ID   IMAGE     COMMAND    CREATED          STATUS                     
 Repeating the example above, but this time with the `-i` and `-t` options set;
 
 ```console
-$ docker run -dit --name topdemo2 ubuntu:22.04 /usr/bin/top -b
+$ docker run -dit --name topdemo2 alpine /usr/bin/top -b
 ```
 
 Now, when attaching to the container, and pressing the `CTRL-p CTRL-q` ("read

--- a/docs/reference/commandline/container_commit.md
+++ b/docs/reference/commandline/container_commit.md
@@ -44,8 +44,8 @@ created. Supported `Dockerfile` instructions:
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker commit c3f279d17e0a  svendowideit/testimage:version3
 
@@ -63,8 +63,8 @@ svendowideit/testimage            version3            f5283438590d        16 sec
 $ docker ps
 
 CONTAINER ID       IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436       ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a       ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436       ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker inspect -f "{{ .Config.Env }}" c3f279d17e0a
 
@@ -85,8 +85,8 @@ $ docker inspect -f "{{ .Config.Env }}" f5283438590d
 $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS              NAMES
-c3f279d17e0a        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:22.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:24.04        /bin/bash           7 days ago          Up 25 hours                            focused_hamilton
 
 $ docker commit --change='CMD ["apachectl", "-DFOREGROUND"]' -c "EXPOSE 80" c3f279d17e0a  svendowideit/testimage:version4
 
@@ -100,6 +100,6 @@ $ docker ps
 
 CONTAINER ID        IMAGE               COMMAND                 CREATED             STATUS              PORTS              NAMES
 89373736e2e7        testimage:version4  "apachectl -DFOREGROU"  3 seconds ago       Up 2 seconds        80/tcp             distracted_fermat
-c3f279d17e0a        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
-197387f1b436        ubuntu:22.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
+c3f279d17e0a        ubuntu:24.04        /bin/bash               7 days ago          Up 25 hours                            desperate_dubinsky
+197387f1b436        ubuntu:24.04        /bin/bash               7 days ago          Up 25 hours                            focused_hamilton
 ```

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -33,7 +33,7 @@ Running `docker ps --no-trunc` showing 2 linked containers.
 $ docker ps --no-trunc
 
 CONTAINER ID                                                     IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
-ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 ubuntu:22.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
+ca5534a51dd04bbcebe9b23ba05f389466cf0c190f1f8f182d7eea92a9671d00 ubuntu:24.04                 bash                   17 seconds ago       Up 16 seconds       3300-3310/tcp       webapp
 9ca9747b233100676a48cc7806131586213fa5dab86dd1972d6a8732e3a84a4d crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
 ```
 
@@ -240,13 +240,13 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 919e1179bdb8        ubuntu-c1           "top"               About a minute ago   Up About a minute                       admiring_lovelace
 ```
 
-Match containers based on the `ubuntu` version `22.04` image:
+Match containers based on the `ubuntu` version `24.04` image:
 
 ```console
-$ docker ps --filter ancestor=ubuntu:22.04
+$ docker ps --filter ancestor=ubuntu:24.04
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+82a598284012        ubuntu:24.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
 ```
 
 The following matches containers based on the layer `d0e008c6cf02` or an image
@@ -256,7 +256,7 @@ that have this layer in its layer stack.
 $ docker ps --filter ancestor=d0e008c6cf02
 
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS               NAMES
-82a598284012        ubuntu:22.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
+82a598284012        ubuntu:24.04        "top"               3 minutes ago        Up 3 minutes                            sleepy_bose
 ```
 
 #### Create time

--- a/docs/reference/commandline/image_pull.md
+++ b/docs/reference/commandline/image_pull.md
@@ -107,8 +107,8 @@ refer to [understand images, containers, and storage drivers](https://docs.docke
 So far, you've pulled images by their name (and "tag"). Using names and tags is
 a convenient way to work with images. When using tags, you can `docker pull` an
 image again to make sure you have the most up-to-date version of that image.
-For example, `docker pull ubuntu:22.04` pulls the latest version of the Ubuntu
-22.04 image.
+For example, `docker pull ubuntu:24.04` pulls the latest version of the Ubuntu
+24.04 image.
 
 In some cases you don't want images to be updated to newer versions, but prefer
 to use a fixed version of an image. Docker enables you to pull an image by its
@@ -117,23 +117,23 @@ of an image to pull. Doing so, allows you to "pin" an image to that version,
 and guarantee that the image you're using is always the same.
 
 To know the digest of an image, pull the image first. Let's pull the latest
-`ubuntu:22.04` image from Docker Hub:
+`ubuntu:24.04` image from Docker Hub:
 
 ```console
-$ docker pull ubuntu:22.04
+$ docker pull ubuntu:24.04
 
-22.04: Pulling from library/ubuntu
+24.04: Pulling from library/ubuntu
 125a6e411906: Pull complete
-Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-Status: Downloaded newer image for ubuntu:22.04
-docker.io/library/ubuntu:22.04
+Digest: sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+Status: Downloaded newer image for ubuntu:24.04
+docker.io/library/ubuntu:24.04
 ```
 
 Docker prints the digest of the image after the pull has finished. In the example
 above, the digest of the image is:
 
 ```console
-sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 ```
 
 Docker also prints the digest of an image when pushing to a registry. This
@@ -143,18 +143,18 @@ A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
 ```console
-$ docker pull ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+$ docker pull ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
-docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d: Pulling from library/ubuntu
-Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-Status: Image is up to date for ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30: Pulling from library/ubuntu
+Digest: sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+Status: Image is up to date for ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 ```
 
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
 ```dockerfile
-FROM ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+FROM ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 ```
 
@@ -215,13 +215,11 @@ shorthand) to see the images that were pulled. The example below shows all the
 ```console
 $ docker image ls --filter reference=ubuntu
 REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
-ubuntu       18.04     c6ad7e71ba7d   5 weeks ago    63.2MB
-ubuntu       bionic    c6ad7e71ba7d   5 weeks ago    63.2MB
-ubuntu       22.04     5ccefbfc0416   2 months ago   78MB
-ubuntu       focal     ff0fea8310f3   2 months ago   72.8MB
-ubuntu       latest    ff0fea8310f3   2 months ago   72.8MB
-ubuntu       jammy     41ba606c8ab9   3 months ago   79MB
-ubuntu       20.04     ba6acccedd29   7 months ago   72.8MB
+ubuntu       22.04     8a3cdc4d1ad3   3 weeks ago    77.9MB
+ubuntu       jammy     8a3cdc4d1ad3   3 weeks ago    77.9MB
+ubuntu       24.04     35a88802559d   6 weeks ago    78.1MB
+ubuntu       latest    35a88802559d   6 weeks ago    78.1MB
+ubuntu       noble     35a88802559d   6 weeks ago    78.1MB
 ```
 
 ### Cancel a pull

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -699,7 +699,7 @@ follows:
 | `node.platform.os`   | Node operating system          | `node.platform.os==windows`                   |
 | `node.platform.arch` | Node architecture              | `node.platform.arch==x86_64`                  |
 | `node.labels`        | User-defined node labels       | `node.labels.security==high`                  |
-| `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-22.04` |
+| `engine.labels`      | Docker Engine's labels         | `engine.labels.operatingsystem==ubuntu-24.04` |
 
 `engine.labels` apply to Docker Engine labels like operating system, drivers,
 etc. Swarm administrators add `node.labels` for operational purposes by using

--- a/docs/reference/commandline/system_events.md
+++ b/docs/reference/commandline/system_events.md
@@ -339,10 +339,10 @@ $ docker events --filter 'type=network'
 
 $ docker events --filter 'container=container_1' --filter 'container=container_2'
 
-2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
-2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
-2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:2.8)
-2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:24.04)
+2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:24.04)
+2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (imager=redis:7.2)
+2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:7.2)
 
 $ docker events --filter 'type=volume'
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -35,7 +35,7 @@ reference to create or run a container based on an image.
 
 An image tag is the image version, which defaults to `latest` when omitted. Use
 the tag to run a container from specific version of an image. For example, to
-run version `23.10` of the `ubuntu` image: `docker run ubuntu:23.10`.
+run version `24.04` of the `ubuntu` image: `docker run ubuntu:24.04`.
 
 #### Image digests
 
@@ -400,14 +400,14 @@ We have four ways to set user memory usage:
 Examples:
 
 ```console
-$ docker run -it ubuntu:22.04 /bin/bash
+$ docker run -it ubuntu:24.04 /bin/bash
 ```
 
 We set nothing about memory, this means the processes in the container can use
 as much memory and swap memory as they need.
 
 ```console
-$ docker run -it -m 300M --memory-swap -1 ubuntu:22.04 /bin/bash
+$ docker run -it -m 300M --memory-swap -1 ubuntu:24.04 /bin/bash
 ```
 
 We set memory limit and disabled swap memory limit, this means the processes in
@@ -415,7 +415,7 @@ the container can use 300M memory and as much swap memory as they need (if the
 host supports swap memory).
 
 ```console
-$ docker run -it -m 300M ubuntu:22.04 /bin/bash
+$ docker run -it -m 300M ubuntu:24.04 /bin/bash
 ```
 
 We set memory limit only, this means the processes in the container can use
@@ -424,7 +424,7 @@ We set memory limit only, this means the processes in the container can use
 would be 2*300M, so processes can use 300M swap memory as well.
 
 ```console
-$ docker run -it -m 300M --memory-swap 1G ubuntu:22.04 /bin/bash
+$ docker run -it -m 300M --memory-swap 1G ubuntu:24.04 /bin/bash
 ```
 
 We set both memory and swap memory, so the processes in the container can use
@@ -450,7 +450,7 @@ The following example limits the memory (`-m`) to 500M and sets the memory
 reservation to 200M.
 
 ```console
-$ docker run -it -m 500M --memory-reservation 200M ubuntu:22.04 /bin/bash
+$ docker run -it -m 500M --memory-reservation 200M ubuntu:24.04 /bin/bash
 ```
 
 Under this configuration, when the container consumes memory more than 200M and
@@ -460,7 +460,7 @@ memory below 200M.
 The following example set memory reservation to 1G without a hard memory limit.
 
 ```console
-$ docker run -it --memory-reservation 1G ubuntu:22.04 /bin/bash
+$ docker run -it --memory-reservation 1G ubuntu:24.04 /bin/bash
 ```
 
 The container can use as much memory as it needs. The memory reservation setting
@@ -478,13 +478,13 @@ The following example limits the memory to 100M and disables the OOM killer for
 this container:
 
 ```console
-$ docker run -it -m 100M --oom-kill-disable ubuntu:22.04 /bin/bash
+$ docker run -it -m 100M --oom-kill-disable ubuntu:24.04 /bin/bash
 ```
 
 The following example, illustrates a dangerous way to use the flag:
 
 ```console
-$ docker run -it --oom-kill-disable ubuntu:22.04 /bin/bash
+$ docker run -it --oom-kill-disable ubuntu:24.04 /bin/bash
 ```
 
 The container has unlimited memory which can cause the host to run out memory
@@ -554,14 +554,14 @@ limit and "K" the kernel limit. There are three possible ways to set limits:
 Examples:
 
 ```console
-$ docker run -it -m 500M --kernel-memory 50M ubuntu:22.04 /bin/bash
+$ docker run -it -m 500M --kernel-memory 50M ubuntu:24.04 /bin/bash
 ```
 
 We set memory and kernel memory, so the processes in the container can use
 500M memory in total, in this 500M memory, it can be 50M kernel memory tops.
 
 ```console
-$ docker run -it --kernel-memory 50M ubuntu:22.04 /bin/bash
+$ docker run -it --kernel-memory 50M ubuntu:24.04 /bin/bash
 ```
 
 We set kernel memory without **-m**, so the processes in the container can
@@ -578,7 +578,7 @@ between 0 and 100. A value of 0 turns off anonymous page swapping. A value of
 For example, you can set:
 
 ```console
-$ docker run -it --memory-swappiness=0 ubuntu:22.04 /bin/bash
+$ docker run -it --memory-swappiness=0 ubuntu:24.04 /bin/bash
 ```
 
 Setting the `--memory-swappiness` option is helpful when you want to retain the
@@ -629,7 +629,7 @@ And usually `--cpu-period` should work with `--cpu-quota`.
 Examples:
 
 ```console
-$ docker run -it --cpu-period=50000 --cpu-quota=25000 ubuntu:22.04 /bin/bash
+$ docker run -it --cpu-period=50000 --cpu-quota=25000 ubuntu:24.04 /bin/bash
 ```
 
 If there is 1 CPU, this means the container can get 50% CPU worth of run-time every 50ms.
@@ -650,13 +650,13 @@ We can set cpus in which to allow execution for containers.
 Examples:
 
 ```console
-$ docker run -it --cpuset-cpus="1,3" ubuntu:22.04 /bin/bash
+$ docker run -it --cpuset-cpus="1,3" ubuntu:24.04 /bin/bash
 ```
 
 This means processes in container can be executed on cpu 1 and cpu 3.
 
 ```console
-$ docker run -it --cpuset-cpus="0-2" ubuntu:22.04 /bin/bash
+$ docker run -it --cpuset-cpus="0-2" ubuntu:24.04 /bin/bash
 ```
 
 This means processes in container can be executed on cpu 0, cpu 1 and cpu 2.
@@ -667,14 +667,14 @@ on NUMA systems.
 Examples:
 
 ```console
-$ docker run -it --cpuset-mems="1,3" ubuntu:22.04 /bin/bash
+$ docker run -it --cpuset-mems="1,3" ubuntu:24.04 /bin/bash
 ```
 
 This example restricts the processes in the container to only use memory from
 memory nodes 1 and 3.
 
 ```console
-$ docker run -it --cpuset-mems="0-2" ubuntu:22.04 /bin/bash
+$ docker run -it --cpuset-mems="0-2" ubuntu:24.04 /bin/bash
 ```
 
 This example restricts the processes in the container to only use memory from
@@ -706,8 +706,8 @@ For example, the commands below create two containers with different blkio
 weight:
 
 ```console
-$ docker run -it --name c1 --blkio-weight 300 ubuntu:22.04 /bin/bash
-$ docker run -it --name c2 --blkio-weight 600 ubuntu:22.04 /bin/bash
+$ docker run -it --name c1 --blkio-weight 300 ubuntu:24.04 /bin/bash
+$ docker run -it --name c2 --blkio-weight 600 ubuntu:24.04 /bin/bash
 ```
 
 If you do block IO in the two containers at the same time, by, for example:
@@ -923,11 +923,11 @@ For interacting with the network stack, instead of using `--privileged` they
 should use `--cap-add=NET_ADMIN` to modify the network interfaces.
 
 ```console
-$ docker run -it --rm  ubuntu:22.04 ip link add dummy0 type dummy
+$ docker run -it --rm  ubuntu:24.04 ip link add dummy0 type dummy
 
 RTNETLINK answers: Operation not permitted
 
-$ docker run -it --rm --cap-add=NET_ADMIN ubuntu:22.04 ip link add dummy0 type dummy
+$ docker run -it --rm --cap-add=NET_ADMIN ubuntu:24.04 ip link add dummy0 type dummy
 ```
 
 To mount a FUSE based filesystem, you need to combine both `--cap-add` and

--- a/man/src/container/attach.md
+++ b/man/src/container/attach.md
@@ -21,16 +21,13 @@ In this example the top command is run inside a container from an ubuntu image,
 in detached mode, then attaches to it, and then terminates the container
 with `CTRL-c`:
 
-    $ docker run -d --name topdemo ubuntu:20.04 /usr/bin/top -b
+    $ docker run -d --name topdemo alpine top -b
     $ docker attach topdemo
-    top - 00:07:01 up  4:54,  0 users,  load average: 0.83, 0.91, 0.82
-    Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
-    %Cpu(s):  2.3 us,  1.6 sy,  0.0 ni, 95.9 id,  0.0 wa,  0.1 hi,  0.1 si,  0.0 st
-    MiB Mem :  15846.2 total,   5729.2 free,   2592.5 used,   7524.4 buff/cache
-    MiB Swap:  16384.0 total,  16384.0 free,      0.0 used.  12097.3 avail Mem 
-    
-        PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
-          1 root      20   0    5976   3256   2828 R   0.0   0.0   0:00.04 top
+    Mem: 2395856K used, 5638884K free, 2328K shrd, 61904K buff, 1524264K cached
+    CPU:   0% usr   0% sys   0% nic  99% idle   0% io   0% irq   0% sirq
+    Load average: 0.15 0.06 0.01 1/567 6
+    PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
+    1     0 root     R     1700   0%   3   0% top -b
     ^C
 
 ## Override the detach sequence

--- a/man/src/container/ls.md
+++ b/man/src/container/ls.md
@@ -48,10 +48,10 @@ Valid placeholders for the Go template are listed below:
 
     $ docker container ls -a
     CONTAINER ID        IMAGE                 COMMAND                CREATED             STATUS      PORTS    NAMES
-    a87ecb4f327c        ubuntu:22.04          /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
+    a87ecb4f327c        ubuntu:24.04          /bin/sh -c #(nop) MA   20 minutes ago      Exit 0               desperate_brattain
     01946d9d34d8        busybox               /bin/sh -c #(nop) MA   33 minutes ago      Exit 0               thirsty_bell
     c1d3b0166030        acffc0358b9e          /bin/sh -c yum -y up   2 weeks ago         Exit 1               determined_torvalds
-    41d50ecd2f57        ubuntu:22.04          /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
+    41d50ecd2f57        ubuntu:24.04          /bin/sh -c #(nop) MA   2 weeks ago         Exit 0               drunk_pike
 
 ## Display only IDs of all containers, including non-running
 

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -10,7 +10,7 @@ The title REPOSITORY for the first title may seem confusing. It is essentially
 the image name. However, because you can tag a specific image, and multiple tags
 (image instances) can be associated with a single name, the name is really a
 repository for all tagged images of the same name. For example consider an image
-called ubuntu. It may be tagged with 20.04 or 22.04, etc. to manage different
+called ubuntu. It may be tagged with 24.04 or 22.04, etc. to manage different
 versions.
 
 ## Filters

--- a/man/src/image/pull.md
+++ b/man/src/image/pull.md
@@ -64,8 +64,8 @@ in the online documentation.
 So far, you've pulled images by their name (and "tag"). Using names and tags is
 a convenient way to work with images. When using tags, you can `docker image pull` an
 image again to make sure you have the most up-to-date version of that image.
-For example, `docker image pull ubuntu:22.04` pulls the latest version of the Ubuntu
-22.04 image.
+For example, `docker image pull ubuntu:24.04` pulls the latest version of the Ubuntu
+24.04 image.
 
 In some cases you don't want images to be updated to newer versions, but prefer
 to use a fixed version of an image. Docker enables you to pull an image by its
@@ -74,20 +74,20 @@ of an image to pull. Doing so, allows you to "pin" an image to that version,
 and guarantee that the image you're using is always the same.
 
 To know the digest of an image, pull the image first. Let's pull the latest
-`ubuntu:22.04` image from Docker Hub:
+`ubuntu:24.04` image from Docker Hub:
 
-    $ docker image pull ubuntu:22.04
+    $ docker image pull ubuntu:24.04
 
-    22.04: Pulling from library/ubuntu
+    24.04: Pulling from library/ubuntu
     125a6e411906: Pull complete
-    Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-    Status: Downloaded newer image for ubuntu:22.04
-    docker.io/library/ubuntu:22.04
+    Digest: sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+    Status: Downloaded newer image for ubuntu:24.04
+    docker.io/library/ubuntu:24.04
 
 Docker prints the digest of the image after the pull has finished. In the example
 above, the digest of the image is:
 
-    sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
 Docker also prints the digest of an image when *pushing* to a registry. This
 may be useful if you want to pin to a version of the image you just pushed.
@@ -95,16 +95,16 @@ may be useful if you want to pin to a version of the image you just pushed.
 A digest takes the place of the tag when pulling an image, for example, to
 pull the above image by digest, run the following command:
 
-    $ docker image pull ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    $ docker image pull ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
-    docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d: Pulling from library/ubuntu
-    Digest: sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-    Status: Image is up to date for ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
-    docker.io/library/ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30: Pulling from library/ubuntu
+    Digest: sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+    Status: Image is up to date for ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
+    docker.io/library/ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
 
 Digest can also be used in the `FROM` of a Dockerfile, for example:
 
-    FROM ubuntu@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d
+    FROM ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30
     LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 
 > **Note**
@@ -159,14 +159,11 @@ images that are present locally:
 
     $ docker image ls --filter reference=ubuntu
     REPOSITORY   TAG       IMAGE ID       CREATED        SIZE
-    ubuntu       18.04     c6ad7e71ba7d   5 weeks ago    63.2MB
-    ubuntu       bionic    c6ad7e71ba7d   5 weeks ago    63.2MB
-    ubuntu       22.04     5ccefbfc0416   2 months ago   78MB
-    ubuntu       focal     ff0fea8310f3   2 months ago   72.8MB
-    ubuntu       latest    ff0fea8310f3   2 months ago   72.8MB
-    ubuntu       jammy     41ba606c8ab9   3 months ago   79MB
-    ubuntu       20.04     ba6acccedd29   7 months ago   72.8MB
-    ...
+    ubuntu       22.04     8a3cdc4d1ad3   3 weeks ago    77.9MB
+    ubuntu       jammy     8a3cdc4d1ad3   3 weeks ago    77.9MB
+    ubuntu       24.04     35a88802559d   6 weeks ago    78.1MB
+    ubuntu       latest    35a88802559d   6 weeks ago    78.1MB
+    ubuntu       noble     35a88802559d   6 weeks ago    78.1MB
 
 ## Cancel a pull
 

--- a/man/src/system/events.md
+++ b/man/src/system/events.md
@@ -62,10 +62,10 @@ The following example outputs all events that were generated in the last 3 minut
 relative to the current time on the client machine:
 
     # docker events --since '3m'
-    2015-05-12T11:51:30.999999999Z07:00  4386fb97867d: (from ubuntu:22.04) die
-    2015-05-12T15:52:12.999999999Z07:00  4386fb97867d: (from ubuntu:22.04) stop
-    2015-05-12T15:53:45.999999999Z07:00  7805c1d35632: (from redis:2.8) die
-    2015-05-12T15:54:03.999999999Z07:00  7805c1d35632: (from redis:2.8) stop
+    2015-05-12T11:51:30.999999999Z07:00  4386fb97867d: (from ubuntu:24.04) die
+    2015-05-12T15:52:12.999999999Z07:00  4386fb97867d: (from ubuntu:24.04) stop
+    2015-05-12T15:53:45.999999999Z07:00  7805c1d35632: (from redis:7.2) die
+    2015-05-12T15:54:03.999999999Z07:00  7805c1d35632: (from redis:7.2) stop
 
 If you do not provide the --since option, the command returns only new and/or
 live events.
@@ -97,26 +97,26 @@ Lines. For information about JSON Lines, refer to https://jsonlines.org .
 ## Filters
 
     $ docker events --filter 'event=stop'
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
-    2014-09-03T17:42:14.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:24.04)
+    2014-09-03T17:42:14.999999999Z07:00 container stop 7805c1d35632 (image=redis:7.2)
 
-    $ docker events --filter 'image=ubuntu:22.04'
-    2014-05-10T17:42:14.999999999Z07:00 container start 4386fb97867d (image=ubuntu:22.04)
-    2014-05-10T17:42:14.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
+    $ docker events --filter 'image=ubuntu:24.04'
+    2014-05-10T17:42:14.999999999Z07:00 container start 4386fb97867d (image=ubuntu:24.04)
+    2014-05-10T17:42:14.999999999Z07:00 container die 4386fb97867d (image=ubuntu:24.04)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:24.04)
 
     $ docker events --filter 'container=7805c1d35632'
-    2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
-    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image= redis:2.8)
+    2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:7.2)
+    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image= redis:7.2)
 
     $ docker events --filter 'container=7805c1d35632' --filter 'container=4386fb97867d'
-    2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:22.04)
-    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:22.04)
-    2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:2.8)
-    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+    2014-09-03T15:49:29.999999999Z07:00 container die 4386fb97867d (image=ubuntu:24.04)
+    2014-05-10T17:42:14.999999999Z07:00 container stop 4386fb97867d (image=ubuntu:24.04)
+    2014-05-10T17:42:14.999999999Z07:00 container die 7805c1d35632 (image=redis:7.2)
+    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:7.2)
 
     $ docker events --filter 'container=7805c1d35632' --filter 'event=stop'
-    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:2.8)
+    2014-09-03T15:49:29.999999999Z07:00 container stop 7805c1d35632 (image=redis:7.2)
 
     $ docker events --filter 'type=volume'
     2015-12-23T21:05:28.136212689Z volume create test-event-volume-local (driver=local)


### PR DESCRIPTION
use current LTS versions of ubuntu where suitable, remove uses of ubuntu:23.10 (which reache EOL), and and update some other examples to use more current versions.


