### PR TITLE
[27.x backport] gha/build: Publish bin image for release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5734
- related to: https://github.com/moby/moby/pull/48450

We moved to the major release branches with a `.x` suffix and forgot to adjust this workflow to run on branches like `27.x`.
