### PR TITLE
TestRunCopyFromContainerToFilesystem: use Tar without options

### DIFF
--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -73,7 +73,7 @@ func TestRunCopyFromContainerToFilesystem(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerCopyFromFunc: func(ctr, srcPath string) (io.ReadCloser, container.PathStat, error) {
 			assert.Check(t, is.Equal("container", ctr))
-			readCloser, err := archive.TarWithOptions(destDir.Path(), &archive.TarOptions{})
+			readCloser, err := archive.Tar(destDir.Path(), archive.Uncompressed)
 			return readCloser, container.PathStat{}, err
 		},
 	})


### PR DESCRIPTION
Just a minor cleanup; use archive.Tar as we're not using other options here.

