### PR TITLE
infer unix:// prefix for path-like DOCKER_HOST values

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -74,7 +74,12 @@ func parseDockerDaemonHost(addr string) (string, error) {
 	proto, host, hasProto := strings.Cut(addr, "://")
 	if !hasProto && proto != "" {
 		host = proto
-		proto = "tcp"
+		// if the addr string starts with "/", "./", or "../", the user very likely meant "path to a socket"
+		if strings.HasPrefix(host, "/") || strings.HasPrefix(host, "./") || strings.HasPrefix(host, "../") {
+			proto = "unix"
+		} else {
+			proto = "tcp"
+		}
 	}
 
 	switch proto {

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -37,6 +37,9 @@ func TestParseHost(t *testing.T) {
 		"unix://path/to/socket":    "unix://path/to/socket",
 		"npipe://":                 "npipe://" + defaultNamedPipe,
 		"npipe:////./pipe/foo":     "npipe:////./pipe/foo",
+		"/some.sock":               "unix:///some.sock",
+		"./single/dot":             "unix://./single/dot",
+		"../double/dot":            "unix://../double/dot",
 	}
 
 	for _, value := range invalid {


### PR DESCRIPTION
This change improves the handling of DOCKER_HOST by automatically inferring a "unix://" prefix when the host string starts with "/", "./", or "../", indicating a unix socket path. Previously, these values were incorrectly interpreted as TCP addresses, leading to confusing error messages.

**- What I did**

Improved the parsing logic of DOCKER_HOST to detect when a value looks like a path and automatically treat it as a Unix socket.

**- How I did it**

Modified parseDockerDaemonHost() to use the "unix://" protocol for addr strings starting with  "/", "./", or ".", where no protocol is specified. Addresses without protocol prefixes that do not resemble a path are given the "tcp://" protocol.

**- How to verify it**

Compare the output of running docker version with DOCKER_HOST set to "/invalid.sock":

```
$ DOCKER_HOST=/invalid.sock docker version
Client:
 Version:           27.5.1
 API version:       1.47
 Go version:        go1.22.11
 Git commit:        9f9e405
 Built:             Wed Jan 22 13:39:08 2025
 OS/Arch:           linux/arm64
 Context:           default
Cannot connect to the Docker daemon at tcp://localhost:2375/invalid.sock. Is the docker daemon running?
```

After this change, the error message shows that the host is interpreted as a unix socket.

```
$ DOCKER_HOST=/invalid.sock docker version
Client:
 Version:           27.5.1
 API version:       1.47
 Go version:        go1.22.11
 Git commit:        9f9e405
 Built:             Wed Jan 22 13:39:08 2025
 OS/Arch:           linux/arm64
 Context:           default
Cannot connect to the Docker daemon at unix:///invalid.sock. Is the docker daemon running?
```

**- Human readable description for the release notes**

```markdown changelog
Improved error clarity for DOCKER_HOST values that are Unix socket paths by inferring the "unix://" prefix when omitted.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Fixes #5846 

