### PR TITLE
registry: warn of `DOCKER_AUTH_CONFIG` usage in login and logout

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -121,6 +121,14 @@ func runLogin(ctx context.Context, dockerCLI command.Cli, opts loginOptions) err
 	}
 	isDefaultRegistry := serverAddress == registry.IndexServer
 
+	if os.Getenv(configfile.DockerEnvConfigKey) != "" {
+		out := tui.NewOutput(dockerCLI.Err())
+		out.PrintlnWithColor(tui.ColorWarning, "WARNING: using DOCKER_AUTH_CONFIG as the registry credential store")
+		out.PrintlnWithColor(tui.ColorWarning, "Unset DOCKER_AUTH_CONFIG to restore the CLI behavior")
+		out.PrintlnWithColor(tui.ColorWarning, "Login will still persist your credentials to disk")
+		out.Println()
+	}
+
 	// attempt login with current (stored) credentials
 	authConfig, err := command.GetDefaultAuthConfig(dockerCLI.ConfigFile(), opts.user == "" && opts.password == "", serverAddress, isDefaultRegistry)
 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -3,11 +3,14 @@ package registry
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/internal/oauth/manager"
+	"github.com/docker/cli/internal/tui"
 	"github.com/docker/docker/registry"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +39,14 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runLogout(ctx context.Context, dockerCLI command.Cli, serverAddress string) error {
+	if os.Getenv(configfile.DockerEnvConfigKey) != "" {
+		out := tui.NewOutput(dockerCLI.Err())
+		out.PrintlnWithColor(tui.ColorWarning, "WARNING: using DOCKER_AUTH_CONFIG as the registry credential store")
+		out.PrintlnWithColor(tui.ColorWarning, "Unset DOCKER_AUTH_CONFIG to restore the CLI behavior")
+		out.PrintlnWithColor(tui.ColorWarning, "Logout will still remove your credentials from disk")
+		out.Println()
+	}
+
 	var isDefaultRegistry bool
 
 	if serverAddress == "" {

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -56,7 +56,7 @@ type configEnv struct {
 	AuthConfigs map[string]configEnvAuth `json:"auths"`
 }
 
-// dockerEnvConfig is an environment variable that contains a JSON encoded
+// DockerEnvConfigKey is an environment variable that contains a JSON encoded
 // credential config. It only supports storing the credentials as a base64
 // encoded string in the format base64("username:pat").
 //
@@ -71,7 +71,7 @@ type configEnv struct {
 //			}
 //		}
 //	}
-const dockerEnvConfig = "DOCKER_AUTH_CONFIG"
+const DockerEnvConfigKey = "DOCKER_AUTH_CONFIG"
 
 // ProxyConfig contains proxy configuration settings
 type ProxyConfig struct {
@@ -296,7 +296,7 @@ func (configFile *ConfigFile) GetCredentialsStore(registryHostname string) crede
 		store = newNativeStore(configFile, helper)
 	}
 
-	envConfig := os.Getenv(dockerEnvConfig)
+	envConfig := os.Getenv(DockerEnvConfigKey)
 	if envConfig == "" {
 		return store
 	}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->


![image](https://github.com/user-attachments/assets/b3854d53-fe29-43dd-8acc-5e27e8de238b)

**- What I did**
Add a warning when `DOCKER_AUTH_CONFIG` is used when running `docker login` and `docker logout`.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
warn of `DOCKER_AUTH_CONFIG` usage on docker login and docker logout
```

**- A picture of a cute animal (not mandatory but encouraged)**

