### PR TITLE
Register CLI commands implicitly

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -6,7 +6,15 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/internal/commands"
 )
+
+func init() {
+	commands.Register(newBuilderCommand)
+	commands.Register(func(c command.Cli) *cobra.Command {
+		return newBakeStubCommand(c)
+	})
+}
 
 // NewBuilderCommand returns a cobra command for `builder` subcommands
 //

--- a/cli/command/checkpoint/cmd.go
+++ b/cli/command/checkpoint/cmd.go
@@ -3,8 +3,13 @@ package checkpoint
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newCheckpointCommand)
+}
 
 // NewCheckpointCommand returns the `checkpoint` subcommand (only in experimental)
 //

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -1,168 +1,31 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/builder"
-	"github.com/docker/cli/cli/command/checkpoint"
-	"github.com/docker/cli/cli/command/config"
-	"github.com/docker/cli/cli/command/container"
-	"github.com/docker/cli/cli/command/context"
-	"github.com/docker/cli/cli/command/image"
-	"github.com/docker/cli/cli/command/manifest"
-	"github.com/docker/cli/cli/command/network"
-	"github.com/docker/cli/cli/command/node"
-	"github.com/docker/cli/cli/command/plugin"
-	"github.com/docker/cli/cli/command/registry"
-	"github.com/docker/cli/cli/command/secret"
-	"github.com/docker/cli/cli/command/service"
-	"github.com/docker/cli/cli/command/stack"
-	"github.com/docker/cli/cli/command/swarm"
-	"github.com/docker/cli/cli/command/system"
-	"github.com/docker/cli/cli/command/trust"
-	"github.com/docker/cli/cli/command/volume"
+	_ "github.com/docker/cli/cli/command/builder"
+	_ "github.com/docker/cli/cli/command/checkpoint"
+	_ "github.com/docker/cli/cli/command/config"
+	_ "github.com/docker/cli/cli/command/container"
+	_ "github.com/docker/cli/cli/command/context"
+	_ "github.com/docker/cli/cli/command/image"
+	_ "github.com/docker/cli/cli/command/manifest"
+	_ "github.com/docker/cli/cli/command/network"
+	_ "github.com/docker/cli/cli/command/node"
+	_ "github.com/docker/cli/cli/command/plugin"
+	_ "github.com/docker/cli/cli/command/registry"
+	_ "github.com/docker/cli/cli/command/secret"
+	_ "github.com/docker/cli/cli/command/service"
+	_ "github.com/docker/cli/cli/command/stack"
+	_ "github.com/docker/cli/cli/command/swarm"
+	_ "github.com/docker/cli/cli/command/system"
+	_ "github.com/docker/cli/cli/command/trust"
+	_ "github.com/docker/cli/cli/command/volume"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
 
