### PR TITLE
cli/context/store: un-export LimitedReader

### DIFF
--- a/cli/context/store/io_utils.go
+++ b/cli/context/store/io_utils.go
@@ -5,14 +5,14 @@ import (
 	"io"
 )
 
-// LimitedReader is a fork of io.LimitedReader to override Read.
-type LimitedReader struct {
+// limitedReader is a fork of [io.LimitedReader] to override Read.
+type limitedReader struct {
 	R io.Reader
 	N int64 // max bytes remaining
 }
 
-// Read is a fork of io.LimitedReader.Read that returns an error when limit exceeded.
-func (l *LimitedReader) Read(p []byte) (n int, err error) {
+// Read is a fork of [io.LimitedReader.Read] that returns an error when limit exceeded.
+func (l *limitedReader) Read(p []byte) (n int, err error) {
 	if l.N < 0 {
 		return 0, errors.New("read exceeds the defined limit")
 	}

--- a/cli/context/store/io_utils_test.go
+++ b/cli/context/store/io_utils_test.go
@@ -15,10 +15,10 @@ func TestLimitReaderReadAll(t *testing.T) {
 	assert.NilError(t, err)
 
 	r = strings.NewReader("Test")
-	_, err = io.ReadAll(&LimitedReader{R: r, N: 4})
+	_, err = io.ReadAll(&limitedReader{R: r, N: 4})
 	assert.NilError(t, err)
 
 	r = strings.NewReader("Test")
-	_, err = io.ReadAll(&LimitedReader{R: r, N: 2})
+	_, err = io.ReadAll(&limitedReader{R: r, N: 2})
 	assert.Error(t, err, "read exceeds the defined limit")
 }

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -356,7 +356,7 @@ func isValidFilePath(p string) error {
 }
 
 func importTar(name string, s Writer, reader io.Reader) error {
-	tr := tar.NewReader(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
+	tr := tar.NewReader(&limitedReader{R: reader, N: maxAllowedFileSizeToImport})
 	tlsData := ContextTLSData{
 		Endpoints: map[string]EndpointTLSData{},
 	}
@@ -406,7 +406,7 @@ func importTar(name string, s Writer, reader io.Reader) error {
 }
 
 func importZip(name string, s Writer, reader io.Reader) error {
-	body, err := io.ReadAll(&LimitedReader{R: reader, N: maxAllowedFileSizeToImport})
+	body, err := io.ReadAll(&limitedReader{R: reader, N: maxAllowedFileSizeToImport})
 	if err != nil {
 		return err
 	}
@@ -434,7 +434,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 				return err
 			}
 
-			data, err := io.ReadAll(&LimitedReader{R: f, N: maxAllowedFileSizeToImport})
+			data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
 			defer f.Close()
 			if err != nil {
 				return err


### PR DESCRIPTION
relates to

- https://github.com/docker/cli/pull/1895
- https://github.com/docker/cli/pull/1895#discussion_r288688768


It was created for internal use, and is not part of the context-store public API. It was introduced as part of the "zip import" functionality added in 291e86289be4ab78840154933b6e744dd6a5fc8e. Initially it was [non-exported][1], but during review, some suggestions were made to improve the implementation, and the [suggested implementation][2] was based on Go stdlib, but review overlooked that the implementation was now exported.

Let's un-export it, as this was (as outlined) never meant to be a public type.

[1]: https://github.com/docker/cli/pull/1895#discussion_r287514522
[2]: https://github.com/docker/cli/pull/1895#discussion_r288688768


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

