### PR TITLE
[28.x backport] cli/command/completion: remove deprecated ValidArgsFn

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -13,11 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ValidArgsFn a function to be used by cobra command as `ValidArgsFunction` to offer command line completion.
-//
-// Deprecated: use [cobra.CompletionFunc].
-type ValidArgsFn = cobra.CompletionFunc
-
 // APIClientProvider provides a method to get an [client.APIClient], initializing
 // it if needed.
 //


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6245

----

- relates to https://github.com/docker/cli/pull/5829

This was deprecated in 9f19820f883f1091256090279a94874d2fecba9d, which is part of v28.x, and unlikely used externally.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/completion: remove deprecated `ValidArgsFn`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

