### PR TITLE
 tests: cleanup table test names

### DIFF
--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -82,7 +82,7 @@ func TestValidateOutputPath(t *testing.T) {
 }
 
 func TestPromptForInput(t *testing.T) {
-	t.Run("case=cancelling the context", func(t *testing.T) {
+	t.Run("cancelling the context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 		reader, _ := io.Pipe()
@@ -116,7 +116,7 @@ func TestPromptForInput(t *testing.T) {
 		}
 	})
 
-	t.Run("case=user input should be properly trimmed", func(t *testing.T) {
+	t.Run("user input should be properly trimmed", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		t.Cleanup(cancel)
 
@@ -196,7 +196,7 @@ func TestPromptForConfirmation(t *testing.T) {
 			return promptReader.Close()
 		}, promptResult{false, nil}},
 	} {
-		t.Run("case="+tc.desc, func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			notifyCtx, notifyCancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 			t.Cleanup(notifyCancel)
 

--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -182,7 +182,7 @@ func TestPromptExitCode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run("case="+tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			buf := new(bytes.Buffer)


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

There's no need for `case=[xxx]` in table tests, Go does a good job of formatting the test output and we're just adding the same information for every test output line.

Previously:
```console
$ go test -count=1 -v -run=TestPromptForConfirmation ./cli/command
=== RUN   TestPromptForConfirmation
=== RUN   TestPromptForConfirmation/case=SIGINT
=== RUN   TestPromptForConfirmation/case=no
=== RUN   TestPromptForConfirmation/case=yes
=== RUN   TestPromptForConfirmation/case=any
=== RUN   TestPromptForConfirmation/case=with_space
=== RUN   TestPromptForConfirmation/case=reader_closed
--- PASS: TestPromptForConfirmation (0.00s)
    --- PASS: TestPromptForConfirmation/case=SIGINT (0.00s)
    --- PASS: TestPromptForConfirmation/case=no (0.00s)
    --- PASS: TestPromptForConfirmation/case=yes (0.00s)
    --- PASS: TestPromptForConfirmation/case=any (0.00s)
    --- PASS: TestPromptForConfirmation/case=with_space (0.00s)
    --- PASS: TestPromptForConfirmation/case=reader_closed (0.00s)
PASS
ok      github.com/docker/cli/cli/command       0.013s
```

After:
```console
$ go test -count=1 -v -run=TestPromptForConfirmation ./cli/command
=== RUN   TestPromptForConfirmation
=== RUN   TestPromptForConfirmation/SIGINT
=== RUN   TestPromptForConfirmation/no
=== RUN   TestPromptForConfirmation/yes
=== RUN   TestPromptForConfirmation/any
=== RUN   TestPromptForConfirmation/with_space
=== RUN   TestPromptForConfirmation/reader_closed
--- PASS: TestPromptForConfirmation (0.00s)
    --- PASS: TestPromptForConfirmation/SIGINT (0.00s)
    --- PASS: TestPromptForConfirmation/no (0.00s)
    --- PASS: TestPromptForConfirmation/yes (0.00s)
    --- PASS: TestPromptForConfirmation/any (0.00s)
    --- PASS: TestPromptForConfirmation/with_space (0.00s)
    --- PASS: TestPromptForConfirmation/reader_closed (0.00s)
PASS
ok      github.com/docker/cli/cli/command       0.009s
```

**- A picture of a cute animal (not mandatory but encouraged)**

