### PR TITLE
[27.x backport] gha: Adjust release branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,7 @@ on:
     branches: 
       - 'master' 
       - '[0-9]+.[0-9]+' 
+      - '[0-9]+.x'
     tags: 
       - 'v*' 
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - 'master'
       - '[0-9]+.[0-9]+'
+      - '[0-9]+.x'
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/5763

Adjust all workflows to also run on branches like `27.x`
