### PR TITLE
system prune: refactor to use "register" functions

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/build"
+	"github.com/moby/moby/api/types/versions"
 	"github.com/spf13/cobra"
 )
 
@@ -112,6 +113,10 @@ type cancelledErr struct{ error }
 
 func (cancelledErr) Cancelled() {}
 
+type errNotImplemented struct{ error }
+
+func (errNotImplemented) NotImplemented() {}
+
 // CachePrune executes a prune command for build cache
 //
 // Deprecated: this function was only used internally and will be removed in the next release.
@@ -122,6 +127,10 @@ func CachePrune(ctx context.Context, dockerCli command.Cli, all bool, filter opt
 // pruneFn prunes the build cache for use in "docker system prune" and
 // returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	if ver := dockerCLI.Client().ClientVersion(); ver != "" && versions.LessThan(ver, "1.31") {
+		// Not supported on older daemons.
+		return 0, "", errNotImplemented{errors.New("builder prune requires API version 1.31 or greater")}
+	}
 	if !options.Confirmed {
 		// Dry-run: perform validation and produce confirmation before pruning.
 		var confirmMsg string

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -117,13 +117,6 @@ type errNotImplemented struct{ error }
 
 func (errNotImplemented) NotImplemented() {}
 
-// CachePrune executes a prune command for build cache
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func CachePrune(ctx context.Context, dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
-	return runPrune(ctx, dockerCli, pruneOptions{force: true, all: all, filter: filter})
-}
-
 // pruneFn prunes the build cache for use in "docker system prune" and
 // returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -122,6 +122,16 @@ func CachePrune(ctx context.Context, dockerCli command.Cli, all bool, filter opt
 // pruneFn prunes the build cache for use in "docker system prune" and
 // returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	if !options.Confirmed {
+		// Dry-run: perform validation and produce confirmation before pruning.
+		var confirmMsg string
+		if options.All {
+			confirmMsg = "all build cache"
+		} else {
+			confirmMsg = "unused build cache"
+		}
+		return 0, confirmMsg, cancelledErr{errors.New("builder prune has been cancelled")}
+	}
 	return runPrune(ctx, dockerCLI, pruneOptions{
 		force:  true,
 		all:    options.All,

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -104,6 +104,11 @@ func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.Fi
 // pruneFn calls the Container Prune API for use in "docker system prune",
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	if !options.Confirmed {
+		// Dry-run: perform validation and produce confirmation before pruning.
+		confirmMsg := "all stopped containers"
+		return 0, confirmMsg, cancelledErr{errors.New("containers prune has been cancelled")}
+	}
 	return runPrune(ctx, dockerCLI, pruneOptions{
 		force:  true,
 		filter: options.Filter,

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -93,14 +93,6 @@ type cancelledErr struct{ error }
 
 func (cancelledErr) Cancelled() {}
 
-// RunPrune calls the Container Prune API
-// This returns the amount of space reclaimed and a detailed output string
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
-	return runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
-}
-
 // pruneFn calls the Container Prune API for use in "docker system prune",
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -7,12 +7,20 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/command/system/pruner"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	// Register the prune command to run as part of "docker system prune"
+	if err := pruner.Register(pruner.TypeContainer, pruneFn); err != nil {
+		panic(err)
+	}
+}
 
 type pruneOptions struct {
 	force  bool
@@ -87,6 +95,17 @@ func (cancelledErr) Cancelled() {}
 
 // RunPrune calls the Container Prune API
 // This returns the amount of space reclaimed and a detailed output string
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
 	return runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
+}
+
+// pruneFn calls the Container Prune API for use in "docker system prune",
+// and returns the amount of space reclaimed and a detailed output string.
+func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	return runPrune(ctx, dockerCLI, pruneOptions{
+		force:  true,
+		filter: options.Filter,
+	})
 }

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -9,12 +9,20 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/command/system/pruner"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	// Register the prune command to run as part of "docker system prune"
+	if err := pruner.Register(pruner.TypeImage, pruneFn); err != nil {
+		panic(err)
+	}
+}
 
 type pruneOptions struct {
 	force  bool
@@ -111,6 +119,18 @@ func (cancelledErr) Cancelled() {}
 
 // RunPrune calls the Image Prune API
 // This returns the amount of space reclaimed and a detailed output string
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func RunPrune(ctx context.Context, dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
 	return runPrune(ctx, dockerCli, pruneOptions{force: true, all: all, filter: filter})
+}
+
+// pruneFn calls the Container Prune API for use in "docker system prune",
+// and returns the amount of space reclaimed and a detailed output string.
+func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	return runPrune(ctx, dockerCLI, pruneOptions{
+		force:  true,
+		all:    options.All,
+		filter: options.Filter,
+	})
 }

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -117,14 +117,6 @@ type cancelledErr struct{ error }
 
 func (cancelledErr) Cancelled() {}
 
