### PR TITLE
Fix flaky `TestCloseRunningCommand` test

### DIFF
--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -48,7 +48,7 @@ func TestCloseRunningCommand(t *testing.T) {
 	defer close(done)
 
 	go func() {
-		c, err := New(ctx, "sh", "-c", "while true; sleep 1; done")
+		c, err := New(ctx, "sh", "-c", "while true; do sleep 1; done")
 		assert.NilError(t, err)
 		cmdConn := c.(*commandConn)
 		assert.Check(t, process.Alive(cmdConn.cmd.Process.Pid))


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Fixed flaky `TestCloseRunningCommand` test.

**- How I did it**

Looks like this test was failing due to bad syntax on the `while` loop, which caused it to die after 1 second. If the test took a bit longer, the process would be dead before the following assertions run, causing the test to fail/be flaky.

**- How to verify it**

Run the test!

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

