### PR TITLE
cli/compose/convert: split exported AddStackLabel from implementation

### DIFF
--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -80,22 +80,19 @@ func Networks(namespace Namespace, networks networkMap, servicesNetworks map[str
 		}
 
 		if nw.Ipam.Driver != "" || len(nw.Ipam.Config) > 0 {
-			createOpts.IPAM = &network.IPAM{}
-		}
-
-		if nw.Ipam.Driver != "" {
-			createOpts.IPAM.Driver = nw.Ipam.Driver
-		}
-		for _, ipamConfig := range nw.Ipam.Config {
-			config := network.IPAMConfig{
-				Subnet: ipamConfig.Subnet,
+			createOpts.IPAM = &network.IPAM{
+				Driver: nw.Ipam.Driver,
 			}
-			createOpts.IPAM.Config = append(createOpts.IPAM.Config, config)
+			for _, ipamConfig := range nw.Ipam.Config {
+				createOpts.IPAM.Config = append(createOpts.IPAM.Config, network.IPAMConfig{
+					Subnet: ipamConfig.Subnet,
+				})
+			}
 		}
 
-		networkName := namespace.Scope(internalName)
-		if nw.Name != "" {
-			networkName = nw.Name
+		networkName := nw.Name
+		if nw.Name == "" {
+			networkName = namespace.Scope(internalName)
 		}
 		result[networkName] = createOpts
 	}

--- a/cli/compose/convert/compose.go
+++ b/cli/compose/convert/compose.go
@@ -42,6 +42,11 @@ func NewNamespace(name string) Namespace {
 
 // AddStackLabel returns labels with the namespace label added
 func AddStackLabel(namespace Namespace, labels map[string]string) map[string]string {
+	return addStackLabel(namespace, labels)
+}
+
+// addStackLabel returns labels with the namespace label added
+func addStackLabel(namespace Namespace, labels map[string]string) map[string]string {
 	if labels == nil {
 		labels = make(map[string]string)
 	}
@@ -67,7 +72,7 @@ func Networks(namespace Namespace, networks networkMap, servicesNetworks map[str
 		}
 
 		createOpts := client.NetworkCreateOptions{
-			Labels:     AddStackLabel(namespace, nw.Labels),
+			Labels:     addStackLabel(namespace, nw.Labels),
 			Driver:     nw.Driver,
 			Options:    nw.DriverOpts,
 			Internal:   nw.Internal,
@@ -171,7 +176,7 @@ func driverObjectConfig(namespace Namespace, name string, obj composetypes.FileO
 	return swarmFileObject{
 		Annotations: swarm.Annotations{
 			Name:   name,
-			Labels: AddStackLabel(namespace, obj.Labels),
+			Labels: addStackLabel(namespace, obj.Labels),
 		},
 		Data: []byte{},
 	}
@@ -192,7 +197,7 @@ func fileObjectConfig(namespace Namespace, name string, obj composetypes.FileObj
 	return swarmFileObject{
 		Annotations: swarm.Annotations{
 			Name:   name,
-			Labels: AddStackLabel(namespace, obj.Labels),
+			Labels: addStackLabel(namespace, obj.Labels),
 		},
 		Data: data,
 	}, nil

--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -30,7 +30,7 @@ func TestAddStackLabel(t *testing.T) {
 	labels := map[string]string{
 		"something": "labeled",
 	}
-	actual := AddStackLabel(Namespace{name: "foo"}, labels)
+	actual := addStackLabel(Namespace{name: "foo"}, labels)
 	expected := map[string]string{
 		"something":    "labeled",
 		LabelNamespace: "foo",

--- a/cli/compose/convert/service.go
+++ b/cli/compose/convert/service.go
@@ -119,7 +119,7 @@ func Service(
 	serviceSpec := swarm.ServiceSpec{
 		Annotations: swarm.Annotations{
 			Name:   name,
-			Labels: AddStackLabel(namespace, service.Deploy.Labels),
+			Labels: addStackLabel(namespace, service.Deploy.Labels),
 		},
 		TaskTemplate: swarm.TaskSpec{
 			ContainerSpec: &swarm.ContainerSpec{
@@ -131,7 +131,7 @@ func Service(
 				DNSConfig:       dnsConfig,
 				Healthcheck:     healthcheck,
 				Env:             convertEnvironment(service.Environment),
-				Labels:          AddStackLabel(namespace, service.Labels),
+				Labels:          addStackLabel(namespace, service.Labels),
 				Dir:             service.WorkingDir,
 				User:            service.User,
 				Mounts:          mounts,

--- a/cli/compose/convert/volume.go
+++ b/cli/compose/convert/volume.go
@@ -80,7 +80,7 @@ func handleVolumeToMount(
 		return result, nil
 	}
 
-	result.VolumeOptions.Labels = AddStackLabel(namespace, stackVolume.Labels)
+	result.VolumeOptions.Labels = addStackLabel(namespace, stackVolume.Labels)
 	if stackVolume.Driver != "" || stackVolume.DriverOpts != nil {
 		result.VolumeOptions.DriverConfig = &mount.Driver{
 			Name:    stackVolume.Driver,


### PR DESCRIPTION
### cli/compose/convert: split exported AddStackLabel from implementation

This function is currently only used within the package; create a non-exported
version of it, to make it clear it's not used elsewhere. This patch keeps
the exported function for now, but we can decide if we need to keep it
in future.


### cli/compose/convert: Networks: use struct-literal for IPAM config

Use a struct-literal for the IPAM config, and combine some of the checks.
Also use the Name field as a default, and only construct a scoped name
if the given name is empty (instead of the reverse).


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

