### PR TITLE
[28.x backport] internal/jsonstream: remove uses of deprecated fields

### DIFF
--- a/internal/jsonstream/display_test.go
+++ b/internal/jsonstream/display_test.go
@@ -30,10 +30,8 @@ func TestDisplay(t *testing.T) {
 				return
 			default:
 				err := enc.Encode(JSONMessage{
-					Status:   "Downloading",
-					ID:       fmt.Sprintf("id-%d", i),
-					TimeNano: time.Now().UnixNano(),
-					Time:     time.Now().Unix(),
+					Status: "Downloading",
+					ID:     fmt.Sprintf("id-%d", i),
 					Progress: &JSONProgress{
 						Current: int64(i),
 						Total:   100,


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6353
- relates to https://github.com/moby/moby/pull/50759
- relates to https://github.com/moby/moby/pull/50762

(cherry picked from commit 045ac0b159e8bddb7d18eff8969fe8985e15947b)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

