### PR TITLE
add shell-completion for --platform flags

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -145,3 +145,47 @@ func FileNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCom
 func NoComplete(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
+
+var commonPlatforms = []string{
+	"linux",
+	"linux/386",
+	"linux/amd64",
+	"linux/arm",
+	"linux/arm/v5",
+	"linux/arm/v6",
+	"linux/arm/v7",
+	"linux/arm64",
+	"linux/arm64/v8",
+
+	// IBM power and z platforms
+	"linux/ppc64le",
+	"linux/s390x",
+
+	// Not yet supported
+	"linux/riscv64",
+
+	"windows",
+	"windows/amd64",
+
+	"wasip1",
+	"wasip1/wasm",
+}
+
+// Platforms offers completion for platform-strings. It provides a non-exhaustive
+// list of platforms to be used for completion. Platform-strings are based on
+// [runtime.GOOS] and [runtime.GOARCH], but with (optional) variants added. A
+// list of recognised os/arch combinations from the Go runtime can be obtained
+// through "go tool dist list".
+//
+// Some noteworthy exclusions from this list:
+//
+//   - arm64 images ("windows/arm64", "windows/arm64/v8") do not yet exist for windows.
+//   - we don't (yet) include `os-variant` for completion (as can be used for Windows images)
+//   - we don't (yet) include platforms for which we don't build binaries, such as
+//     BSD platforms (freebsd, netbsd, openbsd), android, macOS (darwin).
+//   - we currently exclude architectures that may have unofficial builds,
+//     but don't have wide adoption (and no support), such as loong64, mipsXXX,
+//     ppc64 (non-le) to prevent confusion.
+func Platforms(_ *cobra.Command, _ []string, _ string) (platforms []string, _ cobra.ShellCompDirective) {
+	return commonPlatforms, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cli/command/completion/functions_test.go
+++ b/cli/command/completion/functions_test.go
@@ -1,0 +1,15 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestCompletePlatforms(t *testing.T) {
+	values, directives := Platforms(nil, nil, "")
+	assert.Check(t, is.Equal(directives&cobra.ShellCompDirectiveNoFileComp, cobra.ShellCompDirectiveNoFileComp), "Should not perform file completion")
+	assert.Check(t, is.DeepEqual(values, commonPlatforms))
+}

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -83,6 +83,7 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
 	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
 	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
 	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
 	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -74,6 +74,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
 	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
 	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
 	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
 	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/cli-docs-tool/annotation"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api"
@@ -158,6 +159,8 @@ func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&options.squash, "squash", false, "Squash newly built layers into a single new layer")
 	flags.SetAnnotation("squash", "experimental", nil)
 	flags.SetAnnotation("squash", "version", []string{"1.25"})
+
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 
 	return cmd
 }

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	dockeropts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -47,6 +48,7 @@ func NewImportCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.changes, "change", "c", "Apply Dockerfile instruction to the created image")
 	flags.StringVarP(&options.message, "message", "m", "", "Set commit message for imported image")
 	command.AddPlatformFlag(flags, &options.platform)
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 
 	return cmd
 }

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -50,6 +50,8 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 	command.AddPlatformFlag(flags, &opts.platform)
 	command.AddTrustVerificationFlags(flags, &opts.untrusted, dockerCli.ContentTrustEnabled())
 
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+
 	return cmd
 }
 

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -68,6 +68,8 @@ Image index won't be pushed, meaning that other manifests, including attestation
 'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)`)
 	flags.SetAnnotation("platform", "version", []string{"1.46"})
 
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+
 	return cmd
 }
 


### PR DESCRIPTION
### cli/command/completion: add Platforms

Add a utility for completing platform strings.

Platforms offers completion for platform-strings. It provides a non-exhaustive
list of platforms to be used for completion. Platform-strings are based on
[runtime.GOOS] and [runtime.GOARCH], but with (optional) variants added. A
list of recognised os/arch combinations from the Go runtime can be obtained
through "go tool dist list".

Some noteworthy exclusions from this list:

- arm64 images ("windows/arm64", "windows/arm64/v8") do not yet exist for windows.
- we don't (yet) include `os-variant` for completion (as can be used for Windows images)
- we don't (yet) include platforms for which we don't build binaries, such as
  BSD platforms (freebsd, netbsd, openbsd), android, macOS (darwin).
- we currently exclude architectures that may have unofficial builds,
  but don't have wide adoption (and no support), such as loong64, mipsXXX,
  ppc64 (non-le) to prevent confusion.

### cli/command/container: add shell completion for --platform flags

With this patch, completion is provided for `--platform` flags:

    docker run --platform<TAB>
    linux           linux/amd64     linux/arm/v5    linux/arm/v7    linux/arm64/v8  linux/riscv64   wasip1          windows
    linux/386       linux/arm       linux/arm/v6    linux/arm64     linux/ppc64le   linux/s390x     wasip1/wasm     windows/amd64


### cli/command/image: add shell completion for --platform flags

With this patch, completion is provided for `--platform` flags:

    docker pull --platform<TAB>
    linux           linux/amd64     linux/arm/v5    linux/arm/v7    linux/arm64/v8  linux/riscv64   wasip1          windows
    linux/386       linux/arm       linux/arm/v6    linux/arm64     linux/ppc64le   linux/s390x     wasip1/wasm     windows/amd64

Note that `docker buildx build` (with BuildKit) does not yet provide completion;
it's provided through buildx, and uses a different format (accepting multiple
comma-separated platforms). Interestingly, tab-completion for `docker build`
currently uses completion for non-buildkit, and has some other issues that may
have to be looked into.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
add shell-completion for --platform flags
```

**- A picture of a cute animal (not mandatory but encouraged)**

