### PR TITLE
attach: don't return context cancelled error

### DIFF
--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -116,6 +117,10 @@ func TestGetExitStatus(t *testing.T) {
 				StatusCode: 15,
 			},
 			expectedError: cli.StatusError{StatusCode: 15},
+		},
+		{
+			err:           context.Canceled,
+			expectedError: nil,
 		},
 	}
 

--- a/e2e/container/attach_test.go
+++ b/e2e/container/attach_test.go
@@ -1,11 +1,17 @@
 package container
 
 import (
+	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/docker/cli/e2e/internal/fixtures"
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
 
@@ -22,4 +28,27 @@ func TestAttachExitCode(t *testing.T) {
 
 func withStdinNewline(cmd *icmd.Cmd) {
 	cmd.Stdin = strings.NewReader("\n")
+}
+
+// Regression test for https://github.com/docker/cli/issues/5294
+func TestAttachInterrupt(t *testing.T) {
+	result := icmd.RunCommand("docker", "run", "-d", fixtures.AlpineImage, "sh", "-c", "sleep 5")
+	result.Assert(t, icmd.Success)
+	containerID := strings.TrimSpace(result.Stdout())
+
+	// run it as such so we can signal it later
+	c := exec.Command("docker", "attach", containerID)
+	d := bytes.Buffer{}
+	c.Stdout = &d
+	c.Stderr = &d
+	_, err := pty.Start(c)
+	assert.NilError(t, err)
+
+	// have to wait a bit to give time for the command to execute/print
+	time.Sleep(500 * time.Millisecond)
+	c.Process.Signal(os.Interrupt)
+
+	_ = c.Wait()
+	assert.Equal(t, c.ProcessState.ExitCode(), 0)
+	assert.Equal(t, d.String(), "")
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

closes https://github.com/docker/cli/issues/5294

**- What I did**

In https://github.com/docker/cli/pull/4993 we introduced a global signal handler and made sure all the contexts passed into command execution get (appropriately) cancelled when we get a `SIGINT`.

Due to how we use this context in `docker attach`, this caused us to start returning a context cancelation error when a user signals the running `docker attach`.

Since this is the intended behavior, we shouldn't return an error, so this commit adds checks to ignore this specific error in this case.

Also adds a regression test.

**- How to verify it**

Run the added test:
```bash
TESTDIRS="./e2e/container/..." TESTFLAGS="-test.run=TestAttachInterrupt" make -f docker.Makefile test-e2e-non-experimental
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

