### PR TITLE
cli/debug: fix OTELErrorHandler logging messages if there's no error

### DIFF
--- a/cli/debug/debug.go
+++ b/cli/debug/debug.go
@@ -33,5 +33,8 @@ func IsEnabled() bool {
 // The default is to log to the debug level which is only
 // enabled when debugging is enabled.
 var OTELErrorHandler otel.ErrorHandler = otel.ErrorHandlerFunc(func(err error) {
+	if err == nil {
+		return
+	}
 	logrus.WithError(err).Debug("otel error")
 })


### PR DESCRIPTION
- relates to https://github.com/docker/compose/issues/12998

I noticed this in a ticket in the compose issue tracker; with debug logging enabled, the OTEL error-logger may be logging even if there's no error;

    DEBU[0000] Executing bake with args: [bake --file - --progress rawjson --metadata-file /tmp/compose-build-metadataFile-1203980021.json --allow fs.read=/home/user/dev/project --allow fs.read=/home/user/dev/project --allow fs.read=/home/user/dev/project/nginx --allow fs.read=/home/user/dev/project]
    TRAC[0000] Plugin server listening on @docker_cli_d8df486f78df3b7357995be71bf0cef6
    DEBU[0005] otel error                                    error="<nil>"
    ^CTRAC[0055] Closing plugin server
    TRAC[0055] Closing plugin server
    DEBU[0055] otel error                                    error="<nil>"
    DEBU[0055] otel error                                    error="<nil>"

Update the error-handler to not log if there's no error.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix stray "otel error" logs being printed if debug logging is enabled.
```

**- A picture of a cute animal (not mandatory but encouraged)**

