### PR TITLE
[28.x] e2e/testutils: fix incorrect use of PluginConfigInterface

### DIFF
--- a/e2e/testutils/plugins.go
+++ b/e2e/testutils/plugins.go
@@ -32,7 +32,11 @@ func SetupPlugin(t *testing.T, ctx context.Context) *fs.Dir {
 		},
 		Interface: types.PluginConfigInterface{
 			Socket: "basic.sock",
-			Types:  []types.PluginInterfaceType{{Capability: "docker.dummy/1.0"}},
+			Types: []types.PluginInterfaceType{{
+				Capability: "dummy",
+				Prefix:     "docker",
+				Version:    "1.0",
+			}},
 		},
 		Entrypoint: []string{"/basic"},
 	}


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50519#discussion_r2249400722
- relates to https://github.com/docker/cli/pull/6232#discussion_r2249402777

This code was using the type incorrectly; current versions of the API MarshalText ignore this mistake, but the moby/moby/api module produces an error:

    === Failed
    === FAIL: e2e/global TestPromptExitCode/plugin_install (0.28s)
        cli_test.go:203: assertion failed: error is not nil: json: error calling MarshalText for type plugin.CapabilityID: capability "docker.dummy/1.0" cannot contain a dot

    === FAIL: e2e/global TestPromptExitCode/plugin_upgrade (0.26s)
        cli_test.go:203: assertion failed: error is not nil: json: error calling MarshalText for type plugin.CapabilityID: capability "docker.dummy/1.0" cannot contain a dot

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

