### PR TITLE
image/tree: Print longest names first and use full width

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -281,11 +281,23 @@ func printNames(out *streams.Out, headers []imgColumn, img topImage, color, unta
 		_, _ = fmt.Fprint(out, headers[0].Print(untaggedColor, "<untagged>"))
 	}
 
-	for nameIdx, name := range img.Names {
-		if nameIdx != 0 {
-			_, _ = fmt.Fprintln(out, "")
+	// TODO: Replace with namesLongestToShortest := slices.SortedFunc(slices.Values(img.Names))
+	// once we move to Go 1.23.
+	namesLongestToShortest := make([]string, len(img.Names))
+	copy(namesLongestToShortest, img.Names)
+	sort.Slice(namesLongestToShortest, func(i, j int) bool {
+		return len(namesLongestToShortest[i]) > len(namesLongestToShortest[j])
+	})
+
+	for nameIdx, name := range namesLongestToShortest {
+		// Don't limit first names to the column width because only the last
+		// name will be printed alongside other columns.
+		if nameIdx < len(img.Names)-1 {
+			_, fullWidth := out.GetTtySize()
+			_, _ = fmt.Fprintln(out, color.Apply(truncateRunes(name, int(fullWidth))))
+		} else {
+			_, _ = fmt.Fprint(out, headers[0].Print(color, name))
 		}
-		_, _ = fmt.Fprint(out, headers[0].Print(color, name))
 	}
 }
 


### PR DESCRIPTION
When printing image names, sort them by length and print the longest first. This also allows them to use a full terminal width because they are not printed alongside other columns.

**Before**
<img width="954" alt="image" src="https://github.com/user-attachments/assets/63fd9dd4-853d-4279-9a4a-1abfe7931ac4" />

**After**
<img width="954" alt="image" src="https://github.com/user-attachments/assets/d18ee2d4-e17a-40a5-8c51-12c1d582f5b2" />




**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
Fix `docker images --tree` unnecessary truncating long image names when multiple names are available
```

**- A picture of a cute animal (not mandatory but encouraged)**

