### PR TITLE
[27.x backport] docs: fix a typo in run.md

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -134,7 +134,7 @@ You can identify a container in three ways:
 The UUID identifier is a random ID assigned to the container by the daemon.
 
 The daemon generates a random string name for containers automatically. You can
-also defined a custom name using [the `--name` flag](https://docs.docker.com/reference/cli/docker/container/run/#name).
+also define a custom name using [the `--name` flag](https://docs.docker.com/reference/cli/docker/container/run/#name).
 Defining a `name` can be a handy way to add meaning to a container. If you
 specify a `name`, you can use it when referring to the container in a
 user-defined network. This works for both background and foreground Docker


### PR DESCRIPTION
**- What I did**

* Backports https://github.com/docker/cli/pull/5481 to 27.x

(cherry picked from commit 54a20ce54caa3f24349eebd8f2cf6f47959c5556)

**- How I did it**

```
git cherry-pick -xsS 54a20ce54caa3f24349eebd8f2cf6f47959c5556
```

**- How to verify it**
Typo should be fixed in run.md

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

