### PR TITLE
internal/commands: remove mutexes / synchronisation and copy

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -2,32 +2,25 @@ package commands
 
 import (
 	"os"
-	"slices"
-	"sync"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/spf13/cobra"
 )
 
-var (
-	commands []func(command.Cli) *cobra.Command
-	l        sync.RWMutex
-)
+var commands []func(command.Cli) *cobra.Command
 
 // Register pushes the passed in command into an internal queue which can
-// be retrieved using the [Commands] function.
+// be retrieved using the [Commands] function. It is designed to be called
+// in an init function and is not safe for concurrent use.
 func Register(f func(command.Cli) *cobra.Command) {
-	l.Lock()
-	defer l.Unlock()
 	commands = append(commands, f)
 }
 
 // RegisterLegacy functions similarly to [Register], but it checks the
-// `DOCKER_HIDE_LEGACY_COMMANDS` environment variable and if
-// it has been set and is non-empty, the command will be hidden.
+// "DOCKER_HIDE_LEGACY_COMMANDS" environment variable and if it has been
+// set and is non-empty, the command will be hidden. It is designed to be called
+// in an init function and is not safe for concurrent use.
 func RegisterLegacy(f func(command.Cli) *cobra.Command) {
-	l.Lock()
-	defer l.Unlock()
 	commands = append(commands, func(c command.Cli) *cobra.Command {
 		cmd := f(c)
 		if os.Getenv("DOCKER_HIDE_LEGACY_COMMANDS") == "" {
@@ -40,10 +33,8 @@ func RegisterLegacy(f func(command.Cli) *cobra.Command) {
 	})
 }
 
-// Commands returns a copy of the internal queue holding registered commands
-// added via [Register] or [RegisterLegacy].
+// Commands returns the internal queue holding registered commands added
+// via [Register] and [RegisterLegacy].
 func Commands() []func(command.Cli) *cobra.Command {
-	l.RLock()
-	defer l.RUnlock()
-	return slices.Clone(commands)
+	return commands
 }

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -22,14 +22,13 @@ func Register(f func(command.Cli) *cobra.Command) {
 // in an init function and is not safe for concurrent use.
 func RegisterLegacy(f func(command.Cli) *cobra.Command) {
 	commands = append(commands, func(c command.Cli) *cobra.Command {
-		cmd := f(c)
 		if os.Getenv("DOCKER_HIDE_LEGACY_COMMANDS") == "" {
-			return cmd
+			return f(c)
 		}
-		cmdCopy := *cmd
-		cmdCopy.Hidden = true
-		cmdCopy.Aliases = []string{}
-		return &cmdCopy
+		cmd := f(c)
+		cmd.Hidden = true
+		cmd.Aliases = []string{}
+		return cmd
 	})
 }
 


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/6283#discussion_r2282590988


### internal/commands: remove mutexes / synchronisation

The Register and RegisterLegacy functions are designed to be used
in package init() functions, which are guaranteed to be run
sequentially.

From the documentation (https://go.dev/ref/mem#init);

> Program initialization runs in a single goroutine, but that goroutine
> may create other goroutines, which run concurrently. If a package `p`
> imports package `q`, the completion of `q`'s `init` functions happens
> before the start of any of `p`'s.
>
> The completion of all `init` functions is synchronized before the
> start of the function `main.main`.


This patch removes the synchonisation as no concurrency should happen
if these functions are used as intended.

As the internal queue is not expected to be mutated after use, we also
don't have to return a copy.

### internal/commands: RegisterLegacy: remove redundant copy

The RegisterLegacy and Register functions register constructors for
commands, so we should expect them to be a fresh copy that is not
shared, which means that we can mutate the command in-place.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

