### PR TITLE
[27.x backport] Revert "login: normalize `registry-1.docker.io`"

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -111,9 +111,7 @@ func runLogin(ctx context.Context, dockerCli command.Cli, opts loginOptions) err
 		serverAddress string
 		response      *registrytypes.AuthenticateOKBody
 	)
-	if opts.serverAddress != "" &&
-		opts.serverAddress != registry.DefaultNamespace &&
-		opts.serverAddress != registry.DefaultRegistryHost {
+	if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
 		serverAddress = opts.serverAddress
 	} else {
 		serverAddress = registry.IndexServer


### PR DESCRIPTION
Backports https://github.com/docker/cli/pull/5379