### PR TITLE
[25.0 backport] docs, man: dockerd: add documentation for "--log-format" option

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -79,6 +79,7 @@ Options:
       --label list                            Set key=value labels to the daemon
       --live-restore                          Enable live restore of docker when containers are still running
       --log-driver string                     Default driver for container logs (default "json-file")
+      --log-format string                     Set the logging format ("text"|"json") (default "text")
   -l, --log-level string                      Set the logging level ("debug"|"info"|"warn"|"error"|"fatal") (default "info")
       --log-opt map                           Default log driver options for containers (default map[])
       --max-concurrent-downloads int          Set the max concurrent downloads (default 3)
@@ -895,6 +896,33 @@ Alternatively, you can set custom locations for CDI specifications using the
 When CDI is enabled for a daemon, you can view the configured CDI specification
 directories using the `docker info` command.
 
+#### <a name="log-format"></a> Daemon logging format
+
+The `--log-format` option or "log-format" option in the [daemon configuration file](#daemon-configuration-file)
+lets you set the format for logs produced by the daemon. The logging format should
+only be configured either through the `--log-format` command line option or
+through the "log-format" field in the configuration file; using both
+the command-line option and the "log-format" field in the configuration
+file produces an error. If this option is not set, the default is "text".
+
+The following example configures the daemon through the `--log-format` command
+line option to use `json` formatted logs;
+
+```console
+$ dockerd --log-format=json
+# ...
+{"level":"info","msg":"API listen on /var/run/docker.sock","time":"2024-09-16T11:06:08.558145428Z"}
+```
+
+The following example shows a `daemon.json` configuration file with the
+"log-format" set;
+
+```json
+{
+  "log-format": "json"
+}
+```
+
 ### Miscellaneous options
 
 IP masquerading uses address translation to allow containers without a public
@@ -1094,6 +1122,7 @@ The following is a full example of the allowed configuration options on Linux:
   "labels": [],
   "live-restore": true,
   "log-driver": "json-file",
+  "log-format": "text",
   "log-level": "",
   "log-opts": {
     "cache-disabled": "false",
@@ -1189,6 +1218,7 @@ The following is a full example of the allowed configuration options on Windows:
   "insecure-registries": [],
   "labels": [],
   "log-driver": "",
+  "log-format": "text",
   "log-level": "",
   "max-concurrent-downloads": 3,
   "max-concurrent-uploads": 5,

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -52,6 +52,7 @@ dockerd - Enable daemon mode
 [**--label**[=*[]*]]
 [**--live-restore**[=**false**]]
 [**--log-driver**[=*json-file*]]
+[**--log-format**="*text*|*json*"]
 [**--log-opt**[=*map[]*]]
 [**--mtu**[=*0*]]
 [**--max-concurrent-downloads**[=*3*]]
@@ -323,6 +324,9 @@ unix://[/path/to/socket] to use.
 **--log-driver**="**json-file**|**syslog**|**journald**|**gelf**|**fluentd**|**awslogs**|**splunk**|**etwlogs**|**gcplogs**|**none**"
   Default driver for container logs. Default is **json-file**.
   **Warning**: **docker logs** command works only for **json-file** logging driver.
+
+**--log-format**="*text*|*json*"
+  Set the format for logs produced by the daemon. Default is "text".
 
 **--log-opt**=[]
   Logging driver specific options.


### PR DESCRIPTION
**- What I did**
Backport https://github.com/docker/cli/pull/5438 to 25.0 branch

**- How I did it**
```
git cherry-pick -xsS 9ae514fdc7a39f0af23cd25f8c38e714a9d0e6ae
git cherry-pick -xsS baceb4b1586f38b9d6c031ab0a696f32c52852f3
```

**- Description for the changelog**
```markdown changelog
n/a
```

**- A picture of a cute animal (not mandatory but encouraged)**

