### PR TITLE
cli/command/manifest: remove redundant uses of ParseRepositoryInfo

### DIFF
--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/store"
-	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -40,11 +39,6 @@ func createManifestList(ctx context.Context, dockerCLI command.Cli, args []strin
 	targetRef, err := normalizeReference(newRef)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing name for manifest list %s", newRef)
-	}
-
-	_, err = registry.ParseRepositoryInfo(targetRef)
-	if err != nil {
-		return errors.Wrapf(err, "error parsing repository name for manifest list %s", newRef)
 	}
 
 	manifestStore := dockerCLI.ManifestStore()

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/docker/registry"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -113,10 +112,7 @@ func printManifest(dockerCli command.Cli, manifest types.ImageManifest, opts ins
 
 func printManifestList(dockerCli command.Cli, namedRef reference.Named, list []types.ImageManifest, opts inspectOptions) error {
 	if !opts.verbose {
-		targetRepo, err := registry.ParseRepositoryInfo(namedRef)
-		if err != nil {
-			return err
-		}
+		targetRepo := reference.TrimNamed(namedRef)
 
 		manifests := []manifestlist.ManifestDescriptor{}
 		// More than one response. This is a manifest list.


### PR DESCRIPTION
### cli/command/manifest: remove redundant uses of ParseRepositoryInfo

[ParseRepositoryInfo] parses an image reference and returns information
about the Repository and the registry. As part of this, it validates if
the registry's hostname is considered valid using [ValidateIndexName],
as well as normalizing the image reference to strip tags and digests
using [reference.TrimNamed].

ValidateIndexName only provides very limited value; the only validation
happening is to check for the hostname to not start, or end with a hyphen.

The cli/command/manifest package used ParseRepositoryInfo in various
locations where only the repository name was used (i.e., the result
of `reference.TrimNamed` on the given reference), and in one location
only used it to validate the registry name.

For buildPushRequest, the call was fully redundant, as [RepoNameForReference]
was used on the result, calling [newDefaultRepositoryEndpoint], which
uses ParseRepositoryInfo internally, so we were only repeating that work.

This patch removes uses of ParseRepositoryInfo in those places, and instead
calling [reference.TrimNamed] directly.


[ParseRepositoryInfo]: https://github.com/moby/moby/blob/41f781fab3cae181cc9be3ec93cd91b99466fa84/registry/config.go#L375-L381
[ValidateIndexName]: https://github.com/moby/moby/blob/41f781fab3cae181cc9be3ec93cd91b99466fa84/registry/config.go#L288-L299
[reference.TrimNamed]: https://github.com/moby/moby/blob/41f781fab3cae181cc9be3ec93cd91b99466fa84/registry/config.go#L369
[RepoNameForReference]: https://github.com/docker/cli/blob/fe0a8d27912dc6fddc60cedcd35bbef27b776355/cli/registry/client/endpoint.go#L107-L110
[newDefaultRepositoryEndpoint]: https://github.com/docker/cli/blob/fe0a8d27912dc6fddc60cedcd35bbef27b776355/cli/registry/client/endpoint.go#L33-L38


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

