### PR TITLE
[27.x backport] cli-plugins: Fix searching inaccessible directories

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -77,8 +77,10 @@ func getPluginDirs(cfg *configfile.ConfigFile) ([]string, error) {
 
 func addPluginCandidatesFromDir(res map[string][]string, d string) error {
 	dentries, err := os.ReadDir(d)
+	// Silently ignore any directories which we cannot list (e.g. due to
+	// permissions or anything else) or which is not a directory
 	if err != nil {
-		return err
+		return nil
 	}
 	for _, dentry := range dentries {
 		switch dentry.Type() & os.ModeType {
@@ -106,12 +108,6 @@ func addPluginCandidatesFromDir(res map[string][]string, d string) error {
 func listPluginCandidates(dirs []string) (map[string][]string, error) {
 	result := make(map[string][]string)
 	for _, d := range dirs {
-		// Silently ignore any directories which we cannot
-		// Stat (e.g. due to permissions or anything else) or
-		// which is not a directory.
-		if fi, err := os.Stat(d); err != nil || !fi.IsDir() {
-			continue
-		}
 		if err := addPluginCandidatesFromDir(result, d); err != nil {
 			// Silently ignore paths which don't exist.
 			if os.IsNotExist(err) {

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -75,12 +75,12 @@ func getPluginDirs(cfg *configfile.ConfigFile) ([]string, error) {
 	return pluginDirs, nil
 }
 
-func addPluginCandidatesFromDir(res map[string][]string, d string) error {
+func addPluginCandidatesFromDir(res map[string][]string, d string) {
 	dentries, err := os.ReadDir(d)
 	// Silently ignore any directories which we cannot list (e.g. due to
 	// permissions or anything else) or which is not a directory
 	if err != nil {
-		return nil
+		return
 	}
 	for _, dentry := range dentries {
 		switch dentry.Type() & os.ModeType {
@@ -101,22 +101,15 @@ func addPluginCandidatesFromDir(res map[string][]string, d string) error {
 		}
 		res[name] = append(res[name], filepath.Join(d, dentry.Name()))
 	}
-	return nil
 }
 
 // listPluginCandidates returns a map from plugin name to the list of (unvalidated) Candidates. The list is in descending order of priority.
-func listPluginCandidates(dirs []string) (map[string][]string, error) {
+func listPluginCandidates(dirs []string) map[string][]string {
 	result := make(map[string][]string)
 	for _, d := range dirs {
-		if err := addPluginCandidatesFromDir(result, d); err != nil {
-			// Silently ignore paths which don't exist.
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, err // Or return partial result?
-		}
+		addPluginCandidatesFromDir(result, d)
 	}
-	return result, nil
+	return result
 }
 
 // GetPlugin returns a plugin on the system by its name
@@ -126,11 +119,7 @@ func GetPlugin(name string, dockerCli command.Cli, rootcmd *cobra.Command) (*Plu
 		return nil, err
 	}
 
-	candidates, err := listPluginCandidates(pluginDirs)
-	if err != nil {
-		return nil, err
-	}
-
+	candidates := listPluginCandidates(pluginDirs)
 	if paths, ok := candidates[name]; ok {
 		if len(paths) == 0 {
 			return nil, errPluginNotFound(name)
@@ -156,10 +145,7 @@ func ListPlugins(dockerCli command.Cli, rootcmd *cobra.Command) ([]Plugin, error
 		return nil, err
 	}
 
-	candidates, err := listPluginCandidates(pluginDirs)
-	if err != nil {
-		return nil, err
-	}
+	candidates := listPluginCandidates(pluginDirs)
 
 	var plugins []Plugin
 	var mu sync.Mutex

--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -51,8 +51,7 @@ func TestListPluginCandidates(t *testing.T) {
 		dirs = append(dirs, dir.Join(d))
 	}
 
-	candidates, err := listPluginCandidates(dirs)
-	assert.NilError(t, err)
+	candidates := listPluginCandidates(dirs)
 	exp := map[string][]string{
 		"plugin1": {
 			dir.Join("plugins1", "docker-plugin1"),
@@ -94,11 +93,10 @@ func TestListPluginCandidatesInaccesibleDir(t *testing.T) {
 	)
 	defer dir.Remove()
 
-	candidates, err := listPluginCandidates([]string{
+	candidates := listPluginCandidates([]string{
 		dir.Join("no-perm"),
 		dir.Join("plugins"),
 	})
-	assert.NilError(t, err)
 	assert.DeepEqual(t, candidates, map[string][]string{
 		"buildx": {
 			dir.Join("plugins", "docker-buildx"),


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5651

- fixes: https://github.com/docker/cli/issues/5643

Fix a case where one inaccessible plugin search path stops the whole search and prevents latter paths from being scanned.

Remove a preliminary `Stat` call that verifies whether path is an actual directory and is accessible.
It's unneeded and doesn't actually check whether the directory can be listed or not.
`os.ReadDir` will fail in such case anyway, so just attempt to do that and ignore any encountered error, instead of erroring out the whole plugin candidate listing.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**
TestListPluginCandidatesInaccesibleDir

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix inaccessible plugins paths preventing plugins from being detected.
```

**- A picture of a cute animal (not mandatory but encouraged)**

