### PR TITLE
[28.x backport] cli/command/image: deprecate AuthResolver and un-export

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -85,7 +85,7 @@ func runPull(ctx context.Context, dockerCLI command.Cli, opts pullOptions) error
 		}
 	}
 
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, AuthResolver(dockerCLI), distributionRef.String())
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), distributionRef.String())
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/pkg/errors"
@@ -35,7 +34,7 @@ func newRevokeCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 func revokeTrust(ctx context.Context, dockerCLI command.Cli, remote string, options revokeOptions) error {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), remote)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), remote)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -11,7 +11,6 @@ import (
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	imagetypes "github.com/docker/docker/api/types/image"
 	registrytypes "github.com/docker/docker/api/types/registry"
@@ -45,7 +44,7 @@ func newSignCommand(dockerCLI command.Cli) *cobra.Command {
 
 func runSignImage(ctx context.Context, dockerCLI command.Cli, options signOptions) error {
 	imageName := options.imageName
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), imageName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), imageName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/lazyregexp"
 	"github.com/docker/cli/opts"
@@ -80,7 +79,7 @@ func addSigner(ctx context.Context, dockerCLI command.Cli, options signerAddOpti
 }
 
 func addSignerToRepo(ctx context.Context, dockerCLI command.Cli, signerName string, repoName string, signerPubKeys []data.PublicKey) error {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), repoName)
 	if err != nil {
 		return err
 	}

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/pkg/errors"
@@ -91,7 +90,7 @@ func maybePromptForSignerRemoval(ctx context.Context, dockerCLI command.Cli, rep
 // removeSingleSigner attempts to remove a single signer and returns whether signer removal happened.
 // The signer not being removed doesn't necessarily raise an error e.g. user choosing "No" when prompted for confirmation.
 func removeSingleSigner(ctx context.Context, dockerCLI command.Cli, repoName, signerName string, forceYes bool) (bool, error) {
-	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, image.AuthResolver(dockerCLI), repoName)
+	imgRefAndAuth, err := trust.GetImageReferencesAndAuth(ctx, authResolver(dockerCLI), repoName)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6356

This function was exported to share it between "trust" and "image", but was only a shallow wrapper, so split the implementations where used.


(cherry picked from commit 7ad113ccc2c958f4bd39db9d22783678ccbcb044)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/image: deprecate `AuthResolver` utility
```

**- A picture of a cute animal (not mandatory but encouraged)**

