### PR TITLE
Unexport manifest command

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -63,6 +63,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		context.NewContextCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		manifest.NewManifestCommand(dockerCli),
 		network.NewNetworkCommand(dockerCli),
 		plugin.NewPluginCommand(dockerCli),

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -10,7 +10,14 @@ import (
 )
 
 // NewManifestCommand returns a cobra command for `manifest` subcommands
-func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewManifestCommand(dockerCLI command.Cli) *cobra.Command {
+	return newManifestCommand(dockerCLI)
+}
+
+// newManifestCommand returns a cobra command for `manifest` subcommands
+func newManifestCommand(dockerCLI command.Cli) *cobra.Command {
 	// use dockerCli as command.Cli
 	cmd := &cobra.Command{
 		Use:   "manifest COMMAND",
@@ -18,16 +25,16 @@ func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 		Long:  manifestDescription,
 		Args:  cli.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			_, _ = fmt.Fprint(dockerCli.Err(), "\n"+cmd.UsageString())
+			_, _ = fmt.Fprint(dockerCLI.Err(), "\n"+cmd.UsageString())
 		},
 		Annotations: map[string]string{"experimentalCLI": ""},
 	}
 	cmd.AddCommand(
-		newCreateListCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newAnnotateCommand(dockerCli),
-		newPushListCommand(dockerCli),
-		newRmManifestListCommand(dockerCli),
+		newCreateListCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newAnnotateCommand(dockerCLI),
+		newPushListCommand(dockerCLI),
+		newRmManifestListCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported manifest commands and moves the implementation details to an unexported function.

Commands that are affected include:

- manifest.NewManifestCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/manifest: deprecate `NewManifestCommand`. This functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

