### PR TITLE
cli: disable file-completion by default

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -164,6 +164,11 @@ func newPluginCommand(dockerCli *command.DockerCli, plugin *cobra.Command, meta 
 			DisableDescriptions: os.Getenv("DOCKER_CLI_DISABLE_COMPLETION_DESCRIPTION") != "",
 		},
 	}
+
+	// Disable file-completion by default. Most commands and flags should not
+	// complete with filenames.
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
+
 	opts, _ := cli.SetupPluginRootCommand(cmd)
 
 	cmd.SetIn(dockerCli.In())

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -95,13 +95,6 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 
 	addCompletions(cmd, dockerCLI)
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
-
 	return cmd
 }
 

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -76,13 +76,6 @@ func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("detach-keys", completeDetachKeys)
 	addCompletions(cmd, dockerCLI)
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
-
 	return cmd
 }
 

--- a/cli/command/node/list.go
+++ b/cli/command/node/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/moby/moby/api/types/system"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type listOptions struct {
@@ -41,12 +40,6 @@ func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", flagsHelper.FormatHelp)
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/node/ps.go
+++ b/cli/command/node/ps.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type psOptions struct {
@@ -50,12 +49,6 @@ func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", "Pretty-print tasks using a Go template")
 	flags.BoolVarP(&options.quiet, "quiet", "q", false, "Only display task IDs")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/node/update.go
+++ b/cli/command/node/update.go
@@ -40,12 +40,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 
 	_ = cmd.RegisterFlagCompletionFunc(flagRole, completion.FromList("worker", "manager"))
 	_ = cmd.RegisterFlagCompletionFunc(flagAvailability, completion.FromList("active", "pause", "drain"))
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
+
 	return cmd
 }
 

--- a/cli/command/service/create.go
+++ b/cli/command/service/create.go
@@ -91,12 +91,6 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flagUpdateOrder, completion.FromList("start-first", "stop-first"))
 	_ = cmd.RegisterFlagCompletionFunc(flagUpdateFailureAction, completion.FromList("pause", "continue", "rollback"))
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -16,7 +16,6 @@ import (
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type inspectOptions struct {
@@ -48,12 +47,6 @@ func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVarP(&opts.format, "format", "f", "", flagsHelper.InspectFormatHelp)
 	flags.BoolVar(&opts.pretty, "pretty", false, "Print the information in a human friendly format")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/list.go
+++ b/cli/command/service/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type listOptions struct {
@@ -41,12 +40,6 @@ func newListCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", flagsHelper.FormatHelp)
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/logs.go
+++ b/cli/command/service/logs.go
@@ -20,7 +20,6 @@ import (
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type logsOptions struct {
@@ -68,12 +67,6 @@ func newLogsCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.SetAnnotation("details", "version", []string{"1.30"})
 	flags.StringVarP(&opts.tail, "tail", "n", "all", "Number of lines to show from the end of the logs")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/ps.go
+++ b/cli/command/service/ps.go
@@ -14,7 +14,6 @@ import (
 	"github.com/moby/moby/api/types/filters"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type psOptions struct {
@@ -47,12 +46,6 @@ func newPsCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.format, "format", "", "Pretty-print tasks using a Go template")
 	flags.VarP(&options.filter, "filter", "f", "Filter output based on conditions provided")
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/rollback.go
+++ b/cli/command/service/rollback.go
@@ -9,7 +9,6 @@ import (
 	"github.com/moby/moby/api/types/versions"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func newRollbackCommand(dockerCLI command.Cli) *cobra.Command {
@@ -31,12 +30,6 @@ func newRollbackCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.BoolVarP(&options.quiet, flagQuiet, "q", false, "Suppress progress output")
 	addDetachFlag(flags, &options.detach)
 
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 	return cmd
 }
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -133,12 +133,6 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc(flagUpdateFailureAction, completion.FromList("pause", "continue", "rollback"))
 
 	completion.ImageNames(dockerCLI, -1)
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
 
 	return cmd
 }

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -18,7 +18,6 @@ import (
 	"github.com/moby/moby/api/types/image"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 type objectType = string
@@ -82,12 +81,7 @@ func newInspectCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.size, "size", "s", false, "Display total file sizes if the type is container")
 
 	_ = cmd.RegisterFlagCompletionFunc("type", completion.FromList(allTypes...))
-	flags.VisitAll(func(flag *pflag.Flag) {
-		// Set a default completion function if none was set. We don't look
-		// up if it does already have one set, because Cobra does this for
-		// us, and returns an error (which we ignore for this reason).
-		_ = cmd.RegisterFlagCompletionFunc(flag.Name, cobra.NoFileCompletions)
-	})
+
 	return cmd
 }
 

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -144,6 +144,11 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 			DisableDescriptions: os.Getenv("DOCKER_CLI_DISABLE_COMPLETION_DESCRIPTION") != "",
 		},
 	}
+
+	// Disable file-completion by default. Most commands and flags should not
+	// complete with filenames.
+	cmd.CompletionOptions.SetDefaultShellCompDirective(cobra.ShellCompDirectiveNoFileComp)
+
 	cmd.SetIn(dockerCli.In())
 	cmd.SetOut(dockerCli.Out())
 	cmd.SetErr(dockerCli.Err())


### PR DESCRIPTION
- relates to https://github.com/spf13/cobra/issues/2209
- relates to https://github.com/spf13/cobra/pull/2238
- relates to https://github.com/docker/cli/commit/06260e68f3686a0368284a8ce9b910e056bb523b#diff-50fe347eb4bdafebc190aa42b2caa34b089a538cd444b8a151a763372e93c0cf / https://github.com/docker/cli/pull/5580
- [x] depends on https://github.com/docker/cli/pull/6429

### cli: disable file-completion by default

This uses the DefaultShellCompDirective feature which was added
in cobra to override the default (which would complete to use
files for commands and flags).

### cli-plugins: disable file-completion by default

This uses the DefaultShellCompDirective feature which was added
in cobra to override the default (which would complete to use
files for commands and flags).

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

