### PR TITLE
image/inspect: Add --platform flag

### DIFF
--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/containerd/platforms"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -14,12 +15,14 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
 )
 
 type inspectOptions struct {
-	format string
-	refs   []string
+	format   string
+	refs     []string
+	platform string
 }
 
 // newInspectCommand creates a new cobra.Command for `docker image inspect`
@@ -39,14 +42,36 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
+
+	// Don't default to DOCKER_DEFAULT_PLATFORM env variable, always default to
+	// inspecting the image as-is. This also avoids forcing the platform selection
+	// on older APIs which don't support it.
+	flags.StringVar(&opts.platform, "platform", "", `Inspect a specific platform of the multi-platform image.
+If the image or the server is not multi-platform capable, the command will error out if the platform does not match.
+'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)`)
+	flags.SetAnnotation("platform", "version", []string{"1.49"})
+
+	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 	return cmd
 }
 
 func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	var platform *ocispec.Platform
+	if opts.platform != "" {
+		p, err := platforms.Parse(opts.platform)
+		if err != nil {
+			return err
+		}
+		platform = &p
+	}
+
 	apiClient := dockerCLI.Client()
 	return inspect.Inspect(dockerCLI.Out(), opts.refs, opts.format, func(ref string) (any, []byte, error) {
 		var buf bytes.Buffer
-		resp, err := apiClient.ImageInspect(ctx, ref, client.ImageInspectWithRawResponse(&buf))
+		resp, err := apiClient.ImageInspect(ctx, ref,
+			client.ImageInspectWithRawResponse(&buf),
+			client.ImageInspectWithPlatform(platform),
+		)
 		if err != nil {
 			return image.InspectResponse{}, nil, err
 		}

--- a/docs/reference/commandline/image_inspect.md
+++ b/docs/reference/commandline/image_inspect.md
@@ -8,6 +8,7 @@ Display detailed information on one or more images
 | Name             | Type     | Default | Description                                                                                                                                                                                                                                                        |
 |:-----------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-f`, `--format` | `string` |         | Format output using a custom template:<br>'json':             Print in JSON format<br>'TEMPLATE':         Print output using the given Go template.<br>Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates |
+| `--platform`     | `string` |         | Inspect a specific platform of the multi-platform image.<br>If the image or the server is not multi-platform capable, the command will error out if the platform does not match.<br>'os[/arch[/variant]]': Explicit platform (eg. linux/amd64)                     |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
- follow up to: https://github.com/moby/moby/pull/49586

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`docker image inspect` now supports a `--platform` flag to inspect a specific platform of a multi-platform image.
```

**- A picture of a cute animal (not mandatory but encouraged)**

