### PR TITLE
[27.x backport] cli/command/container: set empty args in tests and discard output

### DIFF
--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -128,7 +128,6 @@ func TestContainerListBuildContainerListOptions(t *testing.T) {
 
 func TestContainerListErrors(t *testing.T) {
 	testCases := []struct {
-		args              []string
 		flags             map[string]string
 		containerListFunc func(container.ListOptions) ([]types.Container, error)
 		expectedError     string
@@ -158,10 +157,10 @@ func TestContainerListErrors(t *testing.T) {
 				containerListFunc: tc.containerListFunc,
 			}),
 		)
-		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
 			assert.Check(t, cmd.Flags().Set(key, value))
 		}
+		cmd.SetArgs([]string{})
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)
@@ -181,6 +180,9 @@ func TestContainerListWithoutFormat(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-without-format.golden")
 }
@@ -195,6 +197,9 @@ func TestContainerListNoTrunc(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("no-trunc", "true"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-without-format-no-trunc.golden")
@@ -211,6 +216,9 @@ func TestContainerListNamesMultipleTime(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("format", "{{.Names}} {{.Names}}"))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-name-name.golden")
@@ -227,6 +235,9 @@ func TestContainerListFormatTemplateWithArg(t *testing.T) {
 		},
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.Check(t, cmd.Flags().Set("format", `{{.Names}} {{.Label "some.label"}}`))
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-format-with-arg.golden")
@@ -276,6 +287,9 @@ func TestContainerListFormatSizeSetsOption(t *testing.T) {
 				},
 			})
 			cmd := newListCommand(cli)
+			cmd.SetArgs([]string{})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			assert.Check(t, cmd.Flags().Set("format", tc.format))
 			if tc.sizeFlag != "" {
 				assert.Check(t, cmd.Flags().Set("size", tc.sizeFlag))
@@ -298,6 +312,9 @@ func TestContainerListWithConfigFormat(t *testing.T) {
 		PsFormat: "{{ .Names }} {{ .Image }} {{ .Labels }} {{ .Size}}",
 	})
 	cmd := newListCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	assert.NilError(t, cmd.Execute())
 	golden.Assert(t, cli.OutBuffer().String(), "container-list-with-config-format.golden")
 }
@@ -315,6 +332,9 @@ func TestContainerListWithFormat(t *testing.T) {
 	t.Run("with format", func(t *testing.T) {
 		cli.OutBuffer().Reset()
 		cmd := newListCommand(cli)
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "container-list-with-format.golden")
@@ -323,6 +343,9 @@ func TestContainerListWithFormat(t *testing.T) {
 	t.Run("with format and quiet", func(t *testing.T) {
 		cli.OutBuffer().Reset()
 		cmd := newListCommand(cli)
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		assert.Check(t, cmd.Flags().Set("format", "{{ .Names }} {{ .Image }} {{ .Labels }}"))
 		assert.Check(t, cmd.Flags().Set("quiet", "true"))
 		assert.NilError(t, cmd.Execute())

--- a/cli/command/container/prune_test.go
+++ b/cli/command/container/prune_test.go
@@ -21,6 +21,7 @@ func TestContainerPrunePromptTermination(t *testing.T) {
 		},
 	})
 	cmd := NewPruneCommand(cli)
+	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	test.TerminatePrompt(ctx, t, cmd, cli)

--- a/cli/command/container/utils_test.go
+++ b/cli/command/container/utils_test.go
@@ -38,7 +38,7 @@ func waitFn(cid string) (<-chan container.WaitResponse, <-chan error) {
 }
 
 func TestWaitExitOrRemoved(t *testing.T) {
-	testcases := []struct {
+	tests := []struct {
 		cid      string
 		exitCode int
 	}{
@@ -61,9 +61,11 @@ func TestWaitExitOrRemoved(t *testing.T) {
 	}
 
 	client := &fakeClient{waitFunc: waitFn, Version: api.DefaultVersion}
-	for _, testcase := range testcases {
-		statusC := waitExitOrRemoved(context.Background(), client, testcase.cid, true)
-		exitCode := <-statusC
-		assert.Check(t, is.Equal(testcase.exitCode, exitCode))
+	for _, tc := range tests {
+		t.Run(tc.cid, func(t *testing.T) {
+			statusC := waitExitOrRemoved(context.Background(), client, tc.cid, true)
+			exitCode := <-statusC
+			assert.Check(t, is.Equal(tc.exitCode, exitCode))
+		})
 	}
 }


### PR DESCRIPTION
**- What I did**
Backports https://github.com/docker/cli/pull/5534 to 27.x branch

**- How I did it**
```
git cherry-pick -xsS 3b38dc67be367589c1d58000413d8f66d4670c1c
git cherry-pick -xsS 35d7b1a7a6426080f44e044b6564cee990b35eab
```

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

