### PR TITLE
docs: run: Drop unnecessary command options of the --workdir example

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -388,7 +388,7 @@ none            1.9G     0  1.9G   0% /mnt
 ### <a name="workdir"></a> Set working directory (-w, --workdir)
 
 ```console
-$ docker run -w /path/to/dir/ -i -t ubuntu pwd
+$ docker run -w /path/to/dir/ ubuntu pwd
 ```
 
 The `-w` option runs the command executed inside the directory specified, in this example,


### PR DESCRIPTION
**- What I did**

The `-i` and `-t` options are not needed, as the `pwd` command does not require a TTY nor an interactive session.

**- How I did it**

Drop them to simplify the example and avoid causing unnecessary confusion to the reader.

**- How to verify it**

Build the docs and verify the rendered result.
