### PR TITLE
WIP: add configurable detach delay to logs

### DIFF
--- a/docs/reference/commandline/container_logs.md
+++ b/docs/reference/commandline/container_logs.md
@@ -11,6 +11,7 @@ Fetch the logs of a container
 
 | Name                 | Type     | Default | Description                                                                                        |
 |:---------------------|:---------|:--------|:---------------------------------------------------------------------------------------------------|
+| `-d`, `--delay`      | `int`    | `0`     | Number of seconds to wait for container restart before exiting                                     |
 | `--details`          | `bool`   |         | Show extra details provided to logs                                                                |
 | `-f`, `--follow`     | `bool`   |         | Follow log output                                                                                  |
 | `--since`            | `string` |         | Show logs since timestamp (e.g. `2013-01-02T13:23:37Z`) or relative (e.g. `42m` for 42 minutes)    |

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -11,6 +11,7 @@ Fetch the logs of a container
 
 | Name                 | Type     | Default | Description                                                                                        |
 |:---------------------|:---------|:--------|:---------------------------------------------------------------------------------------------------|
+| `-d`, `--delay`      | `int`    | `0`     | Number of seconds to wait for container restart before exiting                                     |
 | `--details`          | `bool`   |         | Show extra details provided to logs                                                                |
 | `-f`, `--follow`     | `bool`   |         | Follow log output                                                                                  |
 | `--since`            | `string` |         | Show logs since timestamp (e.g. `2013-01-02T13:23:37Z`) or relative (e.g. `42m` for 42 minutes)    |

--- a/e2e/container/logs_test.go
+++ b/e2e/container/logs_test.go
@@ -1,0 +1,46 @@
+package container
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/e2e/internal/fixtures"
+	"gotest.tools/v3/icmd"
+	"gotest.tools/v3/poll"
+)
+
+func TestLogsReattach(t *testing.T) {
+	result := icmd.RunCommand("docker", "run", "-d", fixtures.AlpineImage,
+		"sh", "-c", "echo hi; while true; do sleep 1; done")
+	result.Assert(t, icmd.Success)
+	containerID := strings.TrimSpace(result.Stdout())
+
+	cmd := icmd.Command("docker", "logs", "-f", "-d", "5", containerID)
+	// cmd := icmd.Command("docker", "logs", containerID)
+	result = icmd.StartCmd(cmd)
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		if strings.Contains(result.Stdout(), "hi") {
+			return poll.Success()
+		}
+		return poll.Continue("waiting")
+	}, poll.WithDelay(1*time.Second), poll.WithTimeout(5*time.Second))
+
+	icmd.RunCommand("docker", "restart", containerID).Assert(t, icmd.Success)
+
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		// if there is another "hi" then the container was successfully restarted,
+		// printed "hi" again and `docker logs` stayed attached
+		if strings.Contains(result.Stdout(), "hi\nhi") { //nolint:dupword
+			return poll.Success()
+		}
+		return poll.Continue(result.Stdout())
+	}, poll.WithDelay(1*time.Second), poll.WithTimeout(10*time.Second))
+
+	icmd.RunCommand("docker", "stop", containerID).Assert(t, icmd.Success)
+
+	icmd.WaitOnCmd(time.Second*10, result).Assert(t, icmd.Expected{
+		ExitCode: 0,
+	})
+}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Hacky PR for demonstration/discussion purposes only.

Addresses: https://github.com/docker/cli/issues/5305

**- How I did it**

**- How to verify it**

- `docker run -d --name bork alpine sh -c "while true; do echo hi; sleep 1; done"`
- `docker logs -f --delay 3 bork`
- (in another terminal) `docker restart bork`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

