### PR TITLE
[27.x backport] oauth/api: drain timer channel on each iteration

### DIFF
--- a/cli/internal/oauth/api/api_test.go
+++ b/cli/internal/oauth/api/api_test.go
@@ -198,7 +198,7 @@ func TestWaitForDeviceToken(t *testing.T) {
 		state := State{
 			DeviceCode: "aDeviceCode",
 			UserCode:   "aUserCode",
-			Interval:   1,
+			Interval:   5,
 			ExpiresIn:  1,
 		}
 


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5376

Fixes https://github.com/docker/cli/issues/5375

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Previously, if while polling for oauth device-code login results a user suspended the process (such as with CTRL-Z) and then restored it with `fg`, an error might occur in the form of:

```
failed waiting for authentication: You are polling faster than the specified interval of 5 seconds.
```

This is due to our use of a `time.Ticker` here - if no receiver drains the ticker channel (and timers/tickers use a buffered channel behind the scenes), more than one tick will pile up, causing the program to "tick" twice, in fast succession, after it is resumed.

**- How I did it**

The new implementation replaces the `time.Ticker` with a `time.Timer` (`time.Ticker` is just a nice wrapper) and introduces a helper function `resetTimer` to ensure that before every `select`, the timer is stopped and it's channel is drained.

**- How to verify it**

Reproduce as described in https://github.com/docker/cli/issues/5375

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix issue that will sometimes cause the browser-login flow to fail if the CLI process is suspended and then resumed while waiting for the user to authenticate.
```

**- A picture of a cute animal (not mandatory but encouraged)**

