### PR TITLE
Restrict completion to one suggestion on run, history, push, tag

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -27,8 +27,11 @@ type APIClientProvider interface {
 }
 
 // ImageNames offers completion for images present within the local store
-func ImageNames(dockerCLI APIClientProvider) ValidArgsFn {
+func ImageNames(dockerCLI APIClientProvider, limit int) ValidArgsFn {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if limit > 0 && len(args) >= limit {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
 		list, err := dockerCLI.Client().ImageList(cmd.Context(), image.ListOptions{})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError

--- a/cli/command/completion/functions_test.go
+++ b/cli/command/completion/functions_test.go
@@ -234,7 +234,7 @@ func TestCompleteImageNames(t *testing.T) {
 					}
 					return tc.images, nil
 				},
-			}})
+			}}, -1)
 
 			volumes, directives := comp(&cobra.Command{}, nil, "")
 			assert.Check(t, is.Equal(directives&tc.expDirective, tc.expDirective))

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -60,7 +60,7 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container create, docker create",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -43,7 +43,7 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runRun(cmd.Context(), dockerCli, cmd.Flags(), &options, copts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
 		Annotations: map[string]string{
 			"category-top": "1",
 			"aliases":      "docker container run, docker run",

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -36,7 +36,7 @@ func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
 			opts.image = args[0]
 			return runHistory(cmd.Context(), dockerCli, opts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
 		Annotations: map[string]string{
 			"aliases": "docker image history, docker history",
 		},

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -34,7 +34,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.refs = args
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -51,7 +51,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 			"category-top": "6",
 			"aliases":      "docker image push, docker push",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -29,7 +29,7 @@ func NewRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), dockerCli, opts, args)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
 		Annotations: map[string]string{
 			"aliases": "docker image rm, docker image remove, docker rmi",
 		},

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -34,7 +34,7 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image save, docker save",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -30,7 +30,7 @@ func NewTagCommand(dockerCli command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image tag, docker tag",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli),
+		ValidArgsFunction: completion.ImageNames(dockerCli, 2),
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
Closes #5814

Previously, multiple suggestions were provided when completing
commands like `run`, `history`, `push`, and `tag`. This change
limits completion to a single suggestion for improved accuracy
and usability.

### What I Did
- Modified the `ImageNames` function to return `nil` when the commands
  `run`, `history`, `push`, and `tag` have at least one suggestion.

### How I Did It
- Adjusted the logic within `ImageNames` to prevent multiple suggestions
  from being displayed when completion is triggered.

### How to Verify It
```sh
# Rebuild Docker
docker buildx bake

# Enable Zsh completion
source <(docker completion zsh)

# Test with
build/docker run <TAB>