### PR TITLE
inspect: add shell completion, improve flag-description for `--type` and improve validation

### DIFF
--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -77,7 +77,7 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
-	flags.StringVar(&opts.objectType, "type", "", "Return JSON for specified type")
+	flags.StringVar(&opts.objectType, "type", "", "Only inspect objects of the given type")
 	flags.BoolVarP(&opts.size, "size", "s", false, "Display total file sizes if the type is container")
 
 	_ = cmd.RegisterFlagCompletionFunc("type", completion.FromList(allTypes...))

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/inspect"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api/types"
@@ -20,6 +21,7 @@ import (
 	"github.com/docker/docker/errdefs"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type objectType = string
@@ -56,6 +58,8 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 			opts.ids = args
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
+		// TODO(thaJeztah): should we consider adding completion for common object-types? (images, containers?)
+		ValidArgsFunction: completion.NoComplete,
 	}
 
 	flags := cmd.Flags()
@@ -63,6 +67,12 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.objectType, "type", "", "Return JSON for specified type")
 	flags.BoolVarP(&opts.size, "size", "s", false, "Display total file sizes if the type is container")
 
+	flags.VisitAll(func(flag *pflag.Flag) {
+		// Set a default completion function if none was set. We don't look
+		// up if it does already have one set, because Cobra does this for
+		// us, and returns an error (which we ignore for this reason).
+		_ = cmd.RegisterFlagCompletionFunc(flag.Name, completion.NoComplete)
+	})
 	return cmd
 }
 

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -69,6 +69,9 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.ids = args
+			if cmd.Flags().Changed("type") && opts.objectType == "" {
+				return fmt.Errorf(`type is empty: must be one of "%s"`, strings.Join(allTypes, `", "`))
+			}
 			return runInspect(cmd.Context(), dockerCli, opts)
 		},
 		// TODO(thaJeztah): should we consider adding completion for common object-types? (images, containers?)
@@ -97,7 +100,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 		typePlugin, typeSecret, typeService, typeTask, typeVolume:
 		elementSearcher = inspectAll(ctx, dockerCli, opts.size, opts.objectType)
 	default:
-		return errors.Errorf("%q is not a valid value for --type", opts.objectType)
+		return errors.Errorf(`unknown type: %q: must be one of "%s"`, opts.objectType, strings.Join(allTypes, `", "`))
 	}
 	return inspect.Inspect(dockerCli.Out(), opts.ids, opts.format, elementSearcher)
 }

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -39,6 +39,19 @@ const (
 	typeVolume    objectType = "volume"
 )
 
+var allTypes = []objectType{
+	typeConfig,
+	typeContainer,
+	typeImage,
+	typeNetwork,
+	typeNode,
+	typePlugin,
+	typeSecret,
+	typeService,
+	typeTask,
+	typeVolume,
+}
+
 type inspectOptions struct {
 	format     string
 	objectType objectType
@@ -67,6 +80,7 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 	flags.StringVar(&opts.objectType, "type", "", "Return JSON for specified type")
 	flags.BoolVarP(&opts.size, "size", "s", false, "Display total file sizes if the type is container")
 
+	_ = cmd.RegisterFlagCompletionFunc("type", completion.FromList(allTypes...))
 	flags.VisitAll(func(flag *pflag.Flag) {
 		// Set a default completion function if none was set. We don't look
 		// up if it does already have one set, because Cobra does this for

--- a/cli/command/system/inspect_test.go
+++ b/cli/command/system/inspect_test.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	"io"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestInspectValidateFlagsAndArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "empty type",
+			args:        []string{"--type", "", "something"},
+			expectedErr: `type is empty: must be one of "config", "container", "image", "network", "node", "plugin", "secret", "service", "task", "volume"`,
+		},
+		{
+			name:        "unknown type",
+			args:        []string{"--type", "unknown", "something"},
+			expectedErr: `unknown type: "unknown": must be one of "config", "container", "image", "network", "node", "plugin", "secret", "service", "task", "volume"`,
+		},
+		{
+			name:        "no arg",
+			args:        []string{},
+			expectedErr: `inspect: 'inspect' requires at least 1 argument`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewInspectCommand(test.NewFakeCli(&fakeClient{}))
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if tc.expectedErr != "" {
+				assert.Check(t, is.ErrorContains(err, tc.expectedErr))
+			} else {
+				assert.Check(t, is.Nil(err))
+			}
+		})
+	}
+}

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -9,7 +9,7 @@ Return low-level information on Docker objects
 |:---------------------------------------|:---------|:--------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [`-f`](#format), [`--format`](#format) | `string` |         | Format output using a custom template:<br>'json':             Print in JSON format<br>'TEMPLATE':         Print output using the given Go template.<br>Refer to https://docs.docker.com/go/formatting/ for more information about formatting output with templates |
 | [`-s`](#size), [`--size`](#size)       | `bool`   |         | Display total file sizes if the type is container                                                                                                                                                                                                                  |
-| [`--type`](#type)                      | `string` |         | Return JSON for specified type                                                                                                                                                                                                                                     |
+| [`--type`](#type)                      | `string` |         | Only inspect objects of the given type                                                                                                                                                                                                                             |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
### inspect: disable default (file) completion

Before this patch, flags and arguments would complete using filenames
from the current directory;

    docker inspect --type <TAB>
    AUTHORS       CONTRIBUTING.md             docs/             Makefile            SECURITY.md
    ...
    
    docker inspect <TAB>

With this patch, no completion is provided;

    docker inspect --type <TAB>
    # no results

    docker inspect <TAB>
    # no results

### inspect: add shell-completion for "--type" flag

With this patch:

    docker inspect --type <TAB>
    config     image    node    secret   task
    container  network  plugin  service  volume

### inspect: update flag description of "--type" flag

Before this patch:

    docker inspect --help | grep '\-\-type'
          --type string     Return JSON for specified type

With this patch:

    docker inspect --help | grep '\-\-type'
          --type string     Only inspect objects of the given type

### inspect: improve (flag) validation

Produce an error if the `--type` flag was set, but an empty value
was passed.

Before this patch:

    docker inspect --type "" foo
    # json output

    docker inspect --type unknown foo
    "unknown" is not a valid value for --type

With this patch:

    docker inspect --type "" foo
    type is empty: must be one of "config", "container", "image", "network", "node", "plugin", "secret", "service", "task", "volume"

    docker inspect --type unknown foo
    unknown type: "unknown": must be one of "config", "container", "image", "network", "node", "plugin", "secret", "service", "task", "volume"



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
`docker inspect`: add shell completion, improve flag-description for `--type` and improve validation
```

**- A picture of a cute animal (not mandatory but encouraged)**

