### PR TITLE
telemetry: pass otel errors to the otel handler for shutdown and force flush

### DIFF
--- a/cli/command/telemetry_utils.go
+++ b/cli/command/telemetry_utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -94,7 +95,9 @@ func startCobraCommandTimer(mp metric.MeterProvider, attrs []attribute.KeyValue)
 			metric.WithAttributes(cmdStatusAttrs...),
 		)
 		if mp, ok := mp.(MeterProvider); ok {
-			mp.ForceFlush(ctx)
+			if err := mp.ForceFlush(ctx); err != nil {
+				otel.Handle(err)
+			}
 		}
 	}
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -358,7 +358,9 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 
 	mp := dockerCli.MeterProvider()
 	if mp, ok := mp.(command.MeterProvider); ok {
-		defer mp.Shutdown(ctx)
+		if err := mp.Shutdown(ctx); err != nil {
+			otel.Handle(err)
+		}
 	} else {
 		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
 	}


### PR DESCRIPTION
**- What I did**

Errors returned by otel shutdown and force flush methods are passed to `otel.Handle` to be determined how or if they'll be printed.

**- How I did it**

Checked for the error and invoked `otel.Handle`.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* Print OTEL errors in the CLI on shutdown

```

**- A picture of a cute animal (not mandatory but encouraged)**

