### PR TITLE
lint: replace deprecated linter names 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - govet
     - ineffassign
     - lll
-    - megacheck
     - misspell      # Detects commonly misspelled English words in comments.
     - nakedret
     - nilerr        # Detects code that returns nil even if it checks that the error is not nil.
@@ -36,7 +35,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    - vet
+    - govet
     - wastedassign
 
   disable:


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Got tired of my lsp complaining, so I fixed up our `.golangci.yml`:

- `megacheck` has been deprecated/split into `gosimple`, `staticcheck`,
and `unused`, which we're already using – [link](https://github.com/golangci/golangci-lint/blob/d2b439faa53bc7d0645049c3e23fc858736b8cc4/pkg/lint/lintersdb/validator_test.go#L227)

- `vet` is now `govet` - [link](https://github.com/golangci/golangci-lint/blame/d2b439faa53bc7d0645049c3e23fc858736b8cc4/pkg/lint/lintersdb/validator_test.go#L228)

For more context, see: https://github.com/golangci/golangci-lint/pull/4562

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

