### PR TITLE
cli/command/image: Fix total content size calculation in image tree

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -54,6 +54,8 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) error
 		var totalContent int64
 		children := make([]subImage, 0, len(img.Manifests))
 		for _, im := range img.Manifests {
+			totalContent += im.Size.Content
+
 			if im.Kind == imagetypes.ManifestKindAttestation {
 				attested[im.AttestationData.For] = true
 				continue
@@ -78,7 +80,6 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) error
 				details.InUse = true
 			}
 
-			totalContent += im.Size.Content
 			children = append(children, sub)
 
 			// Add extra spacing between images if there's at least one entry with children.


### PR DESCRIPTION
Before this patch, image total content size would only include container images content size.

<img width="669" alt="image" src="https://github.com/user-attachments/assets/f18d992b-f281-4bbd-aca6-769e45fb5bed" />


```markdown changelog
Fix `docker images --tree` not including non-container images content size in the total image content size.
```

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>