### PR TITLE
gha: update codeql workflow to go1.22.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
         name: Update Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: 1.22.7
       -
         name: Initialize CodeQL
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5387

commit d7d56599ca0d80f3b06b69b6a9a6e91321416775 updated this repository to go1.22, but the codeql action didn't specify a patch version, and was missed.


