### PR TITLE
cli/command/container: copyToContainer: improve error-handling

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -298,50 +298,50 @@ func copyFromContainer(ctx context.Context, dockerCLI command.Cli, copyConfig cp
 // about both the source and destination. The API is a simple tar
 // archive/extract API but we can use the stat info header about the
 // destination to be more informed about exactly what the destination is.
-func copyToContainer(ctx context.Context, dockerCLI command.Cli, copyConfig cpConfig) (retErr error) {
+func copyToContainer(ctx context.Context, dockerCLI command.Cli, copyConfig cpConfig) error {
 	srcPath := copyConfig.sourcePath
 	dstPath := copyConfig.destPath
 
 	if srcPath != "-" {
 		// Get an absolute source path.
-		srcPath, retErr = resolveLocalPath(srcPath)
-		if retErr != nil {
-			return retErr
+		p, err := resolveLocalPath(srcPath)
+		if err != nil {
+			return err
 		}
+		srcPath = p
 	}
 
 	apiClient := dockerCLI.Client()
 	// Prepare destination copy info by stat-ing the container path.
 	dstInfo := archive.CopyInfo{Path: dstPath}
-	dstStat, retErr := apiClient.ContainerStatPath(ctx, copyConfig.container, dstPath)
+	if dstStat, err := apiClient.ContainerStatPath(ctx, copyConfig.container, dstPath); err == nil {
+		// If the destination is a symbolic link, we should evaluate it.
+		if dstStat.Mode&os.ModeSymlink != 0 {
+			linkTarget := dstStat.LinkTarget
+			if !isAbs(linkTarget) {
+				// Join with the parent directory.
+				dstParent, _ := archive.SplitPathDirEntry(dstPath)
+				linkTarget = filepath.Join(dstParent, linkTarget)
+			}
 
-	// If the destination is a symbolic link, we should evaluate it.
-	if retErr == nil && dstStat.Mode&os.ModeSymlink != 0 {
-		linkTarget := dstStat.LinkTarget
-		if !isAbs(linkTarget) {
-			// Join with the parent directory.
-			dstParent, _ := archive.SplitPathDirEntry(dstPath)
-			linkTarget = filepath.Join(dstParent, linkTarget)
+			dstInfo.Path = linkTarget
+			dstStat, err = apiClient.ContainerStatPath(ctx, copyConfig.container, linkTarget)
+		}
+		// Validate the destination path
+		if err == nil {
+			if err := command.ValidateOutputPathFileMode(dstStat.Mode); err != nil {
+				return fmt.Errorf(`destination "%s:%s" must be a directory or a regular file: %w`, copyConfig.container, dstPath, err)
+			}
+			dstInfo.Exists, dstInfo.IsDir = true, dstStat.Mode.IsDir()
 		}
 
-		dstInfo.Path = linkTarget
-		dstStat, retErr = apiClient.ContainerStatPath(ctx, copyConfig.container, linkTarget)
-		// FIXME(thaJeztah): unhandled error (should this return?)
-	}
-
-	// Validate the destination path
-	if err := command.ValidateOutputPathFileMode(dstStat.Mode); err != nil {
-		return fmt.Errorf(`destination "%s:%s" must be a directory or a regular file: %w`, copyConfig.container, dstPath, err)
-	}
-
-	// Ignore any error and assume that the parent directory of the destination
-	// path exists, in which case the copy may still succeed. If there is any
-	// type of conflict (e.g., non-directory overwriting an existing directory
-	// or vice versa) the extraction will fail. If the destination simply did
-	// not exist, but the parent directory does, the extraction will still
-	// succeed.
-	if retErr == nil {
-		dstInfo.Exists, dstInfo.IsDir = true, dstStat.Mode.IsDir()
+		// Ignore any error and assume that the parent directory of the destination
+		// path exists, in which case the copy may still succeed. If there is any
+		// type of conflict (e.g., non-directory overwriting an existing directory
+		// or vice versa) the extraction will fail. If the destination simply did
+		// not exist, but the parent directory does, the extraction will still
+		// succeed.
+		_ = err // Intentionally ignore stat errors (see above)
 	}
 
 	var (


### PR DESCRIPTION
### cli/command/container: copyToContainer rename error-return

Make it more clearly identifiable where we're dealing with the
named error-return

### cli/command/container: copyToContainer: improve error-handling

The logic used in this function was confusing; some errors were ignored,
but responses handled regardless. The intent here is to try to detect
whether the destination exists inside the container and is of the right
"type" (otherwise produce an error).

Failing to "stat" the path in the container means we can't produce a
nice error for the user, but we'll continue the request, which either
would succeed or produce an error returned by the daemon.

While working on this patch, I noticed that some error-handling on the
daemon side is incorrect. This patch does not fix those cases, but
makes the logic slightly easier to follow (we should consider extracting
the "stat" code to a separate function though).

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

