### PR TITLE
[27.x backport]cli/config/credentials: skip saving config-file if credentials didn't change

### DIFF
--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -27,6 +27,10 @@ func NewFileStore(file store) Store {
 
 // Erase removes the given credentials from the file store.
 func (c *fileStore) Erase(serverAddress string) error {
+	if _, exists := c.file.GetAuthConfigs()[serverAddress]; !exists {
+		// nothing to do; no credentials found for the given serverAddress
+		return nil
+	}
 	delete(c.file.GetAuthConfigs(), serverAddress)
 	return c.file.Save()
 }
@@ -52,9 +56,14 @@ func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
 	return c.file.GetAuthConfigs(), nil
 }
 
-// Store saves the given credentials in the file store.
+// Store saves the given credentials in the file store. This function is
+// idempotent and does not update the file if credentials did not change.
 func (c *fileStore) Store(authConfig types.AuthConfig) error {
 	authConfigs := c.file.GetAuthConfigs()
+	if oldAuthConfig, ok := authConfigs[authConfig.ServerAddress]; ok && oldAuthConfig == authConfig {
+		// Credentials didn't change, so skip updating the configuration file.
+		return nil
+	}
 	authConfigs[authConfig.ServerAddress] = authConfig
 	return c.file.Save()
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5553
- fixes https://github.com/moby/moby/discussions/48529


Before this change, the config-file was always updated, even if there were no changes to save. This could cause issues when the config-file already had credentials set and was read-only for the current user.

For example, on NixOS, this poses a problem because `config.json` is a symlink to a write-protected file;

```bash
$ readlink ~/.docker/config.json
/home/username/.config/sops-nix/secrets/ghcr_auth

$ readlink -f ~/.docker/config.json
/run/user/1000/secrets.d/28/ghcr_auth
```

Which causes `docker login` to fail, even if no changes were to be made;

```console
Error saving credentials: rename /home/derek/.docker/config.json2180380217 /home/username/.config/sops-nix/secrets/ghcr_auth: invalid cross-device link
```

This patch updates the code to only update the config file if changes were detected. It there's nothing to save, it skips updating the file, as well as skips printing the warning about credentials being stored insecurely.

With this patch applied:

```bash
$ docker login -u yourname
Password:

WARNING! Your credentials are stored unencrypted in '/root/.docker/config.json'.
Configure a credential helper to remove this warning. See
https://docs.docker.com/go/credential-store/

Login Succeeded

$ docker login -u yourname
Password:
Login Succeeded
```

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
The `docker login` and `docker logout` command no longer update the configuration file if the credentials didn't change.
```

**- A picture of a cute animal (not mandatory but encouraged)**

