### PR TITLE
gha: update test-matrix: remove docker 23.x, 26.x, add 25.x

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,8 +39,7 @@ jobs:
         engine-version:
           - 28  # latest
           - 27  # latest - 1
-          - 26  # github actions default
-          - 23  # mirantis lts
+          - 25  # mirantis lts
     steps:
       -
         name: Checkout


### PR DESCRIPTION
- Mirantis Container Runtime (MCR) 23.0 reached EOL, and the next LTS version of MCR is 25.x
- Docker 26.x reached EOL and is no longer maintained

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

