### PR TITLE
[28.x backport] cli/command/image: pushTrustedReference: internalize constructing indexInfo

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -17,11 +17,9 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/cli/trust"
 	"github.com/docker/cli/internal/jsonstream"
-	"github.com/docker/cli/internal/registry"
 	"github.com/docker/cli/internal/tui"
 	"github.com/docker/docker/api/types/auxprogress"
 	"github.com/docker/docker/api/types/image"
-	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/morikuni/aec"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
@@ -114,12 +112,8 @@ To push the complete multi-platform image, remove the --platform flag.
 		}
 	}
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	indexInfo := registry.NewIndexInfo(ref)
-
 	// Resolve the Auth config relevant for this server
-	authConfig := command.ResolveAuthConfig(dockerCli.ConfigFile(), indexInfo)
-	encodedAuth, err := registrytypes.EncodeAuthConfig(authConfig)
+	encodedAuth, err := command.RetrieveAuthTokenFromImage(dockerCli.ConfigFile(), ref.String())
 	if err != nil {
 		return err
 	}
@@ -142,7 +136,7 @@ To push the complete multi-platform image, remove the --platform flag.
 	}()
 
 	if !opts.untrusted {
-		return pushTrustedReference(ctx, dockerCli, indexInfo, ref, authConfig, responseBody)
+		return pushTrustedReference(ctx, dockerCli, ref, responseBody)
 	}
 
 	if opts.quiet {

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -100,9 +100,11 @@ To push the complete multi-platform image, remove the --platform flag.
 	}
 
 	ref, err := reference.ParseNormalizedNamed(opts.remote)
-	switch {
-	case err != nil:
+	if err != nil {
 		return err
+	}
+
+	switch {
 	case opts.all && !reference.IsNameOnly(ref):
 		return errors.New("tag can't be used with --all-tags/-a")
 	case !opts.all && reference.IsNameOnly(ref):
@@ -121,34 +123,32 @@ To push the complete multi-platform image, remove the --platform flag.
 	if err != nil {
 		return err
 	}
-	options := image.PushOptions{
+
+	responseBody, err := dockerCli.Client().ImagePush(ctx, reference.FamiliarString(ref), image.PushOptions{
 		All:           opts.all,
 		RegistryAuth:  encodedAuth,
 		PrivilegeFunc: nil,
 		Platform:      platform,
-	}
-
-	responseBody, err := dockerCli.Client().ImagePush(ctx, reference.FamiliarString(ref), options)
+	})
 	if err != nil {
 		return err
 	}
 
 	defer func() {
+		_ = responseBody.Close()
 		for _, note := range notes {
 			out.PrintNote(note)
 		}
 	}()
 
-	defer responseBody.Close()
 	if !opts.untrusted {
-		// TODO pushTrustedReference currently doesn't respect `--quiet`
 		return pushTrustedReference(ctx, dockerCli, indexInfo, ref, authConfig, responseBody)
 	}
 
 	if opts.quiet {
 		err = jsonstream.Display(ctx, responseBody, streams.NewOut(io.Discard), jsonstream.WithAuxCallback(handleAux()))
 		if err == nil {
-			fmt.Fprintln(dockerCli.Out(), ref.String())
+			_, _ = fmt.Fprintln(dockerCli.Out(), ref.String())
 		}
 		return err
 	}

--- a/cli/trust/trust.go
+++ b/cli/trust/trust.go
@@ -342,7 +342,10 @@ func GetImageReferencesAndAuth(ctx context.Context,
 		return ImageRefAndAuth{}, err
 	}
 
-	// Resolve the Repository name from fqn to RepositoryInfo
+	// Resolve the Repository name from fqn to RepositoryInfo, and create an
+	// IndexInfo. Docker Content Trust uses the IndexInfo.Official field to
+	// select the right domain for Docker Hub's Notary server;
+	// https://github.com/docker/cli/blob/v28.4.0/cli/trust/trust.go#L65-L79
 	indexInfo := registry.NewIndexInfo(ref)
 	authConfig := authResolver(ctx, indexInfo)
 	return ImageRefAndAuth{


### PR DESCRIPTION
backport:

- https://github.com/docker/cli/pull/6363
- https://github.com/docker/cli/pull/6507