### PR TITLE
cli/command: remove interactive login prompt from docker push/pull

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -74,8 +74,6 @@ Image index won't be pushed, meaning that other manifests, including attestation
 }
 
 // runPush performs a push against the engine based on the specified options.
-//
-//nolint:gocyclo // ignore cyclomatic complexity 17 of func `runPush` is high (> 16) for now.
 func runPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error {
 	var platform *ocispec.Platform
 	out := tui.NewOutput(dockerCli.Out())
@@ -115,14 +113,10 @@ To push the complete multi-platform image, remove the --platform flag.
 	if err != nil {
 		return err
 	}
-	var requestPrivilege registrytypes.RequestAuthConfig
-	if dockerCli.In().IsTerminal() {
-		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, "push")
-	}
 	options := image.PushOptions{
 		All:           opts.all,
 		RegistryAuth:  encodedAuth,
-		PrivilegeFunc: requestPrivilege,
+		PrivilegeFunc: nil,
 		Platform:      platform,
 	}
 

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -149,13 +149,9 @@ func imagePullPrivileged(ctx context.Context, cli command.Cli, imgRefAndAuth tru
 	if err != nil {
 		return err
 	}
-	var requestPrivilege registrytypes.RequestAuthConfig
-	if cli.In().IsTerminal() {
-		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(cli, imgRefAndAuth.RepoInfo().Index, "pull")
-	}
 	responseBody, err := cli.Client().ImagePull(ctx, reference.FamiliarString(imgRefAndAuth.Reference()), image.PullOptions{
 		RegistryAuth:  encodedAuth,
-		PrivilegeFunc: requestPrivilege,
+		PrivilegeFunc: nil,
 		All:           opts.all,
 		Platform:      opts.platform,
 	})

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -56,7 +56,7 @@ func newInstallCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOptions, cmdName string) (types.PluginInstallOptions, error) {
+func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOptions) (types.PluginInstallOptions, error) {
 	// Names with both tag and digest will be treated by the daemon
 	// as a pull by digest with a local name for the tag
 	// (if no local name is provided).
@@ -90,18 +90,13 @@ func buildPullConfig(ctx context.Context, dockerCli command.Cli, opts pluginOpti
 		return types.PluginInstallOptions{}, err
 	}
 
-	var requestPrivilege registrytypes.RequestAuthConfig
-	if dockerCli.In().IsTerminal() {
-		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, repoInfo.Index, cmdName)
-	}
-
 	options := types.PluginInstallOptions{
 		RegistryAuth:          encodedAuth,
 		RemoteRef:             remote,
 		Disabled:              opts.disable,
 		AcceptAllPermissions:  opts.grantPerms,
 		AcceptPermissionsFunc: acceptPrivileges(dockerCli, opts.remote),
-		PrivilegeFunc:         requestPrivilege,
+		PrivilegeFunc:         nil,
 		Args:                  opts.args,
 	}
 	return options, nil
@@ -120,7 +115,7 @@ func runInstall(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 		localName = reference.FamiliarString(reference.TagNameOnly(aref))
 	}
 
-	options, err := buildPullConfig(ctx, dockerCLI, opts, "plugin install")
+	options, err := buildPullConfig(ctx, dockerCLI, opts)
 	if err != nil {
 		return err
 	}

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -73,7 +73,7 @@ func runUpgrade(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 		}
 	}
 
-	options, err := buildPullConfig(ctx, dockerCLI, opts, "plugin upgrade")
+	options, err := buildPullConfig(ctx, dockerCLI, opts)
 	if err != nil {
 		return err
 	}

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -63,13 +63,9 @@ func runSearch(ctx context.Context, dockerCli command.Cli, options searchOptions
 		return err
 	}
 
-	var requestPrivilege registrytypes.RequestAuthConfig
-	if dockerCli.In().IsTerminal() {
-		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCli, indexInfo, "search")
-	}
 	results, err := dockerCli.Client().ImageSearch(ctx, options.term, registrytypes.SearchOptions{
 		RegistryAuth:  encodedAuth,
-		PrivilegeFunc: requestPrivilege,
+		PrivilegeFunc: nil,
 		Filters:       options.filter.Value(),
 		Limit:         options.limit,
 	})

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -82,10 +82,6 @@ func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOption
 			return trust.NotaryError(imgRefAndAuth.RepoInfo().Name.Name(), err)
 		}
 	}
-	var requestPrivilege registrytypes.RequestAuthConfig
-	if dockerCLI.In().IsTerminal() {
-		requestPrivilege = command.RegistryAuthenticationPrivilegedFunc(dockerCLI, imgRefAndAuth.RepoInfo().Index, "push")
-	}
 	target, err := createTarget(notaryRepo, imgRefAndAuth.Tag())
 	if err != nil || options.local {
 		switch err := err.(type) {
@@ -104,7 +100,7 @@ func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOption
 			}
 			responseBody, err := dockerCLI.Client().ImagePush(ctx, reference.FamiliarString(imgRefAndAuth.Reference()), imagetypes.PushOptions{
 				RegistryAuth:  encodedAuth,
-				PrivilegeFunc: requestPrivilege,
+				PrivilegeFunc: nil,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Relates to:
- https://github.com/docker/cli/pull/6172
- https://github.com/moby/moby/pull/50341

**- What I did**

This patch removes the interactive prompts from `docker push/pull`.
The prompt would only execute on a response status code 403 from the registry
after trying the value set in `RegistryAuth`. Docker Hub could return 404
instead or 429, which would never execute the prompt.

The UX regarding the prompt is also questionable since the user might
not actually want to authenticate with a registry and the CLI could fail fast
instead. The user can always run `docker login` or set the `DOCKER_AUTH_CONFIG`
environment variable to get authenticated.

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove interactive login prompt from `docker push` and `docker pull`. Previously, a `docker pull` could trigger an interactive login prompt if the pull failed because authentication was needed, which could disrupt non-interactive use.
This behavior depended on the registry from which the image was pulled (or pushed to), and the authentication mechanism used, making this behavior unpredictable. Instead, the cli now prints the error message produced by the registry, exiting with a non-zero exit code.
```

**- A picture of a cute animal (not mandatory but encouraged)**

