### PR TITLE
cli/command: remove StringSliceReplaceAt utility

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -240,37 +240,6 @@ func ValidateOutputPathFileMode(fileMode os.FileMode) error {
 	return nil
 }
 
-func stringSliceIndex(s, subs []string) int {
-	j := 0
-	if len(subs) > 0 {
-		for i, x := range s {
-			if j < len(subs) && subs[j] == x {
-				j++
-			} else {
-				j = 0
-			}
-			if len(subs) == j {
-				return i + 1 - j
-			}
-		}
-	}
-	return -1
-}
-
-// StringSliceReplaceAt replaces the sub-slice find, with the sub-slice replace, in the string
-// slice s, returning a new slice and a boolean indicating if the replacement happened.
-// requireIdx is the index at which old needs to be found at (or -1 to disregard that).
-func StringSliceReplaceAt(s, find, replace []string, requireIndex int) ([]string, bool) {
-	idx := stringSliceIndex(s, find)
-	if (requireIndex != -1 && requireIndex != idx) || idx == -1 {
-		return s, false
-	}
-	out := append([]string{}, s[:idx]...)
-	out = append(out, replace...)
-	out = append(out, s[idx+len(find):]...)
-	return out, true
-}
-
 // ValidateMountWithAPIVersion validates a mount with the server API version.
 func ValidateMountWithAPIVersion(m mounttypes.Mount, serverAPIVersion string) error {
 	if m.BindOptions != nil {

--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -21,32 +21,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestStringSliceReplaceAt(t *testing.T) {
-	out, ok := command.StringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, -1)
-	assert.Assert(t, ok)
-	assert.DeepEqual(t, []string{"abc", "baz", "bax"}, out)
-
-	out, ok = command.StringSliceReplaceAt([]string{"foo"}, []string{"foo", "bar"}, []string{"baz"}, -1)
-	assert.Assert(t, !ok)
-	assert.DeepEqual(t, []string{"foo"}, out)
-
-	out, ok = command.StringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
-	assert.Assert(t, !ok)
-	assert.DeepEqual(t, []string{"abc", "foo", "bar", "bax"}, out)
-
-	out, ok = command.StringSliceReplaceAt([]string{"foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
-	assert.Assert(t, ok)
-	assert.DeepEqual(t, []string{"baz", "bax"}, out)
-
-	out, ok = command.StringSliceReplaceAt([]string{"abc", "foo", "bar", "baz"}, []string{"foo", "bar"}, nil, -1)
-	assert.Assert(t, ok)
-	assert.DeepEqual(t, []string{"abc", "baz"}, out)
-
-	out, ok = command.StringSliceReplaceAt([]string{"foo"}, nil, []string{"baz"}, -1)
-	assert.Assert(t, !ok)
-	assert.DeepEqual(t, []string{"foo"}, out)
-}
-
 func TestValidateOutputPath(t *testing.T) {
 	basedir := t.TempDir()
 	dir := filepath.Join(basedir, "dir")

--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -43,9 +43,9 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 
 	for _, al := range aliases {
 		var didChange bool
-		args, didChange = command.StringSliceReplaceAt(args, al[0], al[1], 0)
+		args, didChange = stringSliceReplaceAt(args, al[0], al[1], 0)
 		if didChange {
-			osArgs, _ = command.StringSliceReplaceAt(osArgs, al[0], al[1], -1)
+			osArgs, _ = stringSliceReplaceAt(osArgs, al[0], al[1], -1)
 			break
 		}
 	}

--- a/cmd/docker/aliases_utils.go
+++ b/cmd/docker/aliases_utils.go
@@ -1,0 +1,32 @@
+package main
+
+func stringSliceIndex(s, subs []string) int {
+	j := 0
+	if len(subs) > 0 {
+		for i, x := range s {
+			if j < len(subs) && subs[j] == x {
+				j++
+			} else {
+				j = 0
+			}
+			if len(subs) == j {
+				return i + 1 - j
+			}
+		}
+	}
+	return -1
+}
+
+// stringSliceReplaceAt replaces the sub-slice find, with the sub-slice replace, in the string
+// slice s, returning a new slice and a boolean indicating if the replacement happened.
+// requireIdx is the index at which old needs to be found at (or -1 to disregard that).
+func stringSliceReplaceAt(s, find, replace []string, requireIndex int) ([]string, bool) {
+	idx := stringSliceIndex(s, find)
+	if (requireIndex != -1 && requireIndex != idx) || idx == -1 {
+		return s, false
+	}
+	out := append([]string{}, s[:idx]...)
+	out = append(out, replace...)
+	out = append(out, s[idx+len(find):]...)
+	return out, true
+}

--- a/cmd/docker/aliases_utils_test.go
+++ b/cmd/docker/aliases_utils_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestStringSliceReplaceAt(t *testing.T) {
+	out, ok := stringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, -1)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"abc", "baz", "bax"}, out)
+
+	out, ok = stringSliceReplaceAt([]string{"foo"}, []string{"foo", "bar"}, []string{"baz"}, -1)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"foo"}, out)
+
+	out, ok = stringSliceReplaceAt([]string{"abc", "foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"abc", "foo", "bar", "bax"}, out)
+
+	out, ok = stringSliceReplaceAt([]string{"foo", "bar", "bax"}, []string{"foo", "bar"}, []string{"baz"}, 0)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"baz", "bax"}, out)
+
+	out, ok = stringSliceReplaceAt([]string{"abc", "foo", "bar", "baz"}, []string{"foo", "bar"}, nil, -1)
+	assert.Assert(t, ok)
+	assert.DeepEqual(t, []string{"abc", "baz"}, out)
+
+	out, ok = stringSliceReplaceAt([]string{"foo"}, nil, []string{"baz"}, -1)
+	assert.Assert(t, !ok)
+	assert.DeepEqual(t, []string{"foo"}, out)
+}

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -152,8 +152,8 @@ func forwardBuilder(alias string, args, osargs []string) ([]string, []string, []
 		},
 	}
 	for _, al := range aliases {
-		if fwargs, changed := command.StringSliceReplaceAt(args, al[0], al[1], 0); changed {
-			fwosargs, _ := command.StringSliceReplaceAt(osargs, al[0], al[1], -1)
+		if fwargs, changed := stringSliceReplaceAt(args, al[0], al[1], 0); changed {
+			fwosargs, _ := stringSliceReplaceAt(osargs, al[0], al[1], -1)
 			fwcmdpath := al[2]
 			return fwargs, fwosargs, fwcmdpath, true
 		}


### PR DESCRIPTION
It was only used internally in cmd/docker and has no known external consumers. Move it to cmd/docker and un-export it.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

