### PR TITLE
plugins: don't panic on Close if PluginServer nil

### DIFF
--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -95,6 +95,9 @@ func (pl *PluginServer) Addr() net.Addr {
 //
 // The error value is that of the underlying [net.Listner.Close] call.
 func (pl *PluginServer) Close() error {
+	if pl == nil {
+		return nil
+	}
 	logrus.Trace("Closing plugin server")
 	// Close connections first to ensure the connections get io.EOF instead
 	// of a connection reset.

--- a/cli-plugins/socket/socket_test.go
+++ b/cli-plugins/socket/socket_test.go
@@ -117,6 +117,18 @@ func TestPluginServer(t *testing.T) {
 		assert.NilError(t, err, "failed to dial returned server")
 		checkDirNoNewPluginServer(t)
 	})
+
+	t.Run("does not panic on Close if server is nil", func(t *testing.T) {
+		var srv *PluginServer
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("panicked on Close")
+			}
+		}()
+
+		err := srv.Close()
+		assert.NilError(t, err)
+	})
 }
 
 func checkDirNoNewPluginServer(t *testing.T) {


### PR DESCRIPTION
fixes https://github.com/docker/cli/issues/5317

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

We had a report in fixes https://github.com/docker/cli/issues/5317 of a panic at https://github.com/docker/cli/blob/87c6624cb728e9a1c74e8141321ee70d8f67cb46/cli-plugins/socket/socket.go#L111

Looks like this will happen if the call to create a `PluginServer` fails and returns nil, since we're not checking for nilness before attempting to call `Close`:

https://github.com/docker/cli/blob/87c6624cb728e9a1c74e8141321ee70d8f67cb46/cmd/docker/docker.go#L247-L251

https://github.com/docker/cli/blob/87c6624cb728e9a1c74e8141321ee70d8f67cb46/cmd/docker/docker.go#L278


**- How I did it**

Added a nil check to `PluginServer.Close()`. We could also have addressed this at the caller sites, but this seems more robust for little cost.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fixed issue where main CLI process would sometimes panic while running a plugin.
```

**- A picture of a cute animal (not mandatory but encouraged)**

