### PR TITLE
remove uses of cli.DefaultVersion()

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -88,7 +88,7 @@ type DockerCli struct {
 	enableGlobalMeter, enableGlobalTracer bool
 }
 
-// DefaultVersion returns api.defaultVersion.
+// DefaultVersion returns [api.DefaultVersion].
 func (*DockerCli) DefaultVersion() string {
 	return api.DefaultVersion
 }

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -197,8 +197,8 @@ func runVersion(ctx context.Context, dockerCli command.Cli, opts *versionOptions
 func prettyPrintVersion(dockerCli command.Cli, vd versionInfo, tmpl *template.Template) error {
 	t := tabwriter.NewWriter(dockerCli.Out(), 20, 1, 1, ' ', 0)
 	err := tmpl.Execute(t, vd)
-	t.Write([]byte("\n"))
-	t.Flush()
+	_, _ = t.Write([]byte("\n"))
+	_ = t.Flush()
 	return err
 }
 

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -16,6 +16,7 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	"github.com/docker/cli/templates"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -89,20 +90,20 @@ type clientVersion struct {
 // information.
 func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
 	v := clientVersion{
-		Version:   version.Version,
-		GoVersion: runtime.Version(),
-		GitCommit: version.GitCommit,
-		BuildTime: reformatDate(version.BuildTime),
-		Os:        runtime.GOOS,
-		Arch:      arch(),
-		Context:   contextName,
+		Version:           version.Version,
+		DefaultAPIVersion: api.DefaultVersion,
+		GoVersion:         runtime.Version(),
+		GitCommit:         version.GitCommit,
+		BuildTime:         reformatDate(version.BuildTime),
+		Os:                runtime.GOOS,
+		Arch:              arch(),
+		Context:           contextName,
 	}
 	if version.PlatformName != "" {
 		v.Platform = &platformInfo{Name: version.PlatformName}
 	}
 	if dockerCli != nil {
 		v.APIVersion = dockerCli.CurrentVersion()
-		v.DefaultAPIVersion = dockerCli.DefaultVersion()
 	}
 	return v
 }

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -14,6 +14,7 @@ import (
 	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/trust"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/client"
 	notaryclient "github.com/theupdateframework/notary/client"
 )
@@ -104,8 +105,8 @@ func (c *FakeCli) Client() client.APIClient {
 }
 
 // CurrentVersion returns the API version used by FakeCli.
-func (c *FakeCli) CurrentVersion() string {
-	return c.DefaultVersion()
+func (*FakeCli) CurrentVersion() string {
+	return api.DefaultVersion
 }
 
 // Out returns the output stream (stdout) the cli should write on


### PR DESCRIPTION
It's hard-coded to the API defaultversion, so we can use that const directly. Ultimately, this should be something returned by the API client configured on the CLI, not the CLI itself.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

