### PR TITLE
gha: add docker 28 to test matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,11 +38,10 @@ jobs:
           - alpine
           - debian
         engine-version:
-          - 27.0  # latest
-          - 26.1  # latest - 1
-          - 23.0  # mirantis lts
-          # TODO(krissetto) 19.03 needs a look, doesn't work ubuntu 22.04 (cgroup errors). 
-          # we could have a separate job that tests it against ubuntu 20.04
+          - 28  # latest
+          - 27  # latest - 1
+          - 26  # github actions default
+          - 23  # mirantis lts
     steps:
       -
         name: Checkout

--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -4,7 +4,7 @@ services:
     image: 'registry:2'
 
   engine:
-      image: 'docker:${ENGINE_VERSION:-26.1}-dind'
+      image: 'docker:${ENGINE_VERSION:-28}-dind'
       privileged: true
       command: ['--insecure-registry=registry:5000']
       environment:

--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -2,7 +2,7 @@
 
 # ENGINE_VERSION is the version of the (docker-in-docker) Docker Engine to
 # test against.
-ARG ENGINE_VERSION=26.1
+ARG ENGINE_VERSION=28
 
 FROM docker:${ENGINE_VERSION}-dind
 


### PR DESCRIPTION
- related: https://github.com/docker/cli/pull/5863

---

- set default to 28
- remove minor version from matrix; docker:dind images also provide a "docker:28-dind" which point to the latest minor version.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

