### PR TITLE
docs, man: dockerd: remove --api-cors-header (deprecated)

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -54,7 +54,7 @@ The following table provides an overview of the current status of deprecated fea
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
 | Deprecated | [Non-standard fields in image inspect](#non-standard-fields-in-image-inspect)                                                      | v27.0      | v28.0  |
-| Deprecated | [API CORS headers](#api-cors-headers)                                                                                              | v27.0      | v28.0  |
+| Removed    | [API CORS headers](#api-cors-headers)                                                                                              | v27.0      | v28.0  |
 | Deprecated | [Graphdriver plugins (experimental)](#graphdriver-plugins-experimental)                                                            | v27.0      | v28.0  |
 | Deprecated | [Unauthenticated TCP connections](#unauthenticated-tcp-connections)                                                                | v26.0      | v28.0  |
 | Deprecated | [`Container` and `ContainerConfig` fields in Image inspect](#container-and-containerconfig-fields-in-image-inspect)                | v25.0      | v26.0  |
@@ -177,18 +177,19 @@ and a custom [snapshotter](https://github.com/containerd/containerd/tree/v1.7.18
 ### API CORS headers
 
 **Deprecated in Release: v27.0**
-**Target For Removal In Release: v28.0**
+**Disabled by default in Release: v27.0**
+**Removed in release: v28.0**
 
 The `api-cors-header` configuration option for the Docker daemon is insecure,
 and is therefore deprecated and scheduled for removal.
 Incorrectly setting this option could leave a window of opportunity
 for unauthenticated cross-origin requests to be accepted by the daemon.
 
-Starting in Docker Engine v27.0, this flag can still be set,
+In Docker Engine v27.0, this flag can still be set,
 but it has no effect unless the environment variable
 `DOCKERD_DEPRECATED_CORS_HEADER` is also set to a non-empty value.
 
-This flag will be removed altogether in v28.0.
+This flag has been removed altogether in v28.0.
 
 This is a breaking change for authorization plugins and other programs
 that depend on this option for accessing the Docker API from a browser.

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -25,7 +25,6 @@ A self-sufficient runtime for containers.
 Options:
       --add-runtime runtime                   Register an additional OCI compatible runtime (default [])
       --allow-nondistributable-artifacts list Allow push of nondistributable artifacts to registry
-      --api-cors-header string                Set CORS headers in the Engine API
       --authorization-plugin list             Authorization plugins to load
       --bip string                            Specify network bridge IP
   -b, --bridge string                         Attach containers to a network bridge
@@ -1015,7 +1014,6 @@ The following is a full example of the allowed configuration options on Linux:
 ```json
 {
   "allow-nondistributable-artifacts": [],
-  "api-cors-header": "",
   "authorization-plugins": [],
   "bip": "",
   "bridge": "",

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -7,7 +7,6 @@ dockerd - Enable daemon mode
 **dockerd**
 [**--add-runtime**[=*[]*]]
 [**--allow-nondistributable-artifacts**[=*[]*]]
-[**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -135,10 +134,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
   and where they can be distributed and shared. Only use this feature to push
   artifacts to private registries and ensure that you are in compliance with
   any terms that cover redistributing nondistributable artifacts.
-
-**--api-cors-header**=""
-  Set CORS headers in the Engine API. Default is cors disabled. Give urls like
-  "http://foo, http://bar, ...". Give "\*" to allow all.
 
 **--authorization-plugin**=""
   Set authorization plugins to load


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/5085
- https://github.com/moby/moby/pull/45313
- https://github.com/moby/moby/pull/48504
- https://github.com/moby/moby/pull/48209

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove deprecated "api-cors-header" config parameter and the dockerd "--api-cors-header" option
```
