### PR TITLE
[28.x backport] cli/command/plugin: fix linting issues, and assorted cleanups

### DIFF
--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -40,7 +40,7 @@ func validateConfig(path string) error {
 	return err
 }
 
-// validateContextDir validates the given dir and returns abs path on success.
+// validateContextDir validates the given dir and returns its absolute path on success.
 func validateContextDir(contextDir string) (string, error) {
 	absContextDir, err := filepath.Abs(contextDir)
 	if err != nil {

--- a/cli/command/plugin/disable.go
+++ b/cli/command/plugin/disable.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/docker/cli/cli"
@@ -10,27 +9,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDisableCommand(dockerCli command.Cli) *cobra.Command {
-	var force bool
+func newDisableCommand(dockerCLI command.Cli) *cobra.Command {
+	var opts types.PluginDisableOptions
 
 	cmd := &cobra.Command{
 		Use:   "disable [OPTIONS] PLUGIN",
 		Short: "Disable a plugin",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDisable(cmd.Context(), dockerCli, args[0], force)
+			name := args[0]
+			if err := dockerCLI.Client().PluginDisable(cmd.Context(), name, opts); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(dockerCLI.Out(), name)
+			return nil
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.BoolVarP(&force, "force", "f", false, "Force the disable of an active plugin")
+	flags.BoolVarP(&opts.Force, "force", "f", false, "Force the disable of an active plugin")
 	return cmd
-}
-
-func runDisable(ctx context.Context, dockerCli command.Cli, name string, force bool) error {
-	if err := dockerCli.Client().PluginDisable(ctx, name, types.PluginDisableOptions{Force: force}); err != nil {
-		return err
-	}
-	fmt.Fprintln(dockerCli.Out(), name)
-	return nil
 }

--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -11,38 +11,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type enableOpts struct {
-	timeout int
-	name    string
-}
-
 func newEnableCommand(dockerCli command.Cli) *cobra.Command {
-	var opts enableOpts
+	var opts types.PluginEnableOptions
 
 	cmd := &cobra.Command{
 		Use:   "enable [OPTIONS] PLUGIN",
 		Short: "Enable a plugin",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.name = args[0]
-			return runEnable(cmd.Context(), dockerCli, &opts)
+			name := args[0]
+			if err := runEnable(cmd.Context(), dockerCli, name, opts); err != nil {
+				return err
+			}
+			_, _ = fmt.Fprintln(dockerCli.Out(), name)
+			return nil
 		},
 	}
 
 	flags := cmd.Flags()
-	flags.IntVar(&opts.timeout, "timeout", 30, "HTTP client timeout (in seconds)")
+	flags.IntVar(&opts.Timeout, "timeout", 30, "HTTP client timeout (in seconds)")
 	return cmd
 }
 
-func runEnable(ctx context.Context, dockerCli command.Cli, opts *enableOpts) error {
-	name := opts.name
-	if opts.timeout < 0 {
-		return errors.Errorf("negative timeout %d is invalid", opts.timeout)
+func runEnable(ctx context.Context, dockerCli command.Cli, name string, opts types.PluginEnableOptions) error {
+	if opts.Timeout < 0 {
+		return errors.Errorf("negative timeout %d is invalid", opts.Timeout)
 	}
-
-	if err := dockerCli.Client().PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: opts.timeout}); err != nil {
-		return err
-	}
-	fmt.Fprintln(dockerCli.Out(), name)
-	return nil
+	return dockerCli.Client().PluginEnable(ctx, name, opts)
 }

--- a/cli/command/plugin/enable_test.go
+++ b/cli/command/plugin/enable_test.go
@@ -48,7 +48,7 @@ func TestPluginEnableErrors(t *testing.T) {
 		}))
 		cmd.SetArgs(tc.args)
 		for key, value := range tc.flags {
-			cmd.Flags().Set(key, value)
+			assert.NilError(t, cmd.Flags().Set(key, value))
 		}
 		cmd.SetOut(io.Discard)
 		cmd.SetErr(io.Discard)

--- a/cli/command/plugin/formatter.go
+++ b/cli/command/plugin/formatter.go
@@ -12,6 +12,12 @@ const (
 
 	enabledHeader  = "ENABLED"
 	pluginIDHeader = "ID"
+
+	rawFormat = `plugin_id: {{.ID}}
+name: {{.Name}}
+description: {{.Description}}
+enabled: {{.Enabled}}
+`
 )
 
 // NewFormat returns a Format for rendering using a plugin Context
@@ -26,7 +32,7 @@ func NewFormat(source string, quiet bool) formatter.Format {
 		if quiet {
 			return `plugin_id: {{.ID}}`
 		}
-		return `plugin_id: {{.ID}}\nname: {{.Name}}\ndescription: {{.Description}}\nenabled: {{.Enabled}}\n`
+		return rawFormat
 	}
 	return formatter.Format(source)
 }

--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -36,11 +36,9 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	client := dockerCli.Client()
-	getRef := func(ref string) (any, []byte, error) {
-		return client.PluginInspectWithRaw(ctx, ref)
-	}
-
-	return inspect.Inspect(dockerCli.Out(), opts.pluginNames, opts.format, getRef)
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	apiClient := dockerCLI.Client()
+	return inspect.Inspect(dockerCLI.Out(), opts.pluginNames, opts.format, func(ref string) (any, []byte, error) {
+		return apiClient.PluginInspectWithRaw(ctx, ref)
+	})
 }

