### PR TITLE
telemetry: fix early meterprovider shutdown

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -358,9 +358,11 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 
 	mp := dockerCli.MeterProvider()
 	if mp, ok := mp.(command.MeterProvider); ok {
-		if err := mp.Shutdown(ctx); err != nil {
-			otel.Handle(err)
-		}
+		defer func() {
+			if err := mp.Shutdown(ctx); err != nil {
+				otel.Handle(err)
+			}
+		}()
 	} else {
 		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
 	}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

In 4b5a196fee11e82e15d2c2c36ba2883e5717fde3, we changed the CLI global meter provider shutdown in order to handle any error returned by the metric export.

Unfortunately, we dropped a `defer` during the fix, which causes the meter provider to be immediately shutdown after being created and metrics to not be collected/exporter.

**- How I did it**

Re-defer the new Meter Provider shutdown call.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix issue causing CLI OTel metrics to not be collected.
```

**- A picture of a cute animal (not mandatory but encouraged)**


![Screenshot 2024-09-20 at 00 53 09](https://github.com/user-attachments/assets/8d91b2c0-0fdd-48f9-95e3-d8696fbc079a)
