### PR TITLE
e2d skip flaky test: TestPromptExitCode/plugin_upgrade, plugin_install

### DIFF
--- a/e2e/global/cli_test.go
+++ b/e2e/global/cli_test.go
@@ -143,6 +143,7 @@ func TestPromptExitCode(t *testing.T) {
 			name: "plugin install",
 			run: func(t *testing.T) icmd.Cmd {
 				t.Helper()
+				t.Skip("flaky test: see https://github.com/docker/cli/issues/6248")
 				skip.If(t, versions.LessThan(environment.DaemonAPIVersion(t), "1.44"))
 
 				const plugin = "registry:5000/plugin-install-test:latest"
@@ -160,6 +161,7 @@ func TestPromptExitCode(t *testing.T) {
 			name: "plugin upgrade",
 			run: func(t *testing.T) icmd.Cmd {
 				t.Helper()
+				t.Skip("flaky test: see https://github.com/docker/cli/issues/6248")
 				skip.If(t, versions.LessThan(environment.DaemonAPIVersion(t), "1.44"))
 
 				const plugin = "registry:5000/plugin-upgrade-test"


### PR DESCRIPTION
- tracking ticket: https://github.com/docker/cli/issues/6248

This test was recently rewritten from testing plugin upgrade with DCT enabled to just "plugin upgrade", but there's a fair amount of complexity in the e2e tests that set up different daemons and registries.

It's possible that tests are affecting each-other, and some state (config) is left behind.

Let's skip the test for now, and add a tracking ticket to dig deeper.

    === FAIL: e2e/global TestPromptExitCode/plugin_upgrade (7.55s)
        cli_test.go:205: assertion failed:
            Command:  docker plugin push registry:5000/plugin-upgrade-test:latest
            ExitCode: 1
            Error:    exit status 1
            Stdout:   The push refers to repository [registry:5000/plugin-upgrade-test]
            459089aa5943: Preparing
            adc41078d1d9: Preparing
            d7bff979db13: Preparing
            459089aa5943: Preparing

            Stderr:   error pushing plugin: failed to do request: Head "https://registry:5000/v2/plugin-upgrade-test/blobs/sha256:adc41078d1d937495df2f90444e5414a01db31e5a080f8aa4f163c64d41abd11": http: server gave HTTP response to HTTPS client

            Failures:
            ExitCode was 1 expected 0
            Expected no error

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

