### PR TITLE
cli/command, cli-plugins/plugin: some cleanups in WithInitializeClient, withPluginClientConn

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -222,15 +222,6 @@ func (cli *DockerCli) HooksEnabled() bool {
 	return false
 }
 
-// WithInitializeClient is passed to DockerCli.Initialize by callers who wish to set a particular API Client for use by the CLI.
-func WithInitializeClient(makeClient func(dockerCli *DockerCli) (client.APIClient, error)) CLIOption {
-	return func(dockerCli *DockerCli) error {
-		var err error
-		dockerCli.client, err = makeClient(dockerCli)
-		return err
-	}
-}
-
 // Initialize the dockerCli runs initialization that must happen after command
 // line flags are parsed.
 func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption) error {

--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -114,6 +114,16 @@ func WithAPIClient(c client.APIClient) CLIOption {
 	}
 }
 
+// WithInitializeClient is passed to [DockerCli.Initialize] to initialize
+// an API Client for use by the CLI.
+func WithInitializeClient(makeClient func(*DockerCli) (client.APIClient, error)) CLIOption {
+	return func(cli *DockerCli) error {
+		var err error
+		cli.client, err = makeClient(cli)
+		return err
+	}
+}
+
 // envOverrideHTTPHeaders is the name of the environment-variable that can be
 // used to set custom HTTP headers to be sent by the client. This environment
 // variable is the equivalent to the HttpHeaders field in the configuration

--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -118,9 +118,11 @@ func WithAPIClient(c client.APIClient) CLIOption {
 // an API Client for use by the CLI.
 func WithInitializeClient(makeClient func(*DockerCli) (client.APIClient, error)) CLIOption {
 	return func(cli *DockerCli) error {
-		var err error
-		cli.client, err = makeClient(cli)
-		return err
+		c, err := makeClient(cli)
+		if err != nil {
+			return err
+		}
+		return WithAPIClient(c)(cli)
 	}
 }
 


### PR DESCRIPTION
- taken from https://github.com/docker/cli/pull/5925

---

- cli/command: move WithInitializeClient to other options
- cli/command: make WithInitializeClient a wrapper for WithAPIClient
- cli-plugins/plugin: rewrite withPluginClientConn w/ WithAPIClient
   The WithInitializeClient looks redundant altogether, so let's rewrite this function to not depend on it.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

