### PR TITLE
[28.x backport] un-export and deprecate cobra commands

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -25,6 +25,8 @@ func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewPruneCommand(dockerCLI),
+		// we should have a mechanism for registering sub-commands in the cli/internal/commands.Register function.
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewBuildCommand(dockerCLI),
 	)
 	return cmd

--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -9,17 +9,23 @@ import (
 )
 
 // NewBuilderCommand returns a cobra command for `builder` subcommands
-func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewBuilderCommand(dockerCLI command.Cli) *cobra.Command {
+	return newBuilderCommand(dockerCLI)
+}
+
+func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "builder",
 		Short:       "Manage builds",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.31"},
 	}
 	cmd.AddCommand(
-		NewPruneCommand(dockerCli),
-		image.NewBuildCommand(dockerCli),
+		NewPruneCommand(dockerCLI),
+		image.NewBuildCommand(dockerCLI),
 	)
 	return cmd
 }
@@ -28,7 +34,13 @@ func NewBuilderCommand(dockerCli command.Cli) *cobra.Command {
 // This command is a placeholder / stub that is dynamically replaced by an
 // alias for "docker buildx bake" if BuildKit is enabled (and the buildx plugin
 // installed).
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
+	return newBakeStubCommand(dockerCLI)
+}
+
+func newBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
 	return &cobra.Command{
 		Use:   "bake [OPTIONS] [TARGET...]",
 		Short: "Build from a file",

--- a/cli/command/checkpoint/cmd.go
+++ b/cli/command/checkpoint/cmd.go
@@ -7,12 +7,18 @@ import (
 )
 
 // NewCheckpointCommand returns the `checkpoint` subcommand (only in experimental)
-func NewCheckpointCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewCheckpointCommand(dockerCLI command.Cli) *cobra.Command {
+	return newCheckpointCommand(dockerCLI)
+}
+
+func newCheckpointCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "checkpoint",
 		Short: "Manage checkpoints",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"experimental": "",
 			"ostype":       "linux",
@@ -20,9 +26,9 @@ func NewCheckpointCommand(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -35,9 +35,13 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		container.NewExecCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewPsCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewBuildCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewPullCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewPushCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImagesCommand(dockerCli),
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
@@ -55,6 +59,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewContainerCommand(dockerCli),
 		context.NewContextCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
 		manifest.NewManifestCommand(dockerCli),
 		network.NewNetworkCommand(dockerCli),
@@ -113,11 +118,17 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		hide(container.NewUpdateCommand(dockerCli)),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewWaitCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewHistoryCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewImportCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewLoadCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewRemoveCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewSaveCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewTagCommand(dockerCli)),
 		hide(system.NewEventsCommand(dockerCli)),
 		hide(system.NewInspectCommand(dockerCli)),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -89,6 +89,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		service.NewServiceCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		stack.NewStackCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		swarm.NewSwarmCommand(dockerCli),
 
 		// legacy commands may be hidden

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -84,6 +84,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		secret.NewSecretCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		service.NewServiceCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		stack.NewStackCommand(dockerCli),
 		swarm.NewSwarmCommand(dockerCli),
 

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -75,6 +75,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		trust.NewTrustCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		volume.NewVolumeCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -60,6 +60,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		volume.NewVolumeCommand(dockerCli),
 
 		// orchestration (swarm) commands
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		config.NewConfigCommand(dockerCli),
 		node.NewNodeCommand(dockerCli),
 		secret.NewSecretCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -63,6 +63,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		context.NewContextCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		manifest.NewManifestCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		network.NewNetworkCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -47,6 +47,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		builder.NewBakeStubCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		builder.NewBuilderCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		checkpoint.NewCheckpointCommand(dockerCli),
 		container.NewContainerCommand(dockerCli),
 		context.NewContextCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -80,6 +80,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		node.NewNodeCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		secret.NewSecretCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		service.NewServiceCommand(dockerCli),
 		stack.NewStackCommand(dockerCli),
 		swarm.NewSwarmCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -78,6 +78,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		config.NewConfigCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		node.NewNodeCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		secret.NewSecretCommand(dockerCli),
 		service.NewServiceCommand(dockerCli),
 		stack.NewStackCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -71,6 +71,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		manifest.NewManifestCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		network.NewNetworkCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -60,6 +60,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		checkpoint.NewCheckpointCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewContainerCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		context.NewContextCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -46,7 +46,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		registry.NewLoginCommand(dockerCli),
 		registry.NewLogoutCommand(dockerCli),
 		registry.NewSearchCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewVersionCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewInfoCommand(dockerCli),
 
 		// management commands
@@ -64,6 +66,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		manifest.NewManifestCommand(dockerCli),
 		network.NewNetworkCommand(dockerCli),
 		plugin.NewPluginCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),
 		trust.NewTrustCommand(dockerCli),
 		volume.NewVolumeCommand(dockerCli),
@@ -130,7 +133,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		hide(image.NewSaveCommand(dockerCli)),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(image.NewTagCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(system.NewEventsCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(system.NewInspectCommand(dockerCli)),
 	)
 }

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -29,8 +29,11 @@ import (
 func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 	cmd.AddCommand(
 		// commonly used shorthands
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewRunCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewExecCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewPsCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
 		image.NewPullCommand(dockerCli),
@@ -49,6 +52,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		builder.NewBuilderCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		checkpoint.NewCheckpointCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewContainerCommand(dockerCli),
 		context.NewContextCommand(dockerCli),
 		image.NewImageCommand(dockerCli),
@@ -69,25 +73,45 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		swarm.NewSwarmCommand(dockerCli),
 
 		// legacy commands may be hidden
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewAttachCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewCommitCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewCopyCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewCreateCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewDiffCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewExportCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewKillCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewLogsCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewPauseCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewPortCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewRenameCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewRestartCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewRmCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewStartCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewStatsCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewStopCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewTopCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewUnpauseCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewUpdateCommand(dockerCli)),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		hide(container.NewWaitCommand(dockerCli)),
 		hide(image.NewHistoryCommand(dockerCli)),
 		hide(image.NewImportCommand(dockerCli)),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -43,7 +43,9 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		system.NewInfoCommand(dockerCli),
 
 		// management commands
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		builder.NewBakeStubCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		builder.NewBuilderCommand(dockerCli),
 		checkpoint.NewCheckpointCommand(dockerCli),
 		container.NewContainerCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -71,6 +71,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),
 		trust.NewTrustCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		volume.NewVolumeCommand(dockerCli),
 
 		// orchestration (swarm) commands

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -43,8 +43,11 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		image.NewPushCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImagesCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewLoginCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewLogoutCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewSearchCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewVersionCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -75,6 +75,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// orchestration (swarm) commands
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		config.NewConfigCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		node.NewNodeCommand(dockerCli),
 		secret.NewSecretCommand(dockerCli),
 		service.NewServiceCommand(dockerCli),

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -64,6 +64,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
 		manifest.NewManifestCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		network.NewNetworkCommand(dockerCli),
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -9,22 +9,28 @@ import (
 )
 
 // NewConfigCommand returns a cobra command for `config` subcommands
