### PR TITLE
cli/command: PruneFilters: require smaller interface

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/filters"
 	mounttypes "github.com/docker/docker/api/types/mount"
@@ -166,11 +167,12 @@ func PromptForConfirmation(ctx context.Context, ins io.Reader, outs io.Writer, m
 }
 
 // PruneFilters returns consolidated prune filters obtained from config.json and cli
-func PruneFilters(dockerCli Cli, pruneFilters filters.Args) filters.Args {
-	if dockerCli.ConfigFile() == nil {
+func PruneFilters(dockerCLI config.Provider, pruneFilters filters.Args) filters.Args {
+	cfg := dockerCLI.ConfigFile()
+	if cfg == nil {
 		return pruneFilters
 	}
-	for _, f := range dockerCli.ConfigFile().PruneFilters {
+	for _, f := range cfg.PruneFilters {
 		k, v, ok := strings.Cut(f, "=")
 		if !ok {
 			continue


### PR DESCRIPTION
This function only needs access to the CLI's configfile; use the config.Prider interface to be more clear on what's expected.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

