### PR TITLE
cli/formatter: bracket IPv6 addrs prepended to ports

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -5,6 +5,7 @@ package formatter
 
 import (
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -331,7 +332,8 @@ func DisplayablePorts(ports []container.Port) string {
 		portKey := port.Type
 		if port.IP != "" {
 			if port.PublicPort != current {
-				hostMappings = append(hostMappings, fmt.Sprintf("%s:%d->%d/%s", port.IP, port.PublicPort, port.PrivatePort, port.Type))
+				hAddrPort := net.JoinHostPort(port.IP, strconv.Itoa(int(port.PublicPort)))
+				hostMappings = append(hostMappings, fmt.Sprintf("%s->%d/%s", hAddrPort, port.PrivatePort, port.Type))
 				continue
 			}
 			portKey = port.IP + "/" + port.Type

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -561,6 +561,16 @@ func TestDisplayablePorts(t *testing.T) {
 		{
 			ports: []container.Port{
 				{
+					IP:          "::",
+					PrivatePort: 9988,
+					Type:        "tcp",
+				},
+			},
+			expected: "[::]:0->9988/tcp",
+		},
+		{
+			ports: []container.Port{
+				{
 					PrivatePort: 9988,
 					PublicPort:  8899,
 					Type:        "tcp",


### PR DESCRIPTION
**- What I did**

On `docker ps`, port bindings with an IPv6 HostIP should have their addresses put into brackets when joining them to their ports.

RFC 3986 (Section 3.2.2) stipulates that IPv6 addresses should be enclosed within square brackets. This RFC is only about URIs. However, doing so here helps user identifier what's part of the IP address and what's the port. It also makes it easier to copy/paste that '[addr]:port' into other software (including browsers).

**- How to verify it**

CI, or run the following commands with a recent Engine:

```
$ docker run --rm -d --name c0 -p 8000:80/tcp 5201/udp alpine top
$ docker ps
```

**- Description for the changelog**

```markdown changelog
Improve presentation of IPv6-mapped ports, using bracket notation.
```

