### PR TITLE
cli/command/registry: login: improve flag validation

### DIFF
--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -550,12 +550,17 @@ func TestLoginValidateFlags(t *testing.T) {
 		{
 			name:        "--password-stdin without --username",
 			args:        []string{"--password-stdin"},
-			expectedErr: `Must provide --username with --password-stdin`,
+			expectedErr: `the --password-stdin option requires --username to be set`,
 		},
 		{
 			name:        "--password-stdin with empty --username",
 			args:        []string{"--password-stdin", "--username", ""},
-			expectedErr: `Must provide --username with --password-stdin`,
+			expectedErr: `username is empty`,
+		},
+		{
+			name:        "empty --username",
+			args:        []string{"--username", ""},
+			expectedErr: `username is empty`,
 		},
 		{
 			name:        "--username without value",
@@ -565,7 +570,12 @@ func TestLoginValidateFlags(t *testing.T) {
 		{
 			name:        "conflicting options --password-stdin and --password",
 			args:        []string{"--password-stdin", "--password", ""},
-			expectedErr: `Must provide --username with --password-stdin`,
+			expectedErr: `conflicting options: cannot specify both --password and --password-stdin`,
+		},
+		{
+			name:        "empty --password",
+			args:        []string{"--password", ""},
+			expectedErr: `password is empty`,
 		},
 		{
 			name:        "--password without value",


### PR DESCRIPTION
- relates to https://github.com/docker/cli/issues/5792
- closes  https://github.com/docker/cli/issues/5792


### cli/command/registry: login: improve flag validation

Before this change, some errors could be ambiguous as they did not
distinguish a flag to be omitted, or set, but with an empty value.

For example, if a user would try to loging but with an empty username,
the error would suggest that the `--username` flag was not set (which
it was);

I don't have `MY_USERNAME` set in this shell;

```bash
printenv MY_USERNAME || echo 'variable not set'
variable not set
```
Now, attempting to do a non-interactive login would result in an
ambiguous error;

```bash
echo "supersecret" | docker login --password-stdin --username "$MY_USERNAME"
Must provide --username with --password-stdin
```

With this patch applied, the error indicates that the username was empty,
or not set;

```bash
echo "supersecret" | docker login --password-stdin --username "$MY_USERNAME"
username is empty
echo "supersecret" | docker login --password-stdin
the --password-stdin option requires --username to be set
echo "supersecret" | docker login --password-stdin --password "supersecret"
conflicting options: cannot specify both --password and --password-stdin
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
docker login: improve error-messages for invalid options
```

**- A picture of a cute animal (not mandatory but encouraged)**

