### PR TITLE
cli/command/plugins: runRemove: fix incorrect use of errors.Join

### DIFF
--- a/cli/command/plugin/remove.go
+++ b/cli/command/plugin/remove.go
@@ -36,14 +36,16 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runRemove(ctx context.Context, dockerCli command.Cli, opts *rmOptions) error {
-	var errs error
+func runRemove(ctx context.Context, dockerCLI command.Cli, opts *rmOptions) error {
+	apiClient := dockerCLI.Client()
+
+	var errs []error
 	for _, name := range opts.plugins {
-		if err := dockerCli.Client().PluginRemove(ctx, name, types.PluginRemoveOptions{Force: opts.force}); err != nil {
-			errs = errors.Join(errs, err)
+		if err := apiClient.PluginRemove(ctx, name, types.PluginRemoveOptions{Force: opts.force}); err != nil {
+			errs = append(errs, err)
 			continue
 		}
-		_, _ = fmt.Fprintln(dockerCli.Out(), name)
+		_, _ = fmt.Fprintln(dockerCLI.Out(), name)
 	}
-	return errs
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
- follow-up to / fixes https://github.com/docker/cli/pull/5547#discussion_r1810257735


commit 71ebbb81ae3c8509131985c60f5b0dd9c9e93d5a replaced the use of the custom "cli.Errors" type for stdlib's errors.Join, however it made a mistake by calling errors.Join for each error occurred, which "nests" each error instead of putting each error at the same level.

Thanks to Paweł Gronowski for spotting this on the [pull request][1]

[1]: https://github.com/docker/cli/pull/5547/commits/71ebbb81ae3c8509131985c60f5b0dd9c9e93d5a#r1810257735


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

