### PR TITLE
cli/command: deprecate Cli.ManifestStore, Cli.RegistryClient

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -22,7 +21,6 @@ import (
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
-	manifeststore "github.com/docker/cli/cli/manifest/store"
 	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/version"
@@ -56,7 +54,6 @@ type Cli interface {
 	ServerInfo() ServerInfo
 	DefaultVersion() string
 	CurrentVersion() string
-	ManifestStore() manifeststore.Store
 	RegistryClient(bool) registryclient.RegistryClient
 	ContentTrustEnabled() bool
 	BuildKitEnabled() (bool, error)
@@ -65,6 +62,7 @@ type Cli interface {
 	DockerEndpoint() docker.Endpoint
 	TelemetryClient
 	DeprecatedNotaryClient
+	DeprecatedManifestClient
 }
 
 // DockerCli is an instance the docker command line client.
@@ -227,12 +225,6 @@ func (cli *DockerCli) HooksEnabled() bool {
 	}
 	// default to false
 	return false
-}
-
-// ManifestStore returns a store for local manifests
-func (*DockerCli) ManifestStore() manifeststore.Store {
-	// TODO: support override default location from config file
-	return manifeststore.NewStore(filepath.Join(config.Dir(), "manifests"))
 }
 
 // RegistryClient returns a client for communicating with a Docker distribution

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -21,13 +21,11 @@ import (
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/debug"
 	cliflags "github.com/docker/cli/cli/flags"
-	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/version"
 	dopts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
@@ -54,7 +52,6 @@ type Cli interface {
 	ServerInfo() ServerInfo
 	DefaultVersion() string
 	CurrentVersion() string
-	RegistryClient(bool) registryclient.RegistryClient
 	ContentTrustEnabled() bool
 	BuildKitEnabled() (bool, error)
 	ContextStore() store.Store
@@ -225,15 +222,6 @@ func (cli *DockerCli) HooksEnabled() bool {
 	}
 	// default to false
 	return false
-}
-
-// RegistryClient returns a client for communicating with a Docker distribution
-// registry
-func (cli *DockerCli) RegistryClient(allowInsecure bool) registryclient.RegistryClient {
-	resolver := func(ctx context.Context, index *registry.IndexInfo) registry.AuthConfig {
-		return ResolveAuthConfig(cli.ConfigFile(), index)
-	}
-	return registryclient.NewRegistryClient(resolver, UserAgent(), allowInsecure)
 }
 
 // WithInitializeClient is passed to DockerCli.Initialize by callers who wish to set a particular API Client for use by the CLI.

--- a/cli/command/cli_deprecated.go
+++ b/cli/command/cli_deprecated.go
@@ -1,6 +1,10 @@
 package command
 
 import (
+	"path/filepath"
+
+	"github.com/docker/cli/cli/config"
+	manifeststore "github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/cli/cli/trust"
 	notaryclient "github.com/theupdateframework/notary/client"
 )
@@ -12,7 +16,21 @@ type DeprecatedNotaryClient interface {
 	NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error)
 }
 
+type DeprecatedManifestClient interface {
+	// ManifestStore returns a store for local manifests
+	//
+	// Deprecated: use [manifeststore.NewStore] instead. This method is no longer used and will be removed in the next release.
+	ManifestStore() manifeststore.Store
+}
+
 // NotaryClient provides a Notary Repository to interact with signed metadata for an image
 func (cli *DockerCli) NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions []string) (notaryclient.Repository, error) {
 	return trust.GetNotaryRepository(cli.In(), cli.Out(), UserAgent(), imgRefAndAuth.RepoInfo(), imgRefAndAuth.AuthConfig(), actions...)
+}
+
+// ManifestStore returns a store for local manifests
+//
+// Deprecated: use [manifeststore.NewStore] instead. This method is no longer used and will be removed in the next release.
+func (*DockerCli) ManifestStore() manifeststore.Store {
+	return manifeststore.NewStore(filepath.Join(config.Dir(), "manifests"))
 }

--- a/cli/command/cli_deprecated.go
+++ b/cli/command/cli_deprecated.go
@@ -1,11 +1,14 @@
 package command
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/docker/cli/cli/config"
 	manifeststore "github.com/docker/cli/cli/manifest/store"
