### PR TITLE
[28.x backport] cli/manifest/store: deprecate IsNotFound

### DIFF
--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
@@ -97,7 +98,7 @@ func runManifestAnnotate(dockerCLI command.Cli, opts annotateOptions) error {
 	manifestStore := newManifestStore(dockerCLI)
 	imageManifest, err := manifestStore.Get(targetRef, imgRef)
 	switch {
-	case store.IsNotFound(err):
+	case errdefs.IsNotFound(err):
 		return fmt.Errorf("manifest for image %s does not exist in %s", opts.image, opts.target)
 	case err != nil:
 		return err

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/manifest/store"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -44,7 +44,7 @@ func createManifestList(ctx context.Context, dockerCLI command.Cli, args []strin
 	manifestStore := newManifestStore(dockerCLI)
 	_, err = manifestStore.GetList(targetRef)
 	switch {
-	case store.IsNotFound(err):
+	case errdefs.IsNotFound(err):
 		// New manifest list
 	case err != nil:
 		return err

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -3,9 +3,9 @@ package manifest
 import (
 	"context"
 
+	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/cli/cli/manifest/types"
 )
 
@@ -72,7 +72,7 @@ func normalizeReference(ref string) (reference.Named, error) {
 func getManifest(ctx context.Context, dockerCLI command.Cli, listRef, namedRef reference.Named, insecure bool) (types.ImageManifest, error) {
 	data, err := newManifestStore(dockerCLI).Get(listRef, namedRef)
 	switch {
-	case store.IsNotFound(err):
+	case errdefs.IsNotFound(err):
 		return newRegistryClient(dockerCLI, insecure).GetManifest(ctx, namedRef)
 	case err != nil:
 		return types.ImageManifest{}, err

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/manifest/manifestlist"
@@ -152,27 +153,13 @@ func makeFilesafeName(ref string) string {
 	return strings.ReplaceAll(fileName, "/", "_")
 }
 
-type notFoundError struct {
-	object string
+func newNotFoundError(ref string) error {
+	return errdefs.ErrNotFound.WithMessage("No such manifest: " + ref)
 }
-
-func newNotFoundError(ref string) *notFoundError {
-	return &notFoundError{object: ref}
-}
-
-func (n *notFoundError) Error() string {
-	return "No such manifest: " + n.object
-}
-
-// NotFound interface
-func (*notFoundError) NotFound() {}
 
 // IsNotFound returns true if the error is a not found error
+//
+// Deprecated: use [errdefs.IsNotFound]. This function will be removed in the next release.
 func IsNotFound(err error) bool {
-	_, ok := err.(notFound)
-	return ok
-}
-
-type notFound interface {
-	NotFound()
+	return errdefs.IsNotFound(err)
 }

--- a/cli/manifest/store/store_test.go
+++ b/cli/manifest/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/google/go-cmp/cmp"
@@ -86,7 +87,7 @@ func TestStoreSaveAndGet(t *testing.T) {
 			actual, err := store.Get(tc.listRef, tc.manifestRef)
 			if tc.expectedErr != "" {
 				assert.Error(t, err, tc.expectedErr)
-				assert.Check(t, IsNotFound(err))
+				assert.Check(t, errdefs.IsNotFound(err))
 				return
 			}
 			assert.NilError(t, err)
@@ -117,5 +118,5 @@ func TestStoreGetListDoesNotExist(t *testing.T) {
 	listRef := ref("list")
 	_, err := store.GetList(listRef)
 	assert.Error(t, err, "No such manifest: list")
-	assert.Check(t, IsNotFound(err))
+	assert.Check(t, errdefs.IsNotFound(err))
 }


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6513


Deprecate the IsNotFound utility in favor of errdefs.


(cherry picked from commit f3fb7728c7e03909268fa2c621c6febcaca138a0)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/manifest/store: deprecate `IsNotFound()`
```

**- A picture of a cute animal (not mandatory but encouraged)**

