### PR TITLE
context list: remove temporary ContextType from JSON output

### DIFF
--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -69,8 +69,6 @@ func runList(dockerCli command.Cli, opts *listOptions) error {
 				Name:    rawMeta.Name,
 				Current: isCurrent,
 				Error:   err.Error(),
-
-				ContextType: getContextType(nil, opts.format),
 			})
 			continue
 		}
@@ -85,8 +83,6 @@ func runList(dockerCli command.Cli, opts *listOptions) error {
 			Description:    meta.Description,
 			DockerEndpoint: dockerEndpoint.Host,
 			Error:          errMsg,
-
-			ContextType: getContextType(meta.AdditionalFields, opts.format),
 		}
 		contexts = append(contexts, &desc)
 	}
@@ -103,8 +99,6 @@ func runList(dockerCli command.Cli, opts *listOptions) error {
 			Name:    curContext,
 			Current: true,
 			Error:   errMsg,
-
-			ContextType: getContextType(nil, opts.format),
 		})
 	}
 	sort.Slice(contexts, func(i, j int) bool {
@@ -118,30 +112,6 @@ func runList(dockerCli command.Cli, opts *listOptions) error {
 			"To use a context, either set the global --context flag, or unset %[1]s environment variable.\n", client.EnvOverrideHost)
 	}
 	return nil
-}
-
-// getContextType sets the LegacyContextType field for compatibility with
-// Visual Studio, which depends on this field from the "cloud integration"
-// wrapper.
-//
-// https://github.com/docker/compose-cli/blob/c156ce6da4c2b317174d42daf1b019efa87e9f92/api/context/store/contextmetadata.go#L28-L34
-// https://github.com/docker/compose-cli/blob/c156ce6da4c2b317174d42daf1b019efa87e9f92/api/context/store/store.go#L34-L51
-//
-// TODO(thaJeztah): remove this and [ClientContext.ContextType] once Visual Studio is updated to no longer depend on this.
-func getContextType(meta map[string]any, format string) string {
-	if format != formatter.JSONFormat && format != formatter.JSONFormatKey {
-		// We only need the ContextType field when formatting as JSON,
-		// which is the format-string used by Visual Studio to detect the
-		// context-type.
-		return ""
-	}
-	if ct, ok := meta["Type"]; ok {
-		// If the context on-disk has a context-type (ecs, aci), return it.
-		return ct.(string)
-	}
-
-	// Use the default context-type.
-	return "moby"
 }
 
 func format(dockerCli command.Cli, opts *listOptions, contexts []*formatter.ClientContext) error {

--- a/cli/command/context/testdata/list-json.golden
+++ b/cli/command/context/testdata/list-json.golden
@@ -1,5 +1,5 @@
-{"Name":"context1","Description":"description of context1","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"aci"}
-{"Name":"context2","Description":"description of context2","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"ecs"}
-{"Name":"context3","Description":"description of context3","DockerEndpoint":"https://someswarmserver.example.com","Current":false,"Error":"","ContextType":"moby"}
-{"Name":"current","Description":"description of current","DockerEndpoint":"https://someswarmserver.example.com","Current":true,"Error":"","ContextType":"moby"}
-{"Name":"default","Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","Current":false,"Error":"","ContextType":"moby"}
+{"Current":false,"Description":"description of context1","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context1"}
+{"Current":false,"Description":"description of context2","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context2"}
+{"Current":false,"Description":"description of context3","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"context3"}
+{"Current":true,"Description":"description of current","DockerEndpoint":"https://someswarmserver.example.com","Error":"","Name":"current"}
+{"Current":false,"Description":"Current DOCKER_HOST based configuration","DockerEndpoint":"unix:///var/run/docker.sock","Error":"","Name":"default"}

--- a/cli/command/formatter/context.go
+++ b/cli/command/formatter/context.go
@@ -1,7 +1,5 @@
 package formatter
 
-import "encoding/json"
-
 const (
 	// ClientContextTableFormat is the default client context format.
 	ClientContextTableFormat = "table {{.Name}}{{if .Current}} *{{end}}\t{{.Description}}\t{{.DockerEndpoint}}\t{{.Error}}"
@@ -30,13 +28,6 @@ type ClientContext struct {
 	DockerEndpoint string
 	Current        bool
 	Error          string
-
-	// ContextType is a temporary field for compatibility with
-	// Visual Studio, which depends on this from the "cloud integration"
-	// wrapper.
-	//
-	// Deprecated: this type is only for backward-compatibility. Do not use.
-	ContextType string `json:"ContextType,omitempty"`
 }
 
 // ClientContextWrite writes formatted contexts using the Context
@@ -69,13 +60,6 @@ func newClientContextContext() *clientContextContext {
 }
 
 func (c *clientContextContext) MarshalJSON() ([]byte, error) {
-	if c.c.ContextType != "" {
-		// We only have ContextType set for plain "json" or "{{json .}}" formatting,
-		// so we should be able to just use the default json.Marshal with no
-		// special handling.
-		return json.Marshal(c.c)
-	}
-	// FIXME(thaJeztah): why do we need a special marshal function here?
 	return MarshalJSON(c)
 }
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5094


This reverts commit fed9fa0f728d338ccf8ed6f507b2d6e184ba5637.

This removes the ContextType field, which was temporarily added to provide compatibility with the "compose-cli" wrapper that shipped with Docker Desktop. The compose-cli wrapper extended the context struct with an additional field that was not part of the CLI itself, but was used by Visual Studio to detect the type of context.

This temporary field shipped as part of Docker 27.0 June 2024), which should be enough time for Visual Studio to have adjusted their integration.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/context: remove temporary `ContextType` field from JSON output
```

**- A picture of a cute animal (not mandatory but encouraged)**

