### PR TITLE
cli/command/container: TestNewPortCommandOutput: remove DCT

### DIFF
--- a/cli/command/container/port_test.go
+++ b/cli/command/container/port_test.go
@@ -65,7 +65,7 @@ func TestNewPortCommandOutput(t *testing.T) {
 					}
 					return ci, nil
 				},
-			}, test.EnableContentTrust)
+			})
 			cmd := NewPortCommand(cli)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs([]string{"some_container", tc.port})


### PR DESCRIPTION
This looks like a copy/paste from other tests, because this test does not test anything related to docker content trust.


**- A picture of a cute animal (not mandatory but encouraged)**

