### PR TITLE
feat: Add environment variable expansion for docker config plugin dirs

### DIFF
--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -40,15 +40,25 @@ func (e errPluginNotFound) Error() string {
 //
 // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
 func getPluginDirs(cfg *configfile.ConfigFile) []string {
+	var configPluginDirs []string
 	var pluginDirs []string
-
 	if cfg != nil {
-		pluginDirs = append(pluginDirs, cfg.CLIPluginsExtraDirs...)
+		configPluginDirs = append(configPluginDirs, cfg.CLIPluginsExtraDirs...)
 	}
+	pluginDirs = append(pluginDirs, expandEnvironmentVariablesInPluginDirString(configPluginDirs)...)
 	pluginDir := filepath.Join(config.Dir(), "cli-plugins")
 	pluginDirs = append(pluginDirs, pluginDir)
 	pluginDirs = append(pluginDirs, defaultSystemPluginDirs...)
 	return pluginDirs
+}
+
+// Resolve statements like $HOME in plugin directory paths
+func expandEnvironmentVariablesInPluginDirString(pluginDirs []string) []string {
+	var replacedPluginDirs []string
+	for _, dir := range pluginDirs {
+		replacedPluginDirs = append(replacedPluginDirs, os.ExpandEnv(dir))
+	}
+	return replacedPluginDirs
 }
 
 func addPluginCandidatesFromDir(res map[string][]string, d string) {


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

- Added environment variable expansion to the config plugin dirs
- Added an example test (I guess 😅 )

**- How I did it**
- searching for config file references in the code, thinking and assisted by GitHub Copilot

**- How to verify it**

- run the tests (I guess 😅 )

**- Human readable description for the release notes**

Add support to expand environment variables in docker plugin config directory string
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- Add support to expand environment variables in docker plugin config directory string
```

I am really really new to Go like `0.5%` experience. The test is mainly assisted by Copilot with a bit of brain usage by my side. Feel free to help me to add like a negative test or something like that if the current one is not enough

**- A picture of a cute animal (not mandatory but encouraged)**
![ducks](https://github.com/user-attachments/assets/534b252e-9f1a-4d16-a7a1-6a43cb5b365e)

