### PR TITLE
docker run, create: add shell completion for CDI devices for "--device"

### DIFF
--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -158,19 +158,24 @@ func completeDetachKeys(_ *cobra.Command, _ []string, _ string) ([]string, cobra
 // to provide completion for CDI devices that were discovered by the daemon.
 func completeCDIDevices(dockerCLI completion.APIClientProvider) cobra.CompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if strings.HasPrefix(toComplete, "/") {
+			return nil, cobra.ShellCompDirectiveDefault | cobra.ShellCompDirectiveNoSpace
+		}
+
 		info, err := dockerCLI.Client().Info(cmd.Context())
 		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
+			return nil, cobra.ShellCompDirectiveDefault
 		}
 		var devices []string
 		// DiscoveredDevices requires Docker v28.2.0 (API 1.50) or above,
 		// but we just check if it's returned.
 		for _, di := range info.DiscoveredDevices {
 			if di.Source == "cdi" {
-				devices = append(devices, di.ID)
+				devices = append(devices, cobra.CompletionWithDesc(di.ID, "CDI device"))
 			}
 		}
-		return devices, cobra.ShellCompDirectiveNoFileComp
+		devices = append(devices, "/")
+		return devices, cobra.ShellCompDirectiveDefault
 	}
 }
 


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6152

### docker run, create: add shell completion for CDI devices for "--device"

With this patch:

    docker info --format '{{json .DiscoveredDevices}}'
    [{"Source":"cdi","ID":"docker.com/gpu=webgpu"}]

    docker container create --device=<tab>
    docker container create --device=docker.com/gpu=webgpu

    docker run --device=docker.com/gpu=webgpu
    docker run --device=<tab>

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add shell completion for CDI devices for "--device" on `docker run` and `docker create`
```

**- A picture of a cute animal (not mandatory but encouraged)**

