### PR TITLE
fix/dockerfiles: Update CMD instruction in 'Dockerfile.dev' to use exec form

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -47,7 +47,7 @@ RUN  apk add --no-cache \
 RUN echo -e "\nYou are now in a development container. Run '\e\033[1mmake help\e\033[0m' to learn about\navailable make targets.\n" > /etc/motd \
  && echo -e "cat /etc/motd\nPS1=\"\e[0;32m\u@docker-cli-dev\\$ \e[0m\"" >> /root/.bashrc \
  && echo -e "source /etc/bash/bash_completion.sh" >> /root/.bashrc
-CMD bash
+CMD ["/bin/bash"]
 ENV DISABLE_WARN_OUTSIDE_CONTAINER=1
 ENV PATH=$PATH:/go/src/github.com/docker/cli/build
 


### PR DESCRIPTION
**- What I did**

![20250113_23h15m03s_grim](https://github.com/user-attachments/assets/57305bef-2be2-499a-bf7b-8627c928d3c0)

I updated the CMD instruction in the `dockerfiles/Dockerfile.dev` to prevent the `JSONArgsRecommended` build check warning.

**- How I did it**

I followed the [dockerdocs instructions](https://docs.docker.com/reference/build-checks/json-args-recommended/)

**- How to verify it**

You can run `make dev` command on the master branch, when the build finished successfully it shows a yellowish "JSONArgsRecommended" warning.

```lua
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 50)
```

Once you switch to the `fix-dockerfile-exec-form` branch, and re-run `make dev` you will not see any `JSONArgsRecommended` warning.

The expected output: 
![20250113_23h13m33s_grim](https://github.com/user-attachments/assets/3d19ed3f-7292-41ae-b435-f61afcf3ca1e)

- My Docker CLI Version: 27.2.1
- Docker Engine Git Commit: 8b539b8df2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
```

```
Fix "`JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals`"
```

**- A picture of a cute animal (not mandatory but encouraged)**

<a href="https://images.pexels.com/photos/30206451/pexels-photo-30206451/free-photo-of-white-cat-climbing-a-tree-outdoors.jpeg"><image src="https://images.pexels.com/photos/30206451/pexels-photo-30206451/free-photo-of-white-cat-climbing-a-tree-outdoors.jpeg" width="200px" alt="A cute white cat on the tree"></a>