### PR TITLE
cli/config/types: remove deprecated AuthConfig.Email field

### DIFF
--- a/cli/config/types/authconfig.go
+++ b/cli/config/types/authconfig.go
@@ -6,11 +6,6 @@ type AuthConfig struct {
 	Password string `json:"password,omitempty"`
 	Auth     string `json:"auth,omitempty"`
 
-	// Email is an optional value associated with the username.
-	//
-	// Deprecated: This field is deprecated since docker 1.11 (API v1.23) and will be removed in the next release.
-	Email string `json:"email,omitempty"`
-
 	ServerAddress string `json:"serveraddress,omitempty"`
 
 	// IdentityToken is used to authenticate the user and get


### PR DESCRIPTION
- [x] depends on https://github.com/docker/cli/pull/6516

relates to:

- https://github.com/moby/moby/pull/20565
- https://github.com/moby/moby/pull/51059
- https://github.com/docker/cli/pull/6366


----


Relates to [cli@27b2797], which forked this type from the Moby API, and [cli@aab947d], which fixed the deprecation comment.

This field is no longer used since Docker 1.11 (API version 1.23) through [moby@aee260d] and [engine-api@9a9e468], and the fix of the deprecation comment was included in the 28.4.0 release.

This patch removes the field.

[cli@27b2797]: https://github.com/docker/cli/commit/27b2797f7deb3ca5b7f80371d825113deb1faca1
[cli@aab947d]: https://github.com/docker/cli/commit/aab947de8f5cd2db3dd9d8ead0f38d3246557750
[moby@aee260d]: https://github.com/moby/moby/commit/aee260d4eb3aa0fc86ee5038010b7bbc24512ae5
[engine-api@9a9e468]: https://github.com/docker-archive-public/docker.engine-api/commit/9a9e468f503eb731d6fdc9d7f98c122e1b397c86

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/config/types: remove deprecated `AuthConfig.Email` field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

