### PR TITLE
image/tree: Unmark as experimental, warn when redirected

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -208,7 +208,6 @@ func printImageTree(dockerCLI command.Cli, view treeView) error {
 	out.PrintlnWithColor(tui.ColorWarning, "WARNING: This is an experimental feature. The output may change and shouldn't be depended on.")
 
 	out.Println(generateLegend(out, width))
-	out.Println()
 
 	possibleChips := getPossibleChips(view)
 	columns := []imgColumn{

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -6,6 +6,7 @@ package image
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/containerd/platforms"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
+	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/tui"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/filters"
@@ -191,6 +193,10 @@ func getPossibleChips(view treeView) (chips []imageChip) {
 }
 
 func printImageTree(dockerCLI command.Cli, view treeView) error {
+	if streamRedirected(dockerCLI.Out()) {
+		_, _ = fmt.Fprintln(dockerCLI.Err(), "WARNING: This output is designed for human readability. For machine-readable output, please use --format.")
+	}
+
 	out := tui.NewOutput(dockerCLI.Out())
 	_, width := out.GetTtySize()
 	if width == 0 {
@@ -204,8 +210,6 @@ func printImageTree(dockerCLI command.Cli, view treeView) error {
 	normalColor := out.Color(tui.ColorSecondary)
 	untaggedColor := out.Color(tui.ColorTertiary)
 	isTerm := out.IsTerminal()
-
-	out.PrintlnWithColor(tui.ColorWarning, "WARNING: This is an experimental feature. The output may change and shouldn't be depended on.")
 
 	out.Println(generateLegend(out, width))
 
@@ -486,4 +490,18 @@ func widestFirstColumnValue(headers []imgColumn, images []topImage) int {
 		}
 	}
 	return width
+}
+
+func streamRedirected(s *streams.Out) bool {
+	fd := s.FD()
+	if os.Stdout.Fd() != fd {
+		return true
+	}
+
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return true
+	}
+
+	return fi.Mode()&os.ModeCharDevice == 0
 }


### PR DESCRIPTION
<img width="955" height="443" alt="image" src="https://github.com/user-attachments/assets/19141425-6bb2-43fb-9d62-7c5e58055d36" />
