### PR TITLE
cli/config/configfile: deprecate ConfigFile.Experimental field

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -36,12 +36,14 @@ type ConfigFile struct {
 	NodesFormat          string                       `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                     `json:"pruneFilters,omitempty"`
 	Proxies              map[string]ProxyConfig       `json:"proxies,omitempty"`
-	Experimental         string                       `json:"experimental,omitempty"`
 	CurrentContext       string                       `json:"currentContext,omitempty"`
 	CLIPluginsExtraDirs  []string                     `json:"cliPluginsExtraDirs,omitempty"`
 	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
 	Aliases              map[string]string            `json:"aliases,omitempty"`
 	Features             map[string]string            `json:"features,omitempty"`
+
+	// Deprecated: experimental CLI features are always enabled and this field is no longer used. Use [Features] instead for optional features. This field will be removed in a future release.
+	Experimental string `json:"experimental,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/2774
- https://github.com/docker/cli/pull/2773
- https://github.com/docker/cli/pull/2776


Configuration options for experimental CLI features were deprecated in docker 19.03 (3172219932d5d8d8e68715b7495070a1c63f168b), and enabled by default since docker 20.10 (977d3ae046ec6c64be8788a8712251ed547a2bdb).

This deprecates the corresponding field in the config-file.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/config/configfile: deprecate `ConfigFile.Experimental` field. Experimental CLI features are always enabled since version v20.10 and this field is no longer used. Use `ConfigFile.Features` instead for optional features. This field will be removed in a future release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

