### PR TITLE
command: change drive to lowercase for wsl path

### DIFF
--- a/cli/command/telemetry_docker.go
+++ b/cli/command/telemetry_docker.go
@@ -180,7 +180,7 @@ func toWslPath(s string) string {
 	if !ok {
 		return ""
 	}
-	return fmt.Sprintf("mnt/%s%s", drive, p)
+	return fmt.Sprintf("mnt/%s%s", strings.ToLower(drive), p)
 }
 
 func parseUNCPath(s string) (drive, p string, ok bool) {


### PR DESCRIPTION
**- What I did**

On Windows, the drive casing doesn't matter outside of WSL. For WSL, the drives are lowercase. When we're producing a WSL path, lowercase the drive letter.

**- How I did it**

Called `strings.ToLower` on the drive when creating the WSL path.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
* Use lowercase windows drive letter for WSL metrics path
```

**- A picture of a cute animal (not mandatory but encouraged)**

