### PR TITLE
[28.x backport] cli/command: deprecate DockerCli.Apply

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -567,6 +567,8 @@ func (cli *DockerCli) initialize() error {
 }
 
 // Apply all the operation on the cli
+//
+// Deprecated: this method is no longer used and will be removed in the next release if there are no remaining users.
 func (cli *DockerCli) Apply(ops ...CLIOption) error {
 	for _, op := range ops {
 		if err := op(cli); err != nil {


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6496
---

relates to:

- https://github.com/docker/cli/pull/6467
- https://github.com/docker/cli/pull/6475
- https://github.com/docker/cli/pull/4574


### cli/command: deprecate DockerCli.Apply


The Apply method was added when CLI options for constructing the CLI were rewritten into functional options in [cli@7f207f3]. There was no mention in the pull request of this method specifically, and this may have been related to work being done elsewhere on compose-on-kubernetes or the compose-cli plugin that may have needed options to modify the CLI config after it was already initialized.

The CLI itself no longer depends on this method since [cli@133279f], and the only known consumer (docker compose) no longer needs it since [cli@2711800] and [cli@048e931].

This patch deprecates the method with the intent to remove it in a future release.

[cli@7f207f3]: https://github.com/docker/cli/commit/7f207f3f957ed3f5129aeb22bef2a429c14caf22
[cli@133279f]: https://github.com/docker/cli/commit/133279fb0d4adea30d27d27eb8789b79405fc82b
[cli@2711800]: https://github.com/docker/cli/commit/271180043066ec1baaa91351a63f1854667171d4
[cli@048e931]: https://github.com/docker/cli/commit/048e931b422a6baa26d12f818bbb14c501164c09

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate `DockerCli.Apply`. This method is no longer used and will be removed in the next release if there are no remaining uses.
```

**- A picture of a cute animal (not mandatory but encouraged)**


