### PR TITLE
cli-plugins/plugin: Run: allow customizing the CLI

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -82,12 +82,13 @@ func RunPlugin(dockerCli *command.DockerCli, plugin *cobra.Command, meta metadat
 
 // Run is the top-level entry point to the CLI plugin framework. It should
 // be called from the plugin's "main()" function. It initializes a new
-// [command.DockerCli] instance before calling makeCmd to construct the
-// plugin command, then invokes the plugin command using [RunPlugin].
-func Run(makeCmd func(command.Cli) *cobra.Command, meta metadata.Metadata) {
+// [command.DockerCli] instance with the given options before calling
+// makeCmd to construct the plugin command, then invokes the plugin command
+// using [RunPlugin].
+func Run(makeCmd func(command.Cli) *cobra.Command, meta metadata.Metadata, ops ...command.CLIOption) {
 	otel.SetErrorHandler(debug.OTELErrorHandler)
 
-	dockerCLI, err := command.NewDockerCli()
+	dockerCLI, err := command.NewDockerCli(ops...)
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/4574
- https://github.com/docker/compose/pull/13240


Currently, the plugin.Run command constructs the DockerCli using the default options, assuming plugins run with all the same options as the CLI itself; to customize the CLI there's a "Apply" option, but this means mutating the CLI after it's already constructed, which is not ideal.

This patch adds a variadic ops argument to allow CLI plugins to pass custom options to use for the CLI, so that there's no need to mutate its config in most cases.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli-plugins/plugin: Run: allow customizing the CLI
```

**- A picture of a cute animal (not mandatory but encouraged)**

