### PR TITLE
Fix tainted stderr on docker exec

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -43,7 +43,10 @@ func main() {
 	}
 
 	if err != nil && !errdefs.IsCancelled(err) {
-		_, _ = fmt.Fprintln(os.Stderr, err)
+		var stErr cli.StatusError
+		if errors.As(err, &stErr) && stErr.Status != "" {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+		}
 		os.Exit(getExitCode(err))
 	}
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

#5229 (cc @thaJeztah) seems to have introduced a bug, that makes `docker exec` taint stderr, by printing `exit status X`  when a command is run. This was not the case before, and introduces issues with anything that depends on using docker exec to run commands and process the output (something I do a lot when running tests). So, this new behavior breaks this previous contract, and goes against how analog *nix commands work (eg: `sh -c false`).

Here's an example. Given we have a container started with `docker run -ti --rm --name ubuntu ubuntu`, before we could do:

```
$ docker exec ubuntu ls / /bad-path
ls: cannot access '/bad-path': No such file or directory
/:
bin
boot
dev
etc
home
lib
lib64
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
```

and it'd output correct stdout & stderr and exit 2 (coming from `ls`).

After #5229, things changed to:

```
$ docker exec ubuntu ls / /bad-path
ls: cannot access '/bad-path': No such file or directory                              
/:
bin
boot
dev
etc
home
lib
lib64
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
exit status 2
```

so there's an extra line on stderr `exit status 2`.

**- How I did it**

This PR restores the previous functional behavior, by adding an extra if to handle this case, exactly it was handled before, so I'd not expect it to have any unintended side effects.

**- How to verify it**

I've bisected the change to the bad commit #5229, validated the before / after with the commands above, and that this PR fixes the issue.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix unintentionally printing exit status to stderr when `docker exec` returns a non-zero status
```

![image](https://github.com/user-attachments/assets/e6f58e21-21b7-4fe9-b7b3-30fdfb02da2e)