### PR TITLE
remove undocumented top-level "docker remove" command

### DIFF
--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -28,7 +28,7 @@ func NewContainerCommand(dockerCli command.Cli) *cobra.Command {
 		NewPortCommand(dockerCli),
 		NewRenameCommand(dockerCli),
 		NewRestartCommand(dockerCli),
-		NewRmCommand(dockerCli),
+		newRemoveCommand(dockerCli),
 		NewRunCommand(dockerCli),
 		NewStartCommand(dockerCli),
 		NewStatsCommand(dockerCli),

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -27,10 +27,9 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 	var opts rmOptions
 
 	cmd := &cobra.Command{
-		Use:     "rm [OPTIONS] CONTAINER [CONTAINER...]",
-		Aliases: []string{"remove"},
-		Short:   "Remove one or more containers",
-		Args:    cli.RequiresMinArgs(1),
+		Use:   "rm [OPTIONS] CONTAINER [CONTAINER...]",
+		Short: "Remove one or more containers",
+		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
 			return runRm(cmd.Context(), dockerCli, &opts)
@@ -48,6 +47,15 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.rmLink, "link", "l", false, "Remove the specified link")
 	flags.BoolVarP(&opts.force, "force", "f", false, "Force the removal of a running container (uses SIGKILL)")
 	return cmd
+}
+
+// newRemoveCommand adds subcommands for "docker container"; unlike the
+// top-level "docker rm", it also adds a "remove" alias to support
+// "docker container remove" in addition to "docker container rm".
+func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := *NewRmCommand(dockerCli)
+	cmd.Aliases = []string{"rm", "remove"}
+	return &cmd
 }
 
 func runRm(ctx context.Context, dockerCLI command.Cli, opts *rmOptions) error {


### PR DESCRIPTION
- replaces / closes https://github.com/docker/cli/pull/6143
- closes https://github.com/docker/cli/issues/6142
- relates to / introduced in https://github.com/docker/cli/pull/3986
- relates to https://github.com/docker/cli/issues/3985


This was introduced in 9b54d860cd8b131890b92e8591c6ddd650f4d340, which added `docker container remove` as alias for `docker container rm`.

However, due to the `NewRmCommand` being used both for adding the top-level `docker rm` command and for adding the `docker container rm` command, it also introduced a (hidden) top-level `docker remove` command;

    docker remove --help | head -n1
    Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]

The command was not documented, and did not appear in `--help` output, nor was auto-complete provided;

    docker --help | grep remove

    docker r<TAB>
    rename               (Rename a container)  rm  (Remove one or more containers)  run  (Create and run a new container from an image)
    restart  (Restart one or more containers)  rmi     (Remove one or more images)

This patch adds a dedicated, non-exported `newRemoveCommand` to add sub- commands for `docker container`, taking a similar approach as was done in [moby@b993609d5a] for `docker image rm`.

With this patch applied, the hidden command is no longer there, but the `docker rm`, `docker container rm`, and `docker container remove` commands stay functional as intended;

    docker remove foo
    docker: unknown command: docker remove

    Run 'docker --help' for more information

    docker rm --help | head -n1
    Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]
    docker container rm --help | head -n1
    Usage:  docker container rm [OPTIONS] CONTAINER [CONTAINER...]
    docker container remove --help | head -n1
    Usage:  docker container rm [OPTIONS] CONTAINER [CONTAINER...]

[moby@b993609d5a]: https://github.com/moby/moby/commit/b993609d5ad4590da72e217bb43786b74aabc183

Reported-by: Lorenzo Buero <138243046+LorenzoBuero@users.noreply.github.com>

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove an undocumented, hidden, top-level `docker remove` command that was accidentally introduced in docker 23.0
```

**- A picture of a cute animal (not mandatory but encouraged)**

