### PR TITLE
vendor: github.com/docker/docker v28.2.0-dev (f4ffeb8c38b3)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -15,7 +15,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v28.2.0-rc.1.0.20250521172427-b590eff717b3+incompatible // master, v28.2-dev
+	github.com/docker/docker v28.2.0-rc.1.0.20250522084122-f4ffeb8c38b3+incompatible // master, v28.2-dev
 	github.com/docker/docker-credential-helpers v0.9.3
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -57,8 +57,8 @@ github.com/docker/cli-docs-tool v0.10.0/go.mod h1:5EM5zPnT2E7yCLERZmrDA234Vwn09f
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.2.0-rc.1.0.20250521172427-b590eff717b3+incompatible h1:AMRbsUddeTF15KSHZ+blK9kmpl/1nCiucyz00tFqiX0=
-github.com/docker/docker v28.2.0-rc.1.0.20250521172427-b590eff717b3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.2.0-rc.1.0.20250522084122-f4ffeb8c38b3+incompatible h1:nwwWQZnH9eqJhXVmvhy49BcOAE2NVEXgwnkUTy/Px/0=
+github.com/docker/docker v28.2.0-rc.1.0.20250522084122-f4ffeb8c38b3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v28.2.0-rc.1.0.20250521172427-b590eff717b3+incompatible
+# github.com/docker/docker v28.2.0-rc.1.0.20250522084122-f4ffeb8c38b3+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
full diff: https://github.com/docker/docker/compare/b590eff717b3...f4ffeb8c38b3

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>