### PR TITLE
login: improve text on already authenticated and on OAuth login

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -13,8 +13,10 @@ import (
 	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/hints"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal/tui"
 	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/registry"
+	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 )
 
@@ -178,6 +180,9 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 			}
 		}()
 
+		out := tui.NewOutput(cli.Err())
+		out.PrintNote("A Personal Access Token (PAT) can be used instead.\n" +
+			"To create a PAT, visit " + aec.Underline.Apply("https://app.docker.com/settings") + "\n\n")
 		argPassword, err = PromptForInput(ctx, cli.In(), cli.Out(), "Password: ")
 		if err != nil {
 			return registrytypes.AuthConfig{}, err

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -61,14 +61,12 @@ func TestLoginWithCredStoreCreds(t *testing.T) {
 	}{
 		{
 			inputAuthConfig: registrytypes.AuthConfig{},
-			expectedMsg:     "Authenticating with existing credentials...\n",
 		},
 		{
 			inputAuthConfig: registrytypes.AuthConfig{
 				Username: unknownUser,
 			},
 			expectedErr:    errUnknownUser,
-			expectedMsg:    "Authenticating with existing credentials...\n",
 			expectedErrMsg: fmt.Sprintf("Login did not succeed, error: %s\n", errUnknownUser),
 		},
 	}
@@ -83,7 +81,7 @@ func TestLoginWithCredStoreCreds(t *testing.T) {
 			assert.NilError(t, err)
 		}
 		assert.Check(t, is.Equal(tc.expectedMsg, cli.OutBuffer().String()))
-		assert.Check(t, is.Equal(tc.expectedErrMsg, cli.ErrBuffer().String()))
+		assert.Check(t, is.Contains(cli.ErrBuffer().String(), tc.expectedErrMsg))
 		cli.ErrBuffer().Reset()
 		cli.OutBuffer().Reset()
 	}

--- a/cli/internal/oauth/manager/manager.go
+++ b/cli/internal/oauth/manager/manager.go
@@ -13,6 +13,8 @@ import (
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/internal/oauth"
 	"github.com/docker/cli/cli/internal/oauth/api"
+	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal/tui"
 	"github.com/docker/docker/registry"
 	"github.com/morikuni/aec"
 	"github.com/sirupsen/logrus"
@@ -93,7 +95,15 @@ func (m *OAuthManager) LoginDevice(ctx context.Context, w io.Writer) (*types.Aut
 	}
 
 	_, _ = fmt.Fprintln(w, aec.Bold.Apply("\nUSING WEB-BASED LOGIN"))
-	_, _ = fmt.Fprintln(w, "To sign in with credentials on the command line, use 'docker login -u <username>'")
+
+	var out tui.Output
+	switch stream := w.(type) {
+	case *streams.Out:
+		out = tui.NewOutput(stream)
+	default:
+		out = tui.NewOutput(streams.NewOut(w))
+	}
+	out.PrintNote("To sign in with credentials on the command line, use 'docker login -u <username>'\n")
 	_, _ = fmt.Fprintf(w, "\nYour one-time device confirmation code is: "+aec.Bold.Apply("%s\n"), state.UserCode)
 	_, _ = fmt.Fprintf(w, aec.Bold.Apply("Press ENTER")+" to open your browser or submit your device code here: "+aec.Underline.Apply("%s\n"), strings.Split(state.VerificationURI, "?")[0])
 

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -6,11 +6,11 @@ Defaults to Docker Hub if no server is specified.
 
 ### Options
 
-| Name                                         | Type     | Default | Description                  |
-|:---------------------------------------------|:---------|:--------|:-----------------------------|
-| `-p`, `--password`                           | `string` |         | Password                     |
-| [`--password-stdin`](#password-stdin)        | `bool`   |         | Take the password from stdin |
-| [`-u`](#username), [`--username`](#username) | `string` |         | Username                     |
+| Name                                         | Type     | Default | Description                                                 |
+|:---------------------------------------------|:---------|:--------|:------------------------------------------------------------|
+| `-p`, `--password`                           | `string` |         | Password or Personal Access Token (PAT)                     |
+| [`--password-stdin`](#password-stdin)        | `bool`   |         | Take the Password or Personal Access Token (PAT) from stdin |
+| [`-u`](#username), [`--username`](#username) | `string` |         | Username                                                    |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
Users have trouble understanding the different login paths on the CLI.
The default login is performed through an OAuth flow with the option to
fallback to a username and PAT login using the docker login -u <username>
option.

This patch improves the text around docker login, indicating:
- The username is shown when already authenticated
- Steps the user can take to switch user accounts are printed when
  authenticated in an info.
- When not authenticated, the OAuth login flow explains the fallback
  clearly to the user in an info.
- The password prompt now explicitly states that it accepts a PAT in an
  info.

![image](https://github.com/user-attachments/assets/bbfcb619-326b-4092-a5a3-06c6fc437e62)

![image](https://github.com/user-attachments/assets/f0f2c954-012b-4933-8b58-fd1bd29fd850)

![image](https://github.com/user-attachments/assets/ccdbbc8c-1b86-4556-8017-3d3258804cbf)



<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog
improve docker login info regarding personal access tokens
```

**- A picture of a cute animal (not mandatory but encouraged)**

