### PR TITLE
cli/command/container: remove use of ExecOptions.Detach as intermediate

### DIFF
--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -99,7 +99,7 @@ func RunExec(ctx context.Context, dockerCLI command.Cli, containerIDorName strin
 	if _, err := apiClient.ContainerInspect(ctx, containerIDorName); err != nil {
 		return err
 	}
-	if !execOptions.Detach {
+	if !options.Detach {
 		if err := dockerCLI.In().CheckTty(execOptions.AttachStdin, execOptions.Tty); err != nil {
 			return err
 		}
@@ -117,9 +117,9 @@ func RunExec(ctx context.Context, dockerCLI command.Cli, containerIDorName strin
 		return errors.New("exec ID empty")
 	}
 
-	if execOptions.Detach {
+	if options.Detach {
 		return apiClient.ContainerExecStart(ctx, execID, container.ExecStartOptions{
-			Detach:      execOptions.Detach,
+			Detach:      options.Detach,
 			Tty:         execOptions.Tty,
 			ConsoleSize: execOptions.ConsoleSize,
 		})
@@ -223,7 +223,6 @@ func parseExec(execOpts ExecOptions, configFile *configfile.ConfigFile) (*contai
 		Privileged: execOpts.Privileged,
 		Tty:        execOpts.TTY,
 		Cmd:        execOpts.Command,
-		Detach:     execOpts.Detach,
 		WorkingDir: execOpts.Workdir,
 	}
 

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"strconv"
 	"testing"
 
 	"github.com/docker/cli/cli"
@@ -75,8 +76,7 @@ TWO=2
 		{
 			options: withDefaultOpts(ExecOptions{Detach: true}),
 			expected: container.ExecOptions{
-				Detach: true,
-				Cmd:    []string{"command"},
+				Cmd: []string{"command"},
 			},
 		},
 		{
@@ -86,9 +86,8 @@ TWO=2
 				Detach:      true,
 			}),
 			expected: container.ExecOptions{
-				Detach: true,
-				Tty:    true,
-				Cmd:    []string{"command"},
+				Tty: true,
+				Cmd: []string{"command"},
 			},
 		},
 		{
@@ -97,7 +96,6 @@ TWO=2
 			expected: container.ExecOptions{
 				Cmd:        []string{"command"},
 				DetachKeys: "de",
-				Detach:     true,
 			},
 		},
 		{
@@ -109,7 +107,6 @@ TWO=2
 			expected: container.ExecOptions{
 				Cmd:        []string{"command"},
 				DetachKeys: "ab",
-				Detach:     true,
 			},
 		},
 		{
@@ -141,10 +138,12 @@ TWO=2
 		},
 	}
 
-	for _, testcase := range testcases {
-		execConfig, err := parseExec(testcase.options, &testcase.configFile)
-		assert.NilError(t, err)
-		assert.Check(t, is.DeepEqual(testcase.expected, *execConfig))
+	for i, testcase := range testcases {
+		t.Run("test "+strconv.Itoa(i+1), func(t *testing.T) {
+			execConfig, err := parseExec(testcase.options, &testcase.configFile)
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(testcase.expected, *execConfig))
+		})
 	}
 }
 


### PR DESCRIPTION
relates to;

- https://github.com/moby/moby/pull/50218
- https://github.com/moby/moby/pull/8062
- https://github.com/moby/moby/pull/23759



This field was added in [moby@5130fe5d38837302e], which added it for use as intermediate struct when parsing CLI flags (through `runconfig.ParseExec`) in [moby@c786a8ee5e9db8f5f].

Commit [moby@9d9dff3d0d9e92adf] rewrote the CLI to use Cobra, and as part of this introduced a separate `execOptions` type in `api/client/container`, however the ExecOptions.Detach field was still used as intermediate field to store the flag's value.

Given that the client doesn't use this field, let's remove its use to prevent giving the impression that it's used anywhere.

[moby@5130fe5d38837302e]: https://github.com/docker/docker/commit/5130fe5d38837302e72bdc5e4bd1f5fa1df72c7f
[moby@c786a8ee5e9db8f5f]: https://github.com/docker/docker/commit/c786a8ee5e9db8f5f609cf8721bd1e1513fb0043
[moby@9d9dff3d0d9e92adf]: https://github.com/docker/docker/commit/9d9dff3d0d9e92adf7c2e59f94c63766659d1d47

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

