### PR TITLE
golangci-lint: fix invalid nakedret config, disallow for any func length

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - ineffassign
     - lll
     - misspell      # Detects commonly misspelled English words in comments.
-    - nakedret
+    - nakedret      # Detects uses of naked returns.
     - nilerr        # Detects code that returns nil even if it checks that the error is not nil.
     - nolintlint    # Detects ill-formed or insufficient nolint directives.
     - perfsprint    # Detects fmt.Sprintf uses that can be replaced with a faster alternative.
@@ -81,8 +81,9 @@ linters-settings:
   lll:
     line-length: 200
   nakedret:
-    command: nakedret
-    pattern: ^(?P<path>.*?\\.go):(?P<line>\\d+)\\s*(?P<message>.*)$
+    # Disallow naked returns if func has more lines of code than this setting.
+    # Default: 30
+    max-func-lines: 0
 
   revive:
     rules:

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -201,9 +201,10 @@ func runCopy(ctx context.Context, dockerCli command.Cli, opts copyOptions) error
 	}
 }
 
-func resolveLocalPath(localPath string) (absPath string, err error) {
-	if absPath, err = filepath.Abs(localPath); err != nil {
-		return
+func resolveLocalPath(localPath string) (absPath string, _ error) {
+	absPath, err := filepath.Abs(localPath)
+	if err != nil {
+		return "", err
 	}
 	return archive.PreserveTrailingDotOrSeparator(absPath, localPath), nil
 }

--- a/cli/internal/oauth/jwt.go
+++ b/cli/internal/oauth/jwt.go
@@ -56,15 +56,19 @@ type Source struct {
 }
 
 // GetClaims returns claims from an access token without verification.
-func GetClaims(accessToken string) (claims Claims, err error) {
+func GetClaims(accessToken string) (Claims, error) {
 	token, err := parseSigned(accessToken)
 	if err != nil {
-		return
+		return Claims{}, err
 	}
 
+	var claims Claims
 	err = token.UnsafeClaimsWithoutVerification(&claims)
+	if err != nil {
+		return Claims{}, err
+	}
 
-	return
+	return claims, nil
 }
 
 // allowedSignatureAlgorithms is a list of allowed signature algorithms for JWTs.


### PR DESCRIPTION
### cli/internal/oauth: don't use naked returns (nakedret)

    cli/internal/oauth/jwt.go:62:3: naked return in func `GetClaims` with 9 lines of code (nakedret)
            return
            ^
    cli/internal/oauth/jwt.go:67:2: naked return in func `GetClaims` with 9 lines of code (nakedret)
        return
        ^

### cli/command/container: don't use naked returns (nakedret)

    cli/command/container/cp.go:206:3: naked return in func `resolveLocalPath` with 5 lines of code (nakedret)
            return
            ^


### golangci-lint: fix invalid nakedret config, disallow for any func length

The regex was added before we migrateed from gometalinter in
dbd96badb6959c2b7070664aecbcf0f7c299c538 (https://github.com/docker/cli/pull/620), and got migrated to golangci-lint
in b7e06f2845bb4996269a49f2592a735e4cd03e49 (https://github.com/docker/cli/pull/2173). The format used for the config
was invalid, and migrating it to the right format didn't make a difference,
so we can remove it.

As naked returns are generally not desirable, also setting the minimum func
length to 0 (i.e., don't allow any naked returns), instead of the default


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

