### PR TITLE
cli/command/plugins: use errors.Join instead of custom cli.Errors, and deprecate cli.Errors

### DIFF
--- a/cli/command/plugin/remove.go
+++ b/cli/command/plugin/remove.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -36,17 +37,13 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runRemove(ctx context.Context, dockerCli command.Cli, opts *rmOptions) error {
-	var errs cli.Errors
+	var errs error
 	for _, name := range opts.plugins {
 		if err := dockerCli.Client().PluginRemove(ctx, name, types.PluginRemoveOptions{Force: opts.force}); err != nil {
-			errs = append(errs, err)
+			errs = errors.Join(errs, err)
 			continue
 		}
-		fmt.Fprintln(dockerCli.Out(), name)
+		_, _ = fmt.Fprintln(dockerCli.Out(), name)
 	}
-	// Do not simplify to `return errs` because even if errs == nil, it is not a nil-error interface value.
-	if errs != nil {
-		return errs
-	}
-	return nil
+	return errs
 }

--- a/cli/error.go
+++ b/cli/error.go
@@ -8,6 +8,8 @@ import (
 // Errors is a list of errors.
 // Useful in a loop if you don't want to return the error right away and you want to display after the loop,
 // all the errors that happened during the loop.
+//
+// Deprecated: use [errors.Join] instead; will be removed in the next release.
 type Errors []error
 
 func (errList Errors) Error() string {


### PR DESCRIPTION
### cli/command/plugins: use errors.Join instead of custom cli.Errors

This command was using a custom "multi-error" implementation, but it
had some limitations, and the formatting wasn't great.

This patch replaces it with Go's errors.Join.

Before:

    docker plugin remove one two three
    Error response from daemon: plugin "one" not found, Error response from daemon: plugin "two" not found, Error response from daemon: plugin "three" not found

After:

    docker plugin remove one two three
    Error response from daemon: plugin "one" not found
    Error response from daemon: plugin "two" not found
    Error response from daemon: plugin "three" not found


### cli: deprecate Errors type

The Errors type is no longer used by the CLI itself, and this custom
"multi-error" implementation had both limitations (empty list not being
`nil`), as well as formatting not being great. All of this making it not
something to recommend, and better handled with Go's stdlib.

As far as I could find, there's no external consumers of this, but let's
deprecate first, and remove in the next release.




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- improve formatting of errors during `docker plugin remove` 
- go-sdk: deprecate cli.Errors type in favour of Go's errors.Join
```

**- A picture of a cute animal (not mandatory but encouraged)**

