### PR TITLE
Revert "cli/command: remove uses of GetAuthConfigKey, ParseRepositoryInfo"

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/tui"
 	registrytypes "github.com/docker/docker/api/types/registry"
+	"github.com/docker/docker/registry"
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 )
@@ -27,22 +28,16 @@ const (
 		"for organizations using SSO. Learn more at https://docs.docker.com/go/access-tokens/"
 )
 
-// authConfigKey is the key used to store credentials for Docker Hub. It is
-// a copy of [registry.IndexServer].
-//
-// [registry.IndexServer]: https://pkg.go.dev/github.com/docker/docker/registry#IndexServer
-const authConfigKey = "https:/index.docker.io/v1/"
-
 // RegistryAuthenticationPrivilegedFunc returns a RequestPrivilegeFunc from the specified registry index info
 // for the given command.
 func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInfo, cmdName string) registrytypes.RequestAuthConfig {
-	configKey := getAuthConfigKey(index.Name)
-	isDefaultRegistry := configKey == authConfigKey || index.Official
 	return func(ctx context.Context) (string, error) {
 		_, _ = fmt.Fprintf(cli.Out(), "\nLogin prior to %s:\n", cmdName)
-		authConfig, err := GetDefaultAuthConfig(cli.ConfigFile(), true, configKey, isDefaultRegistry)
+		indexServer := registry.GetAuthConfigKey(index)
+		isDefaultRegistry := indexServer == registry.IndexServer
+		authConfig, err := GetDefaultAuthConfig(cli.ConfigFile(), true, indexServer, isDefaultRegistry)
 		if err != nil {
-			_, _ = fmt.Fprintf(cli.Err(), "Unable to retrieve stored credentials for %s, error: %s.\n", authConfigKey, err)
+			_, _ = fmt.Fprintf(cli.Err(), "Unable to retrieve stored credentials for %s, error: %s.\n", indexServer, err)
 		}
 
 		select {
@@ -51,7 +46,7 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
 		default:
 		}
 
-		authConfig, err = PromptUserForCredentials(ctx, cli, "", "", authConfig.Username, authConfigKey)
+		authConfig, err = PromptUserForCredentials(ctx, cli, "", "", authConfig.Username, indexServer)
 		if err != nil {
 			return "", err
 		}
@@ -68,7 +63,7 @@ func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInf
 func ResolveAuthConfig(cfg *configfile.ConfigFile, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
 	configKey := index.Name
 	if index.Official {
-		configKey = authConfigKey
+		configKey = registry.IndexServer
 	}
 
 	a, _ := cfg.GetAuthConfig(configKey)
@@ -137,7 +132,7 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 
 	argUser = strings.TrimSpace(argUser)
 	if argUser == "" {
-		if serverAddress == authConfigKey {
+		if serverAddress == registry.IndexServer {
 			// When signing in to the default (Docker Hub) registry, we display
 			// hints for creating an account, and (if hints are enabled), using
 			// a token instead of a password.
@@ -230,25 +225,9 @@ func resolveAuthConfigFromImage(cfg *configfile.ConfigFile, image string) (regis
 	if err != nil {
 		return registrytypes.AuthConfig{}, err
 	}
-	configKey := getAuthConfigKey(reference.Domain(registryRef))
-	a, err := cfg.GetAuthConfig(configKey)
+	repoInfo, err := registry.ParseRepositoryInfo(registryRef)
 	if err != nil {
 		return registrytypes.AuthConfig{}, err
 	}
-	return registrytypes.AuthConfig(a), nil
-}
-
-// getAuthConfigKey special-cases using the full index address of the official
-// index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
-//
-// It is similar to [registry.GetAuthConfigKey], but does not require on
-// [registrytypes.IndexInfo] as intermediate.
-//
-// [registry.GetAuthConfigKey]: https://pkg.go.dev/github.com/docker/docker/registry#GetAuthConfigKey
-// [registrytypes.IndexInfo]:https://pkg.go.dev/github.com/docker/docker/api/types/registry#IndexInfo
-func getAuthConfigKey(domainName string) string {
-	if domainName == "docker.io" || domainName == "index.docker.io" {
-		return authConfigKey
-	}
-	return domainName
+	return ResolveAuthConfig(cfg, repoInfo.Index), nil
 }


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/issues/5963
- reverts https://github.com/docker/cli/pull/5942

This reverts commit 79141ce5eb8f7c341b03aa50f7ce4b819de20720.

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>