### PR TITLE
cli/command: deprecate RegistryAuthenticationPrivilegedFunc

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -36,6 +36,8 @@ const authConfigKey = "https://index.docker.io/v1/"
 
 // RegistryAuthenticationPrivilegedFunc returns a RequestPrivilegeFunc from the specified registry index info
 // for the given command to prompt the user for username and password.
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInfo, cmdName string) registrytypes.RequestAuthConfig {
 	configKey := getAuthConfigKey(index.Name)
 	isDefaultRegistry := configKey == authConfigKey || index.Official


### PR DESCRIPTION
This patch deprecates the unused `RegistryAuthenticationPrivilegedFunc`. The function would prompt the user when the registry returns a 403 after trying the initial auth value set in `RegistryAuth`.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Relates to:
- https://github.com/docker/cli/pull/6172
- https://github.com/moby/moby/pull/50341
- https://github.com/docker/cli/pull/6174

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: deprecate `cli/command.RegistryAuthenticationPrivilegedFunc`
```

**- A picture of a cute animal (not mandatory but encouraged)**

