### PR TITLE
cli/command/container: unify completion funcs for create and run

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -75,19 +75,9 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Bool("help", false, "Print usage")
 
 	command.AddPlatformFlag(flags, &options.platform)
-	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
-	copts = addFlags(flags)
-
-	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
-	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
-	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
-	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
-	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
-	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCli, true))
+	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
+	copts = addContainerCreateFlags(cmd, dockerCli)
 	return cmd
 }
 

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -9,10 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
@@ -57,10 +59,16 @@ func parseRun(args []string) (*container.Config, *container.HostConfig, *network
 }
 
 func setupRunFlags() (*pflag.FlagSet, *containerOptions) {
-	flags := pflag.NewFlagSet("run", pflag.ContinueOnError)
+	dummyCmd := &cobra.Command{Use: "dummy"}
+	// This will panic when called, but never called in tests
+	type dummyCLI struct {
+		completion.APIClientProvider
+	}
+
+	flags := dummyCmd.Flags()
 	flags.SetOutput(io.Discard)
 	flags.Usage = nil
-	copts := addFlags(flags)
+	copts := addContainerCreateFlags(dummyCmd, dummyCLI{})
 	return flags, copts
 }
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -59,6 +59,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.name, "name", "", "Assign a name to the container")
 	flags.StringVar(&options.detachKeys, "detach-keys", "", "Override the key sequence for detaching a container")
 	flags.StringVar(&options.pull, "pull", PullImageMissing, `Pull image before running ("`+PullImageAlways+`", "`+PullImageMissing+`", "`+PullImageNever+`")`)
+	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Suppress the pull output")
 
 	// Add an explicit help that doesn't have a `-h` to prevent the conflict
@@ -66,19 +67,9 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Bool("help", false, "Print usage")
 
 	command.AddPlatformFlag(flags, &options.platform)
-	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
-	copts = addFlags(flags)
-
-	_ = cmd.RegisterFlagCompletionFunc("cap-add", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("cap-drop", completeLinuxCapabilityNames)
-	_ = cmd.RegisterFlagCompletionFunc("env", completion.EnvVarNames)
-	_ = cmd.RegisterFlagCompletionFunc("env-file", completion.FileNames)
-	_ = cmd.RegisterFlagCompletionFunc("network", completion.NetworkNames(dockerCli))
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	_ = cmd.RegisterFlagCompletionFunc("pull", completion.FromList(PullImageAlways, PullImageMissing, PullImageNever))
-	_ = cmd.RegisterFlagCompletionFunc("restart", completeRestartPolicies)
-	_ = cmd.RegisterFlagCompletionFunc("stop-signal", completeSignals)
-	_ = cmd.RegisterFlagCompletionFunc("volumes-from", completion.ContainerNames(dockerCli, true))
+	command.AddTrustVerificationFlags(flags, &options.untrusted, dockerCli.ContentTrustEnabled())
+	copts = addContainerCreateFlags(cmd, dockerCli)
 	return cmd
 }
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5580

Define completion funcs for create and run together with where the flags are defined.

**- A picture of a cute animal (not mandatory but encouraged)**

