### PR TITLE
[27.x backport] update go-md2man to v2.0.5

### DIFF
--- a/man/go.mod
+++ b/man/go.mod
@@ -7,7 +7,7 @@ go 1.22.0
 
 //require (
 //	github.com/docker/cli v0.0.0+incompatible
-//	github.com/cpuguy83/go-md2man/v2 v2.0.4
+//	github.com/cpuguy83/go-md2man/v2 v2.0.5
 //	github.com/spf13/cobra v1.2.1
 //	github.com/spf13/pflag v1.0.5
 //)

--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-: "${MD2MAN_VERSION=v2.0.4}"
+: "${MD2MAN_VERSION=v2.0.5}"
 
 export GO111MODULE=auto
 


### PR DESCRIPTION
- backport  https://github.com/docker/cli/pull/5689

full diff: https://github.com/cpuguy83/go-md2man/compare/v2.0.4...v2.0.5


(cherry picked from commit eaa8b5716d591ce1d267ab4c12ffaf32d871e638)

