### PR TITLE
[27.x backport] Do not underline image name

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -132,7 +132,7 @@ func printImageTree(dockerCLI command.Cli, view treeView) error {
 
 	warningColor := aec.LightYellowF
 	headerColor := aec.NewBuilder(aec.DefaultF, aec.Bold).ANSI
-	topNameColor := aec.NewBuilder(aec.BlueF, aec.Underline, aec.Bold).ANSI
+	topNameColor := aec.NewBuilder(aec.BlueF, aec.Bold).ANSI
 	normalColor := aec.NewBuilder(aec.DefaultF).ANSI
 	greenColor := aec.NewBuilder(aec.GreenF).ANSI
 	untaggedColor := aec.NewBuilder(aec.Faint).ANSI


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5473

Blue text with underline looks too much as a hyperlink I can click on


(cherry picked from commit 17040890e4627aa65e4aec030c4bad0371ea1e27)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Removed the underline from the blue image names. Blue text with underline looks too much as a hyperlink I can click on

Before:
<img width="1377" alt="Screenshot 2024-09-23 at 15 30 29" src="https://github.com/user-attachments/assets/d70c0d7f-6c22-488c-9b4f-444e290b4c48">

After:
<img width="1377" alt="Screenshot 2024-09-23 at 15 36 06" src="https://github.com/user-attachments/assets/91c6607c-690f-4b86-8d00-7e1e7bbd60d8">

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- containerd image store:  do not underline names in `docker image ls --tree`.
```

**- A picture of a cute animal (not mandatory but encouraged)**


