### PR TITLE
#6142 fixed aliases for docker rm --help

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -36,7 +36,7 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 			return runRm(cmd.Context(), dockerCli, &opts)
 		},
 		Annotations: map[string]string{
-			"aliases": "docker container rm, docker container remove, docker rm",
+			"aliases": "docker container rm, docker container remove, docker remove, docker rm",
 		},
 		ValidArgsFunction: completion.ContainerNames(dockerCli, true, func(ctr container.Summary) bool {
 			return opts.force || ctr.State == container.StateExited || ctr.State == container.StateCreated


### PR DESCRIPTION
fixed typo where the command
`$ docker rm --help`
doesn't show an alias for "docker remove"

