### PR TITLE
cli/command/container: set empty args in tests and discard output

### DIFF
--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -127,7 +127,6 @@ func TestContainerListBuildContainerListOptions(t *testing.T) {
 
 func TestContainerListErrors(t *testing.T) {
 	testCases := []struct {
-		args              []string
 		flags             map[string]string
 		containerListFunc func(container.ListOptions) ([]container.Summary, error)
 		expectedError     string
@@ -157,10 +156,10 @@ func TestContainerListErrors(t *testing.T) {
 				containerListFunc: tc.containerListFunc,
 			}),
 		)
-		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			assert.Check(t, cmd.Flags().Set(key, value))
 		}
+		cmd.SetArgs([]string{})
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -180,6 +179,9 @@ func TestContainerListWithoutFormat(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-without-format.golden")
 }
@@ -194,6 +196,9 @@ func TestContainerListNoTrunc(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("no-trunc", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-without-format-no-trunc.golden")
@@ -210,6 +215,9 @@ func TestContainerListNamesMultipleTime(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("format", "{{.Names}} {{.Names}}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-name-name.golden")
@@ -226,6 +234,9 @@ func TestContainerListFormatTemplateWithArg(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("format", `{{.Names}} {{.Label "some.label"}}`))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-with-arg.golden")
@@ -275,6 +286,9 @@ func TestContainerListFormatSizeSetsOption(t *testing.T) {
 				},
 			})
 			cmd := newListCommand(cli)
+			cmd.SetArgs([]string{})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			assert.Check(t, cmd.Flags().Set("format", tc.format))
 			if tc.sizeFlag != "" {
 				assert.Check(t, cmd.Flags().Set("size", tc.sizeFlag))
@@ -297,6 +311,9 @@ func TestContainerListWithConfigFormat(t *testing.T) {
 		PsFormat: "{{ .Names }} {{ .Image }} {{ .Labels }} {{ .Size}}",
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-with-config-format.golden")
 }
@@ -314,6 +331,9 @@ func TestContainerListWithFormat(t *testing.T) {
 	t.Run("with format", func(t *testing.T) {
 		cli.OutBuffer().Reset()
 		cmd := newListCommand(cli)
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "container-list-with-format.golden")
@@ -322,6 +342,9 @@ func TestContainerListWithFormat(t *testing.T) {
 	t.Run("with format and quiet", func(t *testing.T) {
 		cli.OutBuffer().Reset()
 		cmd := newListCommand(cli)
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
 		assert.Check(t, cmd.Flags().Set("quiet", "true"))
 		assert.NilError(t, cmd.Execute())

--- a/cli/command/container/prune_test.go
+++ b/cli/command/container/prune_test.go
@@ -21,6 +21,7 @@ func TestContainerPrunePromptTermination(t *testing.T) {
 		},
 	})
 	cmd := NewPruneCommand(cli)
+	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	test.TerminatePrompt(ctx, t, cmd, cli)

--- a/cli/command/container/utils_test.go
+++ b/cli/command/container/utils_test.go
@@ -38,7 +38,7 @@ func waitFn(cid string) (<-chan container.WaitResponse, <-chan error) {
 }
 
 func TestWaitExitOrRemoved(t *testing.T) {
-	testcases := []struct {
+	tests := []struct {
 		cid      string
 		exitCode int
 	}{
@@ -61,9 +61,11 @@ func TestWaitExitOrRemoved(t *testing.T) {
 	}
 
 	client := &fakeClient{waitFunc: waitFn, Version: api.DefaultVersion}
-	for _, testcase := range testcases {
-		statusC := waitExitOrRemoved(context.Background(), client, testcase.cid, true)
-		exitCode := <-statusC
-		assert.Check(t, is.Equal(testcase.exitCode, exitCode))
+	for _, tc := range tests {
+		t.Run(tc.cid, func(t *testing.T) {
+			statusC := waitExitOrRemoved(context.Background(), client, tc.cid, true)
+			exitCode := <-statusC
+			assert.Check(t, is.Equal(tc.exitCode, exitCode))
+		})
 	}
 }


### PR DESCRIPTION
### cli/command/container: set empty args in tests and discard output

Prevent some tests from failing when running from a pre-compiled testbinary, and discard output to make the output less noisy.

### cli/command/container: TestWaitExitOrRemoved use subtests

    === RUN   TestWaitExitOrRemoved
    === RUN   TestWaitExitOrRemoved/normal-container
    === RUN   TestWaitExitOrRemoved/give-me-exit-code-42
    === RUN   TestWaitExitOrRemoved/i-want-a-wait-error
    time="2024-10-13T18:48:14+02:00" level=error msg="Error waiting for container: removal failed"
    === RUN   TestWaitExitOrRemoved/non-existent-container-id
    time="2024-10-13T18:48:14+02:00" level=error msg="error waiting for container: no such container: non-existent-container-id"
    --- PASS: TestWaitExitOrRemoved (0.00s)
        --- PASS: TestWaitExitOrRemoved/normal-container (0.00s)
        --- PASS: TestWaitExitOrRemoved/give-me-exit-code-42 (0.00s)
        --- PASS: TestWaitExitOrRemoved/i-want-a-wait-error (0.00s)
        --- PASS: TestWaitExitOrRemoved/non-existent-container-id (0.00s)
    PASS



**- A picture of a cute animal (not mandatory but encouraged)**

