### PR TITLE
cli/command: move PrettyPrint utility to cli/command/formatter

### DIFF
--- a/cli/command/config/formatter.go
+++ b/cli/command/config/formatter.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/docker/docker/api/types/swarm"
@@ -157,11 +156,11 @@ func (ctx *configInspectContext) Labels() map[string]string {
 }
 
 func (ctx *configInspectContext) CreatedAt() string {
-	return command.PrettyPrint(ctx.Config.CreatedAt)
+	return formatter.PrettyPrint(ctx.Config.CreatedAt)
 }
 
 func (ctx *configInspectContext) UpdatedAt() string {
-	return command.PrettyPrint(ctx.Config.UpdatedAt)
+	return formatter.PrettyPrint(ctx.Config.UpdatedAt)
 }
 
 func (ctx *configInspectContext) Data() string {

--- a/cli/command/formatter/displayutils.go
+++ b/cli/command/formatter/displayutils.go
@@ -1,6 +1,8 @@
 package formatter
 
 import (
+	"fmt"
+	"strings"
 	"unicode/utf8"
 
 	"golang.org/x/text/width"
@@ -58,4 +60,28 @@ func Ellipsis(s string, maxDisplayWidth int) string {
 		}
 	}
 	return s
+}
+
+// capitalizeFirst capitalizes the first character of string
+func capitalizeFirst(s string) string {
+	switch l := len(s); l {
+	case 0:
+		return s
+	case 1:
+		return strings.ToLower(s)
+	default:
+		return strings.ToUpper(string(s[0])) + strings.ToLower(s[1:])
+	}
+}
+
+// PrettyPrint outputs arbitrary data for human formatted output by uppercasing the first letter.
+func PrettyPrint(i any) string {
+	switch t := i.(type) {
+	case nil:
+		return "None"
+	case string:
+		return capitalizeFirst(t)
+	default:
+		return capitalizeFirst(fmt.Sprintf("%s", t))
+	}
 }

--- a/cli/command/node/formatter.go
+++ b/cli/command/node/formatter.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/docker/docker/api/types/swarm"
@@ -147,11 +146,11 @@ func (c *nodeContext) Hostname() string {
 }
 
 func (c *nodeContext) Status() string {
-	return command.PrettyPrint(string(c.n.Status.State))
+	return formatter.PrettyPrint(string(c.n.Status.State))
 }
 
 func (c *nodeContext) Availability() string {
-	return command.PrettyPrint(string(c.n.Spec.Availability))
+	return formatter.PrettyPrint(string(c.n.Spec.Availability))
 }
 
 func (c *nodeContext) ManagerStatus() string {
@@ -163,7 +162,7 @@ func (c *nodeContext) ManagerStatus() string {
 			reachability = string(c.n.ManagerStatus.Reachability)
 		}
 	}
-	return command.PrettyPrint(reachability)
+	return formatter.PrettyPrint(reachability)
 }
 
 func (c *nodeContext) TLSStatus() string {
@@ -226,11 +225,11 @@ func (ctx *nodeInspectContext) Hostname() string {
 }
 
 func (ctx *nodeInspectContext) CreatedAt() string {
-	return command.PrettyPrint(ctx.Node.CreatedAt)
+	return formatter.PrettyPrint(ctx.Node.CreatedAt)
 }
 
 func (ctx *nodeInspectContext) StatusState() string {
-	return command.PrettyPrint(ctx.Node.Status.State)
+	return formatter.PrettyPrint(ctx.Node.Status.State)
 }
 
 func (ctx *nodeInspectContext) HasStatusMessage() bool {
@@ -238,11 +237,11 @@ func (ctx *nodeInspectContext) HasStatusMessage() bool {
 }
 
 func (ctx *nodeInspectContext) StatusMessage() string {
-	return command.PrettyPrint(ctx.Node.Status.Message)
+	return formatter.PrettyPrint(ctx.Node.Status.Message)
 }
 
 func (ctx *nodeInspectContext) SpecAvailability() string {
-	return command.PrettyPrint(ctx.Node.Spec.Availability)
+	return formatter.PrettyPrint(ctx.Node.Spec.Availability)
 }
 
 func (ctx *nodeInspectContext) HasStatusAddr() bool {
@@ -262,7 +261,7 @@ func (ctx *nodeInspectContext) ManagerStatusAddr() string {
 }
 
 func (ctx *nodeInspectContext) ManagerStatusReachability() string {
-	return command.PrettyPrint(ctx.Node.ManagerStatus.Reachability)
+	return formatter.PrettyPrint(ctx.Node.ManagerStatus.Reachability)
 }
 
 func (ctx *nodeInspectContext) IsManagerStatusLeader() bool {

--- a/cli/command/secret/formatter.go
+++ b/cli/command/secret/formatter.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/docker/docker/api/types/swarm"
@@ -171,9 +170,9 @@ func (ctx *secretInspectContext) Driver() string {
 }
 
 func (ctx *secretInspectContext) CreatedAt() string {
-	return command.PrettyPrint(ctx.Secret.CreatedAt)
+	return formatter.PrettyPrint(ctx.Secret.CreatedAt)
 }
 
 func (ctx *secretInspectContext) UpdatedAt() string {
-	return command.PrettyPrint(ctx.Secret.UpdatedAt)
+	return formatter.PrettyPrint(ctx.Secret.UpdatedAt)
 }

--- a/cli/command/task/formatter.go
+++ b/cli/command/task/formatter.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/pkg/stringid"
@@ -110,12 +109,12 @@ func (c *taskContext) Node() string {
 }
 
 func (c *taskContext) DesiredState() string {
-	return command.PrettyPrint(c.task.DesiredState)
+	return formatter.PrettyPrint(c.task.DesiredState)
 }
 
 func (c *taskContext) CurrentState() string {
 	return fmt.Sprintf("%s %s ago",
-		command.PrettyPrint(c.task.Status.State),
+		formatter.PrettyPrint(c.task.Status.State),
 		strings.ToLower(units.HumanDuration(time.Since(c.task.Status.Timestamp))),
 	)
 }

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -51,30 +51,6 @@ func CopyToFile(outfile string, r io.Reader) error {
 	return nil
 }
 
-// capitalizeFirst capitalizes the first character of string
-func capitalizeFirst(s string) string {
-	switch l := len(s); l {
-	case 0:
-		return s
-	case 1:
-		return strings.ToLower(s)
-	default:
-		return strings.ToUpper(string(s[0])) + strings.ToLower(s[1:])
-	}
-}
-
-// PrettyPrint outputs arbitrary data for human formatted output by uppercasing the first letter.
-func PrettyPrint(i any) string {
-	switch t := i.(type) {
-	case nil:
-		return "None"
-	case string:
-		return capitalizeFirst(t)
-	default:
-		return capitalizeFirst(fmt.Sprintf("%s", t))
-	}
-}
-
 var ErrPromptTerminated = errdefs.Cancelled(errors.New("prompt terminated"))
 
 // DisableInputEcho disables input echo on the provided streams.In.


### PR DESCRIPTION
This utility was only used internally, and has no external consumers; move it to the "formatter" package, which is also imported in all files using this utility.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: move PrettyPrint utility to cli/command/formatter
```

**- A picture of a cute animal (not mandatory but encouraged)**

