### PR TITLE
cli/command: deprecate CopyToFile and reimplement with atomicwriter

### DIFF
--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -42,8 +42,6 @@ func TestContainerExportOutputToIrregularFile(t *testing.T) {
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"-o", "/dev/random", "container"})
 
-	err := cmd.Execute()
-	assert.Assert(t, err != nil)
-	expected := `"/dev/random" must be a directory or a regular file`
-	assert.ErrorContains(t, err, expected)
+	const expected = `failed to export container: cannot write to a character device file`
+	assert.Error(t, cmd.Execute(), expected)
 }

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -44,12 +44,12 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		{
 			name:          "output directory does not exist",
 			args:          []string{"-o", "fakedir/out.tar", "arg1"},
-			expectedError: "failed to save image: invalid output path: directory \"fakedir\" does not exist",
+			expectedError: `failed to save image: invalid output path: stat fakedir: no such file or directory`,
 		},
 		{
 			name:          "output file is irregular",
 			args:          []string{"-o", "/dev/null", "arg1"},
-			expectedError: "failed to save image: invalid output path: \"/dev/null\" must be a directory or a regular file",
+			expectedError: `failed to save image: cannot write to a character device file`,
 		},
 		{
 			name:          "invalid platform",


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49607
- relates to https://github.com/moby/moby/pull/49608
- relates to https://github.com/docker/compose/pull/12715
- [x] depends on https://github.com/moby/sys/pull/185
- [x] depends on https://github.com/moby/moby/pull/49748
- [x] depends on https://github.com/docker/cli/pull/5921




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

