### PR TITLE
cli/command: remove deprecated CopyToFile, ConfigureAuth utilities

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -99,23 +99,6 @@ func GetDefaultAuthConfig(cfg *configfile.ConfigFile, checkCredStore bool, serve
 	return registrytypes.AuthConfig(authconfig), nil
 }
 
-// ConfigureAuth handles prompting of user's username and password if needed.
-//
-// Deprecated: use [PromptUserForCredentials] instead.
-func ConfigureAuth(ctx context.Context, cli Cli, flUser, flPassword string, authConfig *registrytypes.AuthConfig, _ bool) error {
-	defaultUsername := authConfig.Username
-	serverAddress := authConfig.ServerAddress
-
-	newAuthConfig, err := PromptUserForCredentials(ctx, cli, flUser, flPassword, defaultUsername, serverAddress)
-	if err != nil {
-		return err
-	}
-
-	authConfig.Username = newAuthConfig.Username
-	authConfig.Password = newAuthConfig.Password
-	return nil
-}
-
 // PromptUserForCredentials handles the CLI prompt for the user to input
 // credentials.
 // If argUser is not empty, then the user is only prompted for their password.

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -14,23 +14,9 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/moby/moby/api/types/filters"
-	"github.com/moby/sys/atomicwriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 )
-
-// CopyToFile writes the content of the reader to the specified file
-//
-// Deprecated: use [atomicwriter.New].
-func CopyToFile(outfile string, r io.Reader) error {
-	writer, err := atomicwriter.New(outfile, 0o600)
-	if err != nil {
-		return err
-	}
-	defer writer.Close()
-	_, err = io.Copy(writer, r)
-	return err
-}
 
 const ErrPromptTerminated = prompt.ErrTerminated
 


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/5344
- https://github.com/docker/cli/pull/5344


### cli/command: remove deprecated CopyToFile utility

It was deprecated in 7cc6b8ebf4aa1754ac9309027f315b270ea47c34, which is
part of v28.x

### cli/command: remove deprecated ConfigureAuth utility

It was deprecated in 6e4818e7d6d006f14ebac4c06fbe6ed958237408, which
is part of v28.x and backported to v27.x.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: remove deprecated `CopyToFile` utility
Go SDK: cli/command: remove deprecated `ConfigureAuth` utility
```

**- A picture of a cute animal (not mandatory but encouraged)**

