### PR TITLE
remove remnants of --oom-score-adj daemon config (docs, completion)

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2591,7 +2591,6 @@ _docker_daemon() {
 		--mtu
 		--network-control-plane-mtu
 		--node-generic-resource
-		--oom-score-adjust
 		--pidfile -p
 		--registry-mirror
 		--seccomp-profile

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2770,7 +2770,6 @@ __docker_subcommand() {
                 "($help)--max-concurrent-uploads[Set the max concurrent uploads]" \
                 "($help)--max-download-attempts[Set the max download attempts for each pull]" \
                 "($help)--mtu=[Network MTU]:mtu:(0 576 1420 1500 9000)" \
-                "($help)--oom-score-adjust=[Set the oom_score_adj for the daemon]:oom-score:(-500)" \
                 "($help -p --pidfile)"{-p=,--pidfile=}"[Path to use for daemon PID file]:PID file:_files" \
                 "($help)--raw-logs[Full timestamps without ANSI coloring]" \
                 "($help)*--registry-mirror=[Preferred registry mirror]:registry mirror: " \

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -93,7 +93,6 @@ Options:
       --no-new-privileges                     Set no-new-privileges by default for new containers
       --no-proxy string                       Comma-separated list of hosts or IP addresses for which the proxy is skipped
       --node-generic-resource list            Advertise user-defined resource
-      --oom-score-adjust int                  Set the oom_score_adj for the daemon
   -p, --pidfile string                        Path to use for daemon PID file (default "/var/run/docker.pid")
       --raw-logs                              Full timestamps without ANSI coloring
       --registry-mirror list                  Preferred registry mirror
@@ -1186,7 +1185,6 @@ The following is a full example of the allowed configuration options on Linux:
     "NVIDIA-GPU=UUID1",
     "NVIDIA-GPU=UUID2"
   ],
-  "oom-score-adjust": 0,
   "pidfile": "",
   "raw-logs": false,
   "registry-mirrors": [],


### PR DESCRIPTION
relates to

- https://github.com/moby/moby/pull/45315
- https://github.com/moby/moby/pull/46113


This flag was deprecated in docker v24.0, and no longer functional
since v25.0; fully removed in v26.0, so we can remove the docs
for this.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

