### PR TITLE
cli: remove deprecated VisitAll, DisableFlagsInUseLine utilities

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -166,31 +166,6 @@ func (tcmd *TopLevelCommand) Initialize(ops ...command.CLIOption) error {
 	return tcmd.dockerCli.Initialize(tcmd.opts, ops...)
 }
 
-// VisitAll will traverse all commands from the root.
-//
-// Deprecated: this utility was only used internally and will be removed in the next release.
-func VisitAll(root *cobra.Command, fn func(*cobra.Command)) {
-	visitAll(root, fn)
-}
-
-func visitAll(root *cobra.Command, fn func(*cobra.Command)) {
-	for _, cmd := range root.Commands() {
-		visitAll(cmd, fn)
-	}
-	fn(root)
-}
-
-// DisableFlagsInUseLine sets the DisableFlagsInUseLine flag on all
-// commands within the tree rooted at cmd.
-//
-// Deprecated: this utility was only used internally and will be removed in the next release.
-func DisableFlagsInUseLine(cmd *cobra.Command) {
-	visitAll(cmd, func(ccmd *cobra.Command) {
-		// do not add a `[flags]` to the end of the usage line.
-		ccmd.DisableFlagsInUseLine = true
-	})
-}
-
 var helpCommand = &cobra.Command{
 	Use:               "help [command]",
 	Short:             "Help about the command",


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6273

These were deprecated in 6bd8a4b2b5d8854bf68256ee80964a9031ae931b, and are no longer used.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli: remove deprecated `VisitAll`, `DisableFlagsInUseLine` utilities.
```

**- A picture of a cute animal (not mandatory but encouraged)**

