### PR TITLE
verify that DisableFlagsInUseLine is set for all commands

### DIFF
--- a/cli/command/builder/cmd.go
+++ b/cli/command/builder/cmd.go
@@ -24,6 +24,8 @@ func newBuilderCommand(dockerCLI command.Cli) *cobra.Command {
 		Args:        cli.NoArgs,
 		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.31"},
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newPruneCommand(dockerCLI),
@@ -50,5 +52,6 @@ func newBakeStubCommand(dockerCLI command.Streams) *cobra.Command {
 			"aliases":      "docker buildx bake",
 			"version":      "1.31",
 		},
+		DisableFlagsInUseLine: true,
 	}
 }

--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -50,8 +50,9 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 			_, _ = fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations:       map[string]string{"version": "1.39"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.39"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/checkpoint/cmd.go
+++ b/cli/command/checkpoint/cmd.go
@@ -23,6 +23,7 @@ func newCheckpointCommand(dockerCLI command.Cli) *cobra.Command {
 			"ostype":       "linux",
 			"version":      "1.25",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCLI),

--- a/cli/command/checkpoint/create.go
+++ b/cli/command/checkpoint/create.go
@@ -17,7 +17,7 @@ type createOptions struct {
 	leaveRunning  bool
 }
 
-func newCreateCommand(dockerCli command.Cli) *cobra.Command {
+func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts createOptions
 
 	cmd := &cobra.Command{
@@ -27,9 +27,10 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.container = args[0]
 			opts.checkpoint = args[1]
-			return runCreate(cmd.Context(), dockerCli, opts)
+			return runCreate(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/checkpoint/list.go
+++ b/cli/command/checkpoint/list.go
@@ -15,7 +15,7 @@ type listOptions struct {
 	checkpointDir string
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts listOptions
 
 	cmd := &cobra.Command{
@@ -24,9 +24,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List checkpoints for a container",
 		Args:    cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), dockerCli, args[0], opts)
+			return runList(cmd.Context(), dockerCLI, args[0], opts)
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/checkpoint/remove.go
+++ b/cli/command/checkpoint/remove.go
@@ -13,7 +13,7 @@ type removeOptions struct {
 	checkpointDir string
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts removeOptions
 
 	cmd := &cobra.Command{
@@ -22,8 +22,9 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "Remove a checkpoint",
 		Args:    cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), dockerCli, args[0], args[1], opts)
+			return runRemove(cmd.Context(), dockerCLI, args[0], args[1], opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/config/cmd.go
+++ b/cli/command/config/cmd.go
@@ -24,6 +24,7 @@ func newConfigCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.30",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newConfigListCommand(dockerCLI),

--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -36,7 +36,8 @@ func newConfigCreateCommand(dockerCLI command.Cli) *cobra.Command {
 			createOpts.file = args[1]
 			return runCreate(cmd.Context(), dockerCLI, createOpts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.VarP(&createOpts.labels, "label", "l", "Config labels")

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -35,6 +35,7 @@ func newConfigInspectCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/config/ls.go
+++ b/cli/command/config/ls.go
@@ -32,7 +32,8 @@ func newConfigListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), dockerCLI, listOpts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -22,6 +22,7 @@ func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -58,6 +58,7 @@ func newAttachCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: completion.ContainerNames(dockerCLI, false, func(ctr container.Summary) bool {
 			return ctr.State != container.StatePaused
 		}),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/cmd.go
+++ b/cli/command/container/cmd.go
@@ -41,6 +41,8 @@ func newContainerCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Manage containers",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newAttachCommand(dockerCLI),

--- a/cli/command/container/commit.go
+++ b/cli/command/container/commit.go
@@ -40,7 +40,8 @@ func newCommitCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container commit, docker commit",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -154,6 +154,7 @@ container source to stdout.`,
 		Annotations: map[string]string{
 			"aliases": "docker container cp, docker cp",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -69,7 +69,8 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container create, docker create",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCLI, -1),
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, -1),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/diff.go
+++ b/cli/command/container/diff.go
@@ -22,7 +22,8 @@ func newDiffCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container diff, docker diff",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -59,6 +59,7 @@ func newExecCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "2",
 			"aliases":      "docker container exec, docker exec",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -32,7 +32,8 @@ func newExportCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container export, docker export",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -21,7 +21,7 @@ type inspectOptions struct {
 }
 
 // newInspectCommand creates a new cobra.Command for `docker container inspect`
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -30,9 +30,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.refs = args
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/kill.go
+++ b/cli/command/container/kill.go
@@ -32,7 +32,8 @@ func newKillCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container kill, docker kill",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/list.go
+++ b/cli/command/container/list.go
@@ -43,7 +43,8 @@ func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "3",
 			"aliases":      "docker container ls, docker container list, docker container ps, docker ps",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/logs.go
+++ b/cli/command/container/logs.go
@@ -38,7 +38,8 @@ func newLogsCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container logs, docker logs",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/pause.go
+++ b/cli/command/container/pause.go
@@ -34,6 +34,7 @@ func newPauseCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: completion.ContainerNames(dockerCLI, false, func(ctr container.Summary) bool {
 			return ctr.State != container.StatePaused
 		}),
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/container/port.go
+++ b/cli/command/container/port.go
@@ -24,7 +24,7 @@ type portOptions struct {
 }
 
 // newPortCommand creates a new cobra.Command for "docker container port".
-func newPortCommand(dockerCli command.Cli) *cobra.Command {
+func newPortCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts portOptions
 
 	cmd := &cobra.Command{
@@ -36,12 +36,13 @@ func newPortCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				opts.port = args[1]
 			}
-			return runPort(cmd.Context(), dockerCli, &opts)
+			return runPort(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container port, docker port",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/container/prune.go
+++ b/cli/command/container/prune.go
@@ -45,8 +45,9 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations:       map[string]string{"version": "1.25"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.25"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/rename.go
+++ b/cli/command/container/rename.go
@@ -33,7 +33,8 @@ func newRenameCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container rename, docker rename",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -39,7 +39,8 @@ func newRestartCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container restart, docker restart",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -40,6 +40,7 @@ func newRmCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: completion.ContainerNames(dockerCLI, true, func(ctr container.Summary) bool {
 			return opts.force || ctr.State == container.StateExited || ctr.State == container.StateCreated
 		}),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -48,6 +48,7 @@ func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "1",
 			"aliases":      "docker container run, docker run",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -28,7 +28,7 @@ type StartOptions struct {
 }
 
 // newStartCommand creates a new cobra.Command for "docker container start".
-func newStartCommand(dockerCli command.Cli) *cobra.Command {
+func newStartCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts StartOptions
 
 	cmd := &cobra.Command{
@@ -37,14 +37,15 @@ func newStartCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Containers = args
-			return RunStart(cmd.Context(), dockerCli, &opts)
+			return RunStart(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container start, docker start",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, true, func(ctr container.Summary) bool {
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, true, func(ctr container.Summary) bool {
 			return ctr.State == container.StateExited || ctr.State == container.StateCreated
 		}),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -79,7 +79,8 @@ func newStatsCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container stats, docker stats",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -39,7 +39,8 @@ func newStopCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container stop, docker stop",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/top.go
+++ b/cli/command/container/top.go
@@ -34,7 +34,8 @@ func newTopCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container top, docker top",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/unpause.go
+++ b/cli/command/container/unpause.go
@@ -17,7 +17,7 @@ type unpauseOptions struct {
 }
 
 // newUnpauseCommand creates a new cobra.Command for "docker container unpause".
-func newUnpauseCommand(dockerCli command.Cli) *cobra.Command {
+func newUnpauseCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts unpauseOptions
 
 	cmd := &cobra.Command{
@@ -26,14 +26,15 @@ func newUnpauseCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.containers = args
-			return runUnpause(cmd.Context(), dockerCli, &opts)
+			return runUnpause(cmd.Context(), dockerCLI, &opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container unpause, docker unpause",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCli, false, func(ctr container.Summary) bool {
+		ValidArgsFunction: completion.ContainerNames(dockerCLI, false, func(ctr container.Summary) bool {
 			return ctr.State == container.StatePaused
 		}),
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -52,7 +52,8 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container update, docker update",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, true),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, true),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/container/wait.go
+++ b/cli/command/container/wait.go
@@ -30,7 +30,8 @@ func newWaitCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker container wait, docker wait",
 		},
-		ValidArgsFunction: completion.ContainerNames(dockerCLI, false),
+		ValidArgsFunction:     completion.ContainerNames(dockerCLI, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	return cmd

--- a/cli/command/context/cmd.go
+++ b/cli/command/context/cmd.go
@@ -18,6 +18,8 @@ func newContextCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Manage contexts",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCLI),

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -66,8 +66,9 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 			opts.name = args[0]
 			return runCreate(dockerCLI, &opts)
 		},
-		Long:              longCreateDescription(),
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Long:                  longCreateDescription(),
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.description, "description", "", "Description of the context")

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -35,7 +35,8 @@ func newExportCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runExport(dockerCLI, contextName, dest)
 		},
-		ValidArgsFunction: completeContextNames(dockerCLI, 1, true),
+		ValidArgsFunction:     completeContextNames(dockerCLI, 1, true),
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/context/import.go
+++ b/cli/command/context/import.go
@@ -12,16 +12,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newImportCommand(dockerCli command.Cli) *cobra.Command {
+func newImportCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import CONTEXT FILE|-",
 		Short: "Import a context from a tar or zip file",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runImport(dockerCli, args[0], args[1])
+			return runImport(dockerCLI, args[0], args[1])
 		},
 		// TODO(thaJeztah): this should also include "-"
-		ValidArgsFunction: completion.FileNames,
+		ValidArgsFunction:     completion.FileNames,
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/context/inspect.go
+++ b/cli/command/context/inspect.go
@@ -35,7 +35,8 @@ func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runInspect(dockerCLI, opts)
 		},
-		ValidArgsFunction: completeContextNames(dockerCLI, -1, false),
+		ValidArgsFunction:     completeContextNames(dockerCLI, -1, false),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -23,7 +23,7 @@ type listOptions struct {
 	quiet  bool
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := &listOptions{}
 	cmd := &cobra.Command{
 		Use:     "ls [OPTIONS]",
@@ -31,9 +31,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List contexts",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(dockerCli, opts)
+			return runList(dockerCLI, opts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/context/remove.go
+++ b/cli/command/context/remove.go
@@ -32,7 +32,8 @@ func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(dockerCLI, opts, args)
 		},
-		ValidArgsFunction: completeContextNames(dockerCLI, -1, false),
+		ValidArgsFunction:     completeContextNames(dockerCLI, -1, false),
+		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force the removal of a context in use")
 	return cmd

--- a/cli/command/context/show.go
+++ b/cli/command/context/show.go
@@ -9,16 +9,17 @@ import (
 )
 
 // newShowCommand creates a new cobra.Command for `docker context sow`
-func newShowCommand(dockerCli command.Cli) *cobra.Command {
+func newShowCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Print the name of the current context",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runShow(dockerCli)
+			runShow(dockerCLI)
 			return nil
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -51,8 +51,9 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 			opts.name = args[0]
 			return runUpdate(dockerCLI, &opts)
 		},
-		Long:              longUpdateDescription(),
-		ValidArgsFunction: completeContextNames(dockerCLI, 1, false),
+		Long:                  longUpdateDescription(),
+		ValidArgsFunction:     completeContextNames(dockerCLI, 1, false),
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.description, "description", "", "Description of the context")

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -19,7 +19,8 @@ func newUseCommand(dockerCLI command.Cli) *cobra.Command {
 			name := args[0]
 			return runUse(dockerCLI, name)
 		},
-		ValidArgsFunction: completeContextNames(dockerCLI, 1, false),
+		ValidArgsFunction:     completeContextNames(dockerCLI, 1, false),
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -88,7 +88,7 @@ func NewBuildCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 // newBuildCommand creates a new `docker build` command
-func newBuildCommand(dockerCli command.Cli) *cobra.Command {
+func newBuildCommand(dockerCLI command.Cli) *cobra.Command {
 	options := newBuildOptions()
 
 	cmd := &cobra.Command{
@@ -97,7 +97,7 @@ func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.context = args[0]
-			return runBuild(cmd.Context(), dockerCli, options)
+			return runBuild(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"category-top": "4",
@@ -106,6 +106,7 @@ func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return nil, cobra.ShellCompDirectiveFilterDirs
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()
@@ -146,7 +147,7 @@ func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("target", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/buildx/build/#target"})
 	flags.StringVar(&options.imageIDFile, "iidfile", "", "Write the image ID to the file")
 
-	flags.Bool("disable-content-trust", dockerCli.ContentTrustEnabled(), "Skip image verification (deprecated)")
+	flags.Bool("disable-content-trust", dockerCLI.ContentTrustEnabled(), "Skip image verification (deprecated)")
 	_ = flags.MarkHidden("disable-content-trust")
 
 	flags.StringVar(&options.platform, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"), "Set platform if server is multi-platform capable")

--- a/cli/command/image/cmd.go
+++ b/cli/command/image/cmd.go
@@ -28,6 +28,8 @@ func newImageCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Manage images",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCli.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newBuildCommand(dockerCli),

--- a/cli/command/image/history.go
+++ b/cli/command/image/history.go
@@ -40,6 +40,7 @@ func newHistoryCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image history, docker history",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/import.go
+++ b/cli/command/image/import.go
@@ -40,6 +40,7 @@ func newImportCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image import, docker import",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -26,7 +26,7 @@ type inspectOptions struct {
 }
 
 // newInspectCommand creates a new cobra.Command for `docker image inspect`
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -35,9 +35,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.refs = args
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, -1),
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, -1),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -51,6 +51,7 @@ func newImagesCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "7",
 			"aliases":      "docker image ls, docker image list, docker images",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -36,7 +36,8 @@ func newLoadCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image load, docker load",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/prune.go
+++ b/cli/command/image/prune.go
@@ -48,8 +48,9 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations:       map[string]string{"version": "1.25"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.25"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -38,7 +38,8 @@ func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "5",
 			"aliases":      "docker image pull, docker pull",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -51,7 +51,8 @@ func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "6",
 			"aliases":      "docker image push, docker push",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCLI, 1),
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, 1),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/remove.go
+++ b/cli/command/image/remove.go
@@ -35,6 +35,7 @@ func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image rm, docker image remove, docker rmi",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -36,7 +36,8 @@ func newSaveCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker image save, docker save",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCLI, -1),
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, -1),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -15,7 +15,7 @@ type tagOptions struct {
 }
 
 // newTagCommand creates a new "docker image tag" command.
-func newTagCommand(dockerCli command.Cli) *cobra.Command {
+func newTagCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts tagOptions
 
 	cmd := &cobra.Command{
@@ -25,12 +25,13 @@ func newTagCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.image = args[0]
 			opts.name = args[1]
-			return runTag(cmd.Context(), dockerCli, opts)
+			return runTag(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker image tag, docker tag",
 		},
-		ValidArgsFunction: completion.ImageNames(dockerCli, 2),
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, 2),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -57,7 +57,7 @@ func newRegistryClient(dockerCLI command.Cli, allowInsecure bool) registryclient
 }
 
 // NewAnnotateCommand creates a new `docker manifest annotate` command
-func newAnnotateCommand(dockerCli command.Cli) *cobra.Command {
+func newAnnotateCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts annotateOptions
 
 	cmd := &cobra.Command{
@@ -67,8 +67,9 @@ func newAnnotateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.target = args[0]
 			opts.image = args[1]
-			return runManifestAnnotate(dockerCli, opts)
+			return runManifestAnnotate(dockerCLI, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -25,7 +25,8 @@ func newManifestCommand(dockerCLI command.Cli) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			_, _ = fmt.Fprint(dockerCLI.Err(), "\n"+cmd.UsageString())
 		},
-		Annotations: map[string]string{"experimentalCLI": ""},
+		Annotations:           map[string]string{"experimentalCLI": ""},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newCreateListCommand(dockerCLI),

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -16,7 +16,7 @@ type createOpts struct {
 	insecure bool
 }
 
-func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
+func newCreateListCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := createOpts{}
 
 	cmd := &cobra.Command{
@@ -24,8 +24,9 @@ func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Create a local manifest list for annotating and pushing to a registry",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return createManifestList(cmd.Context(), dockerCli, args, opts)
+			return createManifestList(cmd.Context(), dockerCLI, args, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -22,7 +22,7 @@ type inspectOptions struct {
 }
 
 // NewInspectCommand creates a new `docker manifest inspect` command
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -37,8 +37,9 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 				opts.list = args[0]
 				opts.ref = args[1]
 			}
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -42,7 +42,7 @@ type pushRequest struct {
 	insecure      bool
 }
 
-func newPushListCommand(dockerCli command.Cli) *cobra.Command {
+func newPushListCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := pushOpts{}
 
 	cmd := &cobra.Command{
@@ -51,8 +51,9 @@ func newPushListCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.target = args[0]
-			return runPush(cmd.Context(), dockerCli, opts)
+			return runPush(cmd.Context(), dockerCLI, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/manifest/rm.go
+++ b/cli/command/manifest/rm.go
@@ -18,6 +18,7 @@ func newRmManifestListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), newManifestStore(dockerCLI), args)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	return cmd

--- a/cli/command/network/cmd.go
+++ b/cli/command/network/cmd.go
@@ -19,6 +19,8 @@ func newNetworkCommand(dockerCLI command.Cli) *cobra.Command {
 		Args:        cli.NoArgs,
 		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newConnectCommand(dockerCLI),

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -47,6 +47,7 @@ func newConnectCommand(dockerCLI command.Cli) *cobra.Command {
 			nw := args[0]
 			return completion.ContainerNames(dockerCLI, true, not(isConnected(nw)))(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -68,7 +68,8 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 
 			return runCreate(cmd.Context(), dockerCLI.Client(), dockerCLI.Out(), options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/disconnect.go
+++ b/cli/command/network/disconnect.go
@@ -17,7 +17,7 @@ type disconnectOptions struct {
 	force     bool
 }
 
-func newDisconnectCommand(dockerCli command.Cli) *cobra.Command {
+func newDisconnectCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := disconnectOptions{}
 
 	cmd := &cobra.Command{
@@ -27,15 +27,16 @@ func newDisconnectCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.network = args[0]
 			opts.container = args[1]
-			return runDisconnect(cmd.Context(), dockerCli.Client(), opts)
+			return runDisconnect(cmd.Context(), dockerCLI.Client(), opts)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			if len(args) == 0 {
-				return completion.NetworkNames(dockerCli)(cmd, args, toComplete)
+				return completion.NetworkNames(dockerCLI)(cmd, args, toComplete)
 			}
 			network := args[0]
-			return completion.ContainerNames(dockerCli, true, isConnected(network))(cmd, args, toComplete)
+			return completion.ContainerNames(dockerCLI, true, isConnected(network))(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -33,7 +33,8 @@ func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 			opts.names = args
 			return runInspect(cmd.Context(), dockerCLI.Client(), dockerCLI.Out(), opts)
 		},
-		ValidArgsFunction: completion.NetworkNames(dockerCLI),
+		ValidArgsFunction:     completion.NetworkNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/network/list.go
+++ b/cli/command/network/list.go
@@ -21,7 +21,7 @@ type listOptions struct {
 	filter  opts.FilterOpt
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -30,9 +30,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List networks",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), dockerCli, options)
+			return runList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/prune.go
+++ b/cli/command/network/prune.go
@@ -43,7 +43,8 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return nil
 		},
-		Annotations: map[string]string{"version": "1.25"},
+		Annotations:           map[string]string{"version": "1.25"},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/network/remove.go
+++ b/cli/command/network/remove.go
@@ -18,7 +18,7 @@ type removeOptions struct {
 	force bool
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts removeOptions
 
 	cmd := &cobra.Command{
@@ -27,9 +27,10 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "Remove one or more networks",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), dockerCli, args, &opts)
+			return runRemove(cmd.Context(), dockerCLI, args, &opts)
 		},
-		ValidArgsFunction: completion.NetworkNames(dockerCli),
+		ValidArgsFunction:     completion.NetworkNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/node/cmd.go
+++ b/cli/command/node/cmd.go
@@ -26,6 +26,7 @@ func newNodeCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newDemoteCommand(dockerCLI),

--- a/cli/command/node/demote.go
+++ b/cli/command/node/demote.go
@@ -10,15 +10,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDemoteCommand(dockerCli command.Cli) *cobra.Command {
+func newDemoteCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "demote NODE [NODE...]",
 		Short: "Demote one or more nodes from manager in the swarm",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDemote(cmd.Context(), dockerCli, args)
+			return runDemote(cmd.Context(), dockerCLI, args)
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -21,7 +21,7 @@ type inspectOptions struct {
 	pretty  bool
 }
 
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -30,9 +30,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.nodeIds = args
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -22,7 +22,7 @@ type listOptions struct {
 	filter opts.FilterOpt
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -31,9 +31,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List nodes in the swarm",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), dockerCli, options)
+			return runList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display IDs")

--- a/cli/command/node/promote.go
+++ b/cli/command/node/promote.go
@@ -10,15 +10,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPromoteCommand(dockerCli command.Cli) *cobra.Command {
+func newPromoteCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "promote NODE [NODE...]",
 		Short: "Promote one or more nodes to manager in the swarm",
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPromote(cmd.Context(), dockerCli, args)
+			return runPromote(cmd.Context(), dockerCLI, args)
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -25,7 +25,7 @@ type psOptions struct {
 	filter    opts.FilterOpt
 }
 
-func newPsCommand(dockerCli command.Cli) *cobra.Command {
+func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -39,9 +39,10 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 				options.nodeIDs = args
 			}
 
-			return runPs(cmd.Context(), dockerCli, options)
+			return runPs(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&options.noTrunc, "no-trunc", false, "Do not truncate output")

--- a/cli/command/node/remove.go
+++ b/cli/command/node/remove.go
@@ -15,7 +15,7 @@ type removeOptions struct {
 	force bool
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := removeOptions{}
 
 	cmd := &cobra.Command{
@@ -24,9 +24,10 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "Remove one or more nodes from the swarm",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), dockerCli, args, opts)
+			return runRemove(cmd.Context(), dockerCLI, args, opts)
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.force, "force", "f", false, "Force remove a node from the swarm")

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -17,7 +17,7 @@ import (
 
 var errNoRoleChange = errors.New("role was already set to the requested value")
 
-func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
+func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	options := newNodeOptions()
 
 	cmd := &cobra.Command{
@@ -25,9 +25,10 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Update a node",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd.Context(), dockerCli, cmd.Flags(), args[0])
+			return runUpdate(cmd.Context(), dockerCLI, cmd.Flags(), args[0])
 		},
-		ValidArgsFunction: completeNodeNames(dockerCli),
+		ValidArgsFunction:     completeNodeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/cmd.go
+++ b/cli/command/plugin/cmd.go
@@ -19,6 +19,8 @@ func newPluginCommand(dockerCLI command.Cli) *cobra.Command {
 		Args:        cli.NoArgs,
 		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.25"},
+
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.AddCommand(

--- a/cli/command/plugin/create.go
+++ b/cli/command/plugin/create.go
@@ -64,7 +64,7 @@ type pluginCreateOptions struct {
 	compress bool
 }
 
-func newCreateCommand(dockerCli command.Cli) *cobra.Command {
+func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pluginCreateOptions{}
 
 	cmd := &cobra.Command{
@@ -74,9 +74,10 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.repoName = args[0]
 			options.context = args[1]
-			return runCreate(cmd.Context(), dockerCli, options)
+			return runCreate(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/disable.go
+++ b/cli/command/plugin/disable.go
@@ -24,6 +24,7 @@ func newDisableCommand(dockerCLI command.Cli) *cobra.Command {
 			_, _ = fmt.Fprintln(dockerCLI.Out(), name)
 			return nil
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/enable.go
+++ b/cli/command/plugin/enable.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newEnableCommand(dockerCli command.Cli) *cobra.Command {
+func newEnableCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts client.PluginEnableOptions
 
 	cmd := &cobra.Command{
@@ -20,12 +20,13 @@ func newEnableCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			if err := runEnable(cmd.Context(), dockerCli, name, opts); err != nil {
+			if err := runEnable(cmd.Context(), dockerCLI, name, opts); err != nil {
 				return err
 			}
-			_, _ = fmt.Fprintln(dockerCli.Out(), name)
+			_, _ = fmt.Fprintln(dockerCLI.Out(), name)
 			return nil
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -18,7 +18,7 @@ type inspectOptions struct {
 	format      string
 }
 
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -27,8 +27,9 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.pluginNames = args
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -25,7 +25,7 @@ type pluginOptions struct {
 	skipRemoteCheck bool
 }
 
-func newInstallCommand(dockerCli command.Cli) *cobra.Command {
+func newInstallCommand(dockerCLI command.Cli) *cobra.Command {
 	var options pluginOptions
 	cmd := &cobra.Command{
 		Use:   "install [OPTIONS] PLUGIN [KEY=VALUE...]",
@@ -36,15 +36,16 @@ func newInstallCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) > 1 {
 				options.args = args[1:]
 			}
-			return runInstall(cmd.Context(), dockerCli, options)
+			return runInstall(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()
 	flags.BoolVar(&options.grantPerms, "grant-all-permissions", false, "Grant all permissions necessary to run the plugin")
 	flags.BoolVar(&options.disable, "disable", false, "Do not enable the plugin on install")
 	flags.StringVar(&options.localName, "alias", "", "Local name for plugin")
-	flags.Bool("disable-content-trust", dockerCli.ContentTrustEnabled(), "Skip image verification (deprecated)")
+	flags.Bool("disable-content-trust", dockerCLI.ContentTrustEnabled(), "Skip image verification (deprecated)")
 	_ = flags.MarkHidden("disable-content-trust")
 	return cmd
 }

--- a/cli/command/plugin/list.go
+++ b/cli/command/plugin/list.go
@@ -20,7 +20,7 @@ type listOptions struct {
 	filter  opts.FilterOpt
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -29,9 +29,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Aliases: []string{"list"},
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), dockerCli, options)
+			return runList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -20,6 +20,7 @@ func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 			name := args[0]
 			return runPush(cmd.Context(), dockerCLI, name)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/remove.go
+++ b/cli/command/plugin/remove.go
@@ -17,7 +17,7 @@ type rmOptions struct {
 	plugins []string
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts rmOptions
 
 	cmd := &cobra.Command{
@@ -27,8 +27,9 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.plugins = args
-			return runRemove(cmd.Context(), dockerCli, &opts)
+			return runRemove(cmd.Context(), dockerCLI, &opts)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/plugin/set.go
+++ b/cli/command/plugin/set.go
@@ -6,13 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSetCommand(dockerCli command.Cli) *cobra.Command {
+func newSetCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set PLUGIN KEY=VALUE [KEY=VALUE...]",
 		Short: "Change settings for a plugin",
 		Args:  cli.RequiresMinArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return dockerCli.Client().PluginSet(cmd.Context(), args[0], args[1:])
+			return dockerCLI.Client().PluginSet(cmd.Context(), args[0], args[1:])
 		},
+		DisableFlagsInUseLine: true,
 	}
 }

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newUpgradeCommand(dockerCli command.Cli) *cobra.Command {
+func newUpgradeCommand(dockerCLI command.Cli) *cobra.Command {
 	var options pluginOptions
 	cmd := &cobra.Command{
 		Use:   "upgrade [OPTIONS] PLUGIN [REMOTE]",
@@ -25,14 +25,15 @@ func newUpgradeCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) == 2 {
 				options.remote = args[1]
 			}
-			return runUpgrade(cmd.Context(), dockerCli, options)
+			return runUpgrade(cmd.Context(), dockerCLI, options)
 		},
-		Annotations: map[string]string{"version": "1.26"},
+		Annotations:           map[string]string{"version": "1.26"},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()
 	flags.BoolVar(&options.grantPerms, "grant-all-permissions", false, "Grant all permissions necessary to run the plugin")
-	flags.Bool("disable-content-trust", dockerCli.ContentTrustEnabled(), "Skip image verification (deprecated)")
+	flags.Bool("disable-content-trust", dockerCLI.ContentTrustEnabled(), "Skip image verification (deprecated)")
 	_ = flags.MarkHidden("disable-content-trust")
 	flags.BoolVar(&options.skipRemoteCheck, "skip-remote-check", false, "Do not check if specified remote plugin matches existing plugin image")
 	return cmd

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -56,7 +56,8 @@ func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "8",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -34,6 +34,7 @@ func newLogoutCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "9",
 		},
+		DisableFlagsInUseLine: true,
 		// TODO (thaJeztah) add completion for registries we have authentication stored for
 	}
 

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -43,6 +43,7 @@ func newSearchCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "10",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -24,6 +24,7 @@ func newSecretCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.25",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newSecretListCommand(dockerCLI),

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -22,7 +22,7 @@ type createOptions struct {
 	labels         opts.ListOpts
 }
 
-func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
+func newSecretCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	options := createOptions{
 		labels: opts.NewListOpts(opts.ValidateLabel),
 	}
@@ -36,8 +36,9 @@ func newSecretCreateCommand(dockerCli command.Cli) *cobra.Command {
 			if len(args) == 2 {
 				options.file = args[1]
 			}
-			return runSecretCreate(cmd.Context(), dockerCli, options)
+			return runSecretCreate(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.VarP(&options.labels, "label", "l", "Secret labels")

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -21,7 +21,7 @@ type inspectOptions struct {
 	pretty bool
 }
 
-func newSecretInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newSecretInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] SECRET [SECRET...]",
@@ -29,11 +29,12 @@ func newSecretInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.names = args
-			return runSecretInspect(cmd.Context(), dockerCli, opts)
+			return runSecretInspect(cmd.Context(), dockerCLI, opts)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -20,7 +20,7 @@ type listOptions struct {
 	filter opts.FilterOpt
 }
 
-func newSecretListCommand(dockerCli command.Cli) *cobra.Command {
+func newSecretListCommand(dockerCLI command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -29,11 +29,12 @@ func newSecretListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List secrets",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSecretList(cmd.Context(), dockerCli, options)
+			return runSecretList(cmd.Context(), dockerCLI, options)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -29,6 +29,7 @@ func newSecretRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 }
 

--- a/cli/command/service/cmd.go
+++ b/cli/command/service/cmd.go
@@ -22,6 +22,7 @@ func newServiceCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCLI),

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -29,7 +29,8 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runCreate(cmd.Context(), dockerCLI, cmd.Flags(), opts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opts.mode, flagMode, "replicated", `Service mode ("replicated", "global", "replicated-job", "global-job")`)

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -24,7 +24,7 @@ type inspectOptions struct {
 	pretty bool
 }
 
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -37,9 +37,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 			if opts.pretty && len(opts.format) > 0 {
 				return errors.Errorf("--format is incompatible with human friendly format")
 			}
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completeServiceNames(dockerCli),
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -32,7 +32,8 @@ func newListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -38,7 +38,7 @@ type logsOptions struct {
 	target string
 }
 
-func newLogsCommand(dockerCli command.Cli) *cobra.Command {
+func newLogsCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts logsOptions
 
 	cmd := &cobra.Command{
@@ -47,10 +47,11 @@ func newLogsCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.target = args[0]
-			return runLogs(cmd.Context(), dockerCli, &opts)
+			return runLogs(cmd.Context(), dockerCLI, &opts)
 		},
-		Annotations:       map[string]string{"version": "1.29"},
-		ValidArgsFunction: completeServiceNames(dockerCli),
+		Annotations:           map[string]string{"version": "1.29"},
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -26,7 +26,7 @@ type psOptions struct {
 	filter    opts.FilterOpt
 }
 
-func newPsCommand(dockerCli command.Cli) *cobra.Command {
+func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	options := psOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -35,9 +35,10 @@ func newPsCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.services = args
-			return runPS(cmd.Context(), dockerCli, options)
+			return runPS(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: completeServiceNames(dockerCli),
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display task IDs")

--- a/cli/command/service/remove.go
+++ b/cli/command/service/remove.go
@@ -10,16 +10,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rm SERVICE [SERVICE...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more services",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRemove(cmd.Context(), dockerCli, args)
+			return runRemove(cmd.Context(), dockerCLI, args)
 		},
-		ValidArgsFunction: completeServiceNames(dockerCli),
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 	cmd.Flags()
 

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
+func newRollbackCommand(dockerCLI command.Cli) *cobra.Command {
 	options := newServiceOptions()
 
 	cmd := &cobra.Command{
@@ -20,10 +20,11 @@ func newRollbackCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Revert changes to a service's configuration",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRollback(cmd.Context(), dockerCli, options, args[0])
+			return runRollback(cmd.Context(), dockerCLI, options, args[0])
 		},
-		Annotations:       map[string]string{"version": "1.31"},
-		ValidArgsFunction: completeServiceNames(dockerCli),
+		Annotations:           map[string]string{"version": "1.31"},
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/scale.go
+++ b/cli/command/service/scale.go
@@ -18,7 +18,7 @@ type scaleOptions struct {
 	detach bool
 }
 
-func newScaleCommand(dockerCli command.Cli) *cobra.Command {
+func newScaleCommand(dockerCLI command.Cli) *cobra.Command {
 	options := &scaleOptions{}
 
 	cmd := &cobra.Command{
@@ -26,9 +26,10 @@ func newScaleCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Scale one or multiple replicated services",
 		Args:  scaleArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runScale(cmd.Context(), dockerCli, options, args)
+			return runScale(cmd.Context(), dockerCLI, options, args)
 		},
-		ValidArgsFunction: completeScaleArgs(dockerCli),
+		ValidArgsFunction:     completeScaleArgs(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -33,7 +33,8 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runUpdate(cmd.Context(), dockerCLI, cmd.Flags(), options, args[0])
 		},
-		ValidArgsFunction: completeServiceNames(dockerCLI),
+		ValidArgsFunction:     completeServiceNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/cmd.go
+++ b/cli/command/stack/cmd.go
@@ -26,6 +26,7 @@ func newStackCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.25",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 	defaultHelpFunc := cmd.HelpFunc()
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {

--- a/cli/command/stack/config.go
+++ b/cli/command/stack/config.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func newConfigCommand(dockerCli command.Cli) *cobra.Command {
+func newConfigCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts options.Config
 
 	cmd := &cobra.Command{
@@ -22,7 +22,7 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Outputs the final config file, after doing merges and interpolations",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configDetails, err := loader.GetConfigDetails(opts.Composefiles, dockerCli.In())
+			configDetails, err := loader.GetConfigDetails(opts.Composefiles, dockerCLI.In())
 			if err != nil {
 				return err
 			}
@@ -32,10 +32,11 @@ func newConfigCommand(dockerCli command.Cli) *cobra.Command {
 				return err
 			}
 
-			_, err = fmt.Fprintf(dockerCli.Out(), "%s", cfg)
+			_, err = fmt.Fprintf(dockerCLI.Out(), "%s", cfg)
 			return err
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newDeployCommand(dockerCli command.Cli) *cobra.Command {
+func newDeployCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts options.Deploy
 
 	cmd := &cobra.Command{
@@ -22,15 +22,16 @@ func newDeployCommand(dockerCli command.Cli) *cobra.Command {
 			if err := validateStackName(opts.Namespace); err != nil {
 				return err
 			}
-			config, err := loader.LoadComposefile(dockerCli, opts)
+			config, err := loader.LoadComposefile(dockerCLI, opts)
 			if err != nil {
 				return err
 			}
-			return swarm.RunDeploy(cmd.Context(), dockerCli, cmd.Flags(), &opts, config)
+			return swarm.RunDeploy(cmd.Context(), dockerCLI, cmd.Flags(), &opts, config)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/list.go
+++ b/cli/command/stack/list.go
@@ -30,7 +30,8 @@ func newListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runList(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -41,6 +41,7 @@ func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&opts.noTrunc, "no-trunc", false, "Do not truncate output")

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts options.Remove
 
 	cmd := &cobra.Command{
@@ -21,11 +21,12 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 			if err := validateStackNames(opts.Namespaces); err != nil {
 				return err
 			}
-			return swarm.RunRemove(cmd.Context(), dockerCli, opts)
+			return swarm.RunRemove(cmd.Context(), dockerCLI, opts)
 		},
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCli)(cmd, args, toComplete)
+			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -41,6 +41,7 @@ func newServicesCommand(dockerCLI command.Cli) *cobra.Command {
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completeNames(dockerCLI)(cmd, args, toComplete)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Only display IDs")

--- a/cli/command/swarm/ca.go
+++ b/cli/command/swarm/ca.go
@@ -26,7 +26,7 @@ type caOptions struct {
 	quiet      bool
 }
 
-func newCACommand(dockerCli command.Cli) *cobra.Command {
+func newCACommand(dockerCLI command.Cli) *cobra.Command {
 	opts := caOptions{}
 
 	cmd := &cobra.Command{
@@ -34,13 +34,14 @@ func newCACommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Display and rotate the root CA",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCA(cmd.Context(), dockerCli, cmd.Flags(), opts)
+			return runCA(cmd.Context(), dockerCLI, cmd.Flags(), opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.30",
 			"swarm":   "manager",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/cmd.go
+++ b/cli/command/swarm/cmd.go
@@ -23,6 +23,7 @@ func newSwarmCommand(dockerCLI command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "", // swarm command itself does not require swarm to be enabled (so swarm init and join is always available on API 1.24 and up)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newInitCommand(dockerCLI),

--- a/cli/command/swarm/init.go
+++ b/cli/command/swarm/init.go
@@ -27,7 +27,7 @@ type initOptions struct {
 	DefaultAddrPoolMaskLength uint32
 }
 
-func newInitCommand(dockerCli command.Cli) *cobra.Command {
+func newInitCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := initOptions{
 		listenAddr: NewListenAddrOption(),
 	}
@@ -37,13 +37,14 @@ func newInitCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Initialize a swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInit(cmd.Context(), dockerCli, cmd.Flags(), opts)
+			return runInit(cmd.Context(), dockerCLI, cmd.Flags(), opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "", // swarm init does not require swarm to be active, and is always available on API 1.24 and up
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/join.go
+++ b/cli/command/swarm/join.go
@@ -23,7 +23,7 @@ type joinOptions struct {
 	availability  string
 }
 
-func newJoinCommand(dockerCli command.Cli) *cobra.Command {
+func newJoinCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := joinOptions{
 		listenAddr: NewListenAddrOption(),
 	}
@@ -34,12 +34,13 @@ func newJoinCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
-			return runJoin(cmd.Context(), dockerCli, cmd.Flags(), opts)
+			return runJoin(cmd.Context(), dockerCLI, cmd.Flags(), opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "", // swarm join does not require swarm to be active, and is always available on API 1.24 and up
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/join_token.go
+++ b/cli/command/swarm/join_token.go
@@ -17,7 +17,7 @@ type joinTokenOptions struct {
 	quiet  bool
 }
 
-func newJoinTokenCommand(dockerCli command.Cli) *cobra.Command {
+func newJoinTokenCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := joinTokenOptions{}
 
 	cmd := &cobra.Command{
@@ -26,12 +26,13 @@ func newJoinTokenCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.role = args[0]
-			return runJoinToken(cmd.Context(), dockerCli, opts)
+			return runJoinToken(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/leave.go
+++ b/cli/command/swarm/leave.go
@@ -13,7 +13,7 @@ type leaveOptions struct {
 	force bool
 }
 
-func newLeaveCommand(dockerCli command.Cli) *cobra.Command {
+func newLeaveCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := leaveOptions{}
 
 	cmd := &cobra.Command{
@@ -21,13 +21,14 @@ func newLeaveCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Leave the swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runLeave(cmd.Context(), dockerCli, opts)
+			return runLeave(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "active",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/testdata/update-noargs.golden
+++ b/cli/command/swarm/testdata/update-noargs.golden
@@ -1,7 +1,7 @@
 Update the swarm
 
 Usage:
-  update [OPTIONS] [flags]
+  update [OPTIONS]
 
 Flags:
       --autolock                        Change manager autolocking setting (true|false)

--- a/cli/command/swarm/unlock.go
+++ b/cli/command/swarm/unlock.go
@@ -16,19 +16,20 @@ import (
 	"golang.org/x/term"
 )
 
-func newUnlockCommand(dockerCli command.Cli) *cobra.Command {
+func newUnlockCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unlock",
 		Short: "Unlock swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUnlock(cmd.Context(), dockerCli)
+			return runUnlock(cmd.Context(), dockerCLI)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	return cmd

--- a/cli/command/swarm/unlock_key.go
+++ b/cli/command/swarm/unlock_key.go
@@ -17,7 +17,7 @@ type unlockKeyOptions struct {
 	quiet  bool
 }
 
-func newUnlockKeyCommand(dockerCli command.Cli) *cobra.Command {
+func newUnlockKeyCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := unlockKeyOptions{}
 
 	cmd := &cobra.Command{
@@ -25,13 +25,14 @@ func newUnlockKeyCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Manage the unlock key",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUnlockKey(cmd.Context(), dockerCli, opts)
+			return runUnlockKey(cmd.Context(), dockerCLI, opts)
 		},
 		Annotations: map[string]string{
 			"version": "1.24",
 			"swarm":   "manager",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/swarm/update.go
+++ b/cli/command/swarm/update.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
+func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	opts := swarmOptions{}
 
 	cmd := &cobra.Command{
@@ -20,7 +20,7 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Update the swarm",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd.Context(), dockerCli, cmd.Flags(), opts)
+			return runUpdate(cmd.Context(), dockerCLI, cmd.Flags(), opts)
 		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Flags().NFlag() == 0 {
@@ -32,7 +32,8 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 			"version": "1.24",
 			"swarm":   "manager",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().BoolVar(&opts.autolock, flagAutolock, false, "Change manager autolocking setting (true|false)")

--- a/cli/command/system/cmd.go
+++ b/cli/command/system/cmd.go
@@ -22,6 +22,8 @@ func newSystemCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Manage Docker",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newEventsCommand(dockerCLI),

--- a/cli/command/system/df.go
+++ b/cli/command/system/df.go
@@ -17,7 +17,7 @@ type diskUsageOptions struct {
 }
 
 // newDiskUsageCommand creates a new cobra.Command for `docker df`
-func newDiskUsageCommand(dockerCli command.Cli) *cobra.Command {
+func newDiskUsageCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts diskUsageOptions
 
 	cmd := &cobra.Command{
@@ -25,10 +25,11 @@ func newDiskUsageCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Show docker disk usage",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiskUsage(cmd.Context(), dockerCli, opts)
+			return runDiskUsage(cmd.Context(), dockerCLI, opts)
 		},
-		Annotations:       map[string]string{"version": "1.25"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.25"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/dial_stdio.go
+++ b/cli/command/system/dial_stdio.go
@@ -13,16 +13,17 @@ import (
 )
 
 // newDialStdioCommand creates a new cobra.Command for `docker system dial-stdio`
-func newDialStdioCommand(dockerCli command.Cli) *cobra.Command {
+func newDialStdioCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "dial-stdio",
 		Short:  "Proxy the stdio stream to the daemon connection. Should not be invoked manually.",
 		Args:   cli.NoArgs,
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDialStdio(cmd.Context(), dockerCli)
+			return runDialStdio(cmd.Context(), dockerCLI)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	return cmd
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -41,7 +41,8 @@ func newEventsCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"aliases": "docker system events, docker events",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -73,7 +73,8 @@ func newInfoCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "12",
 			"aliases":      "docker system info, docker info",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -73,7 +73,8 @@ func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
 		// TODO(thaJeztah): should we consider adding completion for common object-types? (images, containers?)
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/prune.go
+++ b/cli/command/system/prune.go
@@ -27,7 +27,7 @@ type pruneOptions struct {
 }
 
 // newPruneCommand creates a new cobra.Command for `docker prune`
-func newPruneCommand(dockerCli command.Cli) *cobra.Command {
+func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	options := pruneOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -35,10 +35,11 @@ func newPruneCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Remove unused data",
 		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPrune(cmd.Context(), dockerCli, options)
+			return runPrune(cmd.Context(), dockerCLI, options)
 		},
-		Annotations:       map[string]string{"version": "1.25"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.25"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -122,7 +122,8 @@ func newVersionCommand(dockerCLI command.Cli) *cobra.Command {
 		Annotations: map[string]string{
 			"category-top": "10",
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/trust/cmd.go
+++ b/cli/command/trust/cmd.go
@@ -18,6 +18,8 @@ func newTrustCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Manage trust on Docker images",
 		Args:  cli.NoArgs,
 		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newRevokeCommand(dockerCLI),

--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -23,7 +23,7 @@ type inspectOptions struct {
 	prettyPrint bool
 }
 
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	options := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect IMAGE[:TAG] [IMAGE[:TAG]...]",
@@ -32,8 +32,9 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.remotes = args
 
-			return runInspect(cmd.Context(), dockerCli, options)
+			return runInspect(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/trust/key.go
+++ b/cli/command/trust/key.go
@@ -7,16 +7,18 @@ import (
 )
 
 // newTrustKeyCommand returns a cobra command for `trust key` subcommands
-func newTrustKeyCommand(dockerCli command.Streams) *cobra.Command {
+func newTrustKeyCommand(dockerCLI command.Streams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "key",
 		Short: "Manage keys for signing Docker images",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		newKeyGenerateCommand(dockerCli),
-		newKeyLoadCommand(dockerCli),
+		newKeyGenerateCommand(dockerCLI),
+		newKeyLoadCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/trust/key_generate.go
+++ b/cli/command/trust/key_generate.go
@@ -23,7 +23,7 @@ type keyGenerateOptions struct {
 	directory string
 }
 
-func newKeyGenerateCommand(dockerCli command.Streams) *cobra.Command {
+func newKeyGenerateCommand(dockerCLI command.Streams) *cobra.Command {
 	options := keyGenerateOptions{}
 	cmd := &cobra.Command{
 		Use:   "generate NAME",
@@ -31,8 +31,9 @@ func newKeyGenerateCommand(dockerCli command.Streams) *cobra.Command {
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.name = args[0]
-			return setupPassphraseAndGenerateKeys(dockerCli, options)
+			return setupPassphraseAndGenerateKeys(dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&options.directory, "dir", "", "Directory to generate key in, defaults to current directory")

--- a/cli/command/trust/key_load.go
+++ b/cli/command/trust/key_load.go
@@ -27,15 +27,16 @@ type keyLoadOptions struct {
 	keyName string
 }
 
-func newKeyLoadCommand(dockerCli command.Streams) *cobra.Command {
+func newKeyLoadCommand(dockerCLI command.Streams) *cobra.Command {
 	var options keyLoadOptions
 	cmd := &cobra.Command{
 		Use:   "load [OPTIONS] KEYFILE",
 		Short: "Load a private key file for signing",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return loadPrivKey(dockerCli, args[0], options)
+			return loadPrivKey(dockerCLI, args[0], options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&options.keyName, "name", "signer", "Name for the loaded key")

--- a/cli/command/trust/revoke.go
+++ b/cli/command/trust/revoke.go
@@ -27,6 +27,7 @@ func newRevokeCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return revokeTrust(cmd.Context(), dockerCLI, args[0], options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.forceYes, "yes", "y", false, "Do not prompt for confirmation")

--- a/cli/command/trust/sign.go
+++ b/cli/command/trust/sign.go
@@ -35,6 +35,7 @@ func newSignCommand(dockerCLI command.Cli) *cobra.Command {
 			options.imageName = args[0]
 			return runSignImage(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVar(&options.local, "local", false, "Sign a locally tagged image")

--- a/cli/command/trust/signer.go
+++ b/cli/command/trust/signer.go
@@ -7,16 +7,18 @@ import (
 )
 
 // newTrustSignerCommand returns a cobra command for `trust signer` subcommands
-func newTrustSignerCommand(dockerCli command.Cli) *cobra.Command {
+func newTrustSignerCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "signer",
 		Short: "Manage entities who can sign Docker images",
 		Args:  cli.NoArgs,
-		RunE:  command.ShowHelp(dockerCli.Err()),
+		RunE:  command.ShowHelp(dockerCLI.Err()),
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
-		newSignerAddCommand(dockerCli),
-		newSignerRemoveCommand(dockerCli),
+		newSignerAddCommand(dockerCLI),
+		newSignerRemoveCommand(dockerCLI),
 	)
 	return cmd
 }

--- a/cli/command/trust/signer_add.go
+++ b/cli/command/trust/signer_add.go
@@ -37,6 +37,7 @@ func newSignerAddCommand(dockerCLI command.Cli) *cobra.Command {
 			options.repos = args[1:]
 			return addSigner(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	options.keys = opts.NewListOpts(nil)

--- a/cli/command/trust/signer_remove.go
+++ b/cli/command/trust/signer_remove.go
@@ -21,7 +21,7 @@ type signerRemoveOptions struct {
 	forceYes bool
 }
 
-func newSignerRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newSignerRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	options := signerRemoveOptions{}
 	cmd := &cobra.Command{
 		Use:   "remove [OPTIONS] NAME REPOSITORY [REPOSITORY...]",
@@ -30,8 +30,9 @@ func newSignerRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.signer = args[0]
 			options.repos = args[1:]
-			return removeSigner(cmd.Context(), dockerCli, options)
+			return removeSigner(cmd.Context(), dockerCLI, options)
 		},
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.BoolVarP(&options.forceYes, "force", "f", false, "Do not prompt for confirmation before removing the most recent signer")

--- a/cli/command/volume/cmd.go
+++ b/cli/command/volume/cmd.go
@@ -19,6 +19,8 @@ func newVolumeCommand(dockerCLI command.Cli) *cobra.Command {
 		Args:        cli.NoArgs,
 		RunE:        command.ShowHelp(dockerCLI.Err()),
 		Annotations: map[string]string{"version": "1.21"},
+
+		DisableFlagsInUseLine: true,
 	}
 	cmd.AddCommand(
 		newCreateCommand(dockerCLI),

--- a/cli/command/volume/create.go
+++ b/cli/command/volume/create.go
@@ -35,7 +35,7 @@ type createOptions struct {
 	preferredTopology opts.ListOpts
 }
 
-func newCreateCommand(dockerCli command.Cli) *cobra.Command {
+func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	options := createOptions{
 		driverOpts:        *opts.NewMapOpts(nil, nil),
 		labels:            opts.NewListOpts(opts.ValidateLabel),
@@ -56,9 +56,10 @@ func newCreateCommand(dockerCli command.Cli) *cobra.Command {
 				options.name = args[0]
 			}
 			options.cluster = hasClusterVolumeOptionSet(cmd.Flags())
-			return runCreate(cmd.Context(), dockerCli, options)
+			return runCreate(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()
 	flags.StringVarP(&options.driver, "driver", "d", "local", "Specify volume driver name")

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -19,7 +19,7 @@ type inspectOptions struct {
 	names  []string
 }
 
-func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts inspectOptions
 
 	cmd := &cobra.Command{
@@ -28,9 +28,10 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 		Args:  cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.names = args
-			return runInspect(cmd.Context(), dockerCli, opts)
+			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: completion.VolumeNames(dockerCli),
+		ValidArgsFunction:     completion.VolumeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	cmd.Flags().StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)

--- a/cli/command/volume/list.go
+++ b/cli/command/volume/list.go
@@ -25,7 +25,7 @@ type listOptions struct {
 	filter  opts.FilterOpt
 }
 
-func newListCommand(dockerCli command.Cli) *cobra.Command {
+func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	options := listOptions{filter: opts.NewFilterOpt()}
 
 	cmd := &cobra.Command{
@@ -34,9 +34,10 @@ func newListCommand(dockerCli command.Cli) *cobra.Command {
 		Short:   "List volumes",
 		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), dockerCli, options)
+			return runList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -47,8 +47,9 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 			fmt.Fprintln(dockerCLI.Out(), "Total reclaimed space:", units.HumanSize(float64(spaceReclaimed)))
 			return nil
 		},
-		Annotations:       map[string]string{"version": "1.25"},
-		ValidArgsFunction: cobra.NoFileCompletions,
+		Annotations:           map[string]string{"version": "1.25"},
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/remove.go
+++ b/cli/command/volume/remove.go
@@ -17,7 +17,7 @@ type removeOptions struct {
 	volumes []string
 }
 
-func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
+func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	var opts removeOptions
 
 	cmd := &cobra.Command{
@@ -28,9 +28,10 @@ func newRemoveCommand(dockerCli command.Cli) *cobra.Command {
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.volumes = args
-			return runRemove(cmd.Context(), dockerCli, &opts)
+			return runRemove(cmd.Context(), dockerCLI, &opts)
 		},
-		ValidArgsFunction: completion.VolumeNames(dockerCli),
+		ValidArgsFunction:     completion.VolumeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cli/command/volume/update.go
+++ b/cli/command/volume/update.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
+func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	var availability string
 
 	cmd := &cobra.Command{
@@ -20,13 +20,14 @@ func newUpdateCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Update a volume (cluster volumes only)",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runUpdate(cmd.Context(), dockerCli, args[0], availability, cmd.Flags())
+			return runUpdate(cmd.Context(), dockerCLI, args[0], availability, cmd.Flags())
 		},
 		Annotations: map[string]string{
 			"version": "1.42",
 			"swarm":   "manager",
 		},
-		ValidArgsFunction: completion.VolumeNames(dockerCli),
+		ValidArgsFunction:     completion.VolumeNames(dockerCLI),
+		DisableFlagsInUseLine: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -163,11 +163,7 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	cmd.SetOut(dockerCli.Out())
 	commands.AddCommands(cmd, dockerCli)
 
-	visitAll(cmd,
-		setValidateArgs(dockerCli),
-		// prevent adding "[flags]" to the end of the usage line.
-		func(c *cobra.Command) { c.DisableFlagsInUseLine = true },
-	)
+	visitAll(cmd, setValidateArgs(dockerCli))
 
 	// flags must be the top-level command flags, not cmd.Flags()
 	return cli.NewTopLevelCommand(cmd, dockerCli, opts, cmd.Flags())

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/commands"
 	"github.com/docker/cli/cli/debug"
 	platformsignals "github.com/docker/cli/cmd/docker/internal/signals"
 	"github.com/sirupsen/logrus"
@@ -18,6 +19,22 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
+
+func TestDisableFlagsInUseLineIsSet(t *testing.T) {
+	dockerCli, err := command.NewDockerCli(command.WithBaseContext(context.TODO()))
+	assert.NilError(t, err)
+	rootCmd := &cobra.Command{DisableFlagsInUseLine: true}
+	commands.AddCommands(rootCmd, dockerCli)
+
+	var errs []error
+	visitAll(rootCmd, func(c *cobra.Command) {
+		if !c.DisableFlagsInUseLine {
+			errs = append(errs, errors.New("DisableFlagsInUseLine is not set for "+c.CommandPath()))
+		}
+	})
+	err = errors.Join(errs...)
+	assert.NilError(t, err)
+}
 
 func TestClientDebugEnabled(t *testing.T) {
 	defer debug.Disable()


### PR DESCRIPTION
- relates to https://github.com/docker/buildx/pull/3394
- [x] stacked on https://github.com/docker/cli/pull/6402
- [x] stacked on https://github.com/docker/cli/pull/6404

This replaces the visitAll recursive function with a test that verifies that the option is set for all commands and subcommands, so that it doesn't have to be modified at runtime.

We currently still have to loop over all functions for the setValidateArgs call, but that can be looked at separately.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

