### PR TITLE
opts: ListOpts: implement cobra.SliceValue to fix shell completion

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -84,6 +84,16 @@ func (opts *ListOpts) GetAll() []string {
 	return *opts.values
 }
 
+// GetSlice returns the values of slice.
+//
+// It implements [cobra.SliceValue] to allow shell completion to be provided
+// multiple times.
+//
+// [cobra.SliceValue]: https://pkg.go.dev/github.com/spf13/cobra@v1.9.1#SliceValue
+func (opts *ListOpts) GetSlice() []string {
+	return *opts.values
+}
+
 // GetAllOrEmpty returns the values of the slice
 // or an empty slice when there are no values.
 func (opts *ListOpts) GetAllOrEmpty() []string {

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -112,6 +112,7 @@ func TestMapOpts(t *testing.T) {
 	}
 }
 
+//nolint:gocyclo // ignore "cyclomatic complexity 17 is too high"
 func TestListOptsWithoutValidator(t *testing.T) {
 	o := NewListOpts(nil)
 	err := o.Set("foo")
@@ -145,12 +146,13 @@ func TestListOptsWithoutValidator(t *testing.T) {
 	if o.String() != "[bar bar]" {
 		t.Errorf("%s != [bar bar]", o.String())
 	}
-	listOpts := o.GetAll()
-	if len(listOpts) != 2 || listOpts[0] != "bar" || listOpts[1] != "bar" {
+	if listOpts := o.GetAll(); len(listOpts) != 2 || listOpts[0] != "bar" || listOpts[1] != "bar" {
 		t.Errorf("Expected [[bar bar]], got [%v]", listOpts)
 	}
-	mapListOpts := o.GetMap()
-	if len(mapListOpts) != 1 {
+	if listOpts := o.GetSlice(); len(listOpts) != 2 || listOpts[0] != "bar" || listOpts[1] != "bar" {
+		t.Errorf("Expected [[bar bar]], got [%v]", listOpts)
+	}
+	if mapListOpts := o.GetMap(); len(mapListOpts) != 1 {
 		t.Errorf("Expected [map[bar:{}]], got [%v]", mapListOpts)
 	}
 }


### PR DESCRIPTION
- relates to https://github.com/spf13/cobra/pull/2210

Cobra's shell completion has specific rules to decide whether a flag can be accepted multiple times. If a flag does not meet that rule, it only completes the flag name once; some of those rules depend on the "type" of the option to end with "Array" or "Slice", which most of our options don't.

Starting with Cobra 1.9, it also checks whether an option implements the [cobra.SliceValue] interface (see [spf13/cobra 2210]).

This patch implements the [cobra.SliceValue] interface on ListOpts, so that these options can be completed multiple times.

In a follow-up, we can update our code to replace our uses of `GetAll()`, which is identical with the `GetSlice()` method, and potentially deprecate the old method.

Before this patch, ListOpts would only be completed once when completing flag names. For example, the following would show the `--label` flag the first time, but omit it if a `--label` flag was already set;

    docker run--l<TAB>
    --label                  (Set meta data on a container)  --link-local-ip  (Container IPv4/IPv6 link-local addresses)
    --label-file  (Read in a line delimited file of labels)  --log-driver             (Logging driver for the container)
    --link                  (Add link to another container)  --log-opt                              (Log driver options)

    docker run --label hello --l<TAB>
    --label-file  (Read in a line delimited file of labels)  --link-local-ip  (Container IPv4/IPv6 link-local addresses)  --log-opt  (Log driver options)
    --link                  (Add link to another container)  --log-driver             (Logging driver for the container)

With this patch, the completion script correctly identifies the `--label` flag to be accepted multiple times, and also completes it when already set;

    docker run --label hello --l<TAB>
    --label                  (Set meta data on a container)  --link-local-ip  (Container IPv4/IPv6 link-local addresses)
    --label-file  (Read in a line delimited file of labels)  --log-driver             (Logging driver for the container)
    --link                  (Add link to another container)  --log-opt                              (Log driver options)

[cobra.SliceValue]: https://pkg.go.dev/github.com/spf13/cobra@v1.9.1#SliceValue
[spf13/cobra 2210]: https://github.com/spf13/cobra/pull/2210

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix shell-completion to only complete some flags once, even though they can be set multiple times.
```

**- A picture of a cute animal (not mandatory but encouraged)**

