### PR TITLE
cli/command: don't use WithInitializeClient in test

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -289,9 +289,9 @@ func TestNewDockerCliAndOperators(t *testing.T) {
 func TestInitializeShouldAlwaysCreateTheContextStore(t *testing.T) {
 	cli, err := NewDockerCli()
 	assert.NilError(t, err)
-	assert.NilError(t, cli.Initialize(flags.NewClientOptions(), WithInitializeClient(func(cli *DockerCli) (client.APIClient, error) {
-		return client.NewClientWithOpts()
-	})))
+	apiClient, err := client.NewClientWithOpts()
+	assert.NilError(t, err)
+	assert.NilError(t, cli.Initialize(flags.NewClientOptions(), WithAPIClient(apiClient)))
 	assert.Check(t, cli.ContextStore() != nil)
 }
 


### PR DESCRIPTION
It's just a wrapper around WithAPIClient, and not needed for this test, which validates that "Initialize" properly creates the context store, even if a client was already set;
3b26cfce8b7af1073b28bb78eb185a0689dbfcbf

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

