### PR TITLE
Fix entrypoint parsing logic

### DIFF
--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -1016,12 +1016,8 @@ func TestParseLabelfileVariables(t *testing.T) {
 
 func TestParseEntryPoint(t *testing.T) {
 	config, _, _, err := parseRun([]string{"--entrypoint=anything", "cmd", "img"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(config.Entrypoint) != 1 && config.Entrypoint[0] != "anything" {
-		t.Fatalf("Expected entrypoint 'anything', got %v", config.Entrypoint)
-	}
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual([]string(config.Entrypoint), []string{"anything"}))
 }
 
 func TestValidateDevice(t *testing.T) {


### PR DESCRIPTION
Right now the test passes even if you change the expected value. It passes if the array has 1 element.

**- What I did**

I was trying to understand the `docker run --entrypoint` parsing process, and run the test:
`go test -v ./cli/command/container -run Entry` and even when I changed the expected value, it still passed?!

**- How to verify it**

change the expected value to `foo` and run: `go test -v ./cli/command/container -run Entry`

