### PR TITLE
cli/registry/client: skip RepositoryInfo as intermediate

### DIFF
--- a/cli/registry/client/client.go
+++ b/cli/registry/client/client.go
@@ -147,7 +147,7 @@ func (c *client) getRepositoryForReference(ctx context.Context, ref reference.Na
 
 func (c *client) getHTTPTransportForRepoEndpoint(ctx context.Context, repoEndpoint repositoryEndpoint) (http.RoundTripper, error) {
 	httpTransport, err := getHTTPTransport(
-		c.authConfigResolver(ctx, repoEndpoint.info.Index),
+		c.authConfigResolver(ctx, repoEndpoint.indexInfo),
 		repoEndpoint.endpoint,
 		repoEndpoint.Name(),
 		c.userAgent,

--- a/cli/registry/client/fetcher.go
+++ b/cli/registry/client/fetcher.go
@@ -220,7 +220,9 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 		return err
 	}
 
+	repoName := reference.TrimNamed(namedRef)
 	repoInfo, _ := registry.ParseRepositoryInfo(namedRef)
+	indexInfo := repoInfo.Index
 
 	confirmedTLSRegistries := make(map[string]bool)
 	for _, endpoint := range endpoints {
@@ -234,7 +236,11 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 		if c.insecureRegistry {
 			endpoint.TLSConfig.InsecureSkipVerify = true
 		}
-		repoEndpoint := repositoryEndpoint{endpoint: endpoint, info: repoInfo}
+		repoEndpoint := repositoryEndpoint{
+			repoName:  repoName,
+			indexInfo: indexInfo,
+			endpoint:  endpoint,
+		}
 		repo, err := c.getRepositoryForReference(ctx, namedRef, repoEndpoint)
 		if err != nil {
 			logrus.Debugf("error %s with repo endpoint %+v", err, repoEndpoint)


### PR DESCRIPTION
Remove RepositoryInfo as intermediate struct in some places; we want to remove the use of this additional abstration. More changes are needed to fully remove it, but chipping away its use in small bits.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

