### PR TITLE
secret create, config create: refactor, use limit reader, and touch up errors

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -51,17 +51,7 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 func RunConfigCreate(ctx context.Context, dockerCLI command.Cli, options CreateOptions) error {
 	apiClient := dockerCLI.Client()
 
-	var in io.Reader = dockerCLI.In()
-	if options.File != "-" {
-		file, err := sequential.Open(options.File)
-		if err != nil {
-			return err
-		}
-		in = file
-		defer file.Close()
-	}
-
-	configData, err := io.ReadAll(in)
+	configData, err := readConfigData(dockerCLI.In(), options.File)
 	if err != nil {
 		return errors.Errorf("Error reading content from %q: %v", options.File, err)
 	}
@@ -83,6 +73,54 @@ func RunConfigCreate(ctx context.Context, dockerCLI command.Cli, options CreateO
 		return err
 	}
 
-	fmt.Fprintln(dockerCLI.Out(), r.ID)
+	_, _ = fmt.Fprintln(dockerCLI.Out(), r.ID)
 	return nil
+}
+
+// maxConfigSize is the maximum byte length of the [swarm.ConfigSpec.Data] field,
+// as defined by [MaxConfigSize] in SwarmKit.
+//
+// [MaxConfigSize]: https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0-20250103191802-8c1959736554/manager/controlapi#MaxConfigSize
+const maxConfigSize = 1000 * 1024 // 1000KB
+
+// readConfigData reads the config from either stdin or the given fileName.
+//
+// It reads up to twice the maximum size of the config ([maxConfigSize]),
+// just in case swarm's limit changes; this is only a safeguard to prevent
+// reading arbitrary files into memory.
+func readConfigData(in io.Reader, fileName string) ([]byte, error) {
+	switch fileName {
+	case "-":
+		data, err := io.ReadAll(io.LimitReader(in, 2*maxConfigSize))
+		if err != nil {
+			return nil, fmt.Errorf("error reading from STDIN: %w", err)
+		}
+		if len(data) == 0 {
+			return nil, errors.New("error reading from STDIN: data is empty")
+		}
+		return data, nil
+	case "":
+		return nil, errors.New("config file is required")
+	default:
+		// Open file with [FILE_FLAG_SEQUENTIAL_SCAN] on Windows, which
+		// prevents Windows from aggressively caching it. We expect this
+		// file to be only read once. Given that this is expected to be
+		// a small file, this may not be a significant optimization, so
+		// we could choose to omit this, and use a regular [os.Open].
+		//
+		// [FILE_FLAG_SEQUENTIAL_SCAN]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
+		f, err := sequential.Open(fileName)
+		if err != nil {
+			return nil, fmt.Errorf("error reading from %s: %w", fileName, err)
+		}
+		defer f.Close()
+		data, err := io.ReadAll(io.LimitReader(f, 2*maxConfigSize))
+		if err != nil {
+			return nil, fmt.Errorf("error reading from %s: %w", fileName, err)
+		}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("error reading from %s: data is empty", fileName)
+		}
+		return data, nil
+	}
 }