--- a/cli/command/plugin/inspect_test.go
+++ b/cli/command/plugin/inspect_test.go
@@ -21,14 +21,14 @@ var pluginFoo = &types.Plugin{
 		Documentation: "plugin foo documentation",
 		Entrypoint:    []string{"/foo"},
 		Interface: types.PluginConfigInterface{
-			Socket: "pluginfoo.sock",
+			Socket: "plugin-foo.sock",
 		},
 		Linux: types.PluginConfigLinux{
 			Capabilities: []string{"CAP_SYS_ADMIN"},
 		},
 		WorkDir: "workdir-foo",
 		Rootfs: &types.PluginConfigRootfs{
-			DiffIds: []string{"sha256:8603eedd4ea52cebb2f22b45405a3dc8f78ba3e31bf18f27b4547a9ff930e0bd"},
+			DiffIds: []string{"sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
 			Type:    "layers",
 		},
 	},
@@ -71,7 +71,7 @@ func TestInspectErrors(t *testing.T) {
 			cmd := newInspectCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.NilError(t, cmd.Flags().Set(key, value))
 			}
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
@@ -142,7 +142,7 @@ func TestInspect(t *testing.T) {
 			cmd := newInspectCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.NilError(t, cmd.Flags().Set(key, value))
 			}
 			assert.NilError(t, cmd.Execute())
 			golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -125,7 +125,9 @@ func runInstall(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 		}
 		return err
 	}
-	defer responseBody.Close()
+	defer func() {
+		_ = responseBody.Close()
+	}()
 	if err := jsonstream.Display(ctx, responseBody, dockerCLI.Out()); err != nil {
 		return err
 	}

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -32,7 +32,7 @@ func TestInstallErrors(t *testing.T) {
 		},
 		{
 			description:   "invalid plugin name",
-			args:          []string{"UPPERCASE_REPONAME"},
+			args:          []string{"UPPERCASE_REPO_NAME"},
 			expectedError: "invalid",
 		},
 		{

--- a/cli/command/plugin/list_test.go
+++ b/cli/command/plugin/list_test.go
@@ -51,7 +51,7 @@ func TestListErrors(t *testing.T) {
 			cmd := newListCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.NilError(t, cmd.Flags().Set(key, value))
 			}
 			cmd.SetOut(io.Discard)
 			cmd.SetErr(io.Discard)
@@ -170,7 +170,7 @@ func TestList(t *testing.T) {
 			cmd := newListCommand(cli)
 			cmd.SetArgs(tc.args)
 			for key, value := range tc.flags {
-				cmd.Flags().Set(key, value)
+				assert.NilError(t, cmd.Flags().Set(key, value))
 			}
 			assert.NilError(t, cmd.Execute())
 			golden.Assert(t, cli.OutBuffer().String(), tc.golden)

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -60,7 +60,9 @@ func runPush(ctx context.Context, dockerCli command.Cli, opts pushOptions) error
 	if err != nil {
 		return err
 	}
-	defer responseBody.Close()
+	defer func() {
+		_ = responseBody.Close()
+	}()
 
 	if !opts.untrusted {
 		repoInfo := &trust.RepositoryInfo{

--- a/cli/command/plugin/remove_test.go
+++ b/cli/command/plugin/remove_test.go
@@ -64,7 +64,7 @@ func TestRemoveWithForceOption(t *testing.T) {
 	})
 	cmd := newRemoveCommand(cli)
 	cmd.SetArgs([]string{"plugin-foo"})
-	cmd.Flags().Set("force", "true")
+	assert.NilError(t, cmd.Flags().Set("force", "true"))
 	assert.NilError(t, cmd.Execute())
 	assert.Check(t, force)
 	assert.Check(t, is.Equal("plugin-foo\n", cli.OutBuffer().String()))

--- a/cli/command/plugin/set.go
+++ b/cli/command/plugin/set.go
@@ -7,7 +7,7 @@ import (
 )
 
 func newSetCommand(dockerCli command.Cli) *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "set PLUGIN KEY=VALUE [KEY=VALUE...]",
 		Short: "Change settings for a plugin",
 		Args:  cli.RequiresMinArgs(2),
@@ -15,6 +15,4 @@ func newSetCommand(dockerCli command.Cli) *cobra.Command {
 			return dockerCli.Client().PluginSet(cmd.Context(), args[0], args[1:])
 		},
 	}
-
-	return cmd
 }

--- a/cli/command/plugin/testdata/plugin-inspect-single-without-format.golden
+++ b/cli/command/plugin/testdata/plugin-inspect-single-without-format.golden
@@ -15,7 +15,7 @@
             ],
             "Env": null,
             "Interface": {
-                "Socket": "pluginfoo.sock",
+                "Socket": "plugin-foo.sock",
                 "Types": null
             },
             "IpcHost": false,
@@ -36,7 +36,7 @@
             "WorkDir": "workdir-foo",
             "rootfs": {
                 "diff_ids": [
-                    "sha256:8603eedd4ea52cebb2f22b45405a3dc8f78ba3e31bf18f27b4547a9ff930e0bd"
+                    "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
                 ],
                 "type": "layers"
             }

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -85,7 +85,9 @@ func runUpgrade(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 		}
 		return err
 	}
-	defer responseBody.Close()
+	defer func() {
+		_ = responseBody.Close()
+	}()
 	if err := jsonstream.Display(ctx, responseBody, dockerCLI.Out()); err != nil {
 		return err
 	}


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6213

-----

- fix various unhandled errors
- remove some locally defined option-types in favor of option-types defined by the client / api
- don't use unkeyed structs in tests, and add docs for some subtests
- fix some values in tests that triggered "spellcheck" warnings
- inline vars / functions that only had a single use.


(cherry picked from commit c6f935eba503c9ad7b5c5b42078b910a08ce72d3)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

