### PR TITLE
golangci-lint: set go version to prevent fallback to go1.17, and fix copyloopvar linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,9 @@ linters:
     - errcheck
 
 run:
+  # prevent golangci-lint from deducting the go version to lint for through go.mod,
+  # which causes it to fallback to go1.17 semantics.
+  go: "1.23.2"
   timeout: 5m
 
 linters-settings:

--- a/cli-plugins/manager/cobra.go
+++ b/cli-plugins/manager/cobra.go
@@ -52,7 +52,6 @@ func AddPluginCommandStubs(dockerCli command.Cli, rootCmd *cobra.Command) (err e
 			return
 		}
 		for _, p := range plugins {
-			p := p
 			vendor := p.Vendor
 			if vendor == "" {
 				vendor = "unknown"

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -187,19 +187,18 @@ func TestInitializeFromClient(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
-		testcase := testcase
-		t.Run(testcase.doc, func(t *testing.T) {
+	for _, tc := range testcases {
+		t.Run(tc.doc, func(t *testing.T) {
 			apiclient := &fakeClient{
-				pingFunc: testcase.pingFunc,
+				pingFunc: tc.pingFunc,
 				version:  defaultVersion,
 			}
 
 			cli := &DockerCli{client: apiclient}
 			err := cli.Initialize(flags.NewClientOptions())
 			assert.NilError(t, err)
-			assert.DeepEqual(t, cli.ServerInfo(), testcase.expectedServer)
-			assert.Equal(t, apiclient.negotiated, testcase.negotiated)
+			assert.DeepEqual(t, cli.ServerInfo(), tc.expectedServer)
+			assert.Equal(t, apiclient.negotiated, tc.negotiated)
 		})
 	}
 }
@@ -277,10 +276,9 @@ func TestExperimentalCLI(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
-		testcase := testcase
-		t.Run(testcase.doc, func(t *testing.T) {
-			dir := fs.NewDir(t, testcase.doc, fs.WithFile("config.json", testcase.configfile))
+	for _, tc := range testcases {
+		t.Run(tc.doc, func(t *testing.T) {
+			dir := fs.NewDir(t, tc.doc, fs.WithFile("config.json", tc.configfile))
 			defer dir.Remove()
 			apiclient := &fakeClient{
 				version: defaultVersion,

--- a/cli/command/completion/functions_test.go
+++ b/cli/command/completion/functions_test.go
@@ -150,7 +150,6 @@ func TestCompleteContainerNames(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			if tc.showIDs {
 				t.Setenv("DOCKER_COMPLETION_SHOW_CONTAINER_IDS", "yes")
@@ -227,7 +226,6 @@ func TestCompleteImageNames(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			comp := ImageNames(fakeCLI{&fakeClient{
 				imageListFunc: func(options image.ListOptions) ([]image.Summary, error) {
@@ -273,7 +271,6 @@ func TestCompleteNetworkNames(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			comp := NetworkNames(fakeCLI{&fakeClient{
 				networkListFunc: func(ctx context.Context, options network.ListOptions) ([]network.Summary, error) {
@@ -331,7 +328,6 @@ func TestCompleteVolumeNames(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			comp := VolumeNames(fakeCLI{&fakeClient{
 				volumeListFunc: func(filter filters.Args) (volume.ListResponse, error) {

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -43,7 +43,6 @@ func TestConfigCreateErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			cmd := newConfigCreateCommand(
 				test.NewFakeCli(&fakeClient{

--- a/cli/command/config/formatter_test.go
+++ b/cli/command/config/formatter_test.go
@@ -61,7 +61,6 @@ id_rsa
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -73,7 +73,6 @@ func TestNewAttachCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc}))
 			cmd.SetOut(io.Discard)

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -178,7 +178,6 @@ func TestSplitCpArg(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			if tc.os == "windows" && runtime.GOOS != "windows" {
 				t.Skip("skipping windows test on non-windows platform")

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -113,7 +113,6 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.PullPolicy, func(t *testing.T) {
 			pullCounter := 0
 
@@ -176,7 +175,6 @@ func TestCreateContainerImagePullPolicyInvalid(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.PullPolicy, func(t *testing.T) {
 			dockerCli := test.NewFakeCli(&fakeClient{})
 			err := runCreate(
@@ -207,7 +205,6 @@ func TestCreateContainerValidateFlags(t *testing.T) {
 			expectedErr: `invalid argument "STDINFO" for "-a, --attach" flag: valid streams are STDIN, STDOUT and STDERR`,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewCreateCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
@@ -251,7 +248,6 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		fakeCLI := test.NewFakeCli(&fakeClient{
 			createContainerFunc: func(config *container.Config,
 				hostConfig *container.HostConfig,
@@ -312,7 +308,6 @@ func TestNewCreateCommandWithWarnings(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeCLI := test.NewFakeCli(&fakeClient{
 				createContainerFunc: func(config *container.Config,

--- a/cli/command/container/formatter_diff_test.go
+++ b/cli/command/container/formatter_diff_test.go
@@ -47,7 +47,6 @@ D: /usr/app/old_app.js
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			out := bytes.NewBufferString("")
 			tc.context.Output = out

--- a/cli/command/container/formatter_stats_test.go
+++ b/cli/command/container/formatter_stats_test.go
@@ -178,7 +178,6 @@ container2  --  --
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out
@@ -223,7 +222,6 @@ func TestContainerStatsContextWriteWithNoStats(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			err := statsFormatWrite(tc.context, []StatsEntry{}, "linux", false)
 			assert.NilError(t, err)
@@ -265,7 +263,6 @@ func TestContainerStatsContextWriteWithNoStatsWindows(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			err := statsFormatWrite(tc.context, []StatsEntry{}, "windows", false)
 			assert.NilError(t, err)

--- a/cli/command/container/list_test.go
+++ b/cli/command/container/list_test.go
@@ -277,7 +277,6 @@ func TestContainerListFormatSizeSetsOption(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				containerListFunc: func(options container.ListOptions) ([]container.Summary, error) {

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -762,7 +762,6 @@ func parseNetworkOpts(copts *containerOptions) (map[string]*networktypes.Endpoin
 	}
 
 	for i, n := range copts.netMode.Value() {
-		n := n
 		if container.NetworkMode(n.Target).IsUserDefined() {
 			hasUserDefined = true
 		} else {

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -126,7 +126,6 @@ func TestParseRunAttach(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			config, _, _ := mustParse(t, tc.input)
 			assert.Equal(t, config.AttachStdin, tc.expected.AttachStdin)
@@ -802,7 +801,6 @@ func TestParseRestartPolicy(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			_, hostConfig, _, err := parseRun([]string{"--restart=" + tc.input, "img", "cmd"})
 			if tc.expectedErr != "" {

--- a/cli/command/container/port_test.go
+++ b/cli/command/container/port_test.go
@@ -43,7 +43,6 @@ func TestNewPortCommandOutput(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				inspectFunc: func(string) (container.InspectResponse, error) {

--- a/cli/command/container/restart_test.go
+++ b/cli/command/container/restart_test.go
@@ -58,7 +58,6 @@ func TestRestart(t *testing.T) {
 			expectedErr: "conflicting options: cannot specify both --timeout and --time",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var restarted []string
 			mutex := new(sync.Mutex)

--- a/cli/command/container/rm_test.go
+++ b/cli/command/container/rm_test.go
@@ -23,7 +23,6 @@ func TestRemoveForce(t *testing.T) {
 		{name: "without force", args: []string{"nosuchcontainer", "mycontainer"}, expectedErr: "no such container"},
 		{name: "with force", args: []string{"--force", "nosuchcontainer", "mycontainer"}, expectedErr: ""},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var removed []string
 			mutex := new(sync.Mutex)

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -35,7 +35,6 @@ func TestRunValidateFlags(t *testing.T) {
 			expectedErr: "conflicting options: cannot specify both --attach and --detach",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewRunCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
@@ -245,7 +244,6 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			fakeCLI := test.NewFakeCli(&fakeClient{
 				createContainerFunc: func(config *container.Config,
@@ -286,7 +284,6 @@ func TestRunContainerImagePullPolicyInvalid(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.PullPolicy, func(t *testing.T) {
 			dockerCli := test.NewFakeCli(&fakeClient{})
 			err := runRun(

--- a/cli/command/container/stop_test.go
+++ b/cli/command/container/stop_test.go
@@ -58,7 +58,6 @@ func TestStop(t *testing.T) {
 			expectedErr: "conflicting options: cannot specify both --timeout and --time",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var stopped []string
 			mutex := new(sync.Mutex)

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -94,7 +94,6 @@ func TestCreate(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.options.Name, func(t *testing.T) {
 			err := RunCreate(cli, &tc.options)
 			if tc.expecterErr == "" {
@@ -164,25 +163,24 @@ func TestCreateFromContext(t *testing.T) {
 
 	cli.SetCurrentContext("dummy")
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			cli.ResetOutputBuffers()
 			err := RunCreate(cli, &CreateOptions{
 				From:        "original",
-				Name:        c.name,
-				Description: c.description,
-				Docker:      c.docker,
+				Name:        tc.name,
+				Description: tc.description,
+				Docker:      tc.docker,
 			})
 			assert.NilError(t, err)
-			assertContextCreateLogging(t, cli, c.name)
-			newContext, err := cli.ContextStore().GetMetadata(c.name)
+			assertContextCreateLogging(t, cli, tc.name)
+			newContext, err := cli.ContextStore().GetMetadata(tc.name)
 			assert.NilError(t, err)
 			newContextTyped, err := command.GetDockerContext(newContext)
 			assert.NilError(t, err)
 			dockerEndpoint, err := docker.EndpointFromContext(newContext)
 			assert.NilError(t, err)
-			assert.Equal(t, newContextTyped.Description, c.expectedDescription)
+			assert.Equal(t, newContextTyped.Description, tc.expectedDescription)
 			assert.Equal(t, dockerEndpoint.Host, "tcp://42.42.42.42:2375")
 		})
 	}
@@ -219,23 +217,22 @@ func TestCreateFromCurrent(t *testing.T) {
 
 	cli.SetCurrentContext("original")
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			cli.ResetOutputBuffers()
 			err := RunCreate(cli, &CreateOptions{
-				Name:        c.name,
-				Description: c.description,
+				Name:        tc.name,
+				Description: tc.description,
 			})
 			assert.NilError(t, err)
-			assertContextCreateLogging(t, cli, c.name)
-			newContext, err := cli.ContextStore().GetMetadata(c.name)
+			assertContextCreateLogging(t, cli, tc.name)
+			newContext, err := cli.ContextStore().GetMetadata(tc.name)
 			assert.NilError(t, err)
 			newContextTyped, err := command.GetDockerContext(newContext)
 			assert.NilError(t, err)
 			dockerEndpoint, err := docker.EndpointFromContext(newContext)
 			assert.NilError(t, err)
-			assert.Equal(t, newContextTyped.Description, c.expectedDescription)
+			assert.Equal(t, newContextTyped.Description, tc.expectedDescription)
 			assert.Equal(t, dockerEndpoint.Host, "tcp://42.42.42.42:2375")
 		})
 	}

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -346,7 +346,6 @@ size: 0B
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out
@@ -411,7 +410,6 @@ func TestContainerContextWriteWithNoContainers(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			err := ContainerWrite(tc.context, containers)
 			assert.NilError(t, err)

--- a/cli/command/formatter/disk_usage_test.go
+++ b/cli/command/formatter/disk_usage_test.go
@@ -106,7 +106,6 @@ Build Cache     0         0         0B        0B
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -304,7 +304,6 @@ image_id: imageID3
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out
@@ -365,7 +364,6 @@ func TestImageContextWriteWithNoImage(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			err := ImageWrite(tc.context, images)
 			assert.NilError(t, err)

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -131,7 +131,6 @@ foobar_bar
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/image/formatter_history_test.go
+++ b/cli/command/image/formatter_history_test.go
@@ -255,7 +255,6 @@ imageID6   17 years ago   /bin/bash echo                                  183MB 
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			err := HistoryWrite(tc.context, true, histories)
 			assert.NilError(t, err)

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -42,7 +42,6 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
 			cmd.SetOut(io.Discard)
@@ -109,7 +108,6 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Set to UTC timezone as timestamps in output are
 			// printed in the current timezone

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -98,7 +98,6 @@ func TestNewImportCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
 			cmd.SetOut(io.Discard)

--- a/cli/command/image/inspect_test.go
+++ b/cli/command/image/inspect_test.go
@@ -25,7 +25,6 @@ func TestNewInspectCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newInspectCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
@@ -79,7 +78,6 @@ func TestNewInspectCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			imageInspectInvocationCount = 0
 			cli := test.NewFakeCli(&fakeClient{imageInspectFunc: tc.imageInspectFunc})

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -35,7 +35,6 @@ func TestNewImagesCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
 			cmd.SetOut(io.Discard)
@@ -83,7 +82,6 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc})
 			cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -52,7 +52,6 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 			cli.In().SetIsTerminal(tc.isTerminalIn)
@@ -116,7 +115,6 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 			cmd := NewLoadCommand(cli)

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -39,7 +39,6 @@ func TestNewPruneCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
 				imagesPruneFunc: tc.imagesPruneFunc,
@@ -98,7 +97,6 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imagesPruneFunc: tc.imagesPruneFunc})
 			// when prompted, answer "Y" to confirm the prune.

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -38,7 +38,6 @@ func TestNewPullCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
 			cmd := NewPullCommand(cli)
@@ -73,7 +72,6 @@ func TestNewPullCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				imagePullFunc: func(ref string, options image.PullOptions) (io.ReadCloser, error) {
@@ -119,7 +117,6 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				imagePullFunc: func(ref string, options image.PullOptions) (io.ReadCloser, error) {

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -38,7 +38,6 @@ func TestNewPushCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
 			cmd := NewPushCommand(cli)
@@ -68,7 +67,6 @@ func TestNewPushCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				imagePushFunc: func(ref string, options image.PushOptions) (io.ReadCloser, error) {

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -62,7 +62,6 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
 				imageRemoveFunc: tc.imageRemoveFunc,
@@ -121,7 +120,6 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc})
 			cmd := NewRemoveCommand(cli)

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -59,7 +59,6 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 			cli.Out().SetIsTerminal(tc.isTerminal)
@@ -113,7 +112,6 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
 			cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
 				imageSaveFunc: tc.imageSaveFunc,

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -56,7 +56,6 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) error
 				continue
 			}
 
-			im := im
 			sub := subImage{
 				Platform:  platforms.Format(im.ImageData.Platform),
 				Available: im.Available,

--- a/cli/command/manifest/create_test.go
+++ b/cli/command/manifest/create_test.go
@@ -31,7 +31,6 @@ func TestManifestCreateErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			cli := test.NewFakeCli(nil)
 			cmd := newCreateListCommand(cli)

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -218,7 +218,6 @@ func TestNetworkCreateIPv6(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				networkCreateFunc: func(ctx context.Context, name string, createBody network.CreateOptions) (network.CreateResponse, error) {

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -161,7 +161,6 @@ foobar_bar 2017-01-01 00:00:00 +0000 UTC
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/network/list_test.go
+++ b/cli/command/network/list_test.go
@@ -83,7 +83,6 @@ func TestNetworkList(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{networkListFunc: tc.networkListFunc})
 			cmd := newListCommand(cli)

--- a/cli/command/network/remove_test.go
+++ b/cli/command/network/remove_test.go
@@ -63,7 +63,6 @@ func TestNetworkRemoveForce(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			fakeCli := test.NewFakeCli(&fakeClient{
 				networkRemoveFunc: func(ctx context.Context, networkID string) error {

--- a/cli/command/node/formatter_test.go
+++ b/cli/command/node/formatter_test.go
@@ -202,7 +202,6 @@ foobar_boo  Unknown
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/node/inspect_test.go
+++ b/cli/command/node/inspect_test.go
@@ -106,7 +106,6 @@ func TestNodeInspectPretty(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				nodeInspectFunc: tc.nodeInspectFunc,

--- a/cli/command/node/ps_test.go
+++ b/cli/command/node/ps_test.go
@@ -134,7 +134,6 @@ func TestNodePs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				infoFunc:           tc.infoFunc,

--- a/cli/command/plugin/formatter_test.go
+++ b/cli/command/plugin/formatter_test.go
@@ -131,7 +131,6 @@ foobar_bar
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/plugin/inspect_test.go
+++ b/cli/command/plugin/inspect_test.go
@@ -66,7 +66,6 @@ func TestInspectErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginInspectFunc: tc.inspectFunc})
 			cmd := newInspectCommand(cli)
@@ -138,7 +137,6 @@ func TestInspect(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginInspectFunc: tc.inspectFunc})
 			cmd := newInspectCommand(cli)

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -54,7 +54,6 @@ func TestInstallErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginInstallFunc: tc.installFunc})
 			cmd := newInstallCommand(cli)
@@ -94,7 +93,6 @@ func TestInstallContentTrustErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				pluginInstallFunc: func(name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
@@ -138,7 +136,6 @@ func TestInstall(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginInstallFunc: tc.installFunc})
 			cmd := newInstallCommand(cli)

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -46,7 +46,6 @@ func TestListErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginListFunc: tc.listFunc})
 			cmd := newListCommand(cli)
@@ -166,7 +165,6 @@ func TestList(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.description, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{pluginListFunc: tc.listFunc})
 			cmd := newListCommand(cli)

--- a/cli/command/registry/formatter_search_test.go
+++ b/cli/command/registry/formatter_search_test.go
@@ -203,7 +203,6 @@ result2 5
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			var out bytes.Buffer
 			err := SearchWrite(formatter.Context{Format: tc.format, Output: &out}, results)

--- a/cli/command/secret/formatter_test.go
+++ b/cli/command/secret/formatter_test.go
@@ -61,7 +61,6 @@ id_rsa
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/secret/inspect_test.go
+++ b/cli/command/secret/inspect_test.go
@@ -93,7 +93,6 @@ func TestSecretInspectWithoutFormat(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,
@@ -132,7 +131,6 @@ func TestSecretInspectWithFormat(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				secretInspectFunc: tc.secretInspectFunc,

--- a/cli/command/service/formatter_test.go
+++ b/cli/command/service/formatter_test.go
@@ -223,7 +223,6 @@ zarp2
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/service/list_test.go
+++ b/cli/command/service/list_test.go
@@ -168,7 +168,6 @@ func TestServiceListServiceStatus(t *testing.T) {
 	}
 
 	for _, tc := range matrix {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			if tc.cluster == nil {
 				tc.cluster = generateCluster(t, tc.opts)

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -50,7 +50,6 @@ func TestCredentialSpecOpt(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var cs credentialSpecOpt
 

--- a/cli/command/service/rollback_test.go
+++ b/cli/command/service/rollback_test.go
@@ -91,7 +91,6 @@ func TestRollbackWithErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newRollbackCommand(
 				test.NewFakeCli(&fakeClient{

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1058,7 +1058,6 @@ func updatePorts(flags *pflag.FlagSet, portConfig *[]swarm.PortConfig) error {
 
 	// Build the current list of portConfig
 	for _, entry := range *portConfig {
-		entry := entry
 		if _, ok := portSet[portConfigToString(&entry)]; !ok {
 			portSet[portConfigToString(&entry)] = entry
 		}
@@ -1086,7 +1085,6 @@ portLoop:
 		ports := flags.Lookup(flagPublishAdd).Value.(*opts.PortOpt).Value()
 
 		for _, port := range ports {
-			port := port
 			if _, ok := portSet[portConfigToString(&port)]; ok {
 				continue
 			}

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1690,7 +1690,6 @@ func TestUpdateUlimits(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			svc := swarm.ServiceSpec{
 				TaskTemplate: swarm.TaskSpec{

--- a/cli/command/stack/formatter/formatter_test.go
+++ b/cli/command/stack/formatter/formatter_test.go
@@ -51,7 +51,6 @@ bar
 		{Name: "bar", Services: 1},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/stack/list_test.go
+++ b/cli/command/stack/list_test.go
@@ -48,7 +48,6 @@ func TestListErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			cmd := newListCommand(test.NewFakeCli(&fakeClient{
 				serviceListFunc: tc.serviceListFunc,
@@ -104,7 +103,6 @@ func TestStackList(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			var services []swarm.Service
 			for _, name := range tc.serviceNames {

--- a/cli/command/stack/ps_test.go
+++ b/cli/command/stack/ps_test.go
@@ -40,7 +40,6 @@ func TestStackPsErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			cmd := newPsCommand(test.NewFakeCli(&fakeClient{
 				taskListFunc: tc.taskListFunc,
@@ -160,7 +159,6 @@ func TestStackPs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				taskListFunc:       tc.taskListFunc,

--- a/cli/command/stack/services_test.go
+++ b/cli/command/stack/services_test.go
@@ -67,7 +67,6 @@ func TestStackServicesErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expectedError, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				serviceListFunc: tc.serviceListFunc,

--- a/cli/command/stack/swarm/deploy_test.go
+++ b/cli/command/stack/swarm/deploy_test.go
@@ -88,7 +88,6 @@ func TestServiceUpdateResolveImageChanged(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.image, func(t *testing.T) {
 			spec := map[string]swarm.ServiceSpec{
 				"myservice": {

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -63,7 +63,6 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newInitCommand(
 				test.NewFakeCli(&fakeClient{

--- a/cli/command/swarm/join_test.go
+++ b/cli/command/swarm/join_test.go
@@ -48,7 +48,6 @@ func TestSwarmJoinErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newJoinCommand(
 				test.NewFakeCli(&fakeClient{
@@ -93,7 +92,6 @@ func TestSwarmJoin(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				infoFunc: tc.infoFunc,

--- a/cli/command/swarm/join_token_test.go
+++ b/cli/command/swarm/join_token_test.go
@@ -87,7 +87,6 @@ func TestSwarmJoinTokenErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				swarmInspectFunc: tc.swarmInspectFunc,
@@ -198,7 +197,6 @@ func TestSwarmJoinToken(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				swarmInspectFunc: tc.swarmInspectFunc,

--- a/cli/command/swarm/leave_test.go
+++ b/cli/command/swarm/leave_test.go
@@ -32,7 +32,6 @@ func TestSwarmLeaveErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newLeaveCommand(
 				test.NewFakeCli(&fakeClient{

--- a/cli/command/swarm/unlock_key_test.go
+++ b/cli/command/swarm/unlock_key_test.go
@@ -80,7 +80,6 @@ func TestSwarmUnlockKeyErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newUnlockKeyCommand(
 				test.NewFakeCli(&fakeClient{
@@ -158,7 +157,6 @@ func TestSwarmUnlockKey(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,

--- a/cli/command/swarm/unlock_test.go
+++ b/cli/command/swarm/unlock_test.go
@@ -64,7 +64,6 @@ func TestSwarmUnlockErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newUnlockCommand(
 				test.NewFakeCli(&fakeClient{

--- a/cli/command/swarm/update_test.go
+++ b/cli/command/swarm/update_test.go
@@ -65,7 +65,6 @@ func TestSwarmUpdateErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newUpdateCommand(
 				test.NewFakeCli(&fakeClient{
@@ -169,7 +168,6 @@ func TestSwarmUpdate(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				swarmInspectFunc:      tc.swarmInspectFunc,

--- a/cli/command/system/events_test.go
+++ b/cli/command/system/events_test.go
@@ -53,7 +53,6 @@ func TestEventsFormat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// Set to UTC timezone as timestamps in output are
 			// printed in the current timezone

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -374,7 +374,6 @@ func TestPrettyPrintInfo(t *testing.T) {
 			expectedError:  "errors pretty printing info",
 		},
 	} {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
 			err := prettyPrintInfo(cli, tc.dockerInfo)
@@ -452,7 +451,6 @@ func TestFormatInfo(t *testing.T) {
 			expectedError: `template: :1:2: executing "" at <.badString>: can't evaluate field badString in type system.dockerInfo`,
 		},
 	} {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
 			info := dockerInfo{
@@ -518,7 +516,6 @@ func TestNeedsServerInfo(t *testing.T) {
 
 	inf := dockerInfo{ClientInfo: &clientInfo{}}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.doc, func(t *testing.T) {
 			assert.Equal(t, needsServerInfo(tc.template, inf), tc.expected)
 		})

--- a/cli/command/task/formatter_test.go
+++ b/cli/command/task/formatter_test.go
@@ -71,7 +71,6 @@ foobar_bar foo2
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/telemetry_utils_test.go
+++ b/cli/command/telemetry_utils_test.go
@@ -56,7 +56,6 @@ func TestGetFullCommandName(t *testing.T) {
 			expected: "root child grandchild",
 		},
 	} {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			actual := getFullCommandName(tc.cmd)
@@ -91,7 +90,6 @@ func TestGetCommandName(t *testing.T) {
 			expected: "child grandchild",
 		},
 	} {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			actual := getCommandName(tc.cmd)
@@ -130,7 +128,6 @@ func TestStdioAttributes(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.test, func(t *testing.T) {
 			t.Parallel()
 			cli := &DockerCli{
@@ -179,7 +176,6 @@ func TestAttributesFromError(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			actual := attributesFromError(tc.err)

--- a/cli/command/trust/formatter_test.go
+++ b/cli/command/trust/formatter_test.go
@@ -127,7 +127,6 @@ tag3         bbbbbbbb
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out
@@ -231,7 +230,6 @@ eve       foobarbazquxquux, key31, key32
 		{Name: "eve", Keys: []string{"key31", "key32", "foobarbazquxquux"}},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			var out bytes.Buffer
 			tc.context.Output = &out

--- a/cli/command/trust/key_load_test.go
+++ b/cli/command/trust/key_load_test.go
@@ -116,7 +116,6 @@ var testKeys = map[string][]byte{
 func TestLoadKeyFromPath(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows")
 	for keyID, keyBytes := range testKeys {
-		keyID, keyBytes := keyID, keyBytes
 		t.Run(fmt.Sprintf("load-key-id-%s-from-path", keyID), func(t *testing.T) {
 			privKeyFilepath := filepath.Join(t.TempDir(), "privkey.pem")
 			assert.NilError(t, os.WriteFile(privKeyFilepath, keyBytes, notary.PrivNoExecPerms))
@@ -163,7 +162,6 @@ func TestLoadKeyFromPath(t *testing.T) {
 func TestLoadKeyTooPermissive(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows")
 	for keyID, keyBytes := range testKeys {
-		keyID, keyBytes := keyID, keyBytes
 		t.Run(fmt.Sprintf("load-key-id-%s-too-permissive", keyID), func(t *testing.T) {
 			privKeyDir := t.TempDir()
 			privKeyFilepath := filepath.Join(privKeyDir, "privkey477.pem")

--- a/cli/command/trust/signer_remove_test.go
+++ b/cli/command/trust/signer_remove_test.go
@@ -30,7 +30,6 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newSignerRemoveCommand(
 				test.NewFakeCli(&fakeClient{}))
@@ -66,7 +65,6 @@ func TestTrustSignerRemoveErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCasesWithOutput {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
 			cli.SetNotaryClient(notaryfake.GetOfflineNotaryRepository)

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -52,7 +52,6 @@ func TestVolumePruneErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := NewPruneCommand(
 				test.NewFakeCli(&fakeClient{
@@ -104,7 +103,6 @@ func TestVolumePruneSuccess(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{volumePruneFunc: tc.volumePruneFunc})
 			cmd := NewPruneCommand(cli)
@@ -166,7 +164,6 @@ func TestVolumePrunePromptNo(t *testing.T) {
 	skip.If(t, runtime.GOOS == "windows", "TODO: fix test on windows")
 
 	for _, input := range []string{"n", "N", "no", "anything", "really"} {
-		input := input
 		t.Run(input, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				volumePruneFunc: simplePruneFunc,

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -409,7 +409,6 @@ func TestConvertCredentialSpec(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			namespace := NewNamespace(tc.name)
 			swarmSpec, err := convertCredentialSpec(namespace, tc.in, tc.configs)
@@ -691,7 +690,6 @@ func TestConvertServiceCapAddAndCapDrop(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.title, func(t *testing.T) {
 			result, err := Service("1.41", Namespace{name: "foo"}, tc.in, nil, nil, nil, nil)
 			assert.NilError(t, err)

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1626,13 +1626,12 @@ services:
 			init: &booleanFalse,
 		},
 	}
-	for _, testcase := range testcases {
-		testcase := testcase
-		t.Run(testcase.doc, func(t *testing.T) {
-			config, err := loadYAML(testcase.yaml)
+	for _, tc := range testcases {
+		t.Run(tc.doc, func(t *testing.T) {
+			config, err := loadYAML(tc.yaml)
 			assert.NilError(t, err)
 			assert.Check(t, is.Len(config.Services, 1))
-			assert.Check(t, is.DeepEqual(testcase.init, config.Services[0].Init))
+			assert.Check(t, is.DeepEqual(tc.init, config.Services[0].Init))
 		})
 	}
 }

--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -68,7 +68,6 @@ func mergeServices(base, override []types.ServiceConfig) ([]types.ServiceConfig,
 		},
 	}
 	for name, overrideService := range overrideServices {
-		overrideService := overrideService
 		if baseService, ok := baseServices[name]; ok {
 			if err := mergo.Merge(&baseService, &overrideService, mergo.WithAppendSlice, mergo.WithOverride, mergo.WithTransformers(specials)); err != nil {
 				return base, errors.Wrapf(err, "cannot merge service %s", name)

--- a/cli/compose/schema/schema_test.go
+++ b/cli/compose/schema/schema_test.go
@@ -215,7 +215,6 @@ func TestValidateCredentialSpecs(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.version, func(t *testing.T) {
 			config := dict{
 				"version": "99.99",

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -277,7 +277,6 @@ func TestExtractVariables(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := ExtractVariables(tc.dict, defaultPattern)
 			assert.Check(t, is.DeepEqual(actual, tc.expected))

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -433,7 +433,6 @@ func TestConfigPath(t *testing.T) {
 			expectedErr: fmt.Sprintf("is outside of root config directory %q", "dummy"),
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			SetDir(tc.dir)
 			f, err := Path(tc.path...)

--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -297,7 +297,6 @@ func TestConvertToHostname(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			actual := ConvertToHostname(tc.input)
 			assert.Equal(t, actual, tc.expected)

--- a/cli/manifest/store/store_test.go
+++ b/cli/manifest/store/store_test.go
@@ -81,17 +81,16 @@ func TestStoreSaveAndGet(t *testing.T) {
 		},
 	}
 
-	for _, testcase := range testcases {
-		testcase := testcase
-		t.Run(testcase.manifestRef.String(), func(t *testing.T) {
-			actual, err := store.Get(testcase.listRef, testcase.manifestRef)
-			if testcase.expectedErr != "" {
-				assert.Error(t, err, testcase.expectedErr)
+	for _, tc := range testcases {
+		t.Run(tc.manifestRef.String(), func(t *testing.T) {
+			actual, err := store.Get(tc.listRef, tc.manifestRef)
+			if tc.expectedErr != "" {
+				assert.Error(t, err, tc.expectedErr)
 				assert.Check(t, IsNotFound(err))
 				return
 			}
 			assert.NilError(t, err)
-			assert.DeepEqual(t, testcase.expected, actual, cmpReferenceNamed)
+			assert.DeepEqual(t, tc.expected, actual, cmpReferenceNamed)
 		})
 	}
 }

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -64,14 +64,13 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 	)
 	defer dir.Remove()
 
-	for _, tt := range testcases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
 			ctx2, cancel2 := context.WithCancel(ctx)
 			defer cancel2()
 
-			if tt.builder != "" {
-				t.Setenv("BUILDX_BUILDER", tt.builder)
+			if tc.builder != "" {
+				t.Setenv("BUILDX_BUILDER", tc.builder)
 			}
 
 			var b bytes.Buffer
@@ -84,10 +83,10 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 			assert.NilError(t, err)
 			assert.NilError(t, dockerCli.Initialize(flags.NewClientOptions()))
 
-			if tt.context != "" {
-				if tt.context != command.DefaultContextName {
+			if tc.context != "" {
+				if tc.context != command.DefaultContextName {
 					assert.NilError(t, dockerCli.ContextStore().CreateOrUpdate(store.Metadata{
-						Name: tt.context,
+						Name: tc.context,
 						Endpoints: map[string]any{
 							"docker": map[string]any{
 								"host": "unix://" + filepath.Join(t.TempDir(), "docker.sock"),
@@ -96,12 +95,12 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 					}))
 				}
 				opts := flags.NewClientOptions()
-				opts.Context = tt.context
+				opts.Context = tc.context
 				assert.NilError(t, dockerCli.Initialize(opts))
 			}
 
 			dockerCli.ConfigFile().CLIPluginsExtraDirs = []string{dir.Path()}
-			if tt.alias {
+			if tc.alias {
 				dockerCli.ConfigFile().Aliases = map[string]string{"builder": "buildx"}
 			}
 
@@ -115,8 +114,8 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 			args, os.Args, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, []string{builderDefaultPlugin, "build", "."}, args)
-			if tt.expectedEnvs != nil {
-				assert.DeepEqual(t, tt.expectedEnvs, envs)
+			if tc.expectedEnvs != nil {
+				assert.DeepEqual(t, tc.expectedEnvs, envs)
 			} else {
 				assert.Check(t, len(envs) == 0)
 			}
@@ -289,10 +288,9 @@ func TestHasBuilderName(t *testing.T) {
 			expected: true,
 		},
 	}
-	for _, tt := range cases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, hasBuilderName(tt.args, tt.envs))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, hasBuilderName(tc.args, tc.envs))
 		})
 	}
 }

--- a/e2e/cli-plugins/flags_test.go
+++ b/e2e/cli-plugins/flags_test.go
@@ -131,7 +131,6 @@ func TestUnknownGlobal(t *testing.T) {
 		"separate-val": {"--unknown", "foo", "helloworld"},
 		"joined-val":   {"--unknown=foo", "helloworld"},
 	} {
-		args := args
 		t.Run(name, func(t *testing.T) {
 			res := icmd.RunCmd(run(args...))
 			res.Assert(t, icmd.Expected{

--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -214,7 +214,6 @@ func TestMountSubvolume(t *testing.T) {
 		{name: "subdirectory mount", cmd: "ls", subpath: "subdir", expectedOut: "hello.txt"},
 		{name: "file mount", cmd: "cat", subpath: "bar.txt", expectedOut: "foo"},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runMount(tc.cmd, "volume-subpath="+tc.subpath).Assert(t, icmd.Expected{
 				Err:      tc.expectedErr,

--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -182,7 +182,6 @@ func TestPromptExitCode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run("case="+tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/opts/capabilities_test.go
+++ b/opts/capabilities_test.go
@@ -36,7 +36,6 @@ func TestNormalizeCapability(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.in, func(t *testing.T) {
 			assert.Equal(t, NormalizeCapability(tc.in), tc.out)
 		})
@@ -108,7 +107,6 @@ func TestEffectiveCapAddCapDrop(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			add, drop := EffectiveCapAddCapDrop(tc.in.add, tc.in.drop)
 			assert.DeepEqual(t, add, tc.out.add)

--- a/opts/config_test.go
+++ b/opts/config_test.go
@@ -64,7 +64,6 @@ func TestConfigOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var opt ConfigOpt
 			assert.NilError(t, opt.Set(tc.input))

--- a/opts/env_test.go
+++ b/opts/env_test.go
@@ -104,7 +104,6 @@ func TestValidateEnv(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			actual, err := ValidateEnv(tc.value)
 

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -281,7 +281,6 @@ func TestValidateExtraHosts(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		if tc.expectedOut == "" {
 			tc.expectedOut = tc.input
 		}

--- a/opts/network_test.go
+++ b/opts/network_test.go
@@ -114,7 +114,6 @@ func TestNetworkOptAdvancedSyntax(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			var network NetworkOpt
 			assert.NilError(t, network.Set(tc.value))
@@ -142,7 +141,6 @@ func TestNetworkOptAdvancedSyntaxInvalid(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			var network NetworkOpt
 			assert.ErrorContains(t, network.Set(tc.value), tc.expectedError)

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -69,7 +69,6 @@ func TestValidateIPAddress(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			actualOut, actualErr := ValidateIPAddress(tc.input)
 			assert.Check(t, is.Equal(tc.expectedOut, actualOut))
@@ -339,7 +338,6 @@ func TestValidateLabel(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			val, err := ValidateLabel(tc.value)
 			if tc.expectedErr != "" {

--- a/opts/parse_test.go
+++ b/opts/parse_test.go
@@ -61,7 +61,6 @@ NO_SUCH_ENV
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			envs, err := ReadKVEnvStrings(tc.files, tc.overrides)
 			assert.NilError(t, err)

--- a/opts/port_test.go
+++ b/opts/port_test.go
@@ -344,7 +344,6 @@ func TestConvertPortToPortConfigWithIP(t *testing.T) {
 	var b bytes.Buffer
 	logrus.SetOutput(&b)
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.value, func(t *testing.T) {
 			_, err := ConvertPortToPortConfig("80/tcp", map[nat.Port][]nat.PortBinding{
 				"80/tcp": {{HostIP: tc.value, HostPort: "2345"}},

--- a/opts/secret_test.go
+++ b/opts/secret_test.go
@@ -64,7 +64,6 @@ func TestSecretOptions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			var opt SecretOpt
 			assert.NilError(t, opt.Set(tc.input))

--- a/service/logs/parse_logs_test.go
+++ b/service/logs/parse_logs_test.go
@@ -47,7 +47,6 @@ func TestParseLogDetails(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.line, func(t *testing.T) {
 			actual, err := ParseLogDetails(tc.line)
 			if tc.expectedErr != "" {

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -64,25 +64,23 @@ func TestParseTruncateFunction(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		tm, err := Parse(testCase.template)
+	for _, tc := range testCases {
+		tm, err := Parse(tc.template)
 		assert.NilError(t, err)
 
-		t.Run("Non Empty Source Test with template: "+testCase.template, func(t *testing.T) {
+		t.Run("Non Empty Source Test with template: "+tc.template, func(t *testing.T) {
 			var b bytes.Buffer
 			assert.NilError(t, tm.Execute(&b, source))
-			assert.Check(t, is.Equal(testCase.expected, b.String()))
+			assert.Check(t, is.Equal(tc.expected, b.String()))
 		})
 
-		t.Run("Empty Source Test with template: "+testCase.template, func(t *testing.T) {
+		t.Run("Empty Source Test with template: "+tc.template, func(t *testing.T) {
 			var c bytes.Buffer
 			assert.NilError(t, tm.Execute(&c, ""))
 			assert.Check(t, is.Equal("", c.String()))
 		})
 
-		t.Run("Nil Source Test with template: "+testCase.template, func(t *testing.T) {
+		t.Run("Nil Source Test with template: "+tc.template, func(t *testing.T) {
 			var c bytes.Buffer
 			assert.Check(t, tm.Execute(&c, nil) != nil)
 			assert.Check(t, is.Equal("", c.String()))


### PR DESCRIPTION
GolangCI-lint attempts to deduct the Go version to lint for through the
go version specified in go.mod, which we don't have, and therefore it
falls back to go1.17 semantics:

    level=warning msg="[linters_context] copyloopvar: this linter is disabled because the Go version (1.17) of your project is lower than Go 1.22


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

