### PR TITLE
Update broken links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ anybody starts working on it.
 We are always thrilled to receive pull requests. We do our best to process them
 quickly. If your pull request is not accepted on the first try,
 don't get discouraged! Our contributor's guide explains [the review process we
-use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contribution/).
+use for simple changes](https://github.com/docker/docker/blob/master/project/REVIEWING.md).
 
 ### Talking to other Docker users and contributors
 
@@ -124,8 +124,8 @@ submitting a pull request.
 Update the documentation when creating or modifying features. Test your
 documentation changes for clarity, concision, and correctness, as well as a
 clean documentation build. See our contributors guide for [our style
-guide](https://docs.docker.com/opensource/doc-style) and instructions on [building
-the documentation](https://docs.docker.com/opensource/project/test-and-docs/#build-and-test-the-documentation).
+guide](https://docs.docker.com/contribute/style/grammar/) and instructions on [building
+the documentation](https://docs.docker.com/contribute/).
 
 Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/3836

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
In CONTRIBUTING.md updated "the review process we use for simple changes", "our style guide" and "building the documentation" with working links.

**- How I did it**
Used google and [docs.docker](https://docs.docker.com/) for information

**- How to verify it**
NA

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
In CONTRIBUTING.md "the review process we use for simple changes", "our style guide" and "building the documentation" will point to the correct working links
```

**- A picture of a cute animal (not mandatory but encouraged)**

![tiger](https://github.com/user-attachments/assets/e4ba1ce2-a17e-4e9c-bb50-bb04603bbfcf)

"closes #5416 "