### PR TITLE
[28.x backport] cli/command: explicitly map AuthConfig fields instead of a direct cast

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -340,8 +340,17 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 	configFile := dockerCli.ConfigFile()
 	creds, _ := configFile.GetAllCredentials()
 	authConfigs := make(map[string]registrytypes.AuthConfig, len(creds))
-	for k, auth := range creds {
-		authConfigs[k] = registrytypes.AuthConfig(auth)
+	for k, authConfig := range creds {
+		authConfigs[k] = registrytypes.AuthConfig{
+			Username:      authConfig.Username,
+			Password:      authConfig.Password,
+			ServerAddress: authConfig.ServerAddress,
+
+			// TODO(thaJeztah): Are these expected to be included?
+			Auth:          authConfig.Auth,
+			IdentityToken: authConfig.IdentityToken,
+			RegistryToken: authConfig.RegistryToken,
+		}
 	}
 	buildOpts := imageBuildOptions(dockerCli, options)
 	buildOpts.Version = buildtypes.BuilderV1

--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -77,7 +77,16 @@ func ResolveAuthConfig(cfg *configfile.ConfigFile, index *registrytypes.IndexInf
 	}
 
 	a, _ := cfg.GetAuthConfig(configKey)
-	return registrytypes.AuthConfig(a)
+	return registrytypes.AuthConfig{
+		Username:      a.Username,
+		Password:      a.Password,
+		ServerAddress: a.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          a.Auth,
+		IdentityToken: a.IdentityToken,
+		RegistryToken: a.RegistryToken,
+	}
 }
 
 // GetDefaultAuthConfig gets the default auth config given a serverAddress
@@ -86,19 +95,27 @@ func GetDefaultAuthConfig(cfg *configfile.ConfigFile, checkCredStore bool, serve
 	if !isDefaultRegistry {
 		serverAddress = credentials.ConvertToHostname(serverAddress)
 	}
-	authconfig := configtypes.AuthConfig{}
+	authCfg := configtypes.AuthConfig{}
 	var err error
 	if checkCredStore {
-		authconfig, err = cfg.GetAuthConfig(serverAddress)
+		authCfg, err = cfg.GetAuthConfig(serverAddress)
 		if err != nil {
 			return registrytypes.AuthConfig{
 				ServerAddress: serverAddress,
 			}, err
 		}
 	}
-	authconfig.ServerAddress = serverAddress
-	authconfig.IdentityToken = ""
-	return registrytypes.AuthConfig(authconfig), nil
+
+	return registrytypes.AuthConfig{
+		Username:      authCfg.Username,
+		Password:      authCfg.Password,
+		ServerAddress: serverAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authCfg.Auth,
+		IdentityToken: "",
+		RegistryToken: authCfg.RegistryToken,
+	}, nil
 }
 
 // PromptUserForCredentials handles the CLI prompt for the user to input
@@ -213,7 +230,16 @@ func RetrieveAuthTokenFromImage(cfg *configfile.ConfigFile, image string) (strin
 		return "", err
 	}
 
-	encodedAuth, err := registrytypes.EncodeAuthConfig(registrytypes.AuthConfig(authConfig))
+	encodedAuth, err := registrytypes.EncodeAuthConfig(registrytypes.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		ServerAddress: authConfig.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -259,12 +259,30 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCLI command.Cli) (msg st
 		return "", err
 	}
 
-	response, err := loginWithRegistry(ctx, dockerCLI.Client(), registrytypes.AuthConfig(*authConfig))
+	response, err := loginWithRegistry(ctx, dockerCLI.Client(), registrytypes.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		ServerAddress: authConfig.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	})
 	if err != nil {
 		return "", err
 	}
 
-	if err = storeCredentials(dockerCLI.ConfigFile(), registrytypes.AuthConfig(*authConfig)); err != nil {
+	if err = storeCredentials(dockerCLI.ConfigFile(), registrytypes.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		ServerAddress: authConfig.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	}); err != nil {
 		return "", err
 	}
 
@@ -273,7 +291,16 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCLI command.Cli) (msg st
 
 func storeCredentials(cfg *configfile.ConfigFile, authConfig registrytypes.AuthConfig) error {
 	creds := cfg.GetCredentialsStore(authConfig.ServerAddress)
-	if err := creds.Store(configtypes.AuthConfig(authConfig)); err != nil {
+	if err := creds.Store(configtypes.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		ServerAddress: authConfig.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	}); err != nil {
 		return errors.Errorf("Error saving credentials: %v", err)
 	}
 

--- a/cli/command/registry/search.go
+++ b/cli/command/registry/search.go
@@ -102,7 +102,16 @@ func getAuth(dockerCLI command.Cli, reposName string) (encodedAuth string, err e
 	// "no credentials found"). We'll get an error when search failed,
 	// so fine to ignore in most situations.
 	authConfig, _ := dockerCLI.ConfigFile().GetAuthConfig(authCfgKey)
-	return registrytypes.EncodeAuthConfig(registrytypes.AuthConfig(authConfig))
+	return registrytypes.EncodeAuthConfig(registrytypes.AuthConfig{
+		Username:      authConfig.Username,
+		Password:      authConfig.Password,
+		ServerAddress: authConfig.ServerAddress,
+
+		// TODO(thaJeztah): Are these expected to be included?
+		Auth:          authConfig.Auth,
+		IdentityToken: authConfig.IdentityToken,
+		RegistryToken: authConfig.RegistryToken,
+	})
 }
 
 // splitReposSearchTerm breaks a search term into an index name and remote name

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -58,8 +58,17 @@ func TestGetDefaultAuthConfig(t *testing.T) {
 		},
 	}
 	cfg := configfile.New("filename")
-	for _, authconfig := range testAuthConfigs {
-		assert.Check(t, cfg.GetCredentialsStore(authconfig.ServerAddress).Store(configtypes.AuthConfig(authconfig)))
+	for _, authConfig := range testAuthConfigs {
+		assert.Check(t, cfg.GetCredentialsStore(authConfig.ServerAddress).Store(configtypes.AuthConfig{
+			Username:      authConfig.Username,
+			Password:      authConfig.Password,
+			ServerAddress: authConfig.ServerAddress,
+
+			// TODO(thaJeztah): Are these expected to be included?
+			Auth:          authConfig.Auth,
+			IdentityToken: authConfig.IdentityToken,
+			RegistryToken: authConfig.RegistryToken,
+		}))
 	}
 	for _, tc := range testCases {
 		serverAddress := tc.inputServerAddress


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6516

relates to:

- https://github.com/docker/cli/pull/1642
- https://github.com/docker/cli/pull/6515#issuecomment-3345966610


Commit [cli@27b2797] forked the AuthConfig type from the API, and changed existing code to do a direct cast / convert of the forked type to the API type. This can cause issues if the API types diverges, such as the removal of the Email field.

This patch explicitly maps each field to the corresponding API type, but adds some TODOs, because various code-paths only included a subset of the fields, which may be intentional for fields that were meant to be handled on the daemon / registry-client only.

We should evaluate these conversions to make sure these fields should be sent from the client or not (and possibly even removed from the API type).

[cli@27b2797]: https://github.com/docker/cli/commit/27b2797f7deb3ca5b7f80371d825113deb1faca1

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**


