### PR TITLE
cli/command/network: fix error-message for cancelled prune

### DIFF
--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -57,7 +57,7 @@ func runPrune(ctx context.Context, dockerCli command.Cli, options pruneOptions) 
 			return "", err
 		}
 		if !r {
-			return "", errdefs.Cancelled(errors.New("network prune cancelled has been cancelled"))
+			return "", errdefs.Cancelled(errors.New("network prune has been cancelled"))
 		}
 	}
 


### PR DESCRIPTION
This error-message was updated in 7c722c08d093c118ea727961be9aa0a23c83b733, but looks like the typo was overlooked in review.

**- A picture of a cute animal (not mandatory but encouraged)**

