### PR TITLE
vendor: github.com/docker/docker 0e2cc22d36ae (v28.2-dev)

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -15,7 +15,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli-docs-tool v0.10.0
 	github.com/docker/distribution v2.8.3+incompatible
-	github.com/docker/docker v28.2.0-rc.2.0.20250526195745-26db31fdab62+incompatible // v28.2-dev
+	github.com/docker/docker v28.2.0-rc.2.0.20250528125821-0e2cc22d36ae+incompatible // v28.2-dev
 	github.com/docker/docker-credential-helpers v0.9.3
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -57,8 +57,8 @@ github.com/docker/cli-docs-tool v0.10.0/go.mod h1:5EM5zPnT2E7yCLERZmrDA234Vwn09f
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v28.2.0-rc.2.0.20250526195745-26db31fdab62+incompatible h1:3qxR7Cek38/BnmNzGP2iSSnGnfOiJ3VMnTrmpqD2THk=
-github.com/docker/docker v28.2.0-rc.2.0.20250526195745-26db31fdab62+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.2.0-rc.2.0.20250528125821-0e2cc22d36ae+incompatible h1:Pdcl2hlBHJ4r5x17UbJFWl2VJT753caMxKDxCjOH8i4=
+github.com/docker/docker v28.2.0-rc.2.0.20250528125821-0e2cc22d36ae+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/docker/distribution/registry/client/transport
 github.com/docker/distribution/registry/storage/cache
 github.com/docker/distribution/registry/storage/cache/memory
 github.com/docker/distribution/uuid
-# github.com/docker/docker v28.2.0-rc.2.0.20250526195745-26db31fdab62+incompatible
+# github.com/docker/docker v28.2.0-rc.2.0.20250528125821-0e2cc22d36ae+incompatible
 ## explicit
 github.com/docker/docker/api
 github.com/docker/docker/api/types


### PR DESCRIPTION
no changes in vendored code

full diff: https://github.com/docker/docker/compare/26db31fdab628a2345ed8f179e575099384166a9...0e2cc22d36ae3013f83863c8da2e1b808f25e78e


**- A picture of a cute animal (not mandatory but encouraged)**

