### PR TITLE
cli/command/stack/swarm: waitOnServices remove redundant check for multi-error

### DIFF
--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -292,10 +292,5 @@ func waitOnServices(ctx context.Context, dockerCli command.Cli, serviceIDs []str
 			errs = append(errs, fmt.Errorf("%s: %w", serviceID, err))
 		}
 	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
This check was redundant, because `errors.Join` already checks if the
list of errors is either empty, or only contains `nil` errors, as can
be seen in [this example][2];

```go
package main

import (
    "errors"
    "testing"
)

func TestMultiErr(t *testing.T) {
    var errs []error
    if err := errors.Join(errs...); err != nil {
        t.Fatal(err)
    }

    errs = append(errs, nil, nil, nil)
    t.Logf("errs contains %d elements", len(errs))
    if err := errors.Join(errs...); err != nil {
        t.Fatal(err)
    }

    errs = append(errs, errors.New("with an error"))
    if err := errors.Join(errs...); err == nil {
        t.Fatal("expected an error")
    }
}
```


[2]: https://go.dev/play/p/iSuGP81eght


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

