### PR TITLE
cli/command/formatter: add missing go:build tag

### DIFF
--- a/cli/command/formatter/displayutils.go
+++ b/cli/command/formatter/displayutils.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package formatter
 
 import (


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5916
- relates to https://github.com/docker/buildx/pull/3033


Alternatively, we could add another build-tag, but this probably is less impactful.

    vendor/github.com/docker/cli/cli/command/formatter/displayutils.go:78:20: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

