### PR TITLE
Add command registration helpers

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1,0 +1,49 @@
+package commands
+
+import (
+	"os"
+	"slices"
+	"sync"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/spf13/cobra"
+)
+
+var (
+	commands []func(command.Cli) *cobra.Command
+	l        sync.RWMutex
+)
+
+// Register pushes the passed in command into an internal queue which can
+// be retrieved using the [Commands] function.
+func Register(f func(command.Cli) *cobra.Command) {
+	l.Lock()
+	defer l.Unlock()
+	commands = append(commands, f)
+}
+
+// RegisterLegacy functions similarly to [Register], but it checks the
+// `DOCKER_HIDE_LEGACY_COMMANDS` environment variable and if
+// it has been set and is non-empty, the command will be hidden.
+func RegisterLegacy(f func(command.Cli) *cobra.Command) {
+	l.Lock()
+	defer l.Unlock()
+	commands = append(commands, func(c command.Cli) *cobra.Command {
+		cmd := f(c)
+		if os.Getenv("DOCKER_HIDE_LEGACY_COMMANDS") == "" {
+			return cmd
+		}
+		cmdCopy := *cmd
+		cmdCopy.Hidden = true
+		cmdCopy.Aliases = []string{}
+		return &cmdCopy
+	})
+}
+
+// Commands returns a copy of the internal queue holding registered commands
+// added via [Register] or [RegisterLegacy].
+func Commands() []func(command.Cli) *cobra.Command {
+	l.RLock()
+	defer l.RUnlock()
+	return slices.Clone(commands)
+}


### PR DESCRIPTION
This patch adds helper methods to the CLI to register cobra commands.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

