### PR TITLE
[28.x backport] opts: deprecate QuotedString

### DIFF
--- a/opts/quotedstring.go
+++ b/opts/quotedstring.go
@@ -2,6 +2,8 @@ package opts
 
 // QuotedString is a string that may have extra quotes around the value. The
 // quotes are stripped from the value.
+//
+// Deprecated: This option type is no longer used and will be removed in the next release.
 type QuotedString struct {
 	value *string
 }
@@ -35,6 +37,8 @@ func trimQuotes(value string) string {
 }
 
 // NewQuotedString returns a new quoted string option
+//
+// Deprecated: This option type is no longer used and will be removed in the next release.
 func NewQuotedString(value *string) *QuotedString {
 	return &QuotedString{value: value}
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6274

----

relates to:

- https://github.com/moby/moby/issues/29761
- https://github.com/moby/moby/pull/43250
- https://github.com/moby/moby/pull/6147


### opts: deprecate QuotedString

The `QuotedString` option was added in [moby@e4c1f07] and [moby@abe32de] to work around a regression in Docker 1.13 that caused `docker-machine` to fail. `docker-machine` produced instructions on how to set up a cli to connect to the Machine it produced. These instructions used quotes around the paths for TLS certificates, but with an `=` for the flag's values instead of a space; due to this the shell would not handle stripping quotes, so the CLI would now get the value including quotes.

Preserving quotes in such cases is expected (and standard behavior), but versions of Docker before 1.13 used a custom "mflag" package for flag parsing, and that package contained custom handling for quotes (added in [moby@0e9c40e]).

For other flags, this problem could be solved by the user, but as these instructions were produced by `docker-machine`'s `config` command, an exception was made for the `--tls-xxx` flags. From [moby-29761]:

> The flag trimming behaviour is really unusual, and I would say unexpected.
> I think removing it is generally the right idea. Since we have one very
> common case where it's necessary for backwards compatibility we need to
> add a special case, but I don't think we should apply that case to every
> flag.

The `QuotedString` implementation has various limitations, as it doesn't follow the same handling of quotes as a shell would.

Given that Docker Machine reached EOL a long time ago and other options, such as `docker context`, have been added to configure the CLI to connect to a specific host (with corresponding TLS configuration), we should remove the special handling for these flags, as it's inconsitent with all other flags, and not worth maintaining for a tool that no longer exists.

This patch deprecates the `QuotedString` option and removes its use. A temporary, non-exported copy is added, but will be removed in the next release.

[moby-29761]: https://github.com/moby/moby/issues/29761#issuecomment-270211265
[moby@e4c1f07]: https://github.com/moby/moby/commit/e4c1f0772923c3069ce14a82d445cd55af3382bc
[moby@abe32de]: https://github.com/moby/moby/commit/abe32de6b46825300f612864e6b4c98606a5bb0e
[moby@0e9c40e]: https://github.com/moby/moby/commit/0e9c40eb8243fa437bc6c3e93aaff64a10cb856e
[moby@c79a169]: https://github.com/moby/moby/commit/c79a169a35f8ee0ecb66cfcffab4b0bd2c77f996

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate `QuotedString`. This utility is no longer used, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**



