### PR TITLE
fixes 4155: duplicate entries in docker node ps when multi nodes are passed

### DIFF
--- a/cli/command/node/client_test.go
+++ b/cli/command/node/client_test.go
@@ -11,20 +11,26 @@ import (
 
 type fakeClient struct {
 	client.Client
-	infoFunc           func() (system.Info, error)
-	nodeInspectFunc    func() (swarm.Node, []byte, error)
-	nodeListFunc       func() ([]swarm.Node, error)
-	nodeRemoveFunc     func() error
-	nodeUpdateFunc     func(nodeID string, version swarm.Version, node swarm.NodeSpec) error
-	taskInspectFunc    func(taskID string) (swarm.Task, []byte, error)
-	taskListFunc       func(options types.TaskListOptions) ([]swarm.Task, error)
-	serviceInspectFunc func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
+	infoFunc                func() (system.Info, error)
+	nodeInspectFunc         func() (swarm.Node, []byte, error)
+	nodeInspectFuncWithArgs func(nodeRef string) (swarm.Node, []byte, error)
+	nodeListFunc            func() ([]swarm.Node, error)
+	nodeRemoveFunc          func() error
+	nodeUpdateFunc          func(nodeID string, version swarm.Version, node swarm.NodeSpec) error
+	taskInspectFunc         func(taskID string) (swarm.Task, []byte, error)
+	taskListFunc            func(options types.TaskListOptions) ([]swarm.Task, error)
+	serviceInspectFunc      func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
 }
 
-func (cli *fakeClient) NodeInspectWithRaw(context.Context, string) (swarm.Node, []byte, error) {
+func (cli *fakeClient) NodeInspectWithRaw(ctx context.Context, nodeRef string) (swarm.Node, []byte, error) {
 	if cli.nodeInspectFunc != nil {
 		return cli.nodeInspectFunc()
 	}
+
+	if cli.nodeInspectFuncWithArgs != nil {
+		return cli.nodeInspectFuncWithArgs(nodeRef)
+	}
+
 	return swarm.Node{}, []byte{}, nil
 }
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -77,7 +76,6 @@ func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error 
 
 		filter := options.filter.Value().Clone()
 		filter.Add("node", node.ID)
-		fmt.Println("filter", filter)
 		nodeTasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 		if err != nil {
 			errs = append(errs, err.Error())

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/docker/cli/cli"
@@ -74,9 +75,9 @@ func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error 
 			continue
 		}
 
-		filter := options.filter.Value()
+		filter := options.filter.Value().Clone()
 		filter.Add("node", node.ID)
-
+		fmt.Println("filter", filter)
 		nodeTasks, err := client.TaskList(ctx, types.TaskListOptions{Filters: filter})
 		if err != nil {
 			errs = append(errs, err.Error())

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -68,14 +68,15 @@ func TestNodePsErrors(t *testing.T) {
 
 func TestNodePs(t *testing.T) {
 	testCases := []struct {
-		name               string
-		args               []string
-		flags              map[string]string
-		infoFunc           func() (system.Info, error)
-		nodeInspectFunc    func() (swarm.Node, []byte, error)
-		taskListFunc       func(options types.TaskListOptions) ([]swarm.Task, error)
-		taskInspectFunc    func(taskID string) (swarm.Task, []byte, error)
-		serviceInspectFunc func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
+		name                    string
+		args                    []string
+		flags                   map[string]string
+		infoFunc                func() (system.Info, error)
+		nodeInspectFunc         func() (swarm.Node, []byte, error)
+		nodeInspectFuncWithArgs func(string) (swarm.Node, []byte, error)
+		taskListFunc            func(options types.TaskListOptions) ([]swarm.Task, error)
+		taskInspectFunc         func(taskID string) (swarm.Task, []byte, error)
+		serviceInspectFunc      func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error)
 	}{
 		{
 			name: "simple",
@@ -132,17 +133,64 @@ func TestNodePs(t *testing.T) {
 				}, []byte{}, nil
 			},
 		},
+		{
+			name: "multiple-nodes-no-duplicates",
+			args: []string{"nodeID1", "nodeID2"},
+			nodeInspectFuncWithArgs: func(nodeRef string) (swarm.Node, []byte, error) {
+				switch nodeRef {
+				case "nodeID1":
+					return *builders.Node(builders.NodeID("nodeID1")), []byte{}, nil
+				case "nodeID2":
+					return *builders.Node(builders.NodeID("nodeID2")), []byte{}, nil
+				default:
+					return swarm.Node{}, []byte{}, errors.Errorf("unexpected nodeRef %q", nodeRef)
+				}
+			},
+			taskListFunc: func(options types.TaskListOptions) ([]swarm.Task, error) {
+				nodeFilter := options.Filters.Get("node")[0]
+				switch nodeFilter {
+				case "nodeID1":
+					return []swarm.Task{
+						*builders.Task(builders.TaskID("taskID1"), builders.TaskServiceID("service1"), builders.TaskNodeID("nodeID1"),
+							builders.WithStatus(builders.Timestamp(time.Now().Add(-2*time.Hour)), builders.TaskState(swarm.TaskStateRunning))),
+						*builders.Task(builders.TaskID("taskID2"), builders.TaskServiceID("service2"), builders.TaskNodeID("nodeID1"),
+							builders.WithStatus(builders.Timestamp(time.Now().Add(-3*time.Hour)), builders.TaskState(swarm.TaskStateRunning))),
+					}, nil
+				case "nodeID2":
+					return []swarm.Task{
+						*builders.Task(builders.TaskID("taskID3"), builders.TaskServiceID("service3"), builders.TaskNodeID("nodeID2"),
+							builders.WithStatus(builders.Timestamp(time.Now().Add(-2*time.Hour)), builders.TaskState(swarm.TaskStateRunning))),
+						*builders.Task(builders.TaskID("taskID4"), builders.TaskServiceID("service4"), builders.TaskNodeID("nodeID2"),
+							builders.WithStatus(builders.Timestamp(time.Now().Add(-3*time.Hour)), builders.TaskState(swarm.TaskStateRunning))),
+					}, nil
+				default:
+					return []swarm.Task{}, nil
+				}
+			},
+			serviceInspectFunc: func(ctx context.Context, serviceID string, opts types.ServiceInspectOptions) (swarm.Service, []byte, error) {
+				return swarm.Service{
+					ID: serviceID,
+					Spec: swarm.ServiceSpec{
+						Annotations: swarm.Annotations{
+							Name: serviceID,
+						},
+					},
+				}, []byte{}, nil
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
-				infoFunc:           tc.infoFunc,
-				nodeInspectFunc:    tc.nodeInspectFunc,
-				taskInspectFunc:    tc.taskInspectFunc,
-				taskListFunc:       tc.taskListFunc,
-				serviceInspectFunc: tc.serviceInspectFunc,
+				infoFunc:                tc.infoFunc,
+				nodeInspectFunc:         tc.nodeInspectFunc,
+				nodeInspectFuncWithArgs: tc.nodeInspectFuncWithArgs,
+				taskInspectFunc:         tc.taskInspectFunc,
+				taskListFunc:            tc.taskListFunc,
+				serviceInspectFunc:      tc.serviceInspectFunc,
 			})
+
 			cmd := newPsCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {

--- a/cli/command/node/testdata/node-ps.multiple-nodes-no-duplicates.golden
+++ b/cli/command/node/testdata/node-ps.multiple-nodes-no-duplicates.golden
@@ -1,0 +1,5 @@
+ID        NAME         IMAGE           NODE              DESIRED STATE   CURRENT STATE         ERROR     PORTS
+taskID1   service1.1   myimage:mytag   defaultNodeName   Ready           Running 2 hours ago             
+taskID2   service2.1   myimage:mytag   defaultNodeName   Ready           Running 3 hours ago             
+taskID3   service3.1   myimage:mytag   defaultNodeName   Ready           Running 2 hours ago             
+taskID4   service4.1   myimage:mytag   defaultNodeName   Ready           Running 3 hours ago             


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
Fixed duplicate entries in docker node ps when multi nodes are passed
**- How I did it**
When running the docker node ps command with multiple nodes in the for loop, the filter state retains node-specific data from previous iterations, causing task entries to be duplicated for the first specified node. This occurs because the filter object, being a dictionary type, was reused and modified across iterations, accumulating previous node filters.
**- How to verify it**
Added a unit test for this case.
**Before:**
![image](https://github.com/user-attachments/assets/4f238bb3-7fab-45b4-8c3c-780a0a376bd7)

**After :**
![image](https://github.com/user-attachments/assets/4c0713da-6c60-40b5-a26f-1daee83f1141)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

