### PR TITLE
cli/command/registry: deprecate OauthLoginEscapeHatchEnvVar

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -183,10 +183,15 @@ func loginWithStoredCredentials(ctx context.Context, dockerCLI command.Cli, auth
 	return response.Status, err
 }
 
+// OauthLoginEscapeHatchEnvVar disables the browser-based OAuth login workflow.
+//
+// Deprecated: this const was only used internally and will be removed in the next release.
 const OauthLoginEscapeHatchEnvVar = "DOCKER_CLI_DISABLE_OAUTH_LOGIN"
 
+const oauthLoginEscapeHatchEnvVar = "DOCKER_CLI_DISABLE_OAUTH_LOGIN"
+
 func isOauthLoginDisabled() bool {
-	if v := os.Getenv(OauthLoginEscapeHatchEnvVar); v != "" {
+	if v := os.Getenv(oauthLoginEscapeHatchEnvVar); v != "" {
 		enabled, err := strconv.ParseBool(v)
 		if err != nil {
 			return false

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -533,7 +533,7 @@ func TestIsOauthLoginDisabled(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Setenv(OauthLoginEscapeHatchEnvVar, tc.envVar)
+		t.Setenv(oauthLoginEscapeHatchEnvVar, tc.envVar)
 
 		disabled := isOauthLoginDisabled()
 


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5361


This const was added in 846ecf59ffb555d615cf78fe4e4c43e71c9697b8, but only used internally. This patch deprecates the const, to be removed in the next release.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/registry: deprecate `OauthLoginEscapeHatchEnvVar` const.
```

**- A picture of a cute animal (not mandatory but encouraged)**

