### PR TITLE
 cli/command/container: deprecate NewDiffFormat, DiffFormatWrite

### DIFF
--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -35,5 +35,5 @@ func runDiff(ctx context.Context, dockerCLI command.Cli, containerID string) err
 		Output: dockerCLI.Out(),
 		Format: newDiffFormat("{{.Type}} {{.Path}}"),
 	}
-	return DiffFormatWrite(diffCtx, changes)
+	return diffFormatWrite(diffCtx, changes)
 }

--- a/cli/command/container/formatter_diff.go
+++ b/cli/command/container/formatter_diff.go
@@ -28,7 +28,14 @@ func newDiffFormat(source string) formatter.Format {
 }
 
 // DiffFormatWrite writes formatted diff using the Context
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func DiffFormatWrite(fmtCtx formatter.Context, changes []container.FilesystemChange) error {
+	return diffFormatWrite(fmtCtx, changes)
+}
+
+// diffFormatWrite writes formatted diff using the [formatter.Context].
+func diffFormatWrite(fmtCtx formatter.Context, changes []container.FilesystemChange) error {
 	return fmtCtx.Write(newDiffContext(), func(format func(subContext formatter.SubContext) error) error {
 		for _, change := range changes {
 			if err := format(&diffContext{c: change}); err != nil {

--- a/cli/command/container/formatter_diff_test.go
+++ b/cli/command/container/formatter_diff_test.go
@@ -50,7 +50,7 @@ D: /usr/app/old_app.js
 		t.Run(string(tc.context.Format), func(t *testing.T) {
 			out := bytes.NewBufferString("")
 			tc.context.Output = out
-			err := DiffFormatWrite(tc.context, diffs)
+			err := diffFormatWrite(tc.context, diffs)
 			if err != nil {
 				assert.Error(t, err, tc.expected)
 			} else {


### PR DESCRIPTION
### cli/command/container: deprecate NewDiffFormat

It's part of the presentation logic of the cli, and only used internally.
We can consider providing utilities for these, but better as part of
separate packages.

### cli/command/container: DiffFormatWrite: remove intermediate var

Also rename "ctx" argument; we shouldn't use this as name for things
that are not a context.Context.

### cli/command/container: newDiffContext: use struct-literal

### cli/command/container: deprecate DiffFormatWrite

It's part of the presentation logic of the cli, and only used internally.
We can consider providing utilities for these, but better as part of
separate packages.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/container: deprecate `NewDiffFormat`, `DiffFormatWrite`. These functions were only used internally and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

