### PR TITLE
[27.x backport] fix: ctx on run image pull

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -25,7 +25,7 @@ type fakeClient struct {
 		platform *specs.Platform,
 		containerName string) (container.CreateResponse, error)
 	containerStartFunc      func(containerID string, options container.StartOptions) error
-	imageCreateFunc         func(parentReference string, options image.CreateOptions) (io.ReadCloser, error)
+	imageCreateFunc         func(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error)
 	infoFunc                func() (system.Info, error)
 	containerStatPathFunc   func(containerID, path string) (container.PathStat, error)
 	containerCopyFromFunc   func(containerID, srcPath string) (io.ReadCloser, container.PathStat, error)
@@ -94,9 +94,9 @@ func (f *fakeClient) ContainerRemove(ctx context.Context, containerID string, op
 	return nil
 }
 
-func (f *fakeClient) ImageCreate(_ context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error) {
+func (f *fakeClient) ImageCreate(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error) {
 	if f.imageCreateFunc != nil {
-		return f.imageCreateFunc(parentReference, options)
+		return f.imageCreateFunc(ctx, parentReference, options)
 	}
 	return nil, nil
 }

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -133,7 +133,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 						return container.CreateResponse{ID: containerID}, nil
 					}
 				},
-				imageCreateFunc: func(parentReference string, options image.CreateOptions) (io.ReadCloser, error) {
+				imageCreateFunc: func(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error) {
 					defer func() { pullCounter++ }()
 					return io.NopCloser(strings.NewReader("")), nil
 				},

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -268,7 +268,6 @@ func TestRunPullTermination(t *testing.T) {
 	case cmdErr := <-cmdErrC:
 		assert.Equal(t, cmdErr, cli.StatusError{
 			StatusCode: 125,
-			Status:     "docker: context canceled\n\nRun 'docker run --help' for more information",
 		})
 	case <-time.After(10 * time.Second):
 		t.Fatal("cmd did not return before the timeout")

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -2,7 +2,9 @@ package container
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"syscall"
@@ -16,7 +18,9 @@ import (
 	"github.com/docker/cli/internal/test/notary"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/pkg/jsonmessage"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/pflag"
 	"gotest.tools/v3/assert"
@@ -185,6 +189,88 @@ func TestRunAttachTermination(t *testing.T) {
 			StatusCode: 130,
 		})
 	case <-time.After(2 * time.Second):
+		t.Fatal("cmd did not return before the timeout")
+	}
+}
+
+func TestRunPullTermination(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	attachCh := make(chan struct{})
+	fakeCLI := test.NewFakeCli(&fakeClient{
+		createContainerFunc: func(config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig,
+			platform *specs.Platform, containerName string,
+		) (container.CreateResponse, error) {
+			select {
+			case <-ctx.Done():
+				return container.CreateResponse{}, ctx.Err()
+			default:
+			}
+			return container.CreateResponse{}, fakeNotFound{}
+		},
+		containerAttachFunc: func(ctx context.Context, containerID string, options container.AttachOptions) (types.HijackedResponse, error) {
+			return types.HijackedResponse{}, errors.New("shouldn't try to attach to a container")
+		},
+		imageCreateFunc: func(ctx context.Context, parentReference string, options image.CreateOptions) (io.ReadCloser, error) {
+			server, client := net.Pipe()
+			t.Cleanup(func() {
+				_ = server.Close()
+			})
+			go func() {
+				enc := json.NewEncoder(server)
+				for i := 0; i < 100; i++ {
+					select {
+					case <-ctx.Done():
+						assert.NilError(t, server.Close(), "failed to close imageCreateFunc server")
+						return
+					default:
+					}
+					assert.NilError(t, enc.Encode(jsonmessage.JSONMessage{
+						Status:   "Downloading",
+						ID:       fmt.Sprintf("id-%d", i),
+						TimeNano: time.Now().UnixNano(),
+						Time:     time.Now().Unix(),
+						Progress: &jsonmessage.JSONProgress{
+							Current: int64(i),
+							Total:   100,
+							Start:   0,
+						},
+					}))
+					time.Sleep(100 * time.Millisecond)
+				}
+			}()
+			attachCh <- struct{}{}
+			return client, nil
+		},
+		Version: "1.30",
+	})
+
+	cmd := NewRunCommand(fakeCLI)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"foobar:latest"})
+
+	cmdErrC := make(chan error, 1)
+	go func() {
+		cmdErrC <- cmd.ExecuteContext(ctx)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("imageCreateFunc was not called before the timeout")
+	case <-attachCh:
+	}
+
+	cancel()
+
+	select {
+	case cmdErr := <-cmdErrC:
+		assert.Equal(t, cmdErr, cli.StatusError{
+			StatusCode: 125,
+			Status:     "docker: context canceled\n\nRun 'docker run --help' for more information",
+		})
+	case <-time.After(10 * time.Second):
 		t.Fatal("cmd did not return before the timeout")
 	}
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

- backport https://github.com/docker/cli/pull/5645
- Fixes https://github.com/docker/cli/issues/5639

After some digging I found that we don't actually explicitly return an error on the `pullImage` function [here](https://github.com/docker/cli/blob/master/cli/command/container/create.go#L132-L152). Once the context is cancelled the response is closed since the API client uses `http.NewRequestWithContext` which then exits the `jsonmessage.DisplayJSONMessagesToStream(responseBody, out, nil)` without any errors. 

The following API request to `ContainerCreate` then immediately fails since the context is closed, which then returns an error.

See this section of the code, it fails to find the image, then pulls the image, and continues to retry creating a container - on this second retry it only then returns with the context error.
https://github.com/docker/cli/blob/master/cli/command/container/create.go#L271-L289

Writing a test for this means that we are building into the test an assumption that we won't error on the `pullImage` function, but rather on the second call to `ContainerCreate`. I'll push what I have, but I honestly think that we will get tripped up by the `pullImage` function again since it's not context aware - actually more so the `jsonmessage` package it is using is actually the root cause found in Moby [here](https://github.com/moby/moby/blob/master/pkg/jsonmessage/jsonmessage.go#L228). It's a bit of a hornets nest since it gets used in many places and by refactoring/improving this it could cause edge case bugs.

**- What I did**
Delay stripping the `cancel` from the function `ctx` so we can still cancel the `createContainer` function. https://github.com/docker/cli/blob/e4e0ea2c1a8f7aa695fee0d77acc8b760462ce00/cli/command/container/run.go#L142

**- How I did it**

**- How to verify it**
Unit test

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fixed bug preventing image pulls from being cancelled during `docker run`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

