### PR TITLE
[28.x backport] cli/command: TestRetrieveAuthTokenFromImage: don't decode authconfig

### DIFF
--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -185,9 +185,9 @@ func TestRetrieveAuthTokenFromImage(t *testing.T) {
 				imageRef := path.Join(tc.prefix, remoteRef)
 				actual, err := command.RetrieveAuthTokenFromImage(&cfg, imageRef)
 				assert.NilError(t, err)
-				ac, err := registry.DecodeAuthConfig(actual)
+				expectedAuthCfg, err := registry.EncodeAuthConfig(tc.expectedAuthCfg)
 				assert.NilError(t, err)
-				assert.Check(t, is.DeepEqual(*ac, tc.expectedAuthCfg))
+				assert.Equal(t, actual, expectedAuthCfg)
 			}
 		})
 	}


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6300
- relates to https://github.com/moby/moby/pull/50765

Rewrite the test to not depend on registry.DecodeAuthConfig, which may be moved internal to the daemon as part of the modules transition.


(cherry picked from commit ae1727c41ef71f41f7a689a800c8009591ccf0d8)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

