### PR TITLE
[27.x backport] cli/command: ConfigureAuth: fix deprecation comment

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -87,7 +87,8 @@ func GetDefaultAuthConfig(cfg *configfile.ConfigFile, checkCredStore bool, serve
 }
 
 // ConfigureAuth handles prompting of user's username and password if needed.
-// Deprecated: use PromptUserForCredentials instead.
+//
+// Deprecated: use [PromptUserForCredentials] instead.
 func ConfigureAuth(ctx context.Context, cli Cli, flUser, flPassword string, authConfig *registrytypes.AuthConfig, _ bool) error {
 	defaultUsername := authConfig.Username
 	serverAddress := authConfig.ServerAddress


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5551
- relates to https://github.com/docker/cli/pull/5344

Deprecation comments must have an empty line before them, otherwise tools and linters may not recognise them. While fixing this, also updated the reference to PromptUserForCredentials to be a docs-link to make it clickable.

Updates 6e4818e7d6d006f14ebac4c06fbe6ed958237408.

## Before this patch:

<img width="803" alt="Screenshot 2024-10-19 at 13 08 20" src="https://github.com/user-attachments/assets/f7440ac9-c920-4696-b7f8-422797bf5475">
<img width="1256" alt="Screenshot 2024-10-19 at 13 00 18" src="https://github.com/user-attachments/assets/b3775ecd-22a7-4082-8bad-87e29986f025">



## With this patch:


<img width="759" alt="Screenshot 2024-10-19 at 13 03 25" src="https://github.com/user-attachments/assets/ccd7c2c8-3f6e-4616-bff8-7e2ef3376792">
<img width="1262" alt="Screenshot 2024-10-19 at 13 03 17" src="https://github.com/user-attachments/assets/b7ec8f72-73db-48ed-96f0-0edefcbf8ad8">



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- go-sdk: fix deprecation of `cli/command.ConfigureAuth()`, which was deprecated since v27.2.1
```

**- A picture of a cute animal (not mandatory but encouraged)**
