### PR TITLE
cli/command/image: remove deprecated AuthResolver utility

### DIFF
--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -211,13 +211,6 @@ func convertTarget(t client.Target) (target, error) {
 	}, nil
 }
 
-// AuthResolver returns an auth resolver function from a [config.Provider].
-//
-// Deprecated: this function was only used internally and will be removed in the next release.
-func AuthResolver(dockerCLI config.Provider) func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
-	return authResolver(dockerCLI)
-}
-
 // authResolver returns an auth resolver function from a [config.Provider].
 func authResolver(dockerCLI config.Provider) func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig {
 	return func(ctx context.Context, index *registrytypes.IndexInfo) registrytypes.AuthConfig {


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/6356

This function was used to share it between "trust" and "image", but was only a shallow wrapper, so split the implementations where used.

It was deprecated in 7ad113ccc2c958f4bd39db9d22783678ccbcb044 and is no longer used.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/image: remove deprecated `AuthResolver` utility
```

**- A picture of a cute animal (not mandatory but encouraged)**

