### PR TITLE
cli/command/container: don't set CopyToContainerOptions.AllowOverwriteDirWithFile

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -398,8 +398,7 @@ func copyToContainer(ctx context.Context, dockerCLI command.Cli, copyConfig cpCo
 	}
 
 	options := container.CopyToContainerOptions{
-		AllowOverwriteDirWithFile: false,
-		CopyUIDGID:                copyConfig.copyUIDGID,
+		CopyUIDGID: copyConfig.copyUIDGID,
 	}
 
 	if copyConfig.quiet {


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/18472
- https://github.com/moby/moby/pull/13171

### cli/command/container: don't set CopyToContainerOptions.AllowOverwriteDirWithFile

The `AllowOverwriteDirWithFile` option was added when reimplementing the CLI using the API Client lib in [moby@1b2b91b]. Before that refactor, the `noOverwriteDirNonDir` query argument [would be set unconditionally][1] by the CLI, with no options to control the behavior.

It's unclear why the `noOverwriteDirNonDir` was implemented as opt-in (not opt-out), as overwriting a file with a directory (or vice-versa) would generally be unexpected behavior.

We're considering making `noOverwriteDirNonDir` unconditional on the daemon side, and to deprecate the `AllowOverwriteDirWithFile` option. This patch removes its use, as it was set to the default either way, and there's no options to configure it from the CLI.

[1]: https://github.com/moby/moby/blob/8c9ad7b818c0a7b1e39f8df1fabba243a0961c2d/api/client/cp.go#L345-L346
[moby@1b2b91b]: https://github.com/moby/moby/commit/1b2b91ba43dc6fa1b4b758fc5a8090ce6cc597ff

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

