### PR TITLE
docker inspect: add support for swarm configs

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -51,7 +51,7 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
 	var elementSearcher inspect.GetRefFunc
 	switch opts.inspectType {
-	case "", "container", "image", "node", "network", "service", "volume", "task", "plugin", "secret":
+	case "", "config", "container", "image", "network", "node", "plugin", "secret", "service", "task", "volume":
 		elementSearcher = inspectAll(ctx, dockerCli, opts.size, opts.inspectType)
 	default:
 		return errors.Errorf("%q is not a valid value for --type", opts.inspectType)
@@ -114,6 +114,12 @@ func inspectSecret(ctx context.Context, dockerCli command.Cli) inspect.GetRefFun
 	}
 }
 
+func inspectConfig(ctx context.Context, dockerCLI command.Cli) inspect.GetRefFunc {
+	return func(ref string) (any, []byte, error) {
+		return dockerCLI.Client().ConfigInspectWithRaw(ctx, ref)
+	}
+}
+
 func inspectAll(ctx context.Context, dockerCli command.Cli, getSize bool, typeConstraint string) inspect.GetRefFunc {
 	inspectAutodetect := []struct {
 		objectType      string
@@ -161,6 +167,11 @@ func inspectAll(ctx context.Context, dockerCli command.Cli, getSize bool, typeCo
 			objectType:      "secret",
 			isSwarmObject:   true,
 			objectInspector: inspectSecret(ctx, dockerCli),
+		},
+		{
+			objectType:      "config",
+			isSwarmObject:   true,
+			objectInspector: inspectConfig(ctx, dockerCli),
 		},
 	}
 

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -29,7 +29,7 @@ all the details of the format.
 
 ### <a name="type"></a> Specify target type (--type)
 
-`--type container|image|node|network|secret|service|volume|task|plugin`
+`--type config|container|image|node|network|secret|service|volume|task|plugin`
 
 The `docker inspect` command matches any type of object by either ID or name. In
 some cases multiple type of objects (for example, a container and a volume)


### PR DESCRIPTION
The docker inspect command did not inspect configs. This patch adds support for it, and while at it, also sorts the list of objects in runInspect.

Before this patch:

    docker config create myconfig ./codecov.yml
    danpeyh8qzb30vgdj9fr665l1

    docker inspect --format='{{.ID}}' myconfig
    []
    Error: No such object: myconfig

    docker inspect --format='{{.ID}}' --type=config myconfig
    "config" is not a valid value for --type

With this patch:

    docker inspect --format='{{.ID}}' myconfig
    danpeyh8qzb30vgdj9fr665l1

    docker inspect --format='{{.ID}}' --type=config myconfig
    danpeyh8qzb30vgdj9fr665l1

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
docker inspect now also allows inspecting swarm configs
```

**- A picture of a cute animal (not mandatory but encouraged)**

