### PR TITLE
Improve shell completion for `docker secret` and `docker config` subcommands

### DIFF
--- a/cli/command/config/create.go
+++ b/cli/command/config/create.go
@@ -36,7 +36,23 @@ func newConfigCreateCommand(dockerCLI command.Cli) *cobra.Command {
 			createOpts.file = args[1]
 			return runCreate(cmd.Context(), dockerCLI, createOpts)
 		},
-		ValidArgsFunction:     cobra.NoFileCompletions,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			switch len(args) {
+			case 0:
+				// No completion for the first argument, which is the name for
+				// the new config, but if a non-empty name is given, we return
+				// it as completion to allow "tab"-ing to the next completion.
+				return []string{toComplete}, cobra.ShellCompDirectiveNoFileComp
+			case 1:
+				// Second argument is either "-" or a file to load.
+				//
+				// TODO(thaJeztah): provide completion for "-".
+				return nil, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveDefault
+			default:
+				// Command only accepts two arguments.
+				return nil, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+			}
+		},
 		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -32,9 +32,7 @@ func newConfigInspectCommand(dockerCLI command.Cli) *cobra.Command {
 			opts.names = args
 			return runInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/config/remove.go
+++ b/cli/command/config/remove.go
@@ -19,9 +19,7 @@ func newConfigRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRemove(cmd.Context(), dockerCLI, args)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 }

--- a/cli/command/secret/cmd.go
+++ b/cli/command/secret/cmd.go
@@ -44,7 +44,7 @@ func completeNames(dockerCLI completion.APIClientProvider) cobra.CompletionFunc 
 		}
 		var names []string
 		for _, secret := range list {
-			names = append(names, secret.ID)
+			names = append(names, secret.Spec.Name)
 		}
 		return names, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/cli/command/secret/create.go
+++ b/cli/command/secret/create.go
@@ -38,6 +38,23 @@ func newSecretCreateCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runSecretCreate(cmd.Context(), dockerCLI, options)
 		},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			switch len(args) {
+			case 0:
+				// No completion for the first argument, which is the name for
+				// the new secret, but if a non-empty name is given, we return
+				// it as completion to allow "tab"-ing to the next completion.
+				return []string{toComplete}, cobra.ShellCompDirectiveNoFileComp
+			case 1:
+				// Second argument is either "-" or a file to load.
+				//
+				// TODO(thaJeztah): provide completion for "-".
+				return nil, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveDefault
+			default:
+				// Command only accepts two arguments.
+				return nil, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+			}
+		},
 		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -31,9 +31,7 @@ func newSecretInspectCommand(dockerCLI command.Cli) *cobra.Command {
 			opts.names = args
 			return runSecretInspect(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -31,7 +31,7 @@ func newSecretListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSecretList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction:     completeNames(dockerCLI),
+		ValidArgsFunction:     cobra.NoFileCompletions,
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/secret/ls.go
+++ b/cli/command/secret/ls.go
@@ -31,9 +31,7 @@ func newSecretListCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSecretList(cmd.Context(), dockerCLI, options)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/secret/remove.go
+++ b/cli/command/secret/remove.go
@@ -26,9 +26,7 @@ func newSecretRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runRemove(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 }

--- a/cli/command/stack/deploy.go
+++ b/cli/command/stack/deploy.go
@@ -45,9 +45,7 @@ func newDeployCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runDeploy(cmd.Context(), dockerCLI, cmd.Flags(), &opts, config)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/stack/ps.go
+++ b/cli/command/stack/ps.go
@@ -38,9 +38,7 @@ func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runPS(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()

--- a/cli/command/stack/remove.go
+++ b/cli/command/stack/remove.go
@@ -36,9 +36,7 @@ func newRemoveCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runRemove(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 

--- a/cli/command/stack/services.go
+++ b/cli/command/stack/services.go
@@ -38,9 +38,7 @@ func newServicesCommand(dockerCLI command.Cli) *cobra.Command {
 			}
 			return runServices(cmd.Context(), dockerCLI, opts)
 		},
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return completeNames(dockerCLI)(cmd, args, toComplete)
-		},
+		ValidArgsFunction:     completeNames(dockerCLI),
 		DisableFlagsInUseLine: true,
 	}
 	flags := cmd.Flags()


### PR DESCRIPTION
### remove redundant closures around completion functions

These were remnants from some earlier implementation.

### cli/command/secret: remove completion for "ls"

This command takes no arguments, so should not provide completion.

### cli/command/secret: fix completion to complete names, not IDs

### cli/command: fix completion for secret create, config create

These commands accept two arguments; the first is a custom name,
the second is either a filename or "-" to create from STDIN.

With this patch:

    # does not provide completion
    docker secret create <tab>

    # starts providing completion once a non-empty name is provided
    docker secret create somename<tab>
    file.txt other-file.txt

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improve shell completion for `docker secret` and `docker config` subcommands.
```

**- A picture of a cute animal (not mandatory but encouraged)**

