### PR TITLE
opts: deprecate ListOpts.GetAll in favor of ListOpts.GetSlice

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -80,6 +80,8 @@ func (opts *ListOpts) GetMap() map[string]struct{} {
 }
 
 // GetAll returns the values of slice.
+//
+// Deprecated: use [ListOpts.GetSlice] instead. This method will be removed in a future release.
 func (opts *ListOpts) GetAll() []string {
 	return *opts.values
 }


### PR DESCRIPTION
depends on:

- [x] https://github.com/docker/cli/pull/6030
- [x] https://github.com/docker/cli/pull/6031

The `GetSlice()` function is part of cobra's [cobra.SliceValue] interface,
and duplicates the older `GetAll()` method. This patch deprecates the
`GetAll()` method in favor of `GetSlice()`.

[cobra.SliceValue]: https://pkg.go.dev/github.com/spf13/cobra@v1.9.1#SliceValue



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate `ListOpts.GetAll` in favor of `ListOpts.GetSlice`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

