### PR TITLE
cli/command: deprecate ResolveDefaultContext

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -254,7 +254,7 @@ func (cli *DockerCli) Initialize(opts *cliflags.ClientOptions, ops ...CLIOption)
 	cli.contextStore = &ContextStoreWithDefault{
 		Store: store.New(config.ContextStoreDir(), *cli.contextStoreConfig),
 		Resolver: func() (*DefaultContext, error) {
-			return ResolveDefaultContext(cli.options, *cli.contextStoreConfig)
+			return resolveDefaultContext(cli.options, *cli.contextStoreConfig)
 		},
 	}
 
@@ -291,7 +291,7 @@ func NewAPIClientFromFlags(opts *cliflags.ClientOptions, configFile *configfile.
 	contextStore := &ContextStoreWithDefault{
 		Store: store.New(config.ContextStoreDir(), storeConfig),
 		Resolver: func() (*DefaultContext, error) {
-			return ResolveDefaultContext(opts, storeConfig)
+			return resolveDefaultContext(opts, storeConfig)
 		},
 	}
 	endpoint, err := resolveDockerEndpoint(contextStore, resolveContextName(opts, configFile))

--- a/cli/command/defaultcontextstore.go
+++ b/cli/command/defaultcontextstore.go
@@ -54,7 +54,14 @@ type EndpointDefaultResolver interface {
 }
 
 // ResolveDefaultContext creates a Metadata for the current CLI invocation parameters
+//
+// Deprecated: this function is exported for testing and meant for internal use. It will be removed in the next release.
 func ResolveDefaultContext(opts *cliflags.ClientOptions, config store.Config) (*DefaultContext, error) {
+	return resolveDefaultContext(opts, config)
+}
+
+// resolveDefaultContext creates a Metadata for the current CLI invocation parameters
+func resolveDefaultContext(opts *cliflags.ClientOptions, config store.Config) (*DefaultContext, error) {
 	contextTLSData := store.ContextTLSData{
 		Endpoints: make(map[string]store.EndpointTLSData),
 	}

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -59,7 +59,7 @@ func TestDefaultContextInitializer(t *testing.T) {
 	assert.NilError(t, err)
 	t.Setenv("DOCKER_HOST", "ssh://someswarmserver")
 	cli.configFile = &configfile.ConfigFile{}
-	ctx, err := ResolveDefaultContext(&cliflags.ClientOptions{
+	ctx, err := resolveDefaultContext(&cliflags.ClientOptions{
 		TLS: true,
 		TLSOptions: &tlsconfig.Options{
 			CAFile: "./testdata/ca.pem",


### PR DESCRIPTION
The ResolveDefaultContext function was exported in [cli@f820766] to allow (unit) testing, but did not document that it was only exported for this purpose. The only external use of this function is in buildx, which uses it in a unit test that can be implemented without this function.

This patch deprecates the function so that we can remove it.

[cli@f820766]: https://github.com/docker/cli/commit/f820766f6ac57188d96c9ca377f2b4627e90da28

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/command: deprecate `ResolveDefaultContext` utility.
```

**- A picture of a cute animal (not mandatory but encouraged)**

