### PR TITLE
[26.1 backport] volume/update: require 1 argument/fix panic

### DIFF
--- a/cli/command/volume/update.go
+++ b/cli/command/volume/update.go
@@ -18,7 +18,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update [OPTIONS] [VOLUME]",
 		Short: "Update a volume (cluster volumes only)",
-		Args:  cli.RequiresMaxArgs(1),
+		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(cmd.Context(), dockerCli, args[0], availability, cmd.Flags())
 		},

--- a/cli/command/volume/update_test.go
+++ b/cli/command/volume/update_test.go
@@ -1,0 +1,22 @@
+package volume
+
+import (
+	"io"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestUpdateCmd(t *testing.T) {
+	cmd := newUpdateCommand(
+		test.NewFakeCli(&fakeClient{}),
+	)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+
+	assert.ErrorContains(t, err, "requires exactly 1 argument")
+}


### PR DESCRIPTION
**- What I did**

* Backports https://github.com/docker/cli/pull/5420 to 26.1 branch

This command was declaring that it requires at least 1 argument, when it needs exactly 1 argument. This was causing the CLI to panic when the command was invoked with no argument:

`docker volume update`

(cherry picked from commit daea277ee839742be94e1f41d5c477f114a81273)

**- How I did it**
```
git cherry-pick -xsS daea277ee839742be94e1f41d5c477f114a81273
```

Similar to https://github.com/docker/cli/pull/5426, this change updates the test as Docker 26.1 CLI does not have the UX improvements which have been added to master.

**- How to verify it**
```
docker volume update
```

**- Description for the changelog**
```markdown changelog
Fix issue where `docker volume update` command would cause the CLI to panic if no argument/volume was passed.
```

**- A picture of a cute animal (not mandatory but encouraged)**

