### PR TITLE
[27.x backport] update go:build tags to use go1.22, fix missing go:build tag

### DIFF
--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package manager
 

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package config
 

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -1,3 +1,7 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+// +build go1.22
+
 package container
 
 import (

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package container
 

--- a/cli/command/context.go
+++ b/cli/command/context.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package context
 

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package context
 

--- a/cli/command/context/inspect.go
+++ b/cli/command/context/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package context
 

--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package context
 

--- a/cli/command/context_test.go
+++ b/cli/command/context_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/defaultcontextstore.go
+++ b/cli/command/defaultcontextstore.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/custom.go
+++ b/cli/command/formatter/custom.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/formatter_test.go
+++ b/cli/command/formatter/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/reflect.go
+++ b/cli/command/formatter/reflect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/reflect_test.go
+++ b/cli/command/formatter/reflect_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package formatter
 

--- a/cli/command/idresolver/idresolver.go
+++ b/cli/command/idresolver/idresolver.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package idresolver
 

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package image
 

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package image
 

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package inspect
 

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package network
 

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package network
 

--- a/cli/command/node/formatter_test.go
+++ b/cli/command/node/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package node
 

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package node
 

--- a/cli/command/plugin/formatter_test.go
+++ b/cli/command/plugin/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package plugin
 

--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package plugin
 

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package secret
 

--- a/cli/command/service/formatter_test.go
+++ b/cli/command/service/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package service
 

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package service
 

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package service
 

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package service
 

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package system
 

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package system
 

--- a/cli/command/telemetry_docker.go
+++ b/cli/command/telemetry_docker.go
@@ -1,5 +1,5 @@
-// FIXME(jsternberg): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
 
 package command
 

--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package trust
 

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package command
 

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package volume
 

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package interpolation
 

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package interpolation
 

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package loader
 

--- a/cli/compose/schema/schema.go
+++ b/cli/compose/schema/schema.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package schema
 

--- a/cli/compose/schema/schema_test.go
+++ b/cli/compose/schema/schema_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package schema
 

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package template
 

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package template
 

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package types
 

--- a/cli/context/store/metadata_test.go
+++ b/cli/context/store/metadata_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/context/store/storeconfig_test.go
+++ b/cli/context/store/storeconfig_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package store
 

--- a/cli/internal/oauth/api/api.go
+++ b/cli/internal/oauth/api/api.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package api
 

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package main
 

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.21
+//go:build go1.22
 
 package templates
 


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5608
    - relates to https://github.com/docker/cli/pull/5594
- backport: https://github.com/docker/cli/pull/5621
    - relates to https://github.com/docker/compose/pull/12297#issuecomment-2478450487
