### PR TITLE
cli/command/context: deprecate exported types and functions

### DIFF
--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -60,7 +60,7 @@ func TestCreate(t *testing.T) {
 	assert.NilError(t, cli.ContextStore().CreateOrUpdate(store.Metadata{Name: "existing-context"}))
 	tests := []struct {
 		doc         string
-		options     CreateOptions
+		options     createOptions
 		expecterErr string
 	}{
 		{
@@ -69,30 +69,30 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			doc: "reserved name",
-			options: CreateOptions{
-				Name: "default",
+			options: createOptions{
+				name: "default",
 			},
 			expecterErr: `"default" is a reserved context name`,
 		},
 		{
 			doc: "whitespace-only name",
-			options: CreateOptions{
-				Name: " ",
+			options: createOptions{
+				name: " ",
 			},
 			expecterErr: `context name " " is invalid`,
 		},
 		{
 			doc: "existing context",
-			options: CreateOptions{
-				Name: "existing-context",
+			options: createOptions{
+				name: "existing-context",
 			},
 			expecterErr: `context "existing-context" already exists`,
 		},
 		{
 			doc: "invalid docker host",
-			options: CreateOptions{
-				Name: "invalid-docker-host",
-				Docker: map[string]string{
+			options: createOptions{
+				name: "invalid-docker-host",
+				endpoint: map[string]string{
 					"host": "some///invalid/host",
 				},
 			},
@@ -100,27 +100,27 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			doc: "ssh host with skip-tls-verify=false",
-			options: CreateOptions{
-				Name: "skip-tls-verify-false",
-				Docker: map[string]string{
+			options: createOptions{
+				name: "skip-tls-verify-false",
+				endpoint: map[string]string{
 					"host": "ssh://example.com,skip-tls-verify=false",
 				},
 			},
 		},
 		{
 			doc: "ssh host with skip-tls-verify=true",
-			options: CreateOptions{
-				Name: "skip-tls-verify-true",
-				Docker: map[string]string{
+			options: createOptions{
+				name: "skip-tls-verify-true",
+				endpoint: map[string]string{
 					"host": "ssh://example.com,skip-tls-verify=true",
 				},
 			},
 		},
 		{
 			doc: "ssh host with skip-tls-verify=INVALID",
-			options: CreateOptions{
-				Name: "skip-tls-verify-invalid",
-				Docker: map[string]string{
+			options: createOptions{
+				name: "skip-tls-verify-invalid",
+				endpoint: map[string]string{
 					"host":            "ssh://example.com",
 					"skip-tls-verify": "INVALID",
 				},
@@ -129,9 +129,9 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			doc: "unknown option",
-			options: CreateOptions{
-				Name: "unknown-option",
-				Docker: map[string]string{
+			options: createOptions{
+				name: "unknown-option",
+				endpoint: map[string]string{
 					"UNKNOWN": "value",
 				},
 			},
@@ -140,7 +140,7 @@ func TestCreate(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.doc, func(t *testing.T) {
-			err := RunCreate(cli, &tc.options)
+			err := runCreate(cli, &tc.options)
 			if tc.expecterErr == "" {
 				assert.NilError(t, err)
 			} else {
@@ -159,9 +159,9 @@ func assertContextCreateLogging(t *testing.T, cli *test.FakeCli, n string) {
 func TestCreateOrchestratorEmpty(t *testing.T) {
 	cli := makeFakeCli(t)
 
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
 	assertContextCreateLogging(t, cli, "test")
@@ -187,20 +187,20 @@ func TestCreateFromContext(t *testing.T) {
 
 	cli := makeFakeCli(t)
 	cli.ResetOutputBuffers()
-	assert.NilError(t, RunCreate(cli, &CreateOptions{
-		Name:        "original",
-		Description: "original description",
-		Docker: map[string]string{
+	assert.NilError(t, runCreate(cli, &createOptions{
+		name:        "original",
+		description: "original description",
+		endpoint: map[string]string{
 			keyHost: "tcp://42.42.42.42:2375",
 		},
 	}))
 	assertContextCreateLogging(t, cli, "original")
 
 	cli.ResetOutputBuffers()
-	assert.NilError(t, RunCreate(cli, &CreateOptions{
-		Name:        "dummy",
-		Description: "dummy description",
-		Docker: map[string]string{
+	assert.NilError(t, runCreate(cli, &createOptions{
+		name:        "dummy",
+		description: "dummy description",
+		endpoint: map[string]string{
 			keyHost: "tcp://24.24.24.24:2375",
 		},
 	}))
@@ -211,11 +211,11 @@ func TestCreateFromContext(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli.ResetOutputBuffers()
-			err := RunCreate(cli, &CreateOptions{
-				From:        "original",
-				Name:        tc.name,
-				Description: tc.description,
-				Docker:      tc.docker,
+			err := runCreate(cli, &createOptions{
+				from:        "original",
+				name:        tc.name,
+				description: tc.description,
+				endpoint:    tc.docker,
 			})
 			assert.NilError(t, err)
 			assertContextCreateLogging(t, cli, tc.name)
@@ -251,10 +251,10 @@ func TestCreateFromCurrent(t *testing.T) {
 
 	cli := makeFakeCli(t)
 	cli.ResetOutputBuffers()
-	assert.NilError(t, RunCreate(cli, &CreateOptions{
-		Name:        "original",
-		Description: "original description",
-		Docker: map[string]string{
+	assert.NilError(t, runCreate(cli, &createOptions{
+		name:        "original",
+		description: "original description",
+		endpoint: map[string]string{
 			keyHost: "tcp://42.42.42.42:2375",
 		},
 	}))
@@ -265,9 +265,9 @@ func TestCreateFromCurrent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cli.ResetOutputBuffers()
-			err := RunCreate(cli, &CreateOptions{
-				Name:        tc.name,
-				Description: tc.description,
+			err := runCreate(cli, &createOptions{
+				name:        tc.name,
+				description: tc.description,
 			})
 			assert.NilError(t, err)
 			assertContextCreateLogging(t, cli, tc.name)

--- a/cli/command/context/export-import_test.go
+++ b/cli/command/context/export-import_test.go
@@ -21,14 +21,11 @@ func TestExportImportWithFile(t *testing.T) {
 		"MyCustomMetadata": t.Name(),
 	})
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, RunExport(cli, &ExportOptions{
-		ContextName: "test",
-		Dest:        contextFile,
-	}))
+	assert.NilError(t, runExport(cli, "test", contextFile))
 	assert.Equal(t, cli.ErrBuffer().String(), fmt.Sprintf("Written file %q\n", contextFile))
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, RunImport(cli, "test2", contextFile))
+	assert.NilError(t, runImport(cli, "test2", contextFile))
 	context1, err := cli.ContextStore().GetMetadata("test")
 	assert.NilError(t, err)
 	context2, err := cli.ContextStore().GetMetadata("test2")
@@ -55,15 +52,12 @@ func TestExportImportPipe(t *testing.T) {
 	})
 	cli.ErrBuffer().Reset()
 	cli.OutBuffer().Reset()
-	assert.NilError(t, RunExport(cli, &ExportOptions{
-		ContextName: "test",
-		Dest:        "-",
-	}))
+	assert.NilError(t, runExport(cli, "test", "-"))
 	assert.Equal(t, cli.ErrBuffer().String(), "")
 	cli.SetIn(streams.NewIn(io.NopCloser(bytes.NewBuffer(cli.OutBuffer().Bytes()))))
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, RunImport(cli, "test2", "-"))
+	assert.NilError(t, runImport(cli, "test2", "-"))
 	context1, err := cli.ContextStore().GetMetadata("test")
 	assert.NilError(t, err)
 	context2, err := cli.ContextStore().GetMetadata("test2")
@@ -88,6 +82,6 @@ func TestExportExistingFile(t *testing.T) {
 	cli := makeFakeCli(t)
 	cli.ErrBuffer().Reset()
 	assert.NilError(t, os.WriteFile(contextFile, []byte{}, 0o644))
-	err := RunExport(cli, &ExportOptions{ContextName: "test", Dest: contextFile})
+	err := runExport(cli, "test", contextFile)
 	assert.Assert(t, os.IsExist(err))
 }

--- a/cli/command/context/import.go
+++ b/cli/command/context/import.go
@@ -18,7 +18,7 @@ func newImportCommand(dockerCli command.Cli) *cobra.Command {
 		Short: "Import a context from a tar or zip file",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunImport(dockerCli, args[0], args[1])
+			return runImport(dockerCli, args[0], args[1])
 		},
 		// TODO(thaJeztah): this should also include "-"
 		ValidArgsFunction: completion.FileNames,
@@ -27,14 +27,21 @@ func newImportCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 // RunImport imports a Docker context
-func RunImport(dockerCli command.Cli, name string, source string) error {
-	if err := checkContextNameForCreation(dockerCli.ContextStore(), name); err != nil {
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
+func RunImport(dockerCLI command.Cli, name string, source string) error {
+	return runImport(dockerCLI, name, source)
+}
+
+// runImport imports a Docker context.
+func runImport(dockerCLI command.Cli, name string, source string) error {
+	if err := checkContextNameForCreation(dockerCLI.ContextStore(), name); err != nil {
 		return err
 	}
 
 	var reader io.Reader
 	if source == "-" {
-		reader = dockerCli.In()
+		reader = dockerCLI.In()
 	} else {
 		f, err := os.Open(source)
 		if err != nil {
@@ -44,11 +51,11 @@ func RunImport(dockerCli command.Cli, name string, source string) error {
 		reader = f
 	}
 
-	if err := store.Import(name, dockerCli.ContextStore(), reader); err != nil {
+	if err := store.Import(name, dockerCLI.ContextStore(), reader); err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(dockerCli.Out(), name)
-	_, _ = fmt.Fprintf(dockerCli.Err(), "Successfully imported context %q\n", name)
+	_, _ = fmt.Fprintln(dockerCLI.Out(), name)
+	_, _ = fmt.Fprintf(dockerCLI.Err(), "Successfully imported context %q\n", name)
 	return nil
 }

--- a/cli/command/context/list_test.go
+++ b/cli/command/context/list_test.go
@@ -19,10 +19,10 @@ func createTestContexts(t *testing.T, cli command.Cli, name ...string) {
 func createTestContext(t *testing.T, cli command.Cli, name string, metaData map[string]any) {
 	t.Helper()
 
-	err := RunCreate(cli, &CreateOptions{
-		Name:        name,
-		Description: "description of " + name,
-		Docker:      map[string]string{keyHost: "https://someswarmserver.example.com"},
+	err := runCreate(cli, &createOptions{
+		name:        name,
+		description: "description of " + name,
+		endpoint:    map[string]string{keyHost: "https://someswarmserver.example.com"},
 
 		metaData: metaData,
 	})

--- a/cli/command/context/remove.go
+++ b/cli/command/context/remove.go
@@ -11,34 +11,48 @@ import (
 )
 
 // RemoveOptions are the options used to remove contexts
+//
+// Deprecated: this type was for internal use and will be removed in the next release.
 type RemoveOptions struct {
 	Force bool
 }
 
+// removeOptions are the options used to remove contexts.
+type removeOptions struct {
+	force bool
+}
+
 func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
-	var opts RemoveOptions
+	var opts removeOptions
 	cmd := &cobra.Command{
 		Use:     "rm CONTEXT [CONTEXT...]",
 		Aliases: []string{"remove"},
 		Short:   "Remove one or more contexts",
 		Args:    cli.RequiresMinArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunRemove(dockerCLI, opts, args)
+			return runRemove(dockerCLI, opts, args)
 		},
 		ValidArgsFunction: completeContextNames(dockerCLI, -1, false),
 	}
-	cmd.Flags().BoolVarP(&opts.Force, "force", "f", false, "Force the removal of a context in use")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force the removal of a context in use")
 	return cmd
 }
 
 // RunRemove removes one or more contexts
-func RunRemove(dockerCLI command.Cli, opts RemoveOptions, names []string) error {
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
+func RunRemove(dockerCLI command.Cli, opts removeOptions, names []string) error {
+	return runRemove(dockerCLI, opts, names)
+}
+
+// runRemove removes one or more contexts.
+func runRemove(dockerCLI command.Cli, opts removeOptions, names []string) error {
 	var errs []error
 	currentCtx := dockerCLI.CurrentContext()
 	for _, name := range names {
 		if name == "default" {
 			errs = append(errs, errors.New(`context "default" cannot be removed`))
-		} else if err := doRemove(dockerCLI, name, name == currentCtx, opts.Force); err != nil {
+		} else if err := doRemove(dockerCLI, name, name == currentCtx, opts.force); err != nil {
 			errs = append(errs, err)
 		} else {
 			_, _ = fmt.Fprintln(dockerCLI.Out(), name)

--- a/cli/command/context/remove_test.go
+++ b/cli/command/context/remove_test.go
@@ -14,7 +14,7 @@ import (
 func TestRemove(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContexts(t, cli, "current", "other")
-	assert.NilError(t, RunRemove(cli, RemoveOptions{}, []string{"other"}))
+	assert.NilError(t, runRemove(cli, removeOptions{}, []string{"other"}))
 	_, err := cli.ContextStore().GetMetadata("current")
 	assert.NilError(t, err)
 	_, err = cli.ContextStore().GetMetadata("other")
@@ -24,10 +24,10 @@ func TestRemove(t *testing.T) {
 func TestRemoveNotAContext(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContexts(t, cli, "current", "other")
-	err := RunRemove(cli, RemoveOptions{}, []string{"not-a-context"})
+	err := runRemove(cli, removeOptions{}, []string{"not-a-context"})
 	assert.ErrorContains(t, err, `context "not-a-context" does not exist`)
 
-	err = RunRemove(cli, RemoveOptions{Force: true}, []string{"not-a-context"})
+	err = runRemove(cli, removeOptions{force: true}, []string{"not-a-context"})
 	assert.NilError(t, err)
 }
 
@@ -35,7 +35,7 @@ func TestRemoveCurrent(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContexts(t, cli, "current", "other")
 	cli.SetCurrentContext("current")
-	err := RunRemove(cli, RemoveOptions{}, []string{"current"})
+	err := runRemove(cli, removeOptions{}, []string{"current"})
 	assert.ErrorContains(t, err, `context "current" is in use, set -f flag to force remove`)
 }
 
@@ -49,7 +49,7 @@ func TestRemoveCurrentForce(t *testing.T) {
 	cli := makeFakeCli(t, withCliConfig(testCfg))
 	createTestContexts(t, cli, "current", "other")
 	cli.SetCurrentContext("current")
-	assert.NilError(t, RunRemove(cli, RemoveOptions{Force: true}, []string{"current"}))
+	assert.NilError(t, runRemove(cli, removeOptions{force: true}, []string{"current"}))
 	reloadedConfig, err := config.Load(configDir)
 	assert.NilError(t, err)
 	assert.Equal(t, "", reloadedConfig.CurrentContext)
@@ -59,6 +59,6 @@ func TestRemoveDefault(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContext(t, cli, "other", nil)
 	cli.SetCurrentContext("current")
-	err := RunRemove(cli, RemoveOptions{}, []string{"default"})
+	err := runRemove(cli, removeOptions{}, []string{"default"})
 	assert.ErrorContains(t, err, `context "default" cannot be removed`)
 }

--- a/cli/command/context/update_test.go
+++ b/cli/command/context/update_test.go
@@ -11,16 +11,16 @@ import (
 
 func TestUpdateDescriptionOnly(t *testing.T) {
 	cli := makeFakeCli(t)
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, RunUpdate(cli, &UpdateOptions{
-		Name:        "test",
-		Description: "description",
+	assert.NilError(t, runUpdate(cli, &updateOptions{
+		name:        "test",
+		description: "description",
 	}))
 	c, err := cli.ContextStore().GetMetadata("test")
 	assert.NilError(t, err)
@@ -35,9 +35,9 @@ func TestUpdateDescriptionOnly(t *testing.T) {
 func TestUpdateDockerOnly(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContext(t, cli, "test", nil)
-	assert.NilError(t, RunUpdate(cli, &UpdateOptions{
-		Name: "test",
-		Docker: map[string]string{
+	assert.NilError(t, runUpdate(cli, &updateOptions{
+		name: "test",
+		endpoint: map[string]string{
 			keyHost: "tcp://some-host",
 		},
 	}))
@@ -52,14 +52,14 @@ func TestUpdateDockerOnly(t *testing.T) {
 
 func TestUpdateInvalidDockerHost(t *testing.T) {
 	cli := makeFakeCli(t)
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
-	err = RunUpdate(cli, &UpdateOptions{
-		Name: "test",
-		Docker: map[string]string{
+	err = runUpdate(cli, &updateOptions{
+		name: "test",
+		endpoint: map[string]string{
 			keyHost: "some///invalid/host",
 		},
 	})

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -17,7 +17,7 @@ func newUseCommand(dockerCLI command.Cli) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
-			return RunUse(dockerCLI, name)
+			return runUse(dockerCLI, name)
 		},
 		ValidArgsFunction: completeContextNames(dockerCLI, 1, false),
 	}
@@ -25,7 +25,14 @@ func newUseCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 // RunUse set the current Docker context
+//
+// Deprecated: this function was for internal use and will be removed in the next release.
 func RunUse(dockerCLI command.Cli, name string) error {
+	return runUse(dockerCLI, name)
+}
+
+// runUse set the current Docker context
+func runUse(dockerCLI command.Cli, name string) error {
 	// configValue uses an empty string for "default"
 	var configValue string
 	if name != command.DefaultContextName {

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -23,9 +23,9 @@ func TestUse(t *testing.T) {
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
 	cli := makeFakeCli(t, withCliConfig(testCfg))
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
 	assert.NilError(t, newUseCommand(cli).RunE(nil, []string{"test"}))
@@ -89,9 +89,9 @@ func TestUseHostOverride(t *testing.T) {
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
 	cli := makeFakeCli(t, withCliConfig(testCfg))
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
 
@@ -136,9 +136,9 @@ func TestUseHostOverrideEmpty(t *testing.T) {
 		assert.NilError(t, cli.Initialize(flags.NewClientOptions()))
 	}
 	loadCli()
-	err := RunCreate(cli, &CreateOptions{
-		Name:   "test",
-		Docker: map[string]string{"host": socketPath},
+	err := runCreate(cli, &createOptions{
+		name:     "test",
+		endpoint: map[string]string{"host": socketPath},
 	})
 	assert.NilError(t, err)
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/1628


### cli/command/context: deprecate exported types and functions

These functions and types are shallow wrappers around the context store and were intended for internal use as implementation for the CLI itself.

They were exported in 3126920af14ea5127e00a2f8f9d8e07a6c3f6ff9 to be used by plugins and Docker Desktop. However, there's currently no public uses of this, and Docker Desktop does not use these functions.

This patch deprecates the exported functions as they were meant to be implementation specific for the CLI. If there's a need to provide utilities for manipulating the context-store other than through the CLI itself, we can consider creating an SDK for that purpose.

This deprecates:

- `RunCreate` and `CreateOptions`
- `RunExport` and `ExportOptions`
- `RunImport`
- `RunRemove` and `RemoveOptions`
- `RunUpdate` and `UpdateOptions`
- `RunUse`

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/context: deprecate `RunCreate` and `CreateOptions`
Go SDK: cli/command/context: deprecate `RunExport` and `ExportOptions`
Go SDK: cli/command/context: deprecate `RunImport`
Go SDK: cli/command/context: deprecate `RunRemove` and `RemoveOptions`
Go SDK: cli/command/context: deprecate `RunUpdate` and `UpdateOptions`
Go SDK: cli/command/context: deprecate `RunUse`
```

**- A picture of a cute animal (not mandatory but encouraged)**

