### PR TITLE
cli/command/stack/*: deprecate exported functions and types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,6 +222,14 @@ linters:
         linters:
           - staticcheck
 
+      # Ignore deprecation linting for cli/command/stack/*.
+      #
+      # FIXME(thaJeztah): remove exception once these functions are un-exported or internal; see https://github.com/docker/cli/pull/6389
+      - text: '^(SA1019): '
+        path: "cli/command/stack"
+        linters:
+          - staticcheck
+
     # Log a warning if an exclusion rule is unused.
     # Default: false
     warn-unused: true

--- a/cli/command/stack/formatter/formatter.go
+++ b/cli/command/stack/formatter/formatter.go
@@ -8,21 +8,31 @@ import (
 
 const (
 	// SwarmStackTableFormat is the default Swarm stack format
+	//
+	// Deprecated: this type was for internal use and will be removed in the next release.
 	SwarmStackTableFormat formatter.Format = "table {{.Name}}\t{{.Services}}"
 
 	stackServicesHeader = "SERVICES"
 
 	// TableFormatKey is an alias for formatter.TableFormatKey
+	//
+	// Deprecated: this type was for internal use and will be removed in the next release.
 	TableFormatKey = formatter.TableFormatKey
 )
 
 // Context is an alias for formatter.Context
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Context = formatter.Context
 
 // Format is an alias for formatter.Format
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Format = formatter.Format
 
 // Stack contains deployed stack information.
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Stack struct {
 	// Name is the name of the stack
 	Name string
@@ -31,6 +41,8 @@ type Stack struct {
 }
 
 // StackWrite writes formatted stacks using the Context
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func StackWrite(ctx formatter.Context, stacks []*Stack) error {
 	render := func(format func(subContext formatter.SubContext) error) error {
 		for _, stack := range stacks {

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -16,8 +16,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type listOptions = options.List
+
 func newListCommand(dockerCli command.Cli) *cobra.Command {
-	opts := options.List{}
+	opts := listOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
@@ -25,7 +27,7 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List stacks",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunList(cmd.Context(), dockerCli, opts)
+			return runList(cmd.Context(), dockerCli, opts)
 		},
 		ValidArgsFunction: completion.NoComplete,
 	}
@@ -36,17 +38,24 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 // RunList performs a stack list against the specified swarm cluster
-func RunList(ctx context.Context, dockerCli command.Cli, opts options.List) error {
-	ss, err := swarm.GetStacks(ctx, dockerCli.Client())
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
+func RunList(ctx context.Context, dockerCLI command.Cli, opts options.List) error {
+	return runList(ctx, dockerCLI, opts)
+}
+
+// runList performs a stack list against the specified swarm cluster
+func runList(ctx context.Context, dockerCLI command.Cli, opts listOptions) error {
+	ss, err := swarm.GetStacks(ctx, dockerCLI.Client())
 	if err != nil {
 		return err
 	}
 	stacks := make([]*formatter.Stack, 0, len(ss))
 	stacks = append(stacks, ss...)
-	return format(dockerCli.Out(), opts, stacks)
+	return format(dockerCLI.Out(), opts, stacks)
 }
 
-func format(out io.Writer, opts options.List, stacks []*formatter.Stack) error {
+func format(out io.Writer, opts listOptions, stacks []*formatter.Stack) error {
 	fmt := formatter.Format(opts.Format)
 	if fmt == "" || fmt == formatter.TableFormatKey {
 		fmt = formatter.SwarmStackTableFormat

--- a/cli/command/stack/loader/loader.go
+++ b/cli/command/stack/loader/loader.go
@@ -22,6 +22,8 @@ import (
 )
 
 // LoadComposefile parse the composefile specified in the cli and returns its Config and version.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func LoadComposefile(dockerCli command.Cli, opts options.Deploy) (*composetypes.Config, error) {
 	configDetails, err := GetConfigDetails(opts.Composefiles, dockerCli.In())
 	if err != nil {
@@ -84,6 +86,8 @@ func propertyWarnings(properties map[string]string) string {
 }
 
 // GetConfigDetails parse the composefiles specified in the cli and returns their ConfigDetails
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func GetConfigDetails(composefiles []string, stdin io.Reader) (composetypes.ConfigDetails, error) {
 	var details composetypes.ConfigDetails
 

--- a/cli/command/stack/options/opts.go
+++ b/cli/command/stack/options/opts.go
@@ -3,6 +3,8 @@ package options
 import "github.com/docker/cli/opts"
 
 // Deploy holds docker stack deploy options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Deploy struct {
 	Composefiles     []string
 	Namespace        string
@@ -14,18 +16,24 @@ type Deploy struct {
 }
 
 // Config holds docker stack config options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Config struct {
 	Composefiles      []string
 	SkipInterpolation bool
 }
 
 // List holds docker stack ls options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type List struct {
 	Format        string
 	AllNamespaces bool
 }
 
 // PS holds docker stack ps options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type PS struct {
 	Filter    opts.FilterOpt
 	NoTrunc   bool
@@ -36,12 +44,16 @@ type PS struct {
 }
 
 // Remove holds docker stack remove options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Remove struct {
 	Namespaces []string
 	Detach     bool
 }
 
 // Services holds docker stack services options
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type Services struct {
 	Quiet     bool
 	Format    string

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -23,6 +23,8 @@ const (
 )
 
 // RunDeploy is the swarm implementation of docker stack deploy
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunDeploy(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, opts *options.Deploy, cfg *composetypes.Config) error {
 	if err := validateResolveImageFlag(opts); err != nil {
 		return err

--- a/cli/command/stack/swarm/list.go
+++ b/cli/command/stack/swarm/list.go
@@ -10,6 +10,8 @@ import (
 )
 
 // GetStacks lists the swarm stacks.
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func GetStacks(ctx context.Context, apiClient client.ServiceAPIClient) ([]*formatter.Stack, error) {
 	services, err := apiClient.ServiceList(
 		ctx,

--- a/cli/command/stack/swarm/ps.go
+++ b/cli/command/stack/swarm/ps.go
@@ -12,6 +12,8 @@ import (
 )
 
 // RunPS is the swarm implementation of docker stack ps
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunPS(ctx context.Context, dockerCLI command.Cli, opts options.PS) error {
 	filter := getStackFilterFromOpt(opts.Namespace, opts.Filter)
 

--- a/cli/command/stack/swarm/remove.go
+++ b/cli/command/stack/swarm/remove.go
@@ -15,6 +15,8 @@ import (
 )
 
 // RunRemove is the swarm implementation of docker stack remove
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunRemove(ctx context.Context, dockerCli command.Cli, opts options.Remove) error {
 	apiClient := dockerCli.Client()
 

--- a/cli/command/stack/swarm/services.go
+++ b/cli/command/stack/swarm/services.go
@@ -11,6 +11,8 @@ import (
 )
 
 // GetServices is the swarm implementation of listing stack services
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func GetServices(ctx context.Context, dockerCLI command.Cli, opts options.Services) ([]swarm.Service, error) {
 	var (
 		err       error


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/3139
- relates to https://github.com/docker/cli/issues/2967

### cli/command/stack/*: deprecate exported functions and types

Functions and types in these packages were exported as part of the "compose
on kubernetes" feature, which was deprecated and removed. These functions
are meant for internal use, and will be removed in the next release.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: deprecate cli/command/stack/formatter
Go SDK: deprecate cli/command/stack/loader
Go SDK: deprecate cli/command/stack/options
Go SDK: deprecate cli/command/stack/swarm
Go SDK: cli/command/stack: deprecate `RunList`, `RunServices`
```

**- A picture of a cute animal (not mandatory but encouraged)**

