### PR TITLE
[25.0 backport] fix flaky `connhelper` tests

### DIFF
--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -155,7 +155,7 @@ func (mockStdoutEOF) Close() error {
 
 func TestCloseWhileWriting(t *testing.T) {
 	cmd := "sh"
-	args := []string{"-c", "while true; sleep 1; done"}
+	args := []string{"-c", "while true; do sleep 1; done"}
 
 	c, err := New(context.TODO(), cmd, args...)
 	assert.NilError(t, err)
@@ -185,7 +185,7 @@ func TestCloseWhileWriting(t *testing.T) {
 
 func TestCloseWhileReading(t *testing.T) {
 	cmd := "sh"
-	args := []string{"-c", "while true; sleep 1; done"}
+	args := []string{"-c", "while true; do sleep 1; done"}
 
 	c, err := New(context.TODO(), cmd, args...)
 	assert.NilError(t, err)

--- a/cli/connhelper/commandconn/commandconn_unix_test.go
+++ b/cli/connhelper/commandconn/commandconn_unix_test.go
@@ -48,7 +48,7 @@ func TestEOFWithoutError(t *testing.T) {
 
 func TestCloseRunningCommand(t *testing.T) {
 	cmd := "sh"
-	args := []string{"-c", "while true; sleep 1; done"}
+	args := []string{"-c", "while true; do sleep 1; done"}
 
 	done := make(chan struct{})
 	defer close(done)


### PR DESCRIPTION
backports https://github.com/docker/cli/pull/5290 and https://github.com/docker/cli/pull/5291
