### PR TITLE
Don't print "context canceled" if user terminated

### DIFF
--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -324,6 +324,7 @@ func toStatusError(err error) error {
 
 	if strings.Contains(errMsg, "executable file not found") || strings.Contains(errMsg, "no such file or directory") || strings.Contains(errMsg, "system cannot find the file specified") {
 		return cli.StatusError{
+			Cause:      err,
 			Status:     withHelp(err, "run").Error(),
 			StatusCode: 127,
 		}
@@ -331,12 +332,14 @@ func toStatusError(err error) error {
 
 	if strings.Contains(errMsg, syscall.EACCES.Error()) || strings.Contains(errMsg, syscall.EISDIR.Error()) {
 		return cli.StatusError{
+			Cause:      err,
 			Status:     withHelp(err, "run").Error(),
 			StatusCode: 126,
 		}
 	}
 
 	return cli.StatusError{
+		Cause:      err,
 		Status:     withHelp(err, "run").Error(),
 		StatusCode: 125,
 	}

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -290,6 +290,7 @@ func TestRunPullTermination(t *testing.T) {
 	select {
 	case cmdErr := <-cmdErrC:
 		assert.Equal(t, cmdErr, cli.StatusError{
+			Cause:      context.Canceled,
 			StatusCode: 125,
 			Status:     "docker: context canceled\n\nRun 'docker run --help' for more information",
 		})

--- a/cli/error.go
+++ b/cli/error.go
@@ -6,6 +6,7 @@ import (
 
 // StatusError reports an unsuccessful exit by a command.
 type StatusError struct {
+	Cause      error
 	Status     string
 	StatusCode int
 }
@@ -14,8 +15,15 @@ type StatusError struct {
 // it is returned as-is, otherwise it generates a generic error-message
 // based on the StatusCode.
 func (e StatusError) Error() string {
-	if e.Status == "" {
-		return "exit status " + strconv.Itoa(e.StatusCode)
+	if e.Status != "" {
+		return e.Status
 	}
-	return e.Status
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "exit status " + strconv.Itoa(e.StatusCode)
+}
+
+func (e StatusError) Unwrap() error {
+	return e.Cause
 }

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -37,12 +37,9 @@ func (e errCtxSignalTerminated) Error() string {
 }
 
 func main() {
-	ctx := context.Background()
-	err := dockerMain(ctx)
-
+	err := dockerMain(context.Background())
 	if errors.As(err, &errCtxSignalTerminated{}) {
 		os.Exit(getExitCode(err))
-		return
 	}
 
 	if err != nil && !errdefs.IsCancelled(err) {


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/5659

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Alternative to/supercedes https://github.com/docker/cli/pull/5666.

Without breaking API compatibility, this patch allows us to know whether a returned `cli/StatusError` was caused by a context cancellation or not, which we can use to provide a nicer UX and not print the Go "context canceled" error message if this is the cause.

This change is safe and does not affect any caller that does not set `Cause` with the root error.

**- How I did it**

(This is basically what I suggested in https://github.com/docker/cli/pull/5666 – see https://github.com/docker/cli/pull/5666#issuecomment-2578311063, and https://github.com/docker/cli/pull/5666#discussion_r1867757214 – and also what @ndeloof [suggested](https://github.com/docker/cli/pull/5666#discussion_r1932370949) – I figured it would be easier to just implement it since I think most of the maintainers are in agreement about this, and don't want to unexport `cli.StatusError` )

By adding a `Cause` field to the `StatusError` type, and implementing `Unwrap` so that `StatusError` can be checked with `errors.Is`.

We can deprecate `Status` later, or we can keep it if we want to let callers set a nicer error message (and always use that if it is set).

**- How to verify it**
`docker run --pull=always ubuntu echo "hi"` and cancel during the pull.

Before:
```
/docker run --pull=always ubuntu echo "hi"
latest: Pulling from library/ubuntu
8bb55f067777: Pulling fs layer
^Cdocker: context canceled

Run 'docker run --help' for more information
```
With the change:
```
 ./build/docker run --pull=always ubuntu echo "hi"
latest: Pulling from library/ubuntu
8bb55f067777: Downloading [=====================>                             ]  12.45MB/28.89MB
^C
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="455" alt="Screenshot 2025-01-29 at 17 16 16" src="https://github.com/user-attachments/assets/3571b1db-7236-44cd-9f0d-ce2cf50aebb5" />

