### PR TITLE
Unexport network commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -64,6 +64,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
 		manifest.NewManifestCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		network.NewNetworkCommand(dockerCli),
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -7,22 +7,29 @@ import (
 )
 
 // NewNetworkCommand returns a cobra command for `network` subcommands
-func NewNetworkCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewNetworkCommand(dockerCLI command.Cli) *cobra.Command {
+	return newNetworkCommand(dockerCLI)
+}
+
+// newNetworkCommand returns a cobra command for `network` subcommands
+func newNetworkCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "network",
 		Short:       "Manage networks",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
-		newConnectCommand(dockerCli),
-		newCreateCommand(dockerCli),
-		newDisconnectCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		NewPruneCommand(dockerCli),
+		newConnectCommand(dockerCLI),
+		newCreateCommand(dockerCLI),
+		newDisconnectCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -26,7 +26,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for networks
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for networks
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -34,12 +41,12 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove all unused networks",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			output, err := runPrune(cmd.Context(), dockerCli, options)
+			output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				_, _ = fmt.Fprintln(dockerCli.Out(), output)
+				_, _ = fmt.Fprintln(dockerCLI.Out(), output)
 			}
 			return nil
 		},

--- a/cli/command/network/prune_test.go
+++ b/cli/command/network/prune_test.go
@@ -20,7 +20,7 @@ func TestNetworkPrunePromptTermination(t *testing.T) {
 			return network.PruneReport{}, errors.New("fakeClient networkPruneFunc should not be called")
 		},
 	})
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)


### PR DESCRIPTION
This patch deprecates exported network commands and moves the implementation details to an unexported function.

Commands that are affected include:

- network.NewNetworkCommand
- network.NewPruneCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/network: deprecate `NewNetworkCommand`. These functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

