### PR TITLE
Add option --ipv4

### DIFF
--- a/cli/command/network/formatter.go
+++ b/cli/command/network/formatter.go
@@ -13,6 +13,7 @@ const (
 	defaultNetworkTableFormat = "table {{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.Scope}}"
 
 	networkIDHeader = "NETWORK ID"
+	ipv4Header      = "IPV4"
 	ipv6Header      = "IPV6"
 	internalHeader  = "INTERNAL"
 )
@@ -51,6 +52,7 @@ func FormatWrite(ctx formatter.Context, networks []network.Summary) error {
 		"Name":      formatter.NameHeader,
 		"Driver":    formatter.DriverHeader,
 		"Scope":     formatter.ScopeHeader,
+		"IPv4":      ipv4Header,
 		"IPv6":      ipv6Header,
 		"Internal":  internalHeader,
 		"Labels":    formatter.LabelsHeader,
@@ -86,6 +88,10 @@ func (c *networkContext) Driver() string {
 
 func (c *networkContext) Scope() string {
 	return c.n.Scope
+}
+
+func (c *networkContext) IPv4() string {
+	return strconv.FormatBool(c.n.EnableIPv4)
 }
 
 func (c *networkContext) IPv6() string {

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -43,6 +43,9 @@ func TestNetworkContext(t *testing.T) {
 			n: network.Summary{Driver: "driver_name"},
 		}, "driver_name", ctx.Driver},
 		{networkContext{
+			n: network.Summary{EnableIPv4: true},
+		}, "true", ctx.IPv4},
+		{networkContext{
 			n: network.Summary{EnableIPv6: true},
 		}, "true", ctx.IPv6},
 		{networkContext{
@@ -180,8 +183,8 @@ func TestNetworkContextWriteJSON(t *testing.T) {
 		{ID: "networkID2", Name: "foobar_bar"},
 	}
 	expectedJSONs := []map[string]any{
-		{"Driver": "", "ID": "networkID1", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_baz", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
-		{"Driver": "", "ID": "networkID2", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_bar", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
+		{"Driver": "", "ID": "networkID1", "IPv4": "false", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_baz", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
+		{"Driver": "", "ID": "networkID2", "IPv4": "false", "IPv6": "false", "Internal": "false", "Labels": "", "Name": "foobar_bar", "Scope": "", "CreatedAt": "0001-01-01 00:00:00 +0000 UTC"},
 	}
 
 	out := bytes.NewBufferString("")

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -18,7 +18,8 @@ Create a network
 | `--ip-range`              | `stringSlice` |           | Allocate container ip from a sub-range                  |
 | `--ipam-driver`           | `string`      | `default` | IP Address Management Driver                            |
 | `--ipam-opt`              | `map`         | `map[]`   | Set IPAM driver specific options                        |
-| `--ipv6`                  | `bool`        |           | Enable or disable IPv6 networking                       |
+| `--ipv4`                  | `bool`        | `true`    | Enable or disable IPv4 address assignment               |
+| `--ipv6`                  | `bool`        |           | Enable or disable IPv6 address assignment               |
 | `--label`                 | `list`        |           | Set metadata on a network                               |
 | `-o`, `--opt`             | `map`         | `map[]`   | Set driver specific options                             |
 | `--scope`                 | `string`      |           | Control the network's scope                             |
@@ -170,7 +171,8 @@ flags used for the `docker0` bridge:
 | `--gateway`           | -                                 | IPv4 or IPv6 Gateway for the master subnet |
 | `--ip-range`          | `--fixed-cidr`, `--fixed-cidr-v6` | Allocate IP addresses from a range         |
 | `--internal`          | -                                 | Restrict external access to the network    |
-| `--ipv6`              | `--ipv6`                          | Enable or disable IPv6 networking          |
+| `--ipv4`              | -                                 | Enable or disable IPv4 address assignment  |
+| `--ipv6`              | `--ipv6`                          | Enable or disable IPv6 address assignment  |
 | `--subnet`            | `--bip`, `--bip6`                 | Subnet for network                         |
 
 For example, let's use `-o` or `--opt` options to specify an IP address binding

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -165,13 +165,13 @@ The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to Docker daemon
 flags used for the docker0 bridge:
 
-| Argument     | Equivalent     | Description                                |
-|--------------|----------------|--------------------------------------------|
-| `--gateway`  | -              | IPv4 or IPv6 Gateway for the master subnet |
-| `--ip-range` | `--fixed-cidr` | Allocate IPs from a range                  |
-| `--internal` | -              | Restrict external access to the network    |
-| `--ipv6`     | `--ipv6`       | Enable or disable IPv6 networking          |
-| `--subnet`   | `--bip`        | Subnet for network                         |
+| Argument     | Equivalent                        | Description                                |
+|--------------|-----------------------------------|--------------------------------------------|
+| `--gateway`  | -                                 | IPv4 or IPv6 Gateway for the master subnet |
+| `--ip-range` | `--fixed-cidr`, `--fixed-cidr-v6` | Allocate IPs from a range                  |
+| `--internal` | -                                 | Restrict external access to the network    |
+| `--ipv6`     | `--ipv6`                          | Enable or disable IPv6 networking          |
+| `--subnet`   | `--bip`, `--bip6`                 | Subnet for network                         |
 
 For example, let's use `-o` or `--opt` options to specify an IP address binding
 when publishing ports:

--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -148,30 +148,30 @@ fails and Docker Engine returns an error.
 
 ### Bridge driver options
 
-When creating a custom network, the default network driver (i.e. `bridge`) has
-additional options that can be passed. The following are those options and the
-equivalent Docker daemon flags used for docker0 bridge:
+When creating a custom `bridge` network, the following additional options can
+be passed. Some of these have equivalent flags that can be used on the dockerd
+command line or in `daemon.json` to configure the default bridge, `docker0`:
 
-| Option                                           | Equivalent  | Description                                           |
-|--------------------------------------------------|-------------|-------------------------------------------------------|
-| `com.docker.network.bridge.name`                 | -           | Bridge name to be used when creating the Linux bridge |
-| `com.docker.network.bridge.enable_ip_masquerade` | `--ip-masq` | Enable IP masquerading                                |
-| `com.docker.network.bridge.enable_icc`           | `--icc`     | Enable or Disable Inter Container Connectivity        |
-| `com.docker.network.bridge.host_binding_ipv4`    | `--ip`      | Default IP when binding container ports               |
-| `com.docker.network.driver.mtu`                  | `--mtu`     | Set the containers network MTU                        |
-| `com.docker.network.container_iface_prefix`      | -           | Set a custom prefix for container interfaces          |
+| Network create option                            | Daemon option for `docker0` | Description                                           |
+|--------------------------------------------------|-----------------------------|-------------------------------------------------------|
+| `com.docker.network.bridge.name`                 | -                           | Bridge name to be used when creating the Linux bridge |
+| `com.docker.network.bridge.enable_ip_masquerade` | `--ip-masq`                 | Enable IP masquerading                                |
+| `com.docker.network.bridge.enable_icc`           | `--icc`                     | Enable or Disable Inter Container Connectivity        |
+| `com.docker.network.bridge.host_binding_ipv4`    | `--ip`                      | Default IP when binding container ports               |
+| `com.docker.network.driver.mtu`                  | `--mtu`                     | Set the containers network MTU                        |
+| `com.docker.network.container_iface_prefix`      | -                           | Set a custom prefix for container interfaces          |
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to Docker daemon
-flags used for the docker0 bridge:
+flags used for the `docker0` bridge:
 
-| Argument     | Equivalent                        | Description                                |
-|--------------|-----------------------------------|--------------------------------------------|
-| `--gateway`  | -                                 | IPv4 or IPv6 Gateway for the master subnet |
-| `--ip-range` | `--fixed-cidr`, `--fixed-cidr-v6` | Allocate IPs from a range                  |
-| `--internal` | -                                 | Restrict external access to the network    |
-| `--ipv6`     | `--ipv6`                          | Enable or disable IPv6 networking          |
-| `--subnet`   | `--bip`, `--bip6`                 | Subnet for network                         |
+| Network create option | Daemon option for `docker0`       | Description                                |
+|-----------------------|-----------------------------------|--------------------------------------------|
+| `--gateway`           | -                                 | IPv4 or IPv6 Gateway for the master subnet |
+| `--ip-range`          | `--fixed-cidr`, `--fixed-cidr-v6` | Allocate IP addresses from a range         |
+| `--internal`          | -                                 | Restrict external access to the network    |
+| `--ipv6`              | `--ipv6`                          | Enable or disable IPv6 networking          |
+| `--subnet`            | `--bip`, `--bip6`                 | Subnet for network                         |
 
 For example, let's use `-o` or `--opt` options to specify an IP address binding
 when publishing ports:


### PR DESCRIPTION
**- What I did**

Added `network create` option `--ipv4` ... like `--ipv6`, but it defaults to `true`.

Updated network create docs to include `--ipv4` - and `--fixed-cidr-v6`, `--bip6` ... and tried to make it more obvious that the short options only affect `docker0`.

**- How I did it**

Mostly by copying code for `--ipv6`.

**- How to verify it**

```
# docker network create b4
0d4a8723ec72d2d4b661e60c095865fcd77819459ae0e318505fa1feadbae3de
# docker network create --ipv6 b46
b24ceec262cf8c01e0586ebcea3bd440b52fa0f9b1d40c93f8cec189b7674865
# docker network create --ipv6 --ipv4=false b6
cdfdd74fc7f3b5c421894b0c5b33d48ae8517e8edfcaca6fd40a448e801a189d

# docker network ls --format "table {{.ID}}\t{{.Name}}\t{{.Driver}}\t{{.Scope}}\t{{.IPv4}}\t{{.IPv6}}"
NETWORK ID     NAME      DRIVER    SCOPE     IPV4      IPV6
0d4a8723ec72   b4        bridge    local     true      false
cdfdd74fc7f3   b6        bridge    local     false     true
b24ceec262cf   b46       bridge    local     true      true
be4cf667c3a7   bridge    bridge    local     true      false
8f0b062d1967   host      host      local     false     false
08d4868e22d1   none      null      local     false     false

# docker run --rm -ti --network b6 alpine ip a show dev eth0
17: eth0@if18: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 86:18:48:8f:f3:3d brd ff:ff:ff:ff:ff:ff
    inet6 fd50:8667:92c::2/64 scope global flags 02
       valid_lft forever preferred_lft forever
    inet6 fe80::8418:48ff:fe8f:f33d/64 scope link tentative
       valid_lft forever preferred_lft forever
```

**- Description for the changelog**
```markdown changelog
- Added `docker network create` option `--ipv4`.
  To disable IPv4 address assignment for a network, use `docker network create --ipv4=false [...]`.
```

