### PR TITLE
remove DOCKER_CLI_DISABLE_OAUTH_LOGIN escape hatch

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/containerd/errdefs"
@@ -183,19 +181,6 @@ func loginWithStoredCredentials(ctx context.Context, dockerCLI command.Cli, auth
 	return response.Status, err
 }
 
-const oauthLoginEscapeHatchEnvVar = "DOCKER_CLI_DISABLE_OAUTH_LOGIN"
-
-func isOauthLoginDisabled() bool {
-	if v := os.Getenv(oauthLoginEscapeHatchEnvVar); v != "" {
-		enabled, err := strconv.ParseBool(v)
-		if err != nil {
-			return false
-		}
-		return enabled
-	}
-	return false
-}
-
 func loginUser(ctx context.Context, dockerCLI command.Cli, opts loginOptions, defaultUsername, serverAddress string) (msg string, _ error) {
 	// Some links documenting this:
 	// - https://code.google.com/archive/p/mintty/issues/56
@@ -209,7 +194,7 @@ func loginUser(ctx context.Context, dockerCLI command.Cli, opts loginOptions, de
 	}
 
 	// If we're logging into the index server and the user didn't provide a username or password, use the device flow
-	if serverAddress == registry.IndexServer && opts.user == "" && opts.password == "" && !isOauthLoginDisabled() {
+	if serverAddress == registry.IndexServer && opts.user == "" && opts.password == "" {
 		var err error
 		msg, err = loginWithDeviceCodeFlow(ctx, dockerCLI)
 		// if the error represents a failure to initiate the device-code flow,

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -497,50 +497,6 @@ func TestLoginTermination(t *testing.T) {
 	}
 }
 
-func TestIsOauthLoginDisabled(t *testing.T) {
-	testCases := []struct {
-		envVar   string
-		disabled bool
-	}{
-		{
-			envVar:   "",
-			disabled: false,
-		},
-		{
-			envVar:   "bork",
-			disabled: false,
-		},
-		{
-			envVar:   "0",
-			disabled: false,
-		},
-		{
-			envVar:   "false",
-			disabled: false,
-		},
-		{
-			envVar:   "true",
-			disabled: true,
-		},
-		{
-			envVar:   "TRUE",
-			disabled: true,
-		},
-		{
-			envVar:   "1",
-			disabled: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Setenv(oauthLoginEscapeHatchEnvVar, tc.envVar)
-
-		disabled := isOauthLoginDisabled()
-
-		assert.Equal(t, disabled, tc.disabled)
-	}
-}
-
 func TestLoginValidateFlags(t *testing.T) {
 	for _, tc := range []struct {
 		name        string

--- a/e2e/registry/login_test.go
+++ b/e2e/registry/login_test.go
@@ -32,25 +32,3 @@ func TestOauthLogin(t *testing.T) {
 	output, _ := io.ReadAll(p)
 	assert.Check(t, strings.Contains(string(output), "USING WEB-BASED LOGIN"), string(output))
 }
-
-func TestLoginWithEscapeHatch(t *testing.T) {
-	t.Parallel()
-	loginCmd := exec.Command("docker", "login")
-	loginCmd.Env = append(loginCmd.Env, "DOCKER_CLI_DISABLE_OAUTH_LOGIN=1")
-
-	p, err := pty.Start(loginCmd)
-	assert.NilError(t, err)
-	defer func() {
-		_ = loginCmd.Wait()
-		_ = p.Close()
-	}()
-
-	time.Sleep(1 * time.Second)
-	pid := loginCmd.Process.Pid
-	t.Logf("terminating PID %d", pid)
-	err = syscall.Kill(pid, syscall.SIGTERM)
-	assert.NilError(t, err)
-
-	output, _ := io.ReadAll(p)
-	assert.Check(t, strings.Contains(string(output), "Username:"), string(output))
-}


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/5361
- https://github.com/docker/cli/pull/6412

### cli/command/registry: remove deprecated OauthLoginEscapeHatchEnvVar

This const was added in 846ecf59ffb555d615cf78fe4e4c43e71c9697b8, but
only used internally; commit 18cdc25bb4675ff9555f221524572f97b706ab8b
deprecated the const, which was included in the 28.4 release.

This patch removes the exported const, as it's unused.


### remove DOCKER_CLI_DISABLE_OAUTH_LOGIN escape hatch

This code was added in 846ecf59ffb555d615cf78fe4e4c43e71c9697b8 as an
escape hatch in case the new OAuth login flow would cause problems.
We have not received reports where the new flow caused problems, and
searching the internet shows no mentions of the env-var.

This env-var was not documented, so we can remove it.



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command/registry: remove deprecated `OauthLoginEscapeHatchEnvVar` const.
```


**- A picture of a cute animal (not mandatory but encouraged)**

