### PR TITLE
docs: Correct `run` exit code 126 description

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -285,7 +285,7 @@ See 'docker run --help'.
 ### 126
 
 Exit code `126` indicates that the specified contained command can't be invoked.
-The container command in the following example is: `/etc; echo $?`.
+The container command in the following example is: `/etc`.
 
 ```console
 $ docker run busybox /etc; echo $?


### PR DESCRIPTION
The command to run inside the container is `/etc`. The semicolon is a statement terminator, which ends the command `docker run busybox /etc`, while `echo $?` prints the exit code of that full docker command.

Having this mistake could confuse someone who thinks that `/etc; echo $?` is all run inside the container, which wouldn't help the reader understand the exit code of the `docker run` command itself.
