### PR TITLE
Unexport image commands

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -25,6 +25,8 @@ func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewPruneCommand(dockerCLI),
+		// we should have a mechanism for registering sub-commands in the cli/internal/commands.Register function.
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewBuildCommand(dockerCLI),
 	)
 	return cmd

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -35,9 +35,13 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		container.NewExecCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewPsCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewBuildCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewPullCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewPushCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImagesCommand(dockerCli),
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
@@ -55,6 +59,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewContainerCommand(dockerCli),
 		context.NewContextCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
 		manifest.NewManifestCommand(dockerCli),
 		network.NewNetworkCommand(dockerCli),
@@ -113,11 +118,17 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		hide(container.NewUpdateCommand(dockerCli)),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewWaitCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewHistoryCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewImportCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewLoadCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewRemoveCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewSaveCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewTagCommand(dockerCli)),
 		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInspectCommand(dockerCli)),

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -81,7 +81,14 @@ func newBuildOptions() buildOptions {
 }
 
 // NewBuildCommand creates a new `docker build` command
-func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewBuildCommand(dockerCLI command.Cli) *cobra.Command {
+	return newBuildCommand(dockerCLI)
+}
+
+// newBuildCommand creates a new `docker build` command
+func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 	options := newBuildOptions()
 
 	cmd := &cobra.Command{

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -120,7 +120,7 @@ COPY data /data
 // to support testing (ex: docker/cli#294)
 func TestRunBuildFromGitHubSpecialCase(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
-	cmd := NewBuildCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newBuildCommand(test.NewFakeCli(&fakeClient{}))
 	// Clone a small repo that exists so git doesn't prompt for credentials
 	cmd.SetArgs([]string{"github.com/docker/for-win"})
 	cmd.SetOut(io.Discard)
@@ -143,7 +143,7 @@ func TestRunBuildFromLocalGitHubDir(t *testing.T) {
 	assert.NilError(t, err)
 
 	client := test.NewFakeCli(&fakeClient{})
-	cmd := NewBuildCommand(client)
+	cmd := newBuildCommand(client)
 	cmd.SetArgs([]string{buildDir})
 	cmd.SetOut(io.Discard)
 	err = cmd.Execute()

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -7,7 +7,14 @@ import (
 )
 
 // NewImageCommand returns a cobra command for `image` subcommands
-func NewImageCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewImageCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImageCommand(dockerCLI)
+}
+
+// newImageCommand returns a cobra command for `image` subcommands
+func newImageCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Manage images",
@@ -15,18 +22,18 @@ func NewImageCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 	}
 	cmd.AddCommand(
-		NewBuildCommand(dockerCli),
-		NewHistoryCommand(dockerCli),
-		NewImportCommand(dockerCli),
-		NewLoadCommand(dockerCli),
-		NewPullCommand(dockerCli),
-		NewPushCommand(dockerCli),
-		NewSaveCommand(dockerCli),
-		NewTagCommand(dockerCli),
+		newBuildCommand(dockerCli),
+		newHistoryCommand(dockerCli),
+		newImportCommand(dockerCli),
+		newLoadCommand(dockerCli),
+		newPullCommand(dockerCli),
+		newPushCommand(dockerCli),
+		newSaveCommand(dockerCli),
+		newTagCommand(dockerCli),
 		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
+		newImageRemoveCommand(dockerCli),
 		newInspectCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newPruneCommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -25,7 +25,14 @@ type historyOptions struct {
 }
 
 // NewHistoryCommand creates a new `docker history` command
-func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewHistoryCommand(dockerCLI command.Cli) *cobra.Command {
+	return newHistoryCommand(dockerCLI)
+}
+
+// newHistoryCommand creates a new `docker history` command
+func newHistoryCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts historyOptions
 
 	cmd := &cobra.Command{
@@ -34,9 +41,9 @@ func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.image = args[0]
-			return runHistory(cmd.Context(), dockerCli, opts)
+			return runHistory(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
 		Annotations: map[string]string{
 			"aliases": "docker image history, docker history",
 		},

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -42,7 +42,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
+			cmd := newHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -114,7 +114,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 			// printed in the current timezone
 			t.Setenv("TZ", "UTC")
 			cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
-			cmd := NewHistoryCommand(cli)
+			cmd := newHistoryCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -23,7 +23,14 @@ type importOptions struct {
 }
 
 // NewImportCommand creates a new `docker import` command
-func NewImportCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewImportCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImportCommand(dockerCLI)
+}
+
+// newImportCommand creates a new `docker import` command
+func newImportCommand(dockerCLI command.Cli) *cobra.Command {
 	var options importOptions
 
 	cmd := &cobra.Command{
@@ -35,7 +42,7 @@ func NewImportCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				options.reference = args[1]
 			}
-			return runImport(cmd.Context(), dockerCli, options)
+			return runImport(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image import, docker import",

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -34,7 +34,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
+		cmd := newImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
 		cmd.SetArgs(tc.args)
@@ -43,7 +43,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 }
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
-	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newImportCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
@@ -99,7 +99,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
+			cmd := newImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -29,7 +29,14 @@ type imagesOptions struct {
 }
 
 // NewImagesCommand creates a new `docker images` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImagesCommand(dockerCLI)
+}
+
+// newImagesCommand creates a new `docker images` command
+func newImagesCommand(dockerCLI command.Cli) *cobra.Command {
 	options := imagesOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -69,7 +76,7 @@ func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 func newListCommand(dockerCLI command.Cli) *cobra.Command {
-	cmd := *NewImagesCommand(dockerCLI)
+	cmd := *newImagesCommand(dockerCLI)
 	cmd.Aliases = []string{"list"}
 	cmd.Use = "ls [OPTIONS] [REPOSITORY[:TAG]]"
 	return &cmd

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
+			cmd := newImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -85,7 +85,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc})
 			cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
-			cmd := NewImagesCommand(cli)
+			cmd := newImagesCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -104,7 +104,7 @@ func TestNewListCommandAlias(t *testing.T) {
 
 func TestNewListCommandAmbiguous(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
-	cmd := NewImagesCommand(cli)
+	cmd := newImagesCommand(cli)
 	cmd.SetOut(io.Discard)
 
 	// Set the Use field to mimic that the command was called as "docker images",

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -23,7 +23,14 @@ type loadOptions struct {
 }
 
 // NewLoadCommand creates a new `docker load` command
-func NewLoadCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewLoadCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLoadCommand(dockerCLI)
+}
+
+// newLoadCommand creates a new `docker load` command
+func newLoadCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loadOptions
 
 	cmd := &cobra.Command{
@@ -31,7 +38,7 @@ func NewLoadCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Load an image from a tar archive or STDIN",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLoad(cmd.Context(), dockerCli, opts)
+			return runLoad(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image load, docker load",

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -54,7 +54,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 			cli.In().SetIsTerminal(tc.isTerminalIn)
-			cmd := NewLoadCommand(cli)
+			cmd := newLoadCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -65,7 +65,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
-	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newLoadCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
@@ -133,7 +133,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
-			cmd := NewLoadCommand(cli)
+			cmd := newLoadCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -31,7 +31,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for images
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for images
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -39,14 +46,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused images",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCli, options)
+			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				fmt.Fprintln(dockerCli.Out(), output)
+				fmt.Fprintln(dockerCLI.Out(), output)
 			}
-			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
+			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
 		Annotations:       map[string]string{"version": "1.25"},

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -27,7 +27,14 @@ type pullOptions struct {
 }
 
 // NewPullCommand creates a new `docker pull` command
-func NewPullCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPullCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPullCommand(dockerCLI)
+}
+
+// newPullCommand creates a new `docker pull` command
+func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pullOptions
 
 	cmd := &cobra.Command{
@@ -36,7 +43,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runPull(cmd.Context(), dockerCli, opts)
+			return runPull(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "5",
@@ -51,7 +58,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 
 	addPlatformFlag(flags, &opts.platform)
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
 
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -40,7 +40,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -79,7 +79,7 @@ func TestNewPullCommandSuccess(t *testing.T) {
 					return io.NopCloser(strings.NewReader("")), nil
 				},
 			})
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -124,7 +124,7 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 				},
 			}, test.EnableContentTrust)
 			cli.SetNotaryClient(tc.notaryFunc)
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -36,7 +36,14 @@ type pushOptions struct {
 }
 
 // NewPushCommand creates a new `docker push` command
-func NewPushCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPushCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPushCommand(dockerCLI)
+}
+
+// newPushCommand creates a new `docker push` command
+func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pushOptions
 
 	cmd := &cobra.Command{
@@ -45,19 +52,19 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runPush(cmd.Context(), dockerCli, opts)
+			return runPush(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "6",
 			"aliases":      "docker image push, docker push",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
 	}
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tags of an image to the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image signing")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image signing")
 
 	// Don't default to DOCKER_DEFAULT_PLATFORM env variable, always default to
 	// pushing the image as-is. This also avoids forcing the platform selection

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -40,7 +40,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
-			cmd := NewPushCommand(cli)
+			cmd := newPushCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -73,7 +73,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 					return io.NopCloser(strings.NewReader("")), nil
 				},
 			})
