### PR TITLE
[28.x backport] cli/command: deprecate DockerCli.ContentTrustEnabled

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -50,7 +50,6 @@ type Cli interface {
 	ServerInfo() ServerInfo
 	DefaultVersion() string
 	CurrentVersion() string
-	ContentTrustEnabled() bool
 	BuildKitEnabled() (bool, error)
 	ContextStore() store.Store
 	CurrentContext() string
@@ -160,6 +159,8 @@ func (cli *DockerCli) ServerInfo() ServerInfo {
 
 // ContentTrustEnabled returns whether content trust has been enabled by an
 // environment variable.
+//
+// Deprecated: check the value of the DOCKER_CONTENT_TRUST environment variable to detect whether content-trust is enabled.
 func (cli *DockerCli) ContentTrustEnabled() bool {
 	return cli.contentTrust
 }

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -96,7 +96,7 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 	addPlatformFlag(flags, &options.platform)
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 
-	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&options.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image verification")
 	copts = addFlags(flags)
 
 	addCompletions(cmd, dockerCLI)

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -249,6 +249,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DOCKER_CONTENT_TRUST", "true")
 			fakeCLI := test.NewFakeCli(&fakeClient{
 				createContainerFunc: func(config *container.Config,
 					hostConfig *container.HostConfig,
@@ -258,7 +259,7 @@ func TestNewCreateCommandWithContentTrustErrors(t *testing.T) {
 				) (container.CreateResponse, error) {
 					return container.CreateResponse{}, errors.New("shouldn't try to pull image")
 				},
-			}, test.EnableContentTrust)
+			})
 			fakeCLI.SetNotaryClient(tc.notaryFunc)
 			cmd := newCreateCommand(fakeCLI)
 			cmd.SetOut(io.Discard)

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/opts"
 	"github.com/docker/docker/api/types/container"
 	"github.com/moby/sys/signal"
@@ -74,7 +75,7 @@ func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 
 	// TODO(thaJeztah): consider adding platform as "image create option" on containerOptions
 	addPlatformFlag(flags, &options.platform)
-	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&options.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image verification")
 	copts = addFlags(flags)
 
 	_ = cmd.RegisterFlagCompletionFunc("detach-keys", completeDetachKeys)

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -323,6 +323,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DOCKER_CONTENT_TRUST", "true")
 			fakeCLI := test.NewFakeCli(&fakeClient{
 				createContainerFunc: func(config *container.Config,
 					hostConfig *container.HostConfig,
@@ -332,7 +333,7 @@ func TestRunCommandWithContentTrustErrors(t *testing.T) {
 				) (container.CreateResponse, error) {
 					return container.CreateResponse{}, errors.New("shouldn't try to pull image")
 				},
-			}, test.EnableContentTrust)
+			})
 			fakeCLI.SetNotaryClient(tc.notaryFunc)
 			cmd := newRunCommand(fakeCLI)
 			cmd.SetArgs(tc.args)

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -151,7 +151,7 @@ func newBuildCommand(dockerCli command.Cli) *cobra.Command {
 	flags.SetAnnotation("target", annotation.ExternalURL, []string{"https://docs.docker.com/reference/cli/docker/buildx/build/#target"})
 	flags.StringVar(&options.imageIDFile, "iidfile", "", "Write the image ID to the file")
 
-	flags.BoolVar(&options.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&options.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image verification")
 
 	flags.StringVar(&options.platform, "platform", os.Getenv("DOCKER_DEFAULT_PLATFORM"), "Set platform if server is multi-platform capable")
 	flags.SetAnnotation("platform", "version", []string{"1.38"})

--- a/cli/command/image/pull.go
+++ b/cli/command/image/pull.go
@@ -56,7 +56,7 @@ func newPullCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
 
 	addPlatformFlag(flags, &opts.platform)
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image verification")
 
 	_ = cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 

--- a/cli/command/image/pull_test.go
+++ b/cli/command/image/pull_test.go
@@ -118,11 +118,12 @@ func TestNewPullCommandWithContentTrustErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DOCKER_CONTENT_TRUST", "true")
 			cli := test.NewFakeCli(&fakeClient{
 				imagePullFunc: func(ref string, options image.PullOptions) (io.ReadCloser, error) {
 					return io.NopCloser(strings.NewReader("")), errors.New("shouldn't try to pull image")
 				},
-			}, test.EnableContentTrust)
+			})
 			cli.SetNotaryClient(tc.notaryFunc)
 			cmd := newPullCommand(cli)
 			cmd.SetOut(io.Discard)

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/docker/cli/internal/registry"
 	"github.com/docker/cli/internal/tui"
@@ -64,7 +65,7 @@ func newPushCommand(dockerCLI command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.all, "all-tags", "a", false, "Push all tags of an image to the repository")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress verbose output")
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCLI.ContentTrustEnabled(), "Skip image signing")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image signing")
 
 	// Don't default to DOCKER_DEFAULT_PLATFORM env variable, always default to
 	// pushing the image as-is. This also avoids forcing the platform selection

--- a/cli/command/plugin/install.go
+++ b/cli/command/plugin/install.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/internal/registry"
@@ -28,9 +29,9 @@ type pluginOptions struct {
 	untrusted       bool
 }
 
