### PR TITLE
cli/command/image: build: remove permissions warning on Windows

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/distribution/reference"
@@ -359,16 +358,6 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 			return cli.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
 		}
 		return err
-	}
-
-	// Windows: show error message about modified file permissions if the
-	// daemon isn't running Windows.
-	if response.OSType != "windows" && runtime.GOOS == "windows" && !options.quiet {
-		_, _ = fmt.Fprintln(dockerCli.Out(), "SECURITY WARNING: You are building a Docker "+
-			"image from Windows against a non-Windows Docker host. All files and "+
-			"directories added to build context will have '-rwxr-xr-x' permissions. "+
-			"It is recommended to double check and reset permissions for sensitive "+
-			"files and directories.")
 	}
 
 	// Everything worked so if -q was provided the output from the daemon


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/11395
- https://github.com/moby/moby/pull/11397
- https://github.com/moby/moby/pull/18472
- (fully) closes https://github.com/moby/moby/issues/24384

This warning was added in [moby@4a8b3ca] to print a warning when building Linux images from a Windows client. Window's filesystem does not have an "executable" bit, which mean that, for example, copying a shell script to an image during build would lose the executable bit. So for Windows clients, the executable bit would be set on all files, unconditionally.

Originally this was detected in the client, which had direct access to the API response headers, but when refactoring the client to use a common library in [moby@535c4c9], this was refactored into a `ImageBuildResponse` wrapper, deconstructing the API response into an `io.Reader` and a string field containing only the `OSType` header.

This was the only use and only purpose of the `OSType` field, and now that BuildKit is the default builder for Linux images, this warning didn't get printed unless BuildKit was explicitly disabled.

This patch removes the warning, so that we can potentially remove the field, or the `ImageBuildResponse` type altogether.

[moby@4a8b3ca]: https://github.com/moby/moby/commit/4a8b3cad6096854027151dfbcfb4b2cd8841ad95
[moby@535c4c9]: https://github.com/moby/moby/commit/535c4c9a59b1e58c897677d6948a595cb3d28639

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

