### PR TITLE
cli: remove deprecated Errors type

### DIFF
--- a/cli/error.go
+++ b/cli/error.go
@@ -2,27 +2,7 @@ package cli
 
 import (
 	"strconv"
-	"strings"
 )
-
-// Errors is a list of errors.
-// Useful in a loop if you don't want to return the error right away and you want to display after the loop,
-// all the errors that happened during the loop.
-//
-// Deprecated: use [errors.Join] instead; will be removed in the next release.
-type Errors []error
-
-func (errList Errors) Error() string {
-	if len(errList) < 1 {
-		return ""
-	}
-
-	out := make([]string, len(errList))
-	for i := range errList {
-		out[i] = errList[i].Error()
-	}
-	return strings.Join(out, ", ")
-}
 
 // StatusError reports an unsuccessful exit by a command.
 type StatusError struct {


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/cli/pull/5547
- [x] depends on https://github.com/docker/cli/pull/5548

### cli: remove deprecated Errors type

The Errors type was deprecated in d3bafa5f3ee9089f71d4c3e3d08267521107d73b,
which has been included in the 27.4.0 release.

This patch removes the type, as there are no external consumers.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- go-sdk: remove deprecated `cli.Errors` type
```

**- A picture of a cute animal (not mandatory but encouraged)**

