### PR TITLE
Remove preceding white space from cobra help template

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -518,4 +518,4 @@ Run '{{.CommandPath}} COMMAND --help' for more information on a command.
 `
 
 const helpTemplate = `
-{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+{{- if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`

--- a/e2e/cli-plugins/testdata/docker-help-helloworld-goodbye.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld-goodbye.golden
@@ -1,4 +1,3 @@
-
 Usage:  docker helloworld goodbye
 
 Say Goodbye instead of Hello

--- a/e2e/cli-plugins/testdata/docker-help-helloworld.golden
+++ b/e2e/cli-plugins/testdata/docker-help-helloworld.golden
@@ -1,4 +1,3 @@
-
 Usage:  docker helloworld [OPTIONS] COMMAND
 
 A basic Hello World plugin for tests

--- a/e2e/stack/testdata/stack-deploy-help.golden
+++ b/e2e/stack/testdata/stack-deploy-help.golden
@@ -1,4 +1,3 @@
-
 Usage:  docker stack deploy [OPTIONS] STACK
 
 Deploy a new stack or update an existing stack


### PR DESCRIPTION
While printing the usage text, I noticed there is always a empty line before the usage text. This was due to not using trim marker in cobra help text template. This PR fixes that.

**- What I did**
Remove preceding white space from cobra help template

**- How I did it**
Add a trim marker before printing the help template.

**- How to verify it**
Before:
```
$ ./build/docker                              

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

...
```

Build the cli on this branch and re-run the binary. Now it will output:
```
$ ./build/docker
Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

...
```

Please note the there is no line before usage text.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Remove preceding white space from cobra help template

```

**- A picture of a cute animal (not mandatory but encouraged)**


