### PR TITLE
[28.x] cli/command: deprecate prompt utilities that were for internal use

### DIFF
--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -17,12 +17,17 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrPromptTerminated is returned if the user terminated the prompt.
+//
+// Deprecated: this error is for internal use and will be removed in the next release.
 const ErrPromptTerminated = prompt.ErrTerminated
 
 // DisableInputEcho disables input echo on the provided streams.In.
 // This is useful when the user provides sensitive information like passwords.
 // The function returns a restore function that should be called to restore the
 // terminal state.
+//
+// Deprecated: this function is for internal use and will be removed in the next release.
 func DisableInputEcho(ins *streams.In) (restore func() error, err error) {
 	return prompt.DisableInputEcho(ins)
 }
@@ -34,6 +39,8 @@ func DisableInputEcho(ins *streams.In) (restore func() error, err error) {
 // When the prompt returns an error, the caller should propagate the error up
 // the stack and close the io.Reader used for the prompt which will prevent the
 // background goroutine from blocking indefinitely.
+//
+// Deprecated: this function is for internal use and will be removed in the next release.
 func PromptForInput(ctx context.Context, in io.Reader, out io.Writer, message string) (string, error) {
 	return prompt.ReadInput(ctx, in, out, message)
 }
@@ -48,6 +55,8 @@ func PromptForInput(ctx context.Context, in io.Reader, out io.Writer, message st
 // When the prompt returns an error, the caller should propagate the error up
 // the stack and close the io.Reader used for the prompt which will prevent the
 // background goroutine from blocking indefinitely.
+//
+// Deprecated: this function is for internal use and will be removed in the next release.
 func PromptForConfirmation(ctx context.Context, ins io.Reader, outs io.Writer, message string) (bool, error) {
 	return prompt.Confirm(ctx, ins, outs, message)
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6243

----

- The `DisableInputEcho` and `PromptForInput` utilities were added in c15ade0c647606b769deb009a3c2e508efa71e67 as part of a bug-fix, which was part of v28.x. [There are no (publicly visible) users][1] of either.
- The `ErrPromptTerminated` was added in v26.x (originally added in 10bf91a02d2abd4dec90b79bd10b91f6fbb8e05d, later updated in commit 7c722c08d093c118ea727961be9aa0a23c83b733. [It is not used][2]
- The `PromptForConfirmation` was added in [moby@280c872] (docker v1.13.0) as part of the `docker <object> prune` subcommands. It was meant for internal use but exported to allow re-using it in the `container`, `image` (etc.) packages. However, a breaking change to its signature was made in 10bf91a02d2abd4dec90b79bd10b91f6fbb8e05d. It currently does [not appear to have any (public) users][2].

This patch deprecates the `ErrPromptTerminated`, `DisableInputEcho`, `PromptForInput`, and `PromptForConfirmation` utilities from the `cli/command` package. The core functionality of these is still available in the `internal/prompt` package, which we may make public at some point, but still needs some refining / decoupling.

[moby@280c872]: https://github.com/moby/moby/commit/280c8723667af385e0807a090ddc5cc57c46807e
[1]: https://grep.app/search?f.lang=Go&regexp=true&q=%5C.%28DisableInputEcho%7CPromptForInput%29%5C%28
[2]: https://grep.app/search?f.lang=Go&q=%5C.ErrPromptTerminated
[3]: https://grep.app/search?f.lang=Go&q=.PromptForConfirmation%28


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: `cli/command`: deprecate the `ErrPromptTerminated`, `DisableInputEcho`,
`PromptForInput`, and `PromptForConfirmation` utilities. These utilities
were for internal use and are no longer used. They will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

