### PR TITLE
cli/command/registry: remove all uses of response message

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -168,7 +168,7 @@ func loginWithStoredCredentials(ctx context.Context, dockerCLI command.Cli, auth
 		} else {
 			_, _ = fmt.Fprintln(dockerCLI.Err(), "Login did not succeed, error:", err)
 		}
-		// TODO(thaJeztah): should this return the error here, or is there a reason for continuing?
+		return err
 	}
 
 	if resp.Auth.IdentityToken != "" {

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -74,7 +74,7 @@ func TestLoginWithCredStoreCreds(t *testing.T) {
 	cli := test.NewFakeCli(&fakeClient{})
 	cli.ConfigFile().Filename = filepath.Join(t.TempDir(), "config.json")
 	for _, tc := range testCases {
-		_, err := loginWithStoredCredentials(ctx, cli, tc.inputAuthConfig)
+		err := loginWithStoredCredentials(ctx, cli, tc.inputAuthConfig)
 		if tc.expectedErrMsg != "" {
 			assert.Check(t, is.Error(err, tc.expectedErr))
 		} else {


### PR DESCRIPTION
The message returned by the API is a hardcoded message; the only real information currently returned by the API is whether or not the auth was successul;
https://github.com/moby/moby/blob/v2.0.0-beta.0/daemon/server/router/system/system_routes.go#L408-L421

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

