### PR TITLE
Replace deprecated usages of `assert.ErrorType`

### DIFF
--- a/cli-plugins/manager/candidate_test.go
+++ b/cli-plugins/manager/candidate_test.go
@@ -1,14 +1,13 @@
 package manager
 
 import (
+	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
-	"gotest.tools/v3/assert/cmp"
 )
 
 type fakeCandidate struct {
@@ -80,7 +79,8 @@ func TestValidateCandidate(t *testing.T) {
 				assert.ErrorContains(t, err, tc.err)
 			case tc.invalid != "":
 				assert.NilError(t, err)
-				assert.Assert(t, cmp.ErrorType(p.Err, reflect.TypeOf(&pluginError{})))
+				var expectedError *pluginError
+				assert.Check(t, errors.As(p.Err, &expectedError))
 				assert.ErrorContains(t, p.Err, tc.invalid)
 			default:
 				assert.NilError(t, err)

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/docker/errdefs"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestRemove(t *testing.T) {
@@ -18,7 +17,7 @@ func TestRemove(t *testing.T) {
 	_, err := cli.ContextStore().GetMetadata("current")
 	assert.NilError(t, err)
 	_, err = cli.ContextStore().GetMetadata("other")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 func TestRemoveNotAContext(t *testing.T) {

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -47,7 +47,7 @@ func TestUse(t *testing.T) {
 func TestUseNoExist(t *testing.T) {
 	cli := makeFakeCli(t)
 	err := newUseCommand(cli).RunE(nil, []string{"test"})
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 // TestUseDefaultWithoutConfigFile verifies that the CLI does not create

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/go-connections/tlsconfig"
 	"gotest.tools/v3/assert"
-	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 )
 
@@ -158,7 +157,7 @@ func TestErrCreateDefault(t *testing.T) {
 		Metadata: testContext{Bar: "baz"},
 		Name:     "default",
 	})
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, errdefs.IsInvalidParameter(err))
 	assert.Error(t, err, "default context cannot be created nor updated")
 }
 
@@ -166,7 +165,7 @@ func TestErrRemoveDefault(t *testing.T) {
 	meta := testDefaultMetadata()
 	s := testStore(t, meta, store.ContextTLSData{})
 	err := s.Remove("default")
-	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidParameter))
+	assert.Check(t, errdefs.IsInvalidParameter(err))
 	assert.Error(t, err, "default context cannot be removed")
 }
 
@@ -174,5 +173,5 @@ func TestErrTLSDataError(t *testing.T) {
 	meta := testDefaultMetadata()
 	s := testStore(t, meta, store.ContextTLSData{})
 	_, err := s.GetTLSData("default", "noop", "noop")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errdefs.IsNotFound(err))
 }

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -5,6 +5,7 @@ package loader
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"runtime"
 	"sort"
@@ -878,7 +879,8 @@ services:
       service: foo
 `)
 
-	assert.ErrorType(t, err, &ForbiddenPropertiesError{})
+	var expectedErr *ForbiddenPropertiesError
+	assert.Check(t, errors.As(err, &expectedErr))
 
 	props := err.(*ForbiddenPropertiesError).Properties
 	assert.Check(t, is.Len(props, 2))

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -128,7 +129,8 @@ func TestMandatoryVariableErrors(t *testing.T) {
 	for _, tc := range testCases {
 		_, err := Substitute(tc.template, defaultMapping)
 		assert.Check(t, is.ErrorContains(err, tc.expectedError))
-		assert.Check(t, is.ErrorType(err, &InvalidTemplateError{}))
+		var expectedError *InvalidTemplateError
+		assert.Check(t, errors.As(err, &expectedError))
 	}
 }
 

--- a/cli/context/store/metadata_test.go
+++ b/cli/context/store/metadata_test.go
@@ -26,7 +26,7 @@ func testMetadata(name string) Metadata {
 func TestMetadataGetNotExisting(t *testing.T) {
 	testee := metadataStore{root: t.TempDir(), config: testCfg}
 	_, err := testee.get("noexist")
-	assert.ErrorType(t, err, errdefs.IsNotFound)
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 func TestMetadataCreateGetRemove(t *testing.T) {
@@ -60,7 +60,7 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 	assert.NilError(t, testee.remove("test-context"))
 	assert.NilError(t, testee.remove("test-context")) // support duplicate remove
 	_, err = testee.get("test-context")
-	assert.ErrorType(t, err, errdefs.IsNotFound)
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 func TestMetadataRespectJsonAnnotation(t *testing.T) {

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -107,7 +107,7 @@ func TestRemove(t *testing.T) {
 	}))
 	assert.NilError(t, s.Remove("source"))
 	_, err = s.GetMetadata("source")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errdefs.IsNotFound(err))
 	f, err := s.ListTLSFiles("source")
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(f))
@@ -122,7 +122,7 @@ func TestListEmptyStore(t *testing.T) {
 func TestErrHasCorrectContext(t *testing.T) {
 	_, err := New(t.TempDir(), testCfg).GetMetadata("no-exists")
 	assert.ErrorContains(t, err, "no-exists")
-	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 func TestDetectImportContentType(t *testing.T) {

--- a/cli/context/store/tlsstore_test.go
+++ b/cli/context/store/tlsstore_test.go
@@ -13,7 +13,7 @@ func TestTlsCreateUpdateGetRemove(t *testing.T) {
 	const contextName = "test-ctx"
 
 	_, err := testee.getData(contextName, "test-ep", "test-data")
-	assert.ErrorType(t, err, errdefs.IsNotFound)
+	assert.Check(t, errdefs.IsNotFound(err))
 
 	err = testee.createOrUpdate(contextName, "test-ep", "test-data", []byte("data"))
 	assert.NilError(t, err)
@@ -29,7 +29,7 @@ func TestTlsCreateUpdateGetRemove(t *testing.T) {
 	err = testee.removeEndpoint(contextName, "test-ep")
 	assert.NilError(t, err)
 	_, err = testee.getData(contextName, "test-ep", "test-data")
-	assert.ErrorType(t, err, errdefs.IsNotFound)
+	assert.Check(t, errdefs.IsNotFound(err))
 }
 
 func TestTlsListAndBatchRemove(t *testing.T) {


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

