### PR TITLE
Unexport plugin commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -71,6 +71,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		manifest.NewManifestCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		network.NewNetworkCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -7,26 +7,33 @@ import (
 )
 
 // NewPluginCommand returns a cobra command for `plugin` subcommands
-func NewPluginCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewPluginCommand(dockerCLI command.Cli) *cobra.Command {
+	return newPluginCommand(dockerCLI)
+}
+
+// newPluginCommand returns a cobra command for `plugin` subcommands
+func newPluginCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "plugin",
 		Short:       "Manage plugins",
 		Args:        cli.NoArgs,
-		RunE:        command.ShowHelp(dockerCli.Err()),
+		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.25"},
 	}
 
 	cmd.AddCommand(
-		newDisableCommand(dockerCli),
-		newEnableCommand(dockerCli),
-		newInspectCommand(dockerCli),
-		newInstallCommand(dockerCli),
-		newListCommand(dockerCli),
-		newRemoveCommand(dockerCli),
-		newSetCommand(dockerCli),
-		newPushCommand(dockerCli),
-		newCreateCommand(dockerCli),
-		newUpgradeCommand(dockerCli),
+		newDisableCommand(dockerCLI),
+		newEnableCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
+		newInstallCommand(dockerCLI),
+		newListCommand(dockerCLI),
+		newRemoveCommand(dockerCLI),
+		newSetCommand(dockerCLI),
+		newPushCommand(dockerCLI),
+		newCreateCommand(dockerCLI),
+		newUpgradeCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported plugin commands and moves the implementation details to an unexported function.

Commands that are affected include:

- plugin.NewPluginCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

