### PR TITLE
Allow absolute path in credential store/helpers

### DIFF
--- a/cli/config/credentials/native_store.go
+++ b/cli/config/credentials/native_store.go
@@ -4,6 +4,7 @@ import (
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
+	"path/filepath"
 )
 
 const (
@@ -22,7 +23,12 @@ type nativeStore struct {
 // NewNativeStore creates a new native store that
 // uses a remote helper program to manage credentials.
 func NewNativeStore(file store, helperSuffix string) Store {
-	name := remoteCredentialsPrefix + helperSuffix
+	var name string
+	if filepath.IsAbs(helperSuffix) {
+		name = helperSuffix
+	} else {
+		name = remoteCredentialsPrefix + helperSuffix
+	}
 	return &nativeStore{
 		programFunc: client.NewShellProgramFunc(name),
 		fileStore:   NewFileStore(file),


### PR DESCRIPTION
Implements #6103

Allows users to use a credential helper that does not live in path. The underlying credentials helper library uses os/exec exec.Command so this should be safe to do.

I should add a test, please advice for the best location to do that.


**- What I did**
Checks if the path is absolute, then return that instead of prepending docker-credential-

**- How I did it**
uses filepath to check if the path is absolute

**- How to verify it**
use an absolute path to a binary file which implements the docker-credential protocol.

**- Human readable description for the release notes**
```markdown changelog
Allows users to use a credential helper that does not live in path.

```