### PR TITLE
[27.x backport] cli/trust: GetNotaryRepository: remove uses of RepositoryInfo.Class

### DIFF
--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -157,7 +157,6 @@ func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo
 	scope := auth.RepositoryScope{
 		Repository: repoInfo.Name.Name(),
 		Actions:    actions,
-		Class:      repoInfo.Class, // TODO(thaJeztah): Class is no longer needed for plugins and can likely be removed; see https://github.com/docker/cli/pull/4114#discussion_r1145430825
 	}
 	creds := simpleCredentialStore{auth: *authConfig}
 	tokenHandlerOptions := auth.TokenHandlerOptions{


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5660
- relates to https://github.com/docker/cli/pull/4114
- relates to https://github.com/moby/moby/pull/49006


The Class field was added because  Docker Hub registry required a special scope to be set for pulling plugins;

    HTTP/1.1 401 Unauthorized
    ...
    Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository(plugin):vieux/sshfs:pull",error="insufficient_scope"

This is no longer a requirement, and the field is no longer set.

updates 0ba820ed0b4a448ad6de2590c75686dd66274a4c


cherry picked from commit ed9fcf31e6cae8be5358964261e34bfb6b0ec428)


**- A picture of a cute animal (not mandatory but encouraged)**

