### PR TITLE
cmd/docker: setFlagErrorFunc: don't load plugins for invalid flags

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -254,10 +254,7 @@ func setHelpFunc(dockerCli command.Cli, cmd *cobra.Command) {
 			ccmd.Println(err)
 			return
 		}
-		if err := hideUnsupportedFeatures(ccmd, dockerCli); err != nil {
-			ccmd.Println(err)
-			return
-		}
+		hideUnsupportedFeatures(ccmd, dockerCli)
 
 		defaultHelpFunc(ccmd, args)
 	})
@@ -557,7 +554,7 @@ func hideSubcommandIf(subcmd *cobra.Command, condition func(string) bool, annota
 	}
 }
 
-func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) error {
+func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) {
 	var (
 		notExperimental = func(_ string) bool { return !details.ServerInfo().HasExperimental }
 		notOSType       = func(v string) bool { return details.ServerInfo().OSType != "" && v != details.ServerInfo().OSType }
@@ -613,7 +610,6 @@ func hideUnsupportedFeatures(cmd *cobra.Command, details versionDetails) error {
 		hideSubcommandIf(subcmd, notSwarmStatus, "swarm")
 		hideSubcommandIf(subcmd, versionOlderThan, "version")
 	}
-	return nil
 }
 
 // Checks if a command or one of its ancestors is in the list


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/1850
    - https://github.com/docker/cli/issues/1813
- https://github.com/docker/cli/pull/5233


### cmd/docker: setFlagErrorFunc: don't load plugins for invalid flags

On Docker CLI versions before v28.0.0, using an unknown flag would print
the usage output, showing all available top-level flags and commands;

    docker --badopt
    unknown flag: --badopt
    See 'docker --help'.
    
    Usage:  docker [OPTIONS] COMMAND
    
    A self-sufficient runtime for containers
    
    Options:
          --config string      Location of client config files (default "/root/.docker")
    ...

This output did not include plugin-commands, making the usage output
incomplete. That issue was fixed in [cli@40a6cf7], which loaded all
available cli-plugins, so that a stub was created for printing the
plugin commands in the usage output. Similarly, [cli@79a75da] added
code to hide experimental commands and commands not supported by the
daemon.

However, since 28.0.0 (commit [cli@f28fc7f]), the usage output was
removed for this error, so loading plugins is no longer needed;

    docker --badopt
    unknown flag: --badopt
    
    Usage:  docker [OPTIONS] COMMAND [ARG...]
    
    Run 'docker --help' for more information

This patch removes the code added in [cli@40a6cf7] and [cli@79a75da].

With this patch, the output is still the same;

    docker --unknown-flag buildx ls --no-such
    unknown flag: --unknown-flag
    
    Usage:  docker [OPTIONS] COMMAND [ARG...]
    
    Run 'docker --help' for more information

This function only handles flags defined by the CLI itself; invalid
flags for plugins are handled by the plugin itself, so are not
impacted;

    docker buildx ls --no-such
    unknown flag: --no-such
    
    Usage:  docker buildx ls
    
    Run 'docker buildx ls --help' for more information

[cli@f28fc7f]: https://github.com/docker/cli/commit/f28fc7f82fc87d0ed521de452b6227cee76fd956
[cli@40a6cf7]: https://github.com/docker/cli/commit/40a6cf7c477cf328134b0b8dcdbd9a09d02f918b
[cli@79a75da]: https://github.com/docker/cli/commit/79a75da0fd97b02311676028c3406b242c785f7c

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

