### PR TITLE
opts: deprecate ValidateHost utility

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -34,7 +34,7 @@ const (
 
 // ValidateHost validates that the specified string is a valid host and returns it.
 //
-// TODO(thaJeztah): ValidateHost appears to be unused; deprecate it.
+// Deprecated: this function is no longer used, and will be removed in the next release.
 func ValidateHost(val string) (string, error) {
 	host := strings.TrimSpace(val)
 	// The empty string means default and is not handled by parseDockerDaemonHost


### PR DESCRIPTION
The `ValidateHost` option was introduced in [moby@1ba1138] to be used as validation func for the `--host` flag on the daemon in and CLI in [moby@5e3f6e7], but is no longer used since [cli@6f61cf0]. which added support for `ssh://` connections, and required validation elsewhere.

[moby@1ba1138]: https://github.com/moby/moby/commit/1ba11384bf82f824b0efbab31aaca439cfba1b4f
[moby@5e3f6e7]: https://github.com/moby/moby/commit/5e3f6e7023fbd0cfd1233a99c332801755340cfb
[cli@6f61cf0]: https://github.com/docker/cli/commit/6f61cf053afc927379cfef91d241539c36d070f6

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate `ValidateHost` utility. This function is no longer used, and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

