### PR TITLE
introduce ParseKeyValueFile

### DIFF
--- a/opts/file_test.go
+++ b/opts/file_test.go
@@ -1,0 +1,26 @@
+package opts
+
+import (
+	"bytes"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseKeyValueFile(t *testing.T) {
+	b := []byte(`
+FOO=BAR
+ZOT`)
+
+	vars := map[string]string{
+		"ZOT": "QIX",
+	}
+	lookupFn := func(s string) (string, bool) {
+		v, ok := vars[s]
+		return v, ok
+	}
+
+	got, err := ParseKeyValueFile(bytes.NewReader(b), "(inlined)", lookupFn)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, got, []string{"FOO=BAR", "ZOT=QIX"})
+}


### PR DESCRIPTION
**- What I did**
introduced `ParseKeyValueFile` so docker/compose can use the same parser as docker/cli when env_file is requested to be loaded in `raw` format. This will be used so a user can get the same behavior using `docker run --env-file` and compose `env_file` while preserving the ability to get variable interpolated by default 😵‍💫

**- How I did it**

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/user-attachments/assets/d625c55d-1b73-43f8-b7cd-d8274bab27e2)
