### PR TITLE
cli-plugins/manager: minor cleanups and refactoring

### DIFF
--- a/cli-plugins/manager/hooks.go
+++ b/cli-plugins/manager/hooks.go
@@ -64,10 +64,7 @@ func invokeAndCollectHooks(ctx context.Context, cfg *configfile.ConfigFile, root
 		return nil
 	}
 
-	pluginDirs, err := getPluginDirs(cfg)
-	if err != nil {
-		return nil
-	}
+	pluginDirs := getPluginDirs(cfg)
 	nextSteps := make([]string, 0, len(pluginsCfg))
 	for pluginName, pluginCfg := range pluginsCfg {
 		match, ok := pluginMatch(pluginCfg, subCmdStr)

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -61,20 +61,16 @@ func IsNotFound(err error) bool {
 // 3. Platform-specific defaultSystemPluginDirs.
 //
 // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
-func getPluginDirs(cfg *configfile.ConfigFile) ([]string, error) {
+func getPluginDirs(cfg *configfile.ConfigFile) []string {
 	var pluginDirs []string
 
 	if cfg != nil {
 		pluginDirs = append(pluginDirs, cfg.CLIPluginsExtraDirs...)
 	}
-	pluginDir, err := config.Path("cli-plugins")
-	if err != nil {
-		return nil, err
-	}
-
+	pluginDir := filepath.Join(config.Dir(), "cli-plugins")
 	pluginDirs = append(pluginDirs, pluginDir)
 	pluginDirs = append(pluginDirs, defaultSystemPluginDirs...)
-	return pluginDirs, nil
+	return pluginDirs
 }
 
 func addPluginCandidatesFromDir(res map[string][]string, d string) {
@@ -116,10 +112,7 @@ func listPluginCandidates(dirs []string) map[string][]string {
 
 // GetPlugin returns a plugin on the system by its name
 func GetPlugin(name string, dockerCLI config.Provider, rootcmd *cobra.Command) (*Plugin, error) {
-	pluginDirs, err := getPluginDirs(dockerCLI.ConfigFile())
-	if err != nil {
-		return nil, err
-	}
+	pluginDirs := getPluginDirs(dockerCLI.ConfigFile())
 	return getPlugin(name, pluginDirs, rootcmd)
 }
 
@@ -145,11 +138,7 @@ func getPlugin(name string, pluginDirs []string, rootcmd *cobra.Command) (*Plugi
 
 // ListPlugins produces a list of the plugins available on the system
 func ListPlugins(dockerCli config.Provider, rootcmd *cobra.Command) ([]Plugin, error) {
-	pluginDirs, err := getPluginDirs(dockerCli.ConfigFile())
-	if err != nil {
-		return nil, err
-	}
-
+	pluginDirs := getPluginDirs(dockerCli.ConfigFile())
 	candidates := listPluginCandidates(pluginDirs)
 	if len(candidates) == 0 {
 		return nil, nil
@@ -210,10 +199,7 @@ func PluginRunCommand(dockerCli config.Provider, name string, rootcmd *cobra.Com
 		return nil, errPluginNotFound(name)
 	}
 	exename := addExeSuffix(metadata.NamePrefix + name)
-	pluginDirs, err := getPluginDirs(dockerCli.ConfigFile())
-	if err != nil {
-		return nil, err
-	}
+	pluginDirs := getPluginDirs(dockerCli.ConfigFile())
 
 	for _, d := range pluginDirs {
 		path := filepath.Join(d, exename)

--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -173,14 +173,11 @@ func TestErrPluginNotFound(t *testing.T) {
 func TestGetPluginDirs(t *testing.T) {
 	cli := test.NewFakeCli(nil)
 
-	pluginDir, err := config.Path("cli-plugins")
-	assert.NilError(t, err)
+	pluginDir := filepath.Join(config.Dir(), "cli-plugins")
 	expected := append([]string{pluginDir}, defaultSystemPluginDirs...)
 
-	var pluginDirs []string
-	pluginDirs, err = getPluginDirs(cli.ConfigFile())
+	pluginDirs := getPluginDirs(cli.ConfigFile())
 	assert.Equal(t, strings.Join(expected, ":"), strings.Join(pluginDirs, ":"))
-	assert.NilError(t, err)
 
 	extras := []string{
 		"foo", "bar", "baz",
@@ -189,7 +186,6 @@ func TestGetPluginDirs(t *testing.T) {
 	cli.SetConfigFile(&configfile.ConfigFile{
 		CLIPluginsExtraDirs: extras,
 	})
-	pluginDirs, err = getPluginDirs(cli.ConfigFile())
+	pluginDirs = getPluginDirs(cli.ConfigFile())
 	assert.DeepEqual(t, expected, pluginDirs)
-	assert.NilError(t, err)
 }


### PR DESCRIPTION
### cli-plugins/manager: ListPlugins: pass context to error-group

This error-group was added in 89583b92b74ec3c2dfe770b0c01437b1e373c1aa, but
passed a context.TODO because the function didn't have a context as argument.

However, it does get the root-command passed, which holds the context, so
we can pass that.


### cli-plugins/manager: rename var that shadowed arg in test

### cli-plugins/manager: add test for empty / non-existing plugin dirs

Verify that listPluginCandidates returns an empty result if nothing was
found.

### cli-plugins/manager: ListPlugins: return early if no candidates

Skip the other logic, which includes listing all commands provided; if
there's no plugin-candidates, those steps won't be needed.



### cli-plugins/manager: getPluginDirs: remove redundant error-return

This function returned an error (if any) from [config.Path]. However, the
only situation in which an error could be returned was if the given path
to append to `config.Dir` was outside of the config directory. This can
only happen if the path to append would try to traverse directories (e.g.,
passing `../../cli-plugins`).

Given that we're passing a hard-coded value, that would not be the case,
so we can simplify the code to join the path directly, and don't have to
handle errors.

[config.Path]: https://github.com/docker/cli/blob/2d74733942be353bc7730c8722ae2414f368b732/cli/config/config.go#L100-L107

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

