### PR TITLE
docs: update example redis tags from 3.0.x to 7.4.x

### DIFF
--- a/docs/reference/commandline/node_ps.md
+++ b/docs/reference/commandline/node_ps.md
@@ -34,11 +34,11 @@ information about available filter options.
 $ docker node ps swarm-manager1
 
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
-redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:3.0.6  swarm-manager1  Running        Running 5 hours
-redis.6.b465edgho06e318egmgjbqo4o   redis:3.0.6  swarm-manager1  Running        Running 29 seconds
-redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
-redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
-redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:7.4.1  swarm-manager1  Running        Running 5 hours
+redis.6.b465edgho06e318egmgjbqo4o   redis:7.4.1  swarm-manager1  Running        Running 29 seconds
+redis.7.bg8c07zzg87di2mufeq51a2qp   redis:7.4.1  swarm-manager1  Running        Running 5 seconds
+redis.9.dkkual96p4bb3s6b10r7coxxt   redis:7.4.1  swarm-manager1  Running        Running 5 seconds
+redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:7.4.1  swarm-manager1  Running        Running 5 seconds
 ```
 
 ### <a name="filter"></a> Filtering (--filter)
@@ -64,11 +64,11 @@ The following filter matches all tasks with a name containing the `redis` string
 $ docker node ps -f name=redis swarm-manager1
 
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
-redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:3.0.6  swarm-manager1  Running        Running 5 hours
-redis.6.b465edgho06e318egmgjbqo4o   redis:3.0.6  swarm-manager1  Running        Running 29 seconds
-redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
-redis.9.dkkual96p4bb3s6b10r7coxxt   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
-redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+redis.1.7q92v0nr1hcgts2amcjyqg3pq   redis:7.4.1  swarm-manager1  Running        Running 5 hours
+redis.6.b465edgho06e318egmgjbqo4o   redis:7.4.1  swarm-manager1  Running        Running 29 seconds
+redis.7.bg8c07zzg87di2mufeq51a2qp   redis:7.4.1  swarm-manager1  Running        Running 5 seconds
+redis.9.dkkual96p4bb3s6b10r7coxxt   redis:7.4.1  swarm-manager1  Running        Running 5 seconds
+redis.10.0tgctg8h8cech4w0k0gwrmr23  redis:7.4.1  swarm-manager1  Running        Running 5 seconds
 ```
 
 #### id
@@ -79,7 +79,7 @@ The `id` filter matches a task's id.
 $ docker node ps -f id=bg8c07zzg87di2mufeq51a2qp swarm-manager1
 
 NAME                                IMAGE        NODE            DESIRED STATE  CURRENT STATE
-redis.7.bg8c07zzg87di2mufeq51a2qp   redis:3.0.6  swarm-manager1  Running        Running 5 seconds
+redis.7.bg8c07zzg87di2mufeq51a2qp   redis:7.4.1  swarm-manager1  Running        Running 5 seconds
 ```
 
 #### label
@@ -93,8 +93,8 @@ The following filter matches tasks with the `usage` label regardless of its valu
 $ docker node ps -f "label=usage"
 
 NAME                               IMAGE        NODE            DESIRED STATE  CURRENT STATE
-redis.6.b465edgho06e318egmgjbqo4o  redis:3.0.6  swarm-manager1  Running        Running 10 minutes
-redis.7.bg8c07zzg87di2mufeq51a2qp  redis:3.0.6  swarm-manager1  Running        Running 9 minutes
+redis.6.b465edgho06e318egmgjbqo4o  redis:7.4.1  swarm-manager1  Running        Running 10 minutes
+redis.7.bg8c07zzg87di2mufeq51a2qp  redis:7.4.1  swarm-manager1  Running        Running 9 minutes
 ```
 
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -99,19 +99,19 @@ Creates a service as described by the specified parameters.
 ### Create a service
 
 ```console
-$ docker service create --name redis redis:3.0.6
+$ docker service create --name redis redis:7.4.1
 
 dmu1ept4cxcfe8k8lhtux3ro3
 
-$ docker service create --mode global --name redis2 redis:3.0.6
+$ docker service create --mode global --name redis2 redis:7.4.1
 
 a8q9dasaafudfs8q8w32udass
 
 $ docker service ls
 
 ID            NAME    MODE        REPLICAS  IMAGE
-dmu1ept4cxcf  redis   replicated  1/1       redis:3.0.6
-a8q9dasaafud  redis2  global      1/1       redis:3.0.6
+dmu1ept4cxcf  redis   replicated  1/1       redis:7.4.1
+a8q9dasaafud  redis2  global      1/1       redis:7.4.1
 ```
 
 #### <a name="with-registry-auth"></a> Create a service using an image on a private registry (--with-registry-auth)
