### PR TITLE
refactor(cli/compose/loader): extract ParseVolume() to its own package

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/cli/cli/compose/loader"
 	"github.com/docker/cli/internal/lazyregexp"
+	"github.com/docker/cli/internal/parsevolume"
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-connections/nat"
 	"github.com/moby/moby/api/types/container"
@@ -364,7 +364,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 	volumes := copts.volumes.GetMap()
 	// add any bind targets to the list of container volumes
 	for bind := range copts.volumes.GetMap() {
-		parsed, err := loader.ParseVolume(bind)
+		parsed, err := parsevolume.ParseVolume(bind)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cli/cli/compose/schema"
 	"github.com/docker/cli/cli/compose/template"
 	"github.com/docker/cli/cli/compose/types"
+	"github.com/docker/cli/internal/parsevolume"
 	"github.com/docker/cli/opts"
 	"github.com/docker/cli/opts/swarmopts"
 	"github.com/docker/go-connections/nat"
@@ -756,7 +757,7 @@ var transformBuildConfig TransformerFunc = func(data any) (any, error) {
 var transformServiceVolumeConfig TransformerFunc = func(data any) (any, error) {
 	switch value := data.(type) {
 	case string:
-		return ParseVolume(value)
+		return parsevolume.ParseVolume(value)
 	case map[string]any:
 		return data, nil
 	default:

--- a/internal/parsevolume/parsevolume.go
+++ b/internal/parsevolume/parsevolume.go
@@ -1,4 +1,4 @@
-package loader
+package parsevolume
 
 import (
 	"strings"

--- a/internal/parsevolume/parsevolume_test.go
+++ b/internal/parsevolume/parsevolume_test.go
@@ -1,4 +1,4 @@
-package loader
+package parsevolume
 
 import (
 	"fmt"


### PR DESCRIPTION
Moves `ParseVolume()` to a new internal package to remove the dependency on `cli/compose/loader`in `cli/command/container/opts.go`
fixes #6188 

**- What I did**
Removed the `cli/compose/loader` dependency from `cli/command/container`.
**- How I did it**
Moved the `cli/compose/loader.ParseVolume` function to a new internal package named `parsevolume`.
**- How to verify it**
Verify that the `cli/command/container` package does not import `cli/compose/loader`.
**- Human readable description for the release notes**
```
Moved ParseVolume function from cli/compose/loader/volume.go to new internal package named parsevolume
```
