### PR TITLE
Check that --ip-range is a CIDR address

### DIFF
--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -163,6 +163,9 @@ func createIPAMConfig(options ipamOptions) (*network.IPAM, error) {
 	for _, r := range options.ipRanges {
 		match := false
 		for _, s := range options.subnets {
+			if _, _, err := net.ParseCIDR(r); err != nil {
+				return nil, err
+			}
 			ok, err := subnetMatches(s, r)
 			if err != nil {
 				return nil, err

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -124,6 +124,15 @@ func TestNetworkCreateErrors(t *testing.T) {
 			},
 			expectedError: "no matching subnet for aux-address",
 		},
+		{
+			args: []string{"toto"},
+			flags: map[string]string{
+				"ip-range": "192.168.83.1-192.168.83.254",
+				"gateway":  "192.168.80.1",
+				"subnet":   "192.168.80.0/20",
+			},
+			expectedError: "invalid CIDR address: 192.168.83.1-192.168.83.254",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**- What I did**

Avoid this sort of confusion (from the community Slack) ...

> I think I have found a bug in docker (Docker version 27.3.1, build ce12230)
> My network at home is a /20 not because I actually need the numbers of devices but to be able to give a complete /24 range to a macvlan while at the same at the same time keeping my devices on their normal ip's ( were a /24 prior )
> so my range on my network is from 192.168.80.1-192.168.95.254
> And when I try to create the macvlan it says
> 
> $ docker network create -d macvlan --subnet 192.168.80.0/20 --gateway 192.168.80.1 --ip-range 192.168.83.1-192.168.83.254 -o parent=eno1 macvlan-test
> no matching subnet for range 192.168.83.1-192.168.83.254

**- How I did it**

Check that `--ip-range` is a CIDR address, to produce a better error message.

The original error message was from the CLI, but it used `subnetMatches(s,r)` to check that the range was ok - that function tries to deal with `r` being a single address as well as a subnet, so it missed the problem. (Validation at the daemon end of the API is already ok.)

**- How to verify it**

Updated test, and ...

```
# docker network create -d macvlan --subnet 192.168.80.0/20 --gateway 192.168.80.1 --ip-range 192.168.83.1-192.168.83.254 -o parent=eno1 macvlan-test
invalid CIDR address: 192.168.83.1-192.168.83.254
```

**- Description for the changelog**
```markdown changelog
n/a
```