### PR TITLE
fix duplicate warnings on docker run / docker create, and slight refactor

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -207,7 +207,6 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	hostConfig := containerCfg.HostConfig
 	networkingConfig := containerCfg.NetworkingConfig
 
-	warnOnOomKillDisable(*hostConfig, dockerCli.Err())
 	warnOnLocalhostDNS(*hostConfig, dockerCli.Err())
 
 	var (
@@ -297,12 +296,6 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	}
 	err = containerIDFile.Write(response.ID)
 	return response.ID, err
-}
-
-func warnOnOomKillDisable(hostConfig container.HostConfig, stderr io.Writer) {
-	if hostConfig.OomKillDisable != nil && *hostConfig.OomKillDisable && hostConfig.Memory == 0 {
-		_, _ = fmt.Fprintln(stderr, "WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.")
-	}
 }
 
 // check the DNS settings passed via --dns against localhost regexp to warn if

--- a/cli/command/container/testdata/container-create-daemon-multiple-warnings.golden
+++ b/cli/command/container/testdata/container-create-daemon-multiple-warnings.golden
@@ -1,0 +1,2 @@
+WARNING: warning from daemon
+WARNING: another warning from daemon

--- a/cli/command/container/testdata/container-create-daemon-single-warning.golden
+++ b/cli/command/container/testdata/container-create-daemon-single-warning.golden
@@ -1,0 +1,1 @@
+WARNING: warning from daemon

--- a/cli/command/container/testdata/container-create-localhost-dns-ipv6.golden
+++ b/cli/command/container/testdata/container-create-localhost-dns-ipv6.golden
@@ -1,1 +1,1 @@
-WARNING: Localhost DNS setting (--dns=::1) may fail in containers.
+WARNING: Localhost DNS (::1) may fail in containers.

--- a/cli/command/container/testdata/container-create-localhost-dns.golden
+++ b/cli/command/container/testdata/container-create-localhost-dns.golden
@@ -1,1 +1,1 @@
-WARNING: Localhost DNS setting (--dns=127.0.0.11) may fail in containers.
+WARNING: Localhost DNS (127.0.0.11) may fail in containers.

--- a/cli/command/container/testdata/container-create-oom-kill-true-without-memory-limit.golden
+++ b/cli/command/container/testdata/container-create-oom-kill-true-without-memory-limit.golden
@@ -1,1 +1,0 @@
-WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.

--- a/cli/command/container/testdata/container-create-oom-kill-without-memory-limit.golden
+++ b/cli/command/container/testdata/container-create-oom-kill-without-memory-limit.golden
@@ -1,1 +1,0 @@
-WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/17356
- https://github.com/docker/cli/pull/1571
- https://github.com/moby/moby/pull/11288

### remove duplicate `--oom-kill-disable` warnings on docker run / docker create

This warning was originally added in [moby@3aa70c1], and moved to be printed on both `run` and `create` in commit 7c514a31c97cc0a4e74b53f5cff73da72e680a01.

However, [moby@57f1305] (docker 19.03, API 1.40) moved such warnings to the daemon side. The patch mentioned this issue:

> This patch will have one side-effect; docker cli's that also perform this check
> client-side will print the warning twice; this can be addressed by disabling
> the cli-side check for newer API versions, but will generate a bit of extra
> noise when using an older CLI.

The CLI does not take this into account currently, and still prints warnings twice; even in cases where the option is not supported by the daemon, and discarded:

On a host without OomKillDisable support:

    docker create --oom-kill-disable alpine
    WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.
    WARNING: Your kernel does not support OomKillDisable. OomKillDisable discarded.

On a host that supports it:

    docker create --oom-kill-disable alpine
    WARNING: Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.
    WARNING: OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.

This patch removes the client-side warning, leaving it to the daemon to report if any warnings should produced (and the client to print them).

With this patch applied:

On a host without OomKillDisable support:

    docker create --oom-kill-disable alpine
    WARNING: Your kernel does not support OomKillDisable. OomKillDisable discarded.

On a host that supports it:

    docker create --oom-kill-disable alpine
    WARNING: OOM killer is disabled for the container, but no memory limit is set, this can result in the system running out of resources.

[moby@3aa70c1]: https://github.com/moby/moby/commit/3aa70c1948e44ab523db0be37a602b63e7eac882
[moby@57f1305]: https://github.com/moby/moby/commit/57f1305e749cbf909238b407b3437d5859a747e2


### container create: combine client-side warning with daemon-side

Use a consistent approach for producing warnings, but add a TODO for moving
this warning to the daemon, which can make a better call if it will work
or not (depending on networking mode).

This warning was originally added in [moby@afa92a9], before integration with
libnetwork, and this warning may be incorrect in many scenarios.

While updating, also removing the custom regular expression used to
detect if the IP is a loopback address, and using go's net package
instead.

[moby@afa92a9]: https://github.com/moby/moby/commit/afa92a9af0f1a77ef25aab73b11aa855a1823666


<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

