### PR TITLE
cli/flags: remove special quote handling for `--tlsXXX` flags

### DIFF
--- a/cli/flags/options.go
+++ b/cli/flags/options.go
@@ -110,22 +110,20 @@ func (o *ClientOptions) InstallFlags(flags *pflag.FlagSet) {
 	if dockerCertPath == "" {
 		dockerCertPath = configDir
 	}
+	o.TLSOptions = &tlsconfig.Options{
+		CAFile:   filepath.Join(dockerCertPath, DefaultCaFile),
+		CertFile: filepath.Join(dockerCertPath, DefaultCertFile),
+		KeyFile:  filepath.Join(dockerCertPath, DefaultKeyFile),
+	}
 
 	flags.StringVar(&o.ConfigDir, "config", configDir, "Location of client config files")
 	flags.BoolVarP(&o.Debug, "debug", "D", false, "Enable debug mode")
 	flags.StringVarP(&o.LogLevel, "log-level", "l", "info", `Set the logging level ("debug", "info", "warn", "error", "fatal")`)
 	flags.BoolVar(&o.TLS, "tls", dockerTLS, "Use TLS; implied by --tlsverify")
 	flags.BoolVar(&o.TLSVerify, FlagTLSVerify, dockerTLSVerify, "Use TLS and verify the remote")
-
-	o.TLSOptions = &tlsconfig.Options{
-		CAFile:   filepath.Join(dockerCertPath, DefaultCaFile),
-		CertFile: filepath.Join(dockerCertPath, DefaultCertFile),
-		KeyFile:  filepath.Join(dockerCertPath, DefaultKeyFile),
-	}
-	tlsOptions := o.TLSOptions
-	flags.Var(&quotedString{&tlsOptions.CAFile}, "tlscacert", "Trust certs signed only by this CA")
-	flags.Var(&quotedString{&tlsOptions.CertFile}, "tlscert", "Path to TLS certificate file")
-	flags.Var(&quotedString{&tlsOptions.KeyFile}, "tlskey", "Path to TLS key file")
+	flags.StringVar(&o.TLSOptions.CAFile, "tlscacert", o.TLSOptions.CAFile, "Trust certs signed only by this CA")
+	flags.StringVar(&o.TLSOptions.CertFile, "tlscert", o.TLSOptions.CertFile, "Path to TLS certificate file")
+	flags.StringVar(&o.TLSOptions.KeyFile, "tlskey", o.TLSOptions.KeyFile, "Path to TLS key file")
 
 	// TODO(thaJeztah): show the default host.
 	// TODO(thaJeztah): this should be a string, not an "array" as we only allow a single host.
@@ -178,34 +176,4 @@ func SetLogLevel(logLevel string) {
 	} else {
 		logrus.SetLevel(logrus.InfoLevel)
 	}
-}
-
-type quotedString struct {
-	value *string
-}
-
-func (s *quotedString) Set(val string) error {
-	*s.value = trimQuotes(val)
-	return nil
-}
-
-func (*quotedString) Type() string {
-	return "string"
-}
-
-func (s *quotedString) String() string {
-	return *s.value
-}
-
-func trimQuotes(value string) string {
-	if len(value) < 2 {
-		return value
-	}
-	lastIndex := len(value) - 1
-	for _, char := range []byte{'\'', '"'} {
-		if value[0] == char && value[lastIndex] == char {
-			return value[1:lastIndex]
-		}
-	}
-	return value
 }

--- a/cli/flags/options_test.go
+++ b/cli/flags/options_test.go
@@ -16,9 +16,9 @@ func TestClientOptionsInstallFlags(t *testing.T) {
 	opts.InstallFlags(flags)
 
 	err := flags.Parse([]string{
-		"--tlscacert=\"/foo/cafile\"",
-		"--tlscert=\"/foo/cert\"",
-		"--tlskey=\"/foo/key\"",
+		"--tlscacert=/foo/cafile",
+		"--tlscert=/foo/cert",
+		"--tlskey=/foo/key",
 	})
 	assert.NilError(t, err)
 	assert.Check(t, is.Equal("/foo/cafile", opts.TLSOptions.CAFile))


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6290
- https://github.com/docker/cli/pull/6291


This non-standard handling for these options was added in [moby@e4c1f07] and [moby@abe32de] to work around a regression in Docker 1.13 that caused `docker-machine` to fail. Preserving quotes in such cases is expected (and standard behavior), but versions of Docker before 1.13 used a custom "mflag" package for flag parsing, and that package contained custom handling for quotes (added in [moby@0e9c40e]).

Given that Docker Machine reached EOL a long time ago and other options, such as `docker context`, have been added to configure the CLI to connect to a specific host (with corresponding TLS configuration), we can remove the special handling for these flags, as it's inconsistent with all other flags, and not worth maintaining for a tool that no longer exists.

[moby@e4c1f07]: https://github.com/moby/moby/commit/e4c1f0772923c3069ce14a82d445cd55af3382bc
[moby@abe32de]: https://github.com/moby/moby/commit/abe32de6b46825300f612864e6b4c98606a5bb0e
[moby@0e9c40e]: https://github.com/moby/moby/commit/0e9c40eb8243fa437bc6c3e93aaff64a10cb856e

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove special handling for quoted values for the `--tlscacert`, `--tlscert`, and `--tlskey` command-line flags.
```

**- A picture of a cute animal (not mandatory but encouraged)**

