### PR TITLE
Update documentation for docker container stop command

### DIFF
--- a/docs/reference/commandline/container_stop.md
+++ b/docs/reference/commandline/container_stop.md
@@ -30,6 +30,8 @@ instruction in the container's Dockerfile, or the `--stop-signal` option to
 $ docker stop my_container
 ```
 
+Note: You can specify containers by either their name or ID (full or unique partial). Both forms are interchangeable in this command.
+
 ### <a name="signal"></a> Stop container with signal (-s, --signal)
 
 The `--signal` flag sends the system call signal to the container to exit.


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Added a note to clarify that container names and IDs are interchangeable in `docker stop` / `docker container stop`.

**- How I did it**

Edited [container_stop.md](https://github.com/docker/cli/blob/master/docs/reference/commandline/stop.md) to include a short note.

**- How to verify it**

Trusting maintainers to verify usefulness:) Added due to gaps in the [official docs](https://docs.docker.com/reference/cli/docker/container/stop/) that caused a bit of internal confusion.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

Clarified support for container names and IDs in docker container stop CLI command

```

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/efb8b300-d9f1-4f5b-bab6-02fc31b0c3ff)
