### PR TITLE
Unexport config command

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -57,6 +57,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		volume.NewVolumeCommand(dockerCli),
 
 		// orchestration (swarm) commands
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		config.NewConfigCommand(dockerCli),
 		node.NewNodeCommand(dockerCli),
 		secret.NewSecretCommand(dockerCli),

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -9,22 +9,28 @@ import (
 )
 
 // NewConfigCommand returns a cobra command for `config` subcommands
-func NewConfigCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewConfigCommand(dockerCLI command.Cli) *cobra.Command {
+	return newConfigCommand(dockerCLI)
+}
+
+func newConfigCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Swarm configs",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.30",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newConfigListCommand(dockerCli),
-		newConfigCreateCommand(dockerCli),
-		newConfigInspectCommand(dockerCli),
-		newConfigRemoveCommand(dockerCli),
+		newConfigListCommand(dockerCLI),
+		newConfigCreateCommand(dockerCLI),
+		newConfigInspectCommand(dockerCLI),
+		newConfigRemoveCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

This patch unexports the `config` command.

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/config: deprecate `NewConfigCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

