### PR TITLE
Allow '--link' with '--network bridge'

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -825,7 +825,9 @@ func applyContainerOptions(n *opts.NetworkAttachmentOpts, copts *containerOption
 		n.Aliases = make([]string, copts.aliases.Len())
 		copy(n.Aliases, copts.aliases.GetAll())
 	}
-	if n.Target != "default" && copts.links.Len() > 0 {
+	// For a user-defined network, "--link" is an endpoint option, it creates an alias. But,
+	// for the default bridge it defines a legacy-link.
+	if container.NetworkMode(n.Target).IsUserDefined() && copts.links.Len() > 0 {
 		n.Links = make([]string, copts.links.Len())
 		copy(n.Links, copts.links.GetAll())
 	}


### PR DESCRIPTION
**- What I did**

Commit f1048e1a ("Create default EndpointSettings if no --network provided") added an exception for `default` in `applyContainerOptions()` ... so that `--link` isn't copied to endpoint settings if it's a legacy-link option for the default bridge.

But, that missed "--network bridge", or the long form "--network name=bridge,..." (needed to specify endpoint options).

**- How I did it**

Check for `IsUserDefined` instead of `!= "default`.

**- How to verify it**

`docker run --rm -ti --network name=bridge,driver-opt=com.docker.network.endpoint.sysctls=net.ipv6.conf.IFNAME.disable_ipv6=1 --name c1 busybox` works with this change.

**- Description for the changelog**
```markdown changelog
- Fixed validation of `--link` option.
```

