### PR TITLE
cli/config/types: update deprecation comment for AuthConfig.Email

### DIFF
--- a/cli/config/credentials/file_store_test.go
+++ b/cli/config/credentials/file_store_test.go
@@ -43,13 +43,13 @@ func TestFileStoreIdempotent(t *testing.T) {
 		},
 	})
 	authOne := types.AuthConfig{
+		Username:      "foo@example.com",
 		Auth:          "super_secret_token",
-		Email:         "foo@example.com",
 		ServerAddress: "https://example.com",
 	}
 	authTwo := types.AuthConfig{
+		Username:      "bar@example.com",
 		Auth:          "also_super_secret_token",
-		Email:         "bar@example.com",
 		ServerAddress: "https://other.example.com",
 	}
 
@@ -106,8 +106,8 @@ func TestFileStoreAddCredentials(t *testing.T) {
 
 	s := NewFileStore(f)
 	auth := types.AuthConfig{
+		Username:      "foo@example.com",
 		Auth:          "super_secret_token",
-		Email:         "foo@example.com",
 		ServerAddress: "https://example.com",
 	}
 	err := s.Store(auth)
@@ -122,8 +122,8 @@ func TestFileStoreAddCredentials(t *testing.T) {
 func TestFileStoreGet(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
 		"https://example.com": {
+			Username:      "foo@example.com",
 			Auth:          "super_secret_token",
-			Email:         "foo@example.com",
 			ServerAddress: "https://example.com",
 		},
 	}}
@@ -136,8 +136,8 @@ func TestFileStoreGet(t *testing.T) {
 	if a.Auth != "super_secret_token" {
 		t.Fatalf("expected auth `super_secret_token`, got %s", a.Auth)
 	}
-	if a.Email != "foo@example.com" {
-		t.Fatalf("expected email `foo@example.com`, got %s", a.Email)
+	if a.Username != "foo@example.com" {
+		t.Fatalf("expected username `foo@example.com`, got %s", a.Username)
 	}
 }
 
@@ -146,13 +146,13 @@ func TestFileStoreGetAll(t *testing.T) {
 	s2 := "https://example2.example.com"
 	f := &fakeStore{configs: map[string]types.AuthConfig{
 		s1: {
+			Username:      "foo@example.com",
 			Auth:          "super_secret_token",
-			Email:         "foo@example.com",
 			ServerAddress: "https://example.com",
 		},
 		s2: {
+			Username:      "foo@example2.com",
 			Auth:          "super_secret_token2",
-			Email:         "foo@example2.com",
 			ServerAddress: "https://example2.example.com",
 		},
 	}}
@@ -168,22 +168,22 @@ func TestFileStoreGetAll(t *testing.T) {
 	if as[s1].Auth != "super_secret_token" {
 		t.Fatalf("expected auth `super_secret_token`, got %s", as[s1].Auth)
 	}
-	if as[s1].Email != "foo@example.com" {
-		t.Fatalf("expected email `foo@example.com`, got %s", as[s1].Email)
+	if as[s1].Username != "foo@example.com" {
+		t.Fatalf("expected username `foo@example.com`, got %s", as[s1].Username)
 	}
 	if as[s2].Auth != "super_secret_token2" {
 		t.Fatalf("expected auth `super_secret_token2`, got %s", as[s2].Auth)
 	}
-	if as[s2].Email != "foo@example2.com" {
-		t.Fatalf("expected email `foo@example2.com`, got %s", as[s2].Email)
+	if as[s2].Username != "foo@example2.com" {
+		t.Fatalf("expected username `foo@example2.com`, got %s", as[s2].Username)
 	}
 }
 
 func TestFileStoreErase(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
 		"https://example.com": {
+			Username:      "foo@example.com",
 			Auth:          "super_secret_token",
-			Email:         "foo@example.com",
 			ServerAddress: "https://example.com",
 		},
 	}}
@@ -202,9 +202,6 @@ func TestFileStoreErase(t *testing.T) {
 
 	if a.Auth != "" {
 		t.Fatalf("expected empty auth token, got %s", a.Auth)
-	}
-	if a.Email != "" {
-		t.Fatalf("expected empty email, got %s", a.Email)
 	}
 }
 

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -99,7 +99,6 @@ func TestNativeStoreAddCredentials(t *testing.T) {
 	auth := types.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
-		Email:         "foo@example.com",
 		ServerAddress: validServerAddress,
 	}
 	err := s.Store(auth)
@@ -109,7 +108,6 @@ func TestNativeStoreAddCredentials(t *testing.T) {
 	actual, ok := f.GetAuthConfigs()[validServerAddress]
 	assert.Check(t, ok)
 	expected := types.AuthConfig{
-		Email:         auth.Email,
 		ServerAddress: auth.ServerAddress,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
@@ -124,7 +122,6 @@ func TestNativeStoreAddInvalidCredentials(t *testing.T) {
 	err := s.Store(types.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
-		Email:         "foo@example.com",
 		ServerAddress: invalidServerAddress,
 	})
 	assert.ErrorContains(t, err, "program failed")
@@ -134,7 +131,7 @@ func TestNativeStoreAddInvalidCredentials(t *testing.T) {
 func TestNativeStoreGet(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
 		validServerAddress: {
-			Email: "foo@example.com",
+			Username: "foo@example.com",
 		},
 	}}
 	s := &nativeStore{
@@ -147,7 +144,6 @@ func TestNativeStoreGet(t *testing.T) {
 	expected := types.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
-		Email:         "foo@example.com",
 		ServerAddress: validServerAddress,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
@@ -155,9 +151,7 @@ func TestNativeStoreGet(t *testing.T) {
 
 func TestNativeStoreGetIdentityToken(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress2: {
-			Email: "foo@example2.com",
-		},
+		validServerAddress2: {},
 	}}
 
 	s := &nativeStore{
@@ -169,7 +163,6 @@ func TestNativeStoreGetIdentityToken(t *testing.T) {
 
 	expected := types.AuthConfig{
 		IdentityToken: "abcd1234",
-		Email:         "foo@example2.com",
 		ServerAddress: validServerAddress2,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
@@ -177,9 +170,7 @@ func TestNativeStoreGetIdentityToken(t *testing.T) {
 
 func TestNativeStoreGetAll(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress: {
-			Email: "foo@example.com",
-		},
+		validServerAddress: {},
 	}}
 
 	s := &nativeStore{
@@ -189,38 +180,20 @@ func TestNativeStoreGetAll(t *testing.T) {
 	as, err := s.GetAll()
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(as, 2))
-
-	if as[validServerAddress].Username != "foo" {
-		t.Fatalf("expected username `foo` for %s, got %s", validServerAddress, as[validServerAddress].Username)
+	expected := types.AuthConfig{
+		Username:      "foo",
+		Password:      "bar",
+		ServerAddress: "https://index.docker.io/v1",
+		IdentityToken: "",
 	}
-	if as[validServerAddress].Password != "bar" {
-		t.Fatalf("expected password `bar` for %s, got %s", validServerAddress, as[validServerAddress].Password)
-	}
-	if as[validServerAddress].IdentityToken != "" {
-		t.Fatalf("expected identity to be empty for %s, got %s", validServerAddress, as[validServerAddress].IdentityToken)
-	}
-	if as[validServerAddress].Email != "foo@example.com" {
-		t.Fatalf("expected email `foo@example.com` for %s, got %s", validServerAddress, as[validServerAddress].Email)
-	}
-	if as[validServerAddress2].Username != "" {
-		t.Fatalf("expected username to be empty for %s, got %s", validServerAddress2, as[validServerAddress2].Username)
-	}
-	if as[validServerAddress2].Password != "" {
-		t.Fatalf("expected password to be empty for %s, got %s", validServerAddress2, as[validServerAddress2].Password)
-	}
-	if as[validServerAddress2].IdentityToken != "abcd1234" {
-		t.Fatalf("expected identity token `abcd1324` for %s, got %s", validServerAddress2, as[validServerAddress2].IdentityToken)
-	}
-	if as[validServerAddress2].Email != "" {
-		t.Fatalf("expected no email for %s, got %s", validServerAddress2, as[validServerAddress2].Email)
-	}
+	actual, ok := as[validServerAddress]
+	assert.Check(t, ok)
+	assert.Check(t, is.DeepEqual(expected, actual))
 }
 
 func TestNativeStoreGetMissingCredentials(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress: {
-			Email: "foo@example.com",
-		},
+		validServerAddress: {},
 	}}
 
 	s := &nativeStore{
@@ -233,9 +206,7 @@ func TestNativeStoreGetMissingCredentials(t *testing.T) {
 
 func TestNativeStoreGetInvalidAddress(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress: {
-			Email: "foo@example.com",
-		},
+		validServerAddress: {},
 	}}
 
 	s := &nativeStore{
@@ -248,9 +219,7 @@ func TestNativeStoreGetInvalidAddress(t *testing.T) {
 
 func TestNativeStoreErase(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress: {
-			Email: "foo@example.com",
-		},
+		validServerAddress: {},
 	}}
 
 	s := &nativeStore{
@@ -264,9 +233,7 @@ func TestNativeStoreErase(t *testing.T) {
 
 func TestNativeStoreEraseInvalidAddress(t *testing.T) {
 	f := &fakeStore{configs: map[string]types.AuthConfig{
-		validServerAddress: {
-			Email: "foo@example.com",
-		},
+		validServerAddress: {},
 	}}
 
 	s := &nativeStore{

--- a/cli/config/types/authconfig.go
+++ b/cli/config/types/authconfig.go
@@ -7,8 +7,8 @@ type AuthConfig struct {
 	Auth     string `json:"auth,omitempty"`
 
 	// Email is an optional value associated with the username.
-	// This field is deprecated and will be removed in a later
-	// version of docker.
+	//
+	// Deprecated: This field is deprecated since docker 1.11 (API v1.23) and will be removed in the next release.
 	Email string `json:"email,omitempty"`
 
 	ServerAddress string `json:"serveraddress,omitempty"`


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/50792
- https://github.com/docker/cli/pull/1642
- https://github.com/moby/moby/issues/6400
- https://github.com/moby/moby/pull/16183
- https://github.com/moby/moby/pull/20565
- https://github.com/docker-archive-public/docker.engine-api/pull/105
- https://github.com/docker-archive-public/docker.engine-api/pull/115


Relates to [cli@27b2797], which forked this type from the Moby API, and [moby@6cfff7e], which made the same change on the API side.

The Email field was originally used to create a new Docker Hub account through the `docker login` command. The `docker login` command could be used both to log in to an existing account (providing only username and password), or to create a new account (providing desired username and password, and an e-mail address to use for the new account).

This functionality was confusing, because it was implemented when Docker Hub was the only registry, but the same functionality could not be used for other registries. This functionality was removed in Docker 1.11 (API version 1.23) through [moby@aee260d], which also removed the Email field ([engine-api@9a9e468]) as it was no longer used.

However, this caused issues when using a new CLI connecting with an old daemon, as the field would no longer be serialized, and the deprecation may not yet be picked up by custom registries, so [engine-api@167efc7] added the field back, deprecated it, and added an "omitempty". There was no official "deprecated" format yet at the time, so let's make sure the deprecation follows the proper format to make sure it gets noticed.

[cli@27b2797]: https://github.com/docker/cli/commit/27b2797f7deb3ca5b7f80371d825113deb1faca1
[moby@6cfff7e]: https://github.com/moby/moby/commit/6cfff7e8803a71b4acb74768b5121e7d17a9e098
[moby@aee260d]: https://github.com/moby/moby/commit/aee260d4eb3aa0fc86ee5038010b7bbc24512ae5
[engine-api@9a9e468]: https://github.com/docker-archive-public/docker.engine-api/commit/9a9e468f503eb731d6fdc9d7f98c122e1b397c86
[engine-api@167efc7]: https://github.com/docker-archive-public/docker.engine-api/commit/167efc72bb24d7ad2bcc91760a9a5d37572e104f

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/config/types: update deprecation message for `AuthConfig.Email` field
```

**- A picture of a cute animal (not mandatory but encouraged)**

