### PR TITLE
cli/command: un-export ResourceAttributesEnvvar, DockerCliAttributePrefix

### DIFF
--- a/cli-plugins/manager/cobra.go
+++ b/cli-plugins/manager/cobra.go
@@ -3,14 +3,10 @@ package manager
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/baggage"
 )
 
 const (
@@ -104,76 +100,4 @@ func AddPluginCommandStubs(dockerCli command.Cli, rootCmd *cobra.Command) (err e
 		}
 	})
 	return err
-}
-
-const (
-	// resourceAttributesEnvVar is the name of the envvar that includes additional
-	// resource attributes for OTEL as defined in the [OpenTelemetry specification].
-	//
-	// [OpenTelemetry specification]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
-	resourceAttributesEnvVar = "OTEL_RESOURCE_ATTRIBUTES"
-
-	// dockerCLIAttributePrefix is the prefix for any docker cli OTEL attributes.
-	//
-	// It is a copy of the const defined in [command.dockerCLIAttributePrefix].
-	dockerCLIAttributePrefix = "docker.cli."
-	cobraCommandPath         = attribute.Key("cobra.command_path")
-)
-
-func getPluginResourceAttributes(cmd *cobra.Command, plugin Plugin) attribute.Set {
-	commandPath := cmd.Annotations[CommandAnnotationPluginCommandPath]
-	if commandPath == "" {
-		commandPath = fmt.Sprintf("%s %s", cmd.CommandPath(), plugin.Name)
-	}
-
-	attrSet := attribute.NewSet(
-		cobraCommandPath.String(commandPath),
-	)
-
-	kvs := make([]attribute.KeyValue, 0, attrSet.Len())
-	for iter := attrSet.Iter(); iter.Next(); {
-		attr := iter.Attribute()
-		kvs = append(kvs, attribute.KeyValue{
-			Key:   dockerCLIAttributePrefix + attr.Key,
-			Value: attr.Value,
-		})
-	}
-	return attribute.NewSet(kvs...)
-}
-
-func appendPluginResourceAttributesEnvvar(env []string, cmd *cobra.Command, plugin Plugin) []string {
-	if attrs := getPluginResourceAttributes(cmd, plugin); attrs.Len() > 0 {
-		// Construct baggage members for each of the attributes.
-		// Ignore any failures as these aren't significant and
-		// represent an internal issue.
-		members := make([]baggage.Member, 0, attrs.Len())
-		for iter := attrs.Iter(); iter.Next(); {
-			attr := iter.Attribute()
-			m, err := baggage.NewMemberRaw(string(attr.Key), attr.Value.AsString())
-			if err != nil {
-				otel.Handle(err)
-				continue
-			}
-			members = append(members, m)
-		}
-
-		// Combine plugin added resource attributes with ones found in the environment
-		// variable. Our own attributes should be namespaced so there shouldn't be a
-		// conflict. We do not parse the environment variable because we do not want
-		// to handle errors in user configuration.
-		attrsSlice := make([]string, 0, 2)
-		if v := strings.TrimSpace(os.Getenv(resourceAttributesEnvVar)); v != "" {
-			attrsSlice = append(attrsSlice, v)
-		}
-		if b, err := baggage.New(members...); err != nil {
-			otel.Handle(err)
-		} else if b.Len() > 0 {
-			attrsSlice = append(attrsSlice, b.String())
-		}
-
-		if len(attrsSlice) > 0 {
-			env = append(env, resourceAttributesEnvVar+"="+strings.Join(attrsSlice, ","))
-		}
-	}
-	return env
 }

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -26,7 +26,9 @@ const (
 
 	// ResourceAttributesEnvvar is the name of the envvar that includes additional
 	// resource attributes for OTEL.
-	ResourceAttributesEnvvar = command.ResourceAttributesEnvvar
+	//
+	// Deprecated: The "OTEL_RESOURCE_ATTRIBUTES" env-var is part of the OpenTelemetry specification; users should define their own const for this. This const will be removed in the next release.
+	ResourceAttributesEnvvar = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
 // errPluginNotFound is the error returned when a plugin could not be found.

--- a/cli-plugins/manager/telemetry.go
+++ b/cli-plugins/manager/telemetry.go
@@ -1,0 +1,84 @@
+package manager
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/baggage"
+)
+
+const (
+	// resourceAttributesEnvVar is the name of the envvar that includes additional
+	// resource attributes for OTEL as defined in the [OpenTelemetry specification].
+	//
+	// [OpenTelemetry specification]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration
+	resourceAttributesEnvVar = "OTEL_RESOURCE_ATTRIBUTES"
+
+	// dockerCLIAttributePrefix is the prefix for any docker cli OTEL attributes.
+	//
+	// It is a copy of the const defined in [command.dockerCLIAttributePrefix].
+	dockerCLIAttributePrefix = "docker.cli."
+	cobraCommandPath         = attribute.Key("cobra.command_path")
+)
+
+func getPluginResourceAttributes(cmd *cobra.Command, plugin Plugin) attribute.Set {
+	commandPath := cmd.Annotations[CommandAnnotationPluginCommandPath]
+	if commandPath == "" {
+		commandPath = fmt.Sprintf("%s %s", cmd.CommandPath(), plugin.Name)
+	}
+
+	attrSet := attribute.NewSet(
+		cobraCommandPath.String(commandPath),
+	)
+
+	kvs := make([]attribute.KeyValue, 0, attrSet.Len())
+	for iter := attrSet.Iter(); iter.Next(); {
+		attr := iter.Attribute()
+		kvs = append(kvs, attribute.KeyValue{
+			Key:   dockerCLIAttributePrefix + attr.Key,
+			Value: attr.Value,
+		})
+	}
+	return attribute.NewSet(kvs...)
+}
+
+func appendPluginResourceAttributesEnvvar(env []string, cmd *cobra.Command, plugin Plugin) []string {
+	if attrs := getPluginResourceAttributes(cmd, plugin); attrs.Len() > 0 {
+		// Construct baggage members for each of the attributes.
+		// Ignore any failures as these aren't significant and
+		// represent an internal issue.
+		members := make([]baggage.Member, 0, attrs.Len())
+		for iter := attrs.Iter(); iter.Next(); {
+			attr := iter.Attribute()
+			m, err := baggage.NewMemberRaw(string(attr.Key), attr.Value.AsString())
+			if err != nil {
+				otel.Handle(err)
+				continue
+			}
+			members = append(members, m)
+		}
+
+		// Combine plugin added resource attributes with ones found in the environment
+		// variable. Our own attributes should be namespaced so there shouldn't be a
+		// conflict. We do not parse the environment variable because we do not want
+		// to handle errors in user configuration.
+		attrsSlice := make([]string, 0, 2)
+		if v := strings.TrimSpace(os.Getenv(resourceAttributesEnvVar)); v != "" {
+			attrsSlice = append(attrsSlice, v)
+		}
+		if b, err := baggage.New(members...); err != nil {
+			otel.Handle(err)
+		} else if b.Len() > 0 {
+			attrsSlice = append(attrsSlice, b.String())
+		}
+
+		if len(attrsSlice) > 0 {
+			env = append(env, resourceAttributesEnvVar+"="+strings.Join(attrsSlice, ","))
+		}
+	}
+	return env
+}

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -592,47 +591,4 @@ func DefaultContextStoreConfig() store.Config {
 		func() any { return &DockerContext{} },
 		defaultStoreEndpoints...,
 	)
