### PR TITLE
ci: update bake-action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,16 +62,11 @@ jobs:
           - glibc
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
           set: |
@@ -104,8 +99,12 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && github.repository == 'docker/cli' }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_CLIBIN_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_CLIBIN_TOKEN }}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -124,19 +123,12 @@ jobs:
             type=ref,event=pr
             type=sha
       -
-        name: Login to DockerHub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_CLIBIN_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_CLIBIN_TOKEN }}
-      -
         name: Build and push image
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           files: |
             ./docker-bake.hcl
-            ${{ steps.meta.outputs.bake-file }}
+            cwd://${{ steps.meta.outputs.bake-file }}
           targets: bin-image-cross
           push: ${{ github.event_name != 'pull_request' }}
           set: |
@@ -171,14 +163,11 @@ jobs:
         platform: ${{ fromJson(needs.prepare-plugins.outputs.matrix) }}
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Build
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: plugins-cross
           set: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       -
         name: Test
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: test-coverage
       -

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,11 +36,8 @@ jobs:
           - update-authors # ensure authors update target runs fine
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
         name: Run
-        uses: docker/bake-action@v5
+        uses: docker/bake-action@v6
         with:
           targets: ${{ matrix.target }}
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -141,16 +141,19 @@ target "update-authors" {
 }
 
 target "test" {
+    inherits = ["_common"]
     target = "test"
     output = ["type=cacheonly"]
 }
 
 target "test-coverage" {
+    inherits = ["_common"]
     target = "test-coverage"
     output = ["build/coverage"]
 }
 
 target "e2e-image" {
+    inherits = ["_common"]
     target = "e2e"
     output = ["type=docker"]
     tags = ["${IMAGE_NAME}"]


### PR DESCRIPTION
closes #5731 

Update back-action to v6 which defaults to Git context so need some changes in our workflows.