### PR TITLE
vendor.mod: update minimum go version to go1.23

### DIFF
--- a/scripts/vendor
+++ b/scripts/vendor
@@ -18,7 +18,7 @@ init() {
   cat > go.mod <<EOL
 module github.com/docker/cli
 
-go 1.22.0
+go 1.23.0
 EOL
 }
 

--- a/vendor.mod
+++ b/vendor.mod
@@ -4,7 +4,7 @@ module github.com/docker/cli
 // There is no 'go.mod' file, as that would imply opting in for all the rules
 // around SemVer, which this repo cannot abide by as it uses CalVer.
 
-go 1.22.0
+go 1.23.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
- subset of https://github.com/docker/cli/pull/5868
- relates to https://github.com/docker/cli/pull/5869
- relates to https://github.com/moby/moby/pull/49541


Go maintainers started to unconditionally update the minimum go version for golang.org/x/ dependencies to go1.23, which means that we'll no longer be able to support any version below that when updating those dependencies;

> all: upgrade go directive to at least 1.23.0 [generated]
>
> By now Go 1.24.0 has been released, and Go 1.22 is no longer supported
> per the Go Release Policy (https://go.dev/doc/devel/release#policy).
>
> For golang/go#69095.

This updates our minimum version to go1.23, as we won't be able to maintain compatibility with older versions because of the above.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

