### PR TITLE
cli/command/container/opts: make entrypoint json array avare

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -413,6 +413,9 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 	if copts.entrypoint != "" {
 		entrypoint = strslice.StrSlice{copts.entrypoint}
+		if entrypoint.UnmarshalJSON([]byte(copts.entrypoint)) != nil {
+			entrypoint = strslice.StrSlice{copts.entrypoint}
+		}
 	} else if flags.Changed("entrypoint") {
 		// if `--entrypoint=` is parsed then Entrypoint is reset
 		entrypoint = []string{""}

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -1020,6 +1020,47 @@ func TestParseEntryPoint(t *testing.T) {
 	assert.Check(t, is.DeepEqual([]string(config.Entrypoint), []string{"anything"}))
 }
 
+func TestParseEntryPointSlice(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "nothing",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "empty list",
+			input:    "--entrypoint=[]",
+			expected: []string{},
+		},
+		{
+			name:     "empty string",
+			input:    "--entrypoint=",
+			expected: []string{""},
+		},
+		{
+			name:     "single",
+			input:    `--entrypoint=["something"]`,
+			expected: []string{"something"},
+		},
+		{
+			name:     "multiple",
+			input:    `--entrypoint=["sh","-c","echo foo bar"]`,
+			expected: []string{"sh", "-c", "echo foo bar"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+			config, _, _, err := parseRun([]string{tc.input})
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual([]string(config.Entrypoint), tc.expected))
+		})
+	}
+}
+
 func TestValidateDevice(t *testing.T) {
 	skip.If(t, runtime.GOOS != "linux") // Windows and macOS validate server-side
 	valid := []string{


### PR DESCRIPTION
**- What I did**

Made the `docker run --entrypoint` handle entrypoint string the same way as:
- Dockerfile's `ENTRYPOINT`
- `docker commit --change='ENTRYPOINT ["myEntryPoint.sh"]'`

**- How I did it**

The enrtypoint option was already defined as strslice, so I just used its `UnmarshalJSON` method.

**- How to verify it**

Test usecases are written for new format. Or for an e2e test you can check binaries, I built from this pr
```
curl -Lo /tmp/docker-hack https://github.com/lalyos/cli-1/releases/download/hack/docker-$(uname)
chmod +x /tmp/docker-hack
alias docker=/tmp/docker-hack

docker run --entrypoint '["sh","-c","echo look ma entrypoint as an array"]' alpine
```


**- Human readable description for the release notes**
```markdown changelog
Docker run --entrypoint option can handle the same json array format as ENTRYPOINT in Dockerfile
```

closes #4870

