### PR TITLE
[28.x backport] remove uses of client options that will be deprecated

### DIFF
--- a/cli/command/builder/prune.go
+++ b/cli/command/builder/prune.go
@@ -85,9 +85,12 @@ func runPrune(ctx context.Context, dockerCli command.Cli, options pruneOptions) 
 	}
 
 	report, err := dockerCli.Client().BuildCachePrune(ctx, build.CachePruneOptions{
-		All:         options.all,
-		KeepStorage: options.keepStorage.Value(), // FIXME(thaJeztah): rewrite to use new options; see https://github.com/moby/moby/pull/48720
-		Filters:     pruneFilters,
+		All: options.all,
+		// TODO(austinvazquez): remove when updated to use github.com/moby/moby/client@v0.1.0
+		// See https://github.com/moby/moby/pull/50772 for more details.
+		KeepStorage:   options.keepStorage.Value(),
+		ReservedSpace: options.keepStorage.Value(),
+		Filters:       pruneFilters,
 	})
 	if err != nil {
 		return 0, "", err

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -603,8 +603,10 @@ func NewDockerCli(ops ...CLIOption) (*DockerCli, error) {
 	ops = append(defaultOps, ops...)
 
 	cli := &DockerCli{baseCtx: context.Background()}
-	if err := cli.Apply(ops...); err != nil {
-		return nil, err
+	for _, op := range ops {
+		if err := op(cli); err != nil {
+			return nil, err
+		}
 	}
 	return cli, nil
 }


### PR DESCRIPTION
backports:

- https://github.com/docker/cli/pull/6467
- https://github.com/docker/cli/pull/6430



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

