### PR TITLE
cli/trust: some cleanups

### DIFF
--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -346,9 +346,9 @@ func GetImageReferencesAndAuth(ctx context.Context,
 
 func getTag(ref reference.Named) string {
 	switch x := ref.(type) {
-	case reference.Canonical, reference.Digested:
-		return ""
-	case reference.NamedTagged:
+	case reference.Digested:
+		return "" // TODO(thaJeztah): is it intentional to discard the tag when "Tagged+Digested"?
+	case reference.Tagged:
 		return x.Tag()
 	default:
 		return ""
@@ -357,12 +357,10 @@ func getTag(ref reference.Named) string {
 
 func getDigest(ref reference.Named) digest.Digest {
 	switch x := ref.(type) {
-	case reference.Canonical:
-		return x.Digest()
 	case reference.Digested:
 		return x.Digest()
 	default:
-		return digest.Digest("")
+		return ""
 	}
 }
 

--- a/cli/trust/trust_push.go
+++ b/cli/trust/trust_push.go
@@ -63,9 +63,9 @@ func PushTrustedReference(ctx context.Context, ioStreams Streams, repoInfo *Repo
 
 	var tag string
 	switch x := ref.(type) {
-	case reference.Canonical:
+	case reference.Digested:
 		return errors.New("cannot push a digest reference")
-	case reference.NamedTagged:
+	case reference.Tagged:
 		tag = x.Tag()
 	default:
 		// We want trust signatures to always take an explicit tag,


### PR DESCRIPTION
This was part of some other changes I was working on; let's push these bits already;

### cli/trust: check for Digested, Tagged reference instead of Canonical

The [Canonical] interface defines images that are both [Named] and
[Digested], but in all places where it was used, we were only interested
whether the reference contained a digest. Similarly [NamedTagged] is
a superset of [Tagged], so checking for [Tagged] is sufficient if we're
already dealing with a [Named] reference.

This patch changes those checks to check for [Digested] and [Tagged]
references, as that's what's relevant for these checks.

[Named]: https://pkg.go.dev/github.com/distribution/reference#Named
[NamedTagged]: https://pkg.go.dev/github.com/distribution/reference#NamedTagged
[Canonical]: https://pkg.go.dev/github.com/distribution/reference#Canonical
[Digested]: https://pkg.go.dev/github.com/distribution/reference#Digested


### cli/trust: GetNotaryRepository: inline variables