### PR TITLE
cli/command/container: fix missing go:build tag

### DIFF
--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -1,3 +1,7 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+// +build go1.22
+
 package container
 
 import (


### PR DESCRIPTION
- relates to https://github.com/docker/compose/pull/12297#issuecomment-2478450487
- relates to https://github.com/docker/cli/pull/4723

---

    make shell
    make -C ./internal/gocompat/

    GO111MODULE=on go test -v
    # github.com/docker/cli/cli/command/container
    ../../cli/command/container/completion.go:37:28: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    ../../cli/command/container/completion.go:82:25: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    ../../cli/command/container/completion.go:92:27: implicit function instantiation requires go1.18 or later (-lang was set to go1.16; check go.mod)
    FAIL	gocompat [build failed]

**- A picture of a cute animal (not mandatory but encouraged)**

