### PR TITLE
[28.x backport] cli/command: deprecate DockerCli.DefaultVersion

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -48,7 +48,6 @@ type Cli interface {
 	Apply(ops ...CLIOption) error
 	config.Provider
 	ServerInfo() ServerInfo
-	DefaultVersion() string
 	CurrentVersion() string
 	ContentTrustEnabled() bool
 	BuildKitEnabled() (bool, error)
@@ -90,6 +89,8 @@ type DockerCli struct {
 }
 
 // DefaultVersion returns [api.DefaultVersion].
+//
+// Deprecated: this function is no longer used and will be removed in the next release.
 func (*DockerCli) DefaultVersion() string {
 	return api.DefaultVersion
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6490

This function was used internally, but is no longer used. There are no known users of this method, so already removing it from the Cli interface.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate `DockerCli.DefaultVersion`. This method is no longer used and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

