### PR TITLE
[28.x backport] cli-plugins/manager: deprecate annotation metadata aliases

### DIFF
--- a/cli-plugins/manager/annotations.go
+++ b/cli-plugins/manager/annotations.go
@@ -6,25 +6,35 @@ const (
 	// CommandAnnotationPlugin is added to every stub command added by
 	// AddPluginCommandStubs with the value "true" and so can be
 	// used to distinguish plugin stubs from regular commands.
+	//
+	// Deprecated: use [metadata.CommandAnnotationPlugin]. This alias will be removed in the next release.
 	CommandAnnotationPlugin = metadata.CommandAnnotationPlugin
 
 	// CommandAnnotationPluginVendor is added to every stub command
 	// added by AddPluginCommandStubs and contains the vendor of
 	// that plugin.
+	//
+	// Deprecated: use [metadata.CommandAnnotationPluginVendor]. This alias will be removed in the next release.
 	CommandAnnotationPluginVendor = metadata.CommandAnnotationPluginVendor
 
 	// CommandAnnotationPluginVersion is added to every stub command
 	// added by AddPluginCommandStubs and contains the version of
 	// that plugin.
+	//
+	// Deprecated: use [metadata.CommandAnnotationPluginVersion]. This alias will be removed in the next release.
 	CommandAnnotationPluginVersion = metadata.CommandAnnotationPluginVersion
 
 	// CommandAnnotationPluginInvalid is added to any stub command
 	// added by AddPluginCommandStubs for an invalid command (that
 	// is, one which failed it's candidate test) and contains the
 	// reason for the failure.
+	//
+	// Deprecated: use [metadata.CommandAnnotationPluginInvalid]. This alias will be removed in the next release.
 	CommandAnnotationPluginInvalid = metadata.CommandAnnotationPluginInvalid
 
 	// CommandAnnotationPluginCommandPath is added to overwrite the
 	// command path for a plugin invocation.
+	//
+	// Deprecated: use [metadata.CommandAnnotationPluginCommandPath]. This alias will be removed in the next release.
 	CommandAnnotationPluginCommandPath = metadata.CommandAnnotationPluginCommandPath
 )


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6297
- relates to https://github.com/docker/cli/pull/5902

----

These aliases were added in 292713c887b17339106e9f7f3647ed50bebc675d (part of v28.0), but did not deprecate them. They are no longer used in the CLI itself, but may be used by cli-plugin implementations.

This deprecates the aliases in `cli-plugins/manager` in favor of their equivalent in `cli-plugins/manager/metadata`:

- `CommandAnnotationPlugin`
- `CommandAnnotationPluginVendor`
- `CommandAnnotationPluginVersion`
- `CommandAnnotationPluginInvalid`
- `CommandAnnotationPluginCommandPath`


(cherry picked from commit 72f76f2720e5a31918f991ee797bfc3041fad37c)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli-plugins/manager: deprecate annotation aliases (`CommandAnnotationPlugin`, `CommandAnnotationPluginVendor`, `CommandAnnotationPluginVersion`, `CommandAnnotationPluginInvalid`, `CommandAnnotationPluginCommandPath`) in favor of their equivalent in `cli-plugins/manager/metadata`
```

**- A picture of a cute animal (not mandatory but encouraged)**

