### PR TITLE
cli/command/image: deprecate AuthResolver and un-export

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -78,7 +78,7 @@ func runPull(ctx context.Context, dockerCLI command.Cli, opts pullOptions) error
 		}
 	}
 
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(dockerCLI), distributionRef.String())
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), distributionRef.String())
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/common.go
+++ b/cli/command/trust/common.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/trust"
 	"github.com/fvbommel/sortorder"
+	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary"
 	"github.com/theupdateframework/notary/client"
@@ -66,7 +67,7 @@ func newNotaryClient(cli command.Streams, imgRefAndAuth trust.ImageRefAndAuth, a
 // lookupTrustInfo returns processed signature and role information about a notary repository.
 // This information is to be pretty printed or serialized into a machine-readable format.
 func lookupTrustInfo(ctx context.Context, cli command.Cli, remote string) ([]trustTagRow, []client.RoleWithSignatures, []data.Role, error) {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(cli), remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(cli), remote)
 	if err != nil {
 		return []trustTagRow{}, []client.RoleWithSignatures{}, []data.Role{}, err
 	}
@@ -166,4 +167,11 @@ func matchReleasedSignatures(allTargets []client.TargetSignedStruct) []trustTagR
 		return sortorder.NaturalLess(signatureRows[i].SignedTag, signatureRows[j].SignedTag)
 	})
 	return signatureRows
+}
+
+// authResolver returns an auth resolver function from a [config.Provider].
+func authResolver(dockerCLI config.Provider) func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
+	return func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
+		return command.ResolveAuthConfig(dockerCLI.ConfigFile(), index)
+	}
 }

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/spf13/cobra"
@@ -35,7 +34,7 @@ func newRevokeCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 func revokeTrust(ctx context.Context, dockerCLI command.Cli, remote string, options revokeOptions) error {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), remote)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -12,7 +12,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	imagetypes "github.com/moby/moby/api/types/image"
 	registrytypes "github.com/moby/moby/api/types/registry"
@@ -45,7 +44,7 @@ func newSignCommand(dockerCLI command.Cli) *cobra.Command {
 
 func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOptions) error {
 	imageName := options.imageName
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), imageName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), imageName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/lazyregexp"
 	"github.com/docker/cli/opts"
@@ -80,7 +79,7 @@ func addSigner(ctx context.Context, dockerCLI command.Cli, options signerAddOpti
 }
 
 func addSignerToRepo(ctx context.Context, dockerCLI command.Cli, signerName string, repoName string, signerPubKeys []data.PublicKey) error {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), repoName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/spf13/cobra"
@@ -91,7 +90,7 @@ func maybePromptForSignerRemoval(ctx context.Context, dockerCLI command.Cli, rep
 // removeSingleSigner attempts to remove a single signer and returns whether signer removal happened.
 // The signer not being removed doesn't necessarily raise an error e.g. user choosing "No" when prompted for confirmation.
 func removeSingleSigner(ctx context.Context, dockerCLI command.Cli, repoName, signerName string, forceYes bool) (bool, error) {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), repoName)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This function was exported to share it between "trust" and "image", but was only a shallow wrapper, so split the implementations where used.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/image: deprecate `AuthResolver` utlity
```

**- A picture of a cute animal (not mandatory but encouraged)**