-// RunPrune calls the Image Prune API
-// This returns the amount of space reclaimed and a detailed output string
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func RunPrune(ctx context.Context, dockerCli command.Cli, all bool, filter opts.FilterOpt) (uint64, string, error) {
-	return runPrune(ctx, dockerCli, pruneOptions{force: true, all: all, filter: filter})
-}
-
 // pruneFn calls the Image Prune API for use in "docker system prune",
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -88,15 +88,6 @@ type cancelledErr struct{ error }
 
 func (cancelledErr) Cancelled() {}
 
-// RunPrune calls the Network Prune API
-// This returns the amount of space reclaimed and a detailed output string
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
-	output, err := runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
-	return 0, output, err
-}
-
 // pruneFn calls the Network Prune API for use in "docker system prune"
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -100,6 +100,11 @@ func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.Fi
 // pruneFn calls the Network Prune API for use in "docker system prune"
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	if !options.Confirmed {
+		// Dry-run: perform validation and produce confirmation before pruning.
+		confirmMsg := "all networks not used by at least one container"
+		return 0, confirmMsg, cancelledErr{errors.New("network prune has been cancelled")}
+	}
 	output, err := runPrune(ctx, dockerCLI, pruneOptions{
 		force:  true,
 		filter: options.Filter,

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -7,10 +7,18 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/system/pruner"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/opts"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	// Register the prune command to run as part of "docker system prune"
+	if err := pruner.Register(pruner.TypeNetwork, pruneFn); err != nil {
+		panic(err)
+	}
+}
 
 type pruneOptions struct {
 	force  bool
@@ -82,7 +90,19 @@ func (cancelledErr) Cancelled() {}
 
 // RunPrune calls the Network Prune API
 // This returns the amount of space reclaimed and a detailed output string
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
 	output, err := runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
+	return 0, output, err
+}
+
+// pruneFn calls the Network Prune API for use in "docker system prune"
+// and returns the amount of space reclaimed and a detailed output string.
+func pruneFn(ctx context.Context, dockerCLI command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	output, err := runPrune(ctx, dockerCLI, pruneOptions{
+		force:  true,
+		filter: options.Filter,
+	})
 	return 0, output, err
 }

--- a/cli/command/system/prune_test.go
+++ b/cli/command/system/prune_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/moby/moby/api/types/network"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+
+	// Make sure pruners are registered for tests (they're included automatically when building).
+	_ "github.com/docker/cli/cli/command/builder"
+	_ "github.com/docker/cli/cli/command/container"
+	_ "github.com/docker/cli/cli/command/image"
+	_ "github.com/docker/cli/cli/command/network"
+	_ "github.com/docker/cli/cli/command/volume"
 )
 
 func TestPrunePromptPre131DoesNotIncludeBuildCache(t *testing.T) {

--- a/cli/command/system/pruner/pruner.go
+++ b/cli/command/system/pruner/pruner.go
@@ -50,9 +50,10 @@ var pruneOrder = []ContentType{
 //     will be pruned (for example, "all stopped containers") instead of
 //     executing the prune. This summary is presented to the user as a
 //     confirmation message. It may return a [ErrCancelled] to indicate
-//     the operation was canceled. Any other error is considered a
-//     validation error of the given options (such as a filter that
-//     is not supported.
+//     the operation was canceled or a [ErrNotImplemented] if the prune
+//     function is not implemented for the daemon's API version. Any
+//     other error is considered a validation error for the given options
+//     (such as a filter that is not supported).
 //   - If [PruneOptions.Confirmed] is "true", the PruneFunc must execute
 //     the prune with the given options.
 //
@@ -64,6 +65,7 @@ var pruneOrder = []ContentType{
 //     presented to the user.
 //
 // [ErrCancelled]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/errdefs#ErrCancelled
+// [ErrNotImplemented]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/errdefs#ErrNotImplemented
 type PruneFunc func(ctx context.Context, dockerCLI command.Cli, pruneOpts PruneOptions) (spaceReclaimed uint64, details string, _ error)
 
 type PruneOptions struct {

--- a/cli/command/system/pruner/pruner.go
+++ b/cli/command/system/pruner/pruner.go
@@ -42,16 +42,39 @@ var pruneOrder = []ContentType{
 	TypeBuildCache,
 }
 
-// PruneFunc is the signature for prune-functions. It returns details about
-// the content pruned;
+// PruneFunc is the signature for prune-functions. The action performed
+// depends on the [PruneOptions.Confirmed] field.
 //
-// - spaceReclaimed is the amount of data removed (in bytes).
-// - details is arbitrary information about the content pruned.
+//   - If [PruneOptions.Confirmed] is "false", the PruneFunc must be run
+//     in "dry-run" mode and return a short description of what content
+//     will be pruned (for example, "all stopped containers") instead of
+//     executing the prune. This summary is presented to the user as a
+//     confirmation message. It may return a [ErrCancelled] to indicate
+//     the operation was canceled. Any other error is considered a
+//     validation error of the given options (such as a filter that
+//     is not supported.
+//   - If [PruneOptions.Confirmed] is "true", the PruneFunc must execute
+//     the prune with the given options.
+//
+// After a successful prune the PruneFunc must return details about the
+// content pruned;
+//
+//   - spaceReclaimed is the amount of data removed (in bytes), if any.
+//   - details is arbitrary information about the content pruned to be
+//     presented to the user.
+//
+// [ErrCancelled]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/errdefs#ErrCancelled
 type PruneFunc func(ctx context.Context, dockerCLI command.Cli, pruneOpts PruneOptions) (spaceReclaimed uint64, details string, _ error)
 
 type PruneOptions struct {
-	All    bool
-	Filter opts.FilterOpt
+	// Confirmed indicates whether pruning was confirmed (or "forced")
+	// by the user. If not set, the PruneFunc must be run in "dry-run"
+	// mode and return a short description of what content will be pruned
+	// (for example, "all stopped containers") instead of executing the
+	// prune. This summary is presented to the user as a confirmation message.
+	Confirmed bool
+	All       bool // Remove all unused content not just dangling (exact meaning differs per content-type).
+	Filter    opts.FilterOpt
 }
 
 // registered holds a map of PruneFunc functions registered through [Register].

--- a/cli/command/system/pruner/pruner.go
+++ b/cli/command/system/pruner/pruner.go
@@ -1,0 +1,115 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.23
+
+// Package pruner registers "prune" functions to be included as part of
+// "docker system prune".
+package pruner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"maps"
+	"slices"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/opts"
+)
+
+// ContentType is an identifier for content that can be pruned.
+type ContentType string
+
+// Pre-defined content-types to prune. Additional types can be registered,
+// and will be pruned after the list of pre-defined types.
+const (
+	TypeContainer  ContentType = "container"
+	TypeNetwork    ContentType = "network"
+	TypeImage      ContentType = "image"
+	TypeVolume     ContentType = "volume"
+	TypeBuildCache ContentType = "buildcache"
+)
+
+// pruneOrder is the order in which ContentType must be pruned. The order
+// in which pruning happens is important to make sure that resources are
+// released before pruning (e.g., a "container" can use a "network" and
+// "volume", so containers must be pruned before networks and volumes).
+var pruneOrder = []ContentType{
+	TypeContainer,
+	TypeNetwork,
+	TypeVolume,
+	TypeImage,
+	TypeBuildCache,
+}
+
+// PruneFunc is the signature for prune-functions. It returns details about
+// the content pruned;
+//
+// - spaceReclaimed is the amount of data removed (in bytes).
+// - details is arbitrary information about the content pruned.
+type PruneFunc func(ctx context.Context, dockerCLI command.Cli, pruneOpts PruneOptions) (spaceReclaimed uint64, details string, _ error)
+
+type PruneOptions struct {
+	All    bool
+	Filter opts.FilterOpt
+}
+
+// registered holds a map of PruneFunc functions registered through [Register].
+// It is considered immutable after startup.
+var registered map[ContentType]PruneFunc
+
+// Register registers a [PruneFunc] under the given name to be included in
+// "docker system prune". It is designed to be called in an init function
+// and is not safe for concurrent use.
+//
+// For example:
+//
+//	 func init() {
+//		// Register the prune command to run as part of "docker system prune".
+//		if err := prune.Register(prune.TypeImage, prunerFn); err != nil {
+//			panic(err)
+//		}
+//	}
+func Register(name ContentType, pruneFunc PruneFunc) error {
+	if name == "" {
+		return errors.New("error registering pruner: invalid prune type: cannot be empty")
+	}
+	if pruneFunc == nil {
+		return errors.New("error registering pruner: prune function is nil for " + string(name))
+	}
+	if registered == nil {
+		registered = make(map[ContentType]PruneFunc)
+	}
+	if _, exists := registered[name]; exists {
+		return fmt.Errorf("error registering pruner: content-type %s is already registered", name)
+	}
+	registered[name] = pruneFunc
+	return nil
+}
+
+// List iterates over all registered pruners, starting with known pruners
+// in their predefined order, followed by any others (sorted alphabetically).
+func List() iter.Seq2[ContentType, PruneFunc] {
+	all := maps.Clone(registered)
+	ordered := make([]ContentType, 0, len(all))
+	for _, ct := range pruneOrder {
+		if _, ok := all[ct]; ok {
+			ordered = append(ordered, ct)
+			delete(all, ct)
+		}
+	}
+	// append any remaining content-types (if any) that may be registered.
+	if len(all) > 0 {
+		ordered = append(ordered, slices.Sorted(maps.Keys(all))...)
+	}
+
+	return func(yield func(ContentType, PruneFunc) bool) {
+		for _, ct := range ordered {
+			if fn := registered[ct]; fn != nil {
+				if !yield(ct, fn) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -8,12 +8,20 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/command/system/pruner"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/opts"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/versions"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	// Register the prune command to run as part of "docker system prune"
+	if err := pruner.Register(pruner.TypeVolume, pruneFn); err != nil {
+		panic(err)
+	}
+}
 
 type pruneOptions struct {
 	all    bool
@@ -112,6 +120,17 @@ func (cancelledErr) Cancelled() {}
 
 // RunPrune calls the Volume Prune API
 // This returns the amount of space reclaimed and a detailed output string
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
 func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
 	return runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
+}
+
+// pruneFn calls the Volume Prune API for use in "docker system prune",
+// and returns the amount of space reclaimed and a detailed output string.
+func pruneFn(ctx context.Context, dockerCli command.Cli, options pruner.PruneOptions) (uint64, string, error) {
+	return runPrune(ctx, dockerCli, pruneOptions{
+		force:  true,
+		filter: options.Filter,
+	})
 }

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -118,14 +118,6 @@ type cancelledErr struct{ error }
 
 func (cancelledErr) Cancelled() {}
 
-// RunPrune calls the Volume Prune API
-// This returns the amount of space reclaimed and a detailed output string
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func RunPrune(ctx context.Context, dockerCli command.Cli, _ bool, filter opts.FilterOpt) (uint64, string, error) {
-	return runPrune(ctx, dockerCli, pruneOptions{force: true, filter: filter})
-}
-
 // pruneFn calls the Volume Prune API for use in "docker system prune",
 // and returns the amount of space reclaimed and a detailed output string.
 func pruneFn(ctx context.Context, dockerCli command.Cli, options pruner.PruneOptions) (uint64, string, error) {


### PR DESCRIPTION
### system prune: use register function for prune functions

Introduce a "prune" package in which we maintain a list of prune
functions that are registered. Known prune "content-types" are
included in a pre-defined order, after which additional content
can be registered.

Using this approach no longer requires the "RunPrune" functions
to be exported, and allows additional content-types to be
introduced without having to import those packages into the
system package, so keeping things more decoupled.

### system prune: delegate confirmation message and validation

This adds a "dry-run" / "pre-check" option for prune-functions,
which delegates constructing the confirmation message (what is
about to be pruned) and validation of the given options to the
prune-functions.

This helps separating concerns, and doesn't enforce knowledge
about what's supported by each content-type onto the system
prune command.

### system prune: delegate version check

Move the version-check for pruners to the pruner, which can
return a [ErrNotImplemented] error to indicate they won't
be run with the API version that's used.

This helps separating concerns, and doesn't enforce knowledge
about what's supported by each content-type onto the system
prune command.

[ErrNotImplemented]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/errdefs#ErrNotImplemented

### cli/command: remove exported "RunPrune" functions

These are no longer used, and unlikely to be used externally.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/builder: remove `CachePrune()`, which was no longer used.
Go SDK: cli/command/container: remove `RunPrune()`, which was no longer used.
Go SDK: cli/command/image: remove `RunPrune()`, which was no longer used.
Go SDK: cli/command/network: remove `RunPrune()`, which was no longer used.
Go SDK: cli/command/volume: remove `RunPrune()`, which was no longer used.
```

**- A picture of a cute animal (not mandatory but encouraged)**

