### PR TITLE
cli/command/registry: assorted refactor and test changes

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -187,7 +187,7 @@ func loginWithUsernameAndPassword(ctx context.Context, dockerCli command.Cli, op
 		return nil, err
 	}
 
-	response, err := loginWithRegistry(ctx, dockerCli, authConfig)
+	response, err := loginWithRegistry(ctx, dockerCli.Client(), authConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCli command.Cli) (*regis
 		return nil, err
 	}
 
-	response, err := loginWithRegistry(ctx, dockerCli, registrytypes.AuthConfig(*authConfig))
+	response, err := loginWithRegistry(ctx, dockerCli.Client(), registrytypes.AuthConfig(*authConfig))
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +231,8 @@ func storeCredentials(dockerCli command.Cli, authConfig registrytypes.AuthConfig
 	return nil
 }
 
-func loginWithRegistry(ctx context.Context, dockerCli command.Cli, authConfig registrytypes.AuthConfig) (*registrytypes.AuthenticateOKBody, error) {
-	response, err := dockerCli.Client().RegistryLogin(ctx, authConfig)
+func loginWithRegistry(ctx context.Context, apiClient client.SystemAPIClient, authConfig registrytypes.AuthConfig) (*registrytypes.AuthenticateOKBody, error) {
+	response, err := apiClient.RegistryLogin(ctx, authConfig)
 	if err != nil {
 		if client.IsErrConnectionFailed(err) {
 			// daemon isn't responding; attempt to login client side.

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -89,7 +89,7 @@ func runLogin(ctx context.Context, dockerCli command.Cli, opts loginOptions) err
 	}
 	var (
 		serverAddress string
-		response      *registrytypes.AuthenticateOKBody
+		msg           string
 	)
 	if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
 		serverAddress = opts.serverAddress
@@ -101,25 +101,25 @@ func runLogin(ctx context.Context, dockerCli command.Cli, opts loginOptions) err
 	// attempt login with current (stored) credentials
 	authConfig, err := command.GetDefaultAuthConfig(dockerCli.ConfigFile(), opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {
-		response, err = loginWithStoredCredentials(ctx, dockerCli, authConfig)
+		msg, err = loginWithStoredCredentials(ctx, dockerCli, authConfig)
 	}
 
 	// if we failed to authenticate with stored credentials (or didn't have stored credentials),
 	// prompt the user for new credentials
 	if err != nil || authConfig.Username == "" || authConfig.Password == "" {
-		response, err = loginUser(ctx, dockerCli, opts, authConfig.Username, authConfig.ServerAddress)
+		msg, err = loginUser(ctx, dockerCli, opts, authConfig.Username, authConfig.ServerAddress)
 		if err != nil {
 			return err
 		}
 	}
 
-	if response != nil && response.Status != "" {
-		_, _ = fmt.Fprintln(dockerCli.Out(), response.Status)
+	if msg != "" {
+		_, _ = fmt.Fprintln(dockerCli.Out(), msg)
 	}
 	return nil
 }
 
-func loginWithStoredCredentials(ctx context.Context, dockerCli command.Cli, authConfig registrytypes.AuthConfig) (*registrytypes.AuthenticateOKBody, error) {
+func loginWithStoredCredentials(ctx context.Context, dockerCli command.Cli, authConfig registrytypes.AuthConfig) (msg string, _ error) {
 	_, _ = fmt.Fprintf(dockerCli.Out(), "Authenticating with existing credentials...\n")
 	response, err := dockerCli.Client().RegistryLogin(ctx, authConfig)
 	if err != nil {
@@ -136,10 +136,10 @@ func loginWithStoredCredentials(ctx context.Context, dockerCli command.Cli, auth
 	}
 
 	if err := storeCredentials(dockerCli.ConfigFile(), authConfig); err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return &response, err
+	return response.Status, err
 }
 
 const OauthLoginEscapeHatchEnvVar = "DOCKER_CLI_DISABLE_OAUTH_LOGIN"
@@ -155,7 +155,7 @@ func isOauthLoginDisabled() bool {
 	return false
 }
 
-func loginUser(ctx context.Context, dockerCli command.Cli, opts loginOptions, defaultUsername, serverAddress string) (*registrytypes.AuthenticateOKBody, error) {
+func loginUser(ctx context.Context, dockerCli command.Cli, opts loginOptions, defaultUsername, serverAddress string) (msg string, _ error) {
 	// Some links documenting this:
 	// - https://code.google.com/archive/p/mintty/issues/56
 	// - https://github.com/docker/docker/issues/15272
@@ -164,16 +164,17 @@ func loginUser(ctx context.Context, dockerCli command.Cli, opts loginOptions, de
 	// will hit this if you attempt docker login from mintty where stdin
 	// is a pipe, not a character based console.
 	if (opts.user == "" || opts.password == "") && !dockerCli.In().IsTerminal() {
-		return nil, errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
+		return "", errors.Errorf("Error: Cannot perform an interactive login from a non TTY device")
 	}
 
 	// If we're logging into the index server and the user didn't provide a username or password, use the device flow
 	if serverAddress == registry.IndexServer && opts.user == "" && opts.password == "" && !isOauthLoginDisabled() {
-		response, err := loginWithDeviceCodeFlow(ctx, dockerCli)
+		var err error
+		msg, err = loginWithDeviceCodeFlow(ctx, dockerCli)
 		// if the error represents a failure to initiate the device-code flow,
 		// then we fallback to regular cli credentials login
 		if !errors.Is(err, manager.ErrDeviceLoginStartFail) {
-			return response, err
+			return msg, err
 		}
 		_, _ = fmt.Fprint(dockerCli.Err(), "Failed to start web-based login - falling back to command line login...\n\n")
 	}
@@ -181,16 +182,16 @@ func loginUser(ctx context.Context, dockerCli command.Cli, opts loginOptions, de
 	return loginWithUsernameAndPassword(ctx, dockerCli, opts, defaultUsername, serverAddress)
 }
 
-func loginWithUsernameAndPassword(ctx context.Context, dockerCli command.Cli, opts loginOptions, defaultUsername, serverAddress string) (*registrytypes.AuthenticateOKBody, error) {
+func loginWithUsernameAndPassword(ctx context.Context, dockerCli command.Cli, opts loginOptions, defaultUsername, serverAddress string) (msg string, _ error) {
 	// Prompt user for credentials
 	authConfig, err := command.PromptUserForCredentials(ctx, dockerCli, opts.user, opts.password, defaultUsername, serverAddress)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	response, err := loginWithRegistry(ctx, dockerCli.Client(), authConfig)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if response.IdentityToken != "" {
@@ -198,29 +199,29 @@ func loginWithUsernameAndPassword(ctx context.Context, dockerCli command.Cli, op
 		authConfig.IdentityToken = response.IdentityToken
 	}
 	if err = storeCredentials(dockerCli.ConfigFile(), authConfig); err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return response, nil
+	return response.Status, nil
 }
 
-func loginWithDeviceCodeFlow(ctx context.Context, dockerCli command.Cli) (*registrytypes.AuthenticateOKBody, error) {
+func loginWithDeviceCodeFlow(ctx context.Context, dockerCli command.Cli) (msg string, _ error) {
 	store := dockerCli.ConfigFile().GetCredentialsStore(registry.IndexServer)
 	authConfig, err := manager.NewManager(store).LoginDevice(ctx, dockerCli.Err())
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	response, err := loginWithRegistry(ctx, dockerCli.Client(), registrytypes.AuthConfig(*authConfig))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if err = storeCredentials(dockerCli.ConfigFile(), registrytypes.AuthConfig(*authConfig)); err != nil {
-		return nil, err
+		return "", err
 	}
 
-	return response, nil
+	return response.Status, nil
 }
 
 func storeCredentials(cfg *configfile.ConfigFile, authConfig registrytypes.AuthConfig) error {

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/config/configfile"
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/internal/oauth/manager"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -134,7 +135,7 @@ func loginWithStoredCredentials(ctx context.Context, dockerCli command.Cli, auth
 		authConfig.IdentityToken = response.IdentityToken
 	}
 
-	if err := storeCredentials(dockerCli, authConfig); err != nil {
+	if err := storeCredentials(dockerCli.ConfigFile(), authConfig); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +197,7 @@ func loginWithUsernameAndPassword(ctx context.Context, dockerCli command.Cli, op
 		authConfig.Password = ""
 		authConfig.IdentityToken = response.IdentityToken
 	}
-	if err = storeCredentials(dockerCli, authConfig); err != nil {
+	if err = storeCredentials(dockerCli.ConfigFile(), authConfig); err != nil {
 		return nil, err
 	}
 
@@ -215,15 +216,15 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCli command.Cli) (*regis
 		return nil, err
 	}
 
-	if err = storeCredentials(dockerCli, registrytypes.AuthConfig(*authConfig)); err != nil {
+	if err = storeCredentials(dockerCli.ConfigFile(), registrytypes.AuthConfig(*authConfig)); err != nil {
 		return nil, err
 	}
 
 	return response, nil
 }
 
-func storeCredentials(dockerCli command.Cli, authConfig registrytypes.AuthConfig) error {
-	creds := dockerCli.ConfigFile().GetCredentialsStore(authConfig.ServerAddress)
+func storeCredentials(cfg *configfile.ConfigFile, authConfig registrytypes.AuthConfig) error {
+	creds := cfg.GetCredentialsStore(authConfig.ServerAddress)
 	if err := creds.Store(configtypes.AuthConfig(authConfig)); err != nil {
 		return errors.Errorf("Error saving credentials: %v", err)
 	}

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -349,16 +349,16 @@ func TestLoginNonInteractive(t *testing.T) {
 		// "" meaning default registry
 		registries := []string{"", "my-registry.com"}
 
-		for _, registry := range registries {
+		for _, registryAddr := range registries {
 			for _, tc := range testCases {
 				t.Run(tc.doc, func(t *testing.T) {
 					tmpFile := fs.NewFile(t, "test-run-login")
 					defer tmpFile.Remove()
 					cli := test.NewFakeCli(&fakeClient{})
-					configfile := cli.ConfigFile()
-					configfile.Filename = tmpFile.Path()
+					cfg := cli.ConfigFile()
+					cfg.Filename = tmpFile.Path()
 					options := loginOptions{
-						serverAddress: registry,
+						serverAddress: registryAddr,
 					}
 					if tc.username {
 						options.user = "my-username"
@@ -412,26 +412,26 @@ func TestLoginNonInteractive(t *testing.T) {
 		// "" meaning default registry
 		registries := []string{"", "my-registry.com"}
 
-		for _, registry := range registries {
+		for _, registryAddr := range registries {
 			for _, tc := range testCases {
 				t.Run(tc.doc, func(t *testing.T) {
 					tmpFile := fs.NewFile(t, "test-run-login")
 					defer tmpFile.Remove()
 					cli := test.NewFakeCli(&fakeClient{})
-					configfile := cli.ConfigFile()
-					configfile.Filename = tmpFile.Path()
-					serverAddress := registry
+					cfg := cli.ConfigFile()
+					cfg.Filename = tmpFile.Path()
+					serverAddress := registryAddr
 					if serverAddress == "" {
 						serverAddress = "https://index.docker.io/v1/"
 					}
-					assert.NilError(t, configfile.GetCredentialsStore(serverAddress).Store(configtypes.AuthConfig{
+					assert.NilError(t, cfg.GetCredentialsStore(serverAddress).Store(configtypes.AuthConfig{
 						Username:      "my-username",
 						Password:      "my-password",
 						ServerAddress: serverAddress,
 					}))
 
 					options := loginOptions{
-						serverAddress: registry,
+						serverAddress: registryAddr,
 					}
 					if tc.username {
 						options.user = "my-username"


### PR DESCRIPTION
### cli/command/registry: don't return creds on error

Be more explicit on not returning a response if there was an error;
change some non-exported functions to return a pointer, and return
nil instead.

### cli/command/registry: loginWithRegistry: use shallower interface

This function only needs the API client, not all of the CLI.


### cli/command/registry: storeCredentials: accept configfile as arg

This function only needs access to the configfile


### cli/command/registry: TestLoginWithCredStoreCreds slight refactor

- also check errors that were previously not handled
- use the fakeCLI's buffer instead of creating one manually

### cli/command/registry: return status only instead of whole response

Various functions were passing through the API response as a whole, but
effectively only needed it for a status message (if any). Reduce what's
returned to only the message.




**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