+	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/trust"
+	"github.com/docker/docker/api/types/registry"
 	notaryclient "github.com/theupdateframework/notary/client"
 )
 
@@ -21,6 +24,12 @@ type DeprecatedManifestClient interface {
 	//
 	// Deprecated: use [manifeststore.NewStore] instead. This method is no longer used and will be removed in the next release.
 	ManifestStore() manifeststore.Store
+
+	// RegistryClient returns a client for communicating with a Docker distribution
+	// registry.
+	//
+	// Deprecated: use [registryclient.NewRegistryClient]. This method is no longer used and will be removed in the next release.
+	RegistryClient(bool) registryclient.RegistryClient
 }
 
 // NotaryClient provides a Notary Repository to interact with signed metadata for an image
@@ -33,4 +42,15 @@ func (cli *DockerCli) NotaryClient(imgRefAndAuth trust.ImageRefAndAuth, actions 
 // Deprecated: use [manifeststore.NewStore] instead. This method is no longer used and will be removed in the next release.
 func (*DockerCli) ManifestStore() manifeststore.Store {
 	return manifeststore.NewStore(filepath.Join(config.Dir(), "manifests"))
+}
+
+// RegistryClient returns a client for communicating with a Docker distribution
+// registry
+//
+// Deprecated: use [registryclient.NewRegistryClient]. This method is no longer used and will be removed in the next release.
+func (cli *DockerCli) RegistryClient(allowInsecure bool) registryclient.RegistryClient {
+	resolver := func(ctx context.Context, index *registry.IndexInfo) registry.AuthConfig {
+		return ResolveAuthConfig(cli.ConfigFile(), index)
+	}
+	return registryclient.NewRegistryClient(resolver, UserAgent(), allowInsecure)
 }

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -41,7 +41,7 @@ func createManifestList(ctx context.Context, dockerCLI command.Cli, args []strin
 		return errors.Wrapf(err, "error parsing name for manifest list %s", newRef)
 	}
 
-	manifestStore := dockerCLI.ManifestStore()
+	manifestStore := newManifestStore(dockerCLI)
 	_, err = manifestStore.GetList(targetRef)
 	switch {
 	case store.IsNotFound(err):

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -75,7 +75,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	// Next try a remote manifest
-	registryClient := dockerCli.RegistryClient(opts.insecure)
+	registryClient := newRegistryClient(dockerCli, opts.insecure)
 	imageManifest, err := registryClient.GetManifest(ctx, namedRef)
 	if err == nil {
 		return printManifest(dockerCli, imageManifest, opts)

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -61,7 +61,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 			return err
 		}
 
-		imageManifest, err := dockerCli.ManifestStore().Get(listRef, namedRef)
+		imageManifest, err := newManifestStore(dockerCli).Get(listRef, namedRef)
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	// Try a local manifest list first
-	localManifestList, err := dockerCli.ManifestStore().GetList(namedRef)
+	localManifestList, err := newManifestStore(dockerCli).GetList(namedRef)
 	if err == nil {
 		return printManifestList(dockerCli, namedRef, localManifestList, opts)
 	}

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -248,7 +248,7 @@ func buildPutManifestRequest(imageManifest types.ImageManifest, targetRef refere
 }
 
 func pushList(ctx context.Context, dockerCLI command.Cli, req pushRequest) error {
-	rclient := dockerCLI.RegistryClient(req.insecure)
+	rclient := newRegistryClient(dockerCLI, req.insecure)
 
 	if err := mountBlobs(ctx, rclient, req.targetRef, req.manifestBlobs); err != nil {
 		return err

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -68,7 +68,7 @@ func runPush(ctx context.Context, dockerCli command.Cli, opts pushOpts) error {
 		return err
 	}
 
-	manifests, err := dockerCli.ManifestStore().GetList(targetRef)
+	manifests, err := newManifestStore(dockerCli).GetList(targetRef)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func runPush(ctx context.Context, dockerCli command.Cli, opts pushOpts) error {
 		return err
 	}
 	if opts.purge {
-		return dockerCli.ManifestStore().Remove(targetRef)
+		return newManifestStore(dockerCli).Remove(targetRef)
 	}
 	return nil
 }

--- a/cli/command/manifest/rm.go
+++ b/cli/command/manifest/rm.go
@@ -16,7 +16,7 @@ func newRmManifestListCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Delete one or more manifest lists from local storage",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), dockerCLI.ManifestStore(), args)
+			return runRemove(cmd.Context(), newManifestStore(dockerCLI), args)
 		},
 	}
 

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -70,7 +70,7 @@ func normalizeReference(ref string) (reference.Named, error) {
 // getManifest from the local store, and fallback to the remote registry if it
 // doesn't exist locally
 func getManifest(ctx context.Context, dockerCli command.Cli, listRef, namedRef reference.Named, insecure bool) (types.ImageManifest, error) {
-	data, err := dockerCli.ManifestStore().Get(listRef, namedRef)
+	data, err := newManifestStore(dockerCli).Get(listRef, namedRef)
 	switch {
 	case store.IsNotFound(err):
 		return dockerCli.RegistryClient(insecure).GetManifest(ctx, namedRef)

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -69,15 +69,15 @@ func normalizeReference(ref string) (reference.Named, error) {
 
 // getManifest from the local store, and fallback to the remote registry if it
 // doesn't exist locally
-func getManifest(ctx context.Context, dockerCli command.Cli, listRef, namedRef reference.Named, insecure bool) (types.ImageManifest, error) {
-	data, err := newManifestStore(dockerCli).Get(listRef, namedRef)
+func getManifest(ctx context.Context, dockerCLI command.Cli, listRef, namedRef reference.Named, insecure bool) (types.ImageManifest, error) {
+	data, err := newManifestStore(dockerCLI).Get(listRef, namedRef)
 	switch {
 	case store.IsNotFound(err):
-		return dockerCli.RegistryClient(insecure).GetManifest(ctx, namedRef)
+		return newRegistryClient(dockerCLI, insecure).GetManifest(ctx, namedRef)
 	case err != nil:
 		return types.ImageManifest{}, err
 	case len(data.Raw) == 0:
-		return dockerCli.RegistryClient(insecure).GetManifest(ctx, namedRef)
+		return newRegistryClient(dockerCLI, insecure).GetManifest(ctx, namedRef)
 	default:
 		return data, nil
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5876

---


### cli/command: internalize constructing ManifestStore

The CLI.ManifestStore method is a shallow wrapper around manifeststore.NewStore
and has no dependency on the CLI itself. However, due to its signature resulted
in various dependencies becoming a dependency of the "command" package.
Consequence of this was that cli-plugins, which need the cli/command package,
would also get those dependencies.

- This patch inlines the code to produce the store, skipping the wrapper.
- Define a local interface for some tests where a dummy store was used.


### cli/command: internalize constructing RegistryClient

The CLI.RegistryClient method is a shallow wrapper around registryclient.NewRegistryClient
but due to its signature resulted in various dependencies becoming a dependency
of the "command" package. Consequence of this was that cli-plugins, which
need the cli/command package, would also get those dependencies.

This patch inlines the code where needed, skipping the wrapper



### cli/command: deprecate Cli.ManifestStore

This method is a shallow wrapper around manifeststore.NewStore, but
due to its signature resulted in various dependencies becoming a dependency
of the "command" package. Consequence of this was that cli-plugins, which
need the cli/command package, would also get those dependencies. It is no
longer used in our code, which constructs the client in packages that need it,
so we can deprecate this method.


### cli/command: deprecate Cli.RegistryClient

This method was a shallow wrapper around registryclient.NewRegistryClient but
due to its signature resulted in various dependencies becoming a dependency
of the "command" package. Consequence of this was that cli-plugins, which
need the cli/command package, would also get those dependencies. It is no
longer used in our code, which constructs the client in packages that need it,
so we can deprecate this method.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate Cli.ManifestStore. This method was only used internally and will be removed in the next release. Use [store.NewStore] instead.
Go SDK: cli/command: deprecate Cli.RegistryClient. This method was only used internally and will be removed in the next release. Use [client.NewRegistryClient] instead

[store.NewStore]: https://pkg.go.dev/github.com/docker/cli@v28.0.1+incompatible/cli/manifest/store#NewStore
[client.NewRegistryClient]: https://pkg.go.dev/github.com/docker/cli@v28.0.1+incompatible/cli/registry/client#NewRegistryClient
```

**- A picture of a cute animal (not mandatory but encouraged)**

