### PR TITLE
fix: gitattributes enforcing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,14 @@
-* text=auto eol=lf
+* text=auto
+
 Dockerfile* linguist-language=Dockerfile
 vendor.mod linguist-language=Go-Module
 vendor.sum linguist-language=Go-Checksums
-*.bat text eol=crlf
+
+*.go -text diff=golang
+
+# scripts directory contains shell scripts
+# without extensions, so we need to force
+scripts/** text=auto eol=lf
+
+# shell scripts should always have LF
+*.sh text eol=lf


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->



fixes https://github.com/docker/cli/issues/5377

**- What I did**
Switch to an opt-in approach to forcing the `lf` line ending to certain files and directories.

**- How I did it**
Change the first line `* text=auto eol=lf` to not enforce line endings and instead only force the `scripts/` directory to use `lf` line endings. Also add future support for `.bat` files in-case we add them and also enforce `.sh` files with `lf` line endings.

**- How to verify it**
Checkout the branch after setting `git config core.autocrlf true` on a windows machine. On linux we can also enforce the line endings with `git config core.eol crlf` and use that as a test. There shouldn't be any files marked by git as changed.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

