### PR TITLE
Unexport context command

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -60,6 +60,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		checkpoint.NewCheckpointCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		container.NewContainerCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		context.NewContextCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImageCommand(dockerCli),

--- a/cli/command/context/cmd.go
+++ b/cli/command/context/cmd.go
@@ -7,23 +7,30 @@ import (
 )
 
 // NewContextCommand returns the context cli subcommand
-func NewContextCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewContextCommand(dockerCLI command.Cli) *cobra.Command {
+	return newContextCommand(dockerCLI)
+}
+
+// newContextCommand returns the context cli subcommand
+func newContextCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "context",
 		Short: "Manage contexts",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		newCreateCommand(dockerCli),
-		newListCommand(dockerCli),
-		newUseCommand(dockerCli),
-		newExportCommand(dockerCli),
-		newImportCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newShowCommand(dockerCli),
+		newCreateCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newUseCommand(dockerCLI),
+		newExportCommand(dockerCLI),
+		newImportCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newShowCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported context commands and moves the implementation details to an unexported function.

Commands that are affected include:

- context.NewContextCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/context: deprecate `NewContextCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

