### PR TITLE
[28.x backport] cli-plugins/manager: allow schema-versions <= 2.0.0

### DIFF
--- a/cli-plugins/manager/plugin.go
+++ b/cli-plugins/manager/plugin.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/docker/cli/cli-plugins/metadata"
@@ -118,8 +119,8 @@ func newPlugin(c pluginCandidate, cmds []*cobra.Command) (Plugin, error) {
 		p.Err = wrapAsPluginError(err, "invalid metadata")
 		return p, nil
 	}
-	if p.Metadata.SchemaVersion != "0.1.0" {
-		p.Err = newPluginError("plugin SchemaVersion %q is not valid, must be 0.1.0", p.Metadata.SchemaVersion)
+	if err := validateSchemaVersion(p.Metadata.SchemaVersion); err != nil {
+		p.Err = &pluginError{cause: err}
 		return p, nil
 	}
 	if p.Metadata.Vendor == "" {
@@ -127,6 +128,31 @@ func newPlugin(c pluginCandidate, cmds []*cobra.Command) (Plugin, error) {
 		return p, nil
 	}
 	return p, nil
+}
+
+// validateSchemaVersion validates if the plugin's schemaVersion is supported.
+//
+// The current schema-version is "0.1.0", but we don't want to break compatibility
+// until v2.0.0 of the schema version. Check for the major version to be < 2.0.0.
+//
+// Note that CLI versions before 28.4.1 may not support these versions as they were
+// hard-coded to only accept "0.1.0".
+func validateSchemaVersion(version string) error {
+	if version == "0.1.0" {
+		return nil
+	}
+	if version == "" {
+		return errors.New("plugin SchemaVersion version cannot be empty")
+	}
+	major, _, ok := strings.Cut(version, ".")
+	majorVersion, err := strconv.Atoi(major)
+	if !ok || err != nil {
+		return fmt.Errorf("plugin SchemaVersion %q has wrong format: must be <major>.<minor>.<patch>", version)
+	}
+	if majorVersion > 1 {
+		return fmt.Errorf("plugin SchemaVersion %q is not supported: must be lower than 2.0.0", version)
+	}
+	return nil
 }
 
 // RunHook executes the plugin's hooks command


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6479

----


The CLI currently hard-codes the schema-version for CLI plugins to "0.1.0", which doesn't allow us to expand the schema for plugins.

As there's many plugins that we shipped already, we can't break compatibility until we reach 2.0.0, but we can expand the schema with non-breaking changes.

This patch makes the validation more permissive to allow new schema versions <= 2.0.0. Note that existing CLIs will still invalidate such versions, so we cannot update the version until such CLIs are no longer expected to be used, but this patch lays the ground-work to open that option.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

