### PR TITLE
cli/config/configfile: remove deprecated ConfigFile.Experimental field

### DIFF
--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -43,9 +43,6 @@ type ConfigFile struct {
 	Plugins              map[string]map[string]string `json:"plugins,omitempty"`
 	Aliases              map[string]string            `json:"aliases,omitempty"`
 	Features             map[string]string            `json:"features,omitempty"`
-
-	// Deprecated: experimental CLI features are always enabled and this field is no longer used. Use [Features] instead for optional features. This field will be removed in a future release.
-	Experimental string `json:"experimental,omitempty"`
 }
 
 type configEnvAuth struct {


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/2774
- https://github.com/docker/cli/pull/2774
- https://github.com/docker/cli/pull/5977



### cli/config/configfile: remove deprecated ConfigFile.Experimental field

Configuration options for experimental CLI features were deprecated in docker 19.03 (3172219932d5d8d8e68715b7495070a1c63f168b), and enabled by default since docker 20.10 (977d3ae046ec6c64be8788a8712251ed547a2bdb).

This field was deprecated in c8f9187157753e366ee9f25524b56f90913b47a5, which is part of the 28.x release, and is unused. This patch removes the field.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/config/configfile: remove deprecated `ConfigFile.Experimental` field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

