### PR TITLE
[27.x backport] docs: Fix --rm=false flag in container_run.md

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1234,7 +1234,7 @@ the container and remove the file system when the container exits, use the
 `--rm` flag:
 
 ```text
---rm=false: Automatically remove the container when it exits
+--rm: Automatically remove the container when it exits
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Backports: https://github.com/docker/cli/pull/5435