### PR TITLE
[27.x backport] disable pseudoterminal creation

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -52,6 +52,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 					args = append(args, "--host", "unix://"+sp.Path)
 				}
 				sshFlags = addSSHTimeout(sshFlags)
+				sshFlags = disablePseudoTerminalAllocation(sshFlags)
 				args = append(args, "system", "dial-stdio")
 				return commandconn.New(ctx, "ssh", append(sshFlags, sp.Args(args...)...)...)
 			},
@@ -78,4 +79,15 @@ func addSSHTimeout(sshFlags []string) []string {
 		sshFlags = append(sshFlags, "-o ConnectTimeout=30")
 	}
 	return sshFlags
+}
+
+// disablePseudoTerminalAllocation disables pseudo-terminal allocation to
+// prevent SSH from executing as a login shell
+func disablePseudoTerminalAllocation(sshFlags []string) []string {
+	for _, flag := range sshFlags {
+		if flag == "-T" {
+			return sshFlags
+		}
+	}
+	return append(sshFlags, "-T")
 }

--- a/cli/connhelper/connhelper_test.go
+++ b/cli/connhelper/connhelper_test.go
@@ -1,6 +1,7 @@
 package connhelper
 
 import (
+	"reflect"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -27,5 +28,38 @@ func TestSSHFlags(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.DeepEqual(t, addSSHTimeout(tc.in), tc.out)
+	}
+}
+
+func TestDisablePseudoTerminalAllocation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		sshFlags []string
+		expected []string
+	}{
+		{
+			name:     "No -T flag present",
+			sshFlags: []string{"-v", "-oStrictHostKeyChecking=no"},
+			expected: []string{"-v", "-oStrictHostKeyChecking=no", "-T"},
+		},
+		{
+			name:     "Already contains -T flag",
+			sshFlags: []string{"-v", "-T", "-oStrictHostKeyChecking=no"},
+			expected: []string{"-v", "-T", "-oStrictHostKeyChecking=no"},
+		},
+		{
+			name:     "Empty sshFlags",
+			sshFlags: []string{},
+			expected: []string{"-T"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := disablePseudoTerminalAllocation(tc.sshFlags)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Backports: https://github.com/docker/cli/pull/5320

```markdown changelog
Fix issue with remote contexts over SSH where the CLI would allocate a pseudoterminal when connecting to the remote host, which causes issues in rare situations.
```