### PR TITLE
cli/command/image: fix TestNewSaveCommandSuccess to actually test

### DIFF
--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -70,13 +70,13 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 	testCases := []struct {
 		args          []string
 		isTerminal    bool
-		imageSaveFunc func(images []string) (io.ReadCloser, error)
+		imageSaveFunc func(images []string, options image.SaveOptions) (io.ReadCloser, error)
 		deferredFunc  func()
 	}{
 		{
 			args:       []string{"-o", "save_tmp_file", "arg1"},
 			isTerminal: true,
-			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
+			imageSaveFunc: func(images []string, _ image.SaveOptions) (io.ReadCloser, error) {
 				assert.Assert(t, is.Len(images, 1))
 				assert.Check(t, is.Equal("arg1", images[0]))
 				return io.NopCloser(strings.NewReader("")), nil
@@ -88,7 +88,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 		{
 			args:       []string{"arg1", "arg2"},
 			isTerminal: false,
-			imageSaveFunc: func(images []string) (io.ReadCloser, error) {
+			imageSaveFunc: func(images []string, _ image.SaveOptions) (io.ReadCloser, error) {
 				assert.Assert(t, is.Len(images, 2))
 				assert.Check(t, is.Equal("arg1", images[0]))
 				assert.Check(t, is.Equal("arg2", images[1]))
@@ -100,9 +100,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 		tc := tc
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
 			cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
-				imageSaveFunc: func(images []string, options image.SaveOptions) (io.ReadCloser, error) {
-					return io.NopCloser(strings.NewReader("")), nil
-				},
+				imageSaveFunc: tc.imageSaveFunc,
 			}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/32248


This test was added in [moby@b2551c6] as part of a larger PR that implemented unit tests in various packages. In this specific test, it looks like the `imageSaveFunc` that's defined in the test-table was forgotten to be wired up, causing all tests to effectively be skipped.

This patch wires up the function so that it's used in the test.

[moby@b2551c6]: https://github.com/moby/moby/commit/b2551c619d30f163c3ab8c9ee53cdb09bfbeaa55

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

