### PR TITLE
docs: deprecated: mark `fluentd-async-connect` as "removed"

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -80,7 +80,7 @@ The following table provides an overview of the current status of deprecated fea
 | Deprecated | [CLI plugins support](#cli-plugins-support)                                                                                        | v20.10     | -      |
 | Deprecated | [Dockerfile legacy `ENV name value` syntax](#dockerfile-legacy-env-name-value-syntax)                                              | v20.10     | -      |
 | Removed    | [`docker build --stream` flag (experimental)](#docker-build---stream-flag-experimental)                                            | v20.10     | v20.10 |
-| Deprecated | [`fluentd-async-connect` log opt](#fluentd-async-connect-log-opt)                                                                  | v20.10     | v28.0  |
+| Removed    | [`fluentd-async-connect` log opt](#fluentd-async-connect-log-opt)                                                                  | v20.10     | v28.0  |
 | Removed    | [Configuration options for experimental CLI features](#configuration-options-for-experimental-cli-features)                        | v19.03     | v23.0  |
 | Removed    | [Pushing and pulling with image manifest v2 schema 1](#pushing-and-pulling-with-image-manifest-v2-schema-1)                        | v19.03     | v28.2  |
 | Removed    | [`docker engine` subcommands](#docker-engine-subcommands)                                                                          | v19.03     | v20.10 |
@@ -723,7 +723,7 @@ fluent#New: AsyncConnect is now deprecated, use Async instead
 ```
 
 Users are encouraged to use the `fluentd-async` option going forward, as support
-for the old option will be removed in a future release.
+for the old option has been removed.
 
 ### Pushing and pulling with image manifest v2 schema 1
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/46114
- relates to https://github.com/docker/cli/pull/5740


The daemon still has migration code in place, but no longer accepts the option for new containers, so marking it as "removed"; https://github.com/moby/moby//commit/49ec488036d9702df8432ec0e6f33c170a4a2bbe

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

