### PR TITLE
[27.x backport] telemetry: fix early meterprovider shutdown

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -360,9 +360,11 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 
 	mp := dockerCli.MeterProvider()
 	if mp, ok := mp.(command.MeterProvider); ok {
-		if err := mp.Shutdown(ctx); err != nil {
-			otel.Handle(err)
-		}
+		defer func() {
+			if err := mp.Shutdown(ctx); err != nil {
+				otel.Handle(err)
+			}
+		}()
 	} else {
 		fmt.Fprint(dockerCli.Err(), "Warning: Unexpected OTEL error, metrics may not be flushed")
 	}


### PR DESCRIPTION
Backports: https://github.com/docker/cli/pull/5456