### PR TITLE
Improve Cobra completions for `run` and `create`

### DIFF
--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -71,6 +71,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
 	_ = cmd.RegisterFlagCompletionFunc("storage-opt", completeStorageOpt)
 	_ = cmd.RegisterFlagCompletionFunc("ulimit", completeUlimit)
+	_ = cmd.RegisterFlagCompletionFunc("userns", completion.FromList("host"))
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
 }
 

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -64,6 +64,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("ipc", completeIpc(dockerCLI))
 	_ = cmd.RegisterFlagCompletionFunc("link", completeLink(dockerCLI))
 	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCLI))
+	_ = cmd.RegisterFlagCompletionFunc("pid", completePid(dockerCLI))
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
 	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
@@ -96,6 +97,20 @@ func completeIpc(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command
 func completeLink(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return postfixWith(":", containerNames(dockerCLI, cmd, args, toComplete)), cobra.ShellCompDirectiveNoSpace
+	}
+}
+
+// completePid implements shell completion for the `--pid` option  of `run` and `create`.
+func completePid(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(toComplete) > 0 && strings.HasPrefix("container", toComplete) { //nolint:gocritic // not swapped, matches partly typed "container"
+			return []string{"container:"}, cobra.ShellCompDirectiveNoSpace
+		}
+		if strings.HasPrefix(toComplete, "container:") {
+			names, _ := completion.ContainerNames(dockerCLI, true)(cmd, args, toComplete)
+			return prefixWith("container:", names), cobra.ShellCompDirectiveNoFileComp
+		}
+		return []string{"container:", "host"}, cobra.ShellCompDirectiveNoFileComp
 	}
 }
 

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -134,6 +134,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("storage-opt", completeStorageOpt)
 	_ = cmd.RegisterFlagCompletionFunc("ulimit", completeUlimit)
 	_ = cmd.RegisterFlagCompletionFunc("userns", completion.FromList("host"))
+	_ = cmd.RegisterFlagCompletionFunc("uts", completion.FromList("host"))
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
 }
 

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -69,6 +69,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
 	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
 	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
+	_ = cmd.RegisterFlagCompletionFunc("storage-opt", completeStorageOpt)
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
 }
 
@@ -112,6 +113,11 @@ func completePid(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command
 		}
 		return []string{"container:", "host"}, cobra.ShellCompDirectiveNoFileComp
 	}
+}
+
+// completeStorageOpt implements shell completion for the `--storage-opt` option  of `run` and `create`.
+func completeStorageOpt(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{"size="}, cobra.ShellCompDirectiveNoSpace
 }
 
 // containerNames contacts the API to get names and optionally IDs of containers.

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -118,6 +118,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("attach", completion.FromList("stderr", "stdin", "stdout"))
 	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
 	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
+	_ = cmd.RegisterFlagCompletionFunc("cgroupns", completeCgroupns())
 	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
 	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
 	_ = cmd.RegisterFlagCompletionFunc("ipc", completeIpc(dockerCLI))
@@ -136,6 +137,11 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("userns", completion.FromList("host"))
 	_ = cmd.RegisterFlagCompletionFunc("uts", completion.FromList("host"))
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
+}
+
+// completeCgroupns implements shell completion for the `--cgroupns` option of `run` and `create`.
+func completeCgroupns() completion.ValidArgsFn {
+	return completion.FromList(string(container.CgroupnsModeHost), string(container.CgroupnsModePrivate))
 }
 
 // completeDetachKeys implements shell completion for the `--detach-keys` option of `run` and `create`.

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -70,6 +70,7 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
 	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
 	_ = cmd.RegisterFlagCompletionFunc("storage-opt", completeStorageOpt)
+	_ = cmd.RegisterFlagCompletionFunc("ulimit", completeUlimit)
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
 }
 
