### PR TITLE
cli/command: NewDockerCli: don't depend on DockerCli.Apply

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -602,8 +602,10 @@ func NewDockerCli(ops ...CLIOption) (*DockerCli, error) {
 	ops = append(defaultOps, ops...)
 
 	cli := &DockerCli{baseCtx: context.Background()}
-	if err := cli.Apply(ops...); err != nil {
-		return nil, err
+	for _, op := range ops {
+		if err := op(cli); err != nil {
+			return nil, err
+		}
 	}
 	return cli, nil
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/1633


### cli/command: NewDockerCli: don't depend on DockerCli.Apply

The Apply method was added when CLI options for constructing the CLI were rewritten into functional options in [cli@7f207f3]. There was no mention in the pull request of this method specifically, and this may have been related to work being done elsewhere on compose-on-kubernetes or the compose-cli plugin that may have needed options to modify the CLI config after it was already initialized.

We should try to remove functions that mutate the CLI configuration after initialization if possible (and likely remove the `Apply` method); currently this function is used in docker compose, but as part of a hack that can probably be avoided.

[cli@7f207f3]: https://github.com/docker/cli/commit/7f207f3f957ed3f5129aeb22bef2a429c14caf22


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

