### PR TITLE
cmd/docker: add tests for flag-completions, and refactor

### DIFF
--- a/cmd/docker/completions.go
+++ b/cmd/docker/completions.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/spf13/cobra"
 )
@@ -10,18 +9,15 @@ type contextStoreProvider interface {
 	ContextStore() store.Store
 }
 
-func registerCompletionFuncForGlobalFlags(dockerCLI contextStoreProvider, cmd *cobra.Command) error {
-	err := cmd.RegisterFlagCompletionFunc("context", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+func completeContextNames(dockerCLI contextStoreProvider) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		names, _ := store.Names(dockerCLI.ContextStore())
 		return names, cobra.ShellCompDirectiveNoFileComp
-	})
-	if err != nil {
-		return err
 	}
-	err = cmd.RegisterFlagCompletionFunc("log-level", completion.FromList("debug", "info", "warn", "error", "fatal"))
-	if err != nil {
-		return err
-	}
+}
 
-	return nil
+var logLevels = []string{"debug", "info", "warn", "error", "fatal", "panic"}
+
+func completeLogLevels(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return cobra.FixedCompletions(logLevels, cobra.ShellCompDirectiveNoFileComp)(nil, nil, "")
 }

--- a/cmd/docker/completions_test.go
+++ b/cmd/docker/completions_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/docker/cli/cli/context/store"
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type fakeCLI struct {
+	contextStore store.Store
+}
+
+func (c *fakeCLI) ContextStore() store.Store {
+	return c.contextStore
+}
+
+type fakeContextStore struct {
+	store.Store
+	names []string
+}
+
+func (f fakeContextStore) List() (c []store.Metadata, _ error) {
+	for _, name := range f.names {
+		c = append(c, store.Metadata{Name: name})
+	}
+	return c, nil
+}
+
+func TestCompleteContextNames(t *testing.T) {
+	expectedNames := []string{"context-b", "context-c", "context-a"}
+	cli := &fakeCLI{
+		contextStore: fakeContextStore{
+			names: expectedNames,
+		},
+	}
+
+	values, directives := completeContextNames(cli)(nil, nil, "")
+	assert.Check(t, is.Equal(directives, cobra.ShellCompDirectiveNoFileComp))
+	assert.Check(t, is.DeepEqual(values, expectedNames))
+}
+
+func TestCompleteLogLevels(t *testing.T) {
+	values, directives := completeLogLevels(nil, nil, "")
+	assert.Check(t, is.Equal(directives, cobra.ShellCompDirectiveNoFileComp))
+	assert.Check(t, is.DeepEqual(values, logLevels))
+}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -100,7 +100,11 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	cmd.SetErr(dockerCli.Err())
 
 	opts, helpCmd = cli.SetupRootCommand(cmd)
-	_ = registerCompletionFuncForGlobalFlags(dockerCli, cmd)
+
+	// TODO(thaJeztah): move configuring completion for these flags to where the flags are added.
+	_ = cmd.RegisterFlagCompletionFunc("context", completeContextNames(dockerCli))
+	_ = cmd.RegisterFlagCompletionFunc("log-level", completeLogLevels)
+
 	cmd.Flags().BoolP("version", "v", false, "Print version information and quit")
 	setFlagErrorFunc(dockerCli, cmd)
 


### PR DESCRIPTION
Remove the registerCompletionFuncForGlobalFlags for now, as the error it returned was ignored, so it didn't add much benefit, other than abstracting things.

Split the underlying completion-functions to separate functions, and add some basic tests for them.

Remove the completions helper, as it now didn't add much, and it saved having the dependency on the package.


**- A picture of a cute animal (not mandatory but encouraged)**

