### PR TITLE
[28.x backport] gha: add macOS 15, remove macOS 13 (deprecated)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13  # macOS 13 on Intel
-          - macos-14  # macOS 14 on arm64 (Apple Silicon M1)
+          - macos-14        # macOS 14 on arm64 (Apple Silicon M1)
+          - macos-15-intel  # macOS 15 on Intel
+          - macos-15        # macOS 15 on arm64 (Apple Silicon M1)
 #          - windows-2022 # FIXME: some tests are failing on the Windows runner, as well as on Appveyor since June 24, 2018: https://ci.appveyor.com/project/docker/cli/history
     steps:
       -


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6530

The macOS 13 runners are deprecated and will be removed on December 4th, with brownouts in November;
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/


(cherry picked from commit 91d8c0bf629e342c55ce940ba94885bdef5cca9d)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

