### PR TITLE
cli/manifest/store: remove deprecated IsNotFound

### DIFF
--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -156,10 +156,3 @@ func makeFilesafeName(ref string) string {
 func newNotFoundError(ref string) error {
 	return errdefs.ErrNotFound.WithMessage("No such manifest: " + ref)
 }
-
-// IsNotFound returns true if the error is a not found error
-//
-// Deprecated: use [errdefs.IsNotFound]. This function will be removed in the next release.
-func IsNotFound(err error) bool {
-	return errdefs.IsNotFound(err)
-}


### PR DESCRIPTION
This was deprecated in f3fb7728c7e03909268fa2c621c6febcaca138a0, which is part of 28.5.0, and no longer used.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/manifest/store: remove deprecated `IsNotFound`
```

**- A picture of a cute animal (not mandatory but encouraged)**

