### PR TITLE
docs/generate: remove uses of pkg/errors

### DIFF
--- a/docs/generate/generate.go
+++ b/docs/generate/generate.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/commands"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -64,7 +64,7 @@ func gen(opts *options) error {
 				return err
 			}
 		default:
-			return errors.Errorf("unknown format %q", format)
+			return errors.New("unknown format: " + format)
 		}
 	}
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5781
- will conflict with https://github.com/docker/cli/pull/4228


While there may be reasons to keep pkg/errors in production code, we don't need them for these tests.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

