### PR TITLE
run: correctly handle only STDIN attached

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -228,16 +228,14 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		}
 	}
 
-	if errCh != nil {
-		if err := <-errCh; err != nil {
-			if _, ok := err.(term.EscapeError); ok {
-				// The user entered the detach escape sequence.
-				return nil
-			}
-
-			logrus.Debugf("Error hijack: %s", err)
-			return err
+	if err := <-errCh; err != nil {
+		if _, ok := err.(term.EscapeError); ok {
+			// The user entered the detach escape sequence.
+			return nil
 		}
+
+		logrus.Debugf("Error hijack: %s", err)
+		return err
 	}
 
 	status := <-statusChan

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -161,7 +161,8 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		waitDisplayID chan struct{}
 		errCh         chan error
 	)
-	if !config.AttachStdout && !config.AttachStderr {
+	attach := config.AttachStdin || config.AttachStdout || config.AttachStderr
+	if !attach {
 		// Make this asynchronous to allow the client to write to stdin before having to read the ID
 		waitDisplayID = make(chan struct{})
 		go func() {
@@ -169,7 +170,6 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 			_, _ = fmt.Fprintln(stdout, containerID)
 		}()
 	}
-	attach := config.AttachStdin || config.AttachStdout || config.AttachStderr
 	if attach {
 		detachKeys := dockerCli.ConfigFile().DetachKeys
 		if runOpts.detachKeys != "" {
@@ -234,7 +234,7 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 	}
 
 	// Detached mode: wait for the id to be displayed and return.
-	if !config.AttachStdout && !config.AttachStderr {
+	if !attach {
 		// Detached mode
 		<-waitDisplayID
 		return nil

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -215,7 +215,7 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		return toStatusError(err)
 	}
 
-	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && dockerCli.Out().IsTerminal() {
+	if attach && config.Tty && dockerCli.Out().IsTerminal() {
 		if err := MonitorTtySize(ctx, dockerCli, containerID, false); err != nil {
 			_, _ = fmt.Fprintln(stderr, "Error monitoring TTY size:", err)
 		}

--- a/e2e/container/attach_test.go
+++ b/e2e/container/attach_test.go
@@ -37,7 +37,6 @@ func TestAttachInterrupt(t *testing.T) {
 	// todo(laurazard): make this test work w/ dind over ssh
 	skip.If(t, strings.Contains(os.Getenv("DOCKER_HOST"), "ssh://"))
 
-	// if
 	result := icmd.RunCommand("docker", "run", "-d", fixtures.AlpineImage,
 		"sh", "-c", "trap \"exit 33\" SIGINT; for i in $(seq 100); do sleep 0.1; done; exit 34")
 	result.Assert(t, icmd.Success)


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Overall make the `docker run -a stdin` handling more consistent + some assorted cleanups.

The most significant changes are making the "print container ID and immediately exit if detached" check more consistent (also account for `-a stdin` instead of just `stdout` and `stderr`), and making `docker run -a stdin` exit if the container exits/is removed.

**- How I did it**

aee9eebf349dd6d8634e4ea7d5624e276c6da0a2:

During a `docker run`, the CLI has some different behavior/output depending on whether the run is "detached" or not.

In some cases, the CLI is checking whether either `stdin`, `stdout` or `stderr` are attached, but in other cases we're only checking `stdout` and `stderr`, which leads to some inconsistencies:

```
$ docker run -a stdout --rm --name test alpine top
[docker kill test]
exit status 137

$ docker run -a stderr --rm --name test alpine top
[docker kill test]
exit status 137

$ docker run -a stdin --rm --name test alpine top
56820d94a89b96889478241ae68920323332c6d4cf9b51ba9340cba01e9e0565
[docker kill test]
[no exit code]
```

Since we're not checking for whether `stdin` is attached when deciding whether to early exit without receiving on `statusChan`, the `docker run -a stdin` is falling into the "detached mode" logic, which simply prints the container ID and doesn't print/return the exit code.

This patch makes the "attached" checks consistent.

8431298824ef57e51d1b5c0a7af85cb17fd7a3e8: small cleanup

446f36ce58c2c67dd727e8ec7963218e85a36ed5: Since everything else after the `apiClient.ContainerStart` block is under an `if attach` conditional, we can move the "not attached" early exit up.

a3d9fc49414b5e6972e589d2baa8df676a984c9b:

Now, if running in "detached" mode, we early exit at L222.

Similarly, if `attachContainer` errors out, it returns an error that gets handled on L190.

As such, `errCh` can never be nil on L231. Remove the nil check.

a8650d8b3e7571fa1aa67143ce28d67a1fd2dded:

If STDOUT or STDERR are attached and the container exits, the streams will be closed by the daemon while the container is exiting, causing the streamer to return an error
https://github.com/docker/cli/blob/61b02e636d2afed778f2e871c3ec1c6adee69ca4/cli/command/container/hijack.go#L53
that gets sent
https://github.com/docker/cli/blob/61b02e636d2afed778f2e871c3ec1c6adee69ca4/cli/command/container/run.go#L278
and received
https://github.com/docker/cli/blob/61b02e636d2afed778f2e871c3ec1c6adee69ca4/cli/command/container/run.go#L225
on `errCh`.

However, if only STDIN is attached, it's not closed (since this is attached to the user's TTY) when the container exits, so the streamer doesn't exit and nothing gets sent on `errCh`, meaning the CLI execution hangs receiving on `errCh` on L231.

Change the logic to receive on both `errCh` and `statusChan` – this way, if the container exits, we get notified on `statusChan` (even if only STDIN is attached), and can cancel the streamer and exit.

bae9b980b3a0276fe03dd9c7bab1fa87facee5dd: cleaned up a comment on another test

**- How to verify it**

```console
$ docker run -a stdin --rm --name rborkrr alpine sh -c 'sleep 2 && exit 7'
```

Check that it doesn't hang, and that the container ID is not printed (like with `-a stdout/stderr`), but `exit status 7` is.

Also, run the added e2e test:
```console
TESTFLAGS="-test.run=TestRunAttach" make -f docker.Makefile test-e2e-non-experimental
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
- Fix issue causing output of `docker run` to be inconsistent when using `--attach stdout or `--attach stderr` vs `stdin`.
- `docker run --attach stdin` now exits if the container exits.
```

**- A picture of a cute animal (not mandatory but encouraged)**