### PR TITLE
remove deprecated `bind-nonrecursive` option for `--mount`

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -63,6 +63,7 @@ The following table provides an overview of the current status of deprecated fea
 | Removed    | [`Container` and `ContainerConfig` fields in Image inspect](#container-and-containerconfig-fields-in-image-inspect)                | v25.0      | v26.0  |
 | Removed    | [Deprecate legacy API versions](#deprecate-legacy-api-versions)                                                                    | v25.0      | v26.0  |
 | Removed    | [Container short ID in network Aliases field](#container-short-id-in-network-aliases-field)                                        | v25.0      | v26.0  |
+| Removed    | [Mount `bind-nonrecursive` option](#mount-bind-nonrecursive-option)                                                                | v25.0      | v29.0  |
 | Removed    | [IsAutomated field, and `is-automated` filter on `docker search`](#isautomated-field-and-is-automated-filter-on-docker-search)     | v25.0      | v28.2  |
 | Removed    | [logentries logging driver](#logentries-logging-driver)                                                                            | v24.0      | v25.0  |
 | Removed    | [OOM-score adjust for the daemon](#oom-score-adjust-for-the-daemon)                                                                | v24.0      | v25.0  |
@@ -380,6 +381,26 @@ and `docker run` flag `--network-alias`.
 A new field `DNSNames` containing the container name (if one was specified),
 the hostname, the network aliases, as well as the container short ID, has been
 introduced in v25.0 and should be used instead of the `Aliases` field.
+
+### Mount `bind-nonrecursive` option
+
+**Deprecated in Release: v25.0**
+**Removed In Release: v29.0**
+
+The `bind-nonrecursive` option was replaced with the [`bind-recursive`]
+option (see [cli-4316], [cli-4671]). The option was still accepted, but
+printed a deprecation warning:
+
+```console
+bind-nonrecursive is deprecated, use bind-recursive=disabled instead
+```
+
+In the v29.0 release, this warning is removed, and returned as an error.
+Users should use the equivalent `bind-recursive=disabled` option instead.
+
+[`bind-recursive`]: https://docs.docker.com/engine/storage/bind-mounts/#recursive-mounts
+[cli-4316]: https://github.com/docker/cli/pull/4316
+[cli-4671]: https://github.com/docker/cli/pull/4671
 
 ### IsAutomated field, and `is-automated` filter on `docker search`
 

--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -455,20 +455,6 @@ The following options can only be used for bind mounts (`type=bind`):
       When the option is not specified, the default behavior correponds to setting <tt>enabled</tt>.
     </td>
   </tr>
-  <tr>
-    <td><b>bind-nonrecursive</b></td>
-    <td>
-      <tt>bind-nonrecursive</tt> is deprecated since Docker Engine v25.0.
-      Use <tt>bind-recursive</tt>instead.<br />
-      <br />
-      A value is optional:<br />
-      <br />
-      <ul>
-        <li><tt>true</tt> or <tt>1</tt>:  Equivalent to <tt>bind-recursive=disabled</tt>.</li>
-        <li><tt>false</tt> or <tt>0</tt>: Equivalent to <tt>bind-recursive=enabled</tt>.</li>
-      </ul>
-    </td>
-  </tr>
 </table>
 
 ##### Bind propagation

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -479,8 +479,6 @@ according to RFC4862.
       If set to `disabled`, submounts are not recursively bind-mounted.
       If set to `writable`, submounts are recursively bind-mounted but not made recursively read-only.
       If set to `readonly`, submounts are recursively bind-mounted and forcibly made recursively read-only.
-   * `bind-nonrecursive` (Deprecated): `true` or `false` (default). Setting `true` equates to `bind-recursive=disabled`.
-     Setting `false` equates to `bind-recursive=enabled`.
 
    Options specific to `volume`:
 

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/go-units"
 	mounttypes "github.com/moby/moby/api/types/mount"
-	"github.com/sirupsen/logrus"
 )
 
 // MountOpt is a Value type for parsing mounts
@@ -88,8 +87,7 @@ func (m *MountOpt) Set(value string) error {
 				volumeOptions().NoCopy = true
 				continue
 			case "bind-nonrecursive":
-				bindOptions().NonRecursive = true
-				continue
+				return errors.New("bind-nonrecursive is deprecated, use bind-recursive=disabled instead")
 			default:
 				return fmt.Errorf("invalid field '%s' must be a key=value pair", field)
 			}
@@ -117,16 +115,12 @@ func (m *MountOpt) Set(value string) error {
 		case "bind-propagation":
 			bindOptions().Propagation = mounttypes.Propagation(strings.ToLower(val))
 		case "bind-nonrecursive":
-			bindOptions().NonRecursive, err = strconv.ParseBool(val)
-			if err != nil {
-				return fmt.Errorf("invalid value for %s: %s", key, val)
-			}
-			logrus.Warn("bind-nonrecursive is deprecated, use bind-recursive=disabled instead")
+			return errors.New("bind-nonrecursive is deprecated, use bind-recursive=disabled instead")
 		case "bind-recursive":
 			switch val {
 			case "enabled": // read-only mounts are recursively read-only if Engine >= v25 && kernel >= v5.12, otherwise writable
 				// NOP
-			case "disabled": // alias of bind-nonrecursive=true
+			case "disabled": // previously "bind-nonrecursive=true"
 				bindOptions().NonRecursive = true
 			case "writable": // conforms to the default read-only bind-mount of Docker v24; read-only mounts are recursively mounted but not recursively read-only
 				bindOptions().ReadOnlyNonRecursive = true

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -259,21 +259,6 @@ func TestMountOptSetTmpfsError(t *testing.T) {
 	assert.ErrorContains(t, m.Set("type=tmpfs"), "target is required")
 }
 
-func TestMountOptSetBindNonRecursive(t *testing.T) {
-	var m MountOpt
-	assert.NilError(t, m.Set("type=bind,source=/foo,target=/bar,bind-nonrecursive"))
-	assert.Check(t, is.DeepEqual([]mount.Mount{
-		{
-			Type:   mount.TypeBind,
-			Source: "/foo",
-			Target: "/bar",
-			BindOptions: &mount.BindOptions{
-				NonRecursive: true,
-			},
-		},
-	}, m.Value()))
-}
-
 func TestMountOptSetBindRecursive(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		var m MountOpt


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/4316
- https://github.com/docker/cli/pull/4671


The `bind-nonrecursive` option was replaced with the [`bind-recursive`] option (see [cli-4316], [cli-4671]). The option was still accepted, but printed a deprecation warning:

    bind-nonrecursive is deprecated, use bind-recursive=disabled instead

In the v29.0 release, this warning is removed, and returned as an error. Users should use the equivalent `bind-recursive=disabled` option instead.

[`bind-recursive`]: https://docs.docker.com/engine/storage/bind-mounts/#recursive-mounts
[cli-4316]: https://github.com/docker/cli/pull/4316
[cli-4671]: https://github.com/docker/cli/pull/4671

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
remove deprecated `bind-nonrecursive` option for `--mount`
```

**- A picture of a cute animal (not mandatory but encouraged)**

