### PR TITLE
[27.x backport] test-fixes

### DIFF
--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -67,14 +67,15 @@ func TestRunCopyFromContainerToStdout(t *testing.T) {
 }
 
 func TestRunCopyFromContainerToFilesystem(t *testing.T) {
-	destDir := fs.NewDir(t, "cp-test",
+	srcDir := fs.NewDir(t, "cp-test",
 		fs.WithFile("file1", "content\n"))
-	defer destDir.Remove()
+
+	destDir := fs.NewDir(t, "cp-test")
 
 	cli := test.NewFakeCli(&fakeClient{
 		containerCopyFromFunc: func(ctr, srcPath string) (io.ReadCloser, container.PathStat, error) {
 			assert.Check(t, is.Equal("container", ctr))
-			readCloser, err := archive.Tar(destDir.Path(), archive.Uncompressed)
+			readCloser, err := archive.Tar(srcDir.Path(), archive.Uncompressed)
 			return readCloser, container.PathStat{}, err
 		},
 	})

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -74,7 +74,7 @@ func TestRunCopyFromContainerToFilesystem(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{
 		containerCopyFromFunc: func(ctr, srcPath string) (io.ReadCloser, container.PathStat, error) {
 			assert.Check(t, is.Equal("container", ctr))
-			readCloser, err := archive.TarWithOptions(destDir.Path(), &archive.TarOptions{})
+			readCloser, err := archive.Tar(destDir.Path(), archive.Uncompressed)
 			return readCloser, container.PathStat{}, err
 		},
 	})


### PR DESCRIPTION
backport:

- (for a clean cherry-pick) https://github.com/docker/cli/pull/5710
- https://github.com/docker/cli/pull/5715