### PR TITLE
cli/command/plugin: simplify auth

### DIFF
--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -10,9 +10,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/docker/cli/internal/prompt"
-	"github.com/docker/cli/internal/registry"
 	"github.com/moby/moby/api/types/plugin"
-	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -60,8 +58,7 @@ func buildPullConfig(dockerCLI command.Cli, opts pluginOptions) (client.PluginIn
 		return client.PluginInstallOptions{}, err
 	}
 
-	authConfig := command.ResolveAuthConfig(dockerCLI.ConfigFile(), registry.NewIndexInfo(ref))
-	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
+	encodedAuth, err := command.RetrieveAuthTokenFromImage(dockerCLI.ConfigFile(), ref.String())
 	if err != nil {
 		return client.PluginInstallOptions{}, err
 	}

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -8,8 +8,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/internal/jsonstream"
-	"github.com/docker/cli/internal/registry"
-	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/spf13/cobra"
 )
 
@@ -40,8 +38,7 @@ func runPush(ctx context.Context, dockerCli command.Cli, name string) error {
 	}
 
 	named = reference.TagNameOnly(named)
-	authConfig := command.ResolveAuthConfig(dockerCli.ConfigFile(), registry.NewIndexInfo(named))
-	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
+	encodedAuth, err := command.RetrieveAuthTokenFromImage(dockerCli.ConfigFile(), named.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5925

Now that 3f5b1bdd3240d390f48290c75dd724788eddfb6f removed DCT, which needed some of the intermediate types (indexInfo), we can simplify the auth code further and just get the base64-encoded AuthConfig to be set as header.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