-			cmd := NewPushCommand(cli)
+			cmd := newPushCommand(cli)
 			cmd.SetOut(cli.OutBuffer())
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -21,7 +21,14 @@ type removeOptions struct {
 }
 
 // NewRemoveCommand creates a new `docker remove` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewRemoveCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRemoveCommand(dockerCLI)
+}
+
+// newRemoveCommand creates a new `docker remove` command
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var options removeOptions
 
 	cmd := &cobra.Command{
@@ -50,8 +57,9 @@ func NewRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
-	cmd := *NewRemoveCommand(dockerCli)
+// newImageRemoveCommand is a sub-command under `image` (`docker image rm`)
+func newImageRemoveCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := *newRemoveCommand(dockerCli)
 	cmd.Aliases = []string{"rmi", "remove"}
 	cmd.Use = "rm [OPTIONS] IMAGE [IMAGE...]"
 	return &cmd

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -24,7 +24,7 @@ func (n notFound) Error() string {
 func (notFound) NotFound() {}
 
 func TestNewRemoveCommandAlias(t *testing.T) {
-	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newImageRemoveCommand(test.NewFakeCli(&fakeClient{}))
 	assert.Check(t, cmd.HasAlias("rmi"))
 	assert.Check(t, cmd.HasAlias("remove"))
 	assert.Check(t, !cmd.HasAlias("other"))
@@ -63,7 +63,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
+			cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{
 				imageRemoveFunc: tc.imageRemoveFunc,
 			}))
 			cmd.SetOut(io.Discard)
@@ -122,7 +122,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc})
-			cmd := NewRemoveCommand(cli)
+			cmd := newRemoveCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -22,7 +22,14 @@ type saveOptions struct {
 }
 
 // NewSaveCommand creates a new `docker save` command
