### PR TITLE
Unexport secret commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -75,6 +75,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		config.NewConfigCommand(dockerCli),
 		node.NewNodeCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		secret.NewSecretCommand(dockerCli),
 		service.NewServiceCommand(dockerCli),
 		stack.NewStackCommand(dockerCli),

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -9,22 +9,28 @@ import (
 )
 
 // NewSecretCommand returns a cobra command for `secret` subcommands
-func NewSecretCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSecretCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSecretCommand(dockerCLI)
+}
+
+func newSecretCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Manage Swarm secrets",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newSecretListCommand(dockerCli),
-		newSecretCreateCommand(dockerCli),
-		newSecretInspectCommand(dockerCli),
-		newSecretRemoveCommand(dockerCli),
+		newSecretListCommand(dockerCLI),
+		newSecretCreateCommand(dockerCLI),
+		newSecretInspectCommand(dockerCLI),
+		newSecretRemoveCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported secret commands and moves the implementation details to an unexported function.

Commands that are affected include:

- secrets.NewSecretCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/secret: deprecate `NewSecretCommand`. This functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

