### PR TITLE
docs: fix janky rendering of toc on docs.docker.com

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -892,7 +892,7 @@ Alternatively, you can set custom locations for CDI specifications using the
 When CDI is enabled for a daemon, you can view the configured CDI specification
 directories using the `docker info` command.
 
-#### <a name="log-format"></a> Daemon logging format
+#### Daemon logging format {#log-format}
 
 The `--log-format` option or "log-format" option in the [daemon configuration file](#daemon-configuration-file)
 lets you set the format for logs produced by the daemon. The logging format should
@@ -1000,7 +1000,7 @@ Example of usage:
 }
 ```
 
-### <a name="feature"></a> Enable feature in the daemon (--feature)
+### Enable feature in the daemon (--feature) {#feature}
 
 The `--feature` option lets you enable or disable a feature in the daemon.
 This option corresponds with the "features" field in the [daemon.json configuration file](#daemon-configuration-file).


### PR DESCRIPTION
The right-hand toc was rendering in a janky way due to empty anchor tags

<img width="351" alt="image" src="https://github.com/user-attachments/assets/43ed521d-7a24-415d-ac07-c56ee8c78764">
<img width="407" alt="image" src="https://github.com/user-attachments/assets/dedb4839-22ee-405d-b77a-8077171f5f44">
