### PR TITLE
cli/command: remove deprecated RegistryAuthenticationPrivilegedFunc

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -34,34 +34,6 @@ const (
 // [registry.IndexServer]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/registry#IndexServer
 const authConfigKey = "https://index.docker.io/v1/"
 
-// RegistryAuthenticationPrivilegedFunc returns a RequestPrivilegeFunc from the specified registry index info
-// for the given command to prompt the user for username and password.
-//
-// Deprecated: this function is no longer used and will be removed in the next release.
-func RegistryAuthenticationPrivilegedFunc(cli Cli, index *registrytypes.IndexInfo, cmdName string) registrytypes.RequestAuthConfig {
-	configKey := getAuthConfigKey(index.Name)
-	isDefaultRegistry := configKey == authConfigKey || index.Official
-	return func(ctx context.Context) (string, error) {
-		_, _ = fmt.Fprintf(cli.Out(), "\nLogin prior to %s:\n", cmdName)
-		authConfig, err := GetDefaultAuthConfig(cli.ConfigFile(), true, configKey, isDefaultRegistry)
-		if err != nil {
-			_, _ = fmt.Fprintf(cli.Err(), "Unable to retrieve stored credentials for %s, error: %s.\n", configKey, err)
-		}
-
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-		}
-
-		authConfig, err = PromptUserForCredentials(ctx, cli, "", "", authConfig.Username, configKey)
-		if err != nil {
-			return "", err
-		}
-		return registrytypes.EncodeAuthConfig(authConfig)
-	}
-}
-
 // ResolveAuthConfig returns auth-config for the given registry from the
 // credential-store. It returns an empty AuthConfig if no credentials were
 // found.


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6184

This function was deprecated in 29263e865b2d309753759b26fcbe16d94a8f25e3 and is no longer used.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: remove deprecated `RegistryAuthenticationPrivilegedFunc`
```

**- A picture of a cute animal (not mandatory but encouraged)**

