### PR TITLE
[27.x backport] vendor: github.com/docker/docker 3ab5c7d0036c (v27.2.0-dev)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -13,7 +13,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli-docs-tool v0.8.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v27.2.0-rc.1.0.20240826110426-b27de4ef1634+incompatible // 27.x branch (v27.2.0-dev)
+	github.com/docker/docker v27.2.0-rc.1.0.20240827140014-3ab5c7d0036c+incompatible // 27.x branch (v27.2.0-dev)
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -57,8 +57,8 @@ github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsB
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.2.0-rc.1.0.20240826110426-b27de4ef1634+incompatible h1:zhepkLpBCbSFRV/g39GZQSO1pxhlYiDE00kyyQQ82/A=
-github.com/docker/docker v27.2.0-rc.1.0.20240826110426-b27de4ef1634+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.2.0-rc.1.0.20240827140014-3ab5c7d0036c+incompatible h1:EuHKrI999zfPX8J2mF6AcHVAMQvSTkawrSGh81s5ncU=
+github.com/docker/docker v27.2.0-rc.1.0.20240827140014-3ab5c7d0036c+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v27.2.0-rc.1.0.20240826110426-b27de4ef1634+incompatible
+# github.com/docker/docker v27.2.0-rc.1.0.20240827140014-3ab5c7d0036c+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
full diff: https://github.com/docker/docker/compare/b27de4ef1634...3ab5c7d0036c
