### PR TITLE
[28.x backport] cli/command/config: deprecate exported types and functions

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -16,6 +16,8 @@ import (
 )
 
 // CreateOptions specifies some options that are used when creating a config.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type CreateOptions struct {
 	Name           string
 	TemplateDriver string
@@ -23,9 +25,17 @@ type CreateOptions struct {
 	Labels         opts.ListOpts
 }
 
-func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
-	createOpts := CreateOptions{
-		Labels: opts.NewListOpts(opts.ValidateLabel),
+// createOptions specifies some options that are used when creating a config.
+type createOptions struct {
+	name           string
+	templateDriver string
+	file           string
+	labels         opts.ListOpts
+}
+
+func newConfigCreateCommand(dockerCLI command.Cli) *cobra.Command {
+	createOpts := createOptions{
+		labels: opts.NewListOpts(opts.ValidateLabel),
 	}
 
 	cmd := &cobra.Command{
@@ -33,39 +43,51 @@ func newConfigCreateCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Create a config from a file or STDIN",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			createOpts.Name = args[0]
-			createOpts.File = args[1]
-			return RunConfigCreate(cmd.Context(), dockerCli, createOpts)
+			createOpts.name = args[0]
+			createOpts.file = args[1]
+			return runCreate(cmd.Context(), dockerCLI, createOpts)
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
 	flags := cmd.Flags()
-	flags.VarP(&createOpts.Labels, "label", "l", "Config labels")
-	flags.StringVar(&createOpts.TemplateDriver, "template-driver", "", "Template driver")
-	flags.SetAnnotation("template-driver", "version", []string{"1.37"})
+	flags.VarP(&createOpts.labels, "label", "l", "Config labels")
+	flags.StringVar(&createOpts.templateDriver, "template-driver", "", "Template driver")
+	_ = flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
 }
 
 // RunConfigCreate creates a config with the given options.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunConfigCreate(ctx context.Context, dockerCLI command.Cli, options CreateOptions) error {
+	return runCreate(ctx, dockerCLI, createOptions{
+		name:           options.Name,
+		templateDriver: options.TemplateDriver,
+		file:           options.File,
+		labels:         options.Labels,
+	})
+}
+
+// runCreate creates a config with the given options.
+func runCreate(ctx context.Context, dockerCLI command.Cli, options createOptions) error {
 	apiClient := dockerCLI.Client()
 
-	configData, err := readConfigData(dockerCLI.In(), options.File)
+	configData, err := readConfigData(dockerCLI.In(), options.file)
 	if err != nil {
-		return errors.Errorf("Error reading content from %q: %v", options.File, err)
+		return errors.Errorf("Error reading content from %q: %v", options.file, err)
 	}
 
 	spec := swarm.ConfigSpec{
 		Annotations: swarm.Annotations{
-			Name:   options.Name,
-			Labels: opts.ConvertKVStringsToMap(options.Labels.GetSlice()),
+			Name:   options.name,
+			Labels: opts.ConvertKVStringsToMap(options.labels.GetSlice()),
 		},
 		Data: configData,
 	}
-	if options.TemplateDriver != "" {
+	if options.templateDriver != "" {
 		spec.Templating = &swarm.Driver{
-			Name: options.TemplateDriver,
+			Name: options.templateDriver,
 		}
 	}
 	r, err := apiClient.ConfigCreate(ctx, spec)

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -16,57 +16,76 @@ import (
 )
 
 // InspectOptions contains options for the docker config inspect command.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type InspectOptions struct {
 	Names  []string
 	Format string
 	Pretty bool
 }
 
-func newConfigInspectCommand(dockerCli command.Cli) *cobra.Command {
-	opts := InspectOptions{}
+// inspectOptions contains options for the docker config inspect command.
+type inspectOptions struct {
+	names  []string
+	format string
+	pretty bool
+}
+
+func newConfigInspectCommand(dockerCLI command.Cli) *cobra.Command {
+	opts := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] CONFIG [CONFIG...]",
 		Short: "Display detailed information on one or more configs",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Names = args
-			return RunConfigInspect(cmd.Context(), dockerCli, opts)
+			opts.names = args
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.Format, "format", "f", "", flagsHelper.InspectFormatHelp)
-	cmd.Flags().BoolVar(&opts.Pretty, "pretty", false, "Print the information in a human friendly format")
+	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
+	cmd.Flags().BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
 	return cmd
 }
 
 // RunConfigInspect inspects the given Swarm config.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunConfigInspect(ctx context.Context, dockerCLI command.Cli, opts InspectOptions) error {
+	return runInspect(ctx, dockerCLI, inspectOptions{
+		names:  opts.Names,
+		format: opts.Format,
+		pretty: opts.Pretty,
+	})
+}
+
+// runInspect inspects the given Swarm config.
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
 	apiClient := dockerCLI.Client()
 
