### PR TITLE
Add e2e test for authorized pull/push to private repo

### DIFF
--- a/e2e/auth_test.go
+++ b/e2e/auth_test.go
@@ -1,0 +1,33 @@
+package e2e
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func runCmd(t *testing.T, name string, args ...string) string {
+	cmd := exec.Command(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command failed: %s %v\nOutput: %s\nError: %v", name, args, output, err)
+	}
+	return string(output)
+}
+
+func TestAuthorizedPullPush(t *testing.T) {
+	username := os.Getenv("DOCKER_USERNAME")
+	password := os.Getenv("DOCKER_PASSWORD")
+	privateRepo := os.Getenv("PRIVATE_REPO")
+
+	if username == "" || password == "" || privateRepo == "" {
+		t.Fatal("DOCKER_USERNAME, DOCKER_PASSWORD, and PRIVATE_REPO must be set")
+	}
+
+	runCmd(t, "docker", "login", "--username", username, "--password", password)
+	runCmd(t, "docker", "pull", "alpine")
+	runCmd(t, "docker", "tag", "alpine", privateRepo)
+	runCmd(t, "docker", "push", privateRepo)
+	runCmd(t, "docker", "rmi", privateRepo)
+	runCmd(t, "docker", "pull", privateRepo)
+}


### PR DESCRIPTION
**- What I did**

Added an end-to-end (e2e) test to verify authenticated pull and push operations to a private Docker registry.

**- How I did it**

Created `e2e/auth_test.go` which:
- Uses environment variables for credentials (`DOCKER_USERNAME`, `DOCKER_PASSWORD`, `PRIVATE_REPO`)
- Logs in to Docker registry
- Pulls, tags, pushes, removes, and pulls back a Docker image

**- How to verify it**

Run the e2e test with the required environment variables set in your local or CI environment.

**- Human readable description for the release notes**
```markdown changelog
Add e2e test for authenticated pull/push to private Docker registry
````

**- Related issue**
Closes #5965

