### PR TITLE
login: handle non-tty scenario consistently

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -124,17 +124,6 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 		cli.SetIn(streams.NewIn(os.Stdin))
 	}
 
-	// Some links documenting this:
-	// - https://code.google.com/archive/p/mintty/issues/56
-	// - https://github.com/docker/docker/issues/15272
-	// - https://mintty.github.io/ (compatibility)
-	// Linux will hit this if you attempt `cat | docker login`, and Windows
-	// will hit this if you attempt docker login from mintty where stdin
-	// is a pipe, not a character based console.
-	if argPassword == "" && !cli.In().IsTerminal() {
-		return authConfig, errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
-	}
-
 	isDefaultRegistry := serverAddress == registry.IndexServer
 	defaultUsername = strings.TrimSpace(defaultUsername)
 


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Running `docker login` in a non-interactive environment sometimes errors out if no username/password is provided.

Before:
| `--username` | `--password` | Result                                                             |
|:------------:|:------------:| ------------------------------------------------------------------ |
|      ✅      |      ✅      | ✅                                                                 |
|      ❌      |      ❌      | `Error: Cannot perform an interactive login from a non TTY device` |
|      ✅      |      ❌      | `Error: Cannot perform an interactive login from a non TTY device` |
|      ❌      |      ✅      | hangs                                                              |

After:
| `--username` | `--password` | Result                                                             |
|:------------:|:------------:| ------------------------------------------------------------------ |
|      ✅      |      ✅      | ✅                                                                 |
|      ❌      |      ❌      | `Error: Cannot perform an interactive login from a non TTY device` |
|      ✅      |      ❌      | `Error: Cannot perform an interactive login from a non TTY device` |
|      ❌      |      ✅      | `Error: Cannot perform an interactive login from a non TTY device` |

It's worth calling out a separate scenario – if there are previous, valid credentials, then running `docker login` with no username or password provided will use the previously stored credentials, and not error out.

```console
cat ~/.docker/config.json
{
        "auths": {
                "https://index.docker.io/v1/": {
                        "auth": "xxxxxxxxxxx"
                }
        }
}
⭑ docker login 0>/dev/null
Authenticating with existing credentials...

Login Succeeded
```

**- What I did**

This PR makes this handling consistent, and also adds some tests.

**- How I did it**

Made the non-tty handling consistent by also erroring out when a user runs `docker login --password bork` (with no username) when stdin is not a tty.

Also applied the same non-interactive handling logic to the new web-based login flow, which means that now, if there are no prior credentials stored and a user runs `docker login`, instead of initiating the new web-based login flow, an error is returned.

**- How to verify it**

Run the added tests, or
- `docker login 0>/dev/null`
- `docker login -u [username] -p [password] 0>/dev/null`
- `docker login -u [username] 0>/dev/null`
- `docker login -p [password] 0>/dev/null`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`docker login` now returns an error instead of hanging if called non-interactively with `--password` or `--password-stdin` but without `--user`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

