### PR TITLE
cli: deprecate `cli.StatusError` direct field usage

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/cli/cli/debug"
-	"github.com/docker/cli/internal"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -94,12 +93,12 @@ func Run(makeCmd func(command.Cli) *cobra.Command, meta manager.Metadata) {
 	plugin := makeCmd(dockerCli)
 
 	if err := RunPlugin(dockerCli, plugin, meta); err != nil {
-		var stErr internal.StatusError
+		var stErr cli.StatusCodeError
 		if errors.As(err, &stErr) {
 			_, _ = fmt.Fprintln(dockerCli.Err(), stErr)
 			// StatusError should only be used for errors, and all errors should
 			// have a non-zero exit status, so never exit with 0
-			os.Exit(stErr.StatusCode)
+			os.Exit(stErr.GetStatusCode())
 		}
 		_, _ = fmt.Fprintln(dockerCli.Err(), err)
 		os.Exit(1)

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -10,6 +10,7 @@ import (
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
 	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/pkg/homedir"
 	"github.com/docker/docker/registry"
 	"github.com/fvbommel/sortorder"
@@ -92,8 +93,8 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 		return nil
 	}
 
-	return StatusError{
-		Status:     fmt.Sprintf("%s\n\nUsage:  %s\n\nRun '%s --help' for more information", err, cmd.UseLine(), cmd.CommandPath()),
+	return internal.StatusError{
+		Cause:      fmt.Errorf("%w\n\nUsage:  %s\n\nRun '%s --help' for more information", err, cmd.UseLine(), cmd.CommandPath()),
 		StatusCode: 125,
 	}
 }

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +68,7 @@ func RunConfigInspect(ctx context.Context, dockerCli command.Cli, opts InspectOp
 	}
 
 	if err := InspectFormatWrite(configCtx, opts.Names, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return internal.StatusError{StatusCode: 1, Cause: err}
 	}
 	return nil
 }

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/moby/sys/signal"
@@ -161,7 +162,7 @@ func getExitStatus(errC <-chan error, resultC <-chan container.WaitResponse) err
 			return errors.New(result.Error.Message)
 		}
 		if result.StatusCode != 0 {
-			return cli.StatusError{StatusCode: int(result.StatusCode)}
+			return internal.StatusError{StatusCode: int(result.StatusCode)}
 		}
 	case err := <-errC:
 		return err

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/docker/cli/cli"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types/container"
 	"github.com/pkg/errors"
@@ -110,7 +110,7 @@ func TestGetExitStatus(t *testing.T) {
 			result: &container.WaitResponse{
 				StatusCode: 15,
 			},
-			expectedError: cli.StatusError{StatusCode: 15},
+			expectedError: internal.StatusError{StatusCode: 15},
 		},
 	}
 

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	imagetypes "github.com/docker/docker/api/types/image"
@@ -92,8 +93,8 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 
 func runCreate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, options *createOptions, copts *containerOptions) error {
 	if err := validatePullOpt(options.pull); err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "create").Error(),
+		return internal.StatusError{
+			Cause:      withHelp(err, "create"),
 			StatusCode: 125,
 		}
 	}
@@ -109,14 +110,14 @@ func runCreate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet,
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
 	containerCfg, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
 	if err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "create").Error(),
+		return internal.StatusError{
+			Cause:      withHelp(err, "create"),
 			StatusCode: 125,
 		}
 	}
 	if err = validateAPIVersion(containerCfg, dockerCli.Client().ClientVersion()); err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "create").Error(),
+		return internal.StatusError{
+			Cause:      withHelp(err, "create"),
 			StatusCode: 125,
 		}
 	}

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/internal/test/notary"
 	"github.com/docker/docker/api/types/container"
@@ -185,7 +185,7 @@ func TestCreateContainerImagePullPolicyInvalid(t *testing.T) {
 				&containerOptions{},
 			)
 
-			statusErr := cli.StatusError{}
+			var statusErr internal.StatusError
 			assert.Check(t, errors.As(err, &statusErr))
 			assert.Check(t, is.Equal(statusErr.StatusCode, 125))
 			assert.Check(t, is.ErrorContains(err, tc.ExpectedErrMsg))

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -206,11 +207,11 @@ func getExecExitStatus(ctx context.Context, apiClient client.ContainerAPIClient,
 		if !client.IsErrConnectionFailed(err) {
 			return err
 		}
-		return cli.StatusError{StatusCode: -1}
+		return internal.StatusError{StatusCode: -1}
 	}
 	status := resp.ExitCode
 	if status != 0 {
-		return cli.StatusError{StatusCode: status}
+		return internal.StatusError{StatusCode: status}
 	}
 	return nil
 }

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types"
@@ -231,7 +231,7 @@ func TestGetExecExitStatus(t *testing.T) {
 		},
 		{
 			exitCode:      15,
-			expectedError: cli.StatusError{StatusCode: 15},
+			expectedError: internal.StatusError{StatusCode: 15},
 		},
 	}
 

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/sys/signal"
 	"github.com/moby/term"
