### PR TITLE
[27.x backport] update link to engine api reference

### DIFF
--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -118,7 +118,7 @@ and Docker Engine perform API version negotiation, and select the highest API
 version that is supported by both the Docker CLI and the Docker Engine.
 
 For example, if the CLI is connecting with Docker Engine version 19.03, it downgrades
-to API version 1.40 (refer to the [API version matrix](https://docs.docker.com/engine/api/#api-version-matrix)
+to API version 1.40 (refer to the [API version matrix](https://docs.docker.com/reference/api/engine/#api-version-matrix)
 to learn about the supported API versions for Docker Engine):
 
 ```console


### PR DESCRIPTION
- backport of #5360

Engine API reference page is moving to /reference/api/engine

Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>
(cherry picked from commit c974a833914090b980de881f4f10cc9dadd9dc00)
