### PR TITLE
cli/cli: use `len()` to check frontend ports in the `port` command

### DIFF
--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -68,7 +68,7 @@ func runPort(ctx context.Context, dockerCli command.Cli, opts *portOptions) erro
 			return errors.Wrapf(err, "Error: invalid port (%s)", port)
 		}
 		frontends, exists := c.NetworkSettings.Ports[nat.Port(port+"/"+proto)]
-		if !exists || frontends == nil {
+		if !exists || len(frontends) == 0 {
 			return errors.Errorf("Error: No public port '%s' published for %s", opts.port, opts.container)
 		}
 		for _, frontend := range frontends {


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
 I ran into the case that `docker port` return an empty string and exist successfully, checking the code base, I found this function check the frontend ports using `nil` check - which may incorrect in the case of empty slice.
 
So, this PR change to logic to use `len(frontends) == 0` for check ports. If the slice is empty (nil or non-nil) it both return an error.

**- How I did it**
use `len()` to check instead of `nil` check

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**
![image1-1024x715](https://github.com/user-attachments/assets/ccca64a2-da08-4873-ac94-87816b750728)
