### PR TITLE
cli/registry/client: deprecate and move internal

### DIFF
--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/manifest/store"
-	registryclient "github.com/docker/cli/cli/registry/client"
+	"github.com/docker/cli/internal/registryclient"
 	"github.com/moby/moby/api/types/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"

--- a/cli/command/manifest/client_test.go
+++ b/cli/command/manifest/client_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/distribution/reference"
 	manifesttypes "github.com/docker/cli/cli/manifest/types"
-	"github.com/docker/cli/cli/registry/client"
+	"github.com/docker/cli/internal/registryclient"
 	"github.com/docker/distribution"
 	"github.com/opencontainers/go-digest"
 )
@@ -45,4 +45,4 @@ func (c *fakeRegistryClient) PutManifest(ctx context.Context, ref reference.Name
 	return digest.Digest(""), nil
 }
 
-var _ client.RegistryClient = &fakeRegistryClient{}
+var _ registryclient.RegistryClient = &fakeRegistryClient{}

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/types"
-	registryclient "github.com/docker/cli/cli/registry/client"
+	"github.com/docker/cli/internal/registryclient"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/ocischema"

--- a/cli/registry/client/client_deprecated.go
+++ b/cli/registry/client/client_deprecated.go
@@ -1,0 +1,21 @@
+package client // Deprecated: this package was only used internally and will be removed in the next release.
+
+import "github.com/docker/cli/internal/registryclient"
+
+// RegistryClient is a client used to communicate with a Docker distribution
+// registry.
+//
+// Deprecated: this interface was only used internally and will be removed in the next release.
+type RegistryClient = registryclient.RegistryClient
+
+// NewRegistryClient returns a new RegistryClient with a resolver
+//
+// Deprecated: this function was only used internally and will be removed in the next release.
+func NewRegistryClient(resolver registryclient.AuthConfigResolver, userAgent string, insecure bool) registryclient.RegistryClient {
+	return registryclient.NewRegistryClient(resolver, userAgent, insecure)
+}
+
+// AuthConfigResolver returns Auth Configuration for an index
+//
+// Deprecated: this type was only used internally and will be removed in the next release.
+type AuthConfigResolver = registryclient.AuthConfigResolver

--- a/internal/registryclient/client.go
+++ b/internal/registryclient/client.go
@@ -1,4 +1,4 @@
-package client
+package registryclient
 
 import (
 	"context"

--- a/internal/registryclient/endpoint.go
+++ b/internal/registryclient/endpoint.go
@@ -1,4 +1,4 @@
-package client
+package registryclient
 
 import (
 	"context"

--- a/internal/registryclient/fetcher.go
+++ b/internal/registryclient/fetcher.go
@@ -1,4 +1,4 @@
-package client
+package registryclient
 
 import (
 	"context"

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -11,9 +11,9 @@ import (
 	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/cli/context/store"
 	manifeststore "github.com/docker/cli/cli/manifest/store"
-	registryclient "github.com/docker/cli/cli/registry/client"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/trust"
+	"github.com/docker/cli/internal/registryclient"
 	"github.com/moby/moby/client"
 	notaryclient "github.com/theupdateframework/notary/client"
 )


### PR DESCRIPTION


**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: the cli/registry/client package is deprecated and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