-func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSaveCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSaveCommand(dockerCLI)
+}
+
+// newSaveCommand creates a new `docker save` command
+func newSaveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts saveOptions
 
 	cmd := &cobra.Command{
@@ -31,12 +38,12 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.images = args
-			return runSave(cmd.Context(), dockerCli, opts)
+			return runSave(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image save, docker save",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, -1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -61,7 +61,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 			cli.Out().SetIsTerminal(tc.isTerminal)
-			cmd := NewSaveCommand(cli)
+			cmd := newSaveCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -134,7 +134,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
+			cmd := newSaveCommand(test.NewFakeCli(&fakeClient{
 				imageSaveFunc: tc.imageSaveFunc,
 			}))
 			cmd.SetOut(io.Discard)

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -15,7 +15,14 @@ type tagOptions struct {
 }
 
 // NewTagCommand creates a new `docker tag` command
-func NewTagCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewTagCommand(dockerCLI command.Cli) *cobra.Command {
+	return newTagCommand(dockerCLI)
+}
+
+// newTagCommand creates a new `docker tag` command
+func newTagCommand(dockerCli command.Cli) *cobra.Command {
 	var opts tagOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -17,7 +17,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 	}
 	expectedError := "'tag' requires 2 arguments"
 	for _, args := range testCases {
-		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
+		cmd := newTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
@@ -26,7 +26,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 }
 
 func TestCliNewTagCommand(t *testing.T) {
-	cmd := NewTagCommand(
+	cmd := newTagCommand(
 		test.NewFakeCli(&fakeClient{
 			imageTagFunc: func(image string, ref string) error {
 				assert.Check(t, is.Equal("image1", image))


### PR DESCRIPTION
This patch deprecates exported image commands and moves the implementation details to an unexported function.

Commands that are affected include:

- image.NewBuildCommand
- image.NewPullCommand
- image.NewPushCommand
- image.NewImagesCommand
- image.NewImageCommand
- image.NewHistoryCommand
- image.NewImportCommand
- image.NewLoadCommand
- image.NewRemoveCommand
- image.NewSaveCommand
- image.NewTagCommand
- image.NewPruneCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/container: deprecate `NewBuildCommand`, `NewPullCommand`, `NewPushCommand`, `NewImagesCommand`, `NewImageCommand`, `NewHistoryCommand`, `NewImportCommand`, `NewLoadCommand`, `NewRemoveCommand`, `NewSaveCommand`, `NewTagCommand`, `NewPruneCommand`. These functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

