### PR TITLE
opts: deprecate ValidateMACAddress

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -353,7 +354,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 	// Validate the input mac address
 	if copts.macAddress != "" {
-		if _, err := opts.ValidateMACAddress(copts.macAddress); err != nil {
+		if _, err := net.ParseMAC(strings.TrimSpace(copts.macAddress)); err != nil {
 			return nil, fmt.Errorf("%s is not a valid mac address", copts.macAddress)
 		}
 	}
@@ -874,7 +875,7 @@ func parseNetworkAttachmentOpt(ep opts.NetworkAttachmentOpts) (*network.Endpoint
 		}
 	}
 	if ep.MacAddress != "" {
-		if _, err := opts.ValidateMACAddress(ep.MacAddress); err != nil {
+		if _, err := net.ParseMAC(strings.TrimSpace(ep.MacAddress)); err != nil {
 			return nil, fmt.Errorf("%s is not a valid mac address", ep.MacAddress)
 		}
 		epConfig.MacAddress = ep.MacAddress

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -191,6 +191,8 @@ func ValidateIPAddress(val string) (string, error) {
 }
 
 // ValidateMACAddress validates a MAC address.
+//
+// Deprecated: use [net.ParseMAC]. This function will be removed in the next release.
 func ValidateMACAddress(val string) (string, error) {
 	_, err := net.ParseMAC(strings.TrimSpace(val))
 	if err != nil {

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -360,20 +360,6 @@ func sampleValidator(val string) (string, error) {
 	return "", fmt.Errorf("invalid key %s", k)
 }
 
-func TestValidateMACAddress(t *testing.T) {
-	if _, err := ValidateMACAddress(`92:d0:c6:0a:29:33`); err != nil {
-		t.Fatalf("ValidateMACAddress(`92:d0:c6:0a:29:33`) got %s", err)
-	}
-
-	if _, err := ValidateMACAddress(`92:d0:c6:0a:33`); err == nil {
-		t.Fatalf("ValidateMACAddress(`92:d0:c6:0a:33`) succeeded; expected failure on invalid MAC")
-	}
-
-	if _, err := ValidateMACAddress(`random invalid string`); err == nil {
-		t.Fatalf("ValidateMACAddress(`random invalid string`) succeeded; expected failure on invalid MAC")
-	}
-}
-
 func TestValidateLink(t *testing.T) {
 	valid := []string{
 		"name",


### PR DESCRIPTION
It was a wrapper around net.ParseMAC from stdlib, so users should use that directly.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate `ValidateMACAddress`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

