### PR TITLE
[28.x backport] cli/command/container: prevent panic during stats on empty event Actor.ID

### DIFF
--- a/cli/command/container/formatter_stats.go
+++ b/cli/command/container/formatter_stats.go
@@ -167,6 +167,7 @@ func (c *statsContext) Container() string {
 }
 
 func (c *statsContext) Name() string {
+	// TODO(thaJeztah): make this explicitly trim the "/" prefix, not just any char.
 	if len(c.s.Name) > 1 {
 		return c.s.Name[1:]
 	}

--- a/cli/command/container/formatter_stats_test.go
+++ b/cli/command/container/formatter_stats_test.go
@@ -14,36 +14,138 @@ func TestContainerStatsContext(t *testing.T) {
 	containerID := test.RandomID()
 
 	var ctx statsContext
-	tt := []struct {
+	tests := []struct {
+		name      string
 		stats     StatsEntry
 		osType    string
 		expValue  string
 		expHeader string
 		call      func() string
 	}{
-		{StatsEntry{Container: containerID}, "", containerID, containerHeader, ctx.Container},
-		{StatsEntry{CPUPercentage: 5.5}, "", "5.50%", cpuPercHeader, ctx.CPUPerc},
-		{StatsEntry{CPUPercentage: 5.5, IsInvalid: true}, "", "--", cpuPercHeader, ctx.CPUPerc},
-		{StatsEntry{NetworkRx: 0.31, NetworkTx: 12.3}, "", "0.31B / 12.3B", netIOHeader, ctx.NetIO},
-		{StatsEntry{NetworkRx: 0.31, NetworkTx: 12.3, IsInvalid: true}, "", "--", netIOHeader, ctx.NetIO},
-		{StatsEntry{BlockRead: 0.1, BlockWrite: 2.3}, "", "0.1B / 2.3B", blockIOHeader, ctx.BlockIO},
-		{StatsEntry{BlockRead: 0.1, BlockWrite: 2.3, IsInvalid: true}, "", "--", blockIOHeader, ctx.BlockIO},
-		{StatsEntry{MemoryPercentage: 10.2}, "", "10.20%", memPercHeader, ctx.MemPerc},
-		{StatsEntry{MemoryPercentage: 10.2, IsInvalid: true}, "", "--", memPercHeader, ctx.MemPerc},
-		{StatsEntry{MemoryPercentage: 10.2}, "windows", "--", memPercHeader, ctx.MemPerc},
-		{StatsEntry{Memory: 24, MemoryLimit: 30}, "", "24B / 30B", memUseHeader, ctx.MemUsage},
-		{StatsEntry{Memory: 24, MemoryLimit: 30, IsInvalid: true}, "", "-- / --", memUseHeader, ctx.MemUsage},
-		{StatsEntry{Memory: 24, MemoryLimit: 30}, "windows", "24B", winMemUseHeader, ctx.MemUsage},
-		{StatsEntry{PidsCurrent: 10}, "", "10", pidsHeader, ctx.PIDs},
-		{StatsEntry{PidsCurrent: 10, IsInvalid: true}, "", "--", pidsHeader, ctx.PIDs},
-		{StatsEntry{PidsCurrent: 10}, "windows", "--", pidsHeader, ctx.PIDs},
+		{
+			name:      "Container",
+			stats:     StatsEntry{Container: containerID},
+			expValue:  containerID,
+			expHeader: containerHeader,
+			call:      ctx.Container,
+		},
+		{
+			name:      "CPUPerc",
+			stats:     StatsEntry{CPUPercentage: 5.5},
+			expValue:  "5.50%",
+			expHeader: cpuPercHeader,
+			call:      ctx.CPUPerc,
+		},
+		{
+			name:      "CPUPerc invalid",
+			stats:     StatsEntry{CPUPercentage: 5.5, IsInvalid: true},
+			expValue:  "--",
+			expHeader: cpuPercHeader,
+			call:      ctx.CPUPerc,
+		},
+		{
+			name:      "NetIO",
+			stats:     StatsEntry{NetworkRx: 0.31, NetworkTx: 12.3},
+			expValue:  "0.31B / 12.3B",
+			expHeader: netIOHeader,
+			call:      ctx.NetIO,
+		},
+		{
+			name:      "NetIO invalid",
+			stats:     StatsEntry{NetworkRx: 0.31, NetworkTx: 12.3, IsInvalid: true},
+			expValue:  "--",
+			expHeader: netIOHeader,
+			call:      ctx.NetIO,
+		},
+		{
+			name:      "BlockIO",
+			stats:     StatsEntry{BlockRead: 0.1, BlockWrite: 2.3},
+			expValue:  "0.1B / 2.3B",
+			expHeader: blockIOHeader,
+			call:      ctx.BlockIO,
+		},
+		{
+			name:      "BlockIO invalid",
+			stats:     StatsEntry{BlockRead: 0.1, BlockWrite: 2.3, IsInvalid: true},
+			expValue:  "--",
+			expHeader: blockIOHeader,
+			call:      ctx.BlockIO,
+		},
+		{
+			name:      "MemPerc",
+			stats:     StatsEntry{MemoryPercentage: 10.2},
+			expValue:  "10.20%",
+			expHeader: memPercHeader,
+			call:      ctx.MemPerc,
+		},
+		{
+			name:      "MemPerc invalid",
+			stats:     StatsEntry{MemoryPercentage: 10.2, IsInvalid: true},
+			expValue:  "--",
+			expHeader: memPercHeader,
+			call:      ctx.MemPerc,
+		},
+		{
+			name:      "MemPerc windows",
+			stats:     StatsEntry{MemoryPercentage: 10.2},
+			osType:    "windows",
+			expValue:  "--",
+			expHeader: memPercHeader,
+			call:      ctx.MemPerc,
+		},
+		{
+			name:      "MemUsage",
+			stats:     StatsEntry{Memory: 24, MemoryLimit: 30},
+			expValue:  "24B / 30B",
+			expHeader: memUseHeader,
+			call:      ctx.MemUsage,
+		},
+		{
+			name:      "MemUsage invalid",
+			stats:     StatsEntry{Memory: 24, MemoryLimit: 30, IsInvalid: true},
+			expValue:  "-- / --",
+			expHeader: memUseHeader,
+			call:      ctx.MemUsage,
+		},
+		{
+			name:      "MemUsage windows",
+			stats:     StatsEntry{Memory: 24, MemoryLimit: 30},
+			osType:    "windows",
+			expValue:  "24B",
+			expHeader: winMemUseHeader,
+			call:      ctx.MemUsage,
+		},
+		{
+			name:      "PIDs",
+			stats:     StatsEntry{PidsCurrent: 10},
+			expValue:  "10",
+			expHeader: pidsHeader,
+			call:      ctx.PIDs,
+		},
+		{
+			name:      "PIDs invalid",
+			stats:     StatsEntry{PidsCurrent: 10, IsInvalid: true},
+			expValue:  "--",
+			expHeader: pidsHeader,
+			call:      ctx.PIDs,
+		},
+		{
+			name:      "PIDs windows",
+			stats:     StatsEntry{PidsCurrent: 10},
+			osType:    "windows",
+			expValue:  "--",
+			expHeader: pidsHeader,
+			call:      ctx.PIDs,
+		},
 	}
 
-	for _, te := range tt {
-		ctx = statsContext{s: te.stats, os: te.osType}
-		if v := te.call(); v != te.expValue {
-			t.Fatalf("Expected %q, got %q", te.expValue, v)
-		}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = statsContext{s: tc.stats, os: tc.osType}
+			if v := tc.call(); v != tc.expValue {
+				t.Fatalf("Expected %q, got %q", tc.expValue, v)
+			}
+		})
 	}
 }
 

