### PR TITLE
cli/command/image: remove exported RunPull, PullOptions

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -14,9 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// PullOptions defines what and how to pull
-type PullOptions = pullOptions
-
 // pullOptions defines what and how to pull.
 type pullOptions struct {
 	remote    string
@@ -56,11 +53,6 @@ func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 
 	return cmd
-}
-
-// RunPull performs a pull against the engine based on the specified options
-func RunPull(ctx context.Context, dockerCLI command.Cli, opts PullOptions) error {
-	return runPull(ctx, dockerCLI, opts)
 }
 
 // runPull performs a pull against the engine based on the specified options


### PR DESCRIPTION
Relates to;

- https://github.com/docker/cli/pull/1026
- https://github.com/docker/cli/pull/1026#discussion_r184953072


These were exported in 812f1136850f6c18bbe3f1b2a960a8ff8a8413f3, but while the function and options are exported, the option-fields were all un-exported, so these were not usable.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

