### PR TITLE
[27.x backport] login: handle non-tty scenario consistently

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -124,17 +124,6 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 		cli.SetIn(streams.NewIn(os.Stdin))
 	}
 
-	// Some links documenting this:
-	// - https://code.google.com/archive/p/mintty/issues/56
-	// - https://github.com/docker/docker/issues/15272
-	// - https://mintty.github.io/ (compatibility)
-	// Linux will hit this if you attempt `cat | docker login`, and Windows
-	// will hit this if you attempt docker login from mintty where stdin
-	// is a pipe, not a character based console.
-	if argPassword == "" && !cli.In().IsTerminal() {
-		return authConfig, errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
-	}
-
 	isDefaultRegistry := serverAddress == registry.IndexServer
 	defaultUsername = strings.TrimSpace(defaultUsername)
 

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -176,6 +176,17 @@ func isOauthLoginDisabled() bool {
 }
 
 func loginUser(ctx context.Context, dockerCli command.Cli, opts loginOptions, defaultUsername, serverAddress string) (*registrytypes.AuthenticateOKBody, error) {
+	// Some links documenting this:
+	// - https://code.google.com/archive/p/mintty/issues/56
+	// - https://github.com/docker/docker/issues/15272
+	// - https://mintty.github.io/ (compatibility)
+	// Linux will hit this if you attempt `cat | docker login`, and Windows
+	// will hit this if you attempt docker login from mintty where stdin
+	// is a pipe, not a character based console.
+	if (opts.user == "" || opts.password == "") && !dockerCli.In().IsTerminal() {
+		return nil, errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
+	}
+
 	// If we're logging into the index server and the user didn't provide a username or password, use the device flow
 	if serverAddress == registry.IndexServer && opts.user == "" && opts.password == "" && !isOauthLoginDisabled() {
 		response, err := loginWithDeviceCodeFlow(ctx, dockerCli)


### PR DESCRIPTION
Backports: https://github.com/docker/cli/pull/5401

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
`docker login` now returns an error instead of hanging if called non-interactively with `--password` or `--password-stdin` but without `--user`.
```