-func loadPullFlags(dockerCli command.Cli, opts *pluginOptions, flags *pflag.FlagSet) {
+func loadPullFlags(opts *pluginOptions, flags *pflag.FlagSet) {
 	flags.BoolVar(&opts.grantPerms, "grant-all-permissions", false, "Grant all permissions necessary to run the plugin")
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image verification")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image verification")
 }
 
 func newInstallCommand(dockerCli command.Cli) *cobra.Command {
@@ -49,7 +50,7 @@ func newInstallCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	loadPullFlags(dockerCli, &options, flags)
+	loadPullFlags(&options, flags)
 	flags.BoolVar(&options.disable, "disable", false, "Do not enable the plugin on install")
 	flags.StringVar(&options.localName, "alias", "", "Local name for plugin")
 	return cmd

--- a/cli/command/plugin/install_test.go
+++ b/cli/command/plugin/install_test.go
@@ -86,11 +86,12 @@ func TestInstallContentTrustErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Setenv("DOCKER_CONTENT_TRUST", "true")
 			cli := test.NewFakeCli(&fakeClient{
 				pluginInstallFunc: func(name string, options types.PluginInstallOptions) (io.ReadCloser, error) {
 					return nil, errors.New("should not try to install plugin")
 				},
-			}, test.EnableContentTrust)
+			})
 			cli.SetNotaryClient(tc.notaryFunc)
 			cmd := newInstallCommand(cli)
 			cmd.SetArgs(tc.args)

--- a/cli/command/plugin/push.go
+++ b/cli/command/plugin/push.go
@@ -33,7 +33,7 @@ func newPushCommand(dockerCli command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 
-	flags.BoolVar(&opts.untrusted, "disable-content-trust", !dockerCli.ContentTrustEnabled(), "Skip image signing")
+	flags.BoolVar(&opts.untrusted, "disable-content-trust", !trust.Enabled(), "Skip image signing")
 
 	return cmd
 }

--- a/cli/command/plugin/upgrade.go
+++ b/cli/command/plugin/upgrade.go
@@ -30,7 +30,7 @@ func newUpgradeCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	loadPullFlags(dockerCli, &options, flags)
+	loadPullFlags(&options, flags)
 	flags.BoolVar(&options.skipRemoteCheck, "skip-remote-check", false, "Do not check if specified remote plugin matches existing plugin image")
 	return cmd
 }

--- a/cli/command/service/trust.go
+++ b/cli/command/service/trust.go
@@ -15,7 +15,7 @@ import (
 )
 
 func resolveServiceImageDigestContentTrust(dockerCli command.Cli, service *swarm.ServiceSpec) error {
-	if !dockerCli.ContentTrustEnabled() {
+	if !trust.Enabled() {
 		// When not using content trust, digest resolution happens later when
 		// contacting the registry to retrieve image information.
 		return nil

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/distribution/reference"
@@ -41,6 +42,20 @@ var (
 	// ActionsPushAndPull defines the actions for read-write interactions with a Notary Repository
 	ActionsPushAndPull = []string{"pull", "push"}
 )
+
+// Enabled returns whether content-trust is enabled through the DOCKER_CONTENT_TRUST env-var.
+//
+// IMPORTANT: this function is for internal use, and may be removed at any moment.
+func Enabled() bool {
+	var enabled bool
+	if e := os.Getenv("DOCKER_CONTENT_TRUST"); e != "" {
+		if t, err := strconv.ParseBool(e); t || err != nil {
+			// treat any other value as true
+			enabled = true
+		}
+	}
+	return enabled
+}
 
 // NotaryServer is the endpoint serving the Notary trust server
 const NotaryServer = "https://notary.docker.io"

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -36,7 +36,6 @@ type FakeCli struct {
 	notaryClientFunc NotaryClientFuncType
 	manifestStore    manifeststore.Store
 	registryClient   registryclient.RegistryClient
-	contentTrust     bool
 	contextStore     store.Store
 	currentContext   string
 	dockerEndpoint   docker.Endpoint
@@ -196,16 +195,6 @@ func (c *FakeCli) SetManifestStore(manifestStore manifeststore.Store) {
 // SetRegistryClient on the fake cli
 func (c *FakeCli) SetRegistryClient(registryClient registryclient.RegistryClient) {
 	c.registryClient = registryClient
-}
-
-// ContentTrustEnabled on the fake cli
-func (c *FakeCli) ContentTrustEnabled() bool {
-	return c.contentTrust
-}
-
-// EnableContentTrust on the fake cli
-func EnableContentTrust(c *FakeCli) {
-	c.contentTrust = true
 }
 
 // BuildKitEnabled on the fake cli


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6494

---

This function was used internally, but is no longer used. Users should check
the value of the `DOCKER_CONTENT_TRUST` environment variable instead.

There are no known external users of this method, so already removing it
from the Cli interface; this method will be removed in the next release.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate `DockerCli.ContentTrustEnabled`. This method is no longer used and will be removed in the next release.
```

**- A picture of a cute animal (not mandatory but encouraged)**

