### PR TITLE
Enable completion for `docker images`

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/command/formatter"
 	flagsHelper "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/opts"
@@ -52,6 +53,7 @@ func newImagesCommand(dockerCLI command.Cli) *cobra.Command {
 			"aliases":      "docker image ls, docker image list, docker images",
 		},
 		DisableFlagsInUseLine: true,
+		ValidArgsFunction:     completion.ImageNamesWithBase(dockerCLI, 1),
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Enabled completion for `docker images`.

**- How I did it**

By adding a new `ImageNamesWithBase` completion function which offers completion for images present within the local store, including both full image names with tags and base image names (repository names only) when multiple tags exist for the same base name.

**- How to verify it**

```
$ ./build/docker images docker/docker-model-<TAB>
docker/docker-model-backend-llamacpp:v0.0.8-rc2-metal  docker/docker-model-cli-desktop-module
docker/docker-model-cli-desktop-module:v0.1.32         docker/docker-model-cli-desktop-module:v0.1.33

$ ./build/docker images docker/docker-model-cli-desktop-module
REPOSITORY                               TAG       IMAGE ID       CREATED        SIZE
docker/docker-model-cli-desktop-module   v0.1.33   e0774d732e37   2 months ago   25.4MB
docker/docker-model-cli-desktop-module   v0.1.32   a638160de27e   2 months ago   26.9MB
```

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Add image name completion for `docker images`.
```

**- A picture of a cute animal (not mandatory but encouraged)**
<img width="1200" height="793" alt="image" src="https://github.com/user-attachments/assets/1e789fd8-83af-452a-9932-b3da3d633185" />
Source: https://earth.org/world-lemur-day/.
