### PR TITLE
cli/formatter: fix unbracketed IPv6 addrs

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -375,7 +375,7 @@ func formGroup(key string, start, last uint16) string {
 		group = fmt.Sprintf("%s-%d", group, last)
 	}
 	if ip != "" {
-		group = fmt.Sprintf("%s:%s->%s", ip, group, group)
+		group = fmt.Sprintf("%s->%s", net.JoinHostPort(ip, group), group)
 	}
 	return group + "/" + groupType
 }

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -592,6 +592,17 @@ func TestDisplayablePorts(t *testing.T) {
 		{
 			ports: []container.Port{
 				{
+					IP:          "::1",
+					PrivatePort: 9988,
+					PublicPort:  8899,
+					Type:        "tcp",
+				},
+			},
+			expected: "[::1]:8899->9988/tcp",
+		},
+		{
+			ports: []container.Port{
+				{
 					IP:          "4.3.2.1",
 					PrivatePort: 9988,
 					PublicPort:  9988,
@@ -599,6 +610,17 @@ func TestDisplayablePorts(t *testing.T) {
 				},
 			},
 			expected: "4.3.2.1:9988->9988/tcp",
+		},
+		{
+			ports: []container.Port{
+				{
+					IP:          "::1",
+					PrivatePort: 9988,
+					PublicPort:  9988,
+					Type:        "tcp",
+				},
+			},
+			expected: "[::1]:9988->9988/tcp",
 		},
 		{
 			ports: []container.Port{
@@ -631,6 +653,22 @@ func TestDisplayablePorts(t *testing.T) {
 		{
 			ports: []container.Port{
 				{
+					IP:          "::1",
+					PublicPort:  9998,
+					PrivatePort: 9998,
+					Type:        "udp",
+				}, {
+					IP:          "::1",
+					PublicPort:  9999,
+					PrivatePort: 9999,
+					Type:        "udp",
+				},
+			},
+			expected: "[::1]:9998-9999->9998-9999/udp",
+		},
+		{
+			ports: []container.Port{
+				{
 					IP:          "1.2.3.4",
 					PublicPort:  8887,
 					PrivatePort: 9998,
@@ -643,6 +681,22 @@ func TestDisplayablePorts(t *testing.T) {
 				},
 			},
 			expected: "1.2.3.4:8887->9998/udp, 1.2.3.4:8888->9999/udp",
+		},
+		{
+			ports: []container.Port{
+				{
+					IP:          "::1",
+					PublicPort:  8887,
+					PrivatePort: 9998,
+					Type:        "udp",
+				}, {
+					IP:          "::1",
+					PublicPort:  8888,
+					PrivatePort: 9999,
+					Type:        "udp",
+				},
+			},
+			expected: "[::1]:8887->9998/udp, [::1]:8888->9999/udp",
 		},
 		{
 			ports: []container.Port{
@@ -688,9 +742,14 @@ func TestDisplayablePorts(t *testing.T) {
 					PrivatePort: 2233,
 					PublicPort:  3322,
 					Type:        "tcp",
+				}, {
+					IP:          "::1",
+					PrivatePort: 2233,
+					PublicPort:  3322,
+					Type:        "tcp",
 				},
 			},
-			expected: "4.3.2.1:3322->2233/tcp, 1.2.3.4:8899->9988/tcp, 1.2.3.4:8899->9988/udp",
+			expected: "4.3.2.1:3322->2233/tcp, [::1]:3322->2233/tcp, 1.2.3.4:8899->9988/tcp, 1.2.3.4:8899->9988/udp",
 		},
 		{
 			ports: []container.Port{


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Follow-up:

- https://github.com/docker/cli/pull/5363

Commit 964155cd tried to enclose all IPv6 addresses within brackets but missed some cases. This commit fixes that, and adds a few test cases.

**- How I did it**

**- How to verify it**

New unit tests.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Fix an issue preventing some IPv6 addresses shown by `docker ps` to be properly bracketed
```

