### PR TITLE
docs: move flag examples to right section

### DIFF
--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -20,6 +20,8 @@ Docker inspect provides detailed information on constructs controlled by Docker.
 
 By default, `docker inspect` will render results in a JSON array.
 
+## Examples
+
 ### <a name="format"></a> Format the output (--format)
 
 If a format is specified, the given template will be executed for each result.
@@ -72,8 +74,6 @@ $ docker exec database fallocate -l 1000 /newfile
 $ docker inspect --size database -f '{{ .SizeRw }}'
 12288
 ```
-
-## Examples
 
 ### Get an instance's IP address
 


### PR DESCRIPTION
When generating our docs, flag-descriptions are currently expected to be under the "examples" section for them to be linked correctly.

Currently; the docs at https://docs.docker.com/reference/cli/docker/inspect/#options doesn't link the flags;

<img width="918" alt="Screenshot 2025-05-06 at 13 30 25" src="https://github.com/user-attachments/assets/943a85e1-1dbb-495e-a919-eb03f12a8360" />


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

