### PR TITLE
[28.x backport] cli/command: rename vars for consistency and prevent shadowing

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -188,16 +188,16 @@ func TestInitializeFromClient(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.doc, func(t *testing.T) {
-			apiclient := &fakeClient{
+			apiClient := &fakeClient{
 				pingFunc: tc.pingFunc,
 				version:  defaultVersion,
 			}
 
-			cli := &DockerCli{client: apiclient}
+			cli := &DockerCli{client: apiClient}
 			err := cli.Initialize(flags.NewClientOptions())
 			assert.NilError(t, err)
 			assert.DeepEqual(t, cli.ServerInfo(), tc.expectedServer)
-			assert.Equal(t, apiclient.negotiated, tc.negotiated)
+			assert.Equal(t, apiClient.negotiated, tc.negotiated)
 		})
 	}
 }

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -116,7 +116,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 		t.Run(tc.PullPolicy, func(t *testing.T) {
 			pullCounter := 0
 
-			client := &fakeClient{
+			apiClient := &fakeClient{
 				createContainerFunc: func(
 					config *container.Config,
 					hostConfig *container.HostConfig,
@@ -140,7 +140,7 @@ func TestCreateContainerImagePullPolicy(t *testing.T) {
 					return system.Info{IndexServerAddress: "https://indexserver.example.com"}, nil
 				},
 			}
-			fakeCLI := test.NewFakeCli(client)
+			fakeCLI := test.NewFakeCli(apiClient)
 			id, err := createContainer(context.Background(), fakeCLI, config, &createOptions{
 				name:      "name",
 				platform:  runtime.GOOS,

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -234,13 +234,13 @@ func TestGetExecExitStatus(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		client := &fakeClient{
+		apiClient := &fakeClient{
 			execInspectFunc: func(id string) (container.ExecInspect, error) {
 				assert.Check(t, is.Equal(execID, id))
 				return container.ExecInspect{ExitCode: testcase.exitCode}, testcase.inspectError
 			},
 		}
-		err := getExecExitStatus(context.Background(), client, execID)
+		err := getExecExitStatus(context.Background(), apiClient, execID)
 		assert.Check(t, is.Equal(testcase.expectedError, err))
 	}
 }

--- a/cli/command/idresolver/idresolver_test.go
+++ b/cli/command/idresolver/idresolver_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func TestResolveError(t *testing.T) {
-	cli := &fakeClient{
+	apiClient := &fakeClient{
 		nodeInspectFunc: func(nodeID string) (swarm.Node, []byte, error) {
 			return swarm.Node{}, []byte{}, errors.New("error inspecting node")
 		},
 	}
 
-	idResolver := New(cli, false)
+	idResolver := New(apiClient, false)
 	_, err := idResolver.Resolve(context.Background(), struct{}{}, "nodeID")
 
 	assert.Error(t, err, "unsupported type")
@@ -26,7 +26,7 @@ func TestResolveError(t *testing.T) {
 
 func TestResolveWithNoResolveOption(t *testing.T) {
 	resolved := false
-	cli := &fakeClient{
+	apiClient := &fakeClient{
 		nodeInspectFunc: func(nodeID string) (swarm.Node, []byte, error) {
 			resolved = true
 			return swarm.Node{}, []byte{}, nil
@@ -37,7 +37,7 @@ func TestResolveWithNoResolveOption(t *testing.T) {
 		},
 	}
 
-	idResolver := New(cli, true)
+	idResolver := New(apiClient, true)
 	id, err := idResolver.Resolve(context.Background(), swarm.Node{}, "nodeID")
 
 	assert.NilError(t, err)
@@ -47,14 +47,14 @@ func TestResolveWithNoResolveOption(t *testing.T) {
 
 func TestResolveWithCache(t *testing.T) {
 	inspectCounter := 0
-	cli := &fakeClient{
+	apiClient := &fakeClient{
 		nodeInspectFunc: func(nodeID string) (swarm.Node, []byte, error) {
 			inspectCounter++
 			return *builders.Node(builders.NodeName("node-foo")), []byte{}, nil
 		},
 	}
 
-	idResolver := New(cli, false)
+	idResolver := New(apiClient, false)
 
 	ctx := context.Background()
 	for i := 0; i < 2; i++ {
@@ -97,10 +97,10 @@ func TestResolveNode(t *testing.T) {
 
 	ctx := context.Background()
 	for _, tc := range testCases {
-		cli := &fakeClient{
+		apiClient := &fakeClient{
 			nodeInspectFunc: tc.nodeInspectFunc,
 		}
-		idResolver := New(cli, false)
+		idResolver := New(apiClient, false)
 		id, err := idResolver.Resolve(ctx, swarm.Node{}, tc.nodeID)
 
 		assert.NilError(t, err)
@@ -132,10 +132,10 @@ func TestResolveService(t *testing.T) {
 
 	ctx := context.Background()
 	for _, tc := range testCases {
-		cli := &fakeClient{
+		apiClient := &fakeClient{
 			serviceInspectFunc: tc.serviceInspectFunc,
 		}
-		idResolver := New(cli, false)
+		idResolver := New(apiClient, false)
 		id, err := idResolver.Resolve(ctx, swarm.Service{}, tc.serviceID)
 
 		assert.NilError(t, err)

--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -45,17 +45,17 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runList(ctx context.Context, dockerCli command.Cli, options listOptions) error {
-	client := dockerCli.Client()
-	networkResources, err := client.NetworkList(ctx, network.ListOptions{Filters: options.filter.Value()})
+func runList(ctx context.Context, dockerCLI command.Cli, options listOptions) error {
+	apiClient := dockerCLI.Client()
+	networkResources, err := apiClient.NetworkList(ctx, network.ListOptions{Filters: options.filter.Value()})
 	if err != nil {
 		return err
 	}
 
 	format := options.format
 	if len(format) == 0 {
-		if len(dockerCli.ConfigFile().NetworksFormat) > 0 && !options.quiet {
-			format = dockerCli.ConfigFile().NetworksFormat
+		if len(dockerCLI.ConfigFile().NetworksFormat) > 0 && !options.quiet {
+			format = dockerCLI.ConfigFile().NetworksFormat
 		} else {
 			format = formatter.TableFormatKey
 		}
@@ -66,7 +66,7 @@ func runList(ctx context.Context, dockerCli command.Cli, options listOptions) er
 	})
 
 	networksCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: newFormat(format, options.quiet),
 		Trunc:  !options.noTrunc,
 	}

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -55,6 +55,8 @@ func Reference(ctx context.Context, apiClient client.APIClient, ref string) (str
 			// If there's no node ID in /info, the node probably
 			// isn't a manager. Call a swarm-specific endpoint to
 			// get a more specific error message.
+			//
+			// FIXME(thaJeztah): this should not require calling a Swarm endpoint, and we could just suffice with info / ping (which has swarm status).
 			_, err = apiClient.NodeList(ctx, swarm.NodeListOptions{})
 			if err != nil {
 				return "", err

--- a/cli/command/node/demote.go
+++ b/cli/command/node/demote.go
@@ -22,17 +22,16 @@ func newDemoteCommand(dockerCli command.Cli) *cobra.Command {
 	}
 }
 
-func runDemote(ctx context.Context, dockerCli command.Cli, nodes []string) error {
+func runDemote(ctx context.Context, dockerCLI command.Cli, nodes []string) error {
 	demote := func(node *swarm.Node) error {
 		if node.Spec.Role == swarm.NodeRoleWorker {
-			_, _ = fmt.Fprintf(dockerCli.Out(), "Node %s is already a worker.\n", node.ID)
+			_, _ = fmt.Fprintf(dockerCLI.Out(), "Node %s is already a worker.\n", node.ID)
 			return errNoRoleChange
 		}
 		node.Spec.Role = swarm.NodeRoleWorker
 		return nil
 	}
-	success := func(nodeID string) {
-		_, _ = fmt.Fprintf(dockerCli.Out(), "Manager %s demoted in the swarm.\n", nodeID)
-	}
-	return updateNodes(ctx, dockerCli, nodes, demote, success)
+	return updateNodes(ctx, dockerCLI.Client(), nodes, demote, func(nodeID string) {
+		_, _ = fmt.Fprintf(dockerCLI.Out(), "Manager %s demoted in the swarm.\n", nodeID)
+	})
 }

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -41,32 +41,31 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	client := dockerCli.Client()
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	apiClient := dockerCLI.Client()
 
 	if opts.pretty {
 		opts.format = "pretty"
 	}
 
 	getRef := func(ref string) (any, []byte, error) {
-		nodeRef, err := Reference(ctx, client, ref)
+		nodeRef, err := Reference(ctx, apiClient, ref)
 		if err != nil {
 			return nil, nil, err
 		}
-		node, _, err := client.NodeInspectWithRaw(ctx, nodeRef)
+		node, _, err := apiClient.NodeInspectWithRaw(ctx, nodeRef)
 		return node, nil, err
 	}
-	f := opts.format
 
 	// check if the user is trying to apply a template to the pretty format, which
 	// is not supported
-	if strings.HasPrefix(f, "pretty") && f != "pretty" {
+	if strings.HasPrefix(opts.format, "pretty") && opts.format != "pretty" {
 		return errors.New("cannot supply extra formatting options to the pretty template")
 	}
 
 	nodeCtx := formatter.Context{
-		Output: dockerCli.Out(),
-		Format: newFormat(f, false),
+		Output: dockerCLI.Out(),
+		Format: newFormat(opts.format, false),
 	}
 
 	if err := inspectFormatWrite(nodeCtx, opts.nodeIds, getRef); err != nil {

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -50,20 +50,20 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runList(ctx context.Context, dockerCli command.Cli, options listOptions) error {
-	client := dockerCli.Client()
+func runList(ctx context.Context, dockerCLI command.Cli, options listOptions) error {
+	apiClient := dockerCLI.Client()
 
-	nodes, err := client.NodeList(
-		ctx,
-		swarm.NodeListOptions{Filters: options.filter.Value()})
+	nodes, err := apiClient.NodeList(ctx, swarm.NodeListOptions{
+		Filters: options.filter.Value(),
+	})
 	if err != nil {
 		return err
 	}
 
-	info := system.Info{}
+	var info system.Info
 	if len(nodes) > 0 && !options.quiet {
 		// only non-empty nodes and not quiet, should we call /info api
-		info, err = client.Info(ctx)
+		info, err = apiClient.Info(ctx)
 		if err != nil {
 			return err
 		}
@@ -72,13 +72,13 @@ func runList(ctx context.Context, dockerCli command.Cli, options listOptions) er
 	format := options.format
 	if len(format) == 0 {
 		format = formatter.TableFormatKey
-		if len(dockerCli.ConfigFile().NodesFormat) > 0 && !options.quiet {
-			format = dockerCli.ConfigFile().NodesFormat
+		if len(dockerCLI.ConfigFile().NodesFormat) > 0 && !options.quiet {
+			format = dockerCLI.ConfigFile().NodesFormat
 		}
 	}
 
 	nodesCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: newFormat(format, options.quiet),
 	}
 	sort.Slice(nodes, func(i, j int) bool {

--- a/cli/command/node/promote.go
+++ b/cli/command/node/promote.go
@@ -22,17 +22,16 @@ func newPromoteCommand(dockerCli command.Cli) *cobra.Command {
 	}
 }
 
-func runPromote(ctx context.Context, dockerCli command.Cli, nodes []string) error {
+func runPromote(ctx context.Context, dockerCLI command.Cli, nodes []string) error {
 	promote := func(node *swarm.Node) error {
 		if node.Spec.Role == swarm.NodeRoleManager {
-			_, _ = fmt.Fprintf(dockerCli.Out(), "Node %s is already a manager.\n", node.ID)
+			_, _ = fmt.Fprintf(dockerCLI.Out(), "Node %s is already a manager.\n", node.ID)
 			return errNoRoleChange
 		}
 		node.Spec.Role = swarm.NodeRoleManager
 		return nil
 	}
-	success := func(nodeID string) {
-		_, _ = fmt.Fprintf(dockerCli.Out(), "Node %s promoted to a manager in the swarm.\n", nodeID)
-	}
-	return updateNodes(ctx, dockerCli, nodes, promote, success)
+	return updateNodes(ctx, dockerCLI.Client(), nodes, promote, func(nodeID string) {
+		_, _ = fmt.Fprintf(dockerCLI.Out(), "Node %s promoted to a manager in the swarm.\n", nodeID)
+	})
 }

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -59,8 +59,8 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error {
-	client := dockerCli.Client()
+func runPs(ctx context.Context, dockerCLI command.Cli, options psOptions) error {
+	apiClient := dockerCLI.Client()
 
 	var (
 		errs  []string
@@ -68,13 +68,13 @@ func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error 
 	)
 
 	for _, nodeID := range options.nodeIDs {
-		nodeRef, err := Reference(ctx, client, nodeID)
+		nodeRef, err := Reference(ctx, apiClient, nodeID)
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}
 
-		node, _, err := client.NodeInspectWithRaw(ctx, nodeRef)
+		node, _, err := apiClient.NodeInspectWithRaw(ctx, nodeRef)
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -83,7 +83,7 @@ func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error 
 		filter := options.filter.Value()
 		filter.Add("node", node.ID)
 
-		nodeTasks, err := client.TaskList(ctx, swarm.TaskListOptions{Filters: filter})
+		nodeTasks, err := apiClient.TaskList(ctx, swarm.TaskListOptions{Filters: filter})
 		if err != nil {
 			errs = append(errs, err.Error())
 			continue
@@ -94,11 +94,11 @@ func runPs(ctx context.Context, dockerCli command.Cli, options psOptions) error 
 
 	format := options.format
 	if len(format) == 0 {
-		format = task.DefaultFormat(dockerCli.ConfigFile(), options.quiet)
+		format = task.DefaultFormat(dockerCLI.ConfigFile(), options.quiet)
 	}
 
 	if len(errs) == 0 || len(tasks) != 0 {
-		if err := task.Print(ctx, dockerCli, tasks, idresolver.New(client, options.noResolve), !options.noTrunc, options.quiet, format); err != nil {
+		if err := task.Print(ctx, dockerCLI, tasks, idresolver.New(apiClient, options.noResolve), !options.noTrunc, options.quiet, format); err != nil {
 			errs = append(errs, err.Error())
 		}
 	}

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -49,8 +49,8 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runSecretCreate(ctx context.Context, dockerCli command.Cli, options createOptions) error {
-	client := dockerCli.Client()
+func runSecretCreate(ctx context.Context, dockerCLI command.Cli, options createOptions) error {
+	apiClient := dockerCLI.Client()
 
 	var secretData []byte
 	if options.driver != "" {
@@ -59,7 +59,7 @@ func runSecretCreate(ctx context.Context, dockerCli command.Cli, options createO
 		}
 	} else {
 		var err error
-		secretData, err = readSecretData(dockerCli.In(), options.file)
+		secretData, err = readSecretData(dockerCLI.In(), options.file)
 		if err != nil {
 			return err
 		}
@@ -82,12 +82,12 @@ func runSecretCreate(ctx context.Context, dockerCli command.Cli, options createO
 			Name: options.templateDriver,
 		}
 	}
-	r, err := client.SecretCreate(ctx, spec)
+	r, err := apiClient.SecretCreate(ctx, spec)
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(dockerCli.Out(), r.ID)
+	_, _ = fmt.Fprintln(dockerCLI.Out(), r.ID)
 	return nil
 }
 

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -41,27 +41,26 @@ func newSecretInspectCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runSecretInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	client := dockerCli.Client()
+func runSecretInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	apiClient := dockerCLI.Client()
 
 	if opts.pretty {
 		opts.format = "pretty"
 	}
 
 	getRef := func(id string) (any, []byte, error) {
-		return client.SecretInspectWithRaw(ctx, id)
+		return apiClient.SecretInspectWithRaw(ctx, id)
 	}
-	f := opts.format
 
 	// check if the user is trying to apply a template to the pretty format, which
 	// is not supported
-	if strings.HasPrefix(f, "pretty") && f != "pretty" {
+	if strings.HasPrefix(opts.format, "pretty") && opts.format != "pretty" {
 		return errors.New("cannot supply extra formatting options to the pretty template")
 	}
 
 	secretCtx := formatter.Context{
-		Output: dockerCli.Out(),
-		Format: newFormat(f, false),
+		Output: dockerCLI.Out(),
+		Format: newFormat(opts.format, false),
 	}
 
 	if err := inspectFormatWrite(secretCtx, opts.names, getRef); err != nil {

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -44,17 +44,17 @@ func newSecretListCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runSecretList(ctx context.Context, dockerCli command.Cli, options listOptions) error {
-	client := dockerCli.Client()
+func runSecretList(ctx context.Context, dockerCLI command.Cli, options listOptions) error {
+	apiClient := dockerCLI.Client()
 
-	secrets, err := client.SecretList(ctx, swarm.SecretListOptions{Filters: options.filter.Value()})
+	secrets, err := apiClient.SecretList(ctx, swarm.SecretListOptions{Filters: options.filter.Value()})
 	if err != nil {
 		return err
 	}
 	format := options.format
 	if len(format) == 0 {
-		if len(dockerCli.ConfigFile().SecretFormat) > 0 && !options.quiet {
-			format = dockerCli.ConfigFile().SecretFormat
+		if len(dockerCLI.ConfigFile().SecretFormat) > 0 && !options.quiet {
+			format = dockerCLI.ConfigFile().SecretFormat
 		} else {
 			format = formatter.TableFormatKey
 		}
@@ -65,7 +65,7 @@ func runSecretList(ctx context.Context, dockerCli command.Cli, options listOptio
 	})
 
 	secretCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: newFormat(format, options.quiet),
 	}
 	return formatWrite(secretCtx, secrets)

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -57,8 +57,8 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	client := dockerCli.Client()
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	apiClient := dockerCLI.Client()
 
 	if opts.pretty {
 		opts.format = "pretty"
@@ -66,7 +66,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 
 	getRef := func(ref string) (any, []byte, error) {
 		// Service inspect shows defaults values in empty fields.
-		service, _, err := client.ServiceInspectWithRaw(ctx, ref, swarm.ServiceInspectOptions{InsertDefaults: true})
+		service, _, err := apiClient.ServiceInspectWithRaw(ctx, ref, swarm.ServiceInspectOptions{InsertDefaults: true})
 		if err == nil || !errdefs.IsNotFound(err) {
 			return service, nil, err
 		}
@@ -74,7 +74,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	getNetwork := func(ref string) (any, []byte, error) {
-		nw, _, err := client.NetworkInspectWithRaw(ctx, ref, network.InspectOptions{Scope: "swarm"})
+		nw, _, err := apiClient.NetworkInspectWithRaw(ctx, ref, network.InspectOptions{Scope: "swarm"})
 		if err == nil || !errdefs.IsNotFound(err) {
 			return nw, nil, err
 		}
@@ -84,8 +84,8 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	f := opts.format
 	if len(f) == 0 {
 		f = "raw"
-		if len(dockerCli.ConfigFile().ServiceInspectFormat) > 0 {
-			f = dockerCli.ConfigFile().ServiceInspectFormat
+		if len(dockerCLI.ConfigFile().ServiceInspectFormat) > 0 {
+			f = dockerCLI.ConfigFile().ServiceInspectFormat
 		}
 	}
 
@@ -96,7 +96,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	serviceCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: newFormat(f),
 	}
 

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -190,7 +190,7 @@ func TestToServiceNetwork(t *testing.T) {
 		{Name: "zzz-network", ID: "id111"},
 	}
 
-	client := &fakeClient{
+	apiClient := &fakeClient{
 		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 			for _, nw := range nws {
 				if nw.ID == networkID || nw.Name == networkID {
@@ -212,7 +212,7 @@ func TestToServiceNetwork(t *testing.T) {
 
 	ctx := context.Background()
 	flags := newCreateCommand(nil).Flags()
-	service, err := o.ToService(ctx, client, flags)
+	service, err := o.ToService(ctx, apiClient, flags)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id111"}, {Target: "id555"}, {Target: "id999"}}, service.TaskTemplate.Networks))
 }

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -851,7 +851,7 @@ func TestUpdateNetworks(t *testing.T) {
 		{Name: "zzz-network", ID: "id111"},
 	}
 
-	client := &fakeClient{
+	apiClient := &fakeClient{
 		networkInspectFunc: func(ctx context.Context, networkID string, options network.InspectOptions) (network.Inspect, error) {
 			for _, nw := range nws {
 				if nw.ID == networkID || nw.Name == networkID {
@@ -874,28 +874,28 @@ func TestUpdateNetworks(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	err := flags.Set(flagNetworkAdd, "aaa-network")
 	assert.NilError(t, err)
-	err = updateService(ctx, client, flags, &svc)
+	err = updateService(ctx, apiClient, flags, &svc)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id555"}, {Target: "id999"}}, svc.TaskTemplate.Networks))
 
 	flags = newUpdateCommand(nil).Flags()
 	err = flags.Set(flagNetworkAdd, "aaa-network")
 	assert.NilError(t, err)
-	err = updateService(ctx, client, flags, &svc)
+	err = updateService(ctx, apiClient, flags, &svc)
 	assert.Error(t, err, "service is already attached to network aaa-network")
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id555"}, {Target: "id999"}}, svc.TaskTemplate.Networks))
 
 	flags = newUpdateCommand(nil).Flags()
 	err = flags.Set(flagNetworkAdd, "id555")
 	assert.NilError(t, err)
-	err = updateService(ctx, client, flags, &svc)
+	err = updateService(ctx, apiClient, flags, &svc)
 	assert.Error(t, err, "service is already attached to network id555")
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id555"}, {Target: "id999"}}, svc.TaskTemplate.Networks))
 
 	flags = newUpdateCommand(nil).Flags()
 	err = flags.Set(flagNetworkRemove, "id999")
 	assert.NilError(t, err)
-	err = updateService(ctx, client, flags, &svc)
+	err = updateService(ctx, apiClient, flags, &svc)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id555"}}, svc.TaskTemplate.Networks))
 
@@ -904,7 +904,7 @@ func TestUpdateNetworks(t *testing.T) {
 	assert.NilError(t, err)
 	err = flags.Set(flagNetworkRemove, "aaa-network")
 	assert.NilError(t, err)
-	err = updateService(ctx, client, flags, &svc)
+	err = updateService(ctx, apiClient, flags, &svc)
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual([]swarm.NetworkAttachmentConfig{{Target: "id999"}}, svc.TaskTemplate.Networks))
 }

--- a/cli/command/stack/remove_test.go
+++ b/cli/command/stack/remove_test.go
@@ -99,14 +99,14 @@ func TestRemoveStackSkipEmpty(t *testing.T) {
 	allConfigs := []string{objectName("bar", "config1")}
 	allConfigIDs := buildObjectIDs(allConfigs)
 
-	fakeClient := &fakeClient{
+	apiClient := &fakeClient{
 		version:  "1.30",
 		services: allServices,
 		networks: allNetworks,
 		secrets:  allSecrets,
 		configs:  allConfigs,
 	}
-	fakeCli := test.NewFakeCli(fakeClient)
+	fakeCli := test.NewFakeCli(apiClient)
 	cmd := newRemoveCommand(fakeCli)
 	cmd.SetArgs([]string{"foo", "bar"})
 
@@ -120,10 +120,10 @@ func TestRemoveStackSkipEmpty(t *testing.T) {
 	}
 	assert.Check(t, is.Equal(strings.Join(expectedList, "\n"), fakeCli.OutBuffer().String()))
 	assert.Check(t, is.Contains(fakeCli.ErrBuffer().String(), "Nothing found in stack: foo\n"))
-	assert.Check(t, is.DeepEqual(allServiceIDs, fakeClient.removedServices))
-	assert.Check(t, is.DeepEqual(allNetworkIDs, fakeClient.removedNetworks))
-	assert.Check(t, is.DeepEqual(allSecretIDs, fakeClient.removedSecrets))
-	assert.Check(t, is.DeepEqual(allConfigIDs, fakeClient.removedConfigs))
+	assert.Check(t, is.DeepEqual(allServiceIDs, apiClient.removedServices))
+	assert.Check(t, is.DeepEqual(allNetworkIDs, apiClient.removedNetworks))
+	assert.Check(t, is.DeepEqual(allSecretIDs, apiClient.removedSecrets))
+	assert.Check(t, is.DeepEqual(allConfigIDs, apiClient.removedConfigs))
 }
 
 func TestRemoveContinueAfterError(t *testing.T) {
@@ -140,7 +140,7 @@ func TestRemoveContinueAfterError(t *testing.T) {
 	allConfigIDs := buildObjectIDs(allConfigs)
 
 	removedServices := []string{}
-	cli := &fakeClient{
+	apiClient := &fakeClient{
 		version:  "1.30",
 		services: allServices,
 		networks: allNetworks,
@@ -156,14 +156,14 @@ func TestRemoveContinueAfterError(t *testing.T) {
 			return nil
 		},
 	}
-	cmd := newRemoveCommand(test.NewFakeCli(cli))
+	cmd := newRemoveCommand(test.NewFakeCli(apiClient))
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"foo", "bar"})
 
 	assert.Error(t, cmd.Execute(), "failed to remove some resources from stack: foo")
 	assert.Check(t, is.DeepEqual(allServiceIDs, removedServices))
-	assert.Check(t, is.DeepEqual(allNetworkIDs, cli.removedNetworks))
-	assert.Check(t, is.DeepEqual(allSecretIDs, cli.removedSecrets))
-	assert.Check(t, is.DeepEqual(allConfigIDs, cli.removedConfigs))
+	assert.Check(t, is.DeepEqual(allNetworkIDs, apiClient.removedNetworks))
+	assert.Check(t, is.DeepEqual(allSecretIDs, apiClient.removedSecrets))
+	assert.Check(t, is.DeepEqual(allConfigIDs, apiClient.removedConfigs))
 }

--- a/cli/command/stack/swarm/deploy_test.go
+++ b/cli/command/stack/swarm/deploy_test.go
@@ -18,11 +18,11 @@ func TestPruneServices(t *testing.T) {
 		"new":  {},
 		"keep": {},
 	}
-	client := &fakeClient{services: []string{objectName("foo", "keep"), objectName("foo", "remove")}}
-	dockerCli := test.NewFakeCli(client)
+	apiClient := &fakeClient{services: []string{objectName("foo", "keep"), objectName("foo", "remove")}}
+	dockerCli := test.NewFakeCli(apiClient)
 
 	pruneServices(ctx, dockerCli, namespace, services)
-	assert.Check(t, is.DeepEqual(buildObjectIDs([]string{objectName("foo", "remove")}), client.removedServices))
+	assert.Check(t, is.DeepEqual(buildObjectIDs([]string{objectName("foo", "remove")}), apiClient.removedServices))
 }
 
 // TestServiceUpdateResolveImageChanged tests that the service's

--- a/cli/command/stack/swarm/ps.go
+++ b/cli/command/stack/swarm/ps.go
@@ -12,11 +12,11 @@ import (
 )
 
 // RunPS is the swarm implementation of docker stack ps
-func RunPS(ctx context.Context, dockerCli command.Cli, opts options.PS) error {
+func RunPS(ctx context.Context, dockerCLI command.Cli, opts options.PS) error {
 	filter := getStackFilterFromOpt(opts.Namespace, opts.Filter)
 
-	client := dockerCli.Client()
-	tasks, err := client.TaskList(ctx, swarm.TaskListOptions{Filters: filter})
+	apiClient := dockerCLI.Client()
+	tasks, err := apiClient.TaskList(ctx, swarm.TaskListOptions{Filters: filter})
 	if err != nil {
 		return err
 	}
@@ -27,8 +27,8 @@ func RunPS(ctx context.Context, dockerCli command.Cli, opts options.PS) error {
 
 	format := opts.Format
 	if len(format) == 0 {
-		format = task.DefaultFormat(dockerCli.ConfigFile(), opts.Quiet)
+		format = task.DefaultFormat(dockerCLI.ConfigFile(), opts.Quiet)
 	}
 
-	return task.Print(ctx, dockerCli, tasks, idresolver.New(client, opts.NoResolve), !opts.NoTrunc, opts.Quiet, format)
+	return task.Print(ctx, dockerCLI, tasks, idresolver.New(apiClient, opts.NoResolve), !opts.NoTrunc, opts.Quiet, format)
 }

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -52,8 +52,8 @@ func newJoinCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runJoin(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, opts joinOptions) error {
-	client := dockerCli.Client()
+func runJoin(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, opts joinOptions) error {
+	apiClient := dockerCLI.Client()
 
 	req := swarm.JoinRequest{
 		JoinToken:     opts.token,
@@ -72,20 +72,20 @@ func runJoin(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, o
 		}
 	}
 
-	err := client.SwarmJoin(ctx, req)
+	err := apiClient.SwarmJoin(ctx, req)
 	if err != nil {
 		return err
 	}
 
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	if err != nil {
 		return err
 	}
 
 	if info.Swarm.ControlAvailable {
-		fmt.Fprintln(dockerCli.Out(), "This node joined a swarm as a manager.")
+		_, _ = fmt.Fprintln(dockerCLI.Out(), "This node joined a swarm as a manager.")
 	} else {
-		fmt.Fprintln(dockerCli.Out(), "This node joined a swarm as a worker.")
+		_, _ = fmt.Fprintln(dockerCLI.Out(), "This node joined a swarm as a worker.")
 	}
 	return nil
 }

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -36,13 +36,13 @@ func newLeaveCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runLeave(ctx context.Context, dockerCli command.Cli, opts leaveOptions) error {
-	client := dockerCli.Client()
+func runLeave(ctx context.Context, dockerCLI command.Cli, opts leaveOptions) error {
+	apiClient := dockerCLI.Client()
 
-	if err := client.SwarmLeave(ctx, opts.force); err != nil {
+	if err := apiClient.SwarmLeave(ctx, opts.force); err != nil {
 		return err
 	}
 
-	fmt.Fprintln(dockerCli.Out(), "Node left the swarm.")
+	_, _ = fmt.Fprintln(dockerCLI.Out(), "Node left the swarm.")
 	return nil
 }

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -35,12 +35,12 @@ func newUnlockCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runUnlock(ctx context.Context, dockerCli command.Cli) error {
-	client := dockerCli.Client()
+func runUnlock(ctx context.Context, dockerCLI command.Cli) error {
+	apiClient := dockerCLI.Client()
 
 	// First see if the node is actually part of a swarm, and if it is actually locked first.
 	// If it's in any other state than locked, don't ask for the key.
-	info, err := client.Info(ctx)
+	info, err := apiClient.Info(ctx)
 	if err != nil {
 		return err
 	}
@@ -54,12 +54,12 @@ func runUnlock(ctx context.Context, dockerCli command.Cli) error {
 		return errors.New("Error: swarm is not locked")
 	}
 
-	key, err := readKey(dockerCli.In(), "Enter unlock key: ")
+	key, err := readKey(dockerCLI.In(), "Enter unlock key: ")
 	if err != nil {
 		return err
 	}
 
-	return client.SwarmUnlock(ctx, swarm.UnlockRequest{
+	return apiClient.SwarmUnlock(ctx, swarm.UnlockRequest{
 		UnlockKey: key,
 	})
 }

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -41,12 +41,12 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runUpdate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, opts swarmOptions) error {
-	client := dockerCli.Client()
+func runUpdate(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, opts swarmOptions) error {
+	apiClient := dockerCLI.Client()
 
 	var updateFlags swarm.UpdateFlags
 
-	swarmInspect, err := client.SwarmInspect(ctx)
+	swarmInspect, err := apiClient.SwarmInspect(ctx)
 	if err != nil {
 		return err
 	}
@@ -57,19 +57,19 @@ func runUpdate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet,
 
 	curAutoLock := swarmInspect.Spec.EncryptionConfig.AutoLockManagers
 
-	err = client.SwarmUpdate(ctx, swarmInspect.Version, swarmInspect.Spec, updateFlags)
+	err = apiClient.SwarmUpdate(ctx, swarmInspect.Version, swarmInspect.Spec, updateFlags)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(dockerCli.Out(), "Swarm updated.")
+	_, _ = fmt.Fprintln(dockerCLI.Out(), "Swarm updated.")
 
 	if curAutoLock && !prevAutoLock {
-		unlockKeyResp, err := client.SwarmGetUnlockKey(ctx)
+		unlockKeyResp, err := apiClient.SwarmGetUnlockKey(ctx)
 		if err != nil {
 			return errors.Wrap(err, "could not fetch unlock key")
 		}
-		printUnlockCommand(dockerCli.Out(), unlockKeyResp.UnlockKey)
+		printUnlockCommand(dockerCLI.Out(), unlockKeyResp.UnlockKey)
 	}
 
 	return nil

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -62,7 +62,7 @@ func newEventsCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runEvents(ctx context.Context, dockerCli command.Cli, options *eventsOptions) error {
+func runEvents(ctx context.Context, dockerCLI command.Cli, options *eventsOptions) error {
 	tmpl, err := makeTemplate(options.format)
 	if err != nil {
 		return cli.StatusError{
@@ -71,14 +71,14 @@ func runEvents(ctx context.Context, dockerCli command.Cli, options *eventsOption
 		}
 	}
 	ctx, cancel := context.WithCancel(ctx)
-	evts, errs := dockerCli.Client().Events(ctx, events.ListOptions{
+	evts, errs := dockerCLI.Client().Events(ctx, events.ListOptions{
 		Since:   options.since,
 		Until:   options.until,
 		Filters: options.filter.Value(),
 	})
 	defer cancel()
 
-	out := dockerCli.Out()
+	out := dockerCLI.Out()
 
 	for {
 		select {

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -38,13 +38,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions) error {
-	client := dockerCli.Client()
-
-	getVolFunc := func(name string) (any, []byte, error) {
-		i, err := client.VolumeInspect(ctx, name)
+func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions) error {
+	apiClient := dockerCLI.Client()
+	return inspect.Inspect(dockerCLI.Out(), opts.names, opts.format, func(name string) (any, []byte, error) {
+		i, err := apiClient.VolumeInspect(ctx, name)
 		return i, nil, err
-	}
-
-	return inspect.Inspect(dockerCli.Out(), opts.names, opts.format, getVolFunc)
+	})
 }

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -51,17 +51,17 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-func runList(ctx context.Context, dockerCli command.Cli, options listOptions) error {
-	client := dockerCli.Client()
-	volumes, err := client.VolumeList(ctx, volume.ListOptions{Filters: options.filter.Value()})
+func runList(ctx context.Context, dockerCLI command.Cli, options listOptions) error {
+	apiClient := dockerCLI.Client()
+	volumes, err := apiClient.VolumeList(ctx, volume.ListOptions{Filters: options.filter.Value()})
 	if err != nil {
 		return err
 	}
 
 	format := options.format
 	if len(format) == 0 && !options.cluster {
-		if len(dockerCli.ConfigFile().VolumesFormat) > 0 && !options.quiet {
-			format = dockerCli.ConfigFile().VolumesFormat
+		if len(dockerCLI.ConfigFile().VolumesFormat) > 0 && !options.quiet {
+			format = dockerCLI.ConfigFile().VolumesFormat
 		} else {
 			format = formatter.TableFormatKey
 		}
@@ -90,7 +90,7 @@ func runList(ctx context.Context, dockerCli command.Cli, options listOptions) er
 	})
 
 	volumeCtx := formatter.Context{
-		Output: dockerCli.Out(),
+		Output: dockerCLI.Out(),
 		Format: formatter.NewVolumeFormat(format, options.quiet),
 	}
 	return formatter.VolumeWrite(volumeCtx, volumes.Volumes)


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6351
- relates to https://github.com/docker/cli/pull/6389

(cherry picked from commit 9fd71c8347f59a6845b04402ffa0d36dd6b1fa65)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

