### PR TITLE
run: fix GetList return empty issue for throttledevice

### DIFF
--- a/opts/throttledevice.go
+++ b/opts/throttledevice.go
@@ -94,7 +94,7 @@ func (opt *ThrottledeviceOpt) String() string {
 
 // GetList returns a slice of pointers to ThrottleDevices.
 func (opt *ThrottledeviceOpt) GetList() []*blkiodev.ThrottleDevice {
-	out := make([]*blkiodev.ThrottleDevice, 0, len(opt.values))
+	out := make([]*blkiodev.ThrottleDevice, len(opt.values))
 	copy(out, opt.values)
 	return out
 }


### PR DESCRIPTION
Test "--device-read-bps" "--device-write-bps" will fail. The root cause is that GetList helper return empty as its local variable initialized to zero size.

**- What I did**
    This patch fix it by setting the related slice size to non-zero.

**- How to verify it**
`docker run --device-read-bps /dev/sda2:10M busybox sh -c 'dd if=/dev/zero of=/tmp.img bs=10M count=10 oflag=direct conv=fsync'`






