### PR TITLE
Unexport swarm commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -89,6 +89,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		service.NewServiceCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		stack.NewStackCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		swarm.NewSwarmCommand(dockerCli),
 
 		// legacy commands may be hidden

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -8,26 +8,33 @@ import (
 )
 
 // NewSwarmCommand returns a cobra command for `swarm` subcommands
-func NewSwarmCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewSwarmCommand(dockerCLI command.Cli) *cobra.Command {
+	return newSwarmCommand(dockerCLI)
+}
+
+// newSwarmCommand returns a cobra command for `swarm` subcommands
+func newSwarmCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "swarm",
 		Short: "Manage Swarm",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "", // swarm command itself does not require swarm to be enabled (so swarm init and join is always available on API 1.24 and up)
 		},
 	}
 	cmd.AddCommand(
-		newInitCommand(dockerCli),
-		newJoinCommand(dockerCli),
-		newJoinTokenCommand(dockerCli),
-		newUnlockKeyCommand(dockerCli),
-		newUpdateCommand(dockerCli),
-		newLeaveCommand(dockerCli),
-		newUnlockCommand(dockerCli),
-		newCACommand(dockerCli),
+		newInitCommand(dockerCLI),
+		newJoinCommand(dockerCLI),
+		newJoinTokenCommand(dockerCLI),
+		newUnlockKeyCommand(dockerCLI),
+		newUpdateCommand(dockerCLI),
+		newLeaveCommand(dockerCLI),
+		newUnlockCommand(dockerCLI),
+		newCACommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported swarm commands and moves the implementation details to an unexported function.

Commands that are affected include:

- swarm.NewSwarmCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/swarm: deprecate `NewSwarmCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

