### PR TITLE
gha/bin-image: Don't push sha tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,6 @@ jobs:
             type=semver,pattern={{version}}
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
       -
         name: Build and push image
         uses: docker/bake-action@v6


### PR DESCRIPTION
- related: https://github.com/moby/moby/pull/50109

This change eliminates the automatic creation of image tags in the
format `dockereng/cli-bin:sha-ad132f5` for every push.

They're not too useful, produce noise and use a lot of space.