### PR TITLE
swarm/init: Fix `--external-ca` ignoring `cacert` option

### DIFF
--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -96,7 +96,7 @@ func runCA(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, opt
 func updateSwarmSpec(spec *swarm.Spec, flags *pflag.FlagSet, opts caOptions) {
 	caCert := opts.rootCACert.Contents()
 	caKey := opts.rootCAKey.Contents()
-	opts.mergeSwarmSpecCAFlags(spec, flags, caCert)
+	opts.mergeSwarmSpecCAFlags(spec, flags, &caCert)
 
 	spec.CAConfig.SigningCACert = caCert
 	spec.CAConfig.SigningCAKey = caKey

--- a/cli/command/swarm/client_test.go
+++ b/cli/command/swarm/client_test.go
@@ -12,7 +12,7 @@ import (
 type fakeClient struct {
 	client.Client
 	infoFunc              func() (system.Info, error)
-	swarmInitFunc         func() (string, error)
+	swarmInitFunc         func(req swarm.InitRequest) (string, error)
 	swarmInspectFunc      func() (swarm.Swarm, error)
 	nodeInspectFunc       func() (swarm.Node, []byte, error)
 	swarmGetUnlockKeyFunc func() (types.SwarmUnlockKeyResponse, error)
@@ -36,9 +36,9 @@ func (cli *fakeClient) NodeInspectWithRaw(context.Context, string) (swarm.Node, 
 	return swarm.Node{}, []byte{}, nil
 }
 
-func (cli *fakeClient) SwarmInit(context.Context, swarm.InitRequest) (string, error) {
+func (cli *fakeClient) SwarmInit(_ context.Context, req swarm.InitRequest) (string, error) {
 	if cli.swarmInitFunc != nil {
-		return cli.swarmInitFunc()
+		return cli.swarmInitFunc(req)
 	}
 	return "", nil
 }

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -4,12 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 	"gotest.tools/v3/golden"
 )
 
@@ -17,7 +20,7 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		flags                 map[string]string
-		swarmInitFunc         func() (string, error)
+		swarmInitFunc         func(swarm.InitRequest) (string, error)
 		swarmInspectFunc      func() (swarm.Swarm, error)
 		swarmGetUnlockKeyFunc func() (types.SwarmUnlockKeyResponse, error)
 		nodeInspectFunc       func() (swarm.Node, []byte, error)
@@ -25,14 +28,14 @@ func TestSwarmInitErrorOnAPIFailure(t *testing.T) {
 	}{
 		{
 			name: "init-failed",
-			swarmInitFunc: func() (string, error) {
+			swarmInitFunc: func(swarm.InitRequest) (string, error) {
 				return "", errors.New("error initializing the swarm")
 			},
 			expectedError: "error initializing the swarm",
 		},
 		{
 			name: "init-failed-with-ip-choice",
-			swarmInitFunc: func() (string, error) {
+			swarmInitFunc: func(swarm.InitRequest) (string, error) {
 				return "", errors.New("could not choose an IP address to advertise")
 			},
 			expectedError: "could not choose an IP address to advertise - specify one with --advertise-addr",
@@ -86,14 +89,14 @@ func TestSwarmInit(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		flags                 map[string]string
-		swarmInitFunc         func() (string, error)
+		swarmInitFunc         func(req swarm.InitRequest) (string, error)
 		swarmInspectFunc      func() (swarm.Swarm, error)
 		swarmGetUnlockKeyFunc func() (types.SwarmUnlockKeyResponse, error)
 		nodeInspectFunc       func() (swarm.Node, []byte, error)
 	}{
 		{
 			name: "init",
-			swarmInitFunc: func() (string, error) {
+			swarmInitFunc: func(swarm.InitRequest) (string, error) {
 				return "nodeID", nil
 			},
 		},
@@ -102,7 +105,7 @@ func TestSwarmInit(t *testing.T) {
 			flags: map[string]string{
 				flagAutolock: "true",
 			},
-			swarmInitFunc: func() (string, error) {
+			swarmInitFunc: func(swarm.InitRequest) (string, error) {
 				return "nodeID", nil
 			},
 			swarmGetUnlockKeyFunc: func() (types.SwarmUnlockKeyResponse, error) {
@@ -131,4 +134,29 @@ func TestSwarmInit(t *testing.T) {
 			golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("init-%s.golden", tc.name))
 		})
 	}
+}
+
+func TestSwarmInitWithExternalCA(t *testing.T) {
+	cli := test.NewFakeCli(&fakeClient{
+		swarmInitFunc: func(req swarm.InitRequest) (string, error) {
+			if assert.Check(t, is.Len(req.Spec.CAConfig.ExternalCAs, 1)) {
+				assert.Equal(t, req.Spec.CAConfig.ExternalCAs[0].CACert, cert)
+				assert.Equal(t, req.Spec.CAConfig.ExternalCAs[0].Protocol, swarm.ExternalCAProtocolCFSSL)
+				assert.Equal(t, req.Spec.CAConfig.ExternalCAs[0].URL, "https://example.com")
+			}
+			return "nodeID", nil
+		},
+	})
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "cert.pem")
+	err := os.WriteFile(certFile, []byte(cert), 0644)
+	assert.NilError(t, err)
+
+	cmd := newInitCommand(cli)
+	cmd.SetArgs([]string{})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	assert.NilError(t, cmd.Flags().Set(flagExternalCA, "protocol=cfssl,url=https://example.com,cacert="+certFile))
+	assert.NilError(t, cmd.Execute())
 }

--- a/cli/command/swarm/init_test.go
+++ b/cli/command/swarm/init_test.go
@@ -150,7 +150,7 @@ func TestSwarmInitWithExternalCA(t *testing.T) {
 
 	tempDir := t.TempDir()
 	certFile := filepath.Join(tempDir, "cert.pem")
-	err := os.WriteFile(certFile, []byte(cert), 0644)
+	err := os.WriteFile(certFile, []byte(cert), 0o644)
 	assert.NilError(t, err)
 
 	cmd := newInitCommand(cli)

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -53,7 +53,7 @@ func runUpdate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet,
 
 	prevAutoLock := swarmInspect.Spec.EncryptionConfig.AutoLockManagers
 
-	opts.mergeSwarmSpec(&swarmInspect.Spec, flags, swarmInspect.ClusterInfo.TLSInfo.TrustRoot)
+	opts.mergeSwarmSpec(&swarmInspect.Spec, flags, &swarmInspect.ClusterInfo.TLSInfo.TrustRoot)
 
 	curAutoLock := swarmInspect.Spec.EncryptionConfig.AutoLockManagers
 


### PR DESCRIPTION
- related to: https://github.com/moby/moby/pull/49677#issuecomment-2790012644

**- What I did**
31d629245855d54294e04c6e7202f21901da5310 mistakenly changed the `ToSpec` function to set all certs passed via `external-ca` to empty strings.

**- How I did it**

**- How to verify it**
- TestSwarmUpdate on in moby `integration-cli`
- TestSwarmInitWithExternalCA

Before:
```bash
$ go test -run TestSwarmInitWithExternalCA
--- FAIL: TestSwarmInitWithExternalCA (0.00s)
    init_test.go:143: assertion failed: 
        --- req.Spec.CAConfig.ExternalCAs[0].CACert
        +++ cert
        @@ -1 +1,13 @@
        -
        +
        +-----BEGIN CERTIFICATE-----
        +MIIBuDCCAV4CCQDOqUYOWdqMdjAKBggqhkjOPQQDAzBjMQswCQYDVQQGEwJVUzEL
        +MAkGA1UECAwCQ0ExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDzANBgNVBAoMBkRv
        +Y2tlcjEPMA0GA1UECwwGRG9ja2VyMQ0wCwYDVQQDDARUZXN0MCAXDTE4MDcwMjIx
        +MjkxOFoYDzMwMTcxMTAyMjEyOTE4WjBjMQswCQYDVQQGEwJVUzELMAkGA1UECAwC
        +Q0ExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xDzANBgNVBAoMBkRvY2tlcjEPMA0G
        +A1UECwwGRG9ja2VyMQ0wCwYDVQQDDARUZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
        +AQcDQgAEgvvZl5Vqpr1e+g5IhoU6TZHgRau+BZETVFTmqyWYajA/mooRQ1MZTozu
        +s9ZZZA8tzUhIqS36gsFuyIZ4YiAlyjAKBggqhkjOPQQDAwNIADBFAiBQ7pCPQrj8
        +8zaItMf0pk8j1NU5XrFqFEZICzvjzUJQBAIhAKq2gFwoTn8KH+cAAXZpAGJPmOsT
        +zsBT8gBAOHhNA6/2
        +-----END CERTIFICATE-----
        
FAIL
exit status 1
FAIL	github.com/docker/cli/cli/command/swarm	0.381s
```

After
```bash
$ go test -run TestSwarmInitWithExternalCA 
PASS
ok  	github.com/docker/cli/cli/command/swarm	1.009
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Fix `docker swarm init` ignoring `cacert` option of `--external-ca`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

