### PR TITLE
cli/command/plugin: remove special error handling on install, upgrade

### DIFF
--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
@@ -94,9 +93,6 @@ func runInstall(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 	}
 	responseBody, err := dockerCLI.Client().PluginInstall(ctx, localName, options)
 	if err != nil {
-		if strings.Contains(err.Error(), "(image) when fetching") {
-			return errors.New(err.Error() + " - Use \"docker image pull\"")
-		}
 		return err
 	}
 	defer func() {

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -42,14 +42,6 @@ func TestInstallErrors(t *testing.T) {
 				return nil, errors.New("error installing plugin")
 			},
 		},
-		{
-			description:   "installation error due to missing image",
-			args:          []string{"foo"},
-			expectedError: "docker image pull",
-			installFunc: func(name string, options client.PluginInstallOptions) (io.ReadCloser, error) {
-				return nil, errors.New("(image) when fetching")
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli"
@@ -83,9 +82,6 @@ func runUpgrade(ctx context.Context, dockerCLI command.Cli, opts pluginOptions) 
 
 	responseBody, err := dockerCLI.Client().PluginUpgrade(ctx, opts.localName, options)
 	if err != nil {
-		if strings.Contains(err.Error(), "target is image") {
-			return errors.New(err.Error() + " - Use `docker image pull`")
-		}
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6374
- https://github.com/moby/moby/pull/30047

Similar to 323fbc485e5902fbbab97ad86cb5d4f90f956e39 - this code was added in [moby@c127d96], but used string-matching to detect cases where a user tried to install an image as plugin. However, this handling no longer matched any error-strings, so no longer worked:

    docker plugin install busybox
    Error response from daemon: did not find plugin config for specified reference docker.io/library/busybox:latest

[moby@c127d96]: https://github.com/moby/moby/commit/c127d9614f5b30bd73861877f8540a63e7d869e9

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

