### PR TITLE
[28.x backport] CI updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
           ln -s vendor.sum go.sum
       -
         name: Update Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.7"
       -

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,8 +39,7 @@ jobs:
         engine-version:
           - 28  # latest
           - 27  # latest - 1
-          - 26  # github actions default
-          - 23  # mirantis lts
+          - 25  # mirantis lts
     steps:
       -
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
           path: ${{ env.GOPATH }}/src/github.com/docker/cli
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24.7"
       -


### PR DESCRIPTION
Backport:

- https://github.com/docker/cli/pull/6426
- https://github.com/docker/cli/pull/6465