### PR TITLE
cli/command/context: fix error-handling of skip-tls-verify

### DIFF
--- a/cli/command/context/options.go
+++ b/cli/command/context/options.go
@@ -68,7 +68,14 @@ func parseBool(config map[string]string, name string) (bool, error) {
 		return false, nil
 	}
 	res, err := strconv.ParseBool(strVal)
-	return res, fmt.Errorf("name: %w", err)
+	if err != nil {
+		var nErr *strconv.NumError
+		if errors.As(err, &nErr) {
+			return res, fmt.Errorf("%s: parsing %q: %w", name, nErr.Num, nErr.Err)
+		}
+		return res, fmt.Errorf("%s: %w", name, err)
+	}
+	return res, nil
 }
 
 func validateConfig(config map[string]string, allowedKeys map[string]struct{}) error {


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/5849
- introduced in https://github.com/docker/cli/pull/5791


Before 2b9a4d5f4c9c4d749ecc208f34d212a2b1c45a08, this function would use "errors.Wrap" which returns nil if the original error was nil. fmt.Errorf does not do this, so without a nil check, it would unconditionally return an error;

    docker context create arm64 --docker host=ssh://172.17.101.26,skip-tls-verify=False

    unable to create docker endpoint config: name: %!w(<nil>)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker context create` always returning an error when using the  "skip-tls-verify" option.
```

**- A picture of a cute animal (not mandatory but encouraged)**

