### PR TITLE
Dockerfile.dev: bump github.com/josephspurrier/goversioninfo to v1.4.1

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     GO111MODULE=on go install gotest.tools/gotestsum@${GOTESTSUM_VERSION}
 
 FROM golang AS goversioninfo
-ARG GOVERSIONINFO_VERSION=v1.3.0
+ARG GOVERSIONINFO_VERSION=v1.4.1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/5630


Re-align the version with the main Dockerfile, which was missed when I updated the version in 93a931920b5d2cf3e246173cb1174e41e9b004a2

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

