### PR TITLE
chore: remove duplicated `govet` linter config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    - govet
     - wastedassign
 
   disable:


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Remove duplicated `govet` linter from `.golangci.yml` configuration file.
