### PR TITLE
opts: deprecate NewNamedListOptsRef, NewNamedMapOpts

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -134,6 +134,8 @@ func (opts *ListOpts) WithValidator(validator ValidatorFctType) *ListOpts {
 
 // NamedOption is an interface that list and map options
 // with names implement.
+//
+// Deprecated: NamedOption is no longer used and will be removed in the next release.
 type NamedOption interface {
 	Name() string
 }
@@ -141,6 +143,8 @@ type NamedOption interface {
 // NamedListOpts is a ListOpts with a configuration name.
 // This struct is useful to keep reference to the assigned
 // field name in the internal configuration struct.
+//
+// Deprecated: NamedListOpts is no longer used and will be removed in the next release.
 type NamedListOpts struct {
 	name string
 	ListOpts
@@ -149,6 +153,8 @@ type NamedListOpts struct {
 var _ NamedOption = &NamedListOpts{}
 
 // NewNamedListOptsRef creates a reference to a new NamedListOpts struct.
+//
+// Deprecated: NewNamedListOptsRef is no longer used and will be removed in the next release.
 func NewNamedListOptsRef(name string, values *[]string, validator ValidatorFctType) *NamedListOpts {
 	return &NamedListOpts{
 		name:     name,
@@ -157,6 +163,8 @@ func NewNamedListOptsRef(name string, values *[]string, validator ValidatorFctTy
 }
 
 // Name returns the name of the NamedListOpts in the configuration.
+//
+// Deprecated: NamedListOpts is no longer used and will be removed in the next release.
 func (o *NamedListOpts) Name() string {
 	return o.name
 }
@@ -210,6 +218,8 @@ func NewMapOpts(values map[string]string, validator ValidatorFctType) *MapOpts {
 // NamedMapOpts is a MapOpts struct with a configuration name.
 // This struct is useful to keep reference to the assigned
 // field name in the internal configuration struct.
+//
+// Deprecated: NamedMapOpts is no longer used and will be removed in the next release.
 type NamedMapOpts struct {
 	name string
 	MapOpts
@@ -218,6 +228,8 @@ type NamedMapOpts struct {
 var _ NamedOption = &NamedMapOpts{}
 
 // NewNamedMapOpts creates a reference to a new NamedMapOpts struct.
+//
+// Deprecated: NamedMapOpts is no longer used and will be removed in the next release.
 func NewNamedMapOpts(name string, values map[string]string, validator ValidatorFctType) *NamedMapOpts {
 	return &NamedMapOpts{
 		name:    name,
@@ -226,6 +238,8 @@ func NewNamedMapOpts(name string, values map[string]string, validator ValidatorF
 }
 
 // Name returns the name of the NamedMapOpts in the configuration.
+//
+// Deprecated: NamedMapOpts is no longer used and will be removed in the next release.
 func (o *NamedMapOpts) Name() string {
 	return o.name
 }


### PR DESCRIPTION
The `NewNamedListOptsRef`, `NewNamedMapOpts` and related `NamedListOpts`, `NamedMapOpts`, and `NamedOption` interface were added in [moby@677a6b3], which added support for a `daemon.json` configuration file. That change required a way to correlate command-line flags with their corresponding fields in the `daemon.json` to detect conflicting options. At the time, the CLI and daemon were produced from the same code, and shared packages for command-line options, but when the CLI was moved to a separate repository, these options were inherited.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate `NewNamedListOptsRef`, `NewNamedMapOpts`, `NamedListOpts`, `NamedMapOpts`, and `NamedOption`. These types and functions are no longer used and will be removed in the next release.
```


[moby@677a6b3]: https://github.com/moby/moby/commit/677a6b3506107468ed8c00331991afd9176fa0b9


**- A picture of a cute animal (not mandatory but encouraged)**

