### PR TITLE
Unexport trust commands

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -74,6 +74,7 @@ func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
 		plugin.NewPluginCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		system.NewSystemCommand(dockerCli),
+		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		trust.NewTrustCommand(dockerCli),
 		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
 		volume.NewVolumeCommand(dockerCli),

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -7,19 +7,25 @@ import (
 )
 
 // NewTrustCommand returns a cobra command for `trust` subcommands
-func NewTrustCommand(dockerCli command.Cli) *cobra.Command {
+//
+// Deprecated: Do not import commands directly. They will be removed in a future release.
+func NewTrustCommand(dockerCLI command.Cli) *cobra.Command {
+	return newTrustCommand(dockerCLI)
+}
+
+func newTrustCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trust",
 		Short: "Manage trust on Docker images",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
 	}
 	cmd.AddCommand(
-		newRevokeCommand(dockerCli),
-		newSignCommand(dockerCli),
-		newTrustKeyCommand(dockerCli),
-		newTrustSignerCommand(dockerCli),
-		newInspectCommand(dockerCli),
+		newRevokeCommand(dockerCLI),
+		newSignCommand(dockerCLI),
+		newTrustKeyCommand(dockerCLI),
+		newTrustSignerCommand(dockerCLI),
+		newInspectCommand(dockerCLI),
 	)
 	return cmd
 }


### PR DESCRIPTION
This patch deprecates exported trust commands and moves the implementation details to an unexported function.

Commands that are affected include:

- trust.NewTrustCommand

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/trust: deprecate `NewTrustCommand`. This function will be removed in the next release.

```

**- A picture of a cute animal (not mandatory but encouraged)**

