### PR TITLE
Fix container cp test to separate source and destination

### DIFF
--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -66,14 +66,15 @@ func TestRunCopyFromContainerToStdout(t *testing.T) {
 }
 
 func TestRunCopyFromContainerToFilesystem(t *testing.T) {
-	destDir := fs.NewDir(t, "cp-test",
+	srcDir := fs.NewDir(t, "cp-test",
 		fs.WithFile("file1", "content\n"))
-	defer destDir.Remove()
+
+	destDir := fs.NewDir(t, "cp-test")
 
 	cli := test.NewFakeCli(&fakeClient{
 		containerCopyFromFunc: func(ctr, srcPath string) (io.ReadCloser, container.PathStat, error) {
 			assert.Check(t, is.Equal("container", ctr))
-			readCloser, err := archive.Tar(destDir.Path(), archive.Uncompressed)
+			readCloser, err := archive.Tar(srcDir.Path(), archive.Uncompressed)
 			return readCloser, container.PathStat{}, err
 		},
 	})


### PR DESCRIPTION
Currently the copy will tar from the same directory it will untar into simultaneously. There is a race between reading the file and truncating the file for write, however, the race will not show up with a large enough buffer on the tar side if buffered before the copy begins.

Also removes the unnecessary deferred removal, the removal is handled by cleanup and respects the no cleanup env.

