### PR TITLE
opts: minor cleanup in tests, and remove some import aliases

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/cli/cli/command/formatter"
 	"github.com/docker/cli/cli/command/inspect"
 	"github.com/docker/docker/api/types/container"
-	mounttypes "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/go-units"
@@ -461,7 +461,7 @@ func (ctx *serviceInspectContext) ContainerInit() bool {
 	return *ctx.Service.Spec.TaskTemplate.ContainerSpec.Init
 }
 
-func (ctx *serviceInspectContext) ContainerMounts() []mounttypes.Mount {
+func (ctx *serviceInspectContext) ContainerMounts() []mount.Mount {
 	return ctx.Service.Spec.TaskTemplate.ContainerSpec.Mounts
 }
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/cli/opts/swarmopts"
 	"github.com/docker/docker/api/types/container"
-	mounttypes "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/api/types/versions"
@@ -943,33 +943,33 @@ func removeItems(
 	return newSeq
 }
 
-func updateMounts(flags *pflag.FlagSet, mounts *[]mounttypes.Mount) error {
-	mountsByTarget := map[string]mounttypes.Mount{}
+func updateMounts(flags *pflag.FlagSet, mounts *[]mount.Mount) error {
+	mountsByTarget := map[string]mount.Mount{}
 
 	if flags.Changed(flagMountAdd) {
 		values := flags.Lookup(flagMountAdd).Value.(*opts.MountOpt).Value()
-		for _, mount := range values {
-			if _, ok := mountsByTarget[mount.Target]; ok {
+		for _, mnt := range values {
+			if _, ok := mountsByTarget[mnt.Target]; ok {
 				return errors.Errorf("duplicate mount target")
 			}
-			mountsByTarget[mount.Target] = mount
+			mountsByTarget[mnt.Target] = mnt
 		}
 	}
 
 	// Add old list of mount points minus updated one.
-	for _, mount := range *mounts {
-		if _, ok := mountsByTarget[mount.Target]; !ok {
-			mountsByTarget[mount.Target] = mount
+	for _, mnt := range *mounts {
+		if _, ok := mountsByTarget[mnt.Target]; !ok {
+			mountsByTarget[mnt.Target] = mnt
 		}
 	}
 
-	newMounts := []mounttypes.Mount{}
+	newMounts := make([]mount.Mount, 0, len(mountsByTarget))
 
 	toRemove := buildToRemoveSet(flags, flagMountRemove)
 
-	for _, mount := range mountsByTarget {
-		if _, exists := toRemove[mount.Target]; !exists {
-			newMounts = append(newMounts, mount)
+	for _, mnt := range mountsByTarget {
+		if _, exists := toRemove[mnt.Target]; !exists {
+			newMounts = append(newMounts, mnt)
 		}
 	}
 	sort.Slice(newMounts, func(i, j int) bool {

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types/container"
-	mounttypes "github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"gotest.tools/v3/assert"
@@ -237,9 +237,9 @@ func TestUpdateMounts(t *testing.T) {
 	flags.Set("mount-add", "type=volume,source=vol2,target=/toadd")
 	flags.Set("mount-rm", "/toremove")
 
-	mounts := []mounttypes.Mount{
-		{Target: "/toremove", Source: "vol1", Type: mounttypes.TypeBind},
-		{Target: "/tokeep", Source: "vol3", Type: mounttypes.TypeBind},
+	mounts := []mount.Mount{
+		{Target: "/toremove", Source: "vol1", Type: mount.TypeBind},
+		{Target: "/tokeep", Source: "vol3", Type: mount.TypeBind},
 	}
 
 	updateMounts(flags, &mounts)
@@ -252,10 +252,10 @@ func TestUpdateMountsWithDuplicateMounts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("mount-add", "type=volume,source=vol4,target=/toadd")
 
-	mounts := []mounttypes.Mount{
-		{Target: "/tokeep1", Source: "vol1", Type: mounttypes.TypeBind},
-		{Target: "/toadd", Source: "vol2", Type: mounttypes.TypeBind},
-		{Target: "/tokeep2", Source: "vol3", Type: mounttypes.TypeBind},
+	mounts := []mount.Mount{
+		{Target: "/tokeep1", Source: "vol1", Type: mount.TypeBind},
+		{Target: "/toadd", Source: "vol2", Type: mount.TypeBind},
+		{Target: "/tokeep2", Source: "vol3", Type: mount.TypeBind},
 	}
 
 	updateMounts(flags, &mounts)


### PR DESCRIPTION
### opts: minor cleanup in tests, and remove some import aliases

- use consistent name for MountOpt vars
- cleanup some comments and make them a GoDoc
- remove import alias
- use subtests for tests that were prepared for it.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

