### PR TITLE
cli/command/container: diff: remove redundant validation and cleanup

### DIFF
--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -7,25 +7,17 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-type diffOptions struct {
-	container string
-}
-
 // NewDiffCommand creates a new cobra.Command for `docker diff`
 func NewDiffCommand(dockerCli command.Cli) *cobra.Command {
-	var opts diffOptions
-
 	return &cobra.Command{
 		Use:   "diff CONTAINER",
 		Short: "Inspect changes to files or directories on a container's filesystem",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.container = args[0]
-			return runDiff(cmd.Context(), dockerCli, &opts)
+			return runDiff(cmd.Context(), dockerCli, args[0])
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container diff, docker diff",
@@ -34,16 +26,13 @@ func NewDiffCommand(dockerCli command.Cli) *cobra.Command {
 	}
 }
 
-func runDiff(ctx context.Context, dockerCli command.Cli, opts *diffOptions) error {
-	if opts.container == "" {
-		return errors.New("Container name cannot be empty")
-	}
-	changes, err := dockerCli.Client().ContainerDiff(ctx, opts.container)
+func runDiff(ctx context.Context, dockerCLI command.Cli, containerID string) error {
+	changes, err := dockerCLI.Client().ContainerDiff(ctx, containerID)
 	if err != nil {
 		return err
 	}
 	diffCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: NewDiffFormat("{{.Type}} {{.Path}}"),
 	}
 	return DiffFormatWrite(diffCtx, changes)

--- a/cli/command/container/diff_test.go
+++ b/cli/command/container/diff_test.go
@@ -77,17 +77,3 @@ func TestRunDiffClientError(t *testing.T) {
 	err := cmd.Execute()
 	assert.ErrorIs(t, err, clientError)
 }
-
-func TestRunDiffEmptyContainerError(t *testing.T) {
-	cli := test.NewFakeCli(&fakeClient{})
-
-	cmd := NewDiffCommand(cli)
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-
-	containerID := ""
-	cmd.SetArgs([]string{containerID})
-
-	err := cmd.Execute()
-	assert.Error(t, err, "Container name cannot be empty")
-}


### PR DESCRIPTION
client.ContainerDiff already validates the given container name/ID, and produces an error when empty, so we don't have to check for this; https://github.com/moby/moby/blob/abba330bbfe10765822b59bb68af99db439736ba/client/container_diff.go#L13-L16

While updating, also;

- remove the diffOptions type, as there were no other options, and make the container name/ID a string argument.
- fix camelCase nameing of dockerCLI

Before this patch:

    docker diff ""
    Container name cannot be empty

With this patch:

    docker diff ""
    invalid container name or ID: value is empty

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

