### PR TITLE
registry/client: remove uses of APIEndpoint.TrimHostName

### DIFF
--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -22,12 +22,7 @@ type repositoryEndpoint struct {
 
 // Name returns the repository name
 func (r repositoryEndpoint) Name() string {
-	repoName := r.info.Name.Name()
-	// If endpoint does not support CanonicalName, use the RemoteName instead
-	if r.endpoint.TrimHostname {
-		repoName = reference.Path(r.info.Name)
-	}
-	return repoName
+	return reference.Path(r.info.Name)
 }
 
 // BaseURL returns the endpoint url

--- a/vendor.mod
+++ b/vendor.mod
@@ -13,7 +13,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli-docs-tool v0.8.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v27.0.2-0.20241209110419-5d72419486fe+incompatible // master (v-next)
+	github.com/docker/docker v27.0.2-0.20241209174241-b249c5ebd214+incompatible // master (v-next)
 	github.com/docker/docker-credential-helpers v0.8.2
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -51,8 +51,8 @@ github.com/docker/cli-docs-tool v0.8.0/go.mod h1:8TQQ3E7mOXoYUs811LiPdUnAhXrcVsB
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v27.0.2-0.20241209110419-5d72419486fe+incompatible h1:d1p7DOid9l/HWswplM9EGvIFy+8KixweVBvqrLxgj3c=
-github.com/docker/docker v27.0.2-0.20241209110419-5d72419486fe+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.0.2-0.20241209174241-b249c5ebd214+incompatible h1:n78wXsuD+b4ch68cGrR/SfpXPi4Q9T3jrBGIN5NEAtE=
+github.com/docker/docker v27.0.2-0.20241209174241-b249c5ebd214+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/github.com/docker/docker/client/utils.go
+++ b/vendor/github.com/docker/docker/client/utils.go
@@ -66,7 +66,7 @@ func encodePlatforms(platform ...ocispec.Platform) ([]string, error) {
 	return out, nil
 }
 
-// encodePlatforms marshals the given platform to JSON format, to
+// encodePlatform marshals the given platform to JSON format, to
 // be used for query-parameters for filtering / selecting platforms. It
 // is used as a helper for encodePlatforms,
 func encodePlatform(platform *ocispec.Platform) (string, error) {

--- a/vendor/github.com/docker/docker/registry/service.go
+++ b/vendor/github.com/docker/docker/registry/service.go
@@ -105,7 +105,7 @@ type APIEndpoint struct {
 	URL                            *url.URL
 	AllowNondistributableArtifacts bool
 	Official                       bool
-	TrimHostname                   bool
+	TrimHostname                   bool // Deprecated: hostname is now trimmed unconditionally for remote names. This field will be removed in the next release.
 	TLSConfig                      *tls.Config
 }
 

--- a/vendor/github.com/docker/docker/registry/service_v2.go
+++ b/vendor/github.com/docker/docker/registry/service_v2.go
@@ -24,17 +24,15 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				return nil, err
 			}
 			endpoints = append(endpoints, APIEndpoint{
-				URL:          mirrorURL,
-				Mirror:       true,
-				TrimHostname: true,
-				TLSConfig:    mirrorTLSConfig,
+				URL:       mirrorURL,
+				Mirror:    true,
+				TLSConfig: mirrorTLSConfig,
 			})
 		}
 		endpoints = append(endpoints, APIEndpoint{
-			URL:          DefaultV2Registry,
-			Official:     true,
-			TrimHostname: true,
-			TLSConfig:    tlsconfig.ServerDefault(),
+			URL:       DefaultV2Registry,
+			Official:  true,
+			TLSConfig: tlsconfig.ServerDefault(),
 
 			AllowNondistributableArtifacts: ana,
 		})
@@ -53,9 +51,9 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "https",
 				Host:   hostname,
 			},
+			TLSConfig: tlsConfig,
+
 			AllowNondistributableArtifacts: ana,
-			TrimHostname:                   true,
-			TLSConfig:                      tlsConfig,
 		},
 	}
 
@@ -65,10 +63,10 @@ func (s *Service) lookupV2Endpoints(hostname string) (endpoints []APIEndpoint, e
 				Scheme: "http",
 				Host:   hostname,
 			},
-			AllowNondistributableArtifacts: ana,
-			TrimHostname:                   true,
 			// used to check if supposed to be secure via InsecureSkipVerify
 			TLSConfig: tlsConfig,
+
+			AllowNondistributableArtifacts: ana,
 		})
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v27.0.2-0.20241209110419-5d72419486fe+incompatible
+# github.com/docker/docker v27.0.2-0.20241209174241-b249c5ebd214+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49005
- relates to https://github.com/moby/moby/pull/13375

### registry/client: remove uses of APIEndpoint.TrimHostName

This field was added in https://github.com/moby/moby/commit/19515a7ad859b28c474d81e756ac245afcd968e3, but looks to be always set for endpoints used, so we can trim remote names unconditionally.

This option was added for possible future expansion, allowing registry- mirrors to get the full reference of the image (including domain-name), for them to host a mirror for multiple upstreams on the same registry.

That approach will unlikely be implemented, and containerd has a different approach for this, where the reference to the original registry is passed through a query parameter instead.


### vendor: github.com/docker/docker b249c5ebd214 (master, v28.0.0-dev)

full diff: https://github.com/docker/docker/compare/5d72419486fe...b249c5ebd214e2977d0fdb1e07d82366f5849cf9


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