-func NewConfigCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewConfigCommand(dockerCLI command.Cli) *cobra.Command {
+	return newConfigCommand(dockerCLI)
+}
+
+func newConfigCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Swarm configs",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.30",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newConfigListCommand(dockerCli),
-		newConfigCreateCommand(dockerCli),
-		newConfigInspectCommand(dockerCli),
-		newConfigRemoveCommand(dockerCli),
+		newConfigListCommand(dockerCLI),
+		newConfigCreateCommand(dockerCLI),
+		newConfigInspectCommand(dockerCLI),
+		newConfigRemoveCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -41,7 +41,13 @@ func inspectContainerAndCheckState(ctx context.Context, apiClient client.APIClie
 }
 
 // NewAttachCommand creates a new cobra.Command for `docker attach`
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewAttachCommand(dockerCLI command.Cli) *cobra.Command {
+	return newAttachCommand(dockerCLI)
+}
+
+func newAttachCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts AttachOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -74,7 +74,7 @@ func TestNewAttachCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewAttachCommand(test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc}))
+			cmd := newAttachCommand(test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -7,39 +7,45 @@ import (
 )
 
 // NewContainerCommand returns a cobra command for `container` subcommands
-func NewContainerCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewContainerCommand(dockerCLI command.Cli) *cobra.Command {
+	return newContainerCommand(dockerCLI)
+}
+
+func newContainerCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "container",
 		Short: "Manage containers",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		NewAttachCommand(dockerCli),
-		NewCommitCommand(dockerCli),
-		NewCopyCommand(dockerCli),
-		NewCreateCommand(dockerCli),
-		NewDiffCommand(dockerCli),
-		NewExecCommand(dockerCli),
-		NewExportCommand(dockerCli),
-		NewKillCommand(dockerCli),
-		NewLogsCommand(dockerCli),
-		NewPauseCommand(dockerCli),
-		NewPortCommand(dockerCli),
-		NewRenameCommand(dockerCli),
-		NewRestartCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		NewRunCommand(dockerCli),
-		NewStartCommand(dockerCli),
-		NewStatsCommand(dockerCli),
-		NewStopCommand(dockerCli),
-		NewTopCommand(dockerCli),
-		NewUnpauseCommand(dockerCli),
-		NewUpdateCommand(dockerCli),
-		NewWaitCommand(dockerCli),
-		newListCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newAttachCommand(dockerCLI),
+		newCommitCommand(dockerCLI),
+		newCopyCommand(dockerCLI),
+		newCreateCommand(dockerCLI),
+		newDiffCommand(dockerCLI),
+		newExecCommand(dockerCLI),
+		newExportCommand(dockerCLI),
+		newKillCommand(dockerCLI),
+		newLogsCommand(dockerCLI),
+		newPauseCommand(dockerCLI),
+		newPortCommand(dockerCLI),
+		newRenameCommand(dockerCLI),
+		newRestartCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newRunCommand(dockerCLI),
+		newStartCommand(dockerCLI),
+		newStatsCommand(dockerCLI),
+		newStopCommand(dockerCLI),
+		newTopCommand(dockerCLI),
+		newUnpauseCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newWaitCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -23,7 +23,13 @@ type commitOptions struct {
 }
 
 // NewCommitCommand creates a new cobra.Command for `docker commit`
-func NewCommitCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewCommitCommand(dockerCLI command.Cli) *cobra.Command {
+	return newCommitCommand(dockerCLI)
+}
+
+func newCommitCommand(dockerCLI command.Cli) *cobra.Command {
 	var options commitOptions
 
 	cmd := &cobra.Command{
@@ -35,12 +41,12 @@ func NewCommitCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				options.reference = args[1]
 			}
-			return runCommit(cmd.Context(), dockerCli, &options)
+			return runCommit(cmd.Context(), dockerCLI, &options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container commit, docker commit",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/commit_test.go
+++ b/cli/command/container/commit_test.go
@@ -29,7 +29,7 @@ func TestRunCommit(t *testing.T) {
 		},
 	})
 
-	cmd := NewCommitCommand(cli)
+	cmd := newCommitCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetArgs(
 		[]string{
@@ -60,7 +60,7 @@ func TestRunCommitClientError(t *testing.T) {
 		},
 	})
 
-	cmd := NewCommitCommand(cli)
+	cmd := newCommitCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"container-id"})

--- a/cli/command/container/completion_test.go
+++ b/cli/command/container/completion_test.go
@@ -59,7 +59,7 @@ func TestCompletePid(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{
 				containerListFunc: tc.containerListFunc,
 			})
-			completions, directive := completePid(cli)(NewRunCommand(cli), nil, tc.toComplete)
+			completions, directive := completePid(cli)(newRunCommand(cli), nil, tc.toComplete)
 			assert.Check(t, is.DeepEqual(completions, tc.expectedCompletions))
 			assert.Check(t, is.Equal(directive, tc.expectedDirective))
 		})

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -122,7 +122,13 @@ func copyProgress(ctx context.Context, dst io.Writer, header string, total *int6
 }
 
 // NewCopyCommand creates a new `docker cp` command