@@ -172,7 +173,7 @@ func RunStart(ctx context.Context, dockerCli command.Cli, opts *StartOptions) er
 		}
 
 		if status := <-statusChan; status != 0 {
-			return cli.StatusError{StatusCode: status}
+			return internal.StatusError{StatusCode: status}
 		}
 		return nil
 	case opts.Checkpoint != "":

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/cli/cli/command/image/build"
 	"github.com/docker/cli/cli/internal/jsonstream"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -372,7 +373,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 			if options.quiet {
 				fmt.Fprintf(dockerCli.Err(), "%s%s", progBuff, buildBuff)
 			}
-			return cli.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
+			return internal.StatusError{Cause: jerr, StatusCode: jerr.Code}
 		}
 		return err
 	}

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/docker/cli/cli"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/templates"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -67,7 +67,7 @@ type GetRefFunc func(ref string) (any, []byte, error)
 func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFunc) error {
 	inspector, err := NewTemplateInspectorFromString(out, tmplStr)
 	if err != nil {
-		return cli.StatusError{StatusCode: 64, Status: err.Error()}
+		return internal.StatusError{StatusCode: 64, Cause: err}
 	}
 
 	var inspectErrs []string
@@ -88,9 +88,9 @@ func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFu
 	}
 
 	if len(inspectErrs) != 0 {
-		return cli.StatusError{
+		return internal.StatusError{
 			StatusCode: 1,
-			Status:     strings.Join(inspectErrs, "\n"),
+			Cause:      errors.New(strings.Join(inspectErrs, "\n")),
 		}
 	}
 	return nil

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
 	"github.com/spf13/cobra"
@@ -68,7 +69,7 @@ func runRemove(ctx context.Context, dockerCli command.Cli, networks []string, op
 	}
 
 	if status != 0 {
-		return cli.StatusError{StatusCode: status}
+		return internal.StatusError{StatusCode: status}
 	}
 	return nil
 }

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +70,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	if err := InspectFormatWrite(nodeCtx, opts.nodeIds, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return internal.StatusError{StatusCode: 1, Cause: err}
 	}
 	return nil
 }

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +66,7 @@ func runSecretInspect(ctx context.Context, dockerCli command.Cli, opts inspectOp
 	}
 
 	if err := InspectFormatWrite(secretCtx, opts.names, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return internal.StatusError{StatusCode: 1, Cause: err}
 	}
 	return nil
 }

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/errdefs"
@@ -94,7 +95,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	if err := InspectFormatWrite(serviceCtx, opts.refs, getRef, getNetwork); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return internal.StatusError{StatusCode: 1, Cause: err}
 	}
 	return nil
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/opts"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types/events"
@@ -58,9 +59,9 @@ func NewEventsCommand(dockerCli command.Cli) *cobra.Command {
 func runEvents(ctx context.Context, dockerCli command.Cli, options *eventsOptions) error {
 	tmpl, err := makeTemplate(options.format)
 	if err != nil {
-		return cli.StatusError{
+		return internal.StatusError{
 			StatusCode: 64,
-			Status:     "Error parsing format: " + err.Error(),
+			Cause:      fmt.Errorf("error parsing format: %w", err),
 		}
 	}
 	ctx, cancel := context.WithCancel(ctx)

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/debug"
 	flagsHelper "github.com/docker/cli/cli/flags"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/system"
@@ -457,9 +458,9 @@ func formatInfo(output io.Writer, info dockerInfo, format string) error {
 
 	tmpl, err := templates.Parse(format)
 	if err != nil {
-		return cli.StatusError{
+		return internal.StatusError{
 			StatusCode: 64,
-			Status:     "template parsing error: " + err.Error(),
+			Cause:      fmt.Errorf("template parsing error: %w", err),
 		}
 	}
 	err = tmpl.Execute(output, info)

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter/tabwriter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
+	"github.com/docker/cli/internal"
 	"github.com/docker/cli/templates"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
@@ -148,7 +149,7 @@ func runVersion(ctx context.Context, dockerCli command.Cli, opts *versionOptions
 	var err error
 	tmpl, err := newVersionTemplate(opts.format)
 	if err != nil {
-		return cli.StatusError{StatusCode: 64, Status: err.Error()}
+		return internal.StatusError{StatusCode: 64, Cause: err}
 	}
 
 	// TODO print error if kubernetes is used?

--- a/cli/error.go
+++ b/cli/error.go
@@ -4,9 +4,21 @@ import (
 	"github.com/docker/cli/internal"
 )
 
-// StatusError reports an unsuccessful exit by a command.
-type StatusError interface {
-	Error() string
+// StatusCodeError is a custom error type that reports an unsuccessful
+// exit by a command.
+//
+// It is preferable to use this interface when seeking the status code
+// of an error returned by the CLI.
+//
+//	var statusCodeError cli.StatusCodeError
+//	err := someFunction()
+//	errors.As(err, &statusCodeError)
+//	fmt.Println(statusCodeError.GetStatusCode())
+//
+// Internal to the CLI can use the [internal.StatusError]
+// implementation directly.
+type StatusCodeError interface {
+	error
 	Unwrap() error
 
 	// GetStatusCode returns the status code of the error.
@@ -14,7 +26,58 @@ type StatusError interface {
 	GetStatusCode() int
 }
 
-// Pin the exported StatusError interface to the internal.StatusError type.
+// StatusError implements [cli.StatusCodeError] and reports
+// an unsuccessful exit by a command.
+//
+// StatusCode must be non-zero.
+// Status/Cause may be empty/nil if a generic error-message is desired.
+//
+// Note: This error type is used by CLI plugins to report
+// the exit code of a command and is thus discouraged from being
+// modified.
+//
+// It is usually discouraged to use this error type directly as the
+// [cli.StatusCodeError] interface should be used instead.
+type StatusError struct {
+	// Deprecated: StatusError.Status is deprecated and should not be
+	// used. Instead, use StatusError.Cause.
+	Status string
+
+	// Cause is the underlying error that caused the failure. It may be
+	// set to nil if a generic error-message is desired.
+	Cause error
+
+	// StatusCode is the exit code of the command. This field must
+	// be non-zero.
+	StatusCode int
+}
+
+// Error formats the error for printing. If a custom Status/Cause
+// is provided, it is returned as-is, otherwise it generates a generic
+// error-message based on the StatusCode.
+func (e StatusError) Error() string {
+	if e.Status != "" {
+		return e.Status
+	}
+	return internal.StatusError{
+		Cause:      e.Cause,
+		StatusCode: e.StatusCode,
+	}.Error()
+}
+
+func (e StatusError) Unwrap() error {
+	return e.Cause
+}
+
+func (e StatusError) GetStatusCode() int {
+	return e.StatusCode
+}
+
+// Pin the exported StatusCodeError interface to the
+// [internal.StatusError] type.
 // This is necessary to ensure that the internal.StatusError type does
 // not break the compatibility of the exported interface.
-var _ StatusError = internal.StatusError{}
+var (
+	_ StatusCodeError = internal.StatusError{}
+	_ StatusCodeError = StatusError{}
+)

--- a/cli/error.go
+++ b/cli/error.go
@@ -1,21 +1,20 @@
 package cli
 
 import (
-	"strconv"
+	"github.com/docker/cli/internal"
 )
 
 // StatusError reports an unsuccessful exit by a command.
-type StatusError struct {
-	Status     string
-	StatusCode int
+type StatusError interface {
+	Error() string
+	Unwrap() error
+
+	// GetStatusCode returns the status code of the error.
+	// The status code will never be 0.
+	GetStatusCode() int
 }
 
-// Error formats the error for printing. If a custom Status is provided,
-// it is returned as-is, otherwise it generates a generic error-message
-// based on the StatusCode.
-func (e StatusError) Error() string {
-	if e.Status == "" {
-		return "exit status " + strconv.Itoa(e.StatusCode)
-	}
-	return e.Status
-}
+// Pin the exported StatusError interface to the internal.StatusError type.
+// This is necessary to ensure that the internal.StatusError type does
+// not break the compatibility of the exported interface.
+var _ StatusError = internal.StatusError{}

--- a/cli/error_test.go
+++ b/cli/error_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/cli/internal"
+	"gotest.tools/v3/assert"
+)
+
+func TestStatusError(t *testing.T) {
+	t.Run("custom status should be returned as-is", func(t *testing.T) {
+		statusError := StatusError{
+			Status:     "status",
+			StatusCode: 1,
+		}
+		assert.Equal(t, statusError.Error(), "status")
+	})
+
+	t.Run("cause error should be returned as-is", func(t *testing.T) {
+		statusError := StatusError{
+			Cause:      errors.New("cause"),
+			StatusCode: 1,
+		}
+		assert.Equal(t, statusError.Error(), "cause")
+	})
+
+	t.Run("generic error-message should be generated based on the StatusCode", func(t *testing.T) {
+		statusError := StatusError{
+			StatusCode: 1,
+		}
+		assert.Equal(t, statusError.Error(), "exit status 1")
+	})
+
+	t.Run("exported StatusCodeError interface should be pinned to internal.StatusError type", func(t *testing.T) {
+		internalStatusError := internal.StatusError{}
+		statusError := StatusError{}
+		var e StatusCodeError
+		assert.Check(t, errors.As(internalStatusError, &e))
+		assert.Check(t, errors.As(statusError, &e))
+	})
+}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -58,9 +58,9 @@ func getExitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	var stErr internal.StatusError
+	var stErr cli.StatusCodeError
 	if errors.As(err, &stErr) {
-		return stErr.StatusCode
+		return stErr.GetStatusCode()
 	}
 
 	// No status-code provided; all errors should have a non-zero exit code.

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	platformsignals "github.com/docker/cli/cmd/docker/internal/signals"
+	"github.com/docker/cli/internal"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
@@ -51,14 +52,14 @@ func dockerMain(ctx context.Context) error {
 }
 
 // getExitCode returns the exit-code to use for the given error.
-// If err is a [cli.StatusError] and has a StatusCode set, it uses the
+// If err is a [internal.StatusError] and has a StatusCode set, it uses the
 // status-code from it, otherwise it returns "1" for any error.
 func getExitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	var stErr cli.StatusError
-	if errors.As(err, &stErr) && stErr.StatusCode != 0 { // FIXME(thaJeztah): StatusCode should never be used with a zero status-code. Check if we do this anywhere.
+	var stErr internal.StatusError
+	if errors.As(err, &stErr) {
 		return stErr.StatusCode
 	}
 
@@ -321,7 +322,7 @@ func tryPluginRun(ctx context.Context, dockerCli command.Cli, cmd *cobra.Command
 		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 			statusCode = ws.ExitStatus()
 		}
-		return cli.StatusError{
+		return internal.StatusError{
 			StatusCode: statusCode,
 		}
 	}

--- a/internal/status_error.go
+++ b/internal/status_error.go
@@ -1,0 +1,36 @@
+package internal
+
+import "strconv"
+
+// StatusError reports an unsuccessful exit by a command.
+// StatusCode must be non-zero.
+// Cause may be nil if a generic error-message is desired.
+type StatusError struct {
+	// Cause is the underlying error.
+	// It may be nil to generate a generic error message.
+	Cause error
+	// StatusCode is the exit status code.
+	// It must be non-zero.
+	StatusCode int
+}
+
+// Error formats the error for printing. If a custom Status is provided,
+// it is returned as-is, otherwise it generates a generic error-message
+// based on the StatusCode.
+func (e StatusError) Error() string {
+	if e.Cause == nil {
+		return "exit status " + strconv.Itoa(e.StatusCode)
+	}
+	return e.Cause.Error()
+}
+
+// Unwrap returns the wrapped error.
+//
+// This allows StatusError to be checked with errors.Is.
+func (e StatusError) Unwrap() error {
+	return e.Cause
+}
+
+func (e StatusError) GetStatusCode() int {
+	return e.StatusCode
+}

--- a/internal/status_error.go
+++ b/internal/status_error.go
@@ -2,7 +2,8 @@ package internal
 
 import "strconv"
 
-// StatusError reports an unsuccessful exit by a command.
+// StatusError implements [cli.StatusCodeError] and
+// reports an unsuccessful exit by a command.
 // StatusCode must be non-zero.
 // Cause may be nil if a generic error-message is desired.
 type StatusError struct {


### PR DESCRIPTION
The exported `cli.StatusError` type may be used
by some directly within their own projects, making it difficult to update the struct's fields.

This patch converts the exported `cli.StatusError` to an interface instead, so that code wrapping the CLI would still be able to match the error and get the status code without exposing the fields.

This is a breaking change for those relying on creating a `cli.StatusError{}` and accessing the error's fields. For those using `errors.As(err, &statusError)` and `err.(cli.StatusError)` will be able to continue using it without breakage.

Users accessing the fields of `cli.StatusError{}.StatusCode` would need to use the new `GetStatusCode()` method.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Closes https://github.com/docker/cli/issues/5659

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
External code importing and using `cli.StatusError` directly (e.g. creating an instance of it) is deprecated.
```

**- A picture of a cute animal (not mandatory but encouraged)**
