### PR TITLE
cli/command/system: TestEventsFormat: set cmd.Args to prevent test-failures

### DIFF
--- a/cli/command/system/events_test.go
+++ b/cli/command/system/events_test.go
@@ -33,22 +33,24 @@ func TestEventsFormat(t *testing.T) {
 		})
 	}
 	tests := []struct {
-		name, format string
+		name string
+		args []string
 	}{
 		{
 			name: "default",
+			args: []string{},
 		},
 		{
-			name:   "json",
-			format: "json",
+			name: "json",
+			args: []string{"--format", "json"},
 		},
 		{
-			name:   "json template",
-			format: "{{ json . }}",
+			name: "json template",
+			args: []string{"--format", "{{ json . }}"},
 		},
 		{
-			name:   "json action",
-			format: "{{ json .Action }}",
+			name: "json action",
+			args: []string{"--format", "{{ json .Action }}"},
 		},
 	}
 
@@ -69,9 +71,9 @@ func TestEventsFormat(t *testing.T) {
 				return messages, errs
 			}})
 			cmd := NewEventsCommand(cli)
-			if tc.format != "" {
-				cmd.Flags().Set("format", tc.format)
-			}
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			assert.Check(t, cmd.Execute())
 			out := cli.OutBuffer().String()
 			assert.Check(t, golden.String(out, fmt.Sprintf("docker-events-%s.golden", strings.ReplaceAll(tc.name, " ", "-"))))


### PR DESCRIPTION
- similar to https://github.com/docker/cli/pull/5224


When running the tests with options set, such as `-update` for updating "golden" files, this test would pick up test arguments because no arguments were set to invoke the command;

    go test . -update
    Error: unknown shorthand flag: 'u' in -update
    Usage:
      events [OPTIONS] [flags]

    Flags:
      -f, --filter filter   Filter output based on conditions provided
          --format string   Format output using a custom template:
                            'json':             Print in JSON format
                            'TEMPLATE':         Print output using the given Go template.
                            Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates
      -h, --help            help for events
          --since string    Show all events created since timestamp
          --until string    Stream events until this timestamp

    --- FAIL: TestEventsFormat (0.00s)
        --- FAIL: TestEventsFormat/default (0.00s)
            events_test.go:75: assertion failed: error is not nil: unknown shorthand flag: 'u' in -update
        --- FAIL: TestEventsFormat/json (0.00s)
            events_test.go:75: assertion failed: error is not nil: unknown shorthand flag: 'u' in -update
        --- FAIL: TestEventsFormat/json_template (0.00s)
            events_test.go:75: assertion failed: error is not nil: unknown shorthand flag: 'u' in -update
        --- FAIL: TestEventsFormat/json_action (0.00s)
            events_test.go:75: assertion failed: error is not nil: unknown shorthand flag: 'u' in -update

This patch:

- changes the test to use command-arguments instead of manually setting the flag options; this also adds test-coverage for parsing actual command arguments.
- discards stdout/stderr of the command to prevent noise in test output

**- A picture of a cute animal (not mandatory but encouraged)**

