### PR TITLE
login: add oauth escape hatch

### DIFF
--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -228,3 +228,47 @@ func TestLoginTermination(t *testing.T) {
 		assert.ErrorIs(t, err, command.ErrPromptTerminated)
 	}
 }
+
+func TestIsOauthLoginDisabled(t *testing.T) {
+	testCases := []struct {
+		envVar   string
+		disabled bool
+	}{
+		{
+			envVar:   "",
+			disabled: false,
+		},
+		{
+			envVar:   "bork",
+			disabled: false,
+		},
+		{
+			envVar:   "0",
+			disabled: false,
+		},
+		{
+			envVar:   "false",
+			disabled: false,
+		},
+		{
+			envVar:   "true",
+			disabled: true,
+		},
+		{
+			envVar:   "TRUE",
+			disabled: true,
+		},
+		{
+			envVar:   "1",
+			disabled: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Setenv(OauthLoginEscapeHatchEnvVar, tc.envVar)
+
+		disabled := isOauthLoginDisabled()
+
+		assert.Equal(t, disabled, tc.disabled)
+	}
+}

--- a/e2e/registry/login_test.go
+++ b/e2e/registry/login_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"gotest.tools/v3/assert"
+)
+
+func TestOauthLogin(t *testing.T) {
+	t.Parallel()
+	loginCmd := exec.Command("docker", "login")
+
+	p, err := pty.Start(loginCmd)
+	assert.NilError(t, err)
+	defer func() {
+		_ = loginCmd.Wait()
+		_ = p.Close()
+	}()
+
+	time.Sleep(1 * time.Second)
+	pid := loginCmd.Process.Pid
+	t.Logf("terminating PID %d", pid)
+	err = syscall.Kill(pid, syscall.SIGTERM)
+	assert.NilError(t, err)
+
+	output, _ := io.ReadAll(p)
+	assert.Check(t, strings.Contains(string(output), "USING WEB BASED LOGIN"), string(output))
+}
+
+func TestLoginWithEscapeHatch(t *testing.T) {
+	t.Parallel()
+	loginCmd := exec.Command("docker", "login")
+	loginCmd.Env = append(loginCmd.Env, "DOCKER_CLI_DISABLE_OAUTH_LOGIN=1")
+
+	p, err := pty.Start(loginCmd)
+	assert.NilError(t, err)
+	defer func() {
+		_ = loginCmd.Wait()
+		_ = p.Close()
+	}()
+
+	time.Sleep(1 * time.Second)
+	pid := loginCmd.Process.Pid
+	t.Logf("terminating PID %d", pid)
+	err = syscall.Kill(pid, syscall.SIGTERM)
+	assert.NilError(t, err)
+
+	output, _ := io.ReadAll(p)
+	assert.Check(t, strings.Contains(string(output), "Username:"), string(output))
+}

--- a/e2e/registry/main_test.go
+++ b/e2e/registry/main_test.go
@@ -1,0 +1,17 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/internal/test/environment"
+)
+
+func TestMain(m *testing.M) {
+	if err := environment.Setup(); err != nil {
+		fmt.Println(err.Error())
+		os.Exit(3)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Add an escape hatch (`DOCKER_CLI_DISABLE_OAUTH_LOGIN`) to turn off new login flow.

**- How I did it**

**- How to verify it**

- `docker login`
- `DOCKER_CLI_DISABLE_OAUTH_LOGIN=1 docker login`
- `DOCKER_CLI_DISABLE_OAUTH_LOGIN=0 docker login`
- `DOCKER_CLI_DISABLE_OAUTH_LOGIN=true docker login`
- `DOCKER_CLI_DISABLE_OAUTH_LOGIN=false docker login`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

