### PR TITLE
scripts/with-go-mod.sh: use symlink instead of -modfile

### DIFF
--- a/scripts/docs/generate-man.sh
+++ b/scripts/docs/generate-man.sh
@@ -8,7 +8,7 @@ if ! command -v "$GO_MD2MAN" > /dev/null; then
   (
     set -x
     # note: this installs all tools defined in go.mod/vendor.mod
-    GOBIN="$(pwd)/build/tools" go install -mod=vendor -modfile=vendor.mod tool
+    GOBIN="$(pwd)/build/tools" go install -mod=vendor tool
   )
   GO_MD2MAN="$(pwd)/build/tools/go-md2man"
 fi
@@ -16,7 +16,7 @@ fi
 mkdir -p man/man1
 (
   set -x
-  go run -mod=vendor -modfile=vendor.mod -tags manpages ./man/generate.go --source "./man/src" --target "./man/man1"
+  go run -mod=vendor -tags manpages ./man/generate.go --source "./man/src" --target "./man/man1"
 )
 
 (

--- a/scripts/docs/generate-md.sh
+++ b/scripts/docs/generate-md.sh
@@ -4,7 +4,7 @@ set -eu
 
 (
   set -x
-  go run -mod=vendor -modfile=vendor.mod -tags docsgen ./docs/generate/generate.go --formats md --source "./docs/reference/commandline" --target "./docs/reference/commandline"
+  go run -mod=vendor -tags docsgen ./docs/generate/generate.go --formats md --source "./docs/reference/commandline" --target "./docs/reference/commandline"
 )
 
 # remove generated help.md file

--- a/scripts/docs/generate-yaml.sh
+++ b/scripts/docs/generate-yaml.sh
@@ -4,4 +4,4 @@ set -eu
 
 mkdir -p docs/yaml
 set -x
-go run -mod=vendor -modfile=vendor.mod -tags docsgen ./docs/generate/generate.go --formats yaml --source "./docs/reference/commandline" --target "./docs/yaml"
+go run -mod=vendor -tags docsgen ./docs/generate/generate.go --formats yaml --source "./docs/reference/commandline" --target "./docs/yaml"

--- a/scripts/vendor
+++ b/scripts/vendor
@@ -14,7 +14,7 @@ if [ -z "$TYP" ]; then
 fi
 
 update() {
-  (set -x ; go mod tidy -modfile=vendor.mod; go mod vendor -modfile=vendor.mod)
+  (set -x ; go mod tidy; go mod vendor)
 }
 
 validate() {
@@ -31,7 +31,7 @@ outdated() {
     echo "go-mod-outdated not found. Install with 'go install github.com/psampaz/go-mod-outdated@v0.8.0'"
     exit 1
   fi
-  (set -x ; go list -mod=vendor -mod=readonly -modfile=vendor.mod -u -m -json all | go-mod-outdated -update -direct)
+  (set -x ; go list -mod=readonly -u -m -json all | go-mod-outdated -update -direct)
 }
 
 case $TYP in

--- a/scripts/with-go-mod.sh
+++ b/scripts/with-go-mod.sh
@@ -17,14 +17,12 @@ create_symlink() {
 	local target="$1"
 	local link="$2"
 
-	if [ -L "$link" ] && [ "$(readlink "$link")" = "$target" ]; then
-		# symlink already present; we're done
-		return
-	fi
-
 	if [ -e "$link" ]; then
-		echo "$(basename "$0"): WARN: $link exists but is not the expected symlink!" >&2
-		echo "$(basename "$0"): WARN: Using your version instead of our generated version -- this may misbehave!" >&2
+		# see https://superuser.com/a/196698
+		if ! [ "$link" -ef "${ROOTDIR}/${target}" ]; then
+			echo "$(basename "$0"): WARN: $link exists but is not the expected symlink!" >&2
+			echo "$(basename "$0"): WARN: Using your version instead of our generated version -- this may misbehave!" >&2
+		fi
 		return
 	fi
 

--- a/scripts/with-go-mod.sh
+++ b/scripts/with-go-mod.sh
@@ -6,28 +6,38 @@
 # when the command is finished. This script should be dropped when this
 # repository is a proper Go module with a permanent go.mod.
 
-set -e
+set -euo pipefail
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOTDIR="$(cd "${SCRIPTDIR}/.." && pwd)"
 
-if test -e "${ROOTDIR}/go.mod"; then
-	{
-		scriptname=$(basename "$0")
-		cat >&2 <<- EOF
-			$scriptname: WARN: go.mod exists in the repository root!
-			$scriptname: WARN: Using your go.mod instead of our generated version -- this may misbehave!
-		EOF
-	} >&2
-else
+cleanup_paths=()
+
+create_symlink() {
+	local target="$1"
+	local link="$2"
+
+	if [ -L "$link" ] && [ "$(readlink "$link")" = "$target" ]; then
+		# symlink already present; we're done
+		return
+	fi
+
+	if [ -e "$link" ]; then
+		echo "$(basename "$0"): WARN: $link exists but is not the expected symlink!" >&2
+		echo "$(basename "$0"): WARN: Using your version instead of our generated version -- this may misbehave!" >&2
+		return
+	fi
+
 	set -x
+	ln -s "$target" "$link"
+	cleanup_paths+=( "$link" )
+}
 
-	tee "${ROOTDIR}/go.mod" >&2 <<- EOF
-		module github.com/docker/cli
+create_symlink "vendor.mod" "${ROOTDIR}/go.mod"
+create_symlink "vendor.sum" "${ROOTDIR}/go.sum"
 
-		go 1.25.0
-	EOF
-	trap 'rm -f "${ROOTDIR}/go.mod"' EXIT
+if [ "${#cleanup_paths[@]}" -gt 0 ]; then
+	trap 'rm -f "${cleanup_paths[@]}"' EXIT
 fi
 
 GO111MODULE=on GOTOOLCHAIN=local "$@"


### PR DESCRIPTION
While the "-modfile=vendor.mod" is slightly more correct, using a symlink allows for most of the go tools to work "as usual", just without an acual `go.mod` being committed in the repository.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