@@ -118,6 +119,32 @@ func completePid(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command
 // completeStorageOpt implements shell completion for the `--storage-opt` option  of `run` and `create`.
 func completeStorageOpt(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	return []string{"size="}, cobra.ShellCompDirectiveNoSpace
+}
+
+// completeUlimit implements shell completion for the `--ulimit` option of `run` and `create`.
+func completeUlimit(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	limits := []string{
+		"as",
+		"chroot",
+		"core",
+		"cpu",
+		"data",
+		"fsize",
+		"locks",
+		"maxlogins",
+		"maxsyslogins",
+		"memlock",
+		"msgqueue",
+		"nice",
+		"nofile",
+		"nproc",
+		"priority",
+		"rss",
+		"rtprio",
+		"sigpending",
+		"stack",
+	}
+	return postfixWith("=", limits), cobra.ShellCompDirectiveNoSpace
 }
 
 // containerNames contacts the API to get names and optionally IDs of containers.

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -54,6 +54,20 @@ var restartPolicies = []string{
 	string(container.RestartPolicyUnlessStopped),
 }
 
+// addCompletions adds the completions that `run` and `create` have in common.
+func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) {
+	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
+	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
+	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
+	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
+	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCLI))
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
+	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
+	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
+	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
+}
+
 func completeLinuxCapabilityNames(cmd *cobra.Command, args []string, toComplete string) (names []string, _ cobra.ShellCompDirective) {
 	return completion.FromList(allLinuxCapabilities()...)(cmd, args, toComplete)
 }

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -75,6 +75,11 @@ func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) 
 	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCLI, true))
 }
 
