### PR TITLE
[27.x backport] Fix bash completion for `events --filter daemon=`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -5081,7 +5081,7 @@ _docker_system_events() {
 			return
 			;;
 		daemon)
-			local name=$(__docker_q info | sed -n 's/^\(ID\|Name\): //p')
+			local name=$(__docker_q info --format '{{.Info.Name}} {{.Info.ID}}')
 			COMPREPLY=( $( compgen -W "$name" -- "${cur##*=}" ) )
 			return
 			;;


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5554

**- What I did**
Fixed the "legacy" bash completion for `events --filter daemon=` that no longer works.

**- How I did it**
Changed completion logic from parsing the bare `docker info` output to using a `--filter` matching the desired values.

**- How to verify it**
type
```shell
docker events --filter daemon=<tab><tab>
```
Before: no completion  
With this fix: completion of ID and hostname of the current docker daemon.

**- Description for the changelog**
Fixed bash completion for `events --filter daemon=`

```markdown changelog
Fixed bash completion for `events --filter daemon=`
```

**- A picture of a cute animal (not mandatory but encouraged)**