-}
-
-const (
-	// ResourceAttributesEnvvar is the name of the envvar that includes additional
-	// resource attributes for OTEL.
-	ResourceAttributesEnvvar = "OTEL_RESOURCE_ATTRIBUTES"
-
-	// DockerCliAttributePrefix is the prefix for any docker cli OTEL attributes.
-	DockerCliAttributePrefix = "docker.cli."
-)
-
-func filterResourceAttributesEnvvar() {
-	if v := os.Getenv(ResourceAttributesEnvvar); v != "" {
-		if filtered := filterResourceAttributes(v); filtered != "" {
-			os.Setenv(ResourceAttributesEnvvar, filtered)
-		} else {
-			os.Unsetenv(ResourceAttributesEnvvar)
-		}
-	}
-}
-
-func filterResourceAttributes(s string) string {
-	if trimmed := strings.TrimSpace(s); trimmed == "" {
-		return trimmed
-	}
-
-	pairs := strings.Split(s, ",")
-	elems := make([]string, 0, len(pairs))
-	for _, p := range pairs {
-		k, _, found := strings.Cut(p, "=")
-		if !found {
-			// Do not interact with invalid otel resources.
-			elems = append(elems, p)
-			continue
-		}
-
-		// Skip attributes that have our docker.cli prefix.
-		if strings.HasPrefix(k, DockerCliAttributePrefix) {
-			continue
-		}
-		elems = append(elems, p)
-	}
-	return strings.Join(elems, ",")
 }


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/5842
- https://github.com/docker/cli/pull/4875


### cli/command: un-export ResourceAttributesEnvvar, DockerCliAttributePrefix

These utility functions were added in 8890a1c9292ed5f2bf45df44a0e57d345f563d31,
and are all related to OTEL. The ResourceAttributesEnvvar const defines
the "OTEL_RESOURCE_ATTRIBUTES" environment-variable to use, which is part
of the [OpenTelemetry specification], so should be considered a well-known
env-var, and not up to us to define a const for. These code-changes were not
yet included in a release, so we don't have to deprecate.

This patch:

- Moves the utility functions to the telemetry files, so that all code related
  to OpenTelemetry is together.
- Un-exports the ResourceAttributesEnvvar to reduce our public API.
- Un-exports the DockerCliAttributePrefix to reduce depdency on cli/command
  in CLI-plugins, but adds a TODO to move telemetry-related code to a common
  (internal) package.
- Deprecates the cli-plugins/manager.ResourceAttributesEnvvar const. This
  const has no known consumers, so we could skip deprecation, but just in
  case some codebase uses this.

[OpenTelemetry specification]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration


### cli-plugins/manager: move OTEL-related code to separate file


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: deprecate `cli-plugins/manager.ResourceAttributesEnvvar` const. This const was used internally, but holds the `OTEL_RESOURCE_ATTRIBUTES` name, which is part of the OpenTelemetry specification. Users of this const should define their own. This const will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

