### PR TITLE
opts: remove ErrBadKey as it's not used as a sentinel error

### DIFF
--- a/opts/file.go
+++ b/opts/file.go
@@ -12,15 +12,6 @@ import (
 
 const whiteSpaces = " \t"
 
-// ErrBadKey typed error for bad environment variable
-type ErrBadKey struct {
-	msg string
-}
-
-func (e ErrBadKey) Error() string {
-	return "poorly formatted environment: " + e.msg
-}
-
 func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]string, error) {
 	fh, err := os.Open(filename)
 	if err != nil {
@@ -51,10 +42,10 @@ func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]
 			// trim the front of a variable, but nothing else
 			variable = strings.TrimLeft(variable, whiteSpaces)
 			if strings.ContainsAny(variable, whiteSpaces) {
-				return []string{}, ErrBadKey{fmt.Sprintf("variable '%s' contains whitespaces", variable)}
+				return []string{}, fmt.Errorf("variable '%s' contains whitespaces", variable)
 			}
 			if len(variable) == 0 {
-				return []string{}, ErrBadKey{fmt.Sprintf("no variable name on line '%s'", line)}
+				return []string{}, fmt.Errorf("no variable name on line '%s'", line)
 			}
 
 			if hasValue {


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/5494
- relates to https://github.com/docker/cli/pull/5491
- relates to https://github.com/moby/moby/pull/4174
- relates to https://github.com/docker/cli/pull/838


This error was originally introduced `ErrBadEnvVariable` in [moby/moby@500c8ba], but merely for convenience, and not used as a sentinel error. After the code was moved from the daemon to the cli repository, it was renamed to be more generic `ErrBadKey` in commit 2b17f4c8a8caad552025edb05a73db683fb8a5c6.

A search on GitHub shows that there's no consumers using this error as sentinel error, and it's not used in our own code as such, so it should be safe to remove this error.

This patch removes the `ErrBadKey` error-type; it also removes the prefix (`poorly formatted environment:`) to make the error more generic, because the same function was used both for env-files and label-files.

[moby/moby@500c8ba]: https://github.com/vdemeester/moby/commit/500c8ba4b66c35cf2c29aeb81a9392cc406835a4

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
opts: remove ErrBadKey as it's not used as a sentinel error
```

**- A picture of a cute animal (not mandatory but encouraged)**

