### PR TITLE
cli-plugins/manager: replace pluginNameRe for isValidPluginName utility

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -169,7 +169,7 @@ func PluginRunCommand(dockerCli config.Provider, name string, rootcmd *cobra.Com
 	// have been provided by cobra to our caller. This is because
 	// they lack e.g. global options which we must propagate here.
 	args := os.Args[1:]
-	if !pluginNameRe.MatchString(name) {
+	if !isValidPluginName(name) {
 		// We treat this as "not found" so that callers will
 		// fallback to their "invalid" command path.
 		return nil, errPluginNotFound(name)


### PR DESCRIPTION
The pluginNameRe was a basic regular expression, effectively only checking if the name consisted of lowercase alphanumeric characters. Replace it with a minimal utility to do the same, without having to use regular expressions (or the "lazyregexp" package).

Some quick benchmarking (not committed) show that the non-regex approach is ~25x faster:

    BenchmarkIsValidPluginName_Regex_Valid-10       13956240        81.39  ns/op       0 B/op        0 allocs/op
    BenchmarkIsValidPluginName_Manual_Valid-10     360003060         3.318 ns/op       0 B/op        0 allocs/op

    BenchmarkIsValidPluginName_Regex_Invalid-10     35281794        33.74  ns/op       0 B/op        0 allocs/op
    BenchmarkIsValidPluginName_Manual_Invalid-10   906072663         1.320 ns/op       0 B/op        0 allocs/op

    BenchmarkIsValidPluginName_Regex_Parallel-10    96595677        12.04  ns/op       0 B/op        0 allocs/op
    BenchmarkIsValidPluginName_Manual_Parallel-10  1000000000        0.4541 ns/op      0 B/op        0 allocs/op


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

