### PR TITLE
cli/command: remove dependency on distribution/uuid

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -62,6 +62,8 @@ linters-settings:
             desc: The containerd platforms package was migrated to a separate module. Use github.com/containerd/platforms instead.
           - pkg: "github.com/docker/docker/pkg/system"
             desc: This package should not be used unless strictly necessary.
+          - pkg: "github.com/docker/distribution/uuid"
+            desc: Use github.com/google/uuid instead.
           - pkg: "io/ioutil"
             desc: The io/ioutil package has been deprecated, see https://go.dev/doc/go1.16#ioutil
   gocyclo:

--- a/cli/command/telemetry.go
+++ b/cli/command/telemetry.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/docker/distribution/uuid"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -142,7 +142,7 @@ func defaultResourceOptions() []resource.Option {
 			// of the CLI is its own instance. Without this, downstream
 			// OTEL processors may think the same process is restarting
 			// continuously.
-			semconv.ServiceInstanceID(uuid.Generate().String()),
+			semconv.ServiceInstanceID(uuid.NewString()),
 		),
 		resource.WithFromEnv(),
 		resource.WithTelemetrySDK(),

--- a/vendor.mod
+++ b/vendor.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/swarmkit/v2 v2.0.0-20250103191802-8c1959736554
@@ -72,7 +73,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect


### PR DESCRIPTION
This uuid package was introduced in 89db01ef977cdd868dddde4c211e58f74457bacb (https://github.com/docker/cli/pull/4889), but we want to reduce dependency on the old docker/distribution module.

Replace it with google/uuid, which is a commonly used module for this and already a dependency.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

