### PR TITLE
chore: enable revive's conditions nesting related rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -147,11 +147,21 @@ linters:
 
     revive:
       rules:
+        - name: early-return      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+          arguments:
+            - preserveScope
         - name: empty-block       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-block
         - name: empty-lines       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
+        - name: if-return         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#if-return
         - name: import-shadowing  # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+        - name: indent-error-flow # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#indent-error-flow
+          arguments:
+            - preserveScope
         - name: line-length-limit # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#line-length-limit
           arguments: [200]
+        - name: superfluous-else # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#superfluous-else
+          arguments:
+            - preserveScope
         - name: unused-receiver   # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
         - name: use-any           # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#use-any
 

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -344,23 +344,22 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	response, err := dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, options.name)
 	if err != nil {
 		// Pull image if it does not exist locally and we have the PullImageMissing option. Default behavior.
-		if errdefs.IsNotFound(err) && namedRef != nil && options.pull == PullImageMissing {
-			if !options.quiet {
-				// we don't want to write to stdout anything apart from container.ID
-				_, _ = fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
-			}
-
-			if err := pullAndTagImage(); err != nil {
-				return "", err
-			}
-
-			var retryErr error
-			response, retryErr = dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, options.name)
-			if retryErr != nil {
-				return "", retryErr
-			}
-		} else {
+		if !errdefs.IsNotFound(err) || namedRef == nil || options.pull != PullImageMissing {
 			return "", err
+		}
+		if !options.quiet {
+			// we don't want to write to stdout anything apart from container.ID
+			_, _ = fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))
+		}
+
+		if err := pullAndTagImage(); err != nil {
+			return "", err
+		}
+
+		var retryErr error
+		response, retryErr = dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, options.name)
+		if retryErr != nil {
+			return "", retryErr
 		}
 	}
 

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -177,15 +177,15 @@ func (c *ContainerContext) Image() string {
 		// truncate digest if no-trunc option was not selected
 		ref, err := reference.ParseNormalizedNamed(c.c.Image)
 		if err == nil {
-			if nt, ok := ref.(reference.NamedTagged); ok {
-				// case for when a tag is provided
-				if namedTagged, err := reference.WithTag(reference.TrimNamed(nt), nt.Tag()); err == nil {
-					return reference.FamiliarString(namedTagged)
-				}
-			} else {
+			nt, ok := ref.(reference.NamedTagged)
+			if !ok {
 				// case for when a tag is not provided
 				named := reference.TrimNamed(ref)
 				return reference.FamiliarString(named)
+			}
+			// case for when a tag is provided
+			if namedTagged, err := reference.WithTag(reference.TrimNamed(nt), nt.Tag()); err == nil {
+				return reference.FamiliarString(namedTagged)
 			}
 		}
 	}

--- a/cli/command/formatter/tabwriter/tabwriter_test.go
+++ b/cli/command/formatter/tabwriter/tabwriter_test.go
@@ -23,13 +23,12 @@ func (b *buffer) clear() { b.a = b.a[0:0] }
 func (b *buffer) Write(buf []byte) (written int, err error) {
 	n := len(b.a)
 	m := len(buf)
-	if n+m <= cap(b.a) {
-		b.a = b.a[0 : n+m]
-		for i := 0; i < m; i++ {
-			b.a[n+i] = buf[i]
-		}
-	} else {
+	if n+m > cap(b.a) {
 		panic("buffer.Write: buffer too small")
+	}
+	b.a = b.a[0 : n+m]
+	for i := 0; i < m; i++ {
+		b.a[n+i] = buf[i]
 	}
 	return len(buf), nil
 }

--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -184,11 +184,10 @@ func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 		switch strings.ToLower(key) {
 		case "protocol":
 			hasProtocol = true
-			if strings.ToLower(value) == string(swarm.ExternalCAProtocolCFSSL) {
-				externalCA.Protocol = swarm.ExternalCAProtocolCFSSL
-			} else {
+			if strings.ToLower(value) != string(swarm.ExternalCAProtocolCFSSL) {
 				return nil, errors.Errorf("unrecognized external CA protocol %s", value)
 			}
+			externalCA.Protocol = swarm.ExternalCAProtocolCFSSL
 		case "url":
 			hasURL = true
 			externalCA.URL = value


### PR DESCRIPTION
**- What I did**

enable and fix revive's conditions nesting related rules

**- How I did it**

Add `early-return`, `if-return`, `indent-error-flow` and `superfluous-else` rules to golangci-lint configuration and run golangci-lint, then apply preconisations

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

No
