### PR TITLE
Makefile: add "shell-completion" target

### DIFF
--- a/scripts/build/shell-completion
+++ b/scripts/build/shell-completion
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+#
+# Build the shell completion scripts
+#
+
+set -eu
+
+. ./scripts/build/.variables
+
+# generate the shell completion scripts and store them in build/completion.
+if [ "$(go env GOOS)" != "windows" ]; then
+		if [ ! -f ./build/docker ]; then
+				echo "Run 'make binary' or 'make dynbinary' first"
+				exit 1
+		fi
+
+		mkdir -p build/completion/bash build/completion/fish build/completion/zsh
+		./build/docker completion bash > build/completion/bash/docker
+		./build/docker completion fish > build/completion/fish/docker.fish
+		./build/docker completion zsh > build/completion/zsh/_docker
+fi


### PR DESCRIPTION
- relates too https://github.com/docker/docker-ce-packaging/pull/1150

Makefile: add "shell-completion" target

Add a target to build the (cobra) generated completion and store
them inside build/completions.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

