### PR TITLE
gha/validate-pr: Replace `continue-on-error`

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -19,14 +19,12 @@ jobs:
     timeout-minutes: 120 # guardrails timeout for the whole job
     steps:
       - name: Missing `area/` label
-        continue-on-error: true
-        if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
+        if: always() && contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'area/')
         run: |
           echo "::error::Every PR with an 'impact/*' label should also have an 'area/*' label"
           exit 1
       - name: Missing `kind/` label
-        continue-on-error: true
-        if: contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'kind/')
+        if: always() && contains(join(github.event.pull_request.labels.*.name, ','), 'impact/') && !contains(join(github.event.pull_request.labels.*.name, ','), 'kind/')
         run: |
           echo "::error::Every PR with an 'impact/*' label should also have a 'kind/*' label"
           exit 1


### PR DESCRIPTION
### gha/validate-pr: Replace `continue-on-error`

The label validation steps now properly fail the workflow when required labels are missing, instead of continuing with errors.  This change removes the `continue-on-error: true` directives and adds `always()` conditions to ensure the validation steps run regardless of previous step outcomes.  