### PR TITLE
Revert "login: normalize `registry-1.docker.io`"

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -90,9 +90,7 @@ func runLogin(ctx context.Context, dockerCli command.Cli, opts loginOptions) err
 		serverAddress string
 		response      *registrytypes.AuthenticateOKBody
 	)
-	if opts.serverAddress != "" &&
-		opts.serverAddress != registry.DefaultNamespace &&
-		opts.serverAddress != registry.DefaultRegistryHost {
+	if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
 		serverAddress = opts.serverAddress
 	} else {
 		serverAddress = registry.IndexServer


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Fixes https://github.com/docker/cli/issues/5378

**- What I did**

Since e6624676e07d718f09d97889ced8d98a0fcf628f, during login, we started normalizing `registry-1.docker.io` to `index.docker.io`. This means that if a user logs in with `docker login -u [username] registry-1.docker.io`, the user's credentials get stored in credhelpers/config.json under `https://index.docker.io/v1/`.

However, while the registry code normalizes an image reference without registry (`docker pull alpine:latest`) and image references explicitly for `index.docker.io` (`docker pull index.docker.io/library/alpine:latest`) to the official index server (`https://index.docker.io/v1/`), and fetches credentials for that auth key, it does not normalize `registry-1.docker.io`, which means pulling explicitly from there (`docker pull registry-1.docker.io/alpine:latest`) will not use credentials stored under `https://index.docker.io/v1/`.

As such, until changes are made to the registry/pull/push code to normalize `registry-1.docker.io` to `https://index.docker.io/v1/`, we should not normalize this during login.

**- How I did it**

Don't normalize `registry-1.docker.io` to `https://index.docker.io/v1/` during login.

**- How to verify it**

- `docker login registry-1.docker.io`
- `docker pull registry-1.docker.io/<some private repo>

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fixed issue related to login, causing credentials to sometimes not be picked up when explicitly pulling/pushing images from `registry-1.docker.io`. 
```

**- A picture of a cute animal (not mandatory but encouraged)**

