### PR TITLE
docs: fix output example for docker system prune

### DIFF
--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -72,7 +72,8 @@ my-network-a
 my-network-b
 
 Deleted Volumes:
-named-vol
+1e31bcd425e913d9f65ec0c3841e9c4ebb543aead2a1cfe0d95a7c5e88bb5026
+6a6ab3d6b8d740a1c1d4dbe36a9c5f043dd4bac5f78abfa7d1f2ae5789fe60b0
 
 Deleted Images:
 untagged: my-curl:latest


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6118#issuecomment-3032941262

The example shows that the `--volumes` option is used, which in current versions of docker only removes "anonymous" volumes, but preserves named volume:

    $ docker system prune -a --volumes
    ...
            - all anonymous volumes not used by at least one container
    ...

But the example output showed that a named volume ("named-vol") was deleted;

    Deleted Volumes:
    named-vol

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