@@ -140,7 +140,7 @@ Use the `--replicas` flag to set the number of replica tasks for a replicated
 service. The following command creates a `redis` service with `5` replica tasks:
 
 ```console
-$ docker service create --name redis --replicas=5 redis:3.0.6
+$ docker service create --name redis --replicas=5 redis:7.4.1
 
 4cdgfyky7ozwh3htjfw0d12qv
 ```
@@ -157,7 +157,7 @@ number of `RUNNING` tasks is `3`:
 $ docker service ls
 
 ID            NAME   MODE        REPLICAS  IMAGE
-4cdgfyky7ozw  redis  replicated  3/5       redis:3.0.7
+4cdgfyky7ozw  redis  replicated  3/5       redis:7.4.1
 ```
 
 Once all the tasks are created and `RUNNING`, the actual number of tasks is
@@ -167,7 +167,7 @@ equal to the desired number:
 $ docker service ls
 
 ID            NAME   MODE        REPLICAS  IMAGE
-4cdgfyky7ozw  redis  replicated  5/5       redis:3.0.7
+4cdgfyky7ozw  redis  replicated  5/5       redis:7.4.1
 ```
 
 ### <a name="secret"></a> Create a service with secrets (--secret)
@@ -178,7 +178,7 @@ Use the `--secret` flag to give a container access to a
 Create a service specifying a secret:
 
 ```console
-$ docker service create --name redis --secret secret.json redis:3.0.6
+$ docker service create --name redis --secret secret.json redis:7.4.1
 
 4cdgfyky7ozwh3htjfw0d12qv
 ```
@@ -189,7 +189,7 @@ Create a service specifying the secret, target, user/group ID, and mode:
 $ docker service create --name redis \
     --secret source=ssh-key,target=ssh \
     --secret source=app-key,target=app,uid=1000,gid=1001,mode=0400 \
-    redis:3.0.6
+    redis:7.4.1
 
 4cdgfyky7ozwh3htjfw0d12qv
 ```
@@ -215,14 +215,14 @@ pre-exist in the container. The `mode` is specified as a 4-number sequence such
 as `0755`.
 
 ```console
-$ docker service create --name=redis --config redis-conf redis:3.0.6
+$ docker service create --name=redis --config redis-conf redis:7.4.1
 ```
 
 Create a service with a config and specify the target location and file mode:
 
 ```console
 $ docker service create --name redis \
-  --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400 redis:3.0.6
+  --config source=redis-conf,target=/etc/redis/redis.conf,mode=0400 redis:7.4.1
 ```
 
 To grant a service access to multiple configs, use multiple `--config` flags.
@@ -239,7 +239,7 @@ $ docker service create \
   --name redis \
   --update-delay 10s \
   --update-parallelism 2 \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 When you run a [service update](service_update.md), the scheduler updates a
@@ -256,7 +256,7 @@ $ docker service create \
   --name redis_2 \
   --replicas 5 \
   --env MYVAR=foo \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 To specify multiple environment variables, specify multiple `--env` flags, each
@@ -268,7 +268,7 @@ $ docker service create \
   --replicas 5 \
   --env MYVAR=foo \
   --env MYVAR2=bar \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 ### <a name="hostname"></a> Create a service with specific hostname (--hostname)
@@ -277,7 +277,7 @@ This option sets the docker service containers hostname to a specific string.
 For example:
 
 ```console
-$ docker service create --name redis --hostname myredis redis:3.0.6
+$ docker service create --name redis --hostname myredis redis:7.4.1
 ```
 
 ### <a name="label"></a> Set metadata on a service (-l, --label)
@@ -290,7 +290,7 @@ $ docker service create \
   --name redis_2 \
   --label com.example.foo="bar" \
   --label bar=baz \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 For more information about labels, refer to [apply custom
@@ -679,7 +679,7 @@ The following command creates a global service:
 $ docker service create \
  --name redis_2 \
  --mode global \
- redis:3.0.6
+ redis:7.4.1
 ```
 
 ### <a name="constraint"></a> Specify service constraints (--constraint)
@@ -712,7 +712,7 @@ $ docker service create \
   --name redis_2 \
   --constraint node.platform.os==linux \
   --constraint node.labels.type==queue \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 If the service constraints exclude all nodes in the cluster, a message is printed
