### PR TITLE
[28.x backport] Add escape hatch for GODEBUG=x509negativeserial

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -284,7 +284,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption)
 
 	meta, err := cli.contextStore.GetMetadata(cli.currentContext)
 	if err == nil {
-		setAllowNegativex509(meta)
+		setGoDebug(meta)
 	}
 
 	return nil
@@ -480,7 +480,7 @@ func (cli *DockerCli) getDockerEndPoint() (ep docker.Endpoint, err error) {
 	return resolveDockerEndpoint(cli.contextStore, cn)
 }
 
-// setAllowNegativex509 is an escape hatch that sets the GODEBUG environment
+// setGoDebug is an escape hatch that sets the GODEBUG environment
 // variable value using docker context metadata.
 //
 //	{
@@ -497,7 +497,7 @@ func (cli *DockerCli) getDockerEndPoint() (ep docker.Endpoint, err error) {
 // This option should only be used for legacy compatibility and never in
 // production environments.
 // Use at your own risk.
-func setAllowNegativex509(meta store.Metadata) {
+func setGoDebug(meta store.Metadata) {
 	fieldName := "GODEBUG"
 	godebugEnv := os.Getenv(fieldName)
 	// early return if GODEBUG is already set. We don't want to override what

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -282,6 +282,12 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption)
 	}
 	filterResourceAttributesEnvvar()
 
+	// early return if GODEBUG is already set or the docker context is
+	// the default context, i.e. is a virtual context where we won't override
+	// any GODEBUG values.
+	if v := os.Getenv("GODEBUG"); cli.currentContext == DefaultContextName || v != "" {
+		return nil
+	}
 	meta, err := cli.contextStore.GetMetadata(cli.currentContext)
 	if err == nil {
 		setGoDebug(meta)

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -355,11 +355,11 @@ func TestHooksEnabled(t *testing.T) {
 	})
 }
 
-func TestAllowNegativex509(t *testing.T) {
+func TestSetGoDebug(t *testing.T) {
 	t.Run("GODEBUG already set", func(t *testing.T) {
 		t.Setenv("GODEBUG", "val1,val2")
 		meta := store.Metadata{}
-		setAllowNegativex509(meta)
+		setGoDebug(meta)
 		assert.Equal(t, "val1,val2", os.Getenv("GODEBUG"))
 	})
 	t.Run("GODEBUG in context metadata can set env", func(t *testing.T) {
@@ -370,7 +370,7 @@ func TestAllowNegativex509(t *testing.T) {
 				},
 			},
 		}
-		setAllowNegativex509(meta)
+		setGoDebug(meta)
 		assert.Equal(t, "val1,val2=1", os.Getenv("GODEBUG"))
 	})
 }

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/flags"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -351,5 +352,25 @@ func TestHooksEnabled(t *testing.T) {
 		cli, err := NewDockerCli()
 		assert.NilError(t, err)
 		assert.Check(t, !cli.HooksEnabled())
+	})
+}
+
+func TestAllowNegativex509(t *testing.T) {
+	t.Run("GODEBUG already set", func(t *testing.T) {
+		t.Setenv("GODEBUG", "val1,val2")
+		meta := store.Metadata{}
+		setAllowNegativex509(meta)
+		assert.Equal(t, "val1,val2", os.Getenv("GODEBUG"))
+	})
+	t.Run("GODEBUG in context metadata can set env", func(t *testing.T) {
+		meta := store.Metadata{
+			Metadata: DockerContext{
+				AdditionalFields: map[string]any{
+					"GODEBUG": "val1,val2=1",
+				},
+			},
+		}
+		setAllowNegativex509(meta)
+		assert.Equal(t, "val1,val2=1", os.Getenv("GODEBUG"))
 	})
 }


### PR DESCRIPTION
- backport: https://github.com/docker/cli/pull/6371

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
Negative serial number certificates are deprecated and Go has also since deprecated them. To use them with Go you need to pass in the GODEBUG=x509negativeserial=1 environment variable.

This PR allows setting the value inside `docker context` instead. This should then propagate environment variables to underlying plugins (such as buildx).

```json5
{
  "Name": "my-context",
  "Metadata": { "GODEBUG": "x509negativeserial=1" },
  "Endpoints": {
    "docker": { "Host": "unix:///var/run/docker.sock", "SkipTLSVerify": false }
  }
}
```

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Allow Docker CLI to set the `GODEBUG` environment variable when the key-value pair (`"GODEBUG":"..."`) exists inside the docker context metadata.

```

**- A picture of a cute animal (not mandatory but encouraged)**

