### PR TITLE
completion: fix / add completion for service names and node-names

### DIFF
--- a/cli/command/node/completion.go
+++ b/cli/command/node/completion.go
@@ -1,0 +1,37 @@
+package node
+
+import (
+	"os"
+
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
+)
+
+// completeNodeNames offers completion for swarm node (host)names and optional IDs.
+// By default, only names are returned.
+// Set DOCKER_COMPLETION_SHOW_NODE_IDS=yes to also complete IDs.
+//
+// TODO(thaJeztah): add support for filters.
+func completeNodeNames(dockerCLI completion.APIClientProvider) completion.ValidArgsFn {
+	// https://github.com/docker/cli/blob/f9ced58158d5e0b358052432244b483774a1983d/contrib/completion/bash/docker#L41-L43
+	showIDs := os.Getenv("DOCKER_COMPLETION_SHOW_NODE_IDS") == "yes"
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCLI.Client().NodeList(cmd.Context(), types.NodeListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, 0, len(list)+1)
+		for _, node := range list {
+			if showIDs {
+				names = append(names, node.Description.Hostname, node.ID)
+			} else {
+				names = append(names, node.Description.Hostname)
+			}
+		}
+		// Nodes allow "self" as magic word for the current node.
+		names = append(names, "self")
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cli/command/node/demote.go
+++ b/cli/command/node/demote.go
@@ -18,6 +18,7 @@ func newDemoteCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDemote(cmd.Context(), dockerCli, args)
 		},
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 }
 

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -32,6 +32,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.nodeIds = args
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/system"
 	"github.com/fvbommel/sortorder"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type listOptions struct {
@@ -40,6 +41,12 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", flagsHelper.FormatHelp)
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/node/promote.go
+++ b/cli/command/node/promote.go
@@ -18,6 +18,7 @@ func newPromoteCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPromote(cmd.Context(), dockerCli, args)
 		},
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 }
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/command/task"
 	"github.com/docker/cli/opts"
@@ -13,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type psOptions struct {
@@ -49,6 +51,12 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", "Pretty-print tasks using a Go template")
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display task IDs")
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/command/task"
 	"github.com/docker/cli/opts"
@@ -41,7 +40,7 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 
 			return runPs(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: completion.NoComplete,
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Do not truncate output")

--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -26,6 +26,7 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), dockerCli, args, opts)
 		},
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.force, "force", "f", false, "Force remove a node from the swarm")

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/pkg/errors"
@@ -34,6 +35,15 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	flags.Var(&options.annotations.labels, flagLabelAdd, `Add or update a node label ("key=value")`)
 	labelKeys := opts.NewListOpts(nil)
 	flags.Var(&labelKeys, flagLabelRemove, "Remove a node label if exists")
+
+	_ = cmd.RegisterFlagCompletionFunc(flagRole, completion.FromList("worker", "manager"))
+	_ = cmd.RegisterFlagCompletionFunc(flagAvailability, completion.FromList("active", "pause", "drain"))
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -25,6 +25,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(cmd.Context(), dockerCli, cmd.Flags(), args[0])
 		},
+		ValidArgsFunction: completeNodeNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
@@ -16,6 +17,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type inspectOptions struct {
@@ -47,6 +49,13 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
 	flags.BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
+
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type listOptions struct {
@@ -41,6 +42,12 @@ func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", flagsHelper.FormatHelp)
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/service/logs"
 	"github.com/docker/docker/api/types"
@@ -22,6 +23,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type logsOptions struct {
@@ -69,6 +71,13 @@ func newLogsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVar(&opts.details, "details", false, "Show extra details provided to logs")
 	flags.SetAnnotation("details", "version", []string{"1.30"})
 	flags.StringVarP(&opts.tail, "tail", "n", "all", "Number of lines to show from the end of the logs")
+
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/idresolver"
 	"github.com/docker/cli/cli/command/node"
 	"github.com/docker/cli/cli/command/task"
@@ -15,6 +16,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type psOptions struct {
@@ -48,6 +50,12 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", "Pretty-print tasks using a Go template")
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
@@ -31,6 +33,12 @@ func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&options.quiet, flagQuiet, "q", false, "Suppress progress output")
 	addDetachFlag(flags, &options.detach)
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/5847


### completion: use service names, and support DOCKER_COMPLETION_SHOW_SERVICE_IDS

Change completion for services to use names by default, and bring back
support for the `DOCKER_COMPLETION_SHOW_SERVICE_IDS` env-var
https://github.com/docker/cli/blob/f9ced58158d5e0b358052432244b483774a1983d/contrib/completion/bash/docker#L41-L43

Before this patch:

    docker service ps
    c9vrp2pwni9gx5ghat20rjpcy  hmthf0tqws9xpmd87ok7diqly

With this patch:

    docker service ps<TAB>
    databaseservice  webservice
    
    export DOCKER_COMPLETION_SHOW_SERVICE_IDS=yes
    docker service ps<TAB>
    c9vrp2pwni9gx5ghat20rjpcy  databaseservice            hmthf0tqws9xpmd87ok7diqly  webservice


### completion: add completion for node names

Change completion for nodes to use names by default, and bring back
support for the `DOCKER_COMPLETION_SHOW_NODE_IDS` env-var
https://github.com/docker/cli/blob/f9ced58158d5e0b358052432244b483774a1983d/contrib/completion/bash/docker#L38

With this patch:

    docker node ps <tab>
    docker-desktop            self

    export DOCKER_COMPLETION_SHOW_NODE_IDS=yes
    docker node ps <TAB>
    docker-desktop             qyeriqk20al6hy4y869d08ff5  self



### completion: add completion for docker node flags

With this patch:

    docker node update --role
    manager  worker

    docker node update --availability
    active  drain   pause

### completion: add completion for docker service flags

Not all flags have completions yet, and for those that don't have completion,
we disable completion to prevent it completing with filenames.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix shell completion suggesting IDs instead of names for services and nodes
```

**- A picture of a cute animal (not mandatory but encouraged)**

