### PR TITLE
info: stop printing "Expected" commits

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -273,21 +273,9 @@ func prettyPrintServerInfo(streams command.Streams, info *dockerInfo) []error {
 
 	if info.OSType == "linux" {
 		fprintln(output, " Init Binary:", info.InitBinary)
-
-		for _, ci := range []struct {
-			Name   string
-			Commit system.Commit
-		}{
-			{"containerd", info.ContainerdCommit},
-			{"runc", info.RuncCommit},
-			{"init", info.InitCommit},
-		} {
-			fprintf(output, " %s version: %s", ci.Name, ci.Commit.ID)
-			if ci.Commit.ID != ci.Commit.Expected {
-				fprintf(output, " (expected: %s)", ci.Commit.Expected)
-			}
-			fprintln(output)
-		}
+		fprintln(output, " containerd version:", info.ContainerdCommit.ID)
+		fprintln(output, " runc version:", info.RuncCommit.ID)
+		fprintln(output, " init version:", info.InitCommit.ID)
 		if len(info.SecurityOptions) != 0 {
 			if kvs, err := system.DecodeSecurityOptions(info.SecurityOptions); err != nil {
 				errs = append(errs, err)


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/27955
- https://github.com/moby/moby/pull/37968
- https://github.com/moby/moby/pull/42776
- https://github.com/moby/moby/issues/38739

The `Commit` type was introduced in https://github.com/moby/moby/commit/2790ac68b32b399c872de88388bdccc359ed7a88, to assist triaging issues that were reported with an incorrect version of runc or containerd. At the time, both `runc` and `containerd` were not yet stable, and had to be built from a specific commit to guarantee compatibility.

We encountered various situations where unexpected (and incompatible) versions of those binaries were packaged, resulting in hard to trace bug-reports. For those situations, a "expected" version was set at compile time, to indicate if the version installed was different from the expected version;

    docker info
    ...
    runc version: a592beb5bc4c4092b1b1bac971afed27687340c5 (expected: 69663f0bd4b60df09991c08812a60108003fa340)

Both `runc` and `containerd` are stable now, and docker 19.03 and up set the expected version to the actual version since https://github.com/moby/moby/commit/c65f0bd13c85d29087419fa555281311091825e7 and 23.0 did the same for the `init` binary https://github.com/moby/moby/commit/b585c64e2b01f924fc358fe059871baa469bb460, to prevent the CLI from reporting "unexpected version".

In short; the `Expected` fields no longer serves a real purpose, so we should no longer print it.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

