### PR TITLE
Fixed a bug with shadowing of variables in the processAliases function

### DIFF
--- a/cli/command/filename
+++ b/cli/command/filename
@@ -1,0 +1,10 @@
+{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "dTA6cDA="
+		},
+		"server1.io": {
+			"auth": "dTE6cDE="
+		}
+	}
+}

--- a/cmd/docker/aliases.go
+++ b/cmd/docker/aliases.go
@@ -38,7 +38,7 @@ func processAliases(dockerCli command.Cli, cmd *cobra.Command, args, osArgs []st
 
 	args, osArgs, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
 	if err != nil {
-		return args, os.Args, envs, err
+		return args, osArgs, envs, err
 	}
 
 	for _, al := range aliases {


### PR DESCRIPTION
## - What I did
Fixed incorrect return value when processBuilder returns an error.

## - How I did it
Previously, if processBuilder returned an error, the fallback used os.Args, which may not reflect the intended argument slice. Changed the fallback to use the (possibly modified) value returned from processBuilder, even in error cases.

This was caused by a variable shadowing bug where the global os.Args was returned instead of the local osArgs variable which holds the (potentially modified) return value from processBuilder.

```diff

	args, osArgs, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
	if err != nil {
                -- return args, os.Args, envs, err
		++ return args, osArgs, envs, err
	}

	for _, al := range aliases {
```
## - How to verify it
Introduce a processBuilder that returns an error along with a modified slice, and confirm that the returned arguments match the expected values.

## - Human readable description for the release notes
Fixed an issue where command-line arguments could be incorrectly handled if `processBuilder` returns an error.