### PR TITLE
Support '!=' operator in filters and record its usage

### DIFF
--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -144,9 +144,14 @@ func confirmationMessage(dockerCli command.Cli, options pruneOptions) string {
 	if pruneFilters.Len() > 0 {
 		// TODO remove fixed list of filters, and print all filters instead,
 		// because the list of filters that is supported by the engine may evolve over time.
+
 		for _, name := range []string{"label", "label!", "until"} {
-			for _, v := range pruneFilters.Get(name) {
-				filters = append(filters, name+"="+v)
+			for v, isEqualOp := range options.filter.Value().GetPair(name) {
+				op := "="
+				if !isEqualOp {
+					op = "!="
+				}
+				filters = append(filters, name+op+v)
 			}
 		}
 		sort.Slice(filters, func(i, j int) bool {

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -345,15 +345,25 @@ func (o *FilterOpt) Set(value string) error {
 	if value == "" {
 		return nil
 	}
-	if !strings.Contains(value, "=") {
-		return errors.New("bad format of filter (expected name=value)")
+
+	var isEqualOp bool
+	// isEqualOp determines the comparison type:
+	// true  => use ="
+	// false => use "!="
+	var sep string
+	if strings.Contains(value, "!=") {
+		isEqualOp, sep = false, "!="
+	} else if strings.Contains(value, "=") {
+		isEqualOp, sep = true, "="
+	} else {
+		return errors.New("bad format of filter (expected name=value or name!=value)")
 	}
-	name, val, _ := strings.Cut(value, "=")
+	name, val, _ := strings.Cut(value, sep)
 
 	// TODO(thaJeztah): these options should not be case-insensitive.
 	name = strings.ToLower(strings.TrimSpace(name))
 	val = strings.TrimSpace(val)
-	o.filter.Add(name, val)
+	o.filter.Add(name, val, isEqualOp)
 	return nil
 }
 

--- a/vendor/github.com/docker/docker/api/types/filters/parse.go
+++ b/vendor/github.com/docker/docker/api/types/filters/parse.go
@@ -123,12 +123,23 @@ func (args Args) Get(key string) []string {
 	return slice
 }
 
+// Get returns the list of children key/value pairs associated with the key
+func (args Args) GetPair(key string) map[string]bool {
+	values := args.fields[key]
+	return values
+}
+
 // Add a new value to the set of values
-func (args Args) Add(key, value string) {
+func (args Args) Add(key, value string, isEqualOps ...bool) {
+	isEqualOp := true
+	if len(isEqualOps) > 0 {
+		isEqualOp = isEqualOps[0]
+	}
+
 	if _, ok := args.fields[key]; ok {
-		args.fields[key][value] = true
+		args.fields[key][value] = isEqualOp
 	} else {
-		args.fields[key] = map[string]bool{value: true}
+		args.fields[key] = map[string]bool{value: isEqualOp}
 	}
 }
 


### PR DESCRIPTION
closes #6021
In `Add()` (vendor/github.com/docker/docker/api/types/filters/parse.go), we previously assigned `args.fields[key][value] = true` with "true" being a placeholder.

Now, it holds `isEqualOp`, a boolean indicating whether the filter uses `=` (true) or `!=` (false). This enables us to distinguish between inclusion and exclusion filters.

The `Set()` function (opts/opts.go) has been updated to detect both `=` and `!=` in filter strings, replacing the previous convention of using a trailing `!` to indicate negation.

Update `confirmationMessage()` function (cli/command/system/prune.go) to include isEqualOp value in print out for prune command.

The daemon is to be updated [this issue](https://github.com/moby/moby/issues/13533) to support exclusionary filters.
