### PR TITLE
internal/registryclient: repositoryEndpoint: memoize repoName

### DIFF
--- a/internal/registryclient/client.go
+++ b/internal/registryclient/client.go
@@ -120,7 +120,7 @@ func (c *client) PutManifest(ctx context.Context, ref reference.Named, manifest 
 }
 
 func (c *client) getRepositoryForReference(ctx context.Context, ref reference.Named, repoEndpoint repositoryEndpoint) (distribution.Repository, error) {
-	repoName, err := reference.WithName(repoEndpoint.Name())
+	repoName, err := reference.WithName(repoEndpoint.repoName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse repo name from %s: %w", ref, err)
 	}
@@ -148,7 +148,7 @@ func (c *client) getHTTPTransportForRepoEndpoint(ctx context.Context, repoEndpoi
 	httpTransport, err := getHTTPTransport(
 		c.authConfigResolver(ctx, repoEndpoint.indexInfo),
 		repoEndpoint.endpoint,
-		repoEndpoint.Name(),
+		repoEndpoint.repoName,
 		c.userAgent,
 		repoEndpoint.actions,
 	)

--- a/internal/registryclient/endpoint.go
+++ b/internal/registryclient/endpoint.go
@@ -16,15 +16,10 @@ import (
 )
 
 type repositoryEndpoint struct {
-	repoName  reference.Named
+	repoName  string
 	indexInfo *registrytypes.IndexInfo
 	endpoint  registry.APIEndpoint
 	actions   []string
-}
-
-// Name returns the repository name
-func (r repositoryEndpoint) Name() string {
-	return reference.Path(r.repoName)
 }
 
 // BaseURL returns the endpoint url
@@ -33,9 +28,7 @@ func (r repositoryEndpoint) BaseURL() string {
 }
 
 func newDefaultRepositoryEndpoint(ref reference.Named, insecure bool) (repositoryEndpoint, error) {
-	repoName := reference.TrimNamed(ref)
 	indexInfo := registry.NewIndexInfo(ref)
-
 	endpoint, err := getDefaultEndpoint(ref, !indexInfo.Secure)
 	if err != nil {
 		return repositoryEndpoint{}, err
@@ -44,7 +37,7 @@ func newDefaultRepositoryEndpoint(ref reference.Named, insecure bool) (repositor
 		endpoint.TLSConfig.InsecureSkipVerify = true
 	}
 	return repositoryEndpoint{
-		repoName:  repoName,
+		repoName:  reference.Path(reference.TrimNamed(ref)),
 		indexInfo: indexInfo,
 		endpoint:  endpoint,
 	}, nil

--- a/internal/registryclient/fetcher.go
+++ b/internal/registryclient/fetcher.go
@@ -221,7 +221,7 @@ func (c *client) iterateEndpoints(ctx context.Context, namedRef reference.Named,
 		return err
 	}
 
-	repoName := reference.TrimNamed(namedRef)
+	repoName := reference.Path(reference.TrimNamed(namedRef))
 	indexInfo := registry.NewIndexInfo(namedRef)
 
 	confirmedTLSRegistries := make(map[string]bool)


### PR DESCRIPTION
- Parse/format the repository name when constructing and store the result.
- Remove the Name() accessor, as this type is only used internally, and no longer had any special handling.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

