### PR TITLE
cli/config: improve error when failing to parse config file

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -143,7 +143,7 @@ func load(configDir string) (*configfile.ConfigFile, error) {
 	defer file.Close()
 	err = configFile.LoadFromReader(file)
 	if err != nil {
-		err = errors.Wrapf(err, "loading config file: %s: ", filename)
+		err = errors.Wrapf(err, "parsing config file (%s)", filename)
 	}
 	return configFile, err
 }

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -118,6 +118,17 @@ func TestEmptyJSON(t *testing.T) {
 	saveConfigAndValidateNewFormat(t, config, tmpHome)
 }
 
+func TestMalformedJSON(t *testing.T) {
+	tmpHome := t.TempDir()
+
+	fn := filepath.Join(tmpHome, ConfigFileName)
+	err := os.WriteFile(fn, []byte("{"), 0o600)
+	assert.NilError(t, err)
+
+	_, err = Load(tmpHome)
+	assert.Check(t, is.ErrorContains(err, fmt.Sprintf(`parsing config file (%s):`, fn)))
+}
+
 func TestNewJSON(t *testing.T) {
 	tmpHome := t.TempDir()
 


### PR DESCRIPTION
The format had a stray colon and space included. While fixing that, also updating the error message to clarify the error happened while parsing the file (not so much "loading" it).

Before:

    WARNING: Error loading config file: /root/.docker/config.json: : json: cannot unmarshal bool into Go struct field ConfigFile.features of type string

After:

    WARNING: Error parsing config file (/root/.docker/config.json): json: cannot unmarshal bool into Go struct field ConfigFile.features of type string

**- A picture of a cute animal (not mandatory but encouraged)**

