### PR TITLE
search: remove deprecated "IsAutomated" placeholder

### DIFF
--- a/cli/command/registry/formatter_search.go
+++ b/cli/command/registry/formatter_search.go
@@ -42,7 +42,6 @@ func SearchWrite(ctx formatter.Context, results []registrytypes.SearchResult) er
 		"Description": formatter.DescriptionHeader,
 		"StarCount":   starsHeader,
 		"IsOfficial":  officialHeader,
-		"IsAutomated": automatedHeader,
 	}
 	return ctx.Write(&searchCtx, render)
 }
@@ -91,11 +90,4 @@ func (c *searchContext) formatBool(value bool) string {
 
 func (c *searchContext) IsOfficial() string {
 	return c.formatBool(c.s.IsOfficial)
-}
-
-// IsAutomated formats the IsAutomated field for printing.
-//
-// Deprecated: the "is_automated" field is deprecated and will always be "false" in the future.
-func (c *searchContext) IsAutomated() string {
-	return c.formatBool(c.s.IsAutomated) //nolint:nolintlint,staticcheck // ignore SA1019 (IsAutomated is deprecated).
 }

--- a/cli/command/registry/formatter_search_test.go
+++ b/cli/command/registry/formatter_search_test.go
@@ -45,19 +45,6 @@ func TestSearchContext(t *testing.T) {
 			},
 			call: ctx.IsOfficial,
 		},
-		{
-			searchCtx: searchContext{
-				s: registrytypes.SearchResult{IsAutomated: true}, //nolint:nolintlint,staticcheck // ignore SA1019 (IsAutomated is deprecated).
-			},
-			expValue: "[OK]",
-			call:     ctx.IsAutomated, //nolint:nolintlint,staticcheck // ignore SA1019 (IsAutomated is deprecated).
-		},
-		{
-			searchCtx: searchContext{
-				s: registrytypes.SearchResult{},
-			},
-			call: ctx.IsAutomated, //nolint:nolintlint,staticcheck // ignore SA1019 (IsAutomated is deprecated).
-		},
 	}
 
 	for _, c := range cases {
@@ -157,8 +144,8 @@ func TestSearchContextWrite(t *testing.T) {
 		{
 			doc:    "JSON format",
 			format: "{{json .}}",
-			expected: `{"Description":"Official build","IsAutomated":"false","IsOfficial":"true","Name":"result1","StarCount":"5000"}
-{"Description":"Not official","IsAutomated":"true","IsOfficial":"false","Name":"result2","StarCount":"5"}
+			expected: `{"Description":"Official build","IsOfficial":"true","Name":"result1","StarCount":"5000"}
+{"Description":"Not official","IsOfficial":"false","Name":"result2","StarCount":"5"}
 `,
 		},
 		{
@@ -199,7 +186,7 @@ result2 5
 
 	results := []registrytypes.SearchResult{
 		{Name: "result1", Description: "Official build", StarCount: 5000, IsOfficial: true},
-		{Name: "result2", Description: "Not official", StarCount: 5, IsAutomated: true},
+		{Name: "result2", Description: "Not official", StarCount: 5},
 	}
 
 	for _, tc := range cases {

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -62,7 +62,7 @@ The following table provides an overview of the current status of deprecated fea
 | Deprecated | [`Container` and `ContainerConfig` fields in Image inspect](#container-and-containerconfig-fields-in-image-inspect)                | v25.0      | v26.0  |
 | Deprecated | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
 | Removed    | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
-| Deprecated | [IsAutomated field, and `is-automated` filter on `docker search`](#isautomated-field-and-is-automated-filter-on-docker-search)     | v25.0      | v26.0  |
+| Deprecated | [IsAutomated field, and `is-automated` filter on `docker search`](#isautomated-field-and-is-automated-filter-on-docker-search)     | v25.0      | v28.2  |
 | Removed    | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
 | Removed    | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
 | Removed    | [BuildKit build information](#buildkit-build-information)                                                                          | v23.0      | v24.0  |
@@ -359,7 +359,7 @@ introduced in v25.0 and should be used instead of the `Aliases` field.
 ### IsAutomated field, and `is-automated` filter on `docker search`
 
 **Deprecated in Release: v25.0**
-**Target For Removal In Release: v26.0**
+**Removed In Release: v28.2**
 
 The `is_automated` field has been deprecated by Docker Hub's search API.
 Consequently, the `IsAutomated` field in image search will always be set
@@ -368,7 +368,7 @@ results.
 
 The `AUTOMATED` column has been removed from the default `docker search`
 and `docker image search` output in v25.0, and the corresponding `IsAutomated`
-templating option will be removed in v26.0.
+templating has been removed in v28.2.
 
 ### Logentries logging driver
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/4413

IsAutomated was deprecated in 4fc3f0e6f6b93cebe591a22e9b4d514f599c2520 (docker v25.0), and marked for removal in docker 26.0 (which we missed). This removes it.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove deprecated `IsAutomated` formatting placeholder from `docker search`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

