### PR TITLE
Deprecate configuration for pushing non-distributable artifacts

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -2551,7 +2551,6 @@ _docker_daemon() {
 	local options_with_args="
 		$global_options_with_args
 		--add-runtime
-		--allow-nondistributable-artifacts
 		--authorization-plugin
 		--bip
 		--bridge -b

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2726,7 +2726,6 @@ __docker_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help)*--add-runtime=[Register an additional OCI compatible runtime]:runtime:__docker_complete_runtimes" \
-                "($help)*--allow-nondistributable-artifacts=[Push nondistributable artifacts to specified registries]:registry: " \
                 "($help)*--authorization-plugin=[Authorization plugins to load]" \
                 "($help -b --bridge)"{-b=,--bridge=}"[Attach containers to a network bridge]:bridge:_net_interfaces" \
                 "($help)--bip=[Network bridge IP]:IP address: " \

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -53,6 +53,7 @@ The following table provides an overview of the current status of deprecated fea
 
 | Status     | Feature                                                                                                                            | Deprecated | Remove |
 |------------|------------------------------------------------------------------------------------------------------------------------------------|------------|--------|
+| Deprecated | [Configuration for pushing  non-distributable artifacts](#configuration-for-pushing-non-distributable-artifacts)                   | v28.0      | v29.0  |
 | Deprecated | [`--time` option on `docker stop` and `docker restart`](#--time-option-on-docker-stop-and-docker-restart)                          | v28.0      | -      |
 | Deprecated | [Non-standard fields in image inspect](#non-standard-fields-in-image-inspect)                                                      | v27.0      | v28.0  |
 | Removed    | [API CORS headers](#api-cors-headers)                                                                                              | v27.0      | v28.0  |
@@ -118,6 +119,45 @@ The following table provides an overview of the current status of deprecated fea
 | Removed    | [`--api-enable-cors` flag on `dockerd`](#--api-enable-cors-flag-on-dockerd)                                                        | v1.6       | v17.09 |
 | Removed    | [`--run` flag on `docker commit`](#--run-flag-on-docker-commit)                                                                    | v0.10      | v1.13  |
 | Removed    | [Three arguments form in `docker import`](#three-arguments-form-in-docker-import)                                                  | v0.6.7     | v1.12  |
+
+## Configuration for pushing non-distributable artifacts
+
+**Deprecated in Release: v28.0**
+**Target For Removal In Release: v29.0**
+
+Non-distributable artifacts (also called foreign layers) were introduced in
+docker v1.12 to accommodate Windows images for which the EULA did not allow
+layers to be distributed through registries other than those hosted by Microsoft.
+The concept of foreign / non-distributable layers was adopted by the OCI distribution
+spec in [oci#233]. These restrictions were relaxed later to allow distributing
+these images through non-public registries, for which a configuration was added
+in Docker v17.0.6.0.
+
+In 2022, Microsoft updated the EULA and [removed these restrictions][msft-3645201],
+followed by the OCI distribution specification deprecating foreign layers in [oci#965].
+In 2023, Microsoft [removed the use of foreign data layers][msft-3846833] for their images,
+making this functionality obsolete.
+
+Docker v28.0 deprecates the `--allow-nondistributable-artifacts` daemon flag and
+corresponding `allow-nondistributable-artifacts` field in `daemon.json`. Setting
+either option no longer takes an effect, but a deprecation warning log is added
+to raise awareness about the deprecation. This warning is planned to become an
+error in the Docker v29.0.
+
+Users currently using these options are therefore recommended to remove this
+option from their configuration to prevent the daemon from starting when
+upgrading to Docker v29.0.
+
+The `AllowNondistributableArtifactsCIDRs` and `AllowNondistributableArtifactsHostnames`
+fields in the `RegistryConfig` of the `GET /info` API response are also deprecated.
+For API version v1.48 and lower, the fields are still included in the response
+but always `null`. In API version v1.49 and higher, the field will be omitted
+entirely.
+
+[oci#233]: https://github.com/opencontainers/image-spec/pull/233
+[oci#965]: https://github.com/opencontainers/image-spec/pull/965
+[msft-3645201]: https://techcommunity.microsoft.com/blog/containers/announcing-windows-container-base-image-redistribution-rights-change/3645201
+[msft-3846833]: https://techcommunity.microsoft.com/blog/containers/announcing-removal-of-foreign-layers-from-windows-container-images/3846833
 
 ### `--time` option on `docker stop` and `docker restart`
 

--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -24,7 +24,6 @@ A self-sufficient runtime for containers.
 
 Options:
       --add-runtime runtime                   Register an additional OCI compatible runtime (default [])
-      --allow-nondistributable-artifacts list Allow push of nondistributable artifacts to registry
       --authorization-plugin list             Authorization plugins to load
       --bip string                            Specify default-bridge IPv4 network
       --bip6 string                           Specify default-bridge IPv6 network
@@ -688,34 +687,6 @@ To set the DNS search domain for all Docker containers, use:
 $ sudo dockerd --dns-search example.com
 ```
 
-### Allow push of non-distributable artifacts
-
-Some images (e.g., Windows base images) contain artifacts whose distribution is
-restricted by license. When these images are pushed to a registry, restricted
-artifacts are not included.
-
-To override this behavior for specific registries, use the
-`--allow-nondistributable-artifacts` option in one of the following forms:
-
-* `--allow-nondistributable-artifacts myregistry:5000` tells the Docker daemon
-  to push non-distributable artifacts to myregistry:5000.
-* `--allow-nondistributable-artifacts 10.1.0.0/16` tells the Docker daemon to
-  push non-distributable artifacts to all registries whose resolved IP address
-  is within the subnet described by the CIDR syntax.
-
-This option can be used multiple times.
-
-This option is useful when pushing images containing non-distributable artifacts
-to a registry on an air-gapped network so hosts on that network can pull the
-images without connecting to another server.
-
-> [!WARNING]
-> Non-distributable artifacts typically have restrictions on how
-> and where they can be distributed and shared. Only use this feature to push
-> artifacts to private registries and ensure that you are in compliance with
-> any terms that cover redistributing non-distributable artifacts.
-{ .warning }
-
 ### Insecure registries
 
 In this section, "registry" refers to a private registry, and `myregistry:5000`
@@ -1086,7 +1057,6 @@ The following is a full example of the allowed configuration options on Linux:
 
 ```json
 {
-  "allow-nondistributable-artifacts": [],
   "authorization-plugins": [],
   "bip": "",
   "bip6": "",
@@ -1234,7 +1204,6 @@ The following is a full example of the allowed configuration options on Windows:
 
 ```json
 {
-  "allow-nondistributable-artifacts": [],
   "authorization-plugins": [],
   "bridge": "",
   "containerd": "\\\\.\\pipe\\containerd-containerd",
@@ -1338,7 +1307,6 @@ The list of currently supported options that can be reconfigured is this:
 | `default-runtime`                  | Configures the runtime to be used if not is specified at container creation.                                |
 | `runtimes`                         | Configures the list of available OCI runtimes that can be used to run containers.                           |
 | `authorization-plugin`             | Specifies the authorization plugins to use.                                                                 |
-| `allow-nondistributable-artifacts` | Specifies a list of registries to which the daemon will push non-distributable artifacts.                   |
 | `insecure-registries`              | Specifies a list of registries that the daemon should consider insecure.                                    |
 | `registry-mirrors`                 | Specifies a list of registry mirrors.                                                                       |
 | `shutdown-timeout`                 | Configures the daemon's existing configuration timeout with a new timeout for shutting down all containers. |

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -6,7 +6,6 @@ dockerd - Enable daemon mode
 # SYNOPSIS
 **dockerd**
 [**--add-runtime**[=*[]*]]
-[**--allow-nondistributable-artifacts**[=*[]*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
 [**--bip**[=*BIP*]]
@@ -125,20 +124,6 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 ```
 
   **Note**: defining runtime arguments via the command line is not supported.
-
-**--allow-nondistributable-artifacts**=[]
-  Push nondistributable artifacts to the specified registries.
-
-  List can contain elements with CIDR notation to specify a whole subnet.
-
-  This option is useful when pushing images containing nondistributable
-  artifacts to a registry on an air-gapped network so hosts on that network can
-  pull the images without connecting to another server.
-
-  **Warning**: Nondistributable artifacts typically have restrictions on how
-  and where they can be distributed and shared. Only use this feature to push
-  artifacts to private registries and ensure that you are in compliance with
-  any terms that cover redistributing nondistributable artifacts.
 
 **--authorization-plugin**=""
   Set authorization plugins to load


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49065


### Deprecate configuration for pushing non-distributable artifacts

Non-distributable artifacts (also called foreign layers) were introduced in docker v1.12 to accommodate Windows images for which the EULA did not allow layers to be distributed through registries other than those hosted by Microsoft. The concept of foreign / non-distributable layers was adopted by the OCI distribution spec in [oci#233]. These restrictions were relaxed later to allow distributing these images through non-public registries, for which a configuration was added in Docker v17.0.6.0.

In 2022, Microsoft updated the EULA and [removed these restrictions][msft-3645201], followed by the OCI distribution specification deprecating foreign layers in [oci#965]. In 2023, Microsoft [removed the use of foreign data layers][msft-3846833] for their images, making this functionality obsolete.

Docker v28.0 deprecates the `--allow-nondistributable-artifacts` daemon flag and corresponding `allow-nondistributable-artifacts` field in `daemon.json`. Setting either option no longer takes an effect, but a deprecation warning log is added to raise awareness about the deprecation. This warning is planned to become an error in the Docker v29.0.

Users currently using these options are therefore recommended to remove this option from their configuration to prevent the daemon from starting when upgrading to Docker v29.0.

The `AllowNondistributableArtifactsCIDRs` and `AllowNondistributableArtifactsHostnames` fields in the `RegistryConfig` of the `GET /info` API response are also deprecated. For API version v1.48 and lower, the fields are still included in the response but always `null`. In API version v1.49 and higher, the field will be omitted entirely.

[oci#233]: https://github.com/opencontainers/image-spec/pull/233
[oci#965]: https://github.com/opencontainers/image-spec/pull/965
[msft-3645201]: https://techcommunity.microsoft.com/blog/containers/announcing-windows-container-base-image-redistribution-rights-change/3645201
[msft-3846833]: https://techcommunity.microsoft.com/blog/containers/announcing-removal-of-foreign-layers-from-windows-container-images/3846833


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Deprecate configuration for pushing non-distributable artifacts
```

**- A picture of a cute animal (not mandatory but encouraged)**