--- a/cli/command/config/create_test.go
+++ b/cli/command/config/create_test.go
@@ -59,7 +59,7 @@ func TestConfigCreateErrors(t *testing.T) {
 }
 
 func TestConfigCreateWithName(t *testing.T) {
-	name := "foo"
+	const name = "config-with-name"
 	var actual []byte
 	cli := test.NewFakeCli(&fakeClient{
 		configCreateFunc: func(_ context.Context, spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {
@@ -87,7 +87,7 @@ func TestConfigCreateWithLabels(t *testing.T) {
 		"lbl1": "Label-foo",
 		"lbl2": "Label-bar",
 	}
-	name := "foo"
+	const name = "config-with-labels"
 
 	data, err := os.ReadFile(filepath.Join("testdata", configDataFile))
 	assert.NilError(t, err)
@@ -124,7 +124,7 @@ func TestConfigCreateWithTemplatingDriver(t *testing.T) {
 	expectedDriver := &swarm.Driver{
 		Name: "template-driver",
 	}
-	name := "foo"
+	const name = "config-with-template-driver"
 
 	cli := test.NewFakeCli(&fakeClient{
 		configCreateFunc: func(_ context.Context, spec swarm.ConfigSpec) (types.ConfigCreateResponse, error) {

--- a/cli/command/secret/create_test.go
+++ b/cli/command/secret/create_test.go
@@ -56,7 +56,7 @@ func TestSecretCreateErrors(t *testing.T) {
 }
 
 func TestSecretCreateWithName(t *testing.T) {
-	name := "foo"
+	const name = "secret-with-name"
 	data, err := os.ReadFile(filepath.Join("testdata", secretDataFile))
 	assert.NilError(t, err)
 
@@ -89,7 +89,7 @@ func TestSecretCreateWithDriver(t *testing.T) {
 	expectedDriver := &swarm.Driver{
 		Name: "secret-driver",
 	}
-	name := "foo"
+	const name = "secret-with-driver"
 
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
@@ -118,7 +118,7 @@ func TestSecretCreateWithTemplatingDriver(t *testing.T) {
 	expectedDriver := &swarm.Driver{
 		Name: "template-driver",
 	}
-	const name = "foo"
+	const name = "secret-with-template-driver"
 
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {
@@ -137,7 +137,7 @@ func TestSecretCreateWithTemplatingDriver(t *testing.T) {
 	})
 
 	cmd := newSecretCreateCommand(cli)
-	cmd.SetArgs([]string{name})
+	cmd.SetArgs([]string{name, filepath.Join("testdata", secretDataFile)})
 	assert.Check(t, cmd.Flags().Set("template-driver", expectedDriver.Name))
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, is.Equal("ID-"+name, strings.TrimSpace(cli.OutBuffer().String())))
@@ -148,7 +148,7 @@ func TestSecretCreateWithLabels(t *testing.T) {
 		"lbl1": "Label-foo",
 		"lbl2": "Label-bar",
 	}
-	const name = "foo"
+	const name = "secret-with-labels"
 
 	cli := test.NewFakeCli(&fakeClient{
 		secretCreateFunc: func(_ context.Context, spec swarm.SecretSpec) (types.SecretCreateResponse, error) {


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49606


### secret create: refactor, use limit reader, and touch up errors

Swarm has size constraints on the size of secrets, but the client-side would
read content into memory, regardless its size. This could lead to either the
client reading too much into memory, or it sending data that's larger than
the size limit of gRPC, which resulted in the error not being handled by
SwarmKit and a generic gRPC error returned.

Reading a secret from a file was added in [moby@c6f0b7f], which used a
system.OpenSequential for reading ([FILE_FLAG_SEQUENTIAL_SCAN]). While
there could be a very marginal benefit to prevent polluting the system's
cache (Windows won’t aggressively keep it in the cache, freeing up system
memory for other tasks). These details were not documented in code, and
possibly may be too marginal, but adding a comment to outline won't hurt
so this patch also adds a comment.

This patch:

- Rewrites readSecretData to not return a nil-error if no file was
  set, in stead only calling it when not using a driver.
- Implements reading the data with a limit-reader to prevent reading
  large files into memory.
- The limit is based on SwarmKits limits ([MaxSecretSize]), but made
  twice that size, just in case larger sizes are supported in future;
  the main goal is to have some constraints, and to prevent hitting
  the gRPC limit.
- Updates some error messages to include STDIN (when used), or the
  filename (when used).

Before this patch:

    ls -lh largefile
    -rw-------  1 thajeztah  staff   8.1M Mar  9 00:19 largefile

    docker secret create nosuchfile ./nosuchfile
    Error reading content from "./nosuchfile": open ./nosuchfile: no such file or directory

    docker secret create toolarge ./largefile
    Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8462870 vs. 4194304)

    docker secret create empty ./emptyfile
    Error response from daemon: rpc error: code = InvalidArgument desc = secret data must be larger than 0 and less than 512000 bytes

    cat ./largefile | docker secret create toolarge -
    Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8462870 vs. 4194304)

    cat ./emptyfile | docker secret create empty -
    Error response from daemon: rpc error: code = InvalidArgument desc = secret data must be larger than 0 and less than 512000 bytes

With this patch:

    docker secret create nosuchfile ./nosuchfile
    error reading from ./nosuchfile: open ./nosuchfile: no such file or directory
    
    docker secret create empty ./emptyfile
    error reading from ./emptyfile: data is empty
    
    docker secret create toolarge ./largefile
    Error response from daemon: rpc error: code = InvalidArgument desc = secret data must be larger than 0 and less than 512000 bytes

    cat ./largefile | docker secret create toolarge -
    Error response from daemon: rpc error: code = InvalidArgument desc = secret data must be larger than 0 and less than 512000 bytes

    cat ./emptyfile | docker secret create empty -
    error reading from STDIN: data is empty


[moby@c6f0b7f]: https://github.com/moby/moby/commit/c6f0b7f448fac4d037d00f944a7908c60c04dff2
[FILE_FLAG_SEQUENTIAL_SCAN]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
[MaxSecretSize]: https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0-20250103191802-8c1959736554/api/validation#MaxSecretSize

### config create: refactor, use limit reader, and touch up errors

Swarm has size constraints on the size of configs, but the client-side would
read content into memory, regardless its size. This could lead to either the
client reading too much into memory, or it sending data that's larger than
the size limit of gRPC, which resulted in the error not being handled by
SwarmKit and a generic gRPC error returned.

Reading a config from a file used a system.OpenSequential for reading
([FILE_FLAG_SEQUENTIAL_SCAN]). While there could be a very marginal benefit
to prevent polluting the system's cache (Windows won’t aggressively keep it
in the cache, freeing up system memory for other tasks). These details were
not documented in code, and possibly may be too marginal, but adding a comment
to outline won't hurt so this patch also adds a comment.

This patch:

- Factors out the reading code to a readConfigData, analogous to the
  equivalent in secret create.
- Implements reading the data with a limit-reader to prevent reading
  large files into memory.
- The limit is based on SwarmKits limits ([MaxConfigSize]), but made
  twice that size, just in case larger sizes are supported in future;
  the main goal is to have some constraints, and to prevent hitting
  the gRPC limit.
- Updates some error messages to include STDIN (when used), or the
  filename (when used).

Before this patch:

    ls -lh largefile
    -rw-------  1 thajeztah  staff   8.1M Mar  9 00:19 largefile

    docker config create nosuchfile ./nosuchfile
    Error reading content from "./nosuchfile": open ./nosuchfile: no such file or directory

    docker config create toolarge ./largefile
    Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8462870 vs. 4194304)

    docker config create empty ./emptyfile
    Error response from daemon: rpc error: code = InvalidArgument desc = config data must be larger than 0 and less than 1024000 bytes

    cat ./largefile | docker config create toolarge -
    Error response from daemon: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (8462870 vs. 4194304)

    cat ./emptyfile | docker config create empty -
    Error response from daemon: rpc error: code = InvalidArgument desc = config data must be larger than 0 and less than 1024000 bytes

With this patch:

    docker config create nosuchfile ./nosuchfile
    error reading from ./nosuchfile: open ./nosuchfile: no such file or directory
    
    docker config create empty ./emptyfile
    error reading from ./emptyfile: data is empty
    
    docker config create toolarge ./largefile
    Error response from daemon: rpc error: code = InvalidArgument desc = config data must be larger than 0 and less than 1024000 bytes

    cat ./largefile | docker config create toolarge -
    Error response from daemon: rpc error: code = InvalidArgument desc = secret data must be larger than 0 and less than 1024000 bytes

    cat ./emptyfile | docker config create empty -
    error reading from STDIN: data is empty


[FILE_FLAG_SEQUENTIAL_SCAN]: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#FILE_FLAG_SEQUENTIAL_SCAN
[MaxConfigSize]: https://pkg.go.dev/github.com/moby/swarmkit/v2@v2.0.0-20250103191802-8c1959736554/manager/controlapi#MaxConfigSize


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

