### PR TITLE
cli/registry/client: remove unused types, and deprecate RepoNameForReference

### DIFF
--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -99,17 +99,10 @@ func buildPushRequest(manifests []types.ImageManifest, targetRef reference.Named
 		return req, err
 	}
 
-	targetRepoName, err := registryclient.RepoNameForReference(targetRef)
-	if err != nil {
-		return req, err
-	}
+	targetRepoName := reference.Path(reference.TrimNamed(targetRef))
 
 	for _, imageManifest := range manifests {
-		manifestRepoName, err := registryclient.RepoNameForReference(imageManifest.Ref)
-		if err != nil {
-			return req, err
-		}
-
+		manifestRepoName := reference.Path(reference.TrimNamed(imageManifest.Ref))
 		repoName, _ := reference.WithName(manifestRepoName)
 		if repoName.Name() != targetRepoName {
 			blobs, err := buildBlobRequestList(imageManifest, repoName)

--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -54,13 +54,13 @@ func (err ErrBlobCreated) Error() string {
 		err.From, err.Target)
 }
 
-// ErrHTTPProto returned if attempting to use TLS with a non-TLS registry
-type ErrHTTPProto struct {
-	OrigErr string
+// httpProtoError returned if attempting to use TLS with a non-TLS registry
+type httpProtoError struct {
+	cause error
 }
 
-func (err ErrHTTPProto) Error() string {
-	return err.OrigErr
+func (e httpProtoError) Error() string {
+	return e.cause.Error()
 }
 
 var _ RegistryClient = &client{}
@@ -131,7 +131,7 @@ func (c *client) getRepositoryForReference(ctx context.Context, ref reference.Na
 			return nil, err
 		}
 		if !repoEndpoint.endpoint.TLSConfig.InsecureSkipVerify {
-			return nil, ErrHTTPProto{OrigErr: err.Error()}
+			return nil, httpProtoError{cause: err}
 		}
 		// --insecure was set; fall back to plain HTTP
 		if url := repoEndpoint.endpoint.URL; url != nil && url.Scheme == "https" {

--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -37,12 +37,6 @@ func NewRegistryClient(resolver AuthConfigResolver, userAgent string, insecure b
 // AuthConfigResolver returns Auth Configuration for an index
 type AuthConfigResolver func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig
 
-// PutManifestOptions is the data sent to push a manifest
-type PutManifestOptions struct {
-	MediaType string
-	Payload   []byte
-}
-
 type client struct {
 	authConfigResolver AuthConfigResolver
 	insecureRegistry   bool

--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -103,14 +103,11 @@ func getHTTPTransport(authConfig registrytypes.AuthConfig, endpoint registry.API
 	return transport.NewTransport(base, modifiers...), nil
 }
 
-// RepoNameForReference returns the repository name from a reference
+// RepoNameForReference returns the repository name from a reference.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func RepoNameForReference(ref reference.Named) (string, error) {
-	// insecure is fine since this only returns the name
-	repo, err := newDefaultRepositoryEndpoint(ref, false)
-	if err != nil {
-		return "", err
-	}
-	return repo.Name(), nil
+	return reference.Path(reference.TrimNamed(ref)), nil
 }
 
 type existingTokenHandler struct {

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -241,7 +241,8 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 		repo, err := c.getRepositoryForReference(ctx, namedRef, repoEndpoint)
 		if err != nil {
 			logrus.Debugf("error %s with repo endpoint %+v", err, repoEndpoint)
-			if _, ok := err.(ErrHTTPProto); ok {
+			var protoErr httpProtoError
+			if errors.As(err, &protoErr) {
 				continue
 			}
 			return err


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/138


### cli/registry/client: remove unused PutManifestOptions

This type was added in 02719bdbb5fb47389e47575bb006509da86df344, but was
never used;

    git rev-parse --verify HEAD
    02719bdbb5fb47389e47575bb006509da86df344
    
    git grep 'PutManifestOptions'
    cli/registry/client/client.go:// PutManifestOptions is the data sent to push a manifest
    cli/registry/client/client.go:type PutManifestOptions struct {

This patch removes it, because it's not used.


### cli/registry/client: un-export ErrHTTPProto

This type was added in 02719bdbb5fb47389e47575bb006509da86df344, but was
never used outside of the package itself. This patch un-exports it.

### cli/registry/client: deprecate RepoNameForReference

This function was added in 02719bdbb5fb47389e47575bb006509da86df344, and
used newDefaultRepositoryEndpoint to get repository info for the given
image-reference.

newDefaultRepositoryEndpoint uses registry.ParseRepositoryInfo under the
hood, but the only information used from the result was the Name field,
which is set using `reference.TrimNamed(name)`. The possible error returned
was based on the domain-name of the image, and only checked for the domain
to not start, or end with a hyphen ("-").

This patch removes the use of RepoNameForReference, deprecates it, and
inlines the code used by it.

There are no known consumers of this function, so we can consider removing
it in the first possible release after this (which can be a minor release).


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

