### PR TITLE
opts: deprecate ParseEnvFile

### DIFF
--- a/cli/compose/loader/envfile.go
+++ b/cli/compose/loader/envfile.go
@@ -1,4 +1,4 @@
-package opts
+package loader
 
 import (
 	"os"
@@ -6,19 +6,21 @@ import (
 	"github.com/docker/cli/pkg/kvfile"
 )
 
-// ParseEnvFile reads a file with environment variables enumerated by lines
+// parseEnvFile reads a file with environment variables enumerated by lines
 //
 // “Environment variable names used by the utilities in the Shell and
-// Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase
+// Utilities volume of [IEEE Std 1003.1-2001] consist solely of uppercase
 // letters, digits, and the '_' (underscore) from the characters defined in
 // Portable Character Set and do not begin with a digit. *But*, other
 // characters may be permitted by an implementation; applications shall
 // tolerate the presence of such names.”
-// -- http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
 //
-// As of #16585, it's up to application inside docker to validate or not
+// As of [moby-16585], it's up to application inside docker to validate or not
 // environment variables, that's why we just strip leading whitespace and
 // nothing more.
-func ParseEnvFile(filename string) ([]string, error) {
+//
+// [IEEE Std 1003.1-2001]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
+// [moby-16585]: https://github.com/moby/moby/issues/16585
+func parseEnvFile(filename string) ([]string, error) {
 	return kvfile.Parse(filename, os.LookupEnv)
 }

--- a/cli/compose/loader/envfile_test.go
+++ b/cli/compose/loader/envfile_test.go
@@ -1,4 +1,4 @@
-package opts
+package loader
 
 import (
 	"os"
@@ -17,13 +17,13 @@ func tmpFileWithContent(t *testing.T, content string) string {
 	return fileName
 }
 
-// Test ParseEnvFile for a non existent file
+// Test parseEnvFile for a non existent file
 func TestParseEnvFileNonExistentFile(t *testing.T) {
-	_, err := ParseEnvFile("no_such_file")
+	_, err := parseEnvFile("no_such_file")
 	assert.Check(t, is.ErrorType(err, os.IsNotExist))
 }
 
-// ParseEnvFile with environment variable import definitions
+// parseEnvFile with environment variable import definitions
 func TestParseEnvVariableDefinitionsFile(t *testing.T) {
 	content := `# comment=
 UNDEFINED_VAR
@@ -32,7 +32,7 @@ DEFINED_VAR
 	tmpFile := tmpFileWithContent(t, content)
 
 	t.Setenv("DEFINED_VAR", "defined-value")
-	variables, err := ParseEnvFile(tmpFile)
+	variables, err := parseEnvFile(tmpFile)
 	assert.NilError(t, err)
 
 	expectedLines := []string{"DEFINED_VAR=defined-value"}

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -469,7 +469,7 @@ func resolveEnvironment(serviceConfig *types.ServiceConfig, workingDir string, l
 
 		for _, file := range serviceConfig.EnvFile {
 			filePath := absPath(workingDir, file)
-			fileVars, err := opts.ParseEnvFile(filePath)
+			fileVars, err := parseEnvFile(filePath)
 			if err != nil {
 				return err
 			}

--- a/opts/env.go
+++ b/opts/env.go
@@ -7,13 +7,14 @@ import (
 )
 
 // ValidateEnv validates an environment variable and returns it.
-// If no value is specified, it obtains its value from the current environment
+// If no value is specified, it obtains its value from the current environment.
 //
-// As on ParseEnvFile and related to #16585, environment variable names
-// are not validated, and it's up to the application inside the container
-// to validate them or not.
+// Environment variable names are not validated, and it's up to the application
+// inside the container to validate them (see [moby-16585]). The only validation
+// here is to check if name is empty, per [moby-25099].
 //
-// The only validation here is to check if name is empty, per #25099
+// [moby-16585]: https://github.com/moby/moby/issues/16585
+// [moby-25099]: https://github.com/moby/moby/issues/25099
 func ValidateEnv(val string) (string, error) {
 	k, _, hasValue := strings.Cut(val, "=")
 	if k == "" {

--- a/opts/envfile_deprecated.go
+++ b/opts/envfile_deprecated.go
@@ -1,0 +1,14 @@
+package opts
+
+import (
+	"os"
+
+	"github.com/docker/cli/pkg/kvfile"
+)
+
+// ParseEnvFile reads a file with environment variables enumerated by lines
+//
+// Deprecated: use [kvfile.Parse] and pass [os.LookupEnv] to lookup env-vars from the current environment.
+func ParseEnvFile(filename string) ([]string, error) {
+	return kvfile.Parse(filename, os.LookupEnv)
+}


### PR DESCRIPTION
It was a wrapper around kvfile.Load, which should be used instead.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate ParseEnvFile in favour of `kvfile.Parse`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

