### PR TITLE
docker images --tree: hide both untagged and dangling images by default

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -135,6 +135,14 @@ func runImages(ctx context.Context, dockerCLI command.Cli, options imagesOptions
 	return nil
 }
 
+// isDangling is a copy of [formatter.isDangling].
+func isDangling(img image.Summary) bool {
+	if len(img.RepoTags) == 0 && len(img.RepoDigests) == 0 {
+		return true
+	}
+	return len(img.RepoTags) == 1 && img.RepoTags[0] == "<none>:<none>" && len(img.RepoDigests) == 1 && img.RepoDigests[0] == "<none>@<none>"
+}
+
 // printAmbiguousHint prints an informational warning if the provided filter
 // argument is ambiguous.
 //

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -1,8 +1,12 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.22
+
 package image
 
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -37,6 +41,9 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) error
 	})
 	if err != nil {
 		return err
+	}
+	if !opts.all {
+		images = slices.DeleteFunc(images, isDangling)
 	}
 
 	view := treeView{


### PR DESCRIPTION
Before this patch, `docker image ls` / `docker image ls` would always show untagged images, but hide "dangling" images (which effectively only were produced by the legacy builder) unless `-a` / `--all` was used. This often resulted in many `<none>:<none>` or `<untagged>` images to be shown, which had little value to interact with, other than to garbage collect (`docker system prune`).


For now, this patch only changes the behavior for `docker image ls --tree`, but we should make this the same for "non" --tree as well.

In future, we want to take more advantage of containerd's garbage-collecting features (removing unused images automatically), and this UX change is a stepping stone toward that.

This patch:

- changes `docker image ls` to hide both "untagged" and "dangling" images by default.
- changes the behavior of `--all` on the client side to make them visible

The API response remains the same for now, but this is something we can consider changing in future (possibly more granular than a single boolean).

Before this patch;

    docker image ls --tree
                                                                           i Info →   U  In Use

    IMAGE                                      ID             DISK USAGE   CONTENT SIZE   EXTRA
    docker:cli                                 28fb556c1ea1        276MB         69.8MB
    ├─ linux/amd64                             828f4f57525d           0B             0B
    ├─ linux/arm/v6                            563c0b58e54b           0B             0B
    ├─ linux/arm/v7                            6045d4846c59           0B             0B
    └─ linux/arm64/v8                          11e8dfd68841        276MB         69.8MB

    alpine:latest                              a8560b36e8b8       12.8MB         3.99MB    U
    ├─ linux/amd64                             1c4eef651f65           0B             0B
    ├─ linux/arm/v6                            903bfe2ae994           0B             0B
    ├─ linux/arm/v7                            9c2d245b3c01           0B             0B
    ├─ linux/arm64/v8                          757d680068d7       12.8MB         3.99MB    U
    ├─ linux/386                               2436f2b3b7d2           0B             0B
    ├─ linux/ppc64le                           9ed53fd3b831           0B             0B
    ├─ linux/riscv64                           1de5eb4a9a67           0B             0B
    └─ linux/s390x                             fe0dcdd1f783           0B             0B

    <untagged>                                 c6c1bcb0fd8d       12.8MB         3.99MB
    └─ linux/arm64                             cb171c618ae8       12.8MB         3.99MB

    <untagged>                                 7361ef970703       12.8MB         3.99MB
    └─ linux/arm64                             07033f43e44a       12.8MB         3.99MB

    <untagged>                                 0c62c63b81ec       12.8MB         3.99MB
    └─ linux/arm64                             94742272117f       12.8MB         3.99MB

    <untagged>                                 91dd947eebd0       12.8MB         3.99MB
    └─ linux/arm64                             ee55d203e26f       12.8MB         3.99MB

    <untagged>                                 382d9f57e8d8       12.8MB         3.99MB
    └─ linux/arm64                             5256d47804e3       12.8MB         3.99MB

    <untagged>                                 56fa17d2a7e7       12.8MB         3.99MB
    ├─ linux/amd64                             483f502c0e6a           0B             0B
    ├─ linux/arm/v6                            c79529000bdf           0B             0B
    ├─ linux/arm/v7                            cc455d4b2c47           0B             0B
    ├─ linux/arm64/v8                          508c1b94e1d2       12.8MB         3.99MB
    ├─ linux/386                               f32403957113           0B             0B
    ├─ linux/ppc64le                           23dbce23b88f           0B             0B
    ├─ linux/riscv64                           f9d2da150cee           0B             0B
    └─ linux/s390x                             6bb03952a007           0B             0B

After this patch

    docker image ls --tree
                                                                           i Info →   U  In Use

    IMAGE                                      ID             DISK USAGE   CONTENT SIZE   EXTRA
    docker:cli                                 28fb556c1ea1        276MB         69.8MB
    ├─ linux/amd64                             828f4f57525d           0B             0B
    ├─ linux/arm/v6                            563c0b58e54b           0B             0B
    ├─ linux/arm/v7                            6045d4846c59           0B             0B
    └─ linux/arm64/v8                          11e8dfd68841        276MB         69.8MB

    alpine:latest                              a8560b36e8b8       12.8MB         3.99MB    U
    ├─ linux/amd64                             1c4eef651f65           0B             0B
    ├─ linux/arm/v6                            903bfe2ae994           0B             0B
    ├─ linux/arm/v7                            9c2d245b3c01           0B             0B
    ├─ linux/arm64/v8                          757d680068d7       12.8MB         3.99MB    U
    ├─ linux/386                               2436f2b3b7d2           0B             0B
    ├─ linux/ppc64le                           9ed53fd3b831           0B             0B
    ├─ linux/riscv64                           1de5eb4a9a67           0B             0B
    └─ linux/s390x                             fe0dcdd1f783           0B             0B

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`docker images --tree`: hide both untagged and dangling images by default
```

**- A picture of a cute animal (not mandatory but encouraged)**

