### PR TITLE
add completion for docker image pull

### DIFF
--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -38,7 +38,9 @@ func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 			"category-top": "5",
 			"aliases":      "docker image pull, docker pull",
 		},
-		ValidArgsFunction:     cobra.NoFileCompletions,
+		// Complete with local images to help pulling the latest version
+		// of images that are in the image cache.
+		ValidArgsFunction:     completion.ImageNames(dockerCLI, 1),
 		DisableFlagsInUseLine: true,
 	}
 


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6418

With this patch, completion is provided for images already present in the local image cache to help pulling the latest version of the same tag;

    docker pull go<tab>
    golang:1.12    golang:1.18.0  golang:1.21    golang:1.24    gopher:latest
    golang:1.13    golang:1.20    golang:1.23    golang:latest

    docker pull golang:<tab>
    1.12    1.13    1.18.0  1.20    1.21    1.23    1.24    latest

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add shell completion for `docker pull` and `docker image pull`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

