### PR TITLE
feat(service): support comma-separated values for host-to-IP mappings

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -95,7 +95,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.SetAnnotation(flagDNSOptionAdd, "version", []string{"1.25"})
 	flags.Var(&options.dnsSearch, flagDNSSearchAdd, "Add or update a custom DNS search domain")
 	flags.SetAnnotation(flagDNSSearchAdd, "version", []string{"1.25"})
-	flags.Var(&options.hosts, flagHostAdd, `Add a custom host-to-IP mapping ("host:ip")`)
+	flags.Var(opts.NewListOptsCSV(&options.hosts), flagHostAdd, `Add a custom host-to-IP mapping ("host:ip")`)
 	flags.SetAnnotation(flagHostAdd, "version", []string{"1.25"})
 	flags.BoolVar(&options.init, flagInit, false, "Use an init inside each service container to forward signals and reap processes")
 	flags.SetAnnotation(flagInit, "version", []string{"1.37"})
@@ -1235,7 +1235,7 @@ func updateHosts(flags *pflag.FlagSet, hosts *[]string) error {
 
 	// Append new hosts (in SwarmKit format)
 	if flags.Changed(flagHostAdd) {
-		values := convertExtraHostsToSwarmHosts(flags.Lookup(flagHostAdd).Value.(*opts.ListOpts).GetSlice())
+		values := convertExtraHostsToSwarmHosts(flags.Lookup(flagHostAdd).Value.(pflag.SliceValue).GetSlice())
 		newHosts = append(newHosts, values...)
 	}
 	*hosts = removeDuplicates(newHosts)

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -388,6 +388,7 @@ func TestUpdateHealthcheckTable(t *testing.T) {
 
 func TestUpdateHosts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
+	flags.Set("host-add", "a:1.1.1.1,b:2.2.2.2")
 	flags.Set("host-add", "example.net:2.2.2.2")
 	flags.Set("host-add", "ipv6.net:2001:db8:abc8::1")
 	// adding the special "host-gateway" target should work
@@ -402,7 +403,7 @@ func TestUpdateHosts(t *testing.T) {
 	assert.ErrorContains(t, flags.Set("host-add", "$example.com$"), `bad format for add-host: "$example.com$"`)
 
 	hosts := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2001:db8:abc8::1 example.net", "gateway.docker.internal:host-gateway"}
-	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net", "host-gateway host.docker.internal"}
+	expected := []string{"1.2.3.4 example.com", "4.3.2.1 example.org", "1.1.1.1 a", "2.2.2.2 b", "2.2.2.2 example.net", "2001:db8:abc8::1 ipv6.net", "host-gateway host.docker.internal"}
 
 	err := updateHosts(flags, &hosts)
 	assert.NilError(t, err)

--- a/docs/reference/commandline/service_update.md
+++ b/docs/reference/commandline/service_update.md
@@ -39,8 +39,8 @@ Update a service
 | `--health-start-interval`                     | `duration`        |         | Time between running the check during the start period (ms\|s\|m\|h)                                |
 | `--health-start-period`                       | `duration`        |         | Start period for the container to initialize before counting retries towards unstable (ms\|s\|m\|h) |
 | `--health-timeout`                            | `duration`        |         | Maximum time to allow one check to run (ms\|s\|m\|h)                                                |
-| `--host-add`                                  | `list`            |         | Add a custom host-to-IP mapping (`host:ip`)                                                         |
-| `--host-rm`                                   | `list`            |         | Remove a custom host-to-IP mapping (`host:ip`)                                                      |
+| `--host-add`                                  | `list`            |         | Add a custom host-to-IP mapping (`host:ip`). Multiple entries can be separated by comma |
+| `--host-rm`                                   | `list`            |         | Remove a custom host-to-IP mapping (`host:ip`) |
 | `--hostname`                                  | `string`          |         | Container hostname                                                                                  |
 | `--image`                                     | `string`          |         | Service image tag                                                                                   |
 | `--init`                                      | `bool`            |         | Use an init inside each service container to forward signals and reap processes                     |


### PR DESCRIPTION
PR Title: support comma-separated values for `--host-add` in `docker service update`

Closes https://github.com/moby/moby/issues/50769

**- What I did**

* Updated `--host-add` flag in `service update` to support comma-separated host mappings (e.g., `--host-add a:1.1.1.1,b:2.2.2.2`).
* Introduced `ListOptsCSV`, a wrapper around `ListOpts` that implements `pflag.SliceValue` for parsing comma-separated lists.
* Adjusted `updateHosts` to use `pflag.SliceValue` instead of `ListOpts`.
* Updated unit tests in `update_test.go` to cover multiple host mappings provided in a single flag instance.
* Updated CLI documentation to reflect support for comma-separated host mappings.

**- How I did it**

* Implemented a new `ListOptsCSV` type in `opts/opts.go` that handles splitting and validating comma-separated values.
* Switched `flags.Var(&options.hosts, flagHostAdd, ...)` to use `opts.NewListOptsCSV(&options.hosts)` in `update.go`.
* Updated `updateHosts` to retrieve values via `pflag.SliceValue`.
* Modified the `service update` reference docs to note that multiple entries can be separated by commas.

**- How to verify it**

1. Run `docker service update --host-add a:1.1.1.1,b:2.2.2.2 <service>`.
2. Inspect the service to confirm that both mappings (`a → 1.1.1.1` and `b → 2.2.2.2`) are applied.
3. Check that existing behavior (multiple `--host-add` flags) still works as expected.
4. Run updated unit tests: `go test ./cli/command/service/...`.

**- Human readable description for the release notes**

```markdown changelog
Added support for specifying multiple `--host-add` entries in a single flag instance using comma-separated values in `docker service update`.
```

**- A picture of a cute animal (not mandatory but encouraged)**
🦦
