### PR TITLE
[27.x backport] use gh alert syntax for callouts

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -562,8 +562,7 @@ Docker API v1.42 and up now ignores this option when set. Older versions of the
 API continue to accept the option, but depending on the OCI runtime used, may
 take no effect.
 
-> **Note**
-> 
+> [!NOTE]
 > While not deprecated (yet) in Docker, the OCI runtime specification also
 > deprecated the `memory.kmem.tcp.limit_in_bytes` option. When using `runc` as
 > runtime, this option takes no effect. The linux kernel did not explicitly

--- a/docs/extend/index.md
+++ b/docs/extend/index.md
@@ -16,8 +16,7 @@ plugins using Docker Engine.
 For information about legacy (non-managed) plugins, refer to
 [Understand legacy Docker Engine plugins](legacy_plugins.md).
 
-> **Note**
->
+> [!NOTE]
 > Docker Engine managed plugins are currently not supported on Windows daemons.
 
 ## Installing and using a plugin
@@ -38,8 +37,7 @@ operation, such as creating a volume.
 In the following example, you install the `sshfs` plugin, verify that it is
 enabled, and use it to create a volume.
 
-> **Note**
->
+> [!NOTE]
 > This example is intended for instructional purposes only. Once the volume is
 > created, your SSH password to the remote host is exposed as plaintext when
 > inspecting the volume. Delete the volume as soon as you are done with the
@@ -126,8 +124,7 @@ commands and options, see the
 The `rootfs` directory represents the root filesystem of the plugin. In this
 example, it was created from a Dockerfile:
 
-> **Note**
->
+> [!NOTE]
 > The `/run/docker/plugins` directory is mandatory inside of the
 > plugin's filesystem for Docker to communicate with the plugin.
 

