### PR TITLE
cli/registry/client: remove dependency on trust / notary

### DIFF
--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/distribution/reference"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
-	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution"
 	distributionclient "github.com/docker/distribution/registry/client"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -78,7 +77,7 @@ func (c *client) MountBlob(ctx context.Context, sourceRef reference.Canonical, t
 	if err != nil {
 		return err
 	}
-	repoEndpoint.actions = trust.ActionsPushAndPull
+	repoEndpoint.actions = []string{"pull", "push"}
 	repo, err := c.getRepositoryForReference(ctx, targetRef, repoEndpoint)
 	if err != nil {
 		return err
@@ -104,7 +103,7 @@ func (c *client) PutManifest(ctx context.Context, ref reference.Named, manifest 
 		return "", err
 	}
 
-	repoEndpoint.actions = trust.ActionsPushAndPull
+	repoEndpoint.actions = []string{"pull", "push"}
 	repo, err := c.getRepositoryForReference(ctx, ref, repoEndpoint)
 	if err != nil {
 		return "", err

--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
-	"github.com/docker/cli/cli/trust"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/transport"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -94,7 +93,7 @@ func getHTTPTransport(authConfig registrytypes.AuthConfig, endpoint registry.API
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, passThruTokenHandler))
 	} else {
 		if len(actions) == 0 {
-			actions = trust.ActionsPullOnly
+			actions = []string{"pull"}
 		}
 		creds := registry.NewStaticCredentialStore(&authConfig)
 		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, actions...)


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/5878


The client was only using the Actions consts, but the trust package also has a dependency on notary. Remove the import to prevent Notary becoming a dependency for uses of the cli code.


**- A picture of a cute animal (not mandatory but encouraged)**

