### PR TITLE
[28.x backport] cli/command: deprecate WithContentTrustFromEnv, WithContentTrust

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -598,7 +598,7 @@ type ServerInfo struct {
 // environment.
 func NewDockerCli(ops ...CLIOption) (*DockerCli, error) {
 	defaultOps := []CLIOption{
-		WithContentTrustFromEnv(),
+		withContentTrustFromEnv(),
 		WithDefaultContextStoreConfig(),
 		WithStandardStreams(),
 		WithUserAgent(UserAgent()),

--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -75,8 +75,8 @@ func WithErrorStream(err io.Writer) CLIOption {
 	}
 }
 
-// WithContentTrustFromEnv enables content trust on a cli from environment variable DOCKER_CONTENT_TRUST value.
-func WithContentTrustFromEnv() CLIOption {
+// withContentTrustFromEnv enables content trust on a cli from environment variable DOCKER_CONTENT_TRUST value.
+func withContentTrustFromEnv() CLIOption {
 	return func(cli *DockerCli) error {
 		cli.contentTrust = false
 		if e := os.Getenv("DOCKER_CONTENT_TRUST"); e != "" {
@@ -89,7 +89,16 @@ func WithContentTrustFromEnv() CLIOption {
 	}
 }
 
+// WithContentTrustFromEnv enables content trust on a cli from environment variable DOCKER_CONTENT_TRUST value.
+//
+// Deprecated: this option is no longer used, and will be removed in the next release.
+func WithContentTrustFromEnv() CLIOption {
+	return withContentTrustFromEnv()
+}
+
 // WithContentTrust enables content trust on a cli.
+//
+// Deprecated: this option is no longer used, and will be removed in the next release.
 func WithContentTrust(enabled bool) CLIOption {
 	return func(cli *DockerCli) error {
 		cli.contentTrust = enabled

--- a/cli/command/cli_options_test.go
+++ b/cli/command/cli_options_test.go
@@ -10,7 +10,7 @@ import (
 func contentTrustEnabled(t *testing.T) bool {
 	t.Helper()
 	var cli DockerCli
-	assert.NilError(t, WithContentTrustFromEnv()(&cli))
+	assert.NilError(t, withContentTrustFromEnv()(&cli))
 	return cli.contentTrust
 }
 


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6488

These options were used internally as defaults for the constructor and only impact commands implemented in the CLI itself.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate `WithContentTrustFromEnv`, `WithContentTrust` options. These options were used internally, and will be removed in the next release..
```

**- A picture of a cute animal (not mandatory but encouraged)**

