### PR TITLE
Unexport node commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -74,6 +74,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		// orchestration (swarm) commands
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		config.NewConfigCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		node.NewNodeCommand(dockerCli),
 		secret.NewSecretCommand(dockerCli),
 		service.NewServiceCommand(dockerCli),

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -12,25 +12,32 @@ import (
 )
 
 // NewNodeCommand returns a cobra command for `node` subcommands
-func NewNodeCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewNodeCommand(dockerCLI command.Cli) *cobra.Command {
+	return newNodeCommand(dockerCLI)
+}
+
+// newNodeCommand returns a cobra command for `node` subcommands
+func newNodeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "node",
 		Short: "Manage Swarm nodes",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newDemoteCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newPromoteCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newUpdateCommand(dockerCli),
+		newDemoteCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newPromoteCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported node commands and moves the implementation details to an unexported function.

Commands that are affected include:

- node.NewNodeCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/node: deprecate `NewNodeCommand`. This functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

