### PR TITLE
cli/command/images: set cmd.Args to prevent test-failures

### DIFF
--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -28,11 +28,13 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		},
 		{
 			name:          "input-to-terminal",
+			args:          []string{},
 			isTerminalIn:  true,
 			expectedError: "requested load from stdin, but stdin is empty",
 		},
 		{
 			name:          "pull-error",
+			args:          []string{},
 			expectedError: "something went wrong",
 			imageLoadFunc: func(input io.Reader, options image.LoadOptions) (image.LoadResponse, error) {
 				return image.LoadResponse{}, errors.Errorf("something went wrong")
@@ -71,12 +73,14 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 	}{
 		{
 			name: "simple",
+			args: []string{},
 			imageLoadFunc: func(input io.Reader, options image.LoadOptions) (image.LoadResponse, error) {
 				return image.LoadResponse{Body: io.NopCloser(strings.NewReader("Success"))}, nil
 			},
 		},
 		{
 			name: "json",
+			args: []string{},
 			imageLoadFunc: func(input io.Reader, options image.LoadOptions) (image.LoadResponse, error) {
 				json := "{\"ID\": \"1\"}"
 				return image.LoadResponse{


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5224
- relates to https://github.com/spf13/cobra/pull/2173


When running tests from my IDE, it compiles the tests before running, then executes the compiled binary to run the tests. Cobra doesn't like that, because in that situation os.Args is taken as argument for the command that's executed. The command that's tested now sees the `test-` flags as arguments (`-test.v -test.run ..`), which causes various tests to fail ("Command XYZ does not accept arguments").

    # compile the tests:
    go test -c -o foo.test

    # execute the test:
    ./foo.test -test.v -test.run TestFoo
    === RUN   TestFoo
    Error: "foo" accepts no arguments.

Set arguments to an empty slice to make sure it doesn't inherit arguments from the test-binary.


