### PR TITLE
fix: docstring for cli/command: `ContainerFormat.CreatedAt`

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -193,7 +193,9 @@ func (c *ContainerContext) Command() string {
 	return strconv.Quote(command)
 }
 
-// CreatedAt returns the "Created" date/time of the container as a unix timestamp.
+// CreatedAt returns the formatted string representing the container's creation date/time.
+// The format may include nanoseconds if present.
+// e.g. "2006-01-02 15:04:05.999999999 -0700 MST" or "2006-01-02 15:04:05 -0700 MST"
 func (c *ContainerContext) CreatedAt() string {
 	return time.Unix(c.c.Created, 0).String()
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->
fixes #2413

**- What I did**

Correct documentation for `CreatedAt`
As @Benehiko suggested in https://github.com/docker/cli/pull/4765#discussion_r1519503919, didn't add `CreatedAtTimestamp`.

**- How I did it**

1. Referred to https://pkg.go.dev/time#Time.String
2. Used commenting style as for `DisplayablePorts` in same file

**- How to verify it**

N/A, or refer to `func TestContainerContextWriteJSON(t *testing.T) {` in `formatter/test_container.go`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
cli/command: fix docstring for ContainerFormat.CreatedAt

```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/54224dda-0758-4604-af7a-10a3fccbc1dd)
