### PR TITLE
cli/command/trust: remove deprecated NewPruneCommand

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -32,13 +32,6 @@ type pruneOptions struct {
 	keepStorage opts.MemBytes
 }
 
-// NewPruneCommand returns a new cobra prune command for images
-//
-// Deprecated: Do not import commands directly. They will be removed in a future release.
-func NewPruneCommand(dockerCli command.Cli) *cobra.Command {
-	return newPruneCommand(dockerCli)
-}
-
 // newPruneCommand returns a new cobra prune command for images
 func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/6342

----

These were deprecated in 7032f5922e4f49648b684b97b700c527fbcd3edf, which
is part of the v28.4 release.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/trust: remove deprecated `NewPruneCommand`
```

**- A picture of a cute animal (not mandatory but encouraged)**

