### PR TITLE
[27.x backport] telemetry: handle otel errors on shutdown

### DIFF
--- a/cli/command/telemetry_utils.go
+++ b/cli/command/telemetry_utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -94,7 +95,9 @@ func startCobraCommandTimer(mp metric.MeterProvider, attrs []attribute.KeyValue)
 			metric.WithAttributes(cmdStatusAttrs...),
 		)
 		if mp, ok := mp.(MeterProvider); ok {
-			mp.ForceFlush(ctx)
+			if err := mp.ForceFlush(ctx); err != nil {
+				otel.Handle(err)
+			}
 		}
 	}
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -360,7 +360,9 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 
 	mp := dockerCli.MeterProvider()
 	if mp, ok := mp.(command.MeterProvider); ok {
-		defer mp.Shutdown(ctx)
+		if err := mp.Shutdown(ctx); err != nil {
+			otel.Handle(err)
+		}
 	} else {
 		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
 	}


### PR DESCRIPTION
Backports: https://github.com/docker/cli/pull/5444