@@ -760,7 +760,7 @@ $ docker service create \
   --replicas 9 \
   --name redis_2 \
   --placement-pref spread=node.labels.datacenter \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 This uses `--placement-pref` with a `spread` strategy (currently the only
@@ -812,7 +812,7 @@ $ docker service create \
   --name redis_2 \
   --placement-pref 'spread=node.labels.datacenter' \
   --placement-pref 'spread=node.labels.rack' \
-  redis:3.0.6
+  redis:7.4.1
 ```
 
 When updating a service with `docker service update`, `--placement-pref-add`

--- a/docs/reference/commandline/service_inspect.md
+++ b/docs/reference/commandline/service_inspect.md
@@ -40,7 +40,7 @@ For example, given the following service;
 ```console
 $ docker service ls
 ID            NAME   MODE        REPLICAS  IMAGE
-dmu1ept4cxcf  redis  replicated  3/3       redis:3.0.6
+dmu1ept4cxcf  redis  replicated  3/3       redis:7.4.1
 ```
 
 Both `docker service inspect redis`, and `docker service inspect dmu1ept4cxcf`
@@ -65,7 +65,7 @@ The output is in JSON format, for example:
       "Name": "redis",
       "TaskTemplate": {
         "ContainerSpec": {
-          "Image": "redis:3.0.6"
+          "Image": "redis:7.4.1"
         },
         "Resources": {
           "Limits": {},

--- a/docs/reference/commandline/service_ls.md
+++ b/docs/reference/commandline/service_ls.md
@@ -37,7 +37,7 @@ $ docker service ls
 
 ID            NAME      MODE            REPLICAS             IMAGE
 c8wgl7q4ndfd  frontend  replicated      5/5                  nginx:alpine
-dmu1ept4cxcf  redis     replicated      3/3                  redis:3.0.6
+dmu1ept4cxcf  redis     replicated      3/3                  redis:7.4.1
 iwe3278osahj  mongo     global          7/7                  mongo:3.3
 hh08h9uu8uwr  job       replicated-job  1/1 (3/5 completed)  nginx:latest
 ```
@@ -68,7 +68,7 @@ The following filter matches services with an ID starting with `0bcjw`:
 ```console
 $ docker service ls -f "id=0bcjw"
 ID            NAME   MODE        REPLICAS  IMAGE
-0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
+0bcjwfh8ychr  redis  replicated  1/1       redis:7.4.1
 ```
 
 #### label
@@ -84,7 +84,7 @@ $ docker service ls --filter label=project
 ID            NAME       MODE        REPLICAS  IMAGE
 01sl1rp6nj5u  frontend2  replicated  1/1       nginx:alpine
 36xvvwwauej0  frontend   replicated  5/5       nginx:alpine
-74nzcxxjv6fq  backend    replicated  3/3       redis:3.0.6
+74nzcxxjv6fq  backend    replicated  3/3       redis:7.4.1
 ```
 
 The following filter matches only services with the `project` label with the
@@ -94,7 +94,7 @@ The following filter matches only services with the `project` label with the
 $ docker service ls --filter label=project=project-a
 ID            NAME      MODE        REPLICAS  IMAGE
 36xvvwwauej0  frontend  replicated  5/5       nginx:alpine
-74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
+74nzcxxjv6fq  backend   replicated  3/3       redis:7.4.1
 ```
 
 #### mode
@@ -118,7 +118,7 @@ The following filter matches services with a name starting with `redis`.
 ```console
 $ docker service ls --filter name=redis
 ID            NAME   MODE        REPLICAS  IMAGE
-0bcjwfh8ychr  redis  replicated  1/1       redis:3.0.6
+0bcjwfh8ychr  redis  replicated  1/1       redis:7.4.1
 ```
 
 ### <a name="format"></a> Format the output (--format)

--- a/docs/reference/commandline/service_ps.md
+++ b/docs/reference/commandline/service_ps.md
@@ -36,35 +36,35 @@ The following command shows all the tasks that are part of the `redis` service:
 $ docker service ps redis
 
 ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE          ERROR  PORTS
-0qihejybwf1x   redis.1   redis:3.0.5  manager1  Running        Running 8 seconds
-bk658fpbex0d   redis.2   redis:3.0.5  worker2   Running        Running 9 seconds
-5ls5s5fldaqg   redis.3   redis:3.0.5  worker1   Running        Running 9 seconds
-8ryt076polmc   redis.4   redis:3.0.5  worker1   Running        Running 9 seconds
-1x0v8yomsncd   redis.5   redis:3.0.5  manager1  Running        Running 8 seconds
-71v7je3el7rr   redis.6   redis:3.0.5  worker2   Running        Running 9 seconds
-4l3zm9b7tfr7   redis.7   redis:3.0.5  worker2   Running        Running 9 seconds
-9tfpyixiy2i7   redis.8   redis:3.0.5  worker1   Running        Running 9 seconds
-3w1wu13yupln   redis.9   redis:3.0.5  manager1  Running        Running 8 seconds
-8eaxrb2fqpbn   redis.10  redis:3.0.5  manager1  Running        Running 8 seconds
+0qihejybwf1x   redis.1   redis:7.4.0  manager1  Running        Running 8 seconds
+bk658fpbex0d   redis.2   redis:7.4.0  worker2   Running        Running 9 seconds
+5ls5s5fldaqg   redis.3   redis:7.4.0  worker1   Running        Running 9 seconds
+8ryt076polmc   redis.4   redis:7.4.0  worker1   Running        Running 9 seconds
+1x0v8yomsncd   redis.5   redis:7.4.0  manager1  Running        Running 8 seconds
+71v7je3el7rr   redis.6   redis:7.4.0  worker2   Running        Running 9 seconds
+4l3zm9b7tfr7   redis.7   redis:7.4.0  worker2   Running        Running 9 seconds
+9tfpyixiy2i7   redis.8   redis:7.4.0  worker1   Running        Running 9 seconds
+3w1wu13yupln   redis.9   redis:7.4.0  manager1  Running        Running 8 seconds
+8eaxrb2fqpbn   redis.10  redis:7.4.0  manager1  Running        Running 8 seconds
 ```
 
 In addition to running tasks, the output also shows the task history. For
-example, after updating the service to use the `redis:3.0.6` image, the output
+example, after updating the service to use the `redis:7.4.1` image, the output
 may look like this:
 
 ```console
 $ docker service ps redis
 
 ID            NAME         IMAGE        NODE      DESIRED STATE  CURRENT STATE                   ERROR  PORTS
-50qe8lfnxaxk  redis.1      redis:3.0.6  manager1  Running        Running 6 seconds ago
-ky2re9oz86r9   \_ redis.1  redis:3.0.5  manager1  Shutdown       Shutdown 8 seconds ago
-3s46te2nzl4i  redis.2      redis:3.0.6  worker2   Running        Running less than a second ago
-nvjljf7rmor4   \_ redis.2  redis:3.0.6  worker2   Shutdown       Rejected 23 seconds ago        "No such image: redis@sha256:6…"
-vtiuz2fpc0yb   \_ redis.2  redis:3.0.5  worker2   Shutdown       Shutdown 1 second ago
-jnarweeha8x4  redis.3      redis:3.0.6  worker1   Running        Running 3 seconds ago
-vs448yca2nz4   \_ redis.3  redis:3.0.5  worker1   Shutdown       Shutdown 4 seconds ago
-jf1i992619ir  redis.4      redis:3.0.6  worker1   Running        Running 10 seconds ago
-blkttv7zs8ee   \_ redis.4  redis:3.0.5  worker1   Shutdown       Shutdown 11 seconds ago
+50qe8lfnxaxk  redis.1      redis:7.4.1  manager1  Running        Running 6 seconds ago
+ky2re9oz86r9   \_ redis.1  redis:7.4.0  manager1  Shutdown       Shutdown 8 seconds ago
+3s46te2nzl4i  redis.2      redis:7.4.1  worker2   Running        Running less than a second ago
+nvjljf7rmor4   \_ redis.2  redis:7.4.1  worker2   Shutdown       Rejected 23 seconds ago        "No such image: redis@sha256:6…"
+vtiuz2fpc0yb   \_ redis.2  redis:7.4.0  worker2   Shutdown       Shutdown 1 second ago
+jnarweeha8x4  redis.3      redis:7.4.1  worker1   Running        Running 3 seconds ago
+vs448yca2nz4   \_ redis.3  redis:7.4.0  worker1   Shutdown       Shutdown 4 seconds ago
+jf1i992619ir  redis.4      redis:7.4.1  worker1   Running        Running 10 seconds ago
+blkttv7zs8ee   \_ redis.4  redis:7.4.0  worker1   Shutdown       Shutdown 11 seconds ago
 ```
 
 The number of items in the task history is determined by the
@@ -82,10 +82,10 @@ example:
 $ docker service ps --no-trunc redis
 
 ID                          NAME         IMAGE                                                                                NODE      DESIRED STATE  CURRENT STATE            ERROR                                                                                           PORTS
-50qe8lfnxaxksi9w2a704wkp7   redis.1      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 5 minutes ago
-ky2re9oz86r9556i2szb8a8af   \_ redis.1   redis:3.0.5@sha256:f8829e00d95672c48c60f468329d6693c4bdd28d1f057e755f8ba8b40008682e  worker2   Shutdown       Shutdown 5 minutes ago
-bk658fpbex0d57cqcwoe3jthu   redis.2      redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 5 seconds
-nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:3.0.6@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
+50qe8lfnxaxksi9w2a704wkp7   redis.1      redis:7.4.1@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  manager1  Running        Running 5 minutes ago
+ky2re9oz86r9556i2szb8a8af   \_ redis.1   redis:7.4.0@sha256:f8829e00d95672c48c60f468329d6693c4bdd28d1f057e755f8ba8b40008682e  worker2   Shutdown       Shutdown 5 minutes ago
+bk658fpbex0d57cqcwoe3jthu   redis.2      redis:7.4.1@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Running        Running 5 seconds
+nvjljf7rmor4htv7l8rwcx7i7   \_ redis.2   redis:7.4.1@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842  worker2   Shutdown       Rejected 5 minutes ago   "No such image: redis@sha256:6a692a76c2081888b589e26e6ec835743119fe453d67ecf03df7de5b73d69842"
 ```
 
 ### <a name="filter"></a> Filtering (--filter)
@@ -111,8 +111,8 @@ The `id` filter matches on all or a prefix of a task's ID.
 $ docker service ps -f "id=8" redis
 
 ID             NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
-8ryt076polmc   redis.4   redis:3.0.6  worker1   Running        Running 9 seconds
-8eaxrb2fqpbn   redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
+8ryt076polmc   redis.4   redis:7.4.1  worker1   Running        Running 9 seconds
+8eaxrb2fqpbn   redis.10  redis:7.4.1  manager1  Running        Running 8 seconds
 ```
 
 #### name
@@ -123,7 +123,7 @@ The `name` filter matches on task names.
 $ docker service ps -f "name=redis.1" redis
 
 ID            NAME     IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
-qihejybwf1x5  redis.1  redis:3.0.6  manager1  Running        Running 8 seconds
+qihejybwf1x5  redis.1  redis:7.4.1  manager1  Running        Running 8 seconds
 ```
 
 
@@ -135,10 +135,10 @@ The `node` filter matches on a node name or a node ID.
 $ docker service ps -f "node=manager1" redis
 
 ID            NAME      IMAGE        NODE      DESIRED STATE  CURRENT STATE      ERROR  PORTS
-0qihejybwf1x  redis.1   redis:3.0.6  manager1  Running        Running 8 seconds
-1x0v8yomsncd  redis.5   redis:3.0.6  manager1  Running        Running 8 seconds
-3w1wu13yupln  redis.9   redis:3.0.6  manager1  Running        Running 8 seconds
-8eaxrb2fqpbn  redis.10  redis:3.0.6  manager1  Running        Running 8 seconds
+0qihejybwf1x  redis.1   redis:7.4.1  manager1  Running        Running 8 seconds
+1x0v8yomsncd  redis.5   redis:7.4.1  manager1  Running        Running 8 seconds
+3w1wu13yupln  redis.9   redis:7.4.1  manager1  Running        Running 8 seconds
+8eaxrb2fqpbn  redis.10  redis:7.4.1  manager1  Running        Running 8 seconds
 ```
 
 #### desired-state

--- a/docs/reference/commandline/service_scale.md
+++ b/docs/reference/commandline/service_scale.md
@@ -84,7 +84,7 @@ $ docker service ls
 
 ID            NAME      MODE        REPLICAS  IMAGE
 3pr5mlvu3fh9  frontend  replicated  5/5       nginx:alpine
-74nzcxxjv6fq  backend   replicated  3/3       redis:3.0.6
+74nzcxxjv6fq  backend   replicated  3/3       redis:7.4.1
 ```
 
 ## Related commands


### PR DESCRIPTION
**- What I did**

Updated redis example tags from 3.0.x to latest patch n and n-1 versions.

3.0.5 and 3.0.6 use image format v1 and they're all just old anyway.

- relates to docker/docs#21337

**- How I did it**

`fd -e md -X sed -i 's,3\.0\.5,7.4.0,g'`
`fd -e md -X sed -i 's,3\.0\.[67],7.4.1,g'`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.ikea.com/se/en/images/products/djungelskog-soft-toy-orangutan__0710167_pe727369_s5.jpg?f=s)
