### PR TITLE
cli/command/registry: loginClientSide: use locally defined message

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -263,13 +263,13 @@ func loginClientSide(ctx context.Context, auth registrytypes.AuthConfig) (*regis
 		return nil, err
 	}
 
-	status, token, err := svc.Auth(ctx, &auth, command.UserAgent())
+	_, token, err := svc.Auth(ctx, &auth, command.UserAgent())
 	if err != nil {
 		return nil, err
 	}
 
 	return &registrytypes.AuthenticateOKBody{
-		Status:        status,
+		Status:        "Login Succeeded",
 		IdentityToken: token,
 	}, nil
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49694


The "Service.Auth" pretended to return a message from the registry, but the message returned is hard-coded in the registry package.

Remove its use to make this more transparent, and not to pretend this is anything returned by the registry.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

