### PR TITLE
cli/command/*: remove deprecated formatting-related functions and types

### DIFF
--- a/cli/command/checkpoint/formatter.go
+++ b/cli/command/checkpoint/formatter.go
@@ -10,26 +10,12 @@ const (
 	checkpointNameHeader    = "CHECKPOINT NAME"
 )
 
-// NewFormat returns a format for use with a checkpoint Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string) formatter.Format {
-	return newFormat(source)
-}
-
 // newFormat returns a format for use with a checkpointContext.
 func newFormat(source string) formatter.Format {
 	if source == formatter.TableFormatKey {
 		return defaultCheckpointFormat
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes formatted checkpoints using the Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, checkpoints []checkpoint.Summary) error {
-	return formatWrite(fmtCtx, checkpoints)
 }
 
 // formatWrite writes formatted checkpoints using the Context

--- a/cli/command/config/formatter.go
+++ b/cli/command/config/formatter.go
@@ -29,13 +29,6 @@ Data:
 {{.Data}}`
 )
 
-// NewFormat returns a Format for rendering using a config Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string, quiet bool) formatter.Format {
-	return newFormat(source, quiet)
-}
-
 // newFormat returns a Format for rendering using a configContext.
 func newFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -48,13 +41,6 @@ func newFormat(source string, quiet bool) formatter.Format {
 		return defaultConfigTableFormat
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, configs []swarm.Config) error {
-	return formatWrite(fmtCtx, configs)
 }
 
 // formatWrite writes the context
@@ -126,13 +112,6 @@ func (c *configContext) Label(name string) string {
 		return ""
 	}
 	return c.c.Spec.Annotations.Labels[name]
-}
-
-// InspectFormatWrite renders the context for a list of configs
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func InspectFormatWrite(fmtCtx formatter.Context, refs []string, getRef inspect.GetRefFunc) error {
-	return inspectFormatWrite(fmtCtx, refs, getRef)
 }
 
 // inspectFormatWrite renders the context for a list of configs

--- a/cli/command/container/formatter_diff.go
+++ b/cli/command/container/formatter_diff.go
@@ -12,26 +12,12 @@ const (
 	pathHeader       = "PATH"
 )
 
-// NewDiffFormat returns a format for use with a diff Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewDiffFormat(source string) formatter.Format {
-	return newDiffFormat(source)
-}
-
 // newDiffFormat returns a format for use with a diff [formatter.Context].
 func newDiffFormat(source string) formatter.Format {
 	if source == formatter.TableFormatKey {
 		return defaultDiffTableFormat
 	}
 	return formatter.Format(source)
-}
-
-// DiffFormatWrite writes formatted diff using the Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func DiffFormatWrite(fmtCtx formatter.Context, changes []container.FilesystemChange) error {
-	return diffFormatWrite(fmtCtx, changes)
 }
 
 // diffFormatWrite writes formatted diff using the [formatter.Context].

--- a/cli/command/image/formatter_history.go
+++ b/cli/command/image/formatter_history.go
@@ -19,13 +19,6 @@ const (
 	commentHeader   = "COMMENT"
 )
 
-// NewHistoryFormat returns a format for rendering an HistoryContext
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewHistoryFormat(source string, quiet bool, human bool) formatter.Format {
-	return newHistoryFormat(source, quiet, human)
-}
-
 // newHistoryFormat returns a format for rendering a historyContext.
 func newHistoryFormat(source string, quiet bool, human bool) formatter.Format {
 	if source == formatter.TableFormatKey {
@@ -40,13 +33,6 @@ func newHistoryFormat(source string, quiet bool, human bool) formatter.Format {
 	}
 
 	return formatter.Format(source)
-}
-
-// HistoryWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func HistoryWrite(fmtCtx formatter.Context, human bool, histories []image.HistoryResponseItem) error {
-	return historyWrite(fmtCtx, human, histories)
 }
 
 // historyWrite writes the context

--- a/cli/command/network/formatter.go
+++ b/cli/command/network/formatter.go
@@ -17,13 +17,6 @@ const (
 	internalHeader  = "INTERNAL"
 )
 
-// NewFormat returns a Format for rendering using a network Context.
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string, quiet bool) formatter.Format {
-	return newFormat(source, quiet)
-}
-
 // newFormat returns a [formatter.Format] for rendering a networkContext.
 func newFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -39,13 +32,6 @@ func newFormat(source string, quiet bool) formatter.Format {
 		return `network_id: {{.ID}}\nname: {{.Name}}\ndriver: {{.Driver}}\nscope: {{.Scope}}\n`
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, networks []network.Summary) error {
-	return formatWrite(fmtCtx, networks)
 }
 
 // formatWrite writes the context.

--- a/cli/command/node/formatter.go
+++ b/cli/command/node/formatter.go
@@ -79,13 +79,6 @@ TLS Info:
 	tlsStatusHeader     = "TLS STATUS"
 )
 
-// NewFormat returns a Format for rendering using a node Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string, quiet bool) formatter.Format {
-	return newFormat(source, quiet)
-}
-
 // newFormat returns a Format for rendering using a nodeContext.
 func newFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -103,13 +96,6 @@ func newFormat(source string, quiet bool) formatter.Format {
 		return `node_id: {{.ID}}\nhostname: {{.Hostname}}\nstatus: {{.Status}}\navailability: {{.Availability}}\nmanager_status: {{.ManagerStatus}}\n`
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, nodes []swarm.Node, info system.Info) error {
-	return formatWrite(fmtCtx, nodes, info)
 }
 
 // formatWrite writes the context.
@@ -191,13 +177,6 @@ func (c *nodeContext) TLSStatus() string {
 
 func (c *nodeContext) EngineVersion() string {
 	return c.n.Description.Engine.EngineVersion
-}
-
-// InspectFormatWrite renders the context for a list of nodes
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func InspectFormatWrite(fmtCtx formatter.Context, refs []string, getRef inspect.GetRefFunc) error {
-	return inspectFormatWrite(fmtCtx, refs, getRef)
 }
 
 // inspectFormatWrite renders the context for a list of nodes.

--- a/cli/command/plugin/formatter.go
+++ b/cli/command/plugin/formatter.go
@@ -20,13 +20,6 @@ enabled: {{.Enabled}}
 `
 )
 
-// NewFormat returns a Format for rendering using a plugin Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string, quiet bool) formatter.Format {
-	return newFormat(source, quiet)
-}
-
 // newFormat returns a Format for rendering using a pluginContext.
 func newFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -42,13 +35,6 @@ func newFormat(source string, quiet bool) formatter.Format {
 		return rawFormat
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, plugins []*plugin.Plugin) error {
-	return formatWrite(fmtCtx, plugins)
 }
 
 // formatWrite writes the context

--- a/cli/command/registry/formatter_search.go
+++ b/cli/command/registry/formatter_search.go
@@ -16,13 +16,6 @@ const (
 	automatedHeader = "AUTOMATED"
 )
 
-// NewSearchFormat returns a Format for rendering using a search Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewSearchFormat(source string) formatter.Format {
-	return newFormat(source)
-}
-
 // newFormat returns a Format for rendering using a searchContext.
 func newFormat(source string) formatter.Format {
 	switch source {
@@ -30,13 +23,6 @@ func newFormat(source string) formatter.Format {
 		return defaultSearchTableFormat
 	}
 	return formatter.Format(source)
-}
-
-// SearchWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func SearchWrite(fmtCtx formatter.Context, results []registrytypes.SearchResult) error {
-	return formatWrite(fmtCtx, results)
 }
 
 // formatWrite writes the context.

--- a/cli/command/secret/formatter.go
+++ b/cli/command/secret/formatter.go
@@ -28,13 +28,6 @@ Created at:        {{.CreatedAt}}
 Updated at:        {{.UpdatedAt}}`
 )
 
-// NewFormat returns a Format for rendering using a secret Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string, quiet bool) formatter.Format {
-	return newFormat(source, quiet)
-}
-
 // newFormat returns a Format for rendering using a secretContext.
 func newFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -47,13 +40,6 @@ func newFormat(source string, quiet bool) formatter.Format {
 		return defaultSecretTableFormat
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, secrets []swarm.Secret) error {
-	return formatWrite(fmtCtx, secrets)
 }
 
 // formatWrite writes the context
@@ -133,13 +119,6 @@ func (c *secretContext) Label(name string) string {
 		return ""
 	}
 	return c.s.Spec.Annotations.Labels[name]
-}
-
-// InspectFormatWrite renders the context for a list of secrets
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func InspectFormatWrite(fmtCtx formatter.Context, refs []string, getRef inspect.GetRefFunc) error {
-	return inspectFormatWrite(fmtCtx, refs, getRef)
 }
 
 // inspectFormatWrite renders the context for a list of secrets.

--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -195,13 +195,6 @@ Ports:
 {{- end }}
 `
 
-// NewFormat returns a Format for rendering using a Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewFormat(source string) formatter.Format {
-	return newFormat(source)
-}
-
 // newFormat returns a Format for rendering using a Context.
 func newFormat(source string) formatter.Format {
 	switch source {
@@ -222,13 +215,6 @@ func resolveNetworks(service swarm.Service, getNetwork inspect.GetRefFunc) map[s
 		}
 	}
 	return networkNames
-}
-
-// InspectFormatWrite renders the context for a list of services
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func InspectFormatWrite(fmtCtx formatter.Context, refs []string, getRef, getNetwork inspect.GetRefFunc) error {
-	return inspectFormatWrite(fmtCtx, refs, getRef, getNetwork)
 }
 
 // inspectFormatWrite renders the context for a list of services

--- a/cli/command/task/formatter.go
+++ b/cli/command/task/formatter.go
@@ -22,13 +22,6 @@ const (
 	maxErrLength = 30
 )
 
-// NewTaskFormat returns a Format for rendering using a task Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewTaskFormat(source string, quiet bool) formatter.Format {
-	return newTaskFormat(source, quiet)
-}
-
 // newTaskFormat returns a Format for rendering using a taskContext.
 func newTaskFormat(source string, quiet bool) formatter.Format {
 	switch source {
@@ -44,13 +37,6 @@ func newTaskFormat(source string, quiet bool) formatter.Format {
 		return `id: {{.ID}}\nname: {{.Name}}\nimage: {{.Image}}\nnode: {{.Node}}\ndesired_state: {{.DesiredState}}\ncurrent_state: {{.CurrentState}}\nerror: {{.Error}}\nports: {{.Ports}}\n`
 	}
 	return formatter.Format(source)
-}
-
-// FormatWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func FormatWrite(fmtCtx formatter.Context, tasks []swarm.Task, names map[string]string, nodes map[string]string) error {
-	return formatWrite(fmtCtx, tasks, names, nodes)
 }
 
 // formatWrite writes the context.

--- a/cli/command/trust/formatter.go
+++ b/cli/command/trust/formatter.go
@@ -17,14 +17,6 @@ const (
 	keysHeader                   = "KEYS"
 )
 
-// SignedTagInfo represents all formatted information needed to describe a signed tag:
-// Name: name of the signed tag
-// Digest: hex encoded digest of the contents
-// Signers: list of entities who signed the tag
-//
-// Deprecated: this type was only used internally and will be removed in the next release.
-type SignedTagInfo = signedTagInfo
-
 // signedTagInfo represents all formatted information needed to describe a signed tag:
 // Name: name of the signed tag
 // Digest: hex encoded digest of the contents
@@ -35,40 +27,12 @@ type signedTagInfo struct {
 	Signers []string
 }
 
-// SignerInfo represents all formatted information needed to describe a signer:
-// Name: name of the signer role
-// Keys: the keys associated with the signer
-//
-// Deprecated: this type was only used internally and will be removed in the next release.
-type SignerInfo = signerInfo
-
 // signerInfo represents all formatted information needed to describe a signer:
 // Name: name of the signer role
 // Keys: the keys associated with the signer
 type signerInfo struct {
 	Name string
 	Keys []string
-}
-
-// NewTrustTagFormat returns a Format for rendering using a trusted tag Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewTrustTagFormat() formatter.Format {
-	return defaultTrustTagTableFormat
-}
-
-// NewSignerInfoFormat returns a Format for rendering a signer role info Context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func NewSignerInfoFormat() formatter.Format {
-	return defaultSignerInfoTableFormat
-}
-
-// TagWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func TagWrite(fmtCtx formatter.Context, signedTagInfoList []signedTagInfo) error {
-	return tagWrite(fmtCtx, signedTagInfoList)
 }
 
 // tagWrite writes the context
@@ -109,13 +73,6 @@ func (c *trustTagContext) Digest() string {
 func (c *trustTagContext) Signers() string {
 	sort.Strings(c.s.Signers)
 	return strings.Join(c.s.Signers, ", ")
-}
-
-// SignerInfoWrite writes the context
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func SignerInfoWrite(fmtCtx formatter.Context, signerInfoList []signerInfo) error {
-	return signerInfoWrite(fmtCtx, signerInfoList)
 }
 
 // signerInfoWrite writes the context.


### PR DESCRIPTION
follow-up to:

- https://github.com/docker/cli/pull/6336
- https://github.com/docker/cli/pull/6187

----

### cli/command/checkpoint: remove deprecated formatting functions

These were deprecated in d861b78a8ac4d98d3c814b798b84e43ce991d26b, which
is part of the v28.4 release.

### cli/command/config: remove deprecated formatting functions

These were deprecated in e626f778ec6e2f5b38c5a87f307e94331c5acf0c, which
is part of the v28.4 release.


### cli/command/container: remove deprecated formatting functions

These were deprecated in 907507e22ade8bdcec81922efe96c240c635f178 and
fdc90caeee3cc6c4d9a9569293b2283c8bc54463, which are part of the v28.4
release.

### cli/command/image: remove deprecated formatting functions

These were deprecated in 15cf4fa912cc6319110065d4f8c83cc6517ca8b2, which
is part of the v28.4 release.

### cli/command/network: remove deprecated formatting functions

These were deprecated in e3903a1ac8722714f8413ccdd28f4bb03b2cde0d, which
is part of the v28.4 release.

### cli/command/node: remove deprecated formatting functions

These were deprecated in 123ef81f7db4ec9e99083a8dc6aae00f3c9ecfcd, which
is part of the v28.4 release.

### cli/command/plugin: remove deprecated formatting functions

These were deprecated in bf47419852f5a41bc079b8f377091780f8bdfe63, which
is part of the v28.4 release.


### cli/command/registry: remove deprecated formatting functions

These were deprecated in 83371c2014711110aaf375c146ca0912a4a5ba85, which
is part of the v28.4 release.


### cli/command/secret: remove deprecated formatting functions

These were deprecated in f3088e37a071ef01fb6cb813e7ca0fce75c516ef, which
is part of the v28.4 release.


### cli/command/service: remove deprecated formatting functions

These were deprecated in 9f453d3fea42f46c779d4ed0df800e118724177c, which
is part of the v28.4 release.

### cli/command/task: remove deprecated formatting functions

These were deprecated in c3ee82fdc325d373e47b6cae733198334db492ff, which
is part of the v28.4 release.

### cli/command/trust: remove deprecated formatting functions

These were deprecated in 95c9b1b13bfd064d1d6d4f2a637862c0564ac237, which
is part of the v28.4 release.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/checkpoint: remove deprecated `NewFormat`, `FormatWrite`.
Go SDK: cli/command/config: remove deprecated `NewFormat`, `FormatWrite`, `InspectFormatWrite`.
Go SDK: cli/command/container: remove deprecated `NewDiffFormat`, `DiffFormatWrite`.
Go SDK: cli/command/image: remove deprecated `NewHistoryFormat`, `HistoryWrite`.
Go SDK: cli/command/image: remove deprecated `NewHistoryFormat`, `HistoryWrite`.
Go SDK: cli/command/network: remove deprecated `NewFormat`, `FormatWrite`.
Go SDK: cli/command/node: remove deprecated `NewFormat`, `FormatWrite`, `InspectFormatWrite`.
Go SDK: cli/command/plugin: remove deprecated `NewFormat`, `FormatWrite`.
Go SDK: cli/command/registry: remove deprecated `NewSearchFormat`, `SearchWrite`.
Go SDK: cli/command/secret: remove deprecated `NewFormat`, `FormatWrite`, `InspectFormatWrite`.
Go SDK: cli/command/service: remove deprecated `NewFormat`, `InspectFormatWrite`.
Go SDK: cli/command/task: remove deprecated `NewTaskFormat`, `FormatWrite`
Go SDK: cli/command/trust: remove deprecated `SignedTagInfo`, `SignerInfo`, `NewTrustTagFormat`, `NewSignerInfoFormat`, `TagWrite`, `SignerInfoWrite`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

