### PR TITLE
cli/command: TestRetrieveAuthTokenFromImage: don't decode authconfig

### DIFF
--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -185,9 +185,9 @@ func TestRetrieveAuthTokenFromImage(t *testing.T) {
 				imageRef := path.Join(tc.prefix, remoteRef)
 				actual, err := command.RetrieveAuthTokenFromImage(&cfg, imageRef)
 				assert.NilError(t, err)
-				ac, err := registry.DecodeAuthConfig(actual)
+				expectedAuthCfg, err := registry.EncodeAuthConfig(tc.expectedAuthCfg)
 				assert.NilError(t, err)
-				assert.Check(t, is.DeepEqual(*ac, tc.expectedAuthCfg))
+				assert.Equal(t, actual, expectedAuthCfg)
 			}
 		})
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50765

Rewrite the test to not depend on registry.DecodeAuthConfig, which may be moved internal to the daemon as part of the modules transition.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

