### PR TITLE
pkg/command: wrap `jsonmessage.DisplayJSONMessagesStream` with go context

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -13,13 +13,13 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	imagetypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/jsonmessage"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -148,7 +148,7 @@ func pullImage(ctx context.Context, dockerCli command.Cli, img string, options *
 	if options.quiet {
 		out = streams.NewOut(io.Discard)
 	}
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, out, nil)
+	return jsonstream.Display(ctx, responseBody, out)
 }
 
 type cidFile struct {

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -8,9 +8,9 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	dockeropts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/cobra"
 )
 
@@ -90,5 +90,5 @@ func runImport(ctx context.Context, dockerCli command.Cli, options importOptions
 	}
 	defer responseBody.Close()
 
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	return jsonstream.Display(ctx, responseBody, dockerCli.Out())
 }

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -8,8 +8,8 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/sys/sequential"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -89,7 +89,7 @@ func runLoad(ctx context.Context, dockerCli command.Cli, opts loadOptions) error
 	defer response.Body.Close()
 
 	if response.Body != nil && response.JSON {
-		return jsonmessage.DisplayJSONMessagesToStream(response.Body, dockerCli.Out(), nil)
+		return jsonstream.Display(ctx, response.Body, dockerCli.Out())
 	}
 
 	_, err = io.Copy(dockerCli.Out(), response.Body)

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -9,9 +9,9 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/docker/api/types"
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -129,7 +129,7 @@ func runInstall(ctx context.Context, dockerCli command.Cli, opts pluginOptions) 
 		return err
 	}
 	defer responseBody.Close()
-	if err := jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil); err != nil {
+	if err := jsonstream.Display(ctx, responseBody, dockerCli.Out()); err != nil {
 		return err
 	}
 	fmt.Fprintf(dockerCli.Out(), "Installed plugin %s\n", opts.remote) // todo: return proper values from the API for this result

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -7,8 +7,8 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	registrytypes "github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -66,8 +66,8 @@ func runPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error
 	defer responseBody.Close()
 
 	if !opts.untrusted {
-		return image.PushTrustedReference(dockerCli, repoInfo, named, authConfig, responseBody)
+		return image.PushTrustedReference(ctx, dockerCli, repoInfo, named, authConfig, responseBody)
 	}
 
-	return jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil)
+	return jsonstream.Display(ctx, responseBody, dockerCli.Out())
 }

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -8,8 +8,8 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/docker/errdefs"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -86,7 +86,7 @@ func runUpgrade(ctx context.Context, dockerCli command.Cli, opts pluginOptions) 
 		return err
 	}
 	defer responseBody.Close()
-	if err := jsonmessage.DisplayJSONMessagesToStream(responseBody, dockerCli.Out(), nil); err != nil {
+	if err := jsonstream.Display(ctx, responseBody, dockerCli.Out()); err != nil {
 		return err
 	}
 	fmt.Fprintf(dockerCli.Out(), "Upgraded plugin %s to %s\n", opts.localName, opts.remote) // todo: return proper values from the API for this result

--- a/cli/command/service/helpers.go
+++ b/cli/command/service/helpers.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/service/progress"
-	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/cli/cli/internal/jsonstream"
 )
 
 // WaitOnService waits for the service to converge. It outputs a progress bar,
@@ -24,7 +24,7 @@ func WaitOnService(ctx context.Context, dockerCli command.Cli, serviceID string,
 		return <-errChan
 	}
 
-	err := jsonmessage.DisplayJSONMessagesToStream(pipeReader, dockerCli.Out(), nil)
+	err := jsonstream.Display(ctx, pipeReader, dockerCli.Out())
 	if err == nil {
 		err = <-errChan
 	}

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -10,8 +10,8 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/swarm/progress"
+	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -120,7 +120,7 @@ func attach(ctx context.Context, dockerCli command.Cli, opts caOptions) error {
 		return <-errChan
 	}
 
-	err := jsonmessage.DisplayJSONMessagesToStream(pipeReader, dockerCli.Out(), nil)
+	err := jsonstream.Display(ctx, pipeReader, dockerCli.Out())
 	if err == nil {
 		err = <-errChan
 	}

--- a/cli/internal/jsonstream/display.go
+++ b/cli/internal/jsonstream/display.go
@@ -1,0 +1,68 @@
+package jsonstream
+
+import (
+	"context"
+	"io"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+type (
+	Stream       = jsonmessage.Stream
+	JSONMessage  = jsonmessage.JSONMessage
+	JSONError    = jsonmessage.JSONError
+	JSONProgress = jsonmessage.JSONProgress
+)
+
+type ctxReader struct {
+	err chan error
+	r   io.Reader
+}
+
+func (r *ctxReader) Read(p []byte) (n int, err error) {
+	select {
+	case err = <-r.err:
+		return 0, err
+	default:
+		return r.r.Read(p)
+	}
+}
+
+type Options func(*options)
+
+type options struct {
+	AuxCallback func(JSONMessage)
+}
+
+func WithAuxCallback(cb func(JSONMessage)) Options {
+	return func(o *options) {
+		o.AuxCallback = cb
+	}
+}
+
+// Display prints the JSON messages from the given reader to the given stream.
+//
+// It wraps the [jsonmessage.DisplayJSONMessagesStream] function to make it
+// "context aware" and appropriately returns why the function was canceled.
+//
+// It returns an error if the context is canceled, but not if the input reader / stream is closed.
+func Display(ctx context.Context, in io.Reader, stream Stream, opts ...Options) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	ctxReader := &ctxReader{err: make(chan error, 1), r: in}
+	stopFunc := context.AfterFunc(ctx, func() { ctxReader.err <- ctx.Err() })
+	defer stopFunc()
+
+	o := options{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	if err := jsonmessage.DisplayJSONMessagesStream(ctxReader, stream, stream.FD(), stream.IsTerminal(), o.AuxCallback); err != nil {
+		return err
+	}
+
+	return ctx.Err()
+}

--- a/cli/internal/jsonstream/display_test.go
+++ b/cli/internal/jsonstream/display_test.go
@@ -1,0 +1,67 @@
+package jsonstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/cli/streams"
+	"gotest.tools/v3/assert"
+)
+
+func TestDisplay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	client, server := io.Pipe()
+	t.Cleanup(func() {
+		assert.NilError(t, server.Close())
+	})
+
+	go func() {
+		enc := json.NewEncoder(server)
+		for i := 0; i < 100; i++ {
+			select {
+			case <-ctx.Done():
+				assert.NilError(t, server.Close(), "failed to close jsonmessage server")
+				return
+			default:
+				err := enc.Encode(JSONMessage{
+					Status:   "Downloading",
+					ID:       fmt.Sprintf("id-%d", i),
+					TimeNano: time.Now().UnixNano(),
+					Time:     time.Now().Unix(),
+					Progress: &JSONProgress{
+						Current: int64(i),
+						Total:   100,
+						Start:   0,
+					},
+				})
+				if err != nil {
+					break
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	t.Cleanup(cancelStream)
+
+	done := make(chan error)
+	go func() {
+		out := streams.NewOut(io.Discard)
+		done <- Display(streamCtx, client, out)
+	}()
+
+	cancelStream()
+
+	select {
+	case <-time.After(time.Second * 3):
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/docker/cli/issues/5639

Allows for the `jsonmessage.DisplayJSONMessagesStream` to
correctly return when the context is cancelled with the
appropriate error message, instead of just a nil error.

Follow-up to https://github.com/docker/cli/commit/30a73ff19c407eee75de489355154ce1f35231a8

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

