### PR TITLE
Unexport stack commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -83,6 +83,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		secret.NewSecretCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		service.NewServiceCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		stack.NewStackCommand(dockerCli),
 		swarm.NewSwarmCommand(dockerCli),
 

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -11,12 +11,19 @@ import (
 )
 
 // NewStackCommand returns a cobra command for `stack` subcommands
-func NewStackCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewStackCommand(dockerCLI command.Cli) *cobra.Command {
+	return newStackCommand(dockerCLI)
+}
+
+// newStackCommand returns a cobra command for `stack` subcommands
+func newStackCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stack [OPTIONS]",
 		Short: "Manage Swarm stacks",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.25",
 			"swarm":   "manager",
@@ -25,18 +32,18 @@ func NewStackCommand(dockerCli command.Cli) *cobra.Command {
 	defaultHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
 		if err := cmd.Root().PersistentPreRunE(c, args); err != nil {
-			fmt.Fprintln(dockerCli.Err(), err)
+			fmt.Fprintln(dockerCLI.Err(), err)
 			return
 		}
 		defaultHelpFunc(c, args)
 	})
 	cmd.AddCommand(
-		newDeployCommand(dockerCli),
-		newListCommand(dockerCli),
-		newPsCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newServicesCommand(dockerCli),
-		newConfigCommand(dockerCli),
+		newDeployCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newPsCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newServicesCommand(dockerCLI),
+		newConfigCommand(dockerCLI),
 	)
 	flags := cmd.PersistentFlags()
 	flags.String("orchestrator", "", "Orchestrator to use (swarm|all)")


### PR DESCRIPTION
This patch deprecates exported stack commands and moves the implementation details to an unexported function.

Commands that are affected include:

- stack.NewStackCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/stack: deprecate `NewStackCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

