### PR TITLE
attach: wait for exit code from `ContainerWait`

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -72,7 +72,8 @@ func RunAttach(ctx context.Context, dockerCLI command.Cli, containerID string, o
 	apiClient := dockerCLI.Client()
 
 	// request channel to wait for client
-	resultC, errC := apiClient.ContainerWait(ctx, containerID, "")
+	waitCtx := context.WithoutCancel(ctx)
+	resultC, errC := apiClient.ContainerWait(waitCtx, containerID, "")
 
 	c, err := inspectContainerAndCheckState(ctx, apiClient, containerID)
 	if err != nil {
@@ -163,9 +164,6 @@ func getExitStatus(errC <-chan error, resultC <-chan container.WaitResponse) err
 			return cli.StatusError{StatusCode: int(result.StatusCode)}
 		}
 	case err := <-errC:
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
 		return err
 	}
 

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -86,11 +85,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 }
 
 func TestGetExitStatus(t *testing.T) {
-	var (
-		expectedErr = errors.New("unexpected error")
-		errC        = make(chan error, 1)
-		resultC     = make(chan container.WaitResponse, 1)
-	)
+	expectedErr := errors.New("unexpected error")
 
 	testcases := []struct {
 		result        *container.WaitResponse
@@ -118,20 +113,20 @@ func TestGetExitStatus(t *testing.T) {
 			},
 			expectedError: cli.StatusError{StatusCode: 15},
 		},
-		{
-			err:           context.Canceled,
-			expectedError: nil,
-		},
 	}
 
 	for _, testcase := range testcases {
+		errC := make(chan error, 1)
+		resultC := make(chan container.WaitResponse, 1)
 		if testcase.err != nil {
 			errC <- testcase.err
 		}
 		if testcase.result != nil {
 			resultC <- *testcase.result
 		}
+
 		err := getExitStatus(errC, resultC)
+
 		if testcase.expectedError == nil {
 			assert.NilError(t, err)
 		} else {


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Follow up to https://github.com/docker/cli/pull/5295

Such as with `docker run`, if a user CTRL-Cs while attached to a container, we should forward the signal and wait for the exit from `ContainerWait`, instead of just returning.

(see [`docker attach` docs](https://docs.docker.com/reference/cli/docker/container/attach/) for a clear explanation of the desired behavior)

**- How I did it**

Used an uncancellable context for the `ContainerWait` call.

**- How to verify it**

Run the test:
```
TESTDIRS="./e2e/container/..." TESTFLAGS="-test.run=TestAttachInterrupt" make -f docker.Makefile test-e2e-non-experimental
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

