### PR TITLE
[28.x backport] remove aliases for containerd/errdefs, disallow docker/errdefs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ linters:
               desc: Use github.com/moby/sys/userns instead.
             - pkg: "github.com/containerd/containerd/platforms"
               desc: The containerd platforms package was migrated to a separate module. Use github.com/containerd/platforms instead.
+            - pkg: "github.com/docker/docker/errdefs"
+              desc: Use github.com/containerd/errdefs instead.
             - pkg: "github.com/docker/docker/pkg/system"
               desc: This package should not be used unless strictly necessary.
             - pkg: "github.com/docker/distribution/uuid"
@@ -124,10 +126,9 @@ linters:
       no-unaliased: true
 
       alias:
-        # Enforce alias to prevent it accidentally being used instead of our
-        # own errdefs package (or vice-versa).
-        - pkg: github.com/containerd/errdefs
-          alias: cerrdefs
+          # Should no longer be aliased, because we no longer allow moby/docker errdefs.
+        - pkg: "github.com/docker/docker/errdefs"
+          alias: ""
         - pkg: github.com/opencontainers/image-spec/specs-go/v1
           alias: ocispec
           # Enforce that gotest.tools/v3/assert/cmp is always aliased as "is"

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
@@ -341,7 +341,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	response, err := dockerCli.Client().ContainerCreate(ctx, config, hostConfig, networkingConfig, platform, options.name)
 	if err != nil {
 		// Pull image if it does not exist locally and we have the PullImageMissing option. Default behavior.
-		if cerrdefs.IsNotFound(err) && namedRef != nil && options.pull == PullImageMissing {
+		if errdefs.IsNotFound(err) && namedRef != nil && options.pull == PullImageMissing {
 			if !options.quiet {
 				// we don't want to write to stdout anything apart from container.ID
 				_, _ = fmt.Fprintf(dockerCli.Err(), "Unable to find image '%s' locally\n", reference.FamiliarString(namedRef))

--- a/cli/command/container/errors.go
+++ b/cli/command/container/errors.go
@@ -1,9 +1,9 @@
 package container
 
-import cerrdefs "github.com/containerd/errdefs"
+import "github.com/containerd/errdefs"
 
 func invalidParameter(err error) error {
-	if err == nil || cerrdefs.IsInvalidArgument(err) {
+	if err == nil || errdefs.IsInvalidArgument(err) {
 		return err
 	}
 	return invalidParameterErr{err}
@@ -17,7 +17,7 @@ func (e invalidParameterErr) Unwrap() error {
 }
 
 func notFound(err error) error {
-	if err == nil || cerrdefs.IsNotFound(err) {
+	if err == nil || errdefs.IsNotFound(err) {
 		return err
 	}
 	return notFoundErr{err}

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -75,7 +75,7 @@ func runRm(ctx context.Context, dockerCLI command.Cli, opts *rmOptions) error {
 	var errs []error
 	for _, name := range opts.containers {
 		if err := <-errChan; err != nil {
-			if opts.force && cerrdefs.IsNotFound(err) {
+			if opts.force && errdefs.IsNotFound(err) {
 				_, _ = fmt.Fprintln(dockerCLI.Err(), err)
 				continue
 			}

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -122,7 +122,7 @@ func checkContextNameForCreation(s store.Reader, name string) error {
 	if err := store.ValidateContextName(name); err != nil {
 		return err
 	}
-	if _, err := s.GetMetadata(name); !cerrdefs.IsNotFound(err) {
+	if _, err := s.GetMetadata(name); !errdefs.IsNotFound(err) {
 		if err != nil {
 			return fmt.Errorf("error while getting existing contexts: %w", err)
 		}

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"gotest.tools/v3/assert"
@@ -18,7 +18,7 @@ func TestRemove(t *testing.T) {
 	_, err := cli.ContextStore().GetMetadata("current")
 	assert.NilError(t, err)
 	_, err = cli.ContextStore().GetMetadata("other")
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestRemoveNotAContext(t *testing.T) {

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
@@ -47,7 +47,7 @@ func TestUse(t *testing.T) {
 func TestUseNoExist(t *testing.T) {
 	cli := makeFakeCli(t)
 	err := newUseCommand(cli).RunE(nil, []string{"test"})
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 // TestUseDefaultWithoutConfigFile verifies that the CLI does not create

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -7,7 +7,7 @@ import (
 	"crypto/rand"
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
@@ -158,7 +158,7 @@ func TestErrCreateDefault(t *testing.T) {
 		Metadata: testContext{Bar: "baz"},
 		Name:     "default",
 	})
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
+	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidArgument))
 	assert.Error(t, err, "default context cannot be created nor updated")
 }
 
@@ -166,7 +166,7 @@ func TestErrRemoveDefault(t *testing.T) {
 	meta := testDefaultMetadata()
 	s := testStore(t, meta, store.ContextTLSData{})
 	err := s.Remove("default")
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsInvalidArgument))
+	assert.Check(t, is.ErrorType(err, errdefs.IsInvalidArgument))
 	assert.Error(t, err, "default context cannot be removed")
 }
 
@@ -174,5 +174,5 @@ func TestErrTLSDataError(t *testing.T) {
 	meta := testDefaultMetadata()
 	s := testStore(t, meta, store.ContextTLSData{})
 	_, err := s.GetTLSData("default", "noop", "noop")
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -79,7 +79,7 @@ func runRemove(ctx context.Context, dockerCLI command.Cli, opts removeOptions, i
 	for _, img := range images {
 		dels, err := apiClient.ImageRemove(ctx, img, options)
 		if err != nil {
-			if !cerrdefs.IsNotFound(err) {
+			if !errdefs.IsNotFound(err) {
 				fatalErr = true
 			}
 			errs = append(errs, err)

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -59,7 +59,7 @@ func runRemove(ctx context.Context, dockerCLI command.Cli, networks []string, op
 			}
 		}
 		if err := apiClient.NetworkRemove(ctx, name); err != nil {
-			if opts.force && cerrdefs.IsNotFound(err) {
+			if opts.force && errdefs.IsNotFound(err) {
 				continue
 			}
 			_, _ = fmt.Fprintln(dockerCLI.Err(), err)

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -159,7 +159,7 @@ func loginWithStoredCredentials(ctx context.Context, dockerCLI command.Cli, auth
 
 	response, err := dockerCLI.Client().RegistryLogin(ctx, authConfig)
 	if err != nil {
-		if cerrdefs.IsUnauthorized(err) {
+		if errdefs.IsUnauthorized(err) {
 			_, _ = fmt.Fprintln(dockerCLI.Err(), "Stored credentials invalid or expired")
 		} else {
 			_, _ = fmt.Fprintln(dockerCLI.Err(), "Login did not succeed, error:", err)

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -67,7 +67,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	getRef := func(ref string) (any, []byte, error) {
 		// Service inspect shows defaults values in empty fields.
 		service, _, err := client.ServiceInspectWithRaw(ctx, ref, swarm.ServiceInspectOptions{InsertDefaults: true})
-		if err == nil || !cerrdefs.IsNotFound(err) {
+		if err == nil || !errdefs.IsNotFound(err) {
 			return service, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such service: %s", ref)
@@ -75,7 +75,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 
 	getNetwork := func(ref string) (any, []byte, error) {
 		nw, _, err := client.NetworkInspectWithRaw(ctx, ref, network.InspectOptions{Scope: "swarm"})
-		if err == nil || !cerrdefs.IsNotFound(err) {
+		if err == nil || !errdefs.IsNotFound(err) {
 			return nw, nil, err
 		}
 		return nil, nil, errors.Errorf("Error: no such network: %s", ref)

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -93,12 +93,12 @@ func runLogs(ctx context.Context, dockerCli command.Cli, opts *logsOptions) erro
 	service, _, err := apiClient.ServiceInspectWithRaw(ctx, opts.target, swarm.ServiceInspectOptions{})
 	if err != nil {
 		// if it's any error other than service not found, it's Real
-		if !cerrdefs.IsNotFound(err) {
+		if !errdefs.IsNotFound(err) {
 			return err
 		}
 		task, _, err := apiClient.TaskInspectWithRaw(ctx, opts.target)
 		if err != nil {
-			if cerrdefs.IsNotFound(err) {
+			if errdefs.IsNotFound(err) {
 				// if the task isn't found, rewrite the error to be clear
 				// that we looked for services AND tasks and found none
 				err = fmt.Errorf("no such task or service: %v", opts.target)

--- a/cli/command/stack/swarm/deploy_composefile.go
+++ b/cli/command/stack/swarm/deploy_composefile.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
 	servicecli "github.com/docker/cli/cli/command/service"
 	"github.com/docker/cli/cli/command/stack/options"
@@ -97,7 +97,7 @@ func validateExternalNetworks(ctx context.Context, apiClient client.NetworkAPICl
 		}
 		nw, err := apiClient.NetworkInspect(ctx, networkName, network.InspectOptions{})
 		switch {
-		case cerrdefs.IsNotFound(err):
+		case errdefs.IsNotFound(err):
 			return fmt.Errorf("network %q is declared as external, but could not be found. You need to create a swarm-scoped network before the stack is deployed", networkName)
 		case err != nil:
 			return err
@@ -119,7 +119,7 @@ func createSecrets(ctx context.Context, dockerCLI command.Cli, secrets []swarm.S
 			if err := apiClient.SecretUpdate(ctx, secret.ID, secret.Meta.Version, secretSpec); err != nil {
 				return fmt.Errorf("failed to update secret %s: %w", secretSpec.Name, err)
 			}
-		case cerrdefs.IsNotFound(err):
+		case errdefs.IsNotFound(err):
 			// secret does not exist, then we create a new one.
 			_, _ = fmt.Fprintln(dockerCLI.Out(), "Creating secret", secretSpec.Name)
 			if _, err := apiClient.SecretCreate(ctx, secretSpec); err != nil {
@@ -143,7 +143,7 @@ func createConfigs(ctx context.Context, dockerCLI command.Cli, configs []swarm.C
 			if err := apiClient.ConfigUpdate(ctx, config.ID, config.Meta.Version, configSpec); err != nil {
 				return fmt.Errorf("failed to update config %s: %w", configSpec.Name, err)
 			}
-		case cerrdefs.IsNotFound(err):
+		case errdefs.IsNotFound(err):
 			// config does not exist, then we create a new one.
 			_, _ = fmt.Fprintln(dockerCLI.Out(), "Creating config", configSpec.Name)
 			if _, err := apiClient.ConfigCreate(ctx, configSpec); err != nil {

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
@@ -279,7 +279,7 @@ func inspectAll(ctx context.Context, dockerCLI command.Cli, getSize bool, typeCo
 }
 
 func isErrSkippable(err error) bool {
-	return cerrdefs.IsNotFound(err) ||
+	return errdefs.IsNotFound(err) ||
 		strings.Contains(err.Error(), "not supported") ||
 		strings.Contains(err.Error(), "invalid reference format")
 }

--- a/cli/context/store/errors.go
+++ b/cli/context/store/errors.go
@@ -1,9 +1,9 @@
 package store
 
-import cerrdefs "github.com/containerd/errdefs"
+import "github.com/containerd/errdefs"
 
 func invalidParameter(err error) error {
-	if err == nil || cerrdefs.IsInvalidArgument(err) {
+	if err == nil || errdefs.IsInvalidArgument(err) {
 		return err
 	}
 	return invalidParameterErr{err}
@@ -14,7 +14,7 @@ type invalidParameterErr struct{ error }
 func (invalidParameterErr) InvalidParameter() {}
 
 func notFound(err error) error {
-	if err == nil || cerrdefs.IsNotFound(err) {
+	if err == nil || errdefs.IsNotFound(err) {
 		return err
 	}
 	return notFoundErr{err}

--- a/cli/context/store/metadata_test.go
+++ b/cli/context/store/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -26,7 +26,7 @@ func testMetadata(name string) Metadata {
 func TestMetadataGetNotExisting(t *testing.T) {
 	testee := metadataStore{root: t.TempDir(), config: testCfg}
 	_, err := testee.get("noexist")
-	assert.ErrorType(t, err, cerrdefs.IsNotFound)
+	assert.ErrorType(t, err, errdefs.IsNotFound)
 }
 
 func TestMetadataCreateGetRemove(t *testing.T) {
@@ -60,7 +60,7 @@ func TestMetadataCreateGetRemove(t *testing.T) {
 	assert.NilError(t, testee.remove("test-context"))
 	assert.NilError(t, testee.remove("test-context")) // support duplicate remove
 	_, err = testee.get("test-context")
-	assert.ErrorType(t, err, cerrdefs.IsNotFound)
+	assert.ErrorType(t, err, errdefs.IsNotFound)
 }
 
 func TestMetadataRespectJsonAnnotation(t *testing.T) {

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -107,7 +107,7 @@ func TestRemove(t *testing.T) {
 	}))
 	assert.NilError(t, s.Remove("source"))
 	_, err = s.GetMetadata("source")
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 	f, err := s.ListTLSFiles("source")
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(f))
@@ -122,7 +122,7 @@ func TestListEmptyStore(t *testing.T) {
 func TestErrHasCorrectContext(t *testing.T) {
 	_, err := New(t.TempDir(), testCfg).GetMetadata("no-exists")
 	assert.ErrorContains(t, err, "no-exists")
-	assert.Check(t, is.ErrorType(err, cerrdefs.IsNotFound))
+	assert.Check(t, is.ErrorType(err, errdefs.IsNotFound))
 }
 
 func TestDetectImportContentType(t *testing.T) {

--- a/cli/context/store/tlsstore_test.go
+++ b/cli/context/store/tlsstore_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -13,7 +13,7 @@ func TestTlsCreateUpdateGetRemove(t *testing.T) {
 	const contextName = "test-ctx"
 
 	_, err := testee.getData(contextName, "test-ep", "test-data")
-	assert.ErrorType(t, err, cerrdefs.IsNotFound)
+	assert.ErrorType(t, err, errdefs.IsNotFound)
 
 	err = testee.createOrUpdate(contextName, "test-ep", "test-data", []byte("data"))
 	assert.NilError(t, err)
@@ -29,7 +29,7 @@ func TestTlsCreateUpdateGetRemove(t *testing.T) {
 	err = testee.removeEndpoint(contextName, "test-ep")
 	assert.NilError(t, err)
 	_, err = testee.getData(contextName, "test-ep", "test-data")
-	assert.ErrorType(t, err, cerrdefs.IsNotFound)
+	assert.ErrorType(t, err, errdefs.IsNotFound)
 }
 
 func TestTlsListAndBatchRemove(t *testing.T) {

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/socket"
@@ -41,7 +41,7 @@ func main() {
 		os.Exit(getExitCode(err))
 	}
 
-	if err != nil && !cerrdefs.IsCanceled(err) {
+	if err != nil && !errdefs.IsCanceled(err) {
 		if err.Error() != "" {
 			_, _ = fmt.Fprintln(os.Stderr, err)
 		}

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"testing"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"gotest.tools/v3/assert"
 )
 
@@ -86,7 +86,7 @@ func TestLoadInsecureRegistries(t *testing.T) {
 				t.Fatalf("expect error '%s', got no error", testCase.err)
 			}
 			assert.ErrorContains(t, err, testCase.err)
-			assert.Check(t, cerrdefs.IsInvalidArgument(err))
+			assert.Check(t, errdefs.IsInvalidArgument(err))
 		}
 	}
 }

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strings"
 
-	cerrdefs "github.com/containerd/errdefs"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/docker/docker/api/types/registry"
 )
@@ -60,7 +60,7 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 	for _, endpoint := range endpoints {
 		authToken, err := loginV2(ctx, authConfig, endpoint, userAgent)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || cerrdefs.IsUnauthorized(err) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errdefs.IsUnauthorized(err) {
 				// Failed to authenticate; don't continue with (non-TLS) endpoints.
 				return "", err
 			}


### PR DESCRIPTION
- backports https://github.com/docker/cli/pull/6217
- [x] depends on / stacked on https://github.com/docker/cli/pull/6221
- needed for https://github.com/docker/cli/pull/6269

