### PR TITLE
Improve completion of containers for `docker rm`

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -38,7 +38,9 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container rm, docker container remove, docker rm",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCli, true, func(ctr container.Summary) bool {
+			return opts.force || ctr.State == "exited" || ctr.State == "created"
+		}),
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
**- What I did**
The cobra completion for `docker rm` completes all containers. This does not make much sense as not all containers are removable unless `--force` is given.
This PR aligns the completion to the legacy completion, where only removable containers are completed unless `--force` is given, see [here](https://github.com/docker/cli/blob/88f1e99e8e00825ec025e242b77175e8f7de4980/contrib/completion/bash/docker#L1862-L1879).

**- How I did it**
Added a filter to the call of `completion.ContainerNames` that filters on container status and the value of `--force`.

**- How to verify it**

**- Description for the changelog**
```markdown changelog
Improve completion of containers for `docker rm`
```

@thaJeztah PTAL
