### PR TITLE
cli/config/configfile: inline getConfiguredCredentialStore

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -319,10 +319,12 @@ func decodeAuth(authStr string) (string, string, error) {
 // GetCredentialsStore returns a new credentials store from the settings in the
 // configuration file
 func (c *ConfigFile) GetCredentialsStore(registryHostname string) credentials.Store {
-	store := credentials.NewFileStore(c)
-
-	if helper := getConfiguredCredentialStore(c, getAuthConfigKey(registryHostname)); helper != "" {
+	var store credentials.Store
+	acKey := getAuthConfigKey(registryHostname)
+	if helper, ok := c.CredentialHelpers[acKey]; ok && helper != "" {
 		store = newNativeStore(c, helper)
+	} else {
+		store = credentials.NewFileStore(c)
 	}
 
 	envConfig := os.Getenv(DockerEnvConfigKey)
@@ -388,18 +390,6 @@ var newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentia
 func (c *ConfigFile) GetAuthConfig(registryHostname string) (types.AuthConfig, error) {
 	acKey := getAuthConfigKey(registryHostname)
 	return c.GetCredentialsStore(acKey).Get(acKey)
-}
-
-// getConfiguredCredentialStore returns the credential helper configured for the
-// given registry, the default credsStore, or the empty string if neither are
-// configured.
-func getConfiguredCredentialStore(c *ConfigFile, registryHostname string) string {
-	if c.CredentialHelpers != nil && registryHostname != "" {
-		if helper, exists := c.CredentialHelpers[registryHostname]; exists {
-			return helper
-		}
-	}
-	return c.CredentialsStore
 }
 
 // GetAllCredentials returns all of the credentials stored in all of the


### PR DESCRIPTION
I have some more changes in this area, but need to dust it off; let's open these already as a PR 😅 

### cli/config/configfile: inline getConfiguredCredentialStore

It was a premature abstraction; the "nil" check for the map was redundant,
making it literally a 1-liner, so just inline it.




**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