+// completeDetachKeys implements shell completion for the `--detach-keys` option of `run` and `create`.
+func completeDetachKeys(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return []string{"ctrl-"}, cobra.ShellCompDirectiveNoSpace
+}
+
 // completeIpc implements shell completion for the `--ipc` option of `run` and `create`.
 // The completion is partly composite.
 func completeIpc(dockerCLI completion.APIClientProvider) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -56,6 +56,7 @@ var restartPolicies = []string{
 
 // addCompletions adds the completions that `run` and `create` have in common.
 func addCompletions(cmd *cobra.Command, dockerCLI completion.APIClientProvider) {
+	_ = cmd.RegisterFlagCompletionFunc("attach", completion.FromList("stderr", "stdin", "stdout"))
 	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
 	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
 	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)

--- a/cli/command/container/completion_test.go
+++ b/cli/command/container/completion_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/cli/internal/test"
+	"github.com/docker/cli/internal/test/builders"
+	"github.com/docker/docker/api/types/container"
 	"github.com/moby/sys/signal"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
@@ -18,6 +21,48 @@ func TestCompleteLinuxCapabilityNames(t *testing.T) {
 	for _, name := range names[1:] {
 		assert.Check(t, strings.HasPrefix(name, "CAP_"))
 		assert.Check(t, is.Equal(name, strings.ToUpper(name)), "Should be formatted uppercase")
+	}
+}
+
+func TestCompletePid(t *testing.T) {
+	tests := []struct {
+		containerListFunc   func(container.ListOptions) ([]container.Summary, error)
+		toComplete          string
+		expectedCompletions []string
+		expectedDirective   cobra.ShellCompDirective
+	}{
+		{
+			toComplete:          "",
+			expectedCompletions: []string{"container:", "host"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			toComplete:          "c",
+			expectedCompletions: []string{"container:"},
+			expectedDirective:   cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			containerListFunc: func(container.ListOptions) ([]container.Summary, error) {
+				return []container.Summary{
+					*builders.Container("c1"),
+					*builders.Container("c2"),
+				}, nil
+			},
+			toComplete:          "container:",
+			expectedCompletions: []string{"container:c1", "container:c2"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.toComplete, func(t *testing.T) {
+			cli := test.NewFakeCli(&fakeClient{
+				containerListFunc: tc.containerListFunc,
+			})
+			completions, directive := completePid(cli)(NewRunCommand(cli), nil, tc.toComplete)
+			assert.Check(t, is.DeepEqual(completions, tc.expectedCompletions))
+			assert.Check(t, is.Equal(directive, tc.expectedDirective))
+		})
 	}
 }
 

--- a/cli/command/container/completion_test.go
+++ b/cli/command/container/completion_test.go
@@ -73,6 +73,59 @@ func TestCompleteRestartPolicies(t *testing.T) {
 	assert.Check(t, is.DeepEqual(values, expected))
 }
 
+func TestCompleteSecurityOpt(t *testing.T) {
+	tests := []struct {
+		toComplete          string
+		expectedCompletions []string
+		expectedDirective   cobra.ShellCompDirective
+	}{
+		{
+			toComplete:          "",
+			expectedCompletions: []string{"apparmor=", "label=", "no-new-privileges", "seccomp=", "systempaths=unconfined"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			toComplete:          "apparmor=",
+			expectedCompletions: []string{"apparmor="},
+			expectedDirective:   cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			toComplete:          "label=",
+			expectedCompletions: []string{"label=disable", "label=level:", "label=role:", "label=type:", "label=user:"},
+			expectedDirective:   cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			toComplete: "s",
+			// We do not filter matching completions but delegate this task to the shell script.
+			expectedCompletions: []string{"apparmor=", "label=", "no-new-privileges", "seccomp=", "systempaths=unconfined"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			toComplete:          "se",
+			expectedCompletions: []string{"seccomp="},
+			expectedDirective:   cobra.ShellCompDirectiveNoSpace,
+		},
+		{
+			toComplete:          "seccomp=",
+			expectedCompletions: []string{"seccomp=unconfined"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+		{
+			toComplete:          "sy",
+			expectedCompletions: []string{"apparmor=", "label=", "no-new-privileges", "seccomp=", "systempaths=unconfined"},
+			expectedDirective:   cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.toComplete, func(t *testing.T) {
+			completions, directive := completeSecurityOpt(nil, nil, tc.toComplete)
+			assert.Check(t, is.DeepEqual(completions, tc.expectedCompletions))
+			assert.Check(t, is.Equal(directive, tc.expectedDirective))
+		})
+	}
+}
+
 func TestCompleteSignals(t *testing.T) {
 	values, directives := completeSignals(nil, nil, "")
 	assert.Check(t, is.Equal(directives&cobra.ShellCompDirectiveNoFileComp, cobra.ShellCompDirectiveNoFileComp), "Should not perform file completion")

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -80,6 +80,13 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 
 	addCompletions(cmd, dockerCli)
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
+
 	return cmd
 }
 

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -78,16 +78,8 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
 	copts = addFlags(flags)
 
-	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
-	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
-	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
-	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
-	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
-	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
-	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCli, true))
+	addCompletions(cmd, dockerCli)
+
 	return cmd
 }
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -72,6 +72,13 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("detach-keys", completeDetachKeys)
 	addCompletions(cmd, dockerCli)
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
+
 	return cmd
 }
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -69,6 +69,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
 	copts = addFlags(flags)
 
+	_ = cmd.RegisterFlagCompletionFunc("detach-keys", completeDetachKeys)
 	addCompletions(cmd, dockerCli)
 
 	return cmd

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -69,16 +69,8 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
 	copts = addFlags(flags)
 
-	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
-	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
-	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
-	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
-	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
-	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
-	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCli, true))
+	addCompletions(cmd, dockerCli)
+
 	return cmd
 }
 


### PR DESCRIPTION
**- What I did**
Added Cobra completion for all options of `docker run` and `docker create`.

**- How I did it**
Provided `FlagCompletionFunc`s for all options except for
- boolean flags (default completion works)
- flags with file completions (default completion works)
- flags that already had a completion function.

The reference for my work was the legacy bash completion.
Features that I did not recreate:
- completion for `--user`
- completion for the individual log driver options
- completion of non-built-in drivers

**- How to verify it**
1. In a dev container, issue `make completion`, then try completions of various `docker run` and `docker create` commands.
2. In another terminal, exec into the container, install the legacy completion with `. ./contrib/completion/bash/docker`. then execute the same completions for reference.

**- Description for the changelog**
Improved completions for `docker run` and `docker create`.

```markdown changelog
Ported some completions from the bash completion to the new cobra based completion.
```
