### PR TITLE
[27.x backport] Fix linting issues in preparation of Go and GolangCI-lint update

### DIFF
--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -18,7 +18,7 @@ func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 		Long:  manifestDescription,
 		Args:  cli.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
+			_, _ = fmt.Fprint(dockerCli.Err(), "\n"+cmd.UsageString())
 		},
 		Annotations: map[string]string{"experimentalCLI": ""},
 	}

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -39,10 +39,10 @@ func runRemove(ctx context.Context, dockerCli command.Cli, sids []string) error 
 			errs = append(errs, err.Error())
 			continue
 		}
-		fmt.Fprintf(dockerCli.Out(), "%s\n", sid)
+		_, _ = fmt.Fprintf(dockerCli.Out(), "%s\n", sid)
 	}
 	if len(errs) > 0 {
-		return errors.Errorf(strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -90,7 +90,7 @@ func runScale(ctx context.Context, dockerCli command.Cli, options *scaleOptions,
 	if len(errs) == 0 {
 		return nil
 	}
-	return errors.Errorf(strings.Join(errs, "\n"))
+	return errors.New(strings.Join(errs, "\n"))
 }
 
 func runServiceScale(ctx context.Context, dockerCli command.Cli, serviceID string, scale uint64) error {

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -48,7 +48,7 @@ func RunRemove(ctx context.Context, dockerCli command.Cli, opts options.Remove) 
 		}
 
 		if len(services)+len(networks)+len(secrets)+len(configs) == 0 {
-			fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", namespace)
+			_, _ = fmt.Fprintf(dockerCli.Err(), "Nothing found in stack: %s\n", namespace)
 			continue
 		}
 
@@ -71,7 +71,7 @@ func RunRemove(ctx context.Context, dockerCli command.Cli, opts options.Remove) 
 	}
 
 	if len(errs) > 0 {
-		return errors.Errorf(strings.Join(errs, "\n"))
+		return errors.New(strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -372,7 +372,7 @@ func prettyPrintServerInfo(streams command.Streams, info *dockerInfo) []error {
 		fprintln(output, " Product License:", info.ProductLicense)
 	}
 
-	if info.DefaultAddressPools != nil && len(info.DefaultAddressPools) > 0 {
+	if len(info.DefaultAddressPools) > 0 {
 		fprintln(output, " Default Address Pools:")
 		for _, pool := range info.DefaultAddressPools {
 			fprintf(output, "   Base: %s, Size: %d\n", pool.Base, pool.Size)

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -222,7 +222,7 @@ func ValidateOutputPath(path string) error {
 		}
 
 		if err := ValidateOutputPathFileMode(fileInfo.Mode()); err != nil {
-			return errors.Wrapf(err, fmt.Sprintf("invalid output path: %q must be a directory or a regular file", path))
+			return errors.Wrapf(err, "invalid output path: %q must be a directory or a regular file", path)
 		}
 	}
 	return nil

--- a/cli/required.go
+++ b/cli/required.go
@@ -27,16 +27,16 @@ func NoArgs(cmd *cobra.Command, args []string) error {
 }
 
 // RequiresMinArgs returns an error if there is not at least min args
-func RequiresMinArgs(min int) cobra.PositionalArgs {
+func RequiresMinArgs(minArgs int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) >= min {
+		if len(args) >= minArgs {
 			return nil
 		}
 		return errors.Errorf(
 			"%q requires at least %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
-			min,
-			pluralize("argument", min),
+			minArgs,
+			pluralize("argument", minArgs),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
@@ -45,16 +45,16 @@ func RequiresMinArgs(min int) cobra.PositionalArgs {
 }
 
 // RequiresMaxArgs returns an error if there is not at most max args
-func RequiresMaxArgs(max int) cobra.PositionalArgs {
+func RequiresMaxArgs(maxArgs int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) <= max {
+		if len(args) <= maxArgs {
 			return nil
 		}
 		return errors.Errorf(
 			"%q requires at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
-			max,
-			pluralize("argument", max),
+			maxArgs,
+			pluralize("argument", maxArgs),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,
@@ -63,17 +63,17 @@ func RequiresMaxArgs(max int) cobra.PositionalArgs {
 }
 
 // RequiresRangeArgs returns an error if there is not at least min args and at most max args
-func RequiresRangeArgs(min int, max int) cobra.PositionalArgs {
+func RequiresRangeArgs(minArgs int, maxArgs int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		if len(args) >= min && len(args) <= max {
+		if len(args) >= minArgs && len(args) <= maxArgs {
 			return nil
 		}
 		return errors.Errorf(
 			"%q requires at least %d and at most %d %s.\nSee '%s --help'.\n\nUsage:  %s\n\n%s",
 			cmd.CommandPath(),
-			min,
-			max,
-			pluralize("argument", max),
+			minArgs,
+			maxArgs,
+			pluralize("argument", maxArgs),
 			cmd.CommandPath(),
 			cmd.UseLine(),
 			cmd.Short,

--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -214,7 +214,7 @@ func TestPromptExitCode(t *testing.T) {
 				default:
 
 					if err := bufioWriter.Flush(); err != nil {
-						return poll.Continue(err.Error())
+						return poll.Continue("%v", err)
 					}
 					if strings.Contains(buf.String(), "[y/N]") {
 						return poll.Success()


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5370
- minor conflicts because https://github.com/docker/cli/pull/5234 is not in the 27.x branch