### PR TITLE
cli/command/completion: remove deprecated NoComplete

### DIFF
--- a/cli/command/completion/functions.go
+++ b/cli/command/completion/functions.go
@@ -138,13 +138,6 @@ func FileNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCom
 	return nil, cobra.ShellCompDirectiveDefault
 }
 
-// NoComplete is used for commands where there's no relevant completion.
-//
-// Deprecated: use [cobra.NoFileCompletions]. This function  will be removed in the next release.
-func NoComplete(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-	return nil, cobra.ShellCompDirectiveNoFileComp
-}
-
 var commonPlatforms = []string{
 	"linux/386",
 	"linux/amd64",


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6404

This function was an exact duplicate of [cobra.NoFileCompletions], and was deprecated in 2827d037baee02889bc9a926755ddc6e39c00935.

[cobra.NoFileCompletions]: https://pkg.go.dev/github.com/spf13/cobra@v1.9.1#NoFileCompletions

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/completion: remove deprecated `NoComplete`
```

**- A picture of a cute animal (not mandatory but encouraged)**

