### PR TITLE
Unexport the builder and bake stub command

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -9,17 +9,23 @@ import (
 )
 
 // NewBuilderCommand returns a cobra command for `builder` subcommands
-func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewBuilderCommand(dockerCLI command.Cli) *cobra.Command {
+	return newBuilderCommand(dockerCLI)
+}
+
+func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "builder",
 		Short:       "Manage builds",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.31"},
 	}
 	cmd.AddCommand(
-		NewPruneCommand(dockerCli),
-		image.NewBuildCommand(dockerCli),
+		NewPruneCommand(dockerCLI),
+		image.NewBuildCommand(dockerCLI),
 	)
 	return cmd
 }
@@ -28,7 +34,13 @@ func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
 // This command is a placeholder / stub that is dynamically replaced by an
 // alias for "docker buildx bake" if BuildKit is enabled (and the buildx plugin
 // installed).
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
+	return newBakeStubCommand(dockerCLI)
+}
+
+func newBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
 	return &cobra.Command{
 		Use:   "bake [OPTIONS] [TARGET...]",
 		Short: "Build from a file",

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -43,7 +43,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		system.NewInfoCommand(dockerCli),
 
 		// management commands
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		builder.NewBakeStubCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		builder.NewBuilderCommand(dockerCli),
 		checkpoint.NewCheckpointCommand(dockerCli),
 		container.NewContainerCommand(dockerCli),


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

This patch unexports the `builder` and `bake` stub command and it adds
deprecation notices on the exported functions.

It also registers the commands using the new `cli/internal/commands`
package when the init function executes.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Move the `builder` and `bake` command to an unexported function and deprecate the exported function.

```

**- A picture of a cute animal (not mandatory but encouraged)**

