### PR TITLE
command: add tests for container kill, commit, and pause

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -42,6 +42,8 @@ type fakeClient struct {
 	containerAttachFunc     func(ctx context.Context, containerID string, options container.AttachOptions) (types.HijackedResponse, error)
 	containerDiffFunc       func(ctx context.Context, containerID string) ([]container.FilesystemChange, error)
 	containerRenameFunc     func(ctx context.Context, oldName, newName string) error
+	containerCommitFunc     func(ctx context.Context, container string, options container.CommitOptions) (types.IDResponse, error)
+	containerPauseFunc      func(ctx context.Context, container string) error
 	Version                 string
 }
 
@@ -211,6 +213,21 @@ func (f *fakeClient) ContainerDiff(ctx context.Context, containerID string) ([]c
 func (f *fakeClient) ContainerRename(ctx context.Context, oldName, newName string) error {
 	if f.containerRenameFunc != nil {
 		return f.containerRenameFunc(ctx, oldName, newName)
+	}
+
+	return nil
+}
+
+func (f *fakeClient) ContainerCommit(ctx context.Context, containerID string, options container.CommitOptions) (types.IDResponse, error) {
+	if f.containerCommitFunc != nil {
+		return f.containerCommitFunc(ctx, containerID, options)
+	}
+	return types.IDResponse{}, nil
+}
+
+func (f *fakeClient) ContainerPause(ctx context.Context, containerID string) error {
+	if f.containerPauseFunc != nil {
+		return f.containerPauseFunc(ctx, containerID)
 	}
 
 	return nil

--- a/cli/command/container/commit_test.go
+++ b/cli/command/container/commit_test.go
@@ -1,0 +1,71 @@
+package container
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/pkg/errors"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestRunCommit(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		containerCommitFunc: func(
+			ctx context.Context,
+			container string,
+			options container.CommitOptions,
+		) (types.IDResponse, error) {
+			assert.Check(t, is.Equal(options.Author, "Author Name <author@name.com>"))
+			assert.Check(t, is.DeepEqual(options.Changes, []string{"EXPOSE 80"}))
+			assert.Check(t, is.Equal(options.Comment, "commit message"))
+			assert.Check(t, is.Equal(options.Pause, false))
+			assert.Check(t, is.Equal(container, "container-id"))
+
+			return types.IDResponse{ID: "image-id"}, nil
+		},
+	})
+
+	cmd := NewCommitCommand(cli)
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs(
+		[]string{
+			"--author", "Author Name <author@name.com>",
+			"--change", "EXPOSE 80",
+			"--message", "commit message",
+			"--pause=false",
+			"container-id",
+		},
+	)
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	assert.Assert(t, is.Equal(cli.OutBuffer().String(), "image-id\n"))
+}
+
+func TestRunCommitClientError(t *testing.T) {
+	clientError := errors.New("client error")
+
+	cli := test.NewFakeCli(&fakeClient{
+		containerCommitFunc: func(
+			ctx context.Context,
+			container string,
+			options container.CommitOptions,
+		) (types.IDResponse, error) {
+			return types.IDResponse{}, clientError
+		},
+	})
+
+	cmd := NewCommitCommand(cli)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"container-id"})
+
+	err := cmd.Execute()
+	assert.ErrorIs(t, err, clientError)
+}

--- a/cli/command/container/kill_test.go
+++ b/cli/command/container/kill_test.go
@@ -1,0 +1,74 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestRunKill(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		containerKillFunc: func(
+			ctx context.Context,
+			container string,
+			signal string,
+		) error {
+			assert.Assert(t, is.Equal(signal, "STOP"))
+			return nil
+		},
+	})
+
+	cmd := NewKillCommand(cli)
+	cmd.SetOut(io.Discard)
+
+	cmd.SetArgs([]string{
+		"--signal", "STOP",
+		"container-id-1",
+		"container-id-2",
+	})
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	containerIDs := strings.SplitN(cli.OutBuffer().String(), "\n", 2)
+	assert.Assert(t, is.Len(containerIDs, 2))
+
+	containerID1 := strings.TrimSpace(containerIDs[0])
+	containerID2 := strings.TrimSpace(containerIDs[1])
+
+	assert.Check(t, is.Equal(containerID1, "container-id-1"))
+	assert.Check(t, is.Equal(containerID2, "container-id-2"))
+}
+
+func TestRunKillClientError(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		containerKillFunc: func(
+			ctx context.Context,
+			container string,
+			signal string,
+		) error {
+			return fmt.Errorf("client error for container %s", container)
+		},
+	})
+
+	cmd := NewKillCommand(cli)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	cmd.SetArgs([]string{"container-id-1", "container-id-2"})
+	err := cmd.Execute()
+
+	errs := strings.SplitN(err.Error(), "\n", 2)
+	assert.Assert(t, is.Len(errs, 2))
+
+	errContainerID1 := errs[0]
+	errContainerID2 := errs[1]
+
+	assert.Assert(t, is.Equal(errContainerID1, "client error for container container-id-1"))
+	assert.Assert(t, is.Equal(errContainerID2, "client error for container container-id-2"))
+}

--- a/cli/command/container/pause_test.go
+++ b/cli/command/container/pause_test.go
@@ -1,0 +1,65 @@
+package container
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestRunPause(t *testing.T) {
+	cli := test.NewFakeCli(
+		&fakeClient{
+			containerPauseFunc: func(ctx context.Context, container string) error {
+				return nil
+			},
+		},
+	)
+
+	cmd := NewPauseCommand(cli)
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{"container-id-1", "container-id-2"})
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	containerIDs := strings.SplitN(cli.OutBuffer().String(), "\n", 2)
+	assert.Assert(t, is.Len(containerIDs, 2))
+
+	containerID1 := strings.TrimSpace(containerIDs[0])
+	containerID2 := strings.TrimSpace(containerIDs[1])
+
+	assert.Check(t, is.Equal(containerID1, "container-id-1"))
+	assert.Check(t, is.Equal(containerID2, "container-id-2"))
+}
+
+func TestRunPauseClientError(t *testing.T) {
+	cli := test.NewFakeCli(
+		&fakeClient{
+			containerPauseFunc: func(ctx context.Context, container string) error {
+				return fmt.Errorf("client error for container %s", container)
+			},
+		},
+	)
+
+	cmd := NewPauseCommand(cli)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"container-id-1", "container-id-2"})
+
+	err := cmd.Execute()
+
+	errs := strings.SplitN(err.Error(), "\n", 2)
+	assert.Assert(t, is.Len(errs, 2))
+
+	errContainerID1 := errs[0]
+	errContainerID2 := errs[1]
+
+	assert.Assert(t, is.Equal(errContainerID1, "client error for container container-id-1"))
+	assert.Assert(t, is.Equal(errContainerID2, "client error for container container-id-2"))
+}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
This commit adds tests for the commands `docker kill`, `docker commit`, and `docker pause`. Also, it creates the mock methods of the docker client `ContainerCommit` and `ContainerPause` so they can be used in the tests.

For `docker kill`, it covers the cases that:
 - the command runs successfully
 - the client returns an error

For `docker commit`, it covers the cases that:
 - the command runs successfully
 - the client returns an error

For `docker pause`, it covers the cases that:
 - the command runs successfully
 - the client returns an error

**- How I did it**
I read all the test cases developed in `cli/command/container` directory and did the same for `kill.go`, `commit.go` and `pause.go` using a `fakeClient` and mocking the client `ContainerKill`, `ContainerCommit` and `ContainerPause` methods.

**- How to verify it**
Run: `make test`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Add tests for container kill, commit, and pause commands
```
