### PR TITLE
Unexport registry commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -43,8 +43,11 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		image.NewPushCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		image.NewImagesCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewLoginCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewLogoutCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		registry.NewSearchCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewVersionCommand(dockerCli),

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -32,7 +32,14 @@ type loginOptions struct {
 }
 
 // NewLoginCommand creates a new `docker login` command
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
 func NewLoginCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLoginCommand(dockerCLI)
+}
+
+// newLoginCommand creates a new `docker login` command
+func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loginOptions
 
 	cmd := &cobra.Command{

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -584,7 +584,7 @@ func TestLoginValidateFlags(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewLoginCommand(test.NewFakeCli(&fakeClient{}))
+			cmd := newLoginCommand(test.NewFakeCli(&fakeClient{}))
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
 			cmd.SetArgs(tc.args)

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -13,7 +13,14 @@ import (
 )
 
 // NewLogoutCommand creates a new `docker logout` command
-func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewLogoutCommand(dockerCLI command.Cli) *cobra.Command {
+	return newLogoutCommand(dockerCLI)
+}
+
+// newLogoutCommand creates a new `docker logout` command
+func newLogoutCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout [SERVER]",
 		Short: "Log out from a registry",
@@ -24,7 +31,7 @@ func NewLogoutCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 0 {
 				serverAddress = args[0]
 			}
-			return runLogout(cmd.Context(), dockerCli, serverAddress)
+			return runLogout(cmd.Context(), dockerCLI, serverAddress)
 		},
 		Annotations: map[string]string{
 			"category-top": "9",

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -22,7 +22,14 @@ type searchOptions struct {
 }
 
 // NewSearchCommand creates a new `docker search` command
-func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSearchCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSearchCommand(dockerCLI)
+}
+
+// newSearchCommand creates a new `docker search` command
+func newSearchCommand(dockerCLI command.Cli) *cobra.Command {
 	options := searchOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -31,7 +38,7 @@ func NewSearchCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.term = args[0]
-			return runSearch(cmd.Context(), dockerCli, options)
+			return runSearch(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"category-top": "10",


### PR DESCRIPTION
This patch deprecates exported registry commands and moves the implementation details to an unexported function.

Commands that are affected include:

- registry.NewLoginCommand
- registry.NewLogoutCommand
- registry.NewSearchCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/registry: deprecate `NewLoginCommand`, `NewLogoutCommand`, `NewSearchCommand`. These functions will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

