### PR TITLE
Remove leading and trailing double quotes from environment variable values in docker run commands

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -209,7 +209,10 @@ func TestParseWithVolumes(t *testing.T) {
 	}
 
 	// Two bind mounts.
-	arr, tryit = setupPlatformVolume([]string{`/hostTmp:/containerTmp`, `/hostVar:/containerVar`}, []string{os.Getenv("ProgramData") + `:c:\ContainerPD`, os.Getenv("TEMP") + `:c:\containerTmp`})
+	arr, tryit = setupPlatformVolume(
+		[]string{`/hostTmp:/containerTmp`, `/hostVar:/containerVar`},
+		[]string{os.Getenv("ProgramData") + `:c:\ContainerPD`, os.Getenv("TEMP") + `:c:\containerTmp`},
+	)
 	if _, hostConfig, _ := mustParse(t, tryit); hostConfig.Binds == nil || compareRandomizedStrings(hostConfig.Binds[0], hostConfig.Binds[1], arr[0], arr[1]) != nil {
 		t.Fatalf("Error parsing volume flags, `%s and %s` did not mount-bind correctly. Received %v", arr[0], arr[1], hostConfig.Binds)
 	}
@@ -218,7 +221,8 @@ func TestParseWithVolumes(t *testing.T) {
 	// TODO Windows: The Windows version uses read-write as that's the only mode it supports. Can change this post TP4
 	arr, tryit = setupPlatformVolume(
 		[]string{`/hostTmp:/containerTmp:ro`, `/hostVar:/containerVar:rw`},
-		[]string{os.Getenv("TEMP") + `:c:\containerTmp:rw`, os.Getenv("ProgramData") + `:c:\ContainerPD:rw`})
+		[]string{os.Getenv("TEMP") + `:c:\containerTmp:rw`, os.Getenv("ProgramData") + `:c:\ContainerPD:rw`},
+	)
 	if _, hostConfig, _ := mustParse(t, tryit); hostConfig.Binds == nil || compareRandomizedStrings(hostConfig.Binds[0], hostConfig.Binds[1], arr[0], arr[1]) != nil {
 		t.Fatalf("Error parsing volume flags, `%s and %s` did not mount-bind correctly. Received %v", arr[0], arr[1], hostConfig.Binds)
 	}
@@ -892,15 +896,18 @@ func TestParseEnvfileVariables(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(config.Env) != 1 || config.Env[0] != "ENV1=value1" {
-		t.Fatalf("Expected a config with [ENV1=value1], got %v", config.Env)
+
+	if len(config.Env) != 2 || config.Env[0] != "ENV1=value1" || config.Env[1] != "ENV2=value2" {
+		t.Fatalf("Expected a config with [ENV1=value1], got %+v", config.Env)
 	}
-	config, _, _, err = parseRun([]string{"--env-file=testdata/valid.env", "--env=ENV2=value2", "img", "cmd"})
+
+	config, _, _, err = parseRun([]string{"--env-file=testdata/valid.env", "--env=ENV3=value3", "--env=ENV4=\"value4\"", "img", "cmd"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(config.Env) != 2 || config.Env[0] != "ENV1=value1" || config.Env[1] != "ENV2=value2" {
-		t.Fatalf("Expected a config with [ENV1=value1 ENV2=value2], got %v", config.Env)
+
+	if len(config.Env) != 4 || config.Env[0] != "ENV1=value1" || config.Env[1] != "ENV2=value2" || config.Env[2] != "ENV3=value3" || config.Env[3] != "ENV4=value4" {
+		t.Fatalf("Expected a config with [ENV1=value1 ENV2=value2, ENV3=value3, ENV4=value4], got %v", config.Env)
 	}
 }
 

--- a/cli/command/container/testdata/valid.env
+++ b/cli/command/container/testdata/valid.env
@@ -1,1 +1,2 @@
 ENV1=value1
+ENV2="value2"

--- a/opts/file.go
+++ b/opts/file.go
@@ -48,6 +48,10 @@ func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]
 		if len(line) > 0 && !strings.HasPrefix(line, "#") {
 			variable, value, hasValue := strings.Cut(line, "=")
 
+			if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+				value = strings.Trim(value, "\"")
+			}
+
 			// trim the front of a variable, but nothing else
 			variable = strings.TrimLeft(variable, whiteSpaces)
 			if strings.ContainsAny(variable, whiteSpaces) {

--- a/opts/parse.go
+++ b/opts/parse.go
@@ -2,6 +2,7 @@ package opts
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -31,6 +32,19 @@ func readKVStrings(files []string, override []string, emptyFn func(string) (stri
 		}
 		variables = append(variables, parsedVars...)
 	}
+
+	for i, value := range override {
+		key, value, ok := strings.Cut(value, "=")
+		if !ok {
+			continue
+		}
+
+		if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+			value = strings.Trim(value, "\"")
+			override[i] = fmt.Sprintf("%s=%s", key, value)
+		}
+	}
+
 	// parse the '-e' and '--env' after, to allow override
 	variables = append(variables, override...)
 


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

### **- What I did**

Implemented functionality to automatically remove leading and trailing double quotes from environment variable values when they are set via the Docker CLI (`docker run`). This enhancement prevents issues caused by unintended double quotes in environment variable values, ensuring that the variables are set correctly inside containers.

### **- How I did it**

- Modified the environment variable parsing logic in `opts/file.go`,`opts/parse.go` to strip leading and trailing double quotes from environment variable values.
- Used `strings.Trim` with `"` as the cutset to remove only the leading and trailing double quotes without affecting any internal quotes within the value.
- Ensured that environment variable names are not altered.
- Added unit tests in `cli/command/container/opts_test.go` to verify that leading and trailing double quotes are correctly removed.
- Verified that values without leading/trailing double quotes remain unaffected.

### **- How to verify it**

1. **Build the Docker CLI** from the modified source code.

2. **Run a container** with an environment variable that includes leading and trailing double quotes in its value:

   ```bash
   ./docker run --env MY_VAR="some value with spaces" alpine sh -c 'echo "[$MY_VAR]"'
   ```
   
3. Expected output: `some value with spaces`