### PR TITLE
e2e/global: TestPromptExitCode: check for trailing newline

### DIFF
--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -240,7 +240,7 @@ func TestPromptExitCode(t *testing.T) {
 			case <-writeDone:
 				buf.Reset()
 				assert.NilError(t, bufioWriter.Flush())
-				assert.Equal(t, buf.String(), "\n", "expected a new line after the process exits from SIGINT")
+				assert.Assert(t, strings.HasSuffix(buf.String(), "\n"), "expected a new line after the process exits from SIGINT")
 			}
 		})
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6121

Make the test slightly more permissive; we're looking for a trailing newline, not necessarily an empty line.

**- A picture of a cute animal (not mandatory but encouraged)**

