### PR TITLE
add top-level "docker bake" command as alias for "docker buildx bake"

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -23,3 +23,22 @@ func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
 	)
 	return cmd
 }
+
+// NewBakeStubCommand returns a cobra command "stub" for the "bake" subcommand.
+// This command is a placeholder / stub that is dynamically replaced by an
+// alias for "docker buildx bake" if BuildKit is enabled (and the buildx plugin
+// installed).
+func NewBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
+	return &cobra.Command{
+		Use:   "bake [OPTIONS] [TARGET...]",
+		Short: "Build from a file",
+		RunE:  command.ShowHelp(dockerCLI.Err()),
+		Annotations: map[string]string{
+			// We want to show this command in the "top" category in --help
+			// output, and not to be grouped under "management commands".
+			"category-top": "5",
+			"aliases":      "docker buildx bake",
+			"version":      "1.31",
+		},
+	}
+}

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -43,6 +43,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		system.NewInfoCommand(dockerCli),
 
 		// management commands
+		builder.NewBakeStubCommand(dockerCli),
 		builder.NewBuilderCommand(dockerCli),
 		checkpoint.NewCheckpointCommand(dockerCli),
 		container.NewContainerCommand(dockerCli),

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -247,6 +247,12 @@ func setHelpFunc(dockerCli command.Cli, cmd *cobra.Command) {
 			}
 		}
 
+		// FIXME(thaJeztah): need a better way for this; hiding the command here, so that it's present" by default for generating docs etc.
+		if c, _, err := ccmd.Find([]string{"buildx"}); c == nil || err != nil {
+			if b, _, _ := ccmd.Find([]string{"bake"}); b != nil {
+				b.Hidden = true
+			}
+		}
 		if err := isSupported(ccmd, dockerCli); err != nil {
 			ccmd.Println(err)
 			return

--- a/docs/reference/commandline/bake.md
+++ b/docs/reference/commandline/bake.md
@@ -1,0 +1,12 @@
+# docker bake
+
+<!---MARKER_GEN_START-->
+Build from a file
+
+### Aliases
+
+`docker buildx bake`
+
+
+<!---MARKER_GEN_END-->
+

--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -8,6 +8,7 @@ The base command for the Docker CLI.
 | Name                          | Description                                                                   |
 |:------------------------------|:------------------------------------------------------------------------------|
 | [`attach`](attach.md)         | Attach local standard input, output, and error streams to a running container |
+| [`bake`](bake.md)             | Build from a file                                                             |
 | [`build`](build.md)           | Build an image from a Dockerfile                                              |
 | [`builder`](builder.md)       | Manage builds                                                                 |
 | [`checkpoint`](checkpoint.md) | Manage checkpoints                                                            |


### PR DESCRIPTION
The [`docker buildx bake`][1] command has reached GA; this patch adds a top-level `docker bake` command as alias for `docker buildx bake` to improve discoverability and make it more convenient to use.

With this patch:

    docker --help

    Usage:  docker [OPTIONS] COMMAND

    A self-sufficient runtime for containers

    Common Commands:
      run         Create and run a new container from an image
      exec        Execute a command in a running container
      ps          List containers
      build       Build an image from a Dockerfile
      bake        Build from a file
      pull        Download an image from a registry
      push        Upload an image to a registry
      images      List images
    ...

The command is hidden if buildx is not installed;

    docker --help
    Usage:  docker [OPTIONS] COMMAND

    A self-sufficient runtime for containers

    Common Commands:
      run         Create and run a new container from an image
      exec        Execute a command in a running container
      ps          List containers
      build       Build an image from a Dockerfile
      pull        Download an image from a registry
      push        Upload an image to a registry
      images      List images
    ...

We can do some tweaking after this; currently it show an error in situations where buildx is missing. We don't account for "DOCKER_BUILDKIT=0", because this is a new feature that requires buildx, and cannot be "disabled";

buildx missing;

    docker bake
    ERROR: bake requires the buildx component but it is missing or broken.
           Install the buildx component to use bake:
           https://docs.docker.com/go/buildx/

BuildKit disabled:

    DOCKER_BUILDKIT=0 docker bake
    ERROR: bake requires the buildx component but it is missing or broken.

[1]: https://www.docker.com/blog/ga-launch-docker-bake/

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add `docker bake` subcommand as alias for `docker buildx bake`
```

**- A picture of a cute animal (not mandatory but encouraged)**