-func NewCopyCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewCopyCommand(dockerCLI command.Cli) *cobra.Command {
+	return newCopyCommand(dockerCLI)
+}
+
+func newCopyCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts copyOptions
 
 	cmd := &cobra.Command{
@@ -147,9 +153,9 @@ container source to stdout.`,
 			opts.destination = args[1]
 			if !cmd.Flag("quiet").Changed {
 				// User did not specify "quiet" flag; suppress output if no terminal is attached
-				opts.quiet = !dockerCli.Out().IsTerminal()
+				opts.quiet = !dockerCLI.Out().IsTerminal()
 			}
-			return runCopy(cmd.Context(), dockerCli, opts)
+			return runCopy(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container cp, docker cp",

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -52,7 +52,13 @@ type createOptions struct {
 }
 
 // NewCreateCommand creates a new cobra.Command for `docker create`
-func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewCreateCommand(dockerCLI command.Cli) *cobra.Command {
+	return newCreateCommand(dockerCLI)
+}
+
+func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	var options createOptions
 	var copts *containerOptions
 
@@ -65,12 +71,12 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				copts.Args = args[1:]
 			}
-			return runCreate(cmd.Context(), dockerCli, cmd.Flags(), &options, copts)
+			return runCreate(cmd.Context(), dockerCLI, cmd.Flags(), &options, copts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container create, docker create",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, -1),
 	}
 
 	flags := cmd.Flags()
@@ -90,10 +96,10 @@ func NewCreateCommand(dockerCli command.Cli) *cobra.Command {
 	addPlatformFlag(flags, &options.platform)
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 
-	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
 	copts = addFlags(flags)
 
-	addCompletions(cmd, dockerCli)
+	addCompletions(cmd, dockerCLI)
 
 	flags.VisitAll(func(flag *pflag.Flag) {
 		// Set a default completion function if none was set. We don't look

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -206,7 +206,7 @@ func TestCreateContainerValidateFlags(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewCreateCommand(test.NewFakeCli(&fakeClient{}))
+			cmd := newCreateCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -260,7 +260,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 				},
 			}, test.EnableContentTrust)
 			fakeCLI.SetNotaryClient(tc.notaryFunc)
-			cmd := NewCreateCommand(fakeCLI)
+			cmd := newCreateCommand(fakeCLI)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -314,7 +314,7 @@ func TestNewCreateCommandWithWarnings(t *testing.T) {
 					return container.CreateResponse{Warnings: tc.warnings}, nil
 				},
 			})
-			cmd := NewCreateCommand(fakeCLI)
+			cmd := newCreateCommand(fakeCLI)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
@@ -366,7 +366,7 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 			},
 		},
 	})
-	cmd := NewCreateCommand(fakeCLI)
+	cmd := newCreateCommand(fakeCLI)
 	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"image:tag"})
 	err := cmd.Execute()

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -11,18 +11,24 @@ import (
 )
 
 // NewDiffCommand creates a new cobra.Command for `docker diff`
-func NewDiffCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewDiffCommand(dockerCLI command.Cli) *cobra.Command {
+	return newDiffCommand(dockerCLI)
+}
+
+func newDiffCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "diff CONTAINER",
 		Short: "Inspect changes to files or directories on a container's filesystem",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiff(cmd.Context(), dockerCli, args[0])
+			return runDiff(cmd.Context(), dockerCLI, args[0])
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container diff, docker diff",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 }
 

--- a/cli/command/container/diff_test.go
+++ b/cli/command/container/diff_test.go
@@ -36,7 +36,7 @@ func TestRunDiff(t *testing.T) {
 		},
 	})
 
-	cmd := NewDiffCommand(cli)
+	cmd := newDiffCommand(cli)
 	cmd.SetOut(io.Discard)
 
 	cmd.SetArgs([]string{"container-id"})
@@ -68,7 +68,7 @@ func TestRunDiffClientError(t *testing.T) {
 		},
 	})
 
-	cmd := NewDiffCommand(cli)
+	cmd := newDiffCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -40,7 +40,13 @@ func NewExecOptions() ExecOptions {
 }
 
 // NewExecCommand creates a new cobra.Command for `docker exec`
-func NewExecCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewExecCommand(dockerCLI command.Cli) *cobra.Command {
+	return newExecCommand(dockerCLI)
+}
+
+func newExecCommand(dockerCLI command.Cli) *cobra.Command {
 	options := NewExecOptions()
 
 	cmd := &cobra.Command{
@@ -50,9 +56,9 @@ func NewExecCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			containerIDorName := args[0]
 			options.Command = args[1:]
-			return RunExec(cmd.Context(), dockerCli, containerIDorName, options)
+			return RunExec(cmd.Context(), dockerCLI, containerIDorName, options)
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(ctr container.Summary) bool {
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false, func(ctr container.Summary) bool {
 			return ctr.State != container.StatePaused
 		}),
 		Annotations: map[string]string{

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -263,7 +263,7 @@ func TestNewExecCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		fakeCLI := test.NewFakeCli(&fakeClient{inspectFunc: tc.containerInspectFunc})
-		cmd := NewExecCommand(fakeCLI)
+		cmd := newExecCommand(fakeCLI)
 		cmd.SetOut(io.Discard)
 		cmd.SetArgs(tc.args)
 		assert.ErrorContains(t, cmd.Execute(), tc.expectedError)

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -18,7 +18,13 @@ type exportOptions struct {
 }
 
 // NewExportCommand creates a new `docker export` command
-func NewExportCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewExportCommand(dockerCLI command.Cli) *cobra.Command {
+	return newExportCommand(dockerCLI)
+}
+
+func newExportCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts exportOptions
 
 	cmd := &cobra.Command{
@@ -27,12 +33,12 @@ func NewExportCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.container = args[0]
-			return runExport(cmd.Context(), dockerCli, opts)
+			return runExport(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container export, docker export",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -19,7 +19,7 @@ func TestContainerExportOutputToFile(t *testing.T) {
 			return io.NopCloser(strings.NewReader("bar")), nil
 		},
 	})
-	cmd := NewExportCommand(cli)
+	cmd := newExportCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"-o", dir.Join("foo"), "container"})
 	assert.NilError(t, cmd.Execute())
@@ -37,7 +37,7 @@ func TestContainerExportOutputToIrregularFile(t *testing.T) {
 			return io.NopCloser(strings.NewReader("foo")), nil
 		},
 	})
-	cmd := NewExportCommand(cli)
+	cmd := newExportCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"-o", "/dev/random", "container"})

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -18,7 +18,13 @@ type killOptions struct {
 }
 
 // NewKillCommand creates a new cobra.Command for `docker kill`
-func NewKillCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewKillCommand(dockerCLI command.Cli) *cobra.Command {
+	return newKillCommand(dockerCLI)
+}
+
+func newKillCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts killOptions
 
 	cmd := &cobra.Command{
@@ -27,12 +33,12 @@ func NewKillCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
-			return runKill(cmd.Context(), dockerCli, &opts)
+			return runKill(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container kill, docker kill",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/kill_test.go
+++ b/cli/command/container/kill_test.go
@@ -24,7 +24,7 @@ func TestRunKill(t *testing.T) {
 		},
 	})
 
-	cmd := NewKillCommand(cli)
+	cmd := newKillCommand(cli)
 	cmd.SetOut(io.Discard)
 
 	cmd.SetArgs([]string{
@@ -56,7 +56,7 @@ func TestRunKillClientError(t *testing.T) {
 		},
 	})
 
-	cmd := NewKillCommand(cli)
+	cmd := newKillCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -29,7 +29,13 @@ type psOptions struct {
 }
 
 // NewPsCommand creates a new cobra.Command for `docker ps`
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewPsCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPsCommand(dockerCLI)
+}
+
+func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -62,7 +68,7 @@ func NewPsCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 func newListCommand(dockerCLI command.Cli) *cobra.Command {
-	cmd := *NewPsCommand(dockerCLI)
+	cmd := *newPsCommand(dockerCLI)
 	cmd.Aliases = []string{"ps", "list"}
 	cmd.Use = "ls [OPTIONS]"
 	return &cmd

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -24,7 +24,13 @@ type logsOptions struct {
 }
 
 // NewLogsCommand creates a new cobra.Command for `docker logs`
-func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewLogsCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLogsCommand(dockerCLI)
+}
+
+func newLogsCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts logsOptions
 
 	cmd := &cobra.Command{
@@ -33,12 +39,12 @@ func NewLogsCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.container = args[0]
-			return runLogs(cmd.Context(), dockerCli, &opts)
+			return runLogs(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container logs, docker logs",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -17,7 +17,13 @@ type pauseOptions struct {
 }
 
 // NewPauseCommand creates a new cobra.Command for `docker pause`
-func NewPauseCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPauseCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPauseCommand(dockerCLI)
+}
+
+func newPauseCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pauseOptions
 
 	return &cobra.Command{
@@ -26,12 +32,12 @@ func NewPauseCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
-			return runPause(cmd.Context(), dockerCli, &opts)
+			return runPause(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container pause, docker pause",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(ctr container.Summary) bool {
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false, func(ctr container.Summary) bool {
 			return ctr.State != container.StatePaused
 		}),
 	}

--- a/cli/command/container/pause_test.go
+++ b/cli/command/container/pause_test.go
@@ -21,7 +21,7 @@ func TestRunPause(t *testing.T) {
 		},
 	)
 
-	cmd := NewPauseCommand(cli)
+	cmd := newPauseCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetArgs([]string{"container-id-1", "container-id-2"})
 
@@ -47,7 +47,7 @@ func TestRunPauseClientError(t *testing.T) {
 		},
 	)
 
-	cmd := NewPauseCommand(cli)
+	cmd := newPauseCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"container-id-1", "container-id-2"})

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -24,7 +24,13 @@ type portOptions struct {
 }
 
 // NewPortCommand creates a new cobra.Command for `docker port`
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewPortCommand(dockerCli command.Cli) *cobra.Command {
+	return newPortCommand(dockerCli)
+}
+
+func newPortCommand(dockerCli command.Cli) *cobra.Command {
 	var opts portOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/container/port_test.go
+++ b/cli/command/container/port_test.go
@@ -66,7 +66,7 @@ func TestNewPortCommandOutput(t *testing.T) {
 					return ci, nil
 				},
 			})
-			cmd := NewPortCommand(cli)
+			cmd := newPortCommand(cli)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs([]string{"some_container", tc.port})
 			err := cmd.Execute()

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -20,7 +20,13 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for containers
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -28,14 +34,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove all stopped containers",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCli, options)
+			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				fmt.Fprintln(dockerCli.Out(), output)
+				fmt.Fprintln(dockerCLI.Out(), output)
 			}
-			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
+			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
 		Annotations:       map[string]string{"version": "1.25"},

--- a/cli/command/container/prune_test.go
+++ b/cli/command/container/prune_test.go
@@ -20,7 +20,7 @@ func TestContainerPrunePromptTermination(t *testing.T) {
 			return container.PruneReport{}, errors.New("fakeClient containerPruneFunc should not be called")
 		},
 	})
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -18,7 +18,13 @@ type renameOptions struct {
 }
 
 // NewRenameCommand creates a new cobra.Command for `docker rename`
-func NewRenameCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewRenameCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRenameCommand(dockerCLI)
+}
+
+func newRenameCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts renameOptions
 
 	cmd := &cobra.Command{
@@ -28,12 +34,12 @@ func NewRenameCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.oldName = args[0]
 			opts.newName = args[1]
-			return runRename(cmd.Context(), dockerCli, &opts)
+			return runRename(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container rename, docker rename",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
 	}
 	return cmd
 }

--- a/cli/command/container/rename_test.go
+++ b/cli/command/container/rename_test.go
@@ -43,7 +43,7 @@ func TestRunRename(t *testing.T) {
 				},
 			})
 
-			cmd := NewRenameCommand(cli)
+			cmd := newRenameCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs([]string{tc.oldName, tc.newName})
@@ -66,7 +66,7 @@ func TestRunRenameClientError(t *testing.T) {
 		},
 	})
 
-	cmd := NewRenameCommand(cli)
+	cmd := newRenameCommand(cli)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"oldName", "newName"})

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -21,7 +21,13 @@ type restartOptions struct {
 }
 
 // NewRestartCommand creates a new cobra.Command for `docker restart`
-func NewRestartCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewRestartCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRestartCommand(dockerCLI)
+}
+
+func newRestartCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts restartOptions
 
 	cmd := &cobra.Command{
@@ -34,12 +40,12 @@ func NewRestartCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			opts.containers = args
 			opts.timeoutChanged = cmd.Flags().Changed("timeout") || cmd.Flags().Changed("time")
-			return runRestart(cmd.Context(), dockerCli, &opts)
+			return runRestart(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container restart, docker restart",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/restart_test.go
+++ b/cli/command/container/restart_test.go
@@ -76,7 +76,7 @@ func TestRestart(t *testing.T) {
 				},
 				Version: "1.36",
 			})
-			cmd := NewRestartCommand(cli)
+			cmd := newRestartCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -23,7 +23,13 @@ type rmOptions struct {
 }
 
 // NewRmCommand creates a new cobra.Command for `docker rm`
-func NewRmCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewRmCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRmCommand(dockerCLI)
+}
+
+func newRmCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts rmOptions
 
 	cmd := &cobra.Command{
@@ -32,12 +38,12 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
-			return runRm(cmd.Context(), dockerCli, &opts)
+			return runRm(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container rm, docker container remove, docker rm",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true, func(ctr container.Summary) bool {
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true, func(ctr container.Summary) bool {
 			return opts.force || ctr.State == container.StateExited || ctr.State == container.StateCreated
 		}),
 	}
@@ -53,7 +59,7 @@ func NewRmCommand(dockerCli command.Cli) *cobra.Command {
 // top-level "docker rm", it also adds a "remove" alias to support
 // "docker container remove" in addition to "docker container rm".
 func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
-	cmd := *NewRmCommand(dockerCli)
+	cmd := *newRmCommand(dockerCli)
 	cmd.Aliases = []string{"rm", "remove"}
 	return &cmd
 }

--- a/cli/command/container/rm_test.go
+++ b/cli/command/container/rm_test.go
@@ -41,7 +41,7 @@ func TestRemoveForce(t *testing.T) {
 				},
 				Version: "1.36",
 			})
-			cmd := NewRmCommand(cli)
+			cmd := newRmCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -28,7 +28,13 @@ type runOptions struct {
 }
 
 // NewRunCommand create a new `docker run` command
-func NewRunCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewRunCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRunCommand(dockerCLI)
+}
+
+func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 	var options runOptions
 	var copts *containerOptions
 
@@ -41,9 +47,9 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				copts.Args = args[1:]
 			}
-			return runRun(cmd.Context(), dockerCli, cmd.Flags(), &options, copts)
+			return runRun(cmd.Context(), dockerCLI, cmd.Flags(), &options, copts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
 		Annotations: map[string]string{
 			"category-top": "1",
 			"aliases":      "docker container run, docker run",
@@ -68,11 +74,11 @@ func NewRunCommand(dockerCli command.Cli) *cobra.Command {
 
 	// TODO(thaJeztah): consider adding platform as "image create option" on containerOptions
 	addPlatformFlag(flags, &options.platform)
-	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
 	copts = addFlags(flags)
 
 	_ = cmd.RegisterFlagCompletionFunc("detach-keys", completeDetachKeys)
-	addCompletions(cmd, dockerCli)
+	addCompletions(cmd, dockerCLI)
 
 	flags.VisitAll(func(flag *pflag.Flag) {
 		// Set a default completion function if none was set. We don't look

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -39,7 +39,7 @@ func TestRunValidateFlags(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewRunCommand(test.NewFakeCli(&fakeClient{}))
+			cmd := newRunCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -63,7 +63,7 @@ func TestRunLabel(t *testing.T) {
 		},
 		Version: "1.36",
 	})
-	cmd := NewRunCommand(fakeCLI)
+	cmd := newRunCommand(fakeCLI)
 	cmd.SetArgs([]string{"--detach=true", "--label", "foo", "busybox"})
 	assert.NilError(t, cmd.Execute())
 }
@@ -110,7 +110,7 @@ func TestRunAttach(t *testing.T) {
 		fc.SetIn(streams.NewIn(tty))
 	})
 
-	cmd := NewRunCommand(fakeCLI)
+	cmd := newRunCommand(fakeCLI)
 	cmd.SetArgs([]string{"-it", "busybox"})
 	cmd.SilenceUsage = true
 	cmdErrC := make(chan error, 1)
@@ -187,7 +187,7 @@ func TestRunAttachTermination(t *testing.T) {
 		fc.SetIn(streams.NewIn(tty))
 	})
 
-	cmd := NewRunCommand(fakeCLI)
+	cmd := newRunCommand(fakeCLI)
 	cmd.SetArgs([]string{"-it", "busybox"})
 	cmd.SilenceUsage = true
 	cmdErrC := make(chan error, 1)
@@ -265,7 +265,7 @@ func TestRunPullTermination(t *testing.T) {
 		Version: "1.30",
 	})
 
-	cmd := NewRunCommand(fakeCLI)
+	cmd := newRunCommand(fakeCLI)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"--pull", "always", "foobar:latest"})
@@ -334,7 +334,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 				},
 			}, test.EnableContentTrust)
 			fakeCLI.SetNotaryClient(tc.notaryFunc)
-			cmd := NewRunCommand(fakeCLI)
+			cmd := newRunCommand(fakeCLI)
 			cmd.SetArgs(tc.args)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -28,7 +28,13 @@ type StartOptions struct {
 }
 
 // NewStartCommand creates a new cobra.Command for `docker start`
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewStartCommand(dockerCli command.Cli) *cobra.Command {
+	return newStartCommand(dockerCli)
+}
+
+func newStartCommand(dockerCli command.Cli) *cobra.Command {
 	var opts StartOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -64,7 +64,13 @@ type StatsOptions struct {
 }
 
 // NewStatsCommand creates a new [cobra.Command] for "docker stats".
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewStatsCommand(dockerCLI command.Cli) *cobra.Command {
+	return newStatsCommand(dockerCLI)
+}
+
+func newStatsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := StatsOptions{}
 
 	cmd := &cobra.Command{

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -21,7 +21,13 @@ type stopOptions struct {
 }
 
 // NewStopCommand creates a new cobra.Command for `docker stop`
-func NewStopCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewStopCommand(dockerCLI command.Cli) *cobra.Command {
+	return newStopCommand(dockerCLI)
+}
+
+func newStopCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts stopOptions
 
 	cmd := &cobra.Command{
@@ -34,12 +40,12 @@ func NewStopCommand(dockerCli command.Cli) *cobra.Command {
 			}
 			opts.containers = args
 			opts.timeoutChanged = cmd.Flags().Changed("timeout") || cmd.Flags().Changed("time")
-			return runStop(cmd.Context(), dockerCli, &opts)
+			return runStop(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container stop, docker stop",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/stop_test.go
+++ b/cli/command/container/stop_test.go
@@ -77,7 +77,7 @@ func TestStop(t *testing.T) {
 				},
 				Version: "1.36",
 			})
-			cmd := NewStopCommand(cli)
+			cmd := newStopCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -19,7 +19,13 @@ type topOptions struct {
 }
 
 // NewTopCommand creates a new cobra.Command for `docker top`
-func NewTopCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewTopCommand(dockerCLI command.Cli) *cobra.Command {
+	return newTopCommand(dockerCLI)
+}
+
+func newTopCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts topOptions
 
 	cmd := &cobra.Command{
@@ -29,12 +35,12 @@ func NewTopCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.container = args[0]
 			opts.args = args[1:]
-			return runTop(cmd.Context(), dockerCli, &opts)
+			return runTop(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container top, docker top",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -17,7 +17,13 @@ type unpauseOptions struct {
 }
 
 // NewUnpauseCommand creates a new cobra.Command for `docker unpause`
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewUnpauseCommand(dockerCli command.Cli) *cobra.Command {
+	return newUnpauseCommand(dockerCli)
+}
+
+func newUnpauseCommand(dockerCli command.Cli) *cobra.Command {
 	var opts unpauseOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -37,7 +37,13 @@ type updateOptions struct {
 }
 
 // NewUpdateCommand creates a new cobra.Command for `docker update`
-func NewUpdateCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewUpdateCommand(dockerCLI command.Cli) *cobra.Command {
+	return newUpdateCommand(dockerCLI)
+}
+
+func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	var options updateOptions
 
 	cmd := &cobra.Command{
@@ -47,12 +53,12 @@ func NewUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.containers = args
 			options.nFlag = cmd.Flags().NFlag()
-			return runUpdate(cmd.Context(), dockerCli, &options)
+			return runUpdate(cmd.Context(), dockerCLI, &options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container update, docker update",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -16,7 +16,13 @@ type waitOptions struct {
 }
 
 // NewWaitCommand creates a new cobra.Command for `docker wait`
-func NewWaitCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewWaitCommand(dockerCLI command.Cli) *cobra.Command {
+	return newWaitCommand(dockerCLI)
+}
+
+func newWaitCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts waitOptions
 
 	cmd := &cobra.Command{
@@ -25,12 +31,12 @@ func NewWaitCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
-			return runWait(cmd.Context(), dockerCli, &opts)
+			return runWait(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container wait, docker wait",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
 	}
 
 	return cmd

--- a/cli/command/context/cmd.go
+++ b/cli/command/context/cmd.go
@@ -7,23 +7,30 @@ import (
 )
 
 // NewContextCommand returns the context cli subcommand
-func NewContextCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewContextCommand(dockerCLI command.Cli) *cobra.Command {
+	return newContextCommand(dockerCLI)
+}
+
+// newContextCommand returns the context cli subcommand
+func newContextCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context",
 		Short: "Manage contexts",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newListCommand(dockerCli),
-		newUseCommand(dockerCli),
-		newExportCommand(dockerCli),
-		newImportCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newShowCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newUseCommand(dockerCLI),
+		newExportCommand(dockerCLI),
+		newImportCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newShowCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -87,7 +87,14 @@ func newBuildOptions() buildOptions {
 }
 
 // NewBuildCommand creates a new `docker build` command
-func NewBuildCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewBuildCommand(dockerCLI command.Cli) *cobra.Command {
+	return newBuildCommand(dockerCLI)
+}
+
+// newBuildCommand creates a new `docker build` command
+func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 	options := newBuildOptions()
 
 	cmd := &cobra.Command{

--- a/cli/command/image/build_test.go
+++ b/cli/command/image/build_test.go
@@ -123,7 +123,7 @@ COPY data /data
 // to support testing (ex: docker/cli#294)
 func TestRunBuildFromGitHubSpecialCase(t *testing.T) {
 	t.Setenv("DOCKER_BUILDKIT", "0")
-	cmd := NewBuildCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newBuildCommand(test.NewFakeCli(&fakeClient{}))
 	// Clone a small repo that exists so git doesn't prompt for credentials
 	cmd.SetArgs([]string{"github.com/docker/for-win"})
 	cmd.SetOut(io.Discard)
@@ -146,7 +146,7 @@ func TestRunBuildFromLocalGitHubDir(t *testing.T) {
 	assert.NilError(t, err)
 
 	client := test.NewFakeCli(&fakeClient{})
-	cmd := NewBuildCommand(client)
+	cmd := newBuildCommand(client)
 	cmd.SetArgs([]string{buildDir})
 	cmd.SetOut(io.Discard)
 	err = cmd.Execute()

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -7,7 +7,14 @@ import (
 )
 
 // NewImageCommand returns a cobra command for `image` subcommands
-func NewImageCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewImageCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImageCommand(dockerCLI)
+}
+
+// newImageCommand returns a cobra command for `image` subcommands
+func newImageCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Manage images",
@@ -15,18 +22,18 @@ func NewImageCommand(dockerCli command.Cli) *cobra.Command {
 		RunE:  command.ShowHelp(dockerCli.Err()),
 	}
 	cmd.AddCommand(
-		NewBuildCommand(dockerCli),
-		NewHistoryCommand(dockerCli),
-		NewImportCommand(dockerCli),
-		NewLoadCommand(dockerCli),
-		NewPullCommand(dockerCli),
-		NewPushCommand(dockerCli),
-		NewSaveCommand(dockerCli),
-		NewTagCommand(dockerCli),
+		newBuildCommand(dockerCli),
+		newHistoryCommand(dockerCli),
+		newImportCommand(dockerCli),
+		newLoadCommand(dockerCli),
+		newPullCommand(dockerCli),
+		newPushCommand(dockerCli),
+		newSaveCommand(dockerCli),
+		newTagCommand(dockerCli),
 		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
+		newImageRemoveCommand(dockerCli),
 		newInspectCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newPruneCommand(dockerCli),
 	)
 	return cmd
 }

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -25,7 +25,14 @@ type historyOptions struct {
 }
 
 // NewHistoryCommand creates a new `docker history` command
-func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewHistoryCommand(dockerCLI command.Cli) *cobra.Command {
+	return newHistoryCommand(dockerCLI)
+}
+
+// newHistoryCommand creates a new `docker history` command
+func newHistoryCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts historyOptions
 
 	cmd := &cobra.Command{
@@ -34,9 +41,9 @@ func NewHistoryCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.image = args[0]
-			return runHistory(cmd.Context(), dockerCli, opts)
+			return runHistory(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
 		Annotations: map[string]string{
 			"aliases": "docker image history, docker history",
 		},

--- a/cli/command/image/history_test.go
+++ b/cli/command/image/history_test.go
@@ -42,7 +42,7 @@ func TestNewHistoryCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
+			cmd := newHistoryCommand(test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -114,7 +114,7 @@ func TestNewHistoryCommandSuccess(t *testing.T) {
 			// printed in the current timezone
 			t.Setenv("TZ", "UTC")
 			cli := test.NewFakeCli(&fakeClient{imageHistoryFunc: tc.imageHistoryFunc})
-			cmd := NewHistoryCommand(cli)
+			cmd := newHistoryCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -23,7 +23,14 @@ type importOptions struct {
 }
 
 // NewImportCommand creates a new `docker import` command
-func NewImportCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewImportCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImportCommand(dockerCLI)
+}
+
+// newImportCommand creates a new `docker import` command
+func newImportCommand(dockerCLI command.Cli) *cobra.Command {
 	var options importOptions
 
 	cmd := &cobra.Command{
@@ -35,7 +42,7 @@ func NewImportCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				options.reference = args[1]
 			}
-			return runImport(cmd.Context(), dockerCli, options)
+			return runImport(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image import, docker import",

--- a/cli/command/image/import_test.go
+++ b/cli/command/image/import_test.go
@@ -34,7 +34,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
+		cmd := newImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
 		cmd.SetArgs(tc.args)
@@ -43,7 +43,7 @@ func TestNewImportCommandErrors(t *testing.T) {
 }
 
 func TestNewImportCommandInvalidFile(t *testing.T) {
-	cmd := NewImportCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newImportCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"testdata/import-command-success.unexistent-file"})
@@ -99,7 +99,7 @@ func TestNewImportCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
+			cmd := newImportCommand(test.NewFakeCli(&fakeClient{imageImportFunc: tc.imageImportFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -29,7 +29,14 @@ type imagesOptions struct {
 }
 
 // NewImagesCommand creates a new `docker images` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
+	return newImagesCommand(dockerCLI)
+}
+
+// newImagesCommand creates a new `docker images` command
+func newImagesCommand(dockerCLI command.Cli) *cobra.Command {
 	options := imagesOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -69,7 +76,7 @@ func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 func newListCommand(dockerCLI command.Cli) *cobra.Command {
-	cmd := *NewImagesCommand(dockerCLI)
+	cmd := *newImagesCommand(dockerCLI)
 	cmd.Aliases = []string{"list"}
 	cmd.Use = "ls [OPTIONS] [REPOSITORY[:TAG]]"
 	return &cmd

--- a/cli/command/image/list_test.go
+++ b/cli/command/image/list_test.go
@@ -36,7 +36,7 @@ func TestNewImagesCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
+			cmd := newImagesCommand(test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -85,7 +85,7 @@ func TestNewImagesCommandSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageListFunc: tc.imageListFunc})
 			cli.SetConfigFile(&configfile.ConfigFile{ImagesFormat: tc.imageFormat})
-			cmd := NewImagesCommand(cli)
+			cmd := newImagesCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -104,7 +104,7 @@ func TestNewListCommandAlias(t *testing.T) {
 
 func TestNewListCommandAmbiguous(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
-	cmd := NewImagesCommand(cli)
+	cmd := newImagesCommand(cli)
 	cmd.SetOut(io.Discard)
 
 	// Set the Use field to mimic that the command was called as "docker images",

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -22,7 +22,14 @@ type loadOptions struct {
 }
 
 // NewLoadCommand creates a new `docker load` command
-func NewLoadCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewLoadCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLoadCommand(dockerCLI)
+}
+
+// newLoadCommand creates a new `docker load` command
+func newLoadCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loadOptions
 
 	cmd := &cobra.Command{
@@ -30,7 +37,7 @@ func NewLoadCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Load an image from a tar archive or STDIN",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLoad(cmd.Context(), dockerCli, opts)
+			return runLoad(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image load, docker load",

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -54,7 +54,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
 			cli.In().SetIsTerminal(tc.isTerminalIn)
-			cmd := NewLoadCommand(cli)
+			cmd := newLoadCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -65,7 +65,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 
 func TestNewLoadCommandInvalidInput(t *testing.T) {
 	expectedError := "open *"
-	cmd := NewLoadCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newLoadCommand(test.NewFakeCli(&fakeClient{}))
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"--input", "*"})
@@ -117,7 +117,7 @@ func TestNewLoadCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageLoadFunc: tc.imageLoadFunc})
-			cmd := NewLoadCommand(cli)
+			cmd := newLoadCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -23,7 +23,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for images
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for images
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -31,14 +38,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused images",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCli, options)
+			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				fmt.Fprintln(dockerCli.Out(), output)
+				fmt.Fprintln(dockerCLI.Out(), output)
 			}
-			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
+			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
 		Annotations:       map[string]string{"version": "1.25"},

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -27,7 +27,14 @@ type pullOptions struct {
 }
 
 // NewPullCommand creates a new `docker pull` command
-func NewPullCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPullCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPullCommand(dockerCLI)
+}
+
+// newPullCommand creates a new `docker pull` command
+func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pullOptions
 
 	cmd := &cobra.Command{
@@ -36,7 +43,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runPull(cmd.Context(), dockerCli, opts)
+			return runPull(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "5",
@@ -51,7 +58,7 @@ func NewPullCommand(dockerCli command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 
 	addPlatformFlag(flags, &opts.platform)
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
 
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -40,7 +40,7 @@ func TestNewPullCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{})
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -79,7 +79,7 @@ func TestNewPullCommandSuccess(t *testing.T) {
 					return io.NopCloser(strings.NewReader("")), nil
 				},
 			})
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -124,7 +124,7 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 				},
 			}, test.EnableContentTrust)
 			cli.SetNotaryClient(tc.notaryFunc)
-			cmd := NewPullCommand(cli)
+			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -36,7 +36,14 @@ type pushOptions struct {
 }
 
 // NewPushCommand creates a new `docker push` command
-func NewPushCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPushCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPushCommand(dockerCLI)
+}
+
+// newPushCommand creates a new `docker push` command
+func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pushOptions
 
 	cmd := &cobra.Command{
@@ -45,19 +52,19 @@ func NewPushCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runPush(cmd.Context(), dockerCli, opts)
+			return runPush(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "6",
 			"aliases":      "docker image push, docker push",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
 	}
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tags of an image to the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image signing")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image signing")
 
 	// Don't default to DOCKER_DEFAULT_PLATFORM env variable, always default to
 	// pushing the image as-is. This also avoids forcing the platform selection

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -40,7 +40,7 @@ func TestNewPushCommandErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imagePushFunc: tc.imagePushFunc})
-			cmd := NewPushCommand(cli)
+			cmd := newPushCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -73,7 +73,7 @@ func TestNewPushCommandSuccess(t *testing.T) {
 					return io.NopCloser(strings.NewReader("")), nil
 				},
 			})
-			cmd := NewPushCommand(cli)
+			cmd := newPushCommand(cli)
 			cmd.SetOut(cli.OutBuffer())
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -21,7 +21,14 @@ type removeOptions struct {
 }
 
 // NewRemoveCommand creates a new `docker remove` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewRemoveCommand(dockerCLI command.Cli) *cobra.Command {
+	return newRemoveCommand(dockerCLI)
+}
+
+// newRemoveCommand creates a new `docker remove` command
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var options removeOptions
 
 	cmd := &cobra.Command{
@@ -50,8 +57,9 @@ func NewRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
-	cmd := *NewRemoveCommand(dockerCli)
+// newImageRemoveCommand is a sub-command under `image` (`docker image rm`)
+func newImageRemoveCommand(dockerCli command.Cli) *cobra.Command {
+	cmd := *newRemoveCommand(dockerCli)
 	cmd.Aliases = []string{"rmi", "remove"}
 	cmd.Use = "rm [OPTIONS] IMAGE [IMAGE...]"
 	return &cmd

--- a/cli/command/image/remove_test.go
+++ b/cli/command/image/remove_test.go
@@ -24,7 +24,7 @@ func (n notFound) Error() string {
 func (notFound) NotFound() {}
 
 func TestNewRemoveCommandAlias(t *testing.T) {
-	cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{}))
+	cmd := newImageRemoveCommand(test.NewFakeCli(&fakeClient{}))
 	assert.Check(t, cmd.HasAlias("rmi"))
 	assert.Check(t, cmd.HasAlias("remove"))
 	assert.Check(t, !cmd.HasAlias("other"))
@@ -63,7 +63,7 @@ func TestNewRemoveCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewRemoveCommand(test.NewFakeCli(&fakeClient{
+			cmd := newRemoveCommand(test.NewFakeCli(&fakeClient{
 				imageRemoveFunc: tc.imageRemoveFunc,
 			}))
 			cmd.SetOut(io.Discard)
@@ -122,7 +122,7 @@ func TestNewRemoveCommandSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageRemoveFunc: tc.imageRemoveFunc})
-			cmd := NewRemoveCommand(cli)
+			cmd := newRemoveCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -21,7 +21,14 @@ type saveOptions struct {
 }
 
 // NewSaveCommand creates a new `docker save` command
-func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSaveCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSaveCommand(dockerCLI)
+}
+
+// newSaveCommand creates a new `docker save` command
+func newSaveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts saveOptions
 
 	cmd := &cobra.Command{
@@ -30,12 +37,12 @@ func NewSaveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.images = args
-			return runSave(cmd.Context(), dockerCli, opts)
+			return runSave(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image save, docker save",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
+		ValidArgsFunction: completion.ImageNames(dockerCLI, -1),
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -61,7 +61,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{imageSaveFunc: tc.imageSaveFunc})
 			cli.Out().SetIsTerminal(tc.isTerminal)
-			cmd := NewSaveCommand(cli)
+			cmd := newSaveCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)
@@ -114,7 +114,7 @@ func TestNewSaveCommandSuccess(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(strings.Join(tc.args, " "), func(t *testing.T) {
-			cmd := NewSaveCommand(test.NewFakeCli(&fakeClient{
+			cmd := newSaveCommand(test.NewFakeCli(&fakeClient{
 				imageSaveFunc: tc.imageSaveFunc,
 			}))
 			cmd.SetOut(io.Discard)

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -15,7 +15,14 @@ type tagOptions struct {
 }
 
 // NewTagCommand creates a new `docker tag` command
-func NewTagCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewTagCommand(dockerCLI command.Cli) *cobra.Command {
+	return newTagCommand(dockerCLI)
+}
+
+// newTagCommand creates a new `docker tag` command
+func newTagCommand(dockerCli command.Cli) *cobra.Command {
 	var opts tagOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/image/tag_test.go
+++ b/cli/command/image/tag_test.go
@@ -17,7 +17,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 	}
 	expectedError := "'tag' requires 2 arguments"
 	for _, args := range testCases {
-		cmd := NewTagCommand(test.NewFakeCli(&fakeClient{}))
+		cmd := newTagCommand(test.NewFakeCli(&fakeClient{}))
 		cmd.SetArgs(args)
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)
@@ -26,7 +26,7 @@ func TestCliNewTagCommandErrors(t *testing.T) {
 }
 
 func TestCliNewTagCommand(t *testing.T) {
-	cmd := NewTagCommand(
+	cmd := newTagCommand(
 		test.NewFakeCli(&fakeClient{
 			imageTagFunc: func(image string, ref string) error {
 				assert.Check(t, is.Equal("image1", image))

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -10,7 +10,14 @@ import (
 )
 
 // NewManifestCommand returns a cobra command for `manifest` subcommands
-func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewManifestCommand(dockerCLI command.Cli) *cobra.Command {
+	return newManifestCommand(dockerCLI)
+}
+
+// newManifestCommand returns a cobra command for `manifest` subcommands
+func newManifestCommand(dockerCLI command.Cli) *cobra.Command {
 	// use dockerCli as command.Cli
 	cmd := &cobra.Command{
 		Use:   "manifest COMMAND",
@@ -18,16 +25,16 @@ func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 		Long:  manifestDescription,
 		Args:  cli.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Fprint(dockerCli.Err(), "\n"+cmd.UsageString())
+			_, _ = fmt.Fprint(dockerCLI.Err(), "\n"+cmd.UsageString())
 		},
 		Annotations: map[string]string{"experimentalCLI": ""},
 	}
 	cmd.AddCommand(
-		newCreateListCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newAnnotateCommand(dockerCli),
-		newPushListCommand(dockerCli),
-		newRmManifestListCommand(dockerCli),
+		newCreateListCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newAnnotateCommand(dockerCLI),
+		newPushListCommand(dockerCLI),
+		newRmManifestListCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -7,22 +7,29 @@ import (
 )
 
 // NewNetworkCommand returns a cobra command for `network` subcommands
-func NewNetworkCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewNetworkCommand(dockerCLI command.Cli) *cobra.Command {
+	return newNetworkCommand(dockerCLI)
+}
+
+// newNetworkCommand returns a cobra command for `network` subcommands
+func newNetworkCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "network",
 		Short:       "Manage networks",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
-		newConnectCommand(dockerCli),
-		newCreateCommand(dockerCli),
-		newDisconnectCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newConnectCommand(dockerCLI),
+		newCreateCommand(dockerCLI),
+		newDisconnectCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -18,7 +18,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for networks
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for networks
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -26,12 +33,12 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove all unused networks",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output, err := runPrune(cmd.Context(), dockerCli, options)
+			output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				_, _ = fmt.Fprintln(dockerCli.Out(), output)
+				_, _ = fmt.Fprintln(dockerCLI.Out(), output)
 			}
 			return nil
 		},

--- a/cli/command/network/prune_test.go
+++ b/cli/command/network/prune_test.go
@@ -20,7 +20,7 @@ func TestNetworkPrunePromptTermination(t *testing.T) {
 			return network.PruneReport{}, errors.New("fakeClient networkPruneFunc should not be called")
 		},
 	})
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -12,25 +12,32 @@ import (
 )
 
 // NewNodeCommand returns a cobra command for `node` subcommands
-func NewNodeCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewNodeCommand(dockerCLI command.Cli) *cobra.Command {
+	return newNodeCommand(dockerCLI)
+}
+
+// newNodeCommand returns a cobra command for `node` subcommands
+func newNodeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Manage Swarm nodes",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newDemoteCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newPromoteCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newUpdateCommand(dockerCli),
+		newDemoteCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newPromoteCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -7,26 +7,33 @@ import (
 )
 
 // NewPluginCommand returns a cobra command for `plugin` subcommands
-func NewPluginCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPluginCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPluginCommand(dockerCLI)
+}
+
+// newPluginCommand returns a cobra command for `plugin` subcommands
+func newPluginCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "plugin",
 		Short:       "Manage plugins",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.25"},
 	}
 
 	cmd.AddCommand(
-		newDisableCommand(dockerCli),
-		newEnableCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newInstallCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newSetCommand(dockerCli),
-		newPushCommand(dockerCli),
-		newCreateCommand(dockerCli),
-		newUpgradeCommand(dockerCli),
+		newDisableCommand(dockerCLI),
+		newEnableCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newInstallCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newSetCommand(dockerCLI),
+		newPushCommand(dockerCLI),
+		newCreateCommand(dockerCLI),
+		newUpgradeCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -32,7 +32,14 @@ type loginOptions struct {
 }
 
 // NewLoginCommand creates a new `docker login` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewLoginCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLoginCommand(dockerCLI)
+}
+
+// newLoginCommand creates a new `docker login` command
+func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loginOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -584,7 +584,7 @@ func TestLoginValidateFlags(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewLoginCommand(test.NewFakeCli(&fakeClient{}))
+			cmd := newLoginCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -13,7 +13,14 @@ import (
 )
 
 // NewLogoutCommand creates a new `docker logout` command
-func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewLogoutCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLogoutCommand(dockerCLI)
+}
+
+// newLogoutCommand creates a new `docker logout` command
+func newLogoutCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout [SERVER]",
 		Short: "Log out from a registry",
@@ -24,7 +31,7 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 0 {
 				serverAddress = args[0]
 			}
-			return runLogout(cmd.Context(), dockerCli, serverAddress)
+			return runLogout(cmd.Context(), dockerCLI, serverAddress)
 		},
 		Annotations: map[string]string{
 			"category-top": "9",

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -22,7 +22,14 @@ type searchOptions struct {
 }
 
 // NewSearchCommand creates a new `docker search` command
-func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSearchCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSearchCommand(dockerCLI)
+}
+
+// newSearchCommand creates a new `docker search` command
+func newSearchCommand(dockerCLI command.Cli) *cobra.Command {
 	options := searchOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -31,7 +38,7 @@ func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.term = args[0]
-			return runSearch(cmd.Context(), dockerCli, options)
+			return runSearch(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"category-top": "10",

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -9,22 +9,28 @@ import (
 )
 
 // NewSecretCommand returns a cobra command for `secret` subcommands
-func NewSecretCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSecretCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSecretCommand(dockerCLI)
+}
+
+func newSecretCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Manage Swarm secrets",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newSecretListCommand(dockerCli),
-		newSecretCreateCommand(dockerCli),
-		newSecretInspectCommand(dockerCli),
-		newSecretRemoveCommand(dockerCli),
+		newSecretListCommand(dockerCLI),
+		newSecretCreateCommand(dockerCLI),
+		newSecretInspectCommand(dockerCLI),
+		newSecretRemoveCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -7,27 +7,34 @@ import (
 )
 
 // NewServiceCommand returns a cobra command for `service` subcommands
-func NewServiceCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewServiceCommand(dockerCLI command.Cli) *cobra.Command {
+	return newServiceCommand(dockerCLI)
+}
+
+// newServiceCommand returns a cobra command for `service` subcommands
+func newServiceCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "service",
 		Short: "Manage Swarm services",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newScaleCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newLogsCommand(dockerCli),
-		newRollbackCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newScaleCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newLogsCommand(dockerCLI),
+		newRollbackCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -11,12 +11,19 @@ import (
 )
 
 // NewStackCommand returns a cobra command for `stack` subcommands
-func NewStackCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewStackCommand(dockerCLI command.Cli) *cobra.Command {
+	return newStackCommand(dockerCLI)
+}
+
+// newStackCommand returns a cobra command for `stack` subcommands
+func newStackCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stack [OPTIONS]",
 		Short: "Manage Swarm stacks",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
 			"swarm":   "manager",
@@ -25,18 +32,18 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	defaultHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
 		if err := cmd.Root().PersistentPreRunE(c, args); err != nil {
-			fmt.Fprintln(dockerCli.Err(), err)
+			fmt.Fprintln(dockerCLI.Err(), err)
 			return
 		}
 		defaultHelpFunc(c, args)
 	})
 	cmd.AddCommand(
-		newDeployCommand(dockerCli),
-		newListCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newServicesCommand(dockerCli),
-		newConfigCommand(dockerCli),
+		newDeployCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newServicesCommand(dockerCLI),
+		newConfigCommand(dockerCLI),
 	)
 	flags := cmd.PersistentFlags()
 	flags.String("orchestrator", "", "Orchestrator to use (swarm|all)")

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -8,26 +8,33 @@ import (
 )
 
 // NewSwarmCommand returns a cobra command for `swarm` subcommands
-func NewSwarmCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSwarmCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSwarmCommand(dockerCLI)
+}
+
+// newSwarmCommand returns a cobra command for `swarm` subcommands
+func newSwarmCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "swarm",
 		Short: "Manage Swarm",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "", // swarm command itself does not require swarm to be enabled (so swarm init and join is always available on API 1.24 and up)
 		},
 	}
 	cmd.AddCommand(
-		newInitCommand(dockerCli),
-		newJoinCommand(dockerCli),
-		newJoinTokenCommand(dockerCli),
-		newUnlockKeyCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newLeaveCommand(dockerCli),
-		newUnlockCommand(dockerCli),
-		newCACommand(dockerCli),
+		newInitCommand(dockerCLI),
+		newJoinCommand(dockerCLI),
+		newJoinTokenCommand(dockerCLI),
+		newUnlockKeyCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newLeaveCommand(dockerCLI),
+		newUnlockCommand(dockerCLI),
+		newCACommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -7,19 +7,26 @@ import (
 )
 
 // NewSystemCommand returns a cobra command for `system` subcommands
-func NewSystemCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSystemCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSystemCommand(dockerCLI)
+}
+
+// newSystemCommand returns a cobra command for `system` subcommands
+func newSystemCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "system",
 		Short: "Manage Docker",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		NewEventsCommand(dockerCli),
-		NewInfoCommand(dockerCli),
-		newDiskUsageCommand(dockerCli),
-		newPruneCommand(dockerCli),
-		newDialStdioCommand(dockerCli),
+		newEventsCommand(dockerCLI),
+		newInfoCommand(dockerCLI),
+		newDiskUsageCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
+		newDialStdioCommand(dockerCLI),
 	)
 
 	return cmd

--- a/cli/command/system/completion_test.go
+++ b/cli/command/system/completion_test.go
@@ -156,7 +156,7 @@ func TestCompleteEventFilter(t *testing.T) {
 	for _, tc := range tests {
 		cli := test.NewFakeCli(tc.client)
 
-		completions, directive := completeEventFilters(cli)(NewEventsCommand(cli), nil, tc.toComplete)
+		completions, directive := completeEventFilters(cli)(newEventsCommand(cli), nil, tc.toComplete)
 
 		assert.DeepEqual(t, completions, tc.expected)
 		assert.Equal(t, directive, cobra.ShellCompDirectiveNoFileComp, fmt.Sprintf("wrong directive in completion for '%s'", tc.toComplete))

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -28,7 +28,14 @@ type eventsOptions struct {
 }
 
 // NewEventsCommand creates a new cobra.Command for `docker events`
-func NewEventsCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewEventsCommand(dockerCLI command.Cli) *cobra.Command {
+	return newEventsCommand(dockerCLI)
+}
+
+// newEventsCommand creates a new cobra.Command for `docker events`
+func newEventsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := eventsOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -36,7 +43,7 @@ func NewEventsCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Get real time events from the server",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runEvents(cmd.Context(), dockerCli, &options)
+			return runEvents(cmd.Context(), dockerCLI, &options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker system events, docker events",
@@ -50,7 +57,7 @@ func NewEventsCommand(dockerCli command.Cli) *cobra.Command {
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 	flags.StringVar(&options.format, "format", "", flagsHelper.InspectFormatHelp) // using the same flag description as "inspect" commands for now.
 
-	_ = cmd.RegisterFlagCompletionFunc("filter", completeEventFilters(dockerCli))
+	_ = cmd.RegisterFlagCompletionFunc("filter", completeEventFilters(dockerCLI))
 
 	return cmd
 }

--- a/cli/command/system/events_test.go
+++ b/cli/command/system/events_test.go
@@ -70,7 +70,7 @@ func TestEventsFormat(t *testing.T) {
 				}()
 				return messages, errs
 			}})
-			cmd := NewEventsCommand(cli)
+			cmd := newEventsCommand(cli)
 			cmd.SetArgs(tc.args)
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -60,7 +60,14 @@ func (i *dockerInfo) clientPlatform() string {
 }
 
 // NewInfoCommand creates a new cobra.Command for `docker info`
-func NewInfoCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewInfoCommand(dockerCLI command.Cli) *cobra.Command {
+	return newInfoCommand(dockerCLI)
+}
+
+// newInfoCommand creates a new cobra.Command for `docker info`
+func newInfoCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts infoOptions
 
 	cmd := &cobra.Command{
@@ -68,7 +75,7 @@ func NewInfoCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Display system-wide information",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInfo(cmd.Context(), cmd, dockerCli, &opts)
+			return runInfo(cmd.Context(), cmd, dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "12",

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -60,7 +60,14 @@ type inspectOptions struct {
 }
 
 // NewInspectCommand creates a new cobra.Command for `docker inspect`
-func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewInspectCommand(dockerCLI command.Cli) *cobra.Command {
+	return newInspectCommand(dockerCLI)
+}
+
+// newInspectCommand creates a new cobra.Command for `docker inspect`
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -72,7 +79,7 @@ func NewInspectCommand(dockerCli command.Cli) *cobra.Command {
 			if cmd.Flags().Changed("type") && opts.objectType == "" {
 				return fmt.Errorf(`type is empty: must be one of "%s"`, strings.Join(allTypes, `", "`))
 			}
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
 		// TODO(thaJeztah): should we consider adding completion for common object-types? (images, containers?)
 		ValidArgsFunction: completion.NoComplete,

--- a/cli/command/system/inspect_test.go
+++ b/cli/command/system/inspect_test.go
@@ -32,7 +32,7 @@ func TestInspectValidateFlagsAndArgs(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewInspectCommand(test.NewFakeCli(&fakeClient{}))
+			cmd := newInspectCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -109,7 +109,14 @@ func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
 }
 
 // NewVersionCommand creates a new cobra.Command for `docker version`
-func NewVersionCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewVersionCommand(dockerCLI command.Cli) *cobra.Command {
+	return newVersionCommand(dockerCLI)
+}
+
+// newVersionCommand creates a new cobra.Command for `docker version`
+func newVersionCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts versionOptions
 
 	cmd := &cobra.Command{
@@ -117,7 +124,7 @@ func NewVersionCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Show the Docker version information",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVersion(cmd.Context(), dockerCli, &opts)
+			return runVersion(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"category-top": "10",

--- a/cli/command/system/version_test.go
+++ b/cli/command/system/version_test.go
@@ -20,7 +20,7 @@ func TestVersionWithoutServer(t *testing.T) {
 			return types.Version{}, errors.New("no server")
 		},
 	})
-	cmd := NewVersionCommand(cli)
+	cmd := newVersionCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(cli.Err())
 	cmd.SetErr(io.Discard)

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -7,19 +7,25 @@ import (
 )
 
 // NewTrustCommand returns a cobra command for `trust` subcommands
-func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewTrustCommand(dockerCLI command.Cli) *cobra.Command {
+	return newTrustCommand(dockerCLI)
+}
+
+func newTrustCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trust",
 		Short: "Manage trust on Docker images",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		newRevokeCommand(dockerCli),
-		newSignCommand(dockerCli),
-		newTrustKeyCommand(dockerCli),
-		newTrustSignerCommand(dockerCli),
-		newInspectCommand(dockerCli),
+		newRevokeCommand(dockerCLI),
+		newSignCommand(dockerCLI),
+		newTrustKeyCommand(dockerCLI),
+		newTrustSignerCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -7,21 +7,28 @@ import (
 )
 
 // NewVolumeCommand returns a cobra command for `volume` subcommands
-func NewVolumeCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewVolumeCommand(dockerCLI command.Cli) *cobra.Command {
+	return newVolumeCommand(dockerCLI)
+}
+
+// newVolumeCommand returns a cobra command for `volume` subcommands
+func newVolumeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "volume COMMAND",
 		Short:       "Manage volumes",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		NewPruneCommand(dockerCli),
-		newUpdateCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -22,7 +22,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for volumes
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for volumes
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -30,14 +37,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCli, options)
+			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				fmt.Fprintln(dockerCli.Out(), output)
+				fmt.Fprintln(dockerCLI.Out(), output)
 			}
-			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
+			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
 		Annotations:       map[string]string{"version": "1.25"},

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -53,7 +53,7 @@ func TestVolumePruneErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewPruneCommand(
+			cmd := newPruneCommand(
 				test.NewFakeCli(&fakeClient{
 					volumePruneFunc: tc.volumePruneFunc,
 				}),
@@ -105,7 +105,7 @@ func TestVolumePruneSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{volumePruneFunc: tc.volumePruneFunc})
-			cmd := NewPruneCommand(cli)
+			cmd := newPruneCommand(cli)
 			if tc.input != "" {
 				cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(tc.input))))
 			}
@@ -135,7 +135,7 @@ func TestVolumePruneForce(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{
 			volumePruneFunc: tc.volumePruneFunc,
 		})
-		cmd := NewPruneCommand(cli)
+		cmd := newPruneCommand(cli)
 		cmd.Flags().Set("force", "true")
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("volume-prune.%s.golden", tc.name))
@@ -152,7 +152,7 @@ func TestVolumePrunePromptYes(t *testing.T) {
 		})
 
 		cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
-		cmd := NewPruneCommand(cli)
+		cmd := newPruneCommand(cli)
 		cmd.SetArgs([]string{})
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "volume-prune-yes.golden")
@@ -170,7 +170,7 @@ func TestVolumePrunePromptNo(t *testing.T) {
 			})
 
 			cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
-			cmd := NewPruneCommand(cli)
+			cmd := newPruneCommand(cli)
 			cmd.SetArgs([]string{})
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
@@ -199,7 +199,7 @@ func TestVolumePrunePromptTerminate(t *testing.T) {
 		},
 	})
 
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/cli/pull/6311

---

backports:

- https://github.com/docker/cli/pull/6284
- https://github.com/docker/cli/pull/6285
- https://github.com/docker/cli/pull/6286
- https://github.com/docker/cli/pull/6299
- https://github.com/docker/cli/pull/6301
- https://github.com/docker/cli/pull/6305
- https://github.com/docker/cli/pull/6316
- https://github.com/docker/cli/pull/6317
- https://github.com/docker/cli/pull/6318
- https://github.com/docker/cli/pull/6319
- https://github.com/docker/cli/pull/6320
- https://github.com/docker/cli/pull/6321
- https://github.com/docker/cli/pull/6322
- https://github.com/docker/cli/pull/6323
- https://github.com/docker/cli/pull/6324
- https://github.com/docker/cli/pull/6325
- https://github.com/docker/cli/pull/6326
- https://github.com/docker/cli/pull/6328



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate exported NewXXX commands
TODO: collect change-logs from backported PRs
```

**- A picture of a cute animal (not mandatory but encouraged)**

