### PR TITLE
[25.0 backport] run: fix GetList return empty issue for throttledevice

### DIFF
--- a/opts/throttledevice.go
+++ b/opts/throttledevice.go
@@ -94,7 +94,7 @@ func (opt *ThrottledeviceOpt) String() string {
 
 // GetList returns a slice of pointers to ThrottleDevices.
 func (opt *ThrottledeviceOpt) GetList() []*blkiodev.ThrottleDevice {
-	out := make([]*blkiodev.ThrottleDevice, 0, len(opt.values))
+	out := make([]*blkiodev.ThrottleDevice, len(opt.values))
 	copy(out, opt.values)
 	return out
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5323
- fixes: https://github.com/docker/cli/issues/5321
- relates to https://github.com/docker/cli/pull/3770


Test "--device-read-bps" "--device-write-bps" will fail. The root cause is that GetList helper return empty as its local variable initialized to zero size.

This patch fix it by setting the related slice size to non-zero.

(cherry picked from commit 73e78a5822224bd7640888b6b5c2ab6b3f35bd13)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix `--device-read-bps` and `--device-write-bps` options not taking effect.
```

**- A picture of a cute animal (not mandatory but encouraged)**

