### PR TITLE
docs: update deprecation status of graphdriver-plugins to "removed"

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -57,7 +57,7 @@ The following table provides an overview of the current status of deprecated fea
 | Deprecated | [`--time` option on `docker stop` and `docker restart`](#--time-option-on-docker-stop-and-docker-restart)                          | v28.0      | -      |
 | Deprecated | [Non-standard fields in image inspect](#non-standard-fields-in-image-inspect)                                                      | v27.0      | v28.0  |
 | Removed    | [API CORS headers](#api-cors-headers)                                                                                              | v27.0      | v28.0  |
-| Deprecated | [Graphdriver plugins (experimental)](#graphdriver-plugins-experimental)                                                            | v27.0      | v28.0  |
+| Removed    | [Graphdriver plugins (experimental)](#graphdriver-plugins-experimental)                                                            | v27.0      | v28.0  |
 | Deprecated | [Unauthenticated TCP connections](#unauthenticated-tcp-connections)                                                                | v26.0      | v28.0  |
 | Deprecated | [`Container` and `ContainerConfig` fields in Image inspect](#container-and-containerconfig-fields-in-image-inspect)                | v25.0      | v26.0  |
 | Deprecated | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
@@ -210,19 +210,13 @@ part of the underlying image's `Config` field, and deprecated:
 **Target For Removal In Release: v28.0**
 
 [Graphdriver plugins](https://github.com/docker/cli/blob/v26.1.4/docs/extend/plugins_graphdriver.md)
-are an experimental feature that allow extending the Docker Engine with custom
+were an experimental feature that allowed extending the Docker Engine with custom
 storage drivers for storing images and containers. This feature was not
-maintained since its inception, and will no longer be supported in upcoming
-releases.
+maintained since its inception.
 
-Support for graphdriver plugins is disabled by default in v27.0, and will be
-removed v28.0. An `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` environment variable
-is provided in v27.0 to re-enable the feature. This environment variable must
-be set to a non-empty value in the daemon's environment.
-
-The `DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS` environment variable, along with
-support for graphdriver plugins, will be removed in v28.0. Users of this feature
-are recommended to instead configure the Docker Engine to use the [containerd image store](https://docs.docker.com/storage/containerd/)
+Support for graphdriver plugins was disabled by default in v27.0, and removed
+in v28.0. Users of this feature are recommended to instead configure the Docker
+Engine to use the [containerd image store](https://docs.docker.com/storage/containerd/)
 and a custom [snapshotter](https://github.com/containerd/containerd/tree/v1.7.18/docs/snapshotters)
 
 ### API CORS headers


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/49602

This functionality, was removed and the DOCKERD_DEPRECATED_GRAPHDRIVER_PLUGINS no longer can be used in v28.0;
https://github.com/moby/moby/commit/42ca9154e9b8f8120011add4c09c6edcecd1e6f5

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

