### PR TITLE
[28.x backport] cli/flags: add "hostVar" to handle --host / -H as a single string

### DIFF
--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -69,18 +69,18 @@ The base command for the Docker CLI.
 
 ### Options
 
-| Name                             | Type          | Default                  | Description                                                                                                                           |
-|:---------------------------------|:--------------|:-------------------------|:--------------------------------------------------------------------------------------------------------------------------------------|
-| `--config`                       | `string`      | `/root/.docker`          | Location of client config files                                                                                                       |
-| `-c`, `--context`                | `string`      |                          | Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with `docker context use`) |
-| `-D`, `--debug`                  | `bool`        |                          | Enable debug mode                                                                                                                     |
-| [`-H`](#host), [`--host`](#host) | `stringArray` |                          | Daemon socket to connect to                                                                                                           |
-| `-l`, `--log-level`              | `string`      | `info`                   | Set the logging level (`debug`, `info`, `warn`, `error`, `fatal`)                                                                     |
-| `--tls`                          | `bool`        |                          | Use TLS; implied by --tlsverify                                                                                                       |
-| `--tlscacert`                    | `string`      | `/root/.docker/ca.pem`   | Trust certs signed only by this CA                                                                                                    |
-| `--tlscert`                      | `string`      | `/root/.docker/cert.pem` | Path to TLS certificate file                                                                                                          |
-| `--tlskey`                       | `string`      | `/root/.docker/key.pem`  | Path to TLS key file                                                                                                                  |
-| `--tlsverify`                    | `bool`        |                          | Use TLS and verify the remote                                                                                                         |
+| Name                             | Type     | Default                  | Description                                                                                                                           |
+|:---------------------------------|:---------|:-------------------------|:--------------------------------------------------------------------------------------------------------------------------------------|
+| `--config`                       | `string` | `/root/.docker`          | Location of client config files                                                                                                       |
+| `-c`, `--context`                | `string` |                          | Name of the context to use to connect to the daemon (overrides DOCKER_HOST env var and default context set with `docker context use`) |
+| `-D`, `--debug`                  | `bool`   |                          | Enable debug mode                                                                                                                     |
+| [`-H`](#host), [`--host`](#host) | `string` |                          | Daemon socket to connect to                                                                                                           |
+| `-l`, `--log-level`              | `string` | `info`                   | Set the logging level (`debug`, `info`, `warn`, `error`, `fatal`)                                                                     |
+| `--tls`                          | `bool`   |                          | Use TLS; implied by --tlsverify                                                                                                       |
+| `--tlscacert`                    | `string` | `/root/.docker/ca.pem`   | Trust certs signed only by this CA                                                                                                    |
+| `--tlscert`                      | `string` | `/root/.docker/cert.pem` | Path to TLS certificate file                                                                                                          |
+| `--tlskey`                       | `string` | `/root/.docker/key.pem`  | Path to TLS key file                                                                                                                  |
+| `--tlsverify`                    | `bool`   |                          | Use TLS and verify the remote                                                                                                         |
 
 
 <!---MARKER_GEN_END-->

--- a/e2e/cli-plugins/flags_test.go
+++ b/e2e/cli-plugins/flags_test.go
@@ -1,6 +1,7 @@
 package cliplugins
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -91,9 +92,9 @@ func TestGlobalArgsOnlyParsedOnce(t *testing.T) {
 			// This is checking the precondition wrt -H mentioned in the function comment
 			name:             "fails-if-H-used-twice",
 			args:             []string{"-H", dh, "-H", dh, "version", "-f", "{{.Client.Version}}"},
-			expectedExitCode: 1,
+			expectedExitCode: 125,
 			expectedOut:      icmd.None,
-			expectedErr:      "Specify only one -H",
+			expectedErr:      fmt.Sprintf(`invalid argument %q for "-H, --host" flag: specify only one -H`, dh),
 		},
 		{
 			name:             "builtin",


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6281

-----


### cli/flags: use a regular StringArray for the `--host` / `-H` flag

The ClientOptions struct and related flags were inherited from the Moby repository, where originally the CLI and Daemon used the same implementation and had a "Common" options struct. When the CLI moved to a separate repository, those structs were duplicated, but some daemon-specific logic remained. For example, the daemon can be configured to listen on multiple ports and sockets ([moby@dede158]), but the CLI [can only connect to a single host][1]. The daemon config also had to account for flags conflicting with `daemon.json`, and use special flag-vars for this ([moby@677a6b3]).

Unfortunately, the `ClientConfig` struct became part of the public API and is used as argument in various places, but we can remove the use of the special flag var. This patch replaces the use of `NewNamedListOptsRef` for a regular `StringArray`.

Unfortunately this changes the flag's type description from `list` to `stringArray`, but we can look at changing that separately.

[moby@dede158]: https://github.com/moby/moby/commit/dede1585ee00f957e153691c464aab293c2dc469
[1]: https://github.com/moby/moby/blob/0af135e9065562e14a77439e13a29b4f1eb627a0/docker/docker.go#L191-L193
[moby@677a6b3]: https://github.com/moby/moby/commit/677a6b3506107468ed8c00331991afd9176fa0b9


### cli/flags: add "hostVar" to handle --host / -H as a single string

hostVar is used for the '--host' / '-H' flag to set [ClientOptions.Hosts].
The [ClientOptions.Hosts] field is a slice because it was originally shared
with the daemon config. However, the CLI only allows for a single host to
be specified.

hostVar presents itself as a "string", but stores the value in a string
slice. It produces an error when trying to set multiple values, matching
the check in [getServerHost].

[getServerHost]: https://github.com/docker/cli/blob/7eab668982645def1cd46fe1b60894cba6fd17a4/cli/command/cli.go#L542-L551

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

