### PR TITLE
mount /var/run/docker.sock for --use-api-socket

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -248,15 +248,14 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 		// 1. Mount the actual docker socket.
 		// 2. A synthezised ~/.docker/config.json with resolved tokens.
 
-		socket := dockerCli.DockerEndpoint().Host
-		if !strings.HasPrefix(socket, "unix://") {
-			return "", fmt.Errorf("flag --use-api-socket can only be used with unix sockets: docker endpoint %s incompatible", socket)
+		if dockerCli.ServerInfo().OSType == "windows" {
+			return "", errors.New("flag --use-api-socket can't be used with a Windows Docker Engine")
 		}
-		socket = strings.TrimPrefix(socket, "unix://") // should we confirm absolute path?
 
+		// hard-code engine socket path until https://github.com/moby/moby/pull/43459 gives us a discovery mechanism
 		containerCfg.HostConfig.Mounts = append(containerCfg.HostConfig.Mounts, mount.Mount{
 			Type:        mount.TypeBind,
-			Source:      socket,
+			Source:      "/var/run/docker.sock",
 			Target:      "/var/run/docker.sock",
 			BindOptions: &mount.BindOptions{},
 		})


### PR DESCRIPTION
**- What I did**

`s.dockerCli.DockerEndpoint().Host` returns the engine URL as seen by client, which is only relevant an Unix/MacOS with a local docker engine. Waiting for engine to expose this information in some API, or implement this feature on its own, hard-coding `/var/run/docker.sock` offer a more reliable path for engine socket to be mounted in container, while not 100% guaranteed to succeed.

**- How I did it**

hard-coded path

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
Fix `--use-api-socket` not working correctly when targeting a remote daemon.
```

**- A picture of a cute animal (not mandatory but encouraged)**