-// AddCommands adds all the commands from cli/command to the root command
-func AddCommands(cmd *cobra.Command, dockerCli command.Cli) {
-	cmd.AddCommand(
-		// commonly used shorthands
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		container.NewRunCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		container.NewExecCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		container.NewPsCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		image.NewBuildCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		image.NewPullCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		image.NewPushCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		image.NewImagesCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		registry.NewLoginCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		registry.NewLogoutCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		registry.NewSearchCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		system.NewVersionCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		system.NewInfoCommand(dockerCli),
-
-		// management commands
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		builder.NewBakeStubCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		builder.NewBuilderCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		checkpoint.NewCheckpointCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		container.NewContainerCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		context.NewContextCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		image.NewImageCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		manifest.NewManifestCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		network.NewNetworkCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		plugin.NewPluginCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		system.NewSystemCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		trust.NewTrustCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		volume.NewVolumeCommand(dockerCli),
-
-		// orchestration (swarm) commands
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		config.NewConfigCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		node.NewNodeCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		secret.NewSecretCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		service.NewServiceCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		stack.NewStackCommand(dockerCli),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		swarm.NewSwarmCommand(dockerCli),
-
-		// legacy commands may be hidden
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewAttachCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewCommitCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewCopyCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewCreateCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewDiffCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewExportCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewKillCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewLogsCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewPauseCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewPortCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewRenameCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewRestartCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewRmCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewStartCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewStatsCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewStopCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewTopCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewUnpauseCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewUpdateCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(container.NewWaitCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewHistoryCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewImportCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewLoadCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewRemoveCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewSaveCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(image.NewTagCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(system.NewEventsCommand(dockerCli)),
-		//nolint:staticcheck // TODO: Remove when migration to cli/internal/commands.Register is complete. (see #6283)
-		hide(system.NewInspectCommand(dockerCli)),
-	)
-}
-
-func hide(cmd *cobra.Command) *cobra.Command {
-	// If the environment variable with name "DOCKER_HIDE_LEGACY_COMMANDS" is not empty,
-	// these legacy commands (such as `docker ps`, `docker exec`, etc)
-	// will not be shown in output console.
-	if os.Getenv("DOCKER_HIDE_LEGACY_COMMANDS") == "" {
-		return cmd
+func AddCommands(cmd *cobra.Command, dockerCLI command.Cli) {
+	for _, c := range commands.Commands() {
+		cmd.AddCommand(c(dockerCLI))
 	}
-	cmdCopy := *cmd
-	cmdCopy.Hidden = true
-	cmdCopy.Aliases = []string{}
-	return &cmdCopy
 }

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -4,9 +4,14 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/commands"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newConfigCommand)
+}
 
 // NewConfigCommand returns a cobra command for `config` subcommands
 //

--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -3,8 +3,36 @@ package container
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newRunCommand)
+	commands.Register(newExecCommand)
+	commands.Register(newPsCommand)
+	commands.Register(newContainerCommand)
+	commands.RegisterLegacy(newAttachCommand)
+	commands.RegisterLegacy(newCommitCommand)
+	commands.RegisterLegacy(newCopyCommand)
+	commands.RegisterLegacy(newCreateCommand)
+	commands.RegisterLegacy(newDiffCommand)
+	commands.RegisterLegacy(newExportCommand)
+	commands.RegisterLegacy(newKillCommand)
+	commands.RegisterLegacy(newLogsCommand)
+	commands.RegisterLegacy(newPauseCommand)
+	commands.RegisterLegacy(newPortCommand)
+	commands.RegisterLegacy(newRenameCommand)
+	commands.RegisterLegacy(newRestartCommand)
+	commands.RegisterLegacy(newRmCommand)
+	commands.RegisterLegacy(newStartCommand)
+	commands.RegisterLegacy(newStatsCommand)
+	commands.RegisterLegacy(newStopCommand)
+	commands.RegisterLegacy(newTopCommand)
+	commands.RegisterLegacy(newUnpauseCommand)
+	commands.RegisterLegacy(newUpdateCommand)
+	commands.RegisterLegacy(newWaitCommand)
+}
 
 // NewContainerCommand returns a cobra command for `container` subcommands
 //

--- a/cli/command/context/cmd.go
+++ b/cli/command/context/cmd.go
@@ -3,8 +3,13 @@ package context
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newContextCommand)
+}
 
 // NewContextCommand returns the context cli subcommand
 //

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -3,8 +3,23 @@ package image
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newBuildCommand)
+	commands.Register(newPullCommand)
+	commands.Register(newPushCommand)
+	commands.Register(newImagesCommand)
+	commands.Register(newImageCommand)
+	commands.RegisterLegacy(newHistoryCommand)
+	commands.RegisterLegacy(newImportCommand)
+	commands.RegisterLegacy(newLoadCommand)
+	commands.RegisterLegacy(newRemoveCommand)
+	commands.RegisterLegacy(newSaveCommand)
+	commands.RegisterLegacy(newTagCommand)
+}
 
 // NewImageCommand returns a cobra command for `image` subcommands
 //

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -5,9 +5,14 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newManifestCommand)
+}
 
 // NewManifestCommand returns a cobra command for `manifest` subcommands
 //

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -3,8 +3,13 @@ package network
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newNetworkCommand)
+}
 
 // NewNetworkCommand returns a cobra command for `network` subcommands
 //

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -6,10 +6,15 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newNodeCommand)
+}
 
 // NewNodeCommand returns a cobra command for `node` subcommands
 //

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -3,8 +3,13 @@ package plugin
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newPluginCommand)
+}
 
 // NewPluginCommand returns a cobra command for `plugin` subcommands
 //

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/config/configfile"
 	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/docker/cli/internal/commands"
 	"github.com/docker/cli/internal/oauth/manager"
 	"github.com/docker/cli/internal/registry"
 	"github.com/docker/cli/internal/tui"
@@ -23,6 +24,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+func init() {
+	commands.Register(newLoginCommand)
+}
 
 type loginOptions struct {
 	serverAddress string

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -7,10 +7,15 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/credentials"
+	"github.com/docker/cli/internal/commands"
 	"github.com/docker/cli/internal/oauth/manager"
 	"github.com/docker/cli/internal/registry"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newLogoutCommand)
+}
 
 // NewLogoutCommand creates a new `docker logout` command
 //

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -8,10 +8,15 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
+	"github.com/docker/cli/internal/commands"
 	"github.com/docker/cli/opts"
 	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newSearchCommand)
+}
 
 type searchOptions struct {
 	format  string

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -4,9 +4,14 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/commands"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newSecretCommand)
+}
 
 // NewSecretCommand returns a cobra command for `secret` subcommands
 //

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -3,8 +3,13 @@ package service
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newServiceCommand)
+}
 
 // NewServiceCommand returns a cobra command for `service` subcommands
 //

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -7,8 +7,13 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/stack/swarm"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newStackCommand)
+}
 
 // NewStackCommand returns a cobra command for `stack` subcommands
 //

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -5,7 +5,12 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 )
+
+func init() {
+	commands.Register(newSwarmCommand)
+}
 
 // NewSwarmCommand returns a cobra command for `swarm` subcommands
 //

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -3,8 +3,17 @@ package system
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newVersionCommand)
+	commands.Register(newInfoCommand)
+	commands.Register(newSystemCommand)
+	commands.RegisterLegacy(newEventsCommand)
+	commands.RegisterLegacy(newInspectCommand)
+}
 
 // NewSystemCommand returns a cobra command for `system` subcommands
 //

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -3,8 +3,13 @@ package trust
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newTrustCommand)
+}
 
 // NewTrustCommand returns a cobra command for `trust` subcommands
 //

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -3,8 +3,13 @@ package volume
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/internal/commands"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	commands.Register(newVolumeCommand)
+}
 
 // NewVolumeCommand returns a cobra command for `volume` subcommands
 //


### PR DESCRIPTION
This patch removes the explicit `commands.AddCommands` function and instead relies upon the `internal/commands` package which registers each CLI command using `init()` instead.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

