### PR TITLE
[27.x backport] docs, man: remove confusing example for "--isolation"

### DIFF
--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -133,8 +133,6 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 | `process` | Namespace isolation only.                                                                                                                                                      |
 | `hyperv`  | Hyper-V hypervisor partition-based isolation.                                                                                                                                  |
 
-Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
-
 ### <a name="security-opt"></a> Optional security options (--security-opt)
 
 This flag is only supported on a daemon running on Windows, and only supports

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -348,8 +348,6 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 * `process`: Namespace isolation only.
 * `hyperv`: Hyper-V hypervisor partition-based isolation.
 
-Specifying the `--isolation` flag without a value is the same as setting `--isolation "default"`.
-
 # HISTORY
 March 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.

--- a/man/src/container/create-example.md
+++ b/man/src/container/create-example.md
@@ -9,8 +9,6 @@ Linux namespaces. On Microsoft Windows, you can specify these values:
 * `process`: Namespace isolation only.
 * `hyperv`: Hyper-V hypervisor partition-based isolation.
 
-Specifying the `--isolation` flag without a value is the same as setting `--isolation="default"`.
-
 ### Dealing with dynamically created devices (--device-cgroup-rule)
 
 Devices available to a container are assigned at creation time. The


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/5718

This snippet was added in [docker@38ec5d8][1]. The intent was to indicate that an empty value is equivalent to passing "default" as value. However, passing the `--isolation` flag _without a value_ (i.e., no `=` specified) will fail in many cases, as any string after it will be parsed as value (e.g. `docker run --isolation busybox` would consider `busybox` as value).

This patch removes these lines as they add more confusion than addressing.

[1]: https://github.com/docker/docker/commit/38ec5d86a355674cfddf8c998591abb098475bab


(cherry picked from commit 7b7a4c020ed8e9143f758b4fa029be4218a24059)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