--- a/cli/command/container/formatter_stats_test.go
+++ b/cli/command/container/formatter_stats_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/cli/internal/test"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestContainerStatsContext(t *testing.T) {
-	containerID := test.RandomID()
+	const actorID = "c74518277ddc15a6afeaaeb06ee5f7433dcb27188224777c1efa7df1e8766d65"
 
 	var ctx statsContext
 	tests := []struct {
@@ -23,11 +22,46 @@ func TestContainerStatsContext(t *testing.T) {
 		call      func() string
 	}{
 		{
-			name:      "Container",
-			stats:     StatsEntry{Container: containerID},
-			expValue:  containerID,
+			name:      "Container id",
+			stats:     StatsEntry{ID: actorID, Container: actorID},
+			expValue:  actorID,
 			expHeader: containerHeader,
 			call:      ctx.Container,
+		},
+		{
+			name:      "Container name",
+			stats:     StatsEntry{ID: actorID, Container: "a-long-container-name"},
+			expValue:  "a-long-container-name",
+			expHeader: containerHeader,
+			call:      ctx.Container,
+		},
+		{
+			name:      "ID",
+			stats:     StatsEntry{ID: actorID},
+			expValue:  actorID,
+			expHeader: formatter.ContainerIDHeader,
+			call:      ctx.ID,
+		},
+		{
+			name:      "Name",
+			stats:     StatsEntry{Name: "/container-name"},
+			expValue:  "container-name",
+			expHeader: formatter.ContainerIDHeader,
+			call:      ctx.Name,
+		},
+		{
+			name:      "Name empty",
+			stats:     StatsEntry{Name: ""},
+			expValue:  "--",
+			expHeader: formatter.ContainerIDHeader,
+			call:      ctx.Name,
+		},
+		{
+			name:      "Name prefix only",
+			stats:     StatsEntry{Name: "/"},
+			expValue:  "--",
+			expHeader: formatter.ContainerIDHeader,
+			call:      ctx.Name,
 		},
 		{
 			name:      "CPUPerc",

--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -139,7 +139,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 		eh := newEventHandler()
 		if options.All {
 			eh.setHandler(events.ActionCreate, func(e events.Message) {
-				s := NewStats(e.Actor.ID[:12])
+				s := NewStats(e.Actor.ID)
 				if cStats.add(s) {
 					waitFirst.Add(1)
 					go collect(ctx, s, apiClient, !options.NoStream, waitFirst)
@@ -148,7 +148,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 		}
 
 		eh.setHandler(events.ActionStart, func(e events.Message) {
-			s := NewStats(e.Actor.ID[:12])
+			s := NewStats(e.Actor.ID)
 			if cStats.add(s) {
 				waitFirst.Add(1)
 				go collect(ctx, s, apiClient, !options.NoStream, waitFirst)
@@ -157,7 +157,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 
 		if !options.All {
 			eh.setHandler(events.ActionDie, func(e events.Message) {
-				cStats.remove(e.Actor.ID[:12])
+				cStats.remove(e.Actor.ID)
 			})
 		}
 
@@ -210,7 +210,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 			return err
 		}
 		for _, ctr := range cs {
-			s := NewStats(ctr.ID[:12])
+			s := NewStats(ctr.ID)
 			if cStats.add(s) {
 				waitFirst.Add(1)
 				go collect(ctx, s, apiClient, !options.NoStream, waitFirst)
@@ -363,7 +363,12 @@ func (eh *eventHandler) watch(c <-chan events.Message) {
 		if !exists {
 			continue
 		}
-		logrus.Debugf("event handler: received event: %v", e)
+		if e.Actor.ID == "" {
+			logrus.WithField("event", e).Errorf("event handler: received %s event with empty ID", e.Action)
+			continue
+		}
+
+		logrus.WithField("event", e).Debugf("event handler: received %s event for: %s", e.Action, e.Actor.ID)
 		go h(e)
 	}
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6451

relates to 

- https://github.com/moby/moby/pull/50832
- https://github.com/moby/moby/pull/26819
- https://github.com/moby/moby/pull/27797



This code was missing a check for the ID field before truncating it to a shorter length for presentation. This would result in a panic if an event would either have an empty ID field or a shorter length ID;

    panic: runtime error: slice bounds out of range [:12] with length 0

    goroutine 82 [running]:
    github.com/docker/cli/cli/command/container.RunStats.func2({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x40001fcba0, 0x9}, {0x40001fcba9, 0x5}, ...})
        /go/src/github.com/docker/cli/cli/command/container/stats.go:146 +0x1d0
    created by github.com/docker/cli/cli/command/container.(*eventHandler).watch in goroutine 6
        /go/src/github.com/docker/cli/cli/command/container/stats.go:363 +0x1c8

We need to look at this code in general; the truncated ID is passed to NewStats, which uses the ID to propagate the `Container` field in the `StatsEntry` struct. which is not used in the default format used by `docker stats` and, having the same content as the `ID` field on the same struct, doesn't make it very useful, other than being able to present it under a `CONTAINER` column (instead of `CONTAINER ID`); we should consider deprecating it; there may be some subtle things to look into here; the `Container` field originally held the container name. This was changed in [moby@ef915fd], which introduced separate `ID` and `Name` fields, renaming the old `Name` field to container.

Looking at [`Stats.SetStatistics()`] and related code in [stats_helpers.go], the `Container` field is used as the "canonical" reference for the stats record; this allows the stats _data_ to be refreshed when a new stats sample arrives for the same container (also see [moby@929a77b], which moved locking to the `Stats` wrapper struct). This construct allows to account for intermediate states, where a stats sample was incomplete or could produce an error; in that case, the reference to the container for which the stats were sampled is kept to allow removing a container from the list once the container was removed. We should consider removing `Container` as a formatting option, and moving the `Container` field to the outer struct; this makes the outer struct responsible for keeping a reference to the container, allowing the `StatsEntry` as a whole to be replaced atomically.

This patch only addresses the panic;

- It changes the logic to preserve the container ID verbatim instead of truncating. This allows stats samples to be matched against the `Actor.ID` as-is.
- Truncating the `Container` is moved to the presentation logic; currently this does not take `--no-trunc` into account to keep the existing behavior, but we can (should) consider adding this.
- Logging is improved to use structured logs, and an extra check is added to prevent empty IDs from being added as watcher.

[`Stats.SetStatistics()`]: https://github.com/docker/cli/blob/82281087e3e186c5a2eafa0d973e849ff84c357d/cli/command/container/formatter_stats.go#L88-L94
[moby@ef915fd]: https://github.com/moby/moby/commit/ef915fd036d9ea5263f9370dce490ef97ea0618d
[moby@929a77b]: https://github.com/moby/moby/commit/929a77b814dfe9ab7a11bffc2d16eebd27bd903a
[stats_helpers.go]: https://github.com/docker/cli/blob/82281087e3e186c5a2eafa0d973e849ff84c357d/cli/command/container/stats_helpers.go#L26-L51

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**


