### PR TITLE
cli/compose: Fix Image Subpath

### DIFF
--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -107,9 +107,9 @@ func handleImageToMount(volume composetypes.ServiceVolumeConfig) (mount.Mount, e
 	if volume.Cluster != nil {
 		return mount.Mount{}, errors.New("cluster options are incompatible with type image")
 	}
-	if volume.Bind != nil {
-		result.BindOptions = &mount.BindOptions{
-			Propagation: mount.Propagation(volume.Bind.Propagation),
+	if volume.Image != nil {
+		result.ImageOptions = &mount.ImageOptions{
+			Subpath: volume.Image.Subpath,
 		}
 	}
 	return result, nil

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -415,7 +415,7 @@ type ServiceVolumeVolume struct {
 
 // ServiceVolumeImage are options for a service volume of type image
 type ServiceVolumeImage struct {
-	Subpath bool `mapstructure:"subpath" yaml:"subpath,omitempty" json:"subpath,omitempty"`
+	Subpath string `mapstructure:"subpath" yaml:"subpath,omitempty" json:"subpath,omitempty"`
 }
 
 // ServiceVolumeTmpfs are options for a service volume of type tmpfs


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/pull/5755

handleImageToMount was an exact copy of handleBindToMount instead of populating the ImageOptions.