### PR TITLE
[27.x backport] cherry-pick doc linkfixes due to refactor

### DIFF
--- a/docs/reference/commandline/container_export.md
+++ b/docs/reference/commandline/container_export.md
@@ -23,7 +23,7 @@ with the container. If a volume is mounted on top of an existing directory in
 the container, `docker export` exports the contents of the underlying
 directory, not the contents of the volume.
 
-Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/storage/volumes/#back-up-restore-or-migrate-data-volumes)
+Refer to [Backup, restore, or migrate data volumes](https://docs.docker.com/engine/storage/volumes/#back-up-restore-or-migrate-data-volumes)
 in the user guide for examples on exporting data in a volume.
 
 ## Examples

--- a/docs/reference/commandline/container_logs.md
+++ b/docs/reference/commandline/container_logs.md
@@ -26,7 +26,7 @@ Fetch the logs of a container
 The `docker logs` command batch-retrieves logs present at the time of execution.
 
 For more information about selecting and configuring logging drivers, refer to
-[Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
+[Configure logging drivers](https://docs.docker.com/engine/logging/configure/).
 
 The `docker logs --follow` command will continue streaming the new output from
 the container's `STDOUT` and `STDERR`.

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -64,7 +64,7 @@ e90b8831a4b8   nginx          "/bin/bash -c 'mkdir "   11 weeks ago   Up 4 hours
   * The "size" information shows the amount of data (on disk) that is used for the _writable_ layer of each container
   * The "virtual size" is the total amount of disk-space used for the read-only _image_ data used by the container and the writable layer.
 
-For more information, refer to the [container size on disk](https://docs.docker.com/storage/storagedriver/#container-size-on-disk) section.
+For more information, refer to the [container size on disk](https://docs.docker.com/engine/storage/drivers/#container-size-on-disk) section.
 
 
 ### <a name="filter"></a> Filtering (--filter)

--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -363,7 +363,7 @@ Docker.
 > for example by adding individual kernel capabilities with `--cap-add`.
 >
 > For more information, see
-> [Runtime privilege and Linux capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities)
+> [Runtime privilege and Linux capabilities](https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities)
 { .warning }
 
 The following example doesn't work, because by default, Docker drops most
@@ -1322,7 +1322,7 @@ the `--log-driver=<DRIVER>` with the `docker run` command to configure the
 container's logging driver.
 
 To learn about the supported logging drivers and how to use them, refer to
-[Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
+[Configure logging drivers](https://docs.docker.com/engine/logging/configure/).
 
 To disable logging for a container, set the `--log-driver` flag to `none`:
 

--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -321,7 +321,7 @@ be set for each environment:
 
 These settings are used to configure proxy settings for containers only, and not
 used as proxy settings for the `docker` CLI or the `dockerd` daemon. Refer to the
-[environment variables](#environment-variables) and [HTTP/HTTPS proxy](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
+[environment variables](#environment-variables) and [HTTP/HTTPS proxy](https://docs.docker.com/config/daemon/proxy/#httphttps-proxy)
 sections for configuring proxy settings for the cli and daemon.
 
 > **Warning**

--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -321,8 +321,8 @@ be set for each environment:
 
 These settings are used to configure proxy settings for containers only, and not
 used as proxy settings for the `docker` CLI or the `dockerd` daemon. Refer to the
-[environment variables](#environment-variables) and [HTTP/HTTPS proxy](https://docs.docker.com/config/daemon/proxy/#httphttps-proxy)
-sections for configuring proxy settings for the cli and daemon.
+[environment variables](#environment-variables) and [HTTP/HTTPS proxy](https://docs.docker.com/engine/daemon/proxy/#httphttps-proxy)
+sections for configuring proxy settings for the CLI and daemon.
 
 > **Warning**
 >

--- a/docs/reference/commandline/image_pull.md
+++ b/docs/reference/commandline/image_pull.md
@@ -99,7 +99,7 @@ the same image tagged with different names. Because they are the same image,
 their layers are stored only once and do not consume extra disk space.
 
 For more information about images, layers, and the content-addressable store,
-refer to [understand images, containers, and storage drivers](https://docs.docker.com/storage/storagedriver/).
+refer to [understand images, containers, and storage drivers](https://docs.docker.com/engine/storage/drivers/).
 
 
 ### Pull an image by digest (immutable identifier)

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -941,7 +941,7 @@ $ docker service create \
 The swarm extends my-network to each node running the service.
 
 Containers on the same network can access each other using
-[service discovery](https://docs.docker.com/network/drivers/overlay/#container-discovery).
+[service discovery](https://docs.docker.com/engine/network/drivers/overlay/#container-discovery).
 
 Long form syntax of `--network` allows to specify list of aliases and driver options:
 `--network name=my-network,alias=web1,driver-opt=field1=value1`

--- a/docs/reference/commandline/service_logs.md
+++ b/docs/reference/commandline/service_logs.md
@@ -42,7 +42,7 @@ display logs from that particular task.
 > the `json-file` or `journald` logging driver.
 
 For more information about selecting and configuring logging drivers, refer to
-[Configure logging drivers](https://docs.docker.com/config/containers/logging/configure/).
+[Configure logging drivers](https://docs.docker.com/engine/logging/configure/).
 
 The `docker service logs --follow` command will continue streaming the new output from
 the service's `STDOUT` and `STDERR`.

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -133,7 +133,7 @@ to [the `daemon.json` file](#daemon-configuration-file).
 
 The following list of environment variables are supported by the `dockerd` daemon.
 Some of these environment variables are supported both by the Docker Daemon and
-the `docker` CLI. Refer to [Environment variables](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables)
+the `docker` CLI. Refer to [Environment variables](https://docs.docker.com/reference/cli/docker/#environment-variables)
 to learn about environment variables supported by the `docker` CLI.
 
 | Variable            | Description                                                                                                                                                                             |
@@ -169,7 +169,7 @@ in three ways:
    options. (Docker Engine version 23.0 or later).
 
 The command-line and configuration file options take precedence over environment
-variables. Refer to [control and configure Docker with systemd](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
+variables. Refer to [control and configure Docker with systemd](https://docs.docker.com/engine/daemon/proxy/)
 to set these environment variables on a host using `systemd`.
 
 ### Daemon socket option
@@ -332,7 +332,7 @@ drivers: `overlay2`, `fuse-overlayfs`, `btrfs`, and `zfs`.
 and is selected by default. Unless users have a strong reason to prefer another storage driver,
 `overlay2` should be used.
 
-You can find out more about storage drivers and how to select one in [Select a storage driver](https://docs.docker.com/storage/storagedriver/select-storage-driver/).
+You can find out more about storage drivers and how to select one in [Select a storage driver](https://docs.docker.com/engine/storage/drivers/select-storage-driver/).
 
 On Windows, the Docker daemon only supports the `windowsfilter` storage driver.
 
@@ -424,7 +424,7 @@ installed outside of `PATH`, must be registered with the daemon, either via the
 configuration file or using the `--add-runtime` command line flag.
 
 For examples on how to use other container runtimes, see
-[Alternative container runtimes](https://docs.docker.com/engine/alternative-runtimes/)
+[Alternative container runtimes](https://docs.docker.com/engine/daemon/alternative-runtimes/)
 
 ##### Configure runtimes using `daemon.json`
 
@@ -609,7 +609,7 @@ $ sudo dockerd --add-runtime <runtime>=<path>
 Defining runtime arguments via the command line is not supported.
 
 For an example configuration for a runc drop-in replacment, see
-[Alternative container runtimes > youki](https://docs.docker.com/engine/alternative-runtimes/#youki)
+[Alternative container runtimes > youki](https://docs.docker.com/engine/daemon/alternative-runtimes/#youki)
 
 ##### Configure the default container runtime
 
@@ -783,7 +783,7 @@ Docker host's configuration:
 
 This only adds the proxy and authentication to the Docker daemon's requests.
 To use the proxy when building images and running containers, see
-[Configure Docker to use a proxy server](https://docs.docker.com/network/proxy/)
+[Configure Docker to use a proxy server](https://docs.docker.com/engine/cli/proxy/)
 
 ### Default `ulimit` settings
 
@@ -952,7 +952,7 @@ to avoid collisions with other Prometheus exporters and services.
 
 If you are running a Prometheus server you can add this address to your scrape configs
 to have Prometheus collect metrics on Docker. For more information, see
-[Collect Docker metrics with Prometheus](https://docs.docker.com/config/daemon/prometheus/).
+[Collect Docker metrics with Prometheus](https://docs.docker.com/engine/daemon/prometheus/).
 
 #### Node generic resources
 
@@ -1151,7 +1151,7 @@ The following is a full example of the allowed configuration options on Linux:
 > daemon startup as a flag.
 > On systems that use systemd to start the Docker daemon, `-H` is already set, so
 > you can't use the `hosts` key in `daemon.json` to add listening addresses.
-> See [custom Docker daemon options](https://docs.docker.com/config/daemon/systemd/#custom-docker-daemon-options)
+> See [custom Docker daemon options](https://docs.docker.com/engine/daemon/proxy/#systemd-unit-file)
 > for an example on how to configure the daemon using systemd drop-in files.
 
 ##### On Windows
@@ -1234,7 +1234,7 @@ The list of feature options include:
 - `containerd-snapshotter`: when set to `true`, the daemon uses containerd
   snapshotters instead of the classic storage drivers for storing image and
   container data. For more information, see
-  [containerd storage](https://docs.docker.com/storage/containerd/).
+  [containerd storage](https://docs.docker.com/engine/storage/containerd/).
 - `windows-dns-proxy`: when set to `true`, the daemon's internal DNS resolver
   will forward requests to external servers. Without this, most applications
   running in the container will still be able to use secondary DNS servers
@@ -1260,7 +1260,7 @@ The list of currently supported options that can be reconfigured is this:
 | ---------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `debug`                            | Toggles debug mode of the daemon.                                                                           |
 | `labels`                           | Replaces the daemon labels with a new set of labels.                                                        |
-| `live-restore`                     | Toggles [live restore](https://docs.docker.com/config/containers/live-restore/).                            |
+| `live-restore`                     | Toggles [live restore](https://docs.docker.com/engine/containers/live-restore/).                            |
 | `max-concurrent-downloads`         | Configures the max concurrent downloads for each pull.                                                      |
 | `max-concurrent-uploads`           | Configures the max concurrent uploads for each push.                                                        |
 | `max-download-attempts`            | Configures the max download attempts for each pull.                                                         |
@@ -1362,7 +1362,7 @@ using the `daemon.json` file.
 ```
 
 This example uses the `bridge` network driver. Refer to the
-[bridge network driver page](https://docs.docker.com/network/drivers/bridge/#options)
+[bridge network driver page](https://docs.docker.com/engine/network/drivers/bridge/#options)
 for an overview of available driver options.
 
 After changing the configuration and restarting the daemon, new networks that


### PR DESCRIPTION
Backports:

- bcd90be73ab162e69913c8dafc6a1771e76afb5c docs: fix link to http proxy document
  - https://github.com/docker/cli/pull/5338
- 73452e316f32694a7101fc0a9cf5c18373adebd2 docs: update internal links after refactor
  - https://github.com/docker/cli/pull/5342

Relates to:
- https://github.com/docker/docs/pull/20573