### PR TITLE
cli/connhelper: getConnectionHelper: move ssh-option funcs out of closure

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -45,14 +45,14 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 		if err != nil {
 			return nil, errors.Wrap(err, "ssh host connection is not valid")
 		}
+		sshFlags = addSSHTimeout(sshFlags)
+		sshFlags = disablePseudoTerminalAllocation(sshFlags)
 		return &ConnectionHelper{
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				args := []string{"docker"}
 				if sp.Path != "" {
 					args = append(args, "--host", "unix://"+sp.Path)
 				}
-				sshFlags = addSSHTimeout(sshFlags)
-				sshFlags = disablePseudoTerminalAllocation(sshFlags)
 				args = append(args, "system", "dial-stdio")
 				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args(args...)...)...)
 			},


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4226
- relates to https://github.com/docker/cli/pull/5320

The addSSHTimeout and disablePseudoTerminalAllocation were added in commits a5ebe2282aabaf983c116525af4a7c5eeedf2c6e and f3c2c26b1025f3e785f142fbd8ebed5cf8265f44, and called inside the Dialer function, which means they're called every time the Dialer is called. Given that the sshFlags slice is not mutated by the Dialer, we can call these functions once.


**- A picture of a cute animal (not mandatory but encouraged)**