--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -43,8 +43,7 @@ Authorization plugins must follow the rules described in [Docker Plugin API](plu
 Each plugin must reside within directories described under the
 [Plugin discovery](plugin_api.md#plugin-discovery) section.
 
-> **Note**
->
+> [!NOTE]
 > The abbreviations `AuthZ` and `AuthN` mean authorization and authentication
 > respectively.
 

--- a/docs/extend/plugins_metrics.md
+++ b/docs/extend/plugins_metrics.md
@@ -8,8 +8,7 @@ Docker exposes internal metrics based on the Prometheus format. Metrics plugins
 enable accessing these metrics in a consistent way by providing a Unix
 socket at a predefined path where the plugin can scrape the metrics.
 
-> **Note**
->
+> [!NOTE]
 > While the plugin interface for metrics is non-experimental, the naming of the
 > metrics and metric labels is still considered experimental and may change in a
 > future version.

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -80,8 +80,7 @@ provide the Docker Daemon with writeable paths on the host filesystem. The Docke
 daemon provides these paths to containers to consume. The Docker daemon makes
 the volumes available by bind-mounting the provided paths into the containers.
 
-> **Note**
->
+> [!NOTE]
 > Volume plugins should *not* write data to the `/var/lib/docker/` directory,
 > including `/var/lib/docker/volumes`. The `/var/lib/docker/` directory is
 > reserved for Docker.

--- a/docs/reference/commandline/config_create.md
+++ b/docs/reference/commandline/config_create.md
@@ -19,8 +19,7 @@ Creates a config using standard input or from a file for the config content.
 
 For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a Swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/config_inspect.md
+++ b/docs/reference/commandline/config_inspect.md
@@ -25,8 +25,7 @@ describes all the details of the format.
 
 For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a Swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/config_ls.md
+++ b/docs/reference/commandline/config_ls.md
@@ -24,8 +24,7 @@ Run this command on a manager node to list the configs in the Swarm.
 
 For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a Swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/config_rm.md
+++ b/docs/reference/commandline/config_rm.md
@@ -16,8 +16,7 @@ Removes the specified configs from the Swarm.
 
 For detailed information about using configs, refer to [store configuration data using Docker Configs](https://docs.docker.com/engine/swarm/configs/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a Swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -32,8 +31,7 @@ $ docker config rm my_config
 sapth4csdo5b6wz2p5uimh5xg
 ```
 
-> **Warning**
->
+> [!WARNING]
 > This command doesn't ask for confirmation before removing a config.
 { .warning }
 

--- a/docs/reference/commandline/container_attach.md
+++ b/docs/reference/commandline/container_attach.md
@@ -25,8 +25,7 @@ Use `docker attach` to attach your terminal's standard input, output, and error
 ID or name. This lets you view its output or control it interactively, as
 though the commands were running directly in your terminal.
 
-> **Note**
->
+> [!NOTE]
 > The `attach` command displays the output of the container's `ENTRYPOINT` and
 > `CMD` process. This can appear as if the attach command is hung when in fact
 > the process may simply not be writing any output at that time.
@@ -39,8 +38,7 @@ container. If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT` to
 the container. If the container was run with `-i` and `-t`, you can detach from
 a container and leave it running using the `CTRL-p CTRL-q` key sequence.
 
-> **Note**
->
+> [!NOTE]
 > A process running as PID 1 inside a container is treated specially by
 > Linux: it ignores any signal with the default action. So, the process
 > doesn't terminate on `SIGINT` or `SIGTERM` unless it's coded to do so.

--- a/docs/reference/commandline/container_kill.md
+++ b/docs/reference/commandline/container_kill.md
@@ -33,8 +33,7 @@ set through `--signal` may be non-terminal, depending on the container's main
 process. For example, the `SIGHUP` signal in most cases will be non-terminal,
 and the container will continue running after receiving the signal.
 
-> **Note**
->
+> [!NOTE]
 > `ENTRYPOINT` and `CMD` in the *shell* form run as a child process of
 > `/bin/sh -c`, which does not pass signals. This means that the executable is
 > not the container’s PID 1 and does not receive Unix signals.

--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -291,8 +291,7 @@ running processes in that namespace. By default, all containers, including
 those with `--network=host`, have their own UTS namespace. Setting `--uts` to
 `host` results in the container using the same UTS namespace as the host.
 
-> **Note**
->
+> [!NOTE]
 > Docker disallows combining the `--hostname` and `--domainname` flags with
 > `--uts=host`. This is to prevent containers running in the host's UTS
 > namespace from attempting to change the hosts' configuration.
@@ -350,8 +349,7 @@ In other words, the container can then do almost everything that the host can
 do. This flag exists to allow special use-cases, like running Docker within
 Docker.
 
-> **Warning**
->
+> [!WARNING]
 > Use the `--privileged` flag with caution.
 > A container with `--privileged` is not a securely sandboxed process.
 > Containers in this mode can get a root shell on the host
@@ -533,8 +531,7 @@ host. You can also specify `udp` and `sctp` ports. The [Networking overview
 page](https://docs.docker.com/network/) explains in detail how to publish ports
 with Docker.
 
-> **Note**
->
+> [!NOTE]
 > If you don't specify an IP address (i.e., `-p 80:80` instead of `-p
 > 127.0.0.1:80:80`) when publishing a container's ports, Docker publishes the
 > port on all interfaces (address `0.0.0.0`) by default. These ports are
@@ -715,8 +712,7 @@ or name. For `overlay` networks or custom plugins that support multi-host
 connectivity, containers connected to the same multi-host network but launched
 from different Engines can also communicate in this way.
 
-> **Note**
->
+> [!NOTE]
 > The default bridge network only allows containers to communicate with each other using
 > internal IP addresses. User-created bridge networks provide DNS resolution between
 > containers using container names.
@@ -784,8 +780,7 @@ $ docker network create --subnet 192.0.2.0/24 my-net
 $ docker run -itd --network=name=my-net,\"driver-opt=com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\",ip=192.0.2.42 busybox
 ```
 
-> **Note**
->
+> [!NOTE]
 > Network drivers may restrict the sysctl settings that can be modified and, to protect
 > the operation of the network, new restrictions may be added in the future.
 
@@ -912,8 +907,7 @@ $ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
 fdisk: unable to open /dev/xvdc: Operation not permitted
 ```
 
-> **Note**
->
+> [!NOTE]
 > The `--device` option cannot be safely used with ephemeral devices. You shouldn't 
 > add block devices that may be removed to untrusted containers with `--device`.
 
@@ -935,15 +929,13 @@ ports on the host visible in the container.
 PS C:\> docker run --device=class/86E0D1E0-8089-11D0-9CE4-08003E301F73 mcr.microsoft.com/windows/servercore:ltsc2019
 ```
 
-> **Note**
->
+> [!NOTE]
 > The `--device` option is only supported on process-isolated Windows containers,
 > and produces an error if the container isolation is `hyperv`.
 
 #### CDI devices
 
-> **Note**
->
+> [!NOTE]
 > The CDI feature is experimental, and potentially subject to change.
 > CDI is currently only supported for Linux containers.
 
@@ -1010,8 +1002,7 @@ ID once the container has finished running.
 $ cat somefile | docker run -i -a stdin mybuilder dobuild
 ```
 
-> **Note**
->
+> [!NOTE]
 > A process running as PID 1 inside a container is treated specially by
 > Linux: it ignores any signal with the default action. So, the process
 > doesn't terminate on `SIGINT` or `SIGTERM` unless it's coded to do so.
@@ -1124,7 +1115,8 @@ $ docker run -d --device-cgroup-rule='c 42:* rmw' --name my-container my-image
 Then, a user could ask `udev` to execute a script that would `docker exec my-container mknod newDevX c 42 <minor>`
 the required device when it is added.
 
-> **Note**: You still need to explicitly add initially present devices to the
+> [!NOTE]
+> You still need to explicitly add initially present devices to the
 > `docker run` / `docker create` command.
 
 ### <a name="gpus"></a> Access an NVIDIA GPU
@@ -1132,8 +1124,7 @@ the required device when it is added.
 The `--gpus` flag allows you to access NVIDIA GPU resources. First you need to
 install the [nvidia-container-runtime](https://nvidia.github.io/nvidia-container-runtime/).
 
-> **Note**
->
+> [!NOTE]
 > You can also specify a GPU as a CDI device with the `--device` flag, see
 > [CDI devices](#cdi-devices).
 
@@ -1246,8 +1237,7 @@ the container and remove the file system when the container exits, use the
 --rm=false: Automatically remove the container when it exits
 ```
 
-> **Note**
->
+> [!NOTE]
 > If you set the `--rm` flag, Docker also removes the anonymous volumes
 > associated with the container when the container is removed. This is similar
 > to running `docker rm -v my-container`. Only volumes that are specified
@@ -1345,14 +1335,12 @@ $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
 1024
 ```
 
-> **Note**
->
+> [!NOTE]
 > If you don't provide a hard limit value, Docker uses the soft limit value
 > for both values. If you don't provide any values, they are inherited from
 > the default `ulimits` set on the daemon.
 
-> **Note**
->
+> [!NOTE]
 > The `as` option is deprecated.
 > In other words, the following script is not supported:
 >
@@ -1417,8 +1405,7 @@ the same content between containers.
 $ docker run --security-opt label=level:s0:c100,c200 -it fedora bash
 ```
 
-> **Note**
->
+> [!NOTE]
 > Automatic translation of MLS labels isn't supported.
 
 To disable the security labeling for a container entirely, you can use
@@ -1436,8 +1423,7 @@ that's only allowed to listen on Apache ports:
 $ docker run --security-opt label=type:svirt_apache_t -it ubuntu bash
 ```
 
-> **Note**
->
+> [!NOTE]
 > You would have to write policy defining a `svirt_apache_t` type.
 
 To prevent your container processes from gaining additional privileges, you can
@@ -1558,8 +1544,7 @@ network namespace, run this command:
 $ docker run --sysctl net.ipv4.ip_forward=1 someimage
 ```
 
-> **Note**
->
+> [!NOTE]
 > Not all sysctls are namespaced. Docker does not support changing sysctls
 > inside of a container that also modify the host system. As the kernel
 > evolves we expect to see more sysctls become namespaced.

--- a/docs/reference/commandline/container_stats.md
+++ b/docs/reference/commandline/container_stats.md
@@ -29,8 +29,7 @@ containers do not return any data.
 If you need more detailed information about a container's resource usage, use
 the `/containers/(id)/stats` API endpoint.
 
-> **Note**
->
+> [!NOTE]
 > On Linux, the Docker CLI reports memory usage by subtracting cache usage from
 > the total memory usage. The API does not perform such a calculation but rather
 > provides the total memory usage and the amount from the cache so that clients
@@ -41,8 +40,7 @@ the `/containers/(id)/stats` API endpoint.
 > field. On cgroup v2 hosts, the cache usage is defined as the value of
 > `inactive_file` field.
 
-> **Note**
->
+> [!NOTE]
 > The `PIDS` column contains the number of processes and kernel threads created
 > by that container. Threads is the term used by Linux kernel. Other equivalent
 > terms are "lightweight process" or "kernel task", etc. A large number in the

--- a/docs/reference/commandline/container_update.md
+++ b/docs/reference/commandline/container_update.md
@@ -42,8 +42,7 @@ options on a running or a stopped container. On kernel version older than
 4.6, you can only update `--kernel-memory` on a stopped container or on
 a running container with kernel memory initialized.
 
-> **Warning**
->
+> [!WARNING]
 > The `docker update` and `docker container update` commands are not supported
 > for Windows containers.
 { .warning }
@@ -78,8 +77,7 @@ running container only if the container was started with `--kernel-memory`.
 If the container was started without `--kernel-memory` you need to stop
 the container before updating kernel memory.
 
-> **Note**
->
+> [!NOTE]
 > The `--kernel-memory` option has been deprecated since Docker 20.10.
 
 For example, if you started a container with this command:

--- a/docs/reference/commandline/container_wait.md
+++ b/docs/reference/commandline/container_wait.md
@@ -10,8 +10,7 @@ Block until one or more containers stop, then print their exit codes
 
 <!---MARKER_GEN_END-->
 
-> **Note**
->
+> [!NOTE]
 > `docker wait` returns `0` when run against a container which had already
 > exited before the `docker wait` command was run.
 

--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -186,8 +186,7 @@ Sometimes, multiple options can call for a more complex value string as for
 $ docker run -v /host:/container example/mysql
 ```
 
-> **Note**
->
+> [!NOTE]
 > Do not use the `-t` and `-a stderr` options together due to
 > limitations in the `pty` implementation. All `stderr` in `pty` mode
 > simply goes to `stdout`.
@@ -247,8 +246,7 @@ By default, configuration file is stored in `~/.docker/config.json`. Refer to th
 [change the `.docker` directory](#change-the-docker-directory) section to use a
 different location.
 
-> **Warning**
->
+> [!WARNING]
 > The configuration file and other files inside the `~/.docker` configuration
 > directory may contain sensitive information, such as authentication information
 > for proxies or, depending on your credential store, credentials for your image
@@ -324,8 +322,7 @@ used as proxy settings for the `docker` CLI or the `dockerd` daemon. Refer to th
 [environment variables](#environment-variables) and [HTTP/HTTPS proxy](https://docs.docker.com/engine/daemon/proxy/#httphttps-proxy)
 sections for configuring proxy settings for the CLI and daemon.
 
-> **Warning**
->
+> [!WARNING]
 > Proxy settings may contain sensitive information (for example, if the proxy
 > requires authentication). Environment variables are stored as plain text in
 > the container's configuration, and as such can be inspected through the remote
@@ -464,8 +461,7 @@ daemon with IP address `174.17.0.1`, listening on port `2376`:
 $ docker -H tcp://174.17.0.1:2376 ps
 ```
 
-> **Note**
->
+> [!NOTE]
 > By convention, the Docker daemon uses port `2376` for secure TLS connections,
 > and port `2375` for insecure, non-TLS connections.
 

--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -47,8 +47,7 @@ Build an image from a Dockerfile
 
 ## Description
 
-> **Note**
->
+> [!NOTE]
 > This page refers to the **legacy implementation** of `docker build`,
 > using the legacy (pre-BuildKit) build backend.
 > This configuration is only relevant if you're building Windows containers.
@@ -146,7 +145,7 @@ the `credentialspec` option. The `credentialspec` must be in the format
 
 #### Overview
 
-> **Note**
+> [!NOTE]
 > The `--squash` option is an experimental feature, and should not be considered
 > stable.
 

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -82,6 +82,7 @@ which removes images with the specified labels. The other
 format is the `label!=...` (`label!=<key>` or `label!=<key>=<value>`), which removes
 images without the specified labels.
 
+> [!NOTE]
 > **Predicting what will be removed**
 >
 > If you are using positive filtering (testing for the existence of a label or
@@ -186,8 +187,7 @@ This example removes images which have a maintainer label not set to `john`:
 $ docker image prune --filter="label!=maintainer=john"
 ```
 
-> **Note**
->
+> [!NOTE]
 > You are prompted for confirmation before the `prune` removes
 > anything, but you are not shown a list of what will potentially be removed.
 > In addition, `docker image ls` doesn't support negative filtering, so it

--- a/docs/reference/commandline/image_pull.md
+++ b/docs/reference/commandline/image_pull.md
@@ -158,8 +158,7 @@ FROM ubuntu@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217
 LABEL org.opencontainers.image.authors="some maintainer <maintainer@example.com>"
 ```
 
-> **Note**
->
+> [!NOTE]
 > Using this feature "pins" an image to a specific version in time.
 > Docker does therefore not pull updated versions of an image, which may include
 > security updates. If you want to pull an updated image, you need to change the

--- a/docs/reference/commandline/manifest.md
+++ b/docs/reference/commandline/manifest.md
@@ -284,8 +284,7 @@ $ docker manifest create --insecure myprivateregistry.mycompany.com/repo/image:1
 $ docker manifest push --insecure myprivateregistry.mycompany.com/repo/image:tag
 ```
 
-> **Note**
->
+> [!NOTE]
 > The `--insecure` flag is not required to annotate a manifest list,
 > since annotations are to a locally-stored copy of a manifest list. You may also
 > skip the `--insecure` flag if you are performing a `docker manifest inspect`

--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -80,8 +80,7 @@ sets `net.ipv4.conf.eth3.log_martians=1` and `net.ipv4.conf.eth3.forwarding=0`.
 $ docker network connect --driver-opt=\"com.docker.network.endpoint.sysctls=net.ipv4.conf.IFNAME.log_martians=1,net.ipv4.conf.IFNAME.forwarding=0\" multi-host-network container2
 ```
 
-> **Note**
->
+> [!NOTE]
 > Network drivers may restrict the sysctl settings that can be modified and, to protect
 > the operation of the network, new restrictions may be added in the future.
 

--- a/docs/reference/commandline/node_demote.md
+++ b/docs/reference/commandline/node_demote.md
@@ -10,8 +10,7 @@ Demote one or more nodes from manager in the swarm
 
 Demotes an existing manager so that it is no longer a manager.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the [Swarm mode
 > section](https://docs.docker.com/engine/swarm/) in the documentation.

--- a/docs/reference/commandline/node_inspect.md
+++ b/docs/reference/commandline/node_inspect.md
@@ -21,8 +21,7 @@ given template for each result. Go's
 [text/template](https://pkg.go.dev/text/template) package describes all the
 details of the format.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/node_ls.md
+++ b/docs/reference/commandline/node_ls.md
@@ -24,8 +24,7 @@ Lists all the nodes that the Docker Swarm manager knows about. You can filter
 using the `-f` or `--filter` flag. Refer to the [filtering](#filter) section
 for more information about available filter options.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -42,8 +41,7 @@ ID                           HOSTNAME        STATUS  AVAILABILITY  MANAGER STATU
 e216jshn25ckzbvmwlnh5jr3g *  swarm-manager1  Ready   Active        Leader
 ```
 
-> **Note**
->
+> [!NOTE]
 > In the above example output, there is a hidden column of `.Self` that indicates
 > if the node is the same node as the current docker daemon. A `*` (e.g.,
 > `e216jshn25ckzbvmwlnh5jr3g *`) means this node is the current docker daemon.

--- a/docs/reference/commandline/node_promote.md
+++ b/docs/reference/commandline/node_promote.md
@@ -10,8 +10,7 @@ Promote one or more nodes to manager in the swarm
 
 Promotes a node to manager. This command can only be executed on a manager node.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -22,8 +22,7 @@ Lists all the tasks on a Node that Docker knows about. You can filter using the
 `-f` or `--filter` flag. Refer to the [filtering](#filter) section for more
 information about available filter options.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/node_rm.md
+++ b/docs/reference/commandline/node_rm.md
@@ -20,8 +20,7 @@ Remove one or more nodes from the swarm
 
 Removes the specified nodes from a swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/node_update.md
+++ b/docs/reference/commandline/node_update.md
@@ -19,8 +19,7 @@ Update a node
 
 Update metadata about a node, such as its availability, labels, or roles.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/plugin_set.md
+++ b/docs/reference/commandline/plugin_set.md
@@ -100,8 +100,7 @@ $ docker plugin inspect -f '{{with $mount := index .Settings.Mounts 0}}{{$mount.
 /bar
 ```
 
-> **Note**
->
+> [!NOTE]
 > Since only `source` is settable in `mymount`,
 > `docker plugins set mymount=/bar myplugin` would work too.
 
@@ -122,8 +121,7 @@ $ docker plugin inspect -f '{{with $device := index .Settings.Devices 0}}{{$devi
 /dev/bar
 ```
 
-> **Note**
->
+> [!NOTE]
 > Since only `path` is settable in `mydevice`,
 > `docker plugins set mydevice=/dev/bar myplugin` would work too.
 

--- a/docs/reference/commandline/secret_create.md
+++ b/docs/reference/commandline/secret_create.md
@@ -20,8 +20,7 @@ Creates a secret using standard input or from a file for the secret content.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/secret_inspect.md
+++ b/docs/reference/commandline/secret_inspect.md
@@ -25,8 +25,7 @@ describes all the details of the format.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/secret_ls.md
+++ b/docs/reference/commandline/secret_ls.md
@@ -24,8 +24,7 @@ Run this command on a manager node to list the secrets in the swarm.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/secret_rm.md
+++ b/docs/reference/commandline/secret_rm.md
@@ -16,8 +16,7 @@ Removes the specified secrets from the swarm.
 
 For detailed information about using secrets, refer to [manage sensitive data with Docker secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -32,8 +31,7 @@ $ docker secret rm secret.json
 sapth4csdo5b6wz2p5uimh5xg
 ```
 
-> **Warning**
->
+> [!WARNING]
 > Unlike `docker rm`, this command does not ask for confirmation before removing
 > a secret.
 { .warning }

--- a/docs/reference/commandline/service.md
+++ b/docs/reference/commandline/service.md
@@ -25,8 +25,7 @@ Manage Swarm services
 
 Manage Swarm services.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -88,8 +88,7 @@ Create a new service
 
 Creates a service as described by the specified parameters.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -23,8 +23,7 @@ the given template will be executed for each result.
 Go's [text/template](https://pkg.go.dev/text/template) package
 describes all the details of the format.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_logs.md
+++ b/docs/reference/commandline/service_logs.md
@@ -24,8 +24,7 @@ Fetch the logs of a service or task
 
 The `docker service logs` command batch-retrieves logs present at the time of execution.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -36,8 +35,7 @@ service, or with the ID of a task. If a service is passed, it will display logs
 for all of the containers in that service. If a task is passed, it will only
 display logs from that particular task.
 
-> **Note**
->
+> [!NOTE]
 > This command is only functional for services that are started with
 > the `json-file` or `journald` logging driver.
 

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -22,8 +22,7 @@ List services
 
 This command lists services that are running in the swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -20,8 +20,7 @@ List the tasks of one or more services
 
 Lists the tasks that are running as part of the specified services.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_rm.md
+++ b/docs/reference/commandline/service_rm.md
@@ -14,8 +14,7 @@ Remove one or more services
 
 Removes the specified services from the swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -35,8 +34,7 @@ $ docker service ls
 ID  NAME  MODE  REPLICAS  IMAGE
 ```
 
-> **Warning**
->
+> [!WARNING]
 > Unlike `docker rm`, this command does not ask for confirmation before removing
 > a running service.
 

--- a/docs/reference/commandline/service_rollback.md
+++ b/docs/reference/commandline/service_rollback.md
@@ -17,8 +17,7 @@ Revert changes to a service's configuration
 
 Roll back a specified service to its previous version from the swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -20,8 +20,7 @@ services which are global mode. The command will return immediately, but the
 actual scaling of the service may take some time. To stop all replicas of a
 service while keeping the service active in the swarm you can set the scale to 0.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -115,8 +115,7 @@ service requires recreating the tasks for it to take effect. For example, only c
 setting. However, the `--force` flag will cause the tasks to be recreated anyway. This can be used to perform a
 rolling restart without any changes to the service parameters.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/stack_deploy.md
+++ b/docs/reference/commandline/stack_deploy.md
@@ -25,8 +25,7 @@ Deploy a new stack or update an existing stack
 
 Create and update a stack from a `compose` file on the swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/stack_ls.md
+++ b/docs/reference/commandline/stack_ls.md
@@ -20,8 +20,7 @@ List stacks
 
 Lists the stacks.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -20,8 +20,7 @@ List the tasks in the stack
 
 Lists the tasks that are running as part of the specified stack.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/stack_rm.md
+++ b/docs/reference/commandline/stack_rm.md
@@ -20,8 +20,7 @@ Remove one or more stacks
 
 Remove the stack from the swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/stack_services.md
+++ b/docs/reference/commandline/stack_services.md
@@ -18,8 +18,7 @@ List the services in the stack
 
 Lists the services that are running as part of the specified stack.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/swarm_ca.md
+++ b/docs/reference/commandline/swarm_ca.md
@@ -22,8 +22,7 @@ Display and rotate the root CA
 
 View or rotate the current swarm CA certificate.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the
@@ -81,8 +80,7 @@ gyg5u9Iliel99l7SuMhNeLkrU7fXs+Of1nTyyM73ig==
 
 ### <a name="rotate"></a> Root CA rotation (--rotate)
 
-> **Note**
->
+> [!NOTE]
 > Mirantis Kubernetes Engine (MKE), formerly known as Docker UCP, provides an external
 > certificate manager service for the swarm. If you run swarm on MKE, you shouldn't
 > rotate the CA certificates manually. Instead, contact Mirantis support if you need

--- a/docs/reference/commandline/swarm_join-token.md
+++ b/docs/reference/commandline/swarm_join-token.md
@@ -21,8 +21,7 @@ role. You pass the token using the `--token` flag when you run
 [swarm join](swarm_join.md). Nodes use the join token only when they join the
 swarm.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/swarm_unlock-key.md
+++ b/docs/reference/commandline/swarm_unlock-key.md
@@ -22,8 +22,7 @@ swarm.
 You can view or rotate the unlock key using `swarm unlock-key`. To view the key,
 run the `docker swarm unlock-key` command without any arguments:
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/swarm_unlock.md
+++ b/docs/reference/commandline/swarm_unlock.md
@@ -13,8 +13,7 @@ used to reactivate a manager after its Docker daemon restarts if the autolock
 setting is turned on. The unlock key is printed at the time when autolock is
 enabled, and is also available from the `docker swarm unlock-key` command.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/swarm_update.md
+++ b/docs/reference/commandline/swarm_update.md
@@ -22,8 +22,7 @@ Update the swarm
 
 Updates a swarm with new parameter values.
 
-> **Note**
->
+> [!NOTE]
 > This is a cluster management command, and must be executed on a swarm
 > manager node. To learn about managers and workers, refer to the
 > [Swarm mode section](https://docs.docker.com/engine/swarm/) in the

--- a/docs/reference/commandline/system_df.md
+++ b/docs/reference/commandline/system_df.md
@@ -62,8 +62,7 @@ my-named-vol                                                       0            
 * `UNIQUE SIZE` is the amount of space that's only used by a given image
 * `SIZE` is the virtual size of the image, it's the sum of `SHARED SIZE` and `UNIQUE SIZE`
 
-> **Note**
->
+> [!NOTE]
 > Network information isn't shown, because it doesn't consume disk space.
 
 ## Performance

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -124,6 +124,7 @@ type `dockerd`.
 To run the daemon with debug output, use `dockerd --debug` or add `"debug": true`
 to [the `daemon.json` file](#daemon-configuration-file).
 
+> [!NOTE]
 > **Enabling experimental features**
 >
 > Enable experimental features by starting `dockerd` with the `--experimental`
@@ -152,8 +153,7 @@ to learn about environment variables supported by the `docker` CLI.
 
 ### Proxy configuration
 
-> **Note**
->
+> [!NOTE]
 > Refer to the [Docker Desktop manual](https://docs.docker.com/desktop/networking/#httphttps-proxy-support)
 > if you are running [Docker Desktop](https://docs.docker.com/desktop/).
 
@@ -191,8 +191,7 @@ interface using its IP address: `-H tcp://192.168.59.103:2375`. It is
 conventional to use port `2375` for un-encrypted, and port `2376` for encrypted
 communication with the daemon.
 
-> **Note**
->
+> [!NOTE]
 > If you're using an HTTPS encrypted socket, keep in mind that only
 > TLS version 1.0 and higher is supported. Protocols SSLv3 and below are not
 > supported for security reasons.
@@ -259,8 +258,7 @@ supported. If your key is protected with passphrase, you need to set up
 
 #### Bind Docker to another host/port or a Unix socket
 
-> **Warning**
->
+> [!WARNING]
 > Changing the default `docker` daemon binding to a TCP port or Unix `docker`
 > user group introduces security risks, as it may allow non-root users to gain
 > root access on the host. Make sure you control access to `docker`. If you are
@@ -709,8 +707,7 @@ This option is useful when pushing images containing non-distributable artifacts
 to a registry on an air-gapped network so hosts on that network can pull the
 images without connecting to another server.
 
-> **Warning**
->
+> [!WARNING]
 > Non-distributable artifacts typically have restrictions on how
 > and where they can be distributed and shared. Only use this feature to push
 > artifacts to private registries and ensure that you are in compliance with
@@ -858,8 +855,7 @@ PING host.docker.internal (192.0.2.0): 56 data bytes
 
 ### Enable CDI devices
 
-> **Note**
->
+> [!NOTE]
 > This is experimental feature and as such doesn't represent a stable API.
 >
 > This feature isn't enabled by default. To this feature, set `features.cdi` to
@@ -1145,8 +1141,7 @@ The following is a full example of the allowed configuration options on Linux:
 }
 ```
 
-> **Note**
->
+> [!NOTE]
 > You can't set options in `daemon.json` that have already been set on
 > daemon startup as a flag.
 > On systems that use systemd to start the Docker daemon, `-H` is already set, so
@@ -1242,7 +1237,7 @@ The list of feature options include:
   external names. The current default is `false`, it will change to `true` in
   a future release. This option is only allowed on Windows.
 
-  > **Warning**
+  > [!WARNING]
   > The `windows-dns-proxy` feature flag will be removed in a future release.
 
 #### Configuration reload behavior
@@ -1275,8 +1270,7 @@ The list of currently supported options that can be reconfigured is this:
 
 ### Run multiple daemons
 
-> **Note**
->
+> [!NOTE]
 > Running multiple daemons on a single host is considered experimental.
 > You may encounter unsolved problems, and things may not work as expected in some cases.
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -69,8 +69,7 @@ to start an interactive shell in the container (if the image you select has an
 $ docker run -it IMAGE sh
 ```
 
-> **Note**
->
+> [!NOTE]
 > Depending on your Docker system configuration, you may be
 > required to preface the `docker run` command with `sudo`. To avoid
 > having to use `sudo` with the `docker` command, your system
@@ -696,8 +695,7 @@ By default, all containers get the same proportion of block IO bandwidth
 container's blkio weight relative to the weighting of all other running
 containers using the `--blkio-weight` flag.
 
-> **Note:**
->
+> [!NOTE]
 > The blkio weight setting is only available for direct IO. Buffered IO is not
 > currently supported.
 
@@ -1039,8 +1037,7 @@ You can reset a containers entrypoint by passing an empty string, for example:
 $ docker run -it --entrypoint="" mysql bash
 ```
 
-> **Note**
->
+> [!NOTE]
 > Passing `--entrypoint` clears out any default command set on the image. That
 > is, any `CMD` instruction in the Dockerfile used to build it.
 
@@ -1223,8 +1220,7 @@ The followings examples are all valid:
 --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]
 ```
 
-> **Note**
->
+> [!NOTE]
 > If you pass a numeric user ID, it must be in the range of 0-2147483647. If
 > you pass a username, the user must exist in the container.
 


### PR DESCRIPTION
cherry picked f1befabe9f1c979d94c39eeb7020e106b3c1e6a6

- backport of: #5350

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

