### PR TITLE
prevent login prompt on registry operations with no TTY attached

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -74,6 +74,8 @@ Image index won't be pushed, meaning that other manifests, including attestation
 }
 
 // runPush performs a push against the engine based on the specified options.
+//
+//nolint:gocyclo // ignore cyclomatic complexity 17 of func `runPush` is high (> 16) for now.
 func runPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error {
 	var platform *ocispec.Platform
 	out := tui.NewOutput(dockerCli.Out())
@@ -113,7 +115,10 @@ To push the complete multi-platform image, remove the --platform flag.
 	if err != nil {
 		return err
 	}
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, "push")
+	var requestPrivilege registrytypes.RequestAuthConfig
+	if dockerCli.In().IsTerminal() {
+		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, "push")
+	}
 	options := image.PushOptions{
 		All:           opts.all,
 		RegistryAuth:  encodedAuth,

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -149,7 +149,10 @@ func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth tru
 	if err != nil {
 		return err
 	}
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(cli, imgRefAndAuth.RepoInfo().Index, "pull")
+	var requestPrivilege registrytypes.RequestAuthConfig
+	if cli.In().IsTerminal() {
+		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(cli, imgRefAndAuth.RepoInfo().Index, "pull")
+	}
 	responseBody, err := cli.Client().ImagePull(ctx, reference.FamiliarString(imgRefAndAuth.Reference()), image.PullOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -90,13 +90,18 @@ func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOpti
 		return types.PluginInstallOptions{}, err
 	}
 
+	var requestPrivilege registrytypes.RequestAuthConfig
+	if dockerCli.In().IsTerminal() {
+		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, cmdName)
+	}
+
 	options := types.PluginInstallOptions{
 		RegistryAuth:          encodedAuth,
 		RemoteRef:             remote,
 		Disabled:              opts.disable,
 		AcceptAllPermissions:  opts.grantPerms,
 		AcceptPermissionsFunc: acceptPrivileges(dockerCli, opts.remote),
-		PrivilegeFunc:         command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, cmdName),
+		PrivilegeFunc:         requestPrivilege,
 		Args:                  opts.args,
 	}
 	return options, nil

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -35,7 +35,7 @@ const (
 const authConfigKey = "https://index.docker.io/v1/"
 
 // RegistryAuthenticationPrivilegedFunc returns a RequestPrivilegeFunc from the specified registry index info
-// for the given command.
+// for the given command to prompt the user for username and password.
 func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInfo, cmdName string) registrytypes.RequestAuthConfig {
 	configKey := getAuthConfigKey(index.Name)
 	isDefaultRegistry := configKey == authConfigKey || index.Official

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -63,7 +63,10 @@ func runSearch(ctx context.Context, dockerCli command.Cli, options searchOptions
 		return err
 	}
 
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCli, indexInfo, "search")
+	var requestPrivilege registrytypes.RequestAuthConfig
+	if dockerCli.In().IsTerminal() {
+		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, indexInfo, "search")
+	}
 	results, err := dockerCli.Client().ImageSearch(ctx, options.term, registrytypes.SearchOptions{
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: requestPrivilege,

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -82,7 +82,10 @@ func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOption
 			return trust.NotaryError(imgRefAndAuth.RepoInfo().Name.Name(), err)
 		}
 	}
-	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(dockerCLI, imgRefAndAuth.RepoInfo().Index, "push")
+	var requestPrivilege registrytypes.RequestAuthConfig
+	if dockerCLI.In().IsTerminal() {
+		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCLI, imgRefAndAuth.RepoInfo().Index, "push")
+	}
 	target, err := createTarget(notaryRepo, imgRefAndAuth.Tag())
 	if err != nil || options.local {
 		switch err := err.(type) {


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6136
- relates to https://github.com/moby/moby/issues/50204


When pulling or pushing images, the CLI could prompt for a password if the push/pull failed and the registry returned a 401 (Unauthorized)

Ironically, this feature did not work when using Docker Hub (and possibly other registries using basic auth), due to some custom error handling added in [moby@19a93a6e3d42], which also discards the registry's status code, changing it to a 404;

    curl -v -XPOST --unix-socket /var/run/docker.sock 'http://localhost/v1.50/images/create?fromImage=docker.io%2Fexample%2Fprivate&tag=latest'
    ...
    < HTTP/1.1 404 Not Found
    < Content-Type: application/json
    ...
    {"message":"pull access denied for example/private, repository does not exist or may require 'docker login'"}

And due to a bug, other registries (not using basic auth) returned a generic error, which resulted in a 500 Internal Server Error. That bug was fixed in docker 28.2, now returning the upstream status code and trigger an interactive prompt;

    docker pull icr.io/my-ns/my-image:latest
    Please login prior to pull:
    Username:

This prompt would be triggered unconditionally, also if the CLI was run non-interactively and no TTY attached;

    docker pull icr.io/my-ns/my-image:latest < /dev/null
    Please login prior to pull:
    Username:

With this PR, no prompt is shown ;

    # without STDIN attached
    docker pull icr.io/my-ns/my-image:latest < /dev/null
    Error response from daemon: error from registry: Authorization required. See https://cloud.ibm.com/docs/Registry?topic=Registry-troubleshoot-auth-req - Authorization required. See https://cloud.ibm.com/docs/Registry?topic=Registry-troubleshoot-auth-req

For now, the prompt is still shown otherwise;

    docker pull icr.io/my-ns/my-image:latest

    Login prior to pull:
    Username: ^C

[moby@19a93a6e3d42]: https://github.com/moby/moby/commit/19a93a6e3d4213c56583bb0c843cf9e33d379752

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker pull/push` hang in non-interactive when authentication is required caused by prompting for login credentials.
```

**- A picture of a cute animal (not mandatory but encouraged)**

