### PR TITLE
cli/command/context: split name from options struct

### DIFF
--- a/cli/command/context/list_test.go
+++ b/cli/command/context/list_test.go
@@ -19,8 +19,7 @@ func createTestContexts(t *testing.T, cli command.Cli, name ...string) {
 func createTestContext(t *testing.T, cli command.Cli, name string, metaData map[string]any) {
 	t.Helper()
 
-	err := runCreate(cli, &createOptions{
-		name:        name,
+	err := runCreate(cli, name, createOptions{
 		description: "description of " + name,
 		endpoint:    map[string]string{keyHost: "https://someswarmserver.example.com"},
 

--- a/cli/command/context/update.go
+++ b/cli/command/context/update.go
@@ -14,7 +14,6 @@ import (
 
 // updateOptions are the options used to update a context.
 type updateOptions struct {
-	name        string
 	description string
 	endpoint    map[string]string
 }
@@ -39,8 +38,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 		Short: "Update a context",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.name = args[0]
-			return runUpdate(dockerCLI, &opts)
+			return runUpdate(dockerCLI, args[0], opts)
 		},
 		Long:                  longUpdateDescription(),
 		ValidArgsFunction:     completeContextNames(dockerCLI, 1, false),
@@ -53,12 +51,12 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 }
 
 // runUpdate updates a Docker context.
-func runUpdate(dockerCLI command.Cli, opts *updateOptions) error {
-	if err := store.ValidateContextName(opts.name); err != nil {
+func runUpdate(dockerCLI command.Cli, name string, opts updateOptions) error {
+	if err := store.ValidateContextName(name); err != nil {
 		return err
 	}
 	s := dockerCLI.ContextStore()
-	c, err := s.GetMetadata(opts.name)
+	c, err := s.GetMetadata(name)
 	if err != nil {
 		return err
 	}
@@ -89,13 +87,13 @@ func runUpdate(dockerCLI command.Cli, opts *updateOptions) error {
 		return err
 	}
 	for ep, tlsData := range tlsDataToReset {
-		if err := s.ResetEndpointTLSMaterial(opts.name, ep, tlsData); err != nil {
+		if err := s.ResetEndpointTLSMaterial(name, ep, tlsData); err != nil {
 			return err
 		}
 	}
 
-	_, _ = fmt.Fprintln(dockerCLI.Out(), opts.name)
-	_, _ = fmt.Fprintf(dockerCLI.Err(), "Successfully updated context %q\n", opts.name)
+	_, _ = fmt.Fprintln(dockerCLI.Out(), name)
+	_, _ = fmt.Fprintf(dockerCLI.Err(), "Successfully updated context %q\n", name)
 	return nil
 }
 

--- a/cli/command/context/update_test.go
+++ b/cli/command/context/update_test.go
@@ -11,15 +11,13 @@ import (
 
 func TestUpdateDescriptionOnly(t *testing.T) {
 	cli := makeFakeCli(t)
-	err := runCreate(cli, &createOptions{
-		name:     "test",
+	err := runCreate(cli, "test", createOptions{
 		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
 	cli.OutBuffer().Reset()
 	cli.ErrBuffer().Reset()
-	assert.NilError(t, runUpdate(cli, &updateOptions{
-		name:        "test",
+	assert.NilError(t, runUpdate(cli, "test", updateOptions{
 		description: "description",
 	}))
 	c, err := cli.ContextStore().GetMetadata("test")
@@ -35,8 +33,7 @@ func TestUpdateDescriptionOnly(t *testing.T) {
 func TestUpdateDockerOnly(t *testing.T) {
 	cli := makeFakeCli(t)
 	createTestContext(t, cli, "test", nil)
-	assert.NilError(t, runUpdate(cli, &updateOptions{
-		name: "test",
+	assert.NilError(t, runUpdate(cli, "test", updateOptions{
 		endpoint: map[string]string{
 			keyHost: "tcp://some-host",
 		},
@@ -52,13 +49,11 @@ func TestUpdateDockerOnly(t *testing.T) {
 
 func TestUpdateInvalidDockerHost(t *testing.T) {
 	cli := makeFakeCli(t)
-	err := runCreate(cli, &createOptions{
-		name:     "test",
+	err := runCreate(cli, "test", createOptions{
 		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
-	err = runUpdate(cli, &updateOptions{
-		name: "test",
+	err = runUpdate(cli, "test", updateOptions{
 		endpoint: map[string]string{
 			keyHost: "some///invalid/host",
 		},

--- a/cli/command/context/use_test.go
+++ b/cli/command/context/use_test.go
@@ -23,8 +23,7 @@ func TestUse(t *testing.T) {
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
 	cli := makeFakeCli(t, withCliConfig(testCfg))
-	err := runCreate(cli, &createOptions{
-		name:     "test",
+	err := runCreate(cli, "test", createOptions{
 		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
@@ -89,8 +88,7 @@ func TestUseHostOverride(t *testing.T) {
 	configFilePath := filepath.Join(configDir, "config.json")
 	testCfg := configfile.New(configFilePath)
 	cli := makeFakeCli(t, withCliConfig(testCfg))
-	err := runCreate(cli, &createOptions{
-		name:     "test",
+	err := runCreate(cli, "test", createOptions{
 		endpoint: map[string]string{},
 	})
 	assert.NilError(t, err)
@@ -136,8 +134,7 @@ func TestUseHostOverrideEmpty(t *testing.T) {
 		assert.NilError(t, cli.Initialize(flags.NewClientOptions()))
 	}
 	loadCli()
-	err := runCreate(cli, &createOptions{
-		name:     "test",
+	err := runCreate(cli, "test", createOptions{
 		endpoint: map[string]string{"host": socketPath},
 	})
 	assert.NilError(t, err)


### PR DESCRIPTION
Name is a required argument for both "create" and "update", so better to split it from the options struct.


**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

