### PR TITLE
docs: use important callout for buildkit vs legacy builder

### DIFF
--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -47,7 +47,7 @@ Build an image from a Dockerfile
 
 ## Description
 
-> [!NOTE]
+> [!IMPORTANT]
 > This page refers to the **legacy implementation** of `docker build`,
 > using the legacy (pre-BuildKit) build backend.
 > This configuration is only relevant if you're building Windows containers.


### PR DESCRIPTION
Use `[!IMPORTANT]` for the legacy builder callout
