### PR TITLE
cli/command/image: deprecate RunPull and make internal

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -15,7 +15,10 @@ import (
 )
 
 // PullOptions defines what and how to pull
-type PullOptions struct {
+type PullOptions = pullOptions
+
+// pullOptions defines what and how to pull.
+type pullOptions struct {
 	remote    string
 	all       bool
 	platform  string
@@ -25,7 +28,7 @@ type PullOptions struct {
 
 // NewPullCommand creates a new `docker pull` command
 func NewPullCommand(dockerCli command.Cli) *cobra.Command {
-	var opts PullOptions
+	var opts pullOptions
 
 	cmd := &cobra.Command{
 		Use:   "pull [OPTIONS] NAME[:TAG|@DIGEST]",
@@ -33,7 +36,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return RunPull(cmd.Context(), dockerCli, opts)
+			return runPull(cmd.Context(), dockerCli, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "5",
@@ -57,6 +60,11 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 
 // RunPull performs a pull against the engine based on the specified options
 func RunPull(ctx context.Context, dockerCLI command.Cli, opts PullOptions) error {
+	return runPull(ctx, dockerCLI, opts)
+}
+
+// runPull performs a pull against the engine based on the specified options
+func runPull(ctx context.Context, dockerCLI command.Cli, opts pullOptions) error {
 	distributionRef, err := reference.ParseNormalizedNamed(opts.remote)
 	switch {
 	case err != nil:

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -45,7 +45,7 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return RunPush(cmd.Context(), dockerCli, opts)
+			return runPush(cmd.Context(), dockerCli, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "6",
@@ -73,8 +73,8 @@ Image index won't be pushed, meaning that other manifests, including attestation
 	return cmd
 }
 
-// RunPush performs a push against the engine based on the specified options
-func RunPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error {
+// runPush performs a push against the engine based on the specified options.
+func runPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error {
 	var platform *ocispec.Platform
 	out := tui.NewOutput(dockerCli.Out())
 	if opts.platform != "" {

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -29,7 +29,7 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.images = args
-			return RunSave(cmd.Context(), dockerCli, opts)
+			return runSave(cmd.Context(), dockerCli, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image save, docker save",
@@ -47,8 +47,8 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-// RunSave performs a save against the engine based on the specified options
-func RunSave(ctx context.Context, dockerCli command.Cli, opts saveOptions) error {
+// runSave performs a save against the engine based on the specified options
+func runSave(ctx context.Context, dockerCli command.Cli, opts saveOptions) error {
 	if opts.output == "" && dockerCli.Out().IsTerminal() {
 		return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
 	}

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -47,7 +47,7 @@ func pushTrustedReference(ctx context.Context, ioStreams command.Streams, repoIn
 }
 
 // trustedPull handles content trust pulling of an image
-func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts PullOptions) error {
+func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts pullOptions) error {
 	refs, err := getTrustedPullTargets(cli, imgRefAndAuth)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func trustedPull(ctx context.Context, cli command.Cli, imgRefAndAuth trust.Image
 		if err != nil {
 			return err
 		}
-		if err := imagePullPrivileged(ctx, cli, updatedImgRefAndAuth, PullOptions{
+		if err := imagePullPrivileged(ctx, cli, updatedImgRefAndAuth, pullOptions{
 			all:      false,
 			platform: opts.platform,
 			quiet:    opts.quiet,
@@ -144,7 +144,7 @@ func getTrustedPullTargets(cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth)
 }
 
 // imagePullPrivileged pulls the image and displays it to the output
-func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts PullOptions) error {
+func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth trust.ImageRefAndAuth, opts pullOptions) error {
 	encodedAuth, err := registrytypes.EncodeAuthConfig(*imgRefAndAuth.AuthConfig())
 	if err != nil {
 		return err


### PR DESCRIPTION
- relates to https://github.com/docker/runtime-team/issues/18
- relates to https://github.com/docker/cli/pull/1123
- relates to https://github.com/docker/app/pull/244
- relates to https://github.com/docker/cli/pull/1026


### cli/command/image: un-export RunPush

This function was exported in e43c7920ea950b0c8f2004bce114e71f7f993854
for use of "docker app", which is now deprecated. The signature of this
function also depended on a non-exported type, so it could not be used
externally.

Make it internal again, as it was never designed to be exported. There
are no known external consumers of this function.

### cli/command/image: un-export RunSave

This function was exported in e43c7920ea950b0c8f2004bce114e71f7f993854
for use of "docker app", which is now deprecated. The signature of this
function also depended on a non-exported type, so it could not be used
externally.

Make it internal again, as it was never designed to be exported. There
are no known external consumers of this function.


### cli/command/image: deprecate RunPull and make internal

This function was exported in 812f1136850f6c18bbe3f1b2a960a8ff8a8413f3
for use in other parts of the CLI, but it's now only used locally.

Make it internal again, as it was never designed to be exported. There
are no known external consumers of this function, but deprecating it
first, in case there are.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/image: Deprecate `RunPull`: this function was only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

