### PR TITLE
docs: add documentation for dockerd --feature flag

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -57,6 +57,7 @@ Options:
       --exec-opt list                         Runtime execution options
       --exec-root string                      Root directory for execution state files (default "/var/run/docker")
       --experimental                          Enable experimental features
+      --feature map                           Enable feature in the daemon
       --fixed-cidr string                     IPv4 subnet for fixed IPs
       --fixed-cidr-v6 string                  IPv6 subnet for fixed IPs
   -G, --group string                          Group for the unix socket (default "docker")
@@ -971,6 +972,36 @@ Example of usage:
 }
 ```
 
+### <a name="feature"></a> Enable feature in the daemon (--feature)
+
+The `--feature` option lets you enable or disable a feature in the daemon.
+This option corresponds with the "features" field in the [daemon.json configuration file](#daemon-configuration-file).
+Features should only be configured either through the `--feature` command line
+option or through the "features" field in the configuration file; using both
+the command-line option and the "features" field in the configuration
+file produces an error. The feature option can be specified multiple times
+to configure multiple features. The `--feature` option accepts a name and
+optional boolean value. When omitting the value, the default is `true`.
+
+The following example runs the daemon with the `cdi` and `containerd-snapshotter`
+features enabled. The `cdi` option is provided with a value;
+
+```console
+$ dockerd --feature cdi=true --feature containerd-snapshotter
+```
+
+The following example is the equivalent using the `daemon.json` configuration
+file;
+
+```json
+{
+  "features": {
+    "cdi": true,
+    "containerd-snapshotter": true
+  }
+}
+```
+
 ### Daemon configuration file
 
 The `--config-file` option allows you to set any configuration option
@@ -1065,7 +1096,10 @@ The following is a full example of the allowed configuration options on Linux:
   "exec-opts": [],
   "exec-root": "",
   "experimental": false,
-  "features": {},
+  "features": {
+    "cdi": true,
+    "containerd-snapshotter": true
+  },
   "fixed-cidr": "",
   "fixed-cidr-v6": "",
   "group": "",

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -31,6 +31,7 @@ dockerd - Enable daemon mode
 [**--exec-opt**[=*[]*]]
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
+[**--feature**[=*NAME*=**true**|**false**]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -221,6 +222,14 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 
 **--experimental**=""
   Enable the daemon experimental features.
+
+**--feature**=*NAME*=**true**|**false**
+  Enable or disable feature feature in the daemon. This option corresponds
+  with the "features" field in the daemon.json configuration file. Using
+  both the command-line option and the "features" field in the configuration
+  file produces an error. The feature option can be specified multiple times
+  to configure multiple features.
+  Usage example: `--feature containerd-snapshotter=true`
 
 **--fixed-cidr**=""
   IPv4 subnet for fixed IPs (e.g., 10.20.0.0/16); this subnet must be nested in

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -31,7 +31,7 @@ dockerd - Enable daemon mode
 [**--exec-opt**[=*[]*]]
 [**--exec-root**[=*/var/run/docker*]]
 [**--experimental**[=**false**]]
-[**--feature**[=*NAME*=**true**|**false**]
+[**--feature**[=*NAME*[=**true**|**false**]]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
 [**--fixed-cidr-v6**[=*FIXED-CIDR-V6*]]
 [**-G**|**--group**[=*docker*]]
@@ -223,13 +223,13 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 **--experimental**=""
   Enable the daemon experimental features.
 
-**--feature**=*NAME*=**true**|**false**
+**--feature**=*NAME*[=**true**|**false**]
   Enable or disable a feature in the daemon. This option corresponds
   with the "features" field in the daemon.json configuration file. Using
   both the command-line option and the "features" field in the configuration
   file produces an error. The feature option can be specified multiple times
   to configure multiple features.
-  Usage example: `--feature containerd-snapshotter=true`
+  Usage example: `--feature containerd-snapshotter` or `--feature containerd-snapshotter=true`.
 
 **--fixed-cidr**=""
   IPv4 subnet for fixed IPs (e.g., 10.20.0.0/16); this subnet must be nested in

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -224,7 +224,7 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   Enable the daemon experimental features.
 
 **--feature**=*NAME*=**true**|**false**
-  Enable or disable feature feature in the daemon. This option corresponds
+  Enable or disable a feature in the daemon. This option corresponds
   with the "features" field in the daemon.json configuration file. Using
   both the command-line option and the "features" field in the configuration
   file produces an error. The feature option can be specified multiple times


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/48167
- https://github.com/moby/moby/pull/48486
- https://github.com/moby/moby/pull/48502

First 3 commits were cherry-picked;

```bash
curl -fsSL "https://github.com/moby/moby/pull/48486/commits/fa06acc851fd1004e0c3610bbdab46669d362255.patch" | git am --3way -S
curl -fsSL "https://github.com/moby/moby/pull/48502/commits/2b6550bb2e4d462d8afa687b59766bb13783ef1f.patch" | git am --3way -S
curl -fsSL "https://github.com/moby/moby/pull/48502/commits/50e83a0713b750d7d63e25482b4df3deefb5827d.patch" | git am --3way -S
````
