### PR TITLE
Ignore `DOCKER_AUTH_CONFIG` without opt-in on Gitlab CI

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -111,7 +111,9 @@ func runLogin(ctx context.Context, dockerCLI command.Cli, opts loginOptions) err
 		return err
 	}
 
-	maybePrintEnvAuthWarning(dockerCLI)
+	if dockerCLI.ConfigFile().PreferDockerAuthConfig() {
+		printEnvAuthWarning(dockerCLI)
+	}
 
 	var (
 		serverAddress string

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -36,7 +36,9 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func runLogout(ctx context.Context, dockerCLI command.Cli, serverAddress string) error {
-	maybePrintEnvAuthWarning(dockerCLI)
+	if dockerCLI.ConfigFile().PreferDockerAuthConfig() {
+		printEnvAuthWarning(dockerCLI)
+	}
 
 	var isDefaultRegistry bool
 

--- a/cli/command/registry/warning.go
+++ b/cli/command/registry/warning.go
@@ -1,18 +1,14 @@
 package registry
 
 import (
-	"os"
-
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/internal/tui"
 )
 
-// maybePrintEnvAuthWarning if the `DOCKER_AUTH_CONFIG` environment variable is
+// printEnvAuthWarning if the `DOCKER_AUTH_CONFIG` environment variable is
 // set this function will output a warning to stdErr
-func maybePrintEnvAuthWarning(out command.Streams) {
-	if os.Getenv(configfile.DockerEnvConfigKey) != "" {
-		tui.NewOutput(out.Err()).
-			PrintWarning("%[1]s is set and takes precedence.\nUnset %[1]s to restore the CLI auth behaviour.\n", configfile.DockerEnvConfigKey)
-	}
+func printEnvAuthWarning(out command.Streams) {
+	tui.NewOutput(out.Err()).
+		PrintWarning("%[1]s is set and takes precedence.\nUnset %[1]s to restore the CLI auth behaviour.\n", configfile.DockerEnvConfigKey)
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -287,6 +287,39 @@ func decodeAuth(authStr string) (string, string, error) {
 	return userName, strings.Trim(password, "\x00"), nil
 }
 
+// PreferDockerAuthConfig returns true if the memory store containing auth
+// config read from DOCKER_AUTH_CONFIG should be preferred over the config file.
+func (configFile *ConfigFile) PreferDockerAuthConfig() bool {
+	order := configFile.Features["auth_config_order"]
+	if v := os.Getenv("DOCKER_AUTH_ORDER"); v != "" {
+		order = v
+	}
+
+	order = strings.TrimSpace(order)
+	if order == "" {
+		// Temporary fix for clashing with GitLab CI
+		// Don't enable by default even if DOCKER_AUTH_CONFIG is set
+		// https://github.com/docker/cli/issues/6156
+		if os.Getenv("GITLAB_CI") == "true" {
+			return false
+		}
+		return true
+	}
+
+	parts := strings.Split(order, ",")
+	if len(parts) == 2 {
+		if parts[0] == "env" && parts[1] == "config" {
+			return true
+		}
+		if parts[0] == "config" && parts[1] == "env" {
+			return false
+		}
+	}
+
+	_, _ = fmt.Fprintln(os.Stderr, "Malformed DOCKER_AUTH_ORDER")
+	return true
+}
+
 // GetCredentialsStore returns a new credentials store from the settings in the
 // configuration file
 func (configFile *ConfigFile) GetCredentialsStore(registryHostname string) credentials.Store {
@@ -307,12 +340,17 @@ func (configFile *ConfigFile) GetCredentialsStore(registryHostname string) crede
 		return store
 	}
 
-	// use DOCKER_AUTH_CONFIG if set
-	// it uses the native or file store as a fallback to fetch and store credentials
-	envStore, err := memorystore.New(
+	opts := []memorystore.Options{
 		memorystore.WithAuthConfig(authConfig),
 		memorystore.WithFallbackStore(store),
-	)
+	}
+	if !configFile.PreferDockerAuthConfig() {
+		opts = append(opts, memorystore.WithPreferFallback())
+	}
+
+	// use DOCKER_AUTH_CONFIG if set
+	// it uses the native or file store as a fallback to fetch and store credentials
+	envStore, err := memorystore.New(opts...)
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "Failed to create credential store from DOCKER_AUTH_CONFIG: ", err)
 		return store


### PR DESCRIPTION
This is a hot-fix that prevents using the `DOCKER_AUTH_CONFIG` env-var as a credential helper when running in Gitlab CI (determined by `GITLAB_CI` environment variable).

An explicit setting controlling this behavior is available through the `auth_config_order` feature flag in the Docker CLI config (and `DOCKER_AUTH_ORDER` environment variable that takes precedence over the feature flag value).

It accepts a comma separated "config" and "env" strings which determine the order.

Currently, possible values are:
- "config,env" - prefer the auth from config.json first
- "env,config" - prefer the auth from `DOCKER_AUTH_CONFIG`

```json ~/.docker/config.json
{
    ...,
    "features": {
        "auth_config_order": "config,env"
    }
}
```

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Temporarily disable `DOCKER_AUTH_CONFIG` taking precedence on Gitlab CI by default. The behavior can be explicitly defined with `DOCKER_AUTH_ORDER=env,config` or `~/.docker/config.json` feature flag: `{ ..., "features": { "auth_config_order": "env,config" } }`
```

**- A picture of a cute animal (not mandatory but encouraged)**

