### PR TITLE
[27.x backport] vendor.mod: put github.com/pkg/browser in the right group

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -32,6 +32,7 @@ require (
 	github.com/morikuni/aec v1.0.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
@@ -80,7 +81,6 @@ require (
 	github.com/moby/sys/symlink v0.2.0 // indirect
 	github.com/moby/sys/user v0.3.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
-	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5407
- relates to https://github.com/moby/buildkit/pull/5304#issuecomment-2331294601

commit fcfdd7b91fbbd41dfdc80d5d66f28337916d935c (https://github.com/docker/cli/pull/5344) introduced github.com/pkg/browser as a direct dependency, but it ended up in the group for indirect dependencies.
