### PR TITLE
cli/command/config: deprecate exported types and functions

### DIFF
--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -16,57 +16,76 @@ import (
 )
 
 // InspectOptions contains options for the docker config inspect command.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type InspectOptions struct {
 	Names  []string
 	Format string
 	Pretty bool
 }
 
-func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
-	opts := InspectOptions{}
+// inspectOptions contains options for the docker config inspect command.
+type inspectOptions struct {
+	names  []string
+	format string
+	pretty bool
+}
+
+func newConfigInspectCommand(dockerCLI command.Cli) *cobra.Command {
+	opts := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] CONFIG [CONFIG...]",
 		Short: "Display detailed information on one or more configs",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Names = args
-			return RunConfigInspect(cmd.Context(), dockerCli, opts)
+			opts.names = args
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Format, "format", "f", "", flagsHelper.InspectFormatHelp)
-	cmd.Flags().BoolVar(&opts.Pretty, "pretty", false, "Print the information in a human friendly format")
+	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
+	cmd.Flags().BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
 	return cmd
 }
 
 // RunConfigInspect inspects the given Swarm config.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunConfigInspect(ctx context.Context, dockerCLI command.Cli, opts InspectOptions) error {
+	return runInspect(ctx, dockerCLI, inspectOptions{
+		names:  opts.Names,
+		format: opts.Format,
+		pretty: opts.Pretty,
+	})
+}
+
+// runInspect inspects the given Swarm config.
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
 	apiClient := dockerCLI.Client()
 
-	if opts.Pretty {
-		opts.Format = "pretty"
+	if opts.pretty {
+		opts.format = "pretty"
 	}
 
 	getRef := func(id string) (any, []byte, error) {
 		return apiClient.ConfigInspectWithRaw(ctx, id)
 	}
-	f := opts.Format
 
 	// check if the user is trying to apply a template to the pretty format, which
 	// is not supported
-	if strings.HasPrefix(f, "pretty") && f != "pretty" {
+	if strings.HasPrefix(opts.format, "pretty") && opts.format != "pretty" {
 		return errors.New("cannot supply extra formatting options to the pretty template")
 	}
 
 	configCtx := formatter.Context{
 		Output: dockerCLI.Out(),
-		Format: newFormat(f, false),
+		Format: newFormat(opts.format, false),
 	}
 
-	if err := inspectFormatWrite(configCtx, opts.Names, getRef); err != nil {
+	if err := inspectFormatWrite(configCtx, opts.names, getRef); err != nil {
 		return cli.StatusError{StatusCode: 1, Status: err.Error()}
 	}
 	return nil

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -11,34 +11,40 @@ import (
 )
 
 // RemoveOptions contains options for the docker config rm command.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type RemoveOptions struct {
 	Names []string
 }
 
-func newConfigRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm CONFIG [CONFIG...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more configs",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := RemoveOptions{
-				Names: args,
-			}
-			return RunConfigRemove(cmd.Context(), dockerCli, opts)
+			return runRemove(cmd.Context(), dockerCLI, args)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
 	}
 }
 
 // RunConfigRemove removes the given Swarm configs.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunConfigRemove(ctx context.Context, dockerCLI command.Cli, opts RemoveOptions) error {
+	return runRemove(ctx, dockerCLI, opts.Names)
+}
+
+// runRemove removes the given Swarm configs.
+func runRemove(ctx context.Context, dockerCLI command.Cli, names []string) error {
 	apiClient := dockerCLI.Client()
 
 	var errs []error
-	for _, name := range opts.Names {
+	for _, name := range names {
 		if err := apiClient.ConfigRemove(ctx, name); err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/1717

These were exported in f60369dfe6b5abba1f3b9751234d5233eb2dfbbb to be used in docker enterprise, but this never happened, and there's no known consumers of these, so we should deprecate these. External consumers can still call the API-client directly, which should've been the correct thing to do in the first place.

This deprecates:

- `RunConfigCreate` and  `CreateOptions`
- `RunConfigInspect` and `InspectOptions`
- `RunConfigList` and `ListOptions`
- `RunConfigRemove` and `RemoveOptions`

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/config: deprecate `RunConfigCreate`,  `CreateOptions`, `RunConfigInspect`, `InspectOptions`, `RunConfigList`, `ListOptions`, `RunConfigRemove`, and `RemoveOptions`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

