### PR TITLE
docs: deprecated: mark API < v1.24 as "removed"

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -60,7 +60,7 @@ The following table provides an overview of the current status of deprecated fea
 | Removed    | [Graphdriver plugins (experimental)](#graphdriver-plugins-experimental)                                                            | v27.0      | v28.0  |
 | Deprecated | [Unauthenticated TCP connections](#unauthenticated-tcp-connections)                                                                | v26.0      | v28.0  |
 | Removed    | [`Container` and `ContainerConfig` fields in Image inspect](#container-and-containerconfig-fields-in-image-inspect)                | v25.0      | v26.0  |
-| Deprecated | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
+| Removed    | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
 | Removed    | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
 | Removed    | [IsAutomated field, and `is-automated` filter on `docker search`](#isautomated-field-and-is-automated-filter-on-docker-search)     | v25.0      | v28.2  |
 | Removed    | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
@@ -320,20 +320,22 @@ Error response from daemon: client version 1.23 is too old. Minimum supported AP
 upgrade your client to a newer version
 ```
 
+Support for API versions lower than `1.24` has been permanently removed in Docker
+Engine v26, and the minimum supported API version will be incrementally raised
+in releases following that.
+
+<!-- keeping the paragraphs below for when we incrementally raise the minimum API version -->
+<!--
 An environment variable (`DOCKER_MIN_API_VERSION`) is introduced that allows
 re-enabling older API versions in the daemon. This environment variable must
 be set in the daemon's environment (for example, through a [systemd override
 file](https://docs.docker.com/config/daemon/systemd/)), and the specified
-API version must be supported by the daemon (`1.12` or higher on Linux, or
-`1.24` or higher on Windows).
-
-Support for API versions lower than `1.24` will be permanently removed in Docker
-Engine v26, and the minimum supported API version will be incrementally raised
-in releases following that.
+API version must be supported by the daemon (`1.24` or higher).
 
 We do not recommend depending on the `DOCKER_MIN_API_VERSION` environment
 variable other than for exceptional cases where it's not possible to update
 old clients, and those clients must be supported.
+-->
 
 ### Container short ID in network Aliases field
 


### PR DESCRIPTION
- relate to https://github.com/moby/moby/pull/47155

Support for API versions lower than v1.24 was removed in v26.0. The DOCKER_MIN_API_VERSION environment-variable is still present in the docker daemon, but can currently only be used to raise the minimum version.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

