### PR TITLE
cli/command/image: pushTrustedReference: internalize constructing indexInfo

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -18,9 +18,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/jsonstream"
-	"github.com/docker/cli/internal/registry"
 	"github.com/docker/cli/internal/tui"
-	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types/auxprogress"
 	"github.com/moby/moby/client"
 	"github.com/morikuni/aec"
@@ -108,12 +106,8 @@ To push the complete multi-platform image, remove the --platform flag.
 		}
 	}
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	indexInfo := registry.NewIndexInfo(ref)
-
 	// Resolve the Auth config relevant for this server
-	authConfig := command.ResolveAuthConfig(dockerCli.ConfigFile(), indexInfo)
-	encodedAuth, err := authconfig.Encode(authConfig)
+	encodedAuth, err := command.RetrieveAuthTokenFromImage(dockerCli.ConfigFile(), ref.String())
 	if err != nil {
 		return err
 	}
@@ -136,7 +130,7 @@ To push the complete multi-platform image, remove the --platform flag.
 	}()
 
 	if !opts.untrusted {
-		return pushTrustedReference(ctx, dockerCli, indexInfo, ref, authConfig, responseBody)
+		return pushTrustedReference(ctx, dockerCli, ref, responseBody)
 	}
 
 	if opts.quiet {

--- a/cli/command/image/trust.go
+++ b/cli/command/image/trust.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/jsonstream"
+	"github.com/docker/cli/internal/registry"
 	"github.com/moby/moby/api/pkg/authconfig"
 	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
@@ -43,12 +44,18 @@ func newNotaryClient(cli command.Streams, imgRefAndAuth trust.ImageRefAndAuth) (
 }
 
 // pushTrustedReference pushes a canonical reference to the trust server.
-func pushTrustedReference(ctx context.Context, ioStreams command.Streams, indexInfo *registrytypes.IndexInfo, ref reference.Named, authConfig registrytypes.AuthConfig, in io.Reader) error {
+func pushTrustedReference(ctx context.Context, dockerCLI command.Cli, ref reference.Named, responseBody io.Reader) error {
+	// Resolve the Repository name from fqn to RepositoryInfo, and create an
+	// IndexInfo. Docker Content Trust uses the IndexInfo.Official field to
+	// select the right domain for Docker Hub's Notary server;
+	// https://github.com/docker/cli/blob/v28.4.0/cli/trust/trust.go#L65-L79
+	indexInfo := registry.NewIndexInfo(ref)
 	repoInfo := &trust.RepositoryInfo{
 		Name:  reference.TrimNamed(ref),
 		Index: indexInfo,
 	}
-	return trust.PushTrustedReference(ctx, ioStreams, repoInfo, ref, authConfig, in, command.UserAgent())
+	authConfig := command.ResolveAuthConfig(dockerCLI.ConfigFile(), indexInfo)
+	return trust.PushTrustedReference(ctx, dockerCLI, repoInfo, ref, authConfig, responseBody, command.UserAgent())
 }
 
 // trustedPull handles content trust pulling of an image

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -340,7 +340,10 @@ func GetImageReferencesAndAuth(ctx context.Context,
 		return ImageRefAndAuth{}, err
 	}
 
-	// Resolve the Repository name from fqn to RepositoryInfo
+	// Resolve the Repository name from fqn to RepositoryInfo, and create an
+	// IndexInfo. Docker Content Trust uses the IndexInfo.Official field to
+	// select the right domain for Docker Hub's Notary server;
+	// https://github.com/docker/cli/blob/v28.4.0/cli/trust/trust.go#L65-L79
 	indexInfo := registry.NewIndexInfo(ref)
 	authConfig := authResolver(ctx, indexInfo)
 	return ImageRefAndAuth{


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/5925

All information needed can be deducted from the image reference, which is used to create a indexInfo, repoInfo, and to resolve auth-config.

In some situations this may result in resolving the auth-config twice after it already was resolved to an encoded auth-config.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

