### PR TITLE
cli/tree: Use single character triple dot

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -309,7 +309,7 @@ type imgColumn struct {
 func truncateRunes(s string, length int) string {
 	runes := []rune(s)
 	if len(runes) > length {
-		return string(runes[:length-3]) + "..."
+		return string(runes[:length-1]) + "…"
 	}
 	return s
 }


### PR DESCRIPTION
Using 3 characters instead of 1 to ellipsize a long string is wasteful.


