### PR TITLE
[27.x] cli/command/completion: alias ValidArgsFn instead of strong type

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ValidArgsFn a function to be used by cobra command as `ValidArgsFunction` to offer command line completion
-type ValidArgsFn func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+type ValidArgsFn = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 
 // APIClientProvider provides a method to get an [client.APIClient], initializing
 // it if needed.


### PR DESCRIPTION
- relates to https://github.com/docker/cli/issues/5827
- relates to https://github.com/spf13/cobra/pull/2220
- relates to https://github.com/spf13/cobra/pull/2231#issuecomment-2661510587


This may help with signature changes in Cobra 1.9.0, which defines a new CompletionFunc type.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

