### PR TITLE
Unexport service commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -79,6 +79,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		node.NewNodeCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		secret.NewSecretCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		service.NewServiceCommand(dockerCli),
 		stack.NewStackCommand(dockerCli),
 		swarm.NewSwarmCommand(dockerCli),

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -7,27 +7,34 @@ import (
 )
 
 // NewServiceCommand returns a cobra command for `service` subcommands
-func NewServiceCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewServiceCommand(dockerCLI command.Cli) *cobra.Command {
+	return newServiceCommand(dockerCLI)
+}
+
+// newServiceCommand returns a cobra command for `service` subcommands
+func newServiceCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "service",
 		Short: "Manage Swarm services",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newScaleCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newLogsCommand(dockerCli),
-		newRollbackCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newScaleCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newLogsCommand(dockerCLI),
+		newRollbackCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported service commands and moves the implementation details to an unexported function.

Commands that are affected include:

- service.NewServiceCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/service: deprecate `NewServiceCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

