### PR TITLE
docs: Add Quick Start examples section to docker run documentation

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -14,6 +14,29 @@ isolated process tree separate from the host.
 
 This page details how to use the `docker run` command to run containers.
 
+## Quick Start Examples
+
+Here are some common use cases for `docker run`:
+
+```console
+# Run a container in interactive mode
+$ docker run -it ubuntu bash
+
+# Run a container in the background (detached mode)
+$ docker run -d nginx
+
+# Run a container with port mapping
+$ docker run -p 8080:80 nginx
+
+# Run a container with environment variables
+$ docker run -e DB_HOST=localhost -e DB_PORT=5432 myapp
+
+# Run a container with volume mount
+$ docker run -v /host/path:/container/path myapp
+```
+
+For more detailed examples and explanations, see the sections below.
+
 ## General form
 
 A `docker run` command takes the following form:


### PR DESCRIPTION
## Description
Added a Quick Start Examples section to the docker run documentation to help users get started quickly with common use cases.

## Changes
- Added a "Quick Start Examples" section at the beginning of the run.md file
- Included examples for:
  - Interactive mode
  - Detached mode
  - Port mapping
  - Environment variables
  - Volume mounting

## Motivation
This change makes it easier for new users to quickly find and understand common docker run usage patterns without having to read through the entire documentation.

Signed-off-by: nived2 <nivedmahendran2@gmail.com>