### PR TITLE
cli/command: internalize and deprecate Cli.NotaryClient

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -25,7 +25,6 @@ import (
 	manifeststore "github.com/docker/cli/cli/manifest/store"
 	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/streams"
-	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/cli/version"
 	dopts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api"
@@ -36,7 +35,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	notaryclient "github.com/theupdateframework/notary/client"
 )
 
 const defaultInitTimeout = 2 * time.Second
@@ -56,7 +54,6 @@ type Cli interface {
 	Apply(ops ...CLIOption) error
 	ConfigFile() *configfile.ConfigFile
 	ServerInfo() ServerInfo
-	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
 	DefaultVersion() string
 	CurrentVersion() string
 	ManifestStore() manifeststore.Store
@@ -67,6 +64,7 @@ type Cli interface {
 	CurrentContext() string
 	DockerEndpoint() docker.Endpoint
 	TelemetryClient
+	DeprecatedNotaryClient
 }
 
 // DockerCli is an instance the docker command line client.
@@ -403,11 +401,6 @@ func (cli *DockerCli) initializeFromClient() {
 		SwarmStatus:     ping.SwarmStatus,
 	}
 	cli.client.NegotiateAPIVersionPing(ping)
-}
-
-// NotaryClient provides a Notary Repository to interact with signed metadata for an image
-func (cli *DockerCli) NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error) {
-	return trust.GetNotaryRepository(cli.In(), cli.Out(), UserAgent(), imgRefAndAuth.RepoInfo(), imgRefAndAuth.AuthConfig(), actions...)
 }
 
 // ContextStore returns the ContextStore

--- a/cli/command/cli_deprecated.go
+++ b/cli/command/cli_deprecated.go
@@ -1,0 +1,18 @@
+package command
+
+import (
+	"github.com/docker/cli/cli/trust"
+	notaryclient "github.com/theupdateframework/notary/client"
+)
+
+type DeprecatedNotaryClient interface {
+	// NotaryClient provides a Notary Repository to interact with signed metadata for an image
+	//
+	// Deprecated: use [trust.GetNotaryRepository] instead. This method is no longer used and will be removed in the next release.
+	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
+}
+
+// NotaryClient provides a Notary Repository to interact with signed metadata for an image
+func (cli *DockerCli) NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error) {
+	return trust.GetNotaryRepository(cli.In(), cli.Out(), UserAgent(), imgRefAndAuth.RepoInfo(), imgRefAndAuth.AuthConfig(), actions...)
+}

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -53,7 +53,7 @@ func revokeTrust(ctx context.Context, dockerCLI command.Cli, remote string, opti
 		}
 	}
 
-	notaryRepo, err := dockerCLI.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := newNotaryClient(dockerCLI, imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -52,7 +52,7 @@ func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOption
 		return err
 	}
 
-	notaryRepo, err := dockerCLI.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := newNotaryClient(dockerCLI, imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return trust.NotaryError(imgRefAndAuth.Reference().Name(), err)
 	}

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -85,7 +85,7 @@ func addSignerToRepo(ctx context.Context, dockerCLI command.Cli, signerName stri
 		return err
 	}
 
-	notaryRepo, err := dockerCLI.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := newNotaryClient(dockerCLI, imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return trust.NotaryError(imgRefAndAuth.Reference().Name(), err)
 	}

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -103,7 +103,7 @@ func removeSingleSigner(ctx context.Context, dockerCLI command.Cli, repoName, si
 	if signerDelegation == releasesRoleTUFName {
 		return false, errors.Errorf("releases is a reserved keyword and cannot be removed")
 	}
-	notaryRepo, err := dockerCLI.NotaryClient(imgRefAndAuth, trust.ActionsPushAndPull)
+	notaryRepo, err := newNotaryClient(dockerCLI, imgRefAndAuth, trust.ActionsPushAndPull)
 	if err != nil {
 		return false, trust.NotaryError(imgRefAndAuth.Reference().Name(), err)
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5876

### cli/command: internalize constructing Notary client

The CLI.NotaryClient method is a shallow wrapper around trust.GetNotaryRepository
and only depends on the CLI itself to pass its StdErr/StrOut streams.

- This patch inlines the code to produce the client, skipping the wrapper.
- Define a local interface for some tests where a dummy notary client was used.


### cli/command: deprecate Cli.NotaryClient

This method is a shallow wrapper around trust.GetNotaryRepository, but
due to its signature resulted in the trust package, and notary dependencies
to become a dependency of the CLI. Consequence of this was that cli-plugins,
which need the cli/command package, would also get notary and its
dependencies as a dependency. It is no longer used in our code, which
constructs the client in packages that need it, so we can deprecate this
method.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate Cli.NotaryClient: use [trust.GetNotaryRepository] instead. This method is no longer used and will be removed in the next release.

[trust.GetNotaryRepository]: https://pkg.go.dev/github.com/docker/cli@v28.0.1+incompatible/cli/trust#GetNotaryRepository
```

**- A picture of a cute animal (not mandatory but encouraged)**

