### PR TITLE
cli/command/config: remove deprecated types and functions

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -15,16 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreateOptions specifies some options that are used when creating a config.
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type CreateOptions struct {
-	Name           string
-	TemplateDriver string
-	File           string
-	Labels         opts.ListOpts
-}
-
 // createOptions specifies some options that are used when creating a config.
 type createOptions struct {
 	name           string
@@ -55,18 +45,6 @@ func newConfigCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	_ = flags.SetAnnotation("template-driver", "version", []string{"1.37"})
 
 	return cmd
-}
-
-// RunConfigCreate creates a config with the given options.
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunConfigCreate(ctx context.Context, dockerCLI command.Cli, options CreateOptions) error {
-	return runCreate(ctx, dockerCLI, createOptions{
-		name:           options.Name,
-		templateDriver: options.TemplateDriver,
-		file:           options.File,
-		labels:         options.Labels,
-	})
 }
 
 // runCreate creates a config with the given options.

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -15,15 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// InspectOptions contains options for the docker config inspect command.
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type InspectOptions struct {
-	Names  []string
-	Format string
-	Pretty bool
-}
-
 // inspectOptions contains options for the docker config inspect command.
 type inspectOptions struct {
 	names  []string
@@ -49,17 +40,6 @@ func newConfigInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
 	cmd.Flags().BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
 	return cmd
-}
-
-// RunConfigInspect inspects the given Swarm config.
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunConfigInspect(ctx context.Context, dockerCLI command.Cli, opts InspectOptions) error {
-	return runInspect(ctx, dockerCLI, inspectOptions{
-		names:  opts.Names,
-		format: opts.Format,
-		pretty: opts.Pretty,
-	})
 }
 
 // runInspect inspects the given Swarm config.

--- a/cli/command/config/ls.go
+++ b/cli/command/config/ls.go
@@ -15,15 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListOptions contains options for the docker config ls command.
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type ListOptions struct {
-	Quiet  bool
-	Format string
-	Filter opts.FilterOpt
-}
-
 // listOptions contains options for the docker config ls command.
 type listOptions struct {
 	quiet  bool
@@ -51,17 +42,6 @@ func newConfigListCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.VarP(&listOpts.filter, "filter", "f", "Filter output based on conditions provided")
 
 	return cmd
-}
-
-// RunConfigList lists Swarm configs.
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunConfigList(ctx context.Context, dockerCLI command.Cli, options ListOptions) error {
-	return runList(ctx, dockerCLI, listOptions{
-		quiet:  options.Quiet,
-		format: options.Format,
-		filter: options.Filter,
-	})
 }
 
 // runList lists Swarm configs.

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -10,13 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RemoveOptions contains options for the docker config rm command.
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type RemoveOptions struct {
-	Names []string
-}
-
 func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:     "rm CONFIG [CONFIG...]",
@@ -30,13 +23,6 @@ func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
 	}
-}
-
-// RunConfigRemove removes the given Swarm configs.
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunConfigRemove(ctx context.Context, dockerCLI command.Cli, opts RemoveOptions) error {
-	return runRemove(ctx, dockerCLI, opts.Names)
 }
 
 // runRemove removes the given Swarm configs.


### PR DESCRIPTION
- [x] follow-up to https://github.com/docker/cli/pull/6368

----

### cli/command/config: remove deprecated types and functions

These were deprecated in a5f4ba08d941df6f3eb768683cbe412ef12487e3 and only
used internally.

This removes the deprecated types and functions:

- `RunConfigCreate` and  `CreateOptions`
- `RunConfigInspect` and `InspectOptions`
- `RunConfigList` and `ListOptions`
- `RunConfigRemove` and `RemoveOptions`


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/config: remove deprecated `RunConfigCreate`,  `CreateOptions`, `RunConfigInspect`, `InspectOptions`, `RunConfigList`, `ListOptions`, `RunConfigRemove`, and `RemoveOptions`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

