### PR TITLE
[28.x backport] e2e: update openssh, openssl to work around openssh bug

### DIFF
--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -7,8 +7,8 @@ ARG ENGINE_VERSION=28
 FROM docker:${ENGINE_VERSION}-dind
 
 # the openssh-client update is needed for security reasons when using docker:23.0-dind, currently maintained as an lts by mirantis
-RUN apk --no-cache upgrade openssh-client && \
-  apk --no-cache add shadow openssh-server && \
+RUN apk --no-cache add openssl openssh-client openssh-server shadow && \
+ apk --no-cache upgrade openssl openssh-client openssh-server &&  \
   # TODO(krissetto): `groupadd` can be removed once we only test against moby >= v24
   # see https://github.com/docker-library/docker/pull/470
   groupadd -f docker && \


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6492

relates to https://gitlab.alpinelinux.org/alpine/aports/-/issues/17547


(cherry picked from commit a2eceee842ed88be3e449846294de3f56113d442)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

