### PR TITLE
small performance optimizations for running hooks

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -194,16 +194,16 @@ func (cli *DockerCli) BuildKitEnabled() (bool, error) {
 
 // HooksEnabled returns whether plugin hooks are enabled.
 func (cli *DockerCli) HooksEnabled() bool {
-	// legacy support DOCKER_CLI_HINTS env var
-	if v := os.Getenv("DOCKER_CLI_HINTS"); v != "" {
+	// use DOCKER_CLI_HOOKS env var value if set and not empty
+	if v := os.Getenv("DOCKER_CLI_HOOKS"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return false
 		}
 		return enabled
 	}
-	// use DOCKER_CLI_HOOKS env var value if set and not empty
-	if v := os.Getenv("DOCKER_CLI_HOOKS"); v != "" {
+	// legacy support DOCKER_CLI_HINTS env var
+	if v := os.Getenv("DOCKER_CLI_HINTS"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return false

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -446,7 +446,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		if err != nil || pluginmanager.IsPluginCommand(ccmd) {
 			err := tryPluginRun(ctx, dockerCli, cmd, args[0], envs)
 			if err == nil {
-				if dockerCli.HooksEnabled() && dockerCli.Out().IsTerminal() && ccmd != nil {
+				if ccmd != nil && dockerCli.Out().IsTerminal() && dockerCli.HooksEnabled() {
 					pluginmanager.RunPluginHooks(ctx, dockerCli, cmd, ccmd, args)
 				}
 				return nil
@@ -471,7 +471,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 
 	// If the command is being executed in an interactive terminal
 	// and hook are enabled, run the plugin hooks.
-	if dockerCli.HooksEnabled() && dockerCli.Out().IsTerminal() && subCommand != nil {
+	if subCommand != nil && dockerCli.Out().IsTerminal() && dockerCli.HooksEnabled() {
 		var errMessage string
 		if err != nil {
 			errMessage = err.Error()


### PR DESCRIPTION
### cmd/docker: small performance optimizations for running hooks

Order conditions to check for lightweight ones first;

- checck if the command is not nil
- dockerCli.Out().IsTerminal() is a lightweight getter
- dockerCli.HooksEnabled() checks for env-vars, parses booleans, and
  reading the CLI config-file


### cli/command: DockerCli.HooksEnabled check current before legacy

The DOCKER_CLI_HINTS env-var is replaced by DOCKER_CLI_HOOKS; check the
new env-var first, and only fall back to checking the legacy env-var
if it's not set.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

