### PR TITLE
templates: deprecate NewParse()

### DIFF
--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -82,7 +82,7 @@ func buildContainerListOptions(options *psOptions) (*container.ListOptions, erro
 
 	// always validate template when `--format` is used, for consistency
 	if len(options.format) > 0 {
-		tmpl, err := templates.NewParse("", options.format)
+		tmpl, err := templates.Parse(options.format)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse template")
 		}

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -162,7 +162,7 @@ func needsServerInfo(template string, info dockerInfo) bool {
 	}
 
 	// A template is provided and has at least one field set.
-	tmpl, err := templates.NewParse("", template)
+	tmpl, err := templates.Parse(template)
 	if err != nil {
 		// ignore parsing errors here, and let regular code handle them
 		return true

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -209,8 +209,7 @@ func newVersionTemplate(templateFormat string) (*template.Template, error) {
 	case formatter.JSONFormatKey:
 		templateFormat = formatter.JSONFormat
 	}
-	tmpl := templates.New("version").Funcs(template.FuncMap{"getDetailsOrder": getDetailsOrder})
-	tmpl, err := tmpl.Parse(templateFormat)
+	tmpl, err := templates.New("version").Funcs(template.FuncMap{"getDetailsOrder": getDetailsOrder}).Parse(templateFormat)
 	if err != nil {
 		return nil, errors.Wrap(err, "template parsing error")
 	}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -71,7 +71,7 @@ var HeaderFunctions = template.FuncMap{
 // Parse creates a new anonymous template with the basic functions
 // and parses the given format.
 func Parse(format string) (*template.Template, error) {
-	return NewParse("", format)
+	return template.New("").Funcs(basicFunctions).Parse(format)
 }
 
 // New creates a new empty template with the provided tag and built-in
@@ -82,8 +82,10 @@ func New(tag string) *template.Template {
 
 // NewParse creates a new tagged template with the basic functions
 // and parses the given format.
+//
+// Deprecated: this function is unused and will be removed in the next release. Use [New] if you need to set a tag, or [Parse] instead.
 func NewParse(tag, format string) (*template.Template, error) {
-	return New(tag).Parse(format)
+	return template.New(tag).Funcs(basicFunctions).Parse(format)
 }
 
 // padWithSpace adds whitespace to the input if the input is non-empty

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -30,7 +30,7 @@ func TestParseStringFunctions(t *testing.T) {
 }
 
 func TestNewParse(t *testing.T) {
-	tm, err := NewParse("foo", "this is a {{ . }}")
+	tm, err := New("foo").Parse("this is a {{ . }}")
 	assert.NilError(t, err)
 
 	var b bytes.Buffer


### PR DESCRIPTION
It it just a chain of `New("sometag").Parse(...)`, and most of our uses don't use a tag for the template, so can call Parse.

There's no public users of this function, but deprecating it first just in case.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: templates: deprecate NewParse() function.
```

**- A picture of a cute animal (not mandatory but encouraged)**

