### PR TITLE
image/tree: Fix top image chip detection

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -170,10 +170,16 @@ func getPossibleChips(view treeView) (chips []imageChip) {
 
 	var possible []imageChip
 	for _, img := range view.images {
+		details := []imageDetails{img.Details}
+
 		for _, c := range img.Children {
+			details = append(details, c.Details)
+		}
+
+		for _, d := range details {
 			for idx := len(remaining) - 1; idx >= 0; idx-- {
 				chip := remaining[idx]
-				if chip.check(&c.Details) {
+				if chip.check(&d) {
 					possible = append(possible, chip)
 					remaining = append(remaining[:idx], remaining[idx+1:]...)
 				}


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/issues/6122

Currently, image tree visualization doesn't properly detect chips for parent images, only looking at child images. This patch fixes the issue by checking both parent and child images when determining which chips to display in the tree view.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

<img width="756" alt="image" src="https://github.com/user-attachments/assets/e5a3d3e2-ba05-4e0f-a361-99660608cadf" />


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker images --tree` not marking images as in-use when the containerd image store is disabled
```

**- A picture of a cute animal (not mandatory but encouraged)**

