### PR TITLE
cli/registry/client: remove deprecated RepoNameForReference

### DIFF
--- a/cli/registry/client/endpoint.go
+++ b/cli/registry/client/endpoint.go
@@ -105,13 +105,6 @@ func getHTTPTransport(authConfig registrytypes.AuthConfig, endpoint registry.API
 	return transport.NewTransport(base, modifiers...), nil
 }
 
-// RepoNameForReference returns the repository name from a reference.
-//
-// Deprecated: this function is no longer used and will be removed in the next release.
-func RepoNameForReference(ref reference.Named) (string, error) {
-	return reference.Path(reference.TrimNamed(ref)), nil
-}
-
 type existingTokenHandler struct {
 	token string
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5882

This was deprecated in 6f46cd2f4b7aa7e4c2017a2cb1748dea706b3388, which is part of v28.x, and no longer used, so we can remove it.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `cli/registry/client`: remove deprecated `RepoNameForReference`
```

**- A picture of a cute animal (not mandatory but encouraged)**

