### PR TITLE
explicitly handle errors when wrapping them

### DIFF
--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -76,9 +76,9 @@ func (c *Context) preFormat() {
 func (c *Context) parseFormat() (*template.Template, error) {
 	tmpl, err := templates.Parse(c.finalFormat)
 	if err != nil {
-		return tmpl, errors.Wrap(err, "template parsing error")
+		return nil, errors.Wrap(err, "template parsing error")
 	}
-	return tmpl, err
+	return tmpl, nil
 }
 
 func (c *Context) postFormat(tmpl *template.Template, subContext SubContext) {

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -210,8 +210,10 @@ func newVersionTemplate(templateFormat string) (*template.Template, error) {
 	}
 	tmpl := templates.New("version").Funcs(template.FuncMap{"getDetailsOrder": getDetailsOrder})
 	tmpl, err := tmpl.Parse(templateFormat)
-
-	return tmpl, errors.Wrap(err, "template parsing error")
+	if err != nil {
+		return nil, errors.Wrap(err, "template parsing error")
+	}
+	return tmpl, nil
 }
 
 func getDetailsOrder(v types.ComponentVersion) []string {

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -67,7 +67,10 @@ func recursiveInterpolate(value any, path Path, opts Options) (any, error) {
 			return newValue, nil
 		}
 		casted, err := caster(newValue)
-		return casted, newPathError(path, errors.Wrap(err, "failed to cast to expected type"))
+		if err != nil {
+			return casted, newPathError(path, errors.Wrap(err, "failed to cast to expected type"))
+		}
+		return casted, nil
 
 	case map[string]any:
 		out := map[string]any{}

--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -121,7 +121,10 @@ func (c *client) PutManifest(ctx context.Context, ref reference.Named, manifest 
 	}
 
 	dgst, err := manifestService.Put(ctx, manifest, opts...)
-	return dgst, errors.Wrapf(err, "failed to put manifest %s", ref)
+	if err != nil {
+		return dgst, errors.Wrapf(err, "failed to put manifest %s", ref)
+	}
+	return dgst, nil
 }
 
 func (c *client) getRepositoryForReference(ctx context.Context, ref reference.Named, repoEndpoint repositoryEndpoint) (distribution.Repository, error) {
@@ -157,7 +160,10 @@ func (c *client) getHTTPTransportForRepoEndpoint(ctx context.Context, repoEndpoi
 		c.userAgent,
 		repoEndpoint.actions,
 	)
-	return httpTransport, errors.Wrap(err, "failed to configure transport")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to configure transport")
+	}
+	return httpTransport, nil
 }
 
 // GetManifest returns an ImageManifest for the reference

--- a/opts/gpus.go
+++ b/opts/gpus.go
@@ -20,7 +20,10 @@ func parseCount(s string) (int, error) {
 		return -1, nil
 	}
 	i, err := strconv.Atoi(s)
-	return i, errors.Wrap(err, "count must be an integer")
+	if err != nil {
+		return 0, errors.Wrap(err, "count must be an integer")
+	}
+	return i, nil
 }
 
 // Set a new mount value


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5850

The errors.Wrap and errors.Wrapf functions gracefully handle nil-errors. This allows them to be used unconditionally regardless if an error was produced.

While this can be convenient, it can also be err-prone, as replacing these with stdlib errors means they unconditionally produce an error.

This patch replaces code uses of errors.Wrap to be gated by a check for nil-errors to future-proof our code.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

