### PR TITLE
cli-plugins/manager: ignore broken symlinks

### DIFF
--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -38,7 +38,7 @@ func TestListPluginCandidates(t *testing.T) {
 			"plugins3-target", // Will be referenced as a symlink from below
 			fs.WithFile("docker-plugin1", ""),
 			fs.WithDir("ignored3"),
-			fs.WithSymlink("docker-brokensymlink", "broken"),           // A broken symlink is still a candidate (but would fail tests later)
+			fs.WithSymlink("docker-brokensymlink", "broken"),           // A broken symlink is ignored
 			fs.WithFile("non-plugin-symlinked", ""),                    // This shouldn't appear, but ...
 			fs.WithSymlink("docker-symlinked", "non-plugin-symlinked"), // ... this link to it should.
 		),
@@ -71,9 +71,6 @@ func TestListPluginCandidates(t *testing.T) {
 		},
 		"hardlink2": {
 			dir.Join("plugins2", "docker-hardlink2"),
-		},
-		"brokensymlink": {
-			dir.Join("plugins3", "docker-brokensymlink"),
 		},
 		"symlinked": {
 			dir.Join("plugins3", "docker-symlinked"),


### PR DESCRIPTION
Before this patch, a broken symlink would print a warning;

    docker info > /dev/null
    WARNING: Plugin "/Users/thajeztah/.docker/cli-plugins/docker-feedback" is not valid: failed to fetch metadata: fork/exec /Users/thajeztah/.docker/cli-plugins/docker-feedback: no such file or directory

After this patch, such symlinks are ignored:

    docker info > /dev/null

With debug enabled, we don't ignore the faulty plugin, which will
make the warning shown on docker info;

    mkdir -p ~/.docker/cli-plugins
    ln -s nosuchplugin ~/.docker/cli-plugins/docker-brokenplugin
    docker --debug info
    Client:
     Version:    29.0.0-dev
     Context:    default
     Debug Mode: true
     Plugins:
      buildx: Docker Buildx (Docker Inc.)
        Version:  v0.25.0
        Path:     /usr/libexec/docker/cli-plugins/docker-buildx
    WARNING: Plugin "/Users/thajeztah/.docker/cli-plugins/docker-brokenplugin" is not valid: failed to fetch metadata: fork/exec /Users/thajeztah/.docker/cli-plugins/docker-brokenplugin: no such file or directory

        # ...

We should als consider passing a "seen" map to de-duplicate entries. Entries can be either a direct symlink or in a symlinked path (for which we can filepath.EvalSymlinks). We need to benchmark the overhead of resolving the symlink vs possibly calling the plugin (to get their metadata) further down the line.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

