### PR TITLE
cli/config/memorystore: remove unused IsErrValueNotFound

### DIFF
--- a/cli/config/memorystore/store.go
+++ b/cli/config/memorystore/store.go
@@ -3,7 +3,6 @@
 package memorystore
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -13,11 +12,16 @@ import (
 	"github.com/docker/cli/cli/config/types"
 )
 
-var errValueNotFound = errors.New("value not found")
+// notFoundErr is the error returned when a plugin could not be found.
+type notFoundErr string
 
-func IsErrValueNotFound(err error) bool {
-	return errors.Is(err, errValueNotFound)
+func (notFoundErr) NotFound() {}
+
+func (e notFoundErr) Error() string {
+	return string(e)
 }
+
+var errValueNotFound notFoundErr = "value not found"
 
 type Config struct {
 	lock              sync.RWMutex


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6008

This utility was added in 9b83d5bbf9d6d7f8abf485609e99bc0cd3300dc0, but was never used. Remove the utility, and rewrite the error returned to implement the errdefs.NotFound interface, so that it can be detected using the errdefs.IsNotFound() utility if needed.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

