### PR TITLE
cli/command: move TestExperimentalCLI to cli/config

### DIFF
--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -398,6 +398,32 @@ func TestLoadDefaultConfigFile(t *testing.T) {
 	})
 }
 
+// The CLI no longer disables/hides experimental CLI features, however, we need
+// to verify that existing configuration files do not break
+func TestLoadLegacyExperimental(t *testing.T) {
+	tests := []struct {
+		doc        string
+		configfile string
+	}{
+		{
+			doc:        "default",
+			configfile: `{}`,
+		},
+		{
+			doc: "experimental",
+			configfile: `{
+	"experimental": "enabled"
+}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			_, err := LoadFromReader(strings.NewReader(tc.configfile))
+			assert.NilError(t, err)
+		})
+	}
+}
+
 func TestConfigPath(t *testing.T) {
 	oldDir := Dir()
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/2774

This test was only testing whether we could load a legacy config-file that contained the "experimental" (experimental CLI) option. Experimental cli options are disabled since 977d3ae046ec6c64be8788a8712251ed547a2bdb (20.10), and now enabled by default, but we should not fail to start the cli if the config-file contains the option.

Move the test to the config package, as it doesn't need the cli for this.

**- A picture of a cute animal (not mandatory but encouraged)**

