### PR TITLE
Unexport volume commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -70,6 +70,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),
 		trust.NewTrustCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		volume.NewVolumeCommand(dockerCli),
 
 		// orchestration (swarm) commands

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -7,21 +7,28 @@ import (
 )
 
 // NewVolumeCommand returns a cobra command for `volume` subcommands
-func NewVolumeCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewVolumeCommand(dockerCLI command.Cli) *cobra.Command {
+	return newVolumeCommand(dockerCLI)
+}
+
+// newVolumeCommand returns a cobra command for `volume` subcommands
+func newVolumeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "volume COMMAND",
 		Short:       "Manage volumes",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		NewPruneCommand(dockerCli),
-		newUpdateCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newPruneCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -30,7 +30,14 @@ type pruneOptions struct {
 }
 
 // NewPruneCommand returns a new cobra prune command for volumes
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPruneCommand(dockerCLI)
+}
+
+// newPruneCommand returns a new cobra prune command for volumes
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -38,14 +45,14 @@ func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused local volumes",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCli, options)
+			spaceReclaimed, output, err := runPrune(cmd.Context(), dockerCLI, options)
 			if err != nil {
 				return err
 			}
 			if output != "" {
-				fmt.Fprintln(dockerCli.Out(), output)
+				fmt.Fprintln(dockerCLI.Out(), output)
 			}
-			fmt.Fprintln(dockerCli.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
+			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
 		Annotations:       map[string]string{"version": "1.25"},

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -53,7 +53,7 @@ func TestVolumePruneErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewPruneCommand(
+			cmd := newPruneCommand(
 				test.NewFakeCli(&fakeClient{
 					volumePruneFunc: tc.volumePruneFunc,
 				}),
@@ -105,7 +105,7 @@ func TestVolumePruneSuccess(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli := test.NewFakeCli(&fakeClient{volumePruneFunc: tc.volumePruneFunc})
-			cmd := NewPruneCommand(cli)
+			cmd := newPruneCommand(cli)
 			if tc.input != "" {
 				cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(tc.input))))
 			}
@@ -135,7 +135,7 @@ func TestVolumePruneForce(t *testing.T) {
 		cli := test.NewFakeCli(&fakeClient{
 			volumePruneFunc: tc.volumePruneFunc,
 		})
-		cmd := NewPruneCommand(cli)
+		cmd := newPruneCommand(cli)
 		cmd.Flags().Set("force", "true")
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), fmt.Sprintf("volume-prune.%s.golden", tc.name))
@@ -152,7 +152,7 @@ func TestVolumePrunePromptYes(t *testing.T) {
 		})
 
 		cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
-		cmd := NewPruneCommand(cli)
+		cmd := newPruneCommand(cli)
 		cmd.SetArgs([]string{})
 		assert.NilError(t, cmd.Execute())
 		golden.Assert(t, cli.OutBuffer().String(), "volume-prune-yes.golden")
@@ -170,7 +170,7 @@ func TestVolumePrunePromptNo(t *testing.T) {
 			})
 
 			cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader(input))))
-			cmd := NewPruneCommand(cli)
+			cmd := newPruneCommand(cli)
 			cmd.SetArgs([]string{})
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
@@ -199,7 +199,7 @@ func TestVolumePrunePromptTerminate(t *testing.T) {
 		},
 	})
 
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)


### PR DESCRIPTION
This patch deprecates exported volume commands and moves the implementation details to an unexported function.

Commands that are affected include:

- volume.NewVolumeCommand
- volume.NewPruneCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/volume: deprecate `NewVolumeCommand`, `NewPruneCommand`. These functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

