### PR TITLE
cli/command/service: un-export CompletionFn

### DIFF
--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -1,12 +1,8 @@
 package service
 
 import (
-	"os"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/completion"
-	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -34,28 +30,4 @@ func NewServiceCommand(dockerCli command.Cli) *cobra.Command {
 		newRollbackCommand(dockerCli),
 	)
 	return cmd
-}
-
-// CompletionFn offers completion for swarm service names and optional IDs.
-// By default, only names are returned.
-// Set DOCKER_COMPLETION_SHOW_SERVICE_IDS=yes to also complete IDs.
-func CompletionFn(dockerCLI completion.APIClientProvider) cobra.CompletionFunc {
-	// https://github.com/docker/cli/blob/f9ced58158d5e0b358052432244b483774a1983d/contrib/completion/bash/docker#L41-L43
-	showIDs := os.Getenv("DOCKER_COMPLETION_SHOW_SERVICE_IDS") == "yes"
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		list, err := dockerCLI.Client().ServiceList(cmd.Context(), types.ServiceListOptions{})
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		names := make([]string, 0, len(list))
-		for _, service := range list {
-			if showIDs {
-				names = append(names, service.Spec.Name, service.ID)
-			} else {
-				names = append(names, service.Spec.Name)
-			}
-		}
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
 }

--- a/cli/command/service/completion.go
+++ b/cli/command/service/completion.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"os"
+
+	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/cobra"
+)
+
+// completeServiceNames offers completion for swarm service names and optional IDs.
+// By default, only names are returned.
+// Set DOCKER_COMPLETION_SHOW_SERVICE_IDS=yes to also complete IDs.
+func completeServiceNames(dockerCLI completion.APIClientProvider) cobra.CompletionFunc {
+	// https://github.com/docker/cli/blob/f9ced58158d5e0b358052432244b483774a1983d/contrib/completion/bash/docker#L41-L43
+	showIDs := os.Getenv("DOCKER_COMPLETION_SHOW_SERVICE_IDS") == "yes"
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		list, err := dockerCLI.Client().ServiceList(cmd.Context(), types.ServiceListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := make([]string, 0, len(list))
+		for _, service := range list {
+			if showIDs {
+				names = append(names, service.Spec.Name, service.ID)
+			} else {
+				names = append(names, service.Spec.Name)
+			}
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -41,9 +41,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCli)(cmd, args, toComplete)
-		},
+		ValidArgsFunction: completeServiceNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -51,10 +51,8 @@ func newLogsCommand(dockerCli command.Cli) *cobra.Command {
 			opts.target = args[0]
 			return runLogs(cmd.Context(), dockerCli, &opts)
 		},
-		Annotations: map[string]string{"version": "1.29"},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCli)(cmd, args, toComplete)
-		},
+		Annotations:       map[string]string{"version": "1.29"},
+		ValidArgsFunction: completeServiceNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -39,9 +39,7 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 			options.services = args
 			return runPS(cmd.Context(), dockerCli, options)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCli)(cmd, args, toComplete)
-		},
+		ValidArgsFunction: completeServiceNames(dockerCli),
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display task IDs")

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -19,9 +19,7 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), dockerCli, args)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCli)(cmd, args, toComplete)
-		},
+		ValidArgsFunction: completeServiceNames(dockerCli),
 	}
 	cmd.Flags()
 

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -23,10 +23,8 @@ func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRollback(cmd.Context(), dockerCli, options, args[0])
 		},
-		Annotations: map[string]string{"version": "1.31"},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCli)(cmd, args, toComplete)
-		},
+		Annotations:       map[string]string{"version": "1.31"},
+		ValidArgsFunction: completeServiceNames(dockerCli),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -121,7 +121,7 @@ func runServiceScale(ctx context.Context, apiClient client.ServiceAPIClient, ser
 func completeScaleArgs(dockerCli command.Cli) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// reuse the existing logic for configurable completion of service names and IDs.
-		completions, directive := CompletionFn(dockerCli)(cmd, args, toComplete)
+		completions, directive := completeServiceNames(dockerCli)(cmd, args, toComplete)
 		if directive == cobra.ShellCompDirectiveError {
 			return completions, directive
 		}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -35,9 +35,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(cmd.Context(), dockerCLI, cmd.Flags(), options, args[0])
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return CompletionFn(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction: completeServiceNames(dockerCLI),
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
It's only used internally, and has no external consumers. Un-export it, rename it to something more descriptive, and move it to a separate file to align with other packages.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

