### PR TITLE
[28.x backport] cli-plugins/manager: deprecate ReexecEnvvar

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -23,6 +23,8 @@ const (
 	// used to originally invoke the docker CLI when executing a
 	// plugin. Assuming $PATH and $CWD remain unchanged this should allow
 	// the plugin to re-execute the original CLI.
+	//
+	// Deprecated: use [metadata.ReexecEnvvar]. This alias will be removed in the next release.
 	ReexecEnvvar = metadata.ReexecEnvvar
 )
 


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6410
- relates to https://github.com/docker/cli/pull/5902
- relates to https://github.com/docker/cli/pull/6237


This alias was added in 4321293972a4ed804e8c063868cc5da6147ce73b, which is part of v28.0, but did not deprecate them. They are no longer used in the CLI itself, but may be used by cli-plugin implementations.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli-plugins/manager: deprecate `ReexecEnvvar`.
```

**- A picture of a cute animal (not mandatory but encouraged)**


