### PR TITLE
cli/command/stack: cleanups and optimizations

### DIFF
--- a/cli/command/stack/formatter/formatter.go
+++ b/cli/command/stack/formatter/formatter.go
@@ -44,29 +44,27 @@ type Stack struct {
 //
 // Deprecated: this function was for internal use and will be removed in the next release.
 func StackWrite(ctx formatter.Context, stacks []*Stack) error {
-	render := func(format func(subContext formatter.SubContext) error) error {
+	fmtCtx := &stackContext{
+		HeaderContext: formatter.HeaderContext{
+			Header: formatter.SubHeaderContext{
+				"Name":     formatter.NameHeader,
+				"Services": stackServicesHeader,
+			},
+		},
+	}
+	return ctx.Write(fmtCtx, func(format func(subContext formatter.SubContext) error) error {
 		for _, stack := range stacks {
 			if err := format(&stackContext{s: stack}); err != nil {
 				return err
 			}
 		}
 		return nil
-	}
-	return ctx.Write(newStackContext(), render)
+	})
 }
 
 type stackContext struct {
 	formatter.HeaderContext
 	s *Stack
-}
-
-func newStackContext() *stackContext {
-	stackCtx := stackContext{}
-	stackCtx.Header = formatter.SubHeaderContext{
-		"Name":     formatter.NameHeader,
-		"Services": stackServicesHeader,
-	}
-	return &stackCtx
 }
 
 func (s *stackContext) MarshalJSON() ([]byte, error) {

--- a/cli/command/stack/formatter/formatter.go
+++ b/cli/command/stack/formatter/formatter.go
@@ -43,7 +43,7 @@ type Stack struct {
 // StackWrite writes formatted stacks using the Context
 //
 // Deprecated: this function was for internal use and will be removed in the next release.
-func StackWrite(ctx formatter.Context, stacks []*Stack) error {
+func StackWrite(ctx formatter.Context, stacks []Stack) error {
 	fmtCtx := &stackContext{
 		HeaderContext: formatter.HeaderContext{
 			Header: formatter.SubHeaderContext{
@@ -64,7 +64,7 @@ func StackWrite(ctx formatter.Context, stacks []*Stack) error {
 
 type stackContext struct {
 	formatter.HeaderContext
-	s *Stack
+	s Stack
 }
 
 func (s *stackContext) MarshalJSON() ([]byte, error) {

--- a/cli/command/stack/formatter/formatter_test.go
+++ b/cli/command/stack/formatter/formatter_test.go
@@ -56,7 +56,7 @@ bar
 				Format: tc.format,
 				Output: &out,
 			}
-			if err := StackWrite(fmtCtx, []*Stack{
+			if err := StackWrite(fmtCtx, []Stack{
 				{Name: "baz", Services: 2},
 				{Name: "bar", Services: 1},
 			}); err != nil {

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -53,7 +53,7 @@ func runList(ctx context.Context, dockerCLI command.Cli, opts listOptions) error
 	return format(dockerCLI.Out(), opts, stacks)
 }
 
-func format(out io.Writer, opts listOptions, stacks []*formatter.Stack) error {
+func format(out io.Writer, opts listOptions, stacks []formatter.Stack) error {
 	fmt := formatter.Format(opts.Format)
 	if fmt == "" || fmt == formatter.TableFormatKey {
 		fmt = formatter.SwarmStackTableFormat

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -46,12 +46,10 @@ func RunList(ctx context.Context, dockerCLI command.Cli, opts options.List) erro
 
 // runList performs a stack list against the specified swarm cluster
 func runList(ctx context.Context, dockerCLI command.Cli, opts listOptions) error {
-	ss, err := swarm.GetStacks(ctx, dockerCLI.Client())
+	stacks, err := swarm.GetStacks(ctx, dockerCLI.Client())
 	if err != nil {
 		return err
 	}
-	stacks := make([]*formatter.Stack, 0, len(ss))
-	stacks = append(stacks, ss...)
 	return format(dockerCLI.Out(), opts, stacks)
 }
 

--- a/cli/command/stack/swarm/deploy.go
+++ b/cli/command/stack/swarm/deploy.go
@@ -69,19 +69,19 @@ func checkDaemonIsSwarmManager(ctx context.Context, dockerCli command.Cli) error
 }
 
 // pruneServices removes services that are no longer referenced in the source
-func pruneServices(ctx context.Context, dockerCCLI command.Cli, namespace convert.Namespace, services map[string]struct{}) {
-	apiClient := dockerCCLI.Client()
+func pruneServices(ctx context.Context, dockerCLI command.Cli, namespace convert.Namespace, services map[string]struct{}) {
+	apiClient := dockerCLI.Client()
 
 	oldServices, err := getStackServices(ctx, apiClient, namespace.Name())
 	if err != nil {
-		_, _ = fmt.Fprintln(dockerCCLI.Err(), "Failed to list services:", err)
+		_, _ = fmt.Fprintln(dockerCLI.Err(), "Failed to list services:", err)
 	}
 
-	pruneServices := []swarm.Service{}
+	toRemove := make([]swarm.Service, 0, len(oldServices))
 	for _, service := range oldServices {
 		if _, exists := services[namespace.Descope(service.Spec.Name)]; !exists {
-			pruneServices = append(pruneServices, service)
+			toRemove = append(toRemove, service)
 		}
 	}
-	removeServices(ctx, dockerCCLI, pruneServices)
+	removeServices(ctx, dockerCLI, toRemove)
 }

--- a/cli/command/stack/swarm/list.go
+++ b/cli/command/stack/swarm/list.go
@@ -12,7 +12,7 @@ import (
 // GetStacks lists the swarm stacks with the number of services they contain.
 //
 // Deprecated: this function was for internal use and will be removed in the next release.
-func GetStacks(ctx context.Context, apiClient client.ServiceAPIClient) ([]*formatter.Stack, error) {
+func GetStacks(ctx context.Context, apiClient client.ServiceAPIClient) ([]formatter.Stack, error) {
 	services, err := apiClient.ServiceList(ctx, client.ServiceListOptions{
 		Filters: getAllStacksFilter(),
 	})
@@ -21,7 +21,7 @@ func GetStacks(ctx context.Context, apiClient client.ServiceAPIClient) ([]*forma
 	}
 
 	idx := make(map[string]int, len(services))
-	out := make([]*formatter.Stack, 0, len(services))
+	out := make([]formatter.Stack, 0, len(services))
 
 	for _, svc := range services {
 		name, ok := svc.Spec.Labels[convert.LabelNamespace]
@@ -33,7 +33,7 @@ func GetStacks(ctx context.Context, apiClient client.ServiceAPIClient) ([]*forma
 			continue
 		}
 		idx[name] = len(out)
-		out = append(out, &formatter.Stack{Name: name, Services: 1})
+		out = append(out, formatter.Stack{Name: name, Services: 1})
 	}
 	return out, nil
 }


### PR DESCRIPTION
### cli/command/stack/formatter: TestStackContextWrite: cleanup test

- Include name in test-table
- Don't use un-keyed values in struct
- Simplify test-table to take a format string instead of a whole formatter.Context

### cli/command/stack/swarm: GetStacks: tidy up

Preserve the original order by avoiding the intermediate map[string] and
keeping an index for the first occurrence of a stack; this also avoids
looping multiple times.

### cli/command/stack/swarm: pruneServices: fix typo and minor cleanup

- fix typo in argument name
- rename var that shadowed function
- pre-allocate slice

### cli/command/stack: runList: remove intermediate slice

This intermediate slice was a left-over from the "Compose on Kubernetes"
feature, which required some conversions, but that code was removed in
193ede9b12b53e8aa595356e8b823f883e49bdc5, so the intermediate slice no
longer has a purpose.

### cli/command/stack/formatter: StackWrite: remove intermediate vars

- inline the closure
- remove newStackContext() constructor and inline it

### cli/command/stack/swarm: GetStacks: don't use pointers for values

These are very small structs, so using pointers doesn't bring much
advantage and makes it slightly more cumbersome to use.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

