### PR TITLE
cli/command/context: remove deprecated types and functions

### DIFF
--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -17,20 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreateOptions are the options used for creating a context
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type CreateOptions struct {
-	Name        string
-	Description string
-	Docker      map[string]string
-	From        string
-
-	// Additional Metadata to store in the context. This option is not
-	// currently exposed to the user.
-	metaData map[string]any
-}
-
 // createOptions are the options used for creating a context
 type createOptions struct {
 	name        string
@@ -74,22 +60,6 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringToStringVar(&opts.endpoint, "docker", nil, "set the docker endpoint")
 	flags.StringVar(&opts.from, "from", "", "create context from a named context")
 	return cmd
-}
-
-// RunCreate creates a Docker context
-
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunCreate(dockerCLI command.Cli, o *CreateOptions) error {
-	if o == nil {
-		o = &CreateOptions{}
-	}
-
-	return runCreate(dockerCLI, &createOptions{
-		name:        o.Name,
-		description: o.Description,
-		endpoint:    o.Docker,
-		metaData:    o.metaData,
-	})
 }
 
 // runCreate creates a Docker context

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -12,14 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ExportOptions are the options used for exporting a context
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type ExportOptions struct {
-	ContextName string
-	Dest        string
-}
-
 func newExportCommand(dockerCLI command.Cli) *cobra.Command {
 	return &cobra.Command{
 		Use:   "export [OPTIONS] CONTEXT [FILE|-]",
@@ -63,16 +55,6 @@ func writeTo(dockerCli command.Cli, reader io.Reader, dest string) error {
 		fmt.Fprintf(dockerCli.Err(), "Written file %q\n", dest)
 	}
 	return nil
-}
-
-// RunExport exports a Docker context
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunExport(dockerCli command.Cli, opts *ExportOptions) error {
-	if opts == nil {
-		opts = &ExportOptions{}
-	}
-	return runExport(dockerCli, opts.ContextName, opts.Dest)
 }
 
 // runExport exports a Docker context.

--- a/cli/command/context/import.go
+++ b/cli/command/context/import.go
@@ -26,13 +26,6 @@ func newImportCommand(dockerCli command.Cli) *cobra.Command {
 	return cmd
 }
 
-// RunImport imports a Docker context
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunImport(dockerCLI command.Cli, name string, source string) error {
-	return runImport(dockerCLI, name, source)
-}
-
 // runImport imports a Docker context.
 func runImport(dockerCLI command.Cli, name string, source string) error {
 	if err := checkContextNameForCreation(dockerCLI.ContextStore(), name); err != nil {

--- a/cli/command/context/remove.go
+++ b/cli/command/context/remove.go
@@ -10,13 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RemoveOptions are the options used to remove contexts
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type RemoveOptions struct {
-	Force bool
-}
-
 // removeOptions are the options used to remove contexts.
 type removeOptions struct {
 	force bool
@@ -36,13 +29,6 @@ func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 	}
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Force the removal of a context in use")
 	return cmd
-}
-
-// RunRemove removes one or more contexts
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunRemove(dockerCLI command.Cli, opts removeOptions, names []string) error {
-	return runRemove(dockerCLI, opts, names)
 }
 
 // runRemove removes one or more contexts.

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -12,15 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// UpdateOptions are the options used to update a context
-//
-// Deprecated: this type was for internal use and will be removed in the next release.
-type UpdateOptions struct {
-	Name        string
-	Description string
-	Docker      map[string]string
-}
-
 // updateOptions are the options used to update a context.
 type updateOptions struct {
 	name        string
@@ -58,20 +49,6 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&opts.description, "description", "", "Description of the context")
 	flags.StringToStringVar(&opts.endpoint, "docker", nil, "set the docker endpoint")
 	return cmd
-}
-
-// RunUpdate updates a Docker context
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunUpdate(dockerCLI command.Cli, o *UpdateOptions) error {
-	if o == nil {
-		o = &UpdateOptions{}
-	}
-	return runUpdate(dockerCLI, &updateOptions{
-		name:        o.Name,
-		description: o.Description,
-		endpoint:    o.Docker,
-	})
 }
 
 // runUpdate updates a Docker context.

--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -24,13 +24,6 @@ func newUseCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
-// RunUse set the current Docker context
-//
-// Deprecated: this function was for internal use and will be removed in the next release.
-func RunUse(dockerCLI command.Cli, name string) error {
-	return runUse(dockerCLI, name)
-}
-
 // runUse set the current Docker context
 func runUse(dockerCLI command.Cli, name string) error {
 	// configValue uses an empty string for "default"


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6402


These functions and types are shallow wrappers around the context store and were intended for internal use as implementation for the CLI itself.

They were exported in 3126920af14ea5127e00a2f8f9d8e07a6c3f6ff9 to be used by plugins and Docker Desktop. However, there's currently no public uses of this, and Docker Desktop does not use these functions. These were deprecated in 95eeafa5514aea3ebe00b9f19c86c097a9eaf0b6 and are no longer used.

This patch removes the deprecated functions as they were meant to be implementation specific for the CLI. If there's a need to provide utilities for manipulating the context-store other than through the CLI itself, we can consider creating an SDK for that purpose.

This removes:

- `RunCreate` and `CreateOptions`
- `RunExport` and `ExportOptions`
- `RunImport`
- `RunRemove` and `RemoveOptions`
- `RunUpdate` and `UpdateOptions`
- `RunUse`


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/context: remove deprecated `RunCreate` and `CreateOptions`
Go SDK: cli/command/context: remove deprecated `RunExport` and `ExportOptions`
Go SDK: cli/command/context: remove deprecated `RunImport`
Go SDK: cli/command/context: remove deprecated `RunRemove` and `RemoveOptions`
Go SDK: cli/command/context: remove deprecated `RunUpdate` and `UpdateOptions`
Go SDK: cli/command/context: remove deprecated `RunUse`
```

**- A picture of a cute animal (not mandatory but encouraged)**

