### PR TITLE
e2e/stack: don't run stack deploy "detached"

### DIFF
--- a/e2e/stack/remove_test.go
+++ b/e2e/stack/remove_test.go
@@ -24,7 +24,7 @@ func TestRemove(t *testing.T) {
 func deployFullStack(t *testing.T, stackname string) {
 	t.Helper()
 	// TODO: this stack should have full options not minimal options
-	result := icmd.RunCommand("docker", "stack", "deploy",
+	result := icmd.RunCommand("docker", "stack", "deploy", "--detach=false",
 		"--compose-file=./testdata/full-stack.yml", stackname)
 	result.Assert(t, icmd.Success)
 


### PR DESCRIPTION
Run stack deploy in "attached" mode, so that progress and errors can be printed on failure.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

