### PR TITLE
cli/compose: implement the ports validation method

### DIFF
--- a/cli/compose/schema/schema.go
+++ b/cli/compose/schema/schema.go
@@ -6,9 +6,11 @@ package schema
 import (
 	"embed"
 	"fmt"
+	"math/big"
 	"strings"
 	"time"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -20,9 +22,18 @@ const (
 
 type portsFormatChecker struct{}
 
-func (checker portsFormatChecker) IsFormat(_ any) bool {
-	// TODO: implement this
-	return true
+func (checker portsFormatChecker) IsFormat(input any) bool {
+	var portSpec string
+
+	switch p := input.(type) {
+	case string:
+		portSpec = p
+	case *big.Rat:
+		portSpec = strings.Split(p.String(), "/")[0]
+	}
+
+	_, err := nat.ParsePortSpec(portSpec)
+	return err == nil
 }
 
 type durationFormatChecker struct{}
@@ -37,7 +48,6 @@ func (checker durationFormatChecker) IsFormat(input any) bool {
 }
 
 func init() {
-	gojsonschema.FormatCheckers.Add("expose", portsFormatChecker{})
 	gojsonschema.FormatCheckers.Add("ports", portsFormatChecker{})
 	gojsonschema.FormatCheckers.Add("duration", durationFormatChecker{})
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
This commit implements a validation method for the port mappings of compose. Also, it removes the ports validation method from the `expose` property since they do not always accept the same type of values. For example, `ports` property accepts the value `8000:8000` but the `expose` property not.

**- How I did it**
After reading the [API Reference](https://docs.docker.com/reference/compose-file/services/#ports) of Docker Compose syntax, I wrote a test that covers all the cases and then implemented the validation method until the tests pass.

**- How to verify it**
Run `make test`

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Implement the ports validation method for compose
```
