### PR TITLE
cmd/dockerd: use stdlib errors

### DIFF
--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli/command"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -26,11 +26,11 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 
 	for k, v := range aliasMap {
 		if _, ok := allowedAliases[k]; !ok {
-			return args, osArgs, envs, errors.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
+			return args, osArgs, envs, fmt.Errorf("not allowed to alias %q (allowed: %#v)", k, allowedAliases)
 		}
 		if c, _, err := cmd.Find(strings.Split(v, " ")); err == nil {
 			if !pluginmanager.IsPluginCommand(c) {
-				return args, osArgs, envs, errors.Errorf("not allowed to alias with builtin %q as target", v)
+				return args, osArgs, envs, fmt.Errorf("not allowed to alias with builtin %q as target", v)
 			}
 		}
 		aliases = append(aliases, [2][]string{{k}, {v}})

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -51,7 +51,7 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	if v := os.Getenv("DOCKER_BUILDKIT"); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
-			return args, osargs, nil, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+			return args, osargs, nil, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w", err)
 		}
 		if !enabled {
 			buildKitDisabled = true

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"syscall"
@@ -12,7 +13,6 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/debug"
 	platformsignals "github.com/docker/cli/cmd/docker/internal/signals"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"


### PR DESCRIPTION
This package is not imported externally, and we don't need the added functionality of pkg/errors here, so use stdlib errors.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

