### PR TITLE
Fix login hints should only show on hub registry

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -186,9 +186,12 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 			}
 		}()
 
-		out := tui.NewOutput(cli.Err())
-		out.PrintNote("A Personal Access Token (PAT) can be used instead.\n" +
-			"To create a PAT, visit " + aec.Underline.Apply("https://app.docker.com/settings") + "\n\n")
+		if serverAddress == authConfigKey {
+			out := tui.NewOutput(cli.Err())
+			out.PrintNote("A Personal Access Token (PAT) can be used instead.\n" +
+				"To create a PAT, visit " + aec.Underline.Apply("https://app.docker.com/settings") + "\n\n")
+		}
+
 		argPassword, err = prompt.ReadInput(ctx, cli.In(), cli.Out(), "Password: ")
 		if err != nil {
 			return registrytypes.AuthConfig{}, err


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Login hints would show up when running `docker login my-custom-registry:8080` which is incorrect. We should limit it to only show up when logging into the docker hub registry.
![Screenshot 2025-04-16 at 17 18 02](https://github.com/user-attachments/assets/25ccfd32-bac5-4324-9cea-2a8165fbf4bf)

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix login hints when logging into a custom registry
```

**- A picture of a cute animal (not mandatory but encouraged)**

