### PR TITLE
Docs: Fix --rm=false flag in container_run.md

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1234,7 +1234,7 @@ the container and remove the file system when the container exits, use the
 `--rm` flag:
 
 ```text
---rm=false: Automatically remove the container when it exits
+--rm: Automatically remove the container when it exits
 ```
 
 > [!NOTE]


### PR DESCRIPTION
**- What I did**

Corrected the usage of the `--rm=false` flag in the `container_run.md` documentation example. See [Docker Container Run - Clean up](https://docs.docker.com/reference/cli/docker/container/run/#rm) for reference.

**- How I did it**

Removed the incorrect `--rm=false` flag from the example and updated it to use the `--rm` flag to comply with the example text: `Automatically remove the container when it exits`. Also for the `--rm=true` flag it is not necessary to specify true, as that is the default behavior.

**- How to verify it**

1. Run the command `docker run --rm alpine echo "Hello World"` in a Docker environment to confirm that the container is automatically removed after execution.
2. Run the command `docker run --rm=false alpine echo "Hello World"` in a Docker environment to confirm that the container is not automatically removed after execution.
3. All available Docker documentation and CLI help indicate that the `--rm` flag is used to remove a container when it exits. There is an error in the example of [container run](https://docs.docker.com/reference/cli/docker/container/run/#rm) when it states that setting `--rm=false` will remove a container when it exits.

**- Description for the changelog**

```markdown changelog
docs/cli/container_run: Fix example usage of `--rm=false` flag to `--rm` in container_run.md
```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://st2.depositphotos.com/1768667/7960/i/450/depositphotos_79609194-stock-photo-lamb3.jpg)