### PR TITLE
Makefile: use go1.22 semantics for gofumpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ shellcheck: ## run shellcheck validation
 .PHONY: fmt
 fmt: ## run gofumpt (if present) or gofmt
 	@if command -v gofumpt > /dev/null; then \
-		gofumpt -w -d -lang=1.21 . ; \
+		gofumpt -w -d -lang=1.23 . ; \
 	else \
 		go list -f {{.Dir}} ./... | xargs gofmt -w -s -d ; \
 	fi


### PR DESCRIPTION
gofumpt defaults to using the go version from go.mod, but as we don't have one, we need to set it explicitly.


**- A picture of a cute animal (not mandatory but encouraged)**