-	if opts.Pretty {
-		opts.Format = "pretty"
+	if opts.pretty {
+		opts.format = "pretty"
 	}
 
 	getRef := func(id string) (any, []byte, error) {
 		return apiClient.ConfigInspectWithRaw(ctx, id)
 	}
-	f := opts.Format
 
 	// check if the user is trying to apply a template to the pretty format, which
 	// is not supported
-	if strings.HasPrefix(f, "pretty") && f != "pretty" {
+	if strings.HasPrefix(opts.format, "pretty") && opts.format != "pretty" {
 		return errors.New("cannot supply extra formatting options to the pretty template")
 	}
 
 	configCtx := formatter.Context{
 		Output: dockerCLI.Out(),
-		Format: newFormat(f, false),
+		Format: newFormat(opts.format, false),
 	}
 
-	if err := inspectFormatWrite(configCtx, opts.Names, getRef); err != nil {
+	if err := inspectFormatWrite(configCtx, opts.names, getRef); err != nil {
 		return cli.StatusError{StatusCode: 1, Status: err.Error()}
 	}
 	return nil

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -11,34 +11,40 @@ import (
 )
 
 // RemoveOptions contains options for the docker config rm command.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type RemoveOptions struct {
 	Names []string
 }
 
-func newConfigRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm CONFIG [CONFIG...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more configs",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts := RemoveOptions{
-				Names: args,
-			}
-			return RunConfigRemove(cmd.Context(), dockerCli, opts)
+			return runRemove(cmd.Context(), dockerCLI, args)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
 	}
 }
 
 // RunConfigRemove removes the given Swarm configs.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunConfigRemove(ctx context.Context, dockerCLI command.Cli, opts RemoveOptions) error {
+	return runRemove(ctx, dockerCLI, opts.Names)
+}
+
+// runRemove removes the given Swarm configs.
+func runRemove(ctx context.Context, dockerCLI command.Cli, names []string) error {
 	apiClient := dockerCLI.Client()
 
 	var errs []error
-	for _, name := range opts.Names {
+	for _, name := range names {
 		if err := apiClient.ConfigRemove(ctx, name); err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6368
- relates to https://github.com/docker/cli/pull/1717

These were exported in f60369dfe6b5abba1f3b9751234d5233eb2dfbbb to be used in docker enterprise, but this never happened, and there's no known consumers of these, so we should deprecate these. External consumers can still call the API-client directly, which should've been the correct thing to do in the first place.

This deprecates:

- `RunConfigCreate` and  `CreateOptions`
- `RunConfigInspect` and `InspectOptions`
- `RunConfigList` and `ListOptions`
- `RunConfigRemove` and `RemoveOptions`

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/config: deprecate `RunConfigCreate`,  `CreateOptions`, `RunConfigInspect`, `InspectOptions`, `RunConfigList`, `ListOptions`, `RunConfigRemove`, and `RemoveOptions`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

