### PR TITLE
Dockerfile: document ALPINE_VERSION build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_VARIANT=alpine
+
+# ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
+# It must be a supported tag in the docker.io/library/alpine image repository
+# that's also available as alpine image variant for the Golang version used.
 ARG ALPINE_VERSION=3.21
 ARG BASE_DEBIAN_DISTRO=bookworm
 

--- a/dockerfiles/Dockerfile.authors
+++ b/dockerfiles/Dockerfile.authors
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1
 
+# ALPINE_VERSION sets the version of the alpine base image to use.
+# It must be a supported tag in the docker.io/library/alpine image repository.
 ARG ALPINE_VERSION=3.21
 
 FROM alpine:${ALPINE_VERSION} AS gen

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.24.5
+
+# ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
+# It must be a supported tag in the docker.io/library/alpine image repository
+# that's also available as alpine image variant for the Golang version used.
 ARG ALPINE_VERSION=3.21
 
 # BUILDX_VERSION sets the version of buildx to install in the dev container.

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.24.5
+
+# ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
+# It must be a supported tag in the docker.io/library/alpine image repository
+# that's also available as alpine image variant for the Golang version used.
 ARG ALPINE_VERSION=3.21
 ARG GOLANGCI_LINT_VERSION=v2.1.5
 

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.24.5
+
+# ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
+# It must be a supported tag in the docker.io/library/alpine image repository
+# that's also available as alpine image variant for the Golang version used.
 ARG ALPINE_VERSION=3.21
 ARG MODOUTDATED_VERSION=v0.8.0
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6179#issuecomment-3067135124

### Dockerfile: document ALPINE_VERSION build-arg

```bash
docker build --call outline .

TARGET: binary

BUILD ARG               VALUE    DESCRIPTION
BASE_VARIANT            alpine
ALPINE_VERSION          3.21     sets the version of the alpine base image to use, including for the golang image.
GO_VERSION              1.24.5
XX_VERSION              1.6.1
GOVERSIONINFO_VERSION   v1.4.1
GO_LINKMODE             static   defines if static or dynamic binary should be produced
GO_BUILDTAGS                     defines additional build tags
GO_STRIP                         strips debugging symbols if set
CGO_ENABLED                      manually sets if cgo is used
VERSION                          sets the version for the produced binary
PACKAGER_NAME                    sets the company that produced the windows binary
```

Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

