### PR TITLE
completion: remove generic "os-only" for platforms

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -152,7 +152,6 @@ func NoComplete(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCo
 }
 
 var commonPlatforms = []string{
-	"linux",
 	"linux/386",
 	"linux/amd64",
 	"linux/arm",
@@ -169,10 +168,8 @@ var commonPlatforms = []string{
 	// Not yet supported
 	"linux/riscv64",
 
-	"windows",
 	"windows/amd64",
 
-	"wasip1",
 	"wasip1/wasm",
 }
 


### PR DESCRIPTION
Using `--platform=linux` or `--platform=windows` is not commonly used (or recommended). Let's remove these from the list of suggested platforms.

We should tweak this completion further, and sort the list based on the daemon's platform (putting linux first for a Linux daemon, and windows first on a Windows daemon), possibly with the correct architecture (and os-version) included, but we don't yet provide that information in `/_ping`.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

