### PR TITLE
cli/command/*: remove deprecated cobra command constructors

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -16,13 +16,7 @@ func init() {
 	})
 }
 
-// NewBuilderCommand returns a cobra command for `builder` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewBuilderCommand(dockerCLI command.Cli) *cobra.Command {
-	return newBuilderCommand(dockerCLI)
-}
-
+// newBuilderCommand returns a cobra command for `builder` subcommands
 func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:         "builder",
@@ -40,16 +34,10 @@ func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
-// NewBakeStubCommand returns a cobra command "stub" for the "bake" subcommand.
+// newBakeStubCommand returns a cobra command "stub" for the "bake" subcommand.
 // This command is a placeholder / stub that is dynamically replaced by an
 // alias for "docker buildx bake" if BuildKit is enabled (and the buildx plugin
 // installed).
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
-	return newBakeStubCommand(dockerCLI)
-}
-
 func newBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
 	return &cobra.Command{
 		Use:   "bake [OPTIONS] [TARGET...]",

--- a/cli/command/checkpoint/cmd.go
+++ b/cli/command/checkpoint/cmd.go
@@ -11,13 +11,7 @@ func init() {
 	commands.Register(newCheckpointCommand)
 }
 
-// NewCheckpointCommand returns the `checkpoint` subcommand (only in experimental)
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewCheckpointCommand(dockerCLI command.Cli) *cobra.Command {
-	return newCheckpointCommand(dockerCLI)
-}
-
+// newCheckpointCommand returns the `checkpoint` subcommand (only in experimental)
 func newCheckpointCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "checkpoint",

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -13,13 +13,7 @@ func init() {
 	commands.Register(newConfigCommand)
 }
 
-// NewConfigCommand returns a cobra command for `config` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewConfigCommand(dockerCLI command.Cli) *cobra.Command {
-	return newConfigCommand(dockerCLI)
-}
-
+// newConfigCommand returns a cobra command for `config` subcommands
 func newConfigCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -40,13 +40,7 @@ func inspectContainerAndCheckState(ctx context.Context, apiClient client.APIClie
 	return &c, nil
 }
 
-// NewAttachCommand creates a new cobra.Command for `docker attach`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewAttachCommand(dockerCLI command.Cli) *cobra.Command {
-	return newAttachCommand(dockerCLI)
-}
-
+// newAttachCommand creates a new cobra.Command for `docker attach`
 func newAttachCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts AttachOptions
 

--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -34,13 +34,7 @@ func init() {
 	commands.RegisterLegacy(newWaitCommand)
 }
 
-// NewContainerCommand returns a cobra command for `container` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewContainerCommand(dockerCLI command.Cli) *cobra.Command {
-	return newContainerCommand(dockerCLI)
-}
-
+// newContainerCommand returns a cobra command for `container` subcommands
 func newContainerCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "container",

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -22,13 +22,7 @@ type commitOptions struct {
 	changes opts.ListOpts
 }
 
-// NewCommitCommand creates a new cobra.Command for `docker commit`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewCommitCommand(dockerCLI command.Cli) *cobra.Command {
-	return newCommitCommand(dockerCLI)
-}
-
+// newCommitCommand creates a new cobra.Command for `docker commit`
 func newCommitCommand(dockerCLI command.Cli) *cobra.Command {
 	var options commitOptions
 

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -121,13 +121,7 @@ func copyProgress(ctx context.Context, dst io.Writer, header string, total *int6
 	return restore, done
 }
 
-// NewCopyCommand creates a new `docker cp` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewCopyCommand(dockerCLI command.Cli) *cobra.Command {
-	return newCopyCommand(dockerCLI)
-}
-
+// newCopyCommand creates a new `docker cp` command
 func newCopyCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts copyOptions
 

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -51,13 +51,7 @@ type createOptions struct {
 	useAPISocket bool
 }
 
-// NewCreateCommand creates a new cobra.Command for `docker create`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewCreateCommand(dockerCLI command.Cli) *cobra.Command {
-	return newCreateCommand(dockerCLI)
-}
-
+// newCreateCommand creates a new cobra.Command for `docker create`
 func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	var options createOptions
 	var copts *containerOptions

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -10,13 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewDiffCommand creates a new cobra.Command for `docker diff`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewDiffCommand(dockerCLI command.Cli) *cobra.Command {
-	return newDiffCommand(dockerCLI)
-}
-
+// newDiffCommand creates a new cobra.Command for `docker diff`
 func newDiffCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "diff CONTAINER",

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -39,13 +39,7 @@ func NewExecOptions() ExecOptions {
 	}
 }
 
-// NewExecCommand creates a new cobra.Command for `docker exec`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewExecCommand(dockerCLI command.Cli) *cobra.Command {
-	return newExecCommand(dockerCLI)
-}
-
+// newExecCommand creates a new cobra.Command for "docker exec".
 func newExecCommand(dockerCLI command.Cli) *cobra.Command {
 	options := NewExecOptions()
 

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -17,13 +17,7 @@ type exportOptions struct {
 	output    string
 }
 
-// NewExportCommand creates a new `docker export` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewExportCommand(dockerCLI command.Cli) *cobra.Command {
-	return newExportCommand(dockerCLI)
-}
-
+// newExportCommand creates a new "docker container export" command.
 func newExportCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts exportOptions
 

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -17,13 +17,7 @@ type killOptions struct {
 	containers []string
 }
 
-// NewKillCommand creates a new cobra.Command for `docker kill`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewKillCommand(dockerCLI command.Cli) *cobra.Command {
-	return newKillCommand(dockerCLI)
-}
-
+// newKillCommand creates a new cobra.Command for "docker container kill"
 func newKillCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts killOptions
 

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -28,13 +28,7 @@ type psOptions struct {
 	filter      opts.FilterOpt
 }
 
-// NewPsCommand creates a new cobra.Command for `docker ps`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPsCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPsCommand(dockerCLI)
-}
-
+// newPsCommand creates a new cobra.Command for "docker container ps"
 func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := psOptions{filter: opts.NewFilterOpt()}
 

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -23,13 +23,7 @@ type logsOptions struct {
 	container string
 }
 
-// NewLogsCommand creates a new cobra.Command for `docker logs`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewLogsCommand(dockerCLI command.Cli) *cobra.Command {
-	return newLogsCommand(dockerCLI)
-}
-
+// newLogsCommand creates a new cobra.Command for "docker container logs"
 func newLogsCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts logsOptions
 

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -16,13 +16,7 @@ type pauseOptions struct {
 	containers []string
 }
 
-// NewPauseCommand creates a new cobra.Command for `docker pause`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPauseCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPauseCommand(dockerCLI)
-}
-
+// newPauseCommand creates a new cobra.Command for "docker container pause"
 func newPauseCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pauseOptions
 

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -23,13 +23,7 @@ type portOptions struct {
 	port string
 }
 
-// NewPortCommand creates a new cobra.Command for `docker port`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPortCommand(dockerCli command.Cli) *cobra.Command {
-	return newPortCommand(dockerCli)
-}
-
+// newPortCommand creates a new cobra.Command for "docker container port".
 func newPortCommand(dockerCli command.Cli) *cobra.Command {
 	var opts portOptions
 

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -27,13 +27,7 @@ type pruneOptions struct {
 	filter opts.FilterOpt
 }
 
-// NewPruneCommand returns a new cobra prune command for containers
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPruneCommand(dockerCLI)
-}
-
+// newPruneCommand returns a new cobra prune command for containers.
 func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -17,13 +17,7 @@ type renameOptions struct {
 	newName string
 }
 
-// NewRenameCommand creates a new cobra.Command for `docker rename`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewRenameCommand(dockerCLI command.Cli) *cobra.Command {
-	return newRenameCommand(dockerCLI)
-}
-
+// newRenameCommand creates a new cobra.Command for "docker container rename".
 func newRenameCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts renameOptions
 

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -20,13 +20,7 @@ type restartOptions struct {
 	containers []string
 }
 
-// NewRestartCommand creates a new cobra.Command for `docker restart`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewRestartCommand(dockerCLI command.Cli) *cobra.Command {
-	return newRestartCommand(dockerCLI)
-}
-
+// newRestartCommand creates a new cobra.Command for "docker container restart".
 func newRestartCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts restartOptions
 

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -22,13 +22,7 @@ type rmOptions struct {
 	containers []string
 }
 
-// NewRmCommand creates a new cobra.Command for `docker rm`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewRmCommand(dockerCLI command.Cli) *cobra.Command {
-	return newRmCommand(dockerCLI)
-}
-
+// newRmCommand creates a new cobra.Command for "docker container rm".
 func newRmCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts rmOptions
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -27,13 +27,7 @@ type runOptions struct {
 	detachKeys string
 }
 
-// NewRunCommand create a new `docker run` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewRunCommand(dockerCLI command.Cli) *cobra.Command {
-	return newRunCommand(dockerCLI)
-}
-
+// newRunCommand create a new "docker run" command.
 func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 	var options runOptions
 	var copts *containerOptions

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -27,13 +27,7 @@ type StartOptions struct {
 	Containers []string
 }
 
-// NewStartCommand creates a new cobra.Command for `docker start`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewStartCommand(dockerCli command.Cli) *cobra.Command {
-	return newStartCommand(dockerCli)
-}
-
+// newStartCommand creates a new cobra.Command for "docker container start".
 func newStartCommand(dockerCli command.Cli) *cobra.Command {
 	var opts StartOptions
 

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -63,13 +63,7 @@ type StatsOptions struct {
 	Filters *filters.Args
 }
 
-// NewStatsCommand creates a new [cobra.Command] for "docker stats".
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewStatsCommand(dockerCLI command.Cli) *cobra.Command {
-	return newStatsCommand(dockerCLI)
-}
-
+// newStatsCommand creates a new [cobra.Command] for "docker container stats".
 func newStatsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := StatsOptions{}
 

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -20,13 +20,7 @@ type stopOptions struct {
 	containers []string
 }
 
-// NewStopCommand creates a new cobra.Command for `docker stop`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewStopCommand(dockerCLI command.Cli) *cobra.Command {
-	return newStopCommand(dockerCLI)
-}
-
+// newStopCommand creates a new cobra.Command for "docker container stop".
 func newStopCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts stopOptions
 

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -18,13 +18,7 @@ type topOptions struct {
 	args []string
 }
 
-// NewTopCommand creates a new cobra.Command for `docker top`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewTopCommand(dockerCLI command.Cli) *cobra.Command {
-	return newTopCommand(dockerCLI)
-}
-
+// newTopCommand creates a new cobra.Command for "docker container top",
 func newTopCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts topOptions
 

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -16,13 +16,7 @@ type unpauseOptions struct {
 	containers []string
 }
 
-// NewUnpauseCommand creates a new cobra.Command for `docker unpause`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewUnpauseCommand(dockerCli command.Cli) *cobra.Command {
-	return newUnpauseCommand(dockerCli)
-}
-
+// newUnpauseCommand creates a new cobra.Command for "docker container unpause".
 func newUnpauseCommand(dockerCli command.Cli) *cobra.Command {
 	var opts unpauseOptions
 

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -36,13 +36,7 @@ type updateOptions struct {
 	containers []string
 }
 
-// NewUpdateCommand creates a new cobra.Command for `docker update`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewUpdateCommand(dockerCLI command.Cli) *cobra.Command {
-	return newUpdateCommand(dockerCLI)
-}
-
+// newUpdateCommand creates a new cobra.Command for "docker container update".
 func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	var options updateOptions
 

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -15,13 +15,7 @@ type waitOptions struct {
 	containers []string
 }
 
-// NewWaitCommand creates a new cobra.Command for `docker wait`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewWaitCommand(dockerCLI command.Cli) *cobra.Command {
-	return newWaitCommand(dockerCLI)
-}
-
+// newWaitCommand creates a new cobra.Command for "docker container wait".
 func newWaitCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts waitOptions
 

--- a/cli/command/context/cmd.go
+++ b/cli/command/context/cmd.go
@@ -11,13 +11,6 @@ func init() {
 	commands.Register(newContextCommand)
 }
 
-// NewContextCommand returns the context cli subcommand
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewContextCommand(dockerCLI command.Cli) *cobra.Command {
-	return newContextCommand(dockerCLI)
-}
-
 // newContextCommand returns the context cli subcommand
 func newContextCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -21,13 +21,6 @@ func init() {
 	commands.RegisterLegacy(newTagCommand)
 }
 
-// NewImageCommand returns a cobra command for `image` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewImageCommand(dockerCLI command.Cli) *cobra.Command {
-	return newImageCommand(dockerCLI)
-}
-
 // newImageCommand returns a cobra command for `image` subcommands
 func newImageCommand(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -24,14 +24,7 @@ type historyOptions struct {
 	format  string
 }
 
-// NewHistoryCommand creates a new `docker history` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewHistoryCommand(dockerCLI command.Cli) *cobra.Command {
-	return newHistoryCommand(dockerCLI)
-}
-
-// newHistoryCommand creates a new `docker history` command
+// newHistoryCommand creates a new "docker image history" command.
 func newHistoryCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts historyOptions
 

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -22,14 +22,7 @@ type importOptions struct {
 	platform  string
 }
 
-// NewImportCommand creates a new `docker import` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewImportCommand(dockerCLI command.Cli) *cobra.Command {
-	return newImportCommand(dockerCLI)
-}
-
-// newImportCommand creates a new `docker import` command
+// newImportCommand creates a new "docker image import" command.
 func newImportCommand(dockerCLI command.Cli) *cobra.Command {
 	var options importOptions
 

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -28,13 +28,6 @@ type imagesOptions struct {
 	tree        bool
 }
 
-// NewImagesCommand creates a new `docker images` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewImagesCommand(dockerCLI command.Cli) *cobra.Command {
-	return newImagesCommand(dockerCLI)
-}
-
 // newImagesCommand creates a new `docker images` command
 func newImagesCommand(dockerCLI command.Cli) *cobra.Command {
 	options := imagesOptions{filter: opts.NewFilterOpt()}

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -22,14 +22,7 @@ type loadOptions struct {
 	platform []string
 }
 
-// NewLoadCommand creates a new `docker load` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewLoadCommand(dockerCLI command.Cli) *cobra.Command {
-	return newLoadCommand(dockerCLI)
-}
-
-// newLoadCommand creates a new `docker load` command
+// newLoadCommand creates a new "docker image load" command.
 func newLoadCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loadOptions
 

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -30,13 +30,6 @@ type pruneOptions struct {
 	filter opts.FilterOpt
 }
 
-// NewPruneCommand returns a new cobra prune command for images
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPruneCommand(dockerCLI)
-}
-
 // newPruneCommand returns a new cobra prune command for images
 func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}

--- a/cli/command/image/prune_test.go
+++ b/cli/command/image/prune_test.go
@@ -40,7 +40,7 @@ func TestNewPruneCommandErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewPruneCommand(test.NewFakeCli(&fakeClient{
+			cmd := newPruneCommand(test.NewFakeCli(&fakeClient{
 				imagesPruneFunc: tc.imagesPruneFunc,
 			}))
 			cmd.SetOut(io.Discard)
@@ -102,7 +102,7 @@ func TestNewPruneCommandSuccess(t *testing.T) {
 			// when prompted, answer "Y" to confirm the prune.
 			// will not be prompted if --force is used.
 			cli.SetIn(streams.NewIn(io.NopCloser(strings.NewReader("Y\n"))))
-			cmd := NewPruneCommand(cli)
+			cmd := newPruneCommand(cli)
 			cmd.SetOut(io.Discard)
 			cmd.SetArgs(tc.args)
 			err := cmd.Execute()
@@ -121,7 +121,7 @@ func TestPrunePromptTermination(t *testing.T) {
 			return image.PruneReport{}, errors.New("fakeClient imagesPruneFunc should not be called")
 		},
 	})
-	cmd := NewPruneCommand(cli)
+	cmd := newPruneCommand(cli)
 	cmd.SetArgs([]string{})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -26,13 +26,6 @@ type pullOptions struct {
 	untrusted bool
 }
 
-// NewPullCommand creates a new `docker pull` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPullCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPullCommand(dockerCLI)
-}
-
 // newPullCommand creates a new `docker pull` command
 func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pullOptions

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -35,13 +35,6 @@ type pushOptions struct {
 	platform  string
 }
 
-// NewPushCommand creates a new `docker push` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPushCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPushCommand(dockerCLI)
-}
-
 // newPushCommand creates a new `docker push` command
 func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts pushOptions

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -20,14 +20,7 @@ type removeOptions struct {
 	platforms []string
 }
 
-// NewRemoveCommand creates a new `docker remove` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewRemoveCommand(dockerCLI command.Cli) *cobra.Command {
-	return newRemoveCommand(dockerCLI)
-}
-
-// newRemoveCommand creates a new `docker remove` command
+// newRemoveCommand creates a new "docker image remove" command
 func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var options removeOptions
 

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -21,14 +21,7 @@ type saveOptions struct {
 	platform []string
 }
 
-// NewSaveCommand creates a new `docker save` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewSaveCommand(dockerCLI command.Cli) *cobra.Command {
-	return newSaveCommand(dockerCLI)
-}
-
-// newSaveCommand creates a new `docker save` command
+// newSaveCommand creates a new "docker image save" command.
 func newSaveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts saveOptions
 

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -14,14 +14,7 @@ type tagOptions struct {
 	name  string
 }
 
-// NewTagCommand creates a new `docker tag` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewTagCommand(dockerCLI command.Cli) *cobra.Command {
-	return newTagCommand(dockerCLI)
-}
-
-// newTagCommand creates a new `docker tag` command
+// newTagCommand creates a new "docker image tag" command.
 func newTagCommand(dockerCli command.Cli) *cobra.Command {
 	var opts tagOptions
 

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -14,13 +14,6 @@ func init() {
 	commands.Register(newManifestCommand)
 }
 
-// NewManifestCommand returns a cobra command for `manifest` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewManifestCommand(dockerCLI command.Cli) *cobra.Command {
-	return newManifestCommand(dockerCLI)
-}
-
 // newManifestCommand returns a cobra command for `manifest` subcommands
 func newManifestCommand(dockerCLI command.Cli) *cobra.Command {
 	// use dockerCli as command.Cli

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -11,13 +11,6 @@ func init() {
 	commands.Register(newNetworkCommand)
 }
 
-// NewNetworkCommand returns a cobra command for `network` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewNetworkCommand(dockerCLI command.Cli) *cobra.Command {
-	return newNetworkCommand(dockerCLI)
-}
-
 // newNetworkCommand returns a cobra command for `network` subcommands
 func newNetworkCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -25,13 +25,6 @@ type pruneOptions struct {
 	filter opts.FilterOpt
 }
 
-// NewPruneCommand returns a new cobra prune command for networks
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPruneCommand(dockerCLI)
-}
-
 // newPruneCommand returns a new cobra prune command for networks
 func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -16,13 +16,6 @@ func init() {
 	commands.Register(newNodeCommand)
 }
 
-// NewNodeCommand returns a cobra command for `node` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewNodeCommand(dockerCLI command.Cli) *cobra.Command {
-	return newNodeCommand(dockerCLI)
-}
-
 // newNodeCommand returns a cobra command for `node` subcommands
 func newNodeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -11,13 +11,6 @@ func init() {
 	commands.Register(newPluginCommand)
 }
 
-// NewPluginCommand returns a cobra command for `plugin` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPluginCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPluginCommand(dockerCLI)
-}
-
 // newPluginCommand returns a cobra command for `plugin` subcommands
 func newPluginCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -36,13 +36,6 @@ type loginOptions struct {
 	passwordStdin bool
 }
 
-// NewLoginCommand creates a new `docker login` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewLoginCommand(dockerCLI command.Cli) *cobra.Command {
-	return newLoginCommand(dockerCLI)
-}
-
 // newLoginCommand creates a new `docker login` command
 func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts loginOptions

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -17,13 +17,6 @@ func init() {
 	commands.Register(newLogoutCommand)
 }
 
-// NewLogoutCommand creates a new `docker logout` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewLogoutCommand(dockerCLI command.Cli) *cobra.Command {
-	return newLogoutCommand(dockerCLI)
-}
-
 // newLogoutCommand creates a new `docker logout` command
 func newLogoutCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -26,13 +26,6 @@ type searchOptions struct {
 	filter  opts.FilterOpt
 }
 
-// NewSearchCommand creates a new `docker search` command
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewSearchCommand(dockerCLI command.Cli) *cobra.Command {
-	return newSearchCommand(dockerCLI)
-}
-
 // newSearchCommand creates a new `docker search` command
 func newSearchCommand(dockerCLI command.Cli) *cobra.Command {
 	options := searchOptions{filter: opts.NewFilterOpt()}

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -13,13 +13,7 @@ func init() {
 	commands.Register(newSecretCommand)
 }
 
-// NewSecretCommand returns a cobra command for `secret` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewSecretCommand(dockerCLI command.Cli) *cobra.Command {
-	return newSecretCommand(dockerCLI)
-}
-
+// newSecretCommand returns a cobra command for `secret` subcommands.
 func newSecretCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "secret",

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -11,13 +11,6 @@ func init() {
 	commands.Register(newServiceCommand)
 }
 
-// NewServiceCommand returns a cobra command for `service` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewServiceCommand(dockerCLI command.Cli) *cobra.Command {
-	return newServiceCommand(dockerCLI)
-}
-
 // newServiceCommand returns a cobra command for `service` subcommands
 func newServiceCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -15,13 +15,6 @@ func init() {
 	commands.Register(newStackCommand)
 }
 
-// NewStackCommand returns a cobra command for `stack` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewStackCommand(dockerCLI command.Cli) *cobra.Command {
-	return newStackCommand(dockerCLI)
-}
-
 // newStackCommand returns a cobra command for `stack` subcommands
 func newStackCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -12,13 +12,6 @@ func init() {
 	commands.Register(newSwarmCommand)
 }
 
-// NewSwarmCommand returns a cobra command for `swarm` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewSwarmCommand(dockerCLI command.Cli) *cobra.Command {
-	return newSwarmCommand(dockerCLI)
-}
-
 // newSwarmCommand returns a cobra command for `swarm` subcommands
 func newSwarmCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -15,13 +15,6 @@ func init() {
 	commands.RegisterLegacy(newInspectCommand)
 }
 
-// NewSystemCommand returns a cobra command for `system` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewSystemCommand(dockerCLI command.Cli) *cobra.Command {
-	return newSystemCommand(dockerCLI)
-}
-
 // newSystemCommand returns a cobra command for `system` subcommands
 func newSystemCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -27,13 +27,6 @@ type eventsOptions struct {
 	format string
 }
 
-// NewEventsCommand creates a new cobra.Command for `docker events`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewEventsCommand(dockerCLI command.Cli) *cobra.Command {
-	return newEventsCommand(dockerCLI)
-}
-
 // newEventsCommand creates a new cobra.Command for `docker events`
 func newEventsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := eventsOptions{filter: opts.NewFilterOpt()}

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -59,13 +59,6 @@ func (i *dockerInfo) clientPlatform() string {
 	return ""
 }
 
-// NewInfoCommand creates a new cobra.Command for `docker info`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewInfoCommand(dockerCLI command.Cli) *cobra.Command {
-	return newInfoCommand(dockerCLI)
-}
-
 // newInfoCommand creates a new cobra.Command for `docker info`
 func newInfoCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts infoOptions

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -59,13 +59,6 @@ type inspectOptions struct {
 	ids        []string
 }
 
-// NewInspectCommand creates a new cobra.Command for `docker inspect`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewInspectCommand(dockerCLI command.Cli) *cobra.Command {
-	return newInspectCommand(dockerCLI)
-}
-
 // newInspectCommand creates a new cobra.Command for `docker inspect`
 func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -108,13 +108,6 @@ func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
 	return v
 }
 
-// NewVersionCommand creates a new cobra.Command for `docker version`
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewVersionCommand(dockerCLI command.Cli) *cobra.Command {
-	return newVersionCommand(dockerCLI)
-}
-
 // newVersionCommand creates a new cobra.Command for `docker version`
 func newVersionCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts versionOptions

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -11,13 +11,7 @@ func init() {
 	commands.Register(newTrustCommand)
 }
 
-// NewTrustCommand returns a cobra command for `trust` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewTrustCommand(dockerCLI command.Cli) *cobra.Command {
-	return newTrustCommand(dockerCLI)
-}
-
+// newTrustCommand returns a cobra command for `trust` subcommands.
 func newTrustCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "trust",

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -11,13 +11,6 @@ func init() {
 	commands.Register(newVolumeCommand)
 }
 
-// NewVolumeCommand returns a cobra command for `volume` subcommands
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewVolumeCommand(dockerCLI command.Cli) *cobra.Command {
-	return newVolumeCommand(dockerCLI)
-}
-
 // newVolumeCommand returns a cobra command for `volume` subcommands
 func newVolumeCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -29,13 +29,6 @@ type pruneOptions struct {
 	filter opts.FilterOpt
 }
 
-// NewPruneCommand returns a new cobra prune command for volumes
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPruneCommand(dockerCLI command.Cli) *cobra.Command {
-	return newPruneCommand(dockerCLI)
-}
-
 // newPruneCommand returns a new cobra prune command for volumes
 func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6312
- https://github.com/docker/cli/pull/6284
- https://github.com/docker/cli/pull/6285
- https://github.com/docker/cli/pull/6286
- https://github.com/docker/cli/pull/6299
- https://github.com/docker/cli/pull/6301
- https://github.com/docker/cli/pull/6305
- https://github.com/docker/cli/pull/6316
- https://github.com/docker/cli/pull/6317
- https://github.com/docker/cli/pull/6318
- https://github.com/docker/cli/pull/6319
- https://github.com/docker/cli/pull/6320
- https://github.com/docker/cli/pull/6321
- https://github.com/docker/cli/pull/6322
- https://github.com/docker/cli/pull/6323
- https://github.com/docker/cli/pull/6324
- https://github.com/docker/cli/pull/6325
- https://github.com/docker/cli/pull/6326
- https://github.com/docker/cli/pull/6328


<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: remove deprecated exported NewXXX commands
TODO: collect change-logs from linked PRs
```

**- A picture of a cute animal (not mandatory but encouraged)**

