### PR TITLE
trust: print deprecation warning when using hub Notary server

### DIFF
--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -108,6 +108,11 @@ func (scs simpleCredentialStore) RefreshToken(*url.URL, string) string {
 
 func (simpleCredentialStore) SetRefreshToken(*url.URL, string, string) {}
 
+const dctDeprecation = `WARNING: Docker is retiring DCT for Docker Official Images (DOI).
+         For details, refer to https://docs.docker.com/go/dct-deprecation/
+
+`
+
 // GetNotaryRepository returns a NotaryRepository which stores all the
 // information needed to operate on a notary repository.
 // It creates an HTTP transport providing authentication support.
@@ -115,6 +120,9 @@ func GetNotaryRepository(in io.Reader, out io.Writer, userAgent string, repoInfo
 	server, err := Server(repoInfo.Index)
 	if err != nil {
 		return nil, err
+	}
+	if server == NotaryServer {
+		_, _ = fmt.Fprint(os.Stderr, dctDeprecation)
 	}
 
 	cfg := tlsconfig.ClientDefault()


### PR DESCRIPTION
- [x] depends on https://github.com/docker/docs/pull/23462


Docker Hub's Notary service is being retired, and now produces failures in most cases. Add a warning when attempting to use it, pending full removal of trust;
https://www.docker.com/blog/retiring-docker-content-trust/

With this PR:

    DOCKER_CONTENT_TRUST=1 docker pull -q hello-world
    WARNING: Docker is retiring DCT for Docker Official Images (DOI).
             For details, refer to https://docs.docker.com/go/dct-deprecation/

    could not validate the path to a trusted root: unable to retrieve valid leaf certificates

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

