### PR TITLE
cli/command/system: don't use "non-distributable-artifacts" fields in tests

### DIFF
--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -70,8 +70,6 @@ var sampleInfoNoSwarm = system.Info{
 	Architecture:       "x86_64",
 	IndexServerAddress: "https://index.docker.io/v1/",
 	RegistryConfig: &registrytypes.ServiceConfig{
-		AllowNondistributableArtifactsCIDRs:     nil,
-		AllowNondistributableArtifactsHostnames: nil,
 		InsecureRegistryCIDRs: []*registrytypes.NetIPNet{
 			{
 				IP:   net.ParseIP("127.0.0.0"),


### PR DESCRIPTION
Nondistributable artifacts are deprecated, and no longer used; we'll be deprecating these fields, so let's already skip their use.


**- A picture of a cute animal (not mandatory but encouraged)**

