### PR TITLE
cli/command/image: move build-context detection to build

### DIFF
--- a/cli/command/image/build/context_detect.go
+++ b/cli/command/image/build/context_detect.go
@@ -1,0 +1,39 @@
+package build
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/builder/remotecontext/urlutil"
+)
+
+// ContextType describes the type (source) of build-context specified.
+type ContextType string
+
+const (
+	ContextTypeStdin  ContextType = "stdin"  // ContextTypeStdin indicates that the build-context is a TAR archive passed through STDIN.
+	ContextTypeLocal  ContextType = "local"  // ContextTypeLocal indicates that the build-context is a local directory.
+	ContextTypeRemote ContextType = "remote" // ContextTypeRemote indicates that the build-context is a remote URL.
+	ContextTypeGit    ContextType = "git"    // ContextTypeGit indicates that the build-context is a GIT URL.
+)
+
+// DetectContextType detects the type (source) of the build-context.
+func DetectContextType(specifiedContext string) (ContextType, error) {
+	switch {
+	case specifiedContext == "-":
+		return ContextTypeStdin, nil
+	case isLocalDir(specifiedContext):
+		return ContextTypeLocal, nil
+	case urlutil.IsGitURL(specifiedContext):
+		return ContextTypeGit, nil
+	case urlutil.IsURL(specifiedContext):
+		return ContextTypeRemote, nil
+	default:
+		return "", fmt.Errorf("unable to prepare context: path %q not found", specifiedContext)
+	}
+}
+
+func isLocalDir(c string) bool {
+	_, err := os.Stat(c)
+	return err == nil
+}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50365#discussion_r2198340305

Besides the docker CLI, compose also uses this for the classic builder, so we need a place to put this; it's likely out of scope for the client itself, so we may as well put it here for now.

Removes direct imports of github.com/docker/docker/builder in the image package, to be moved later.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/image/build: add a `DetectContextType` utility to detect the type of build-context.
```

**- A picture of a cute animal (not mandatory but encouraged)**

