### PR TITLE
opts: deprecate ListOpts.Delete()

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -61,6 +61,8 @@ func (opts *ListOpts) Set(value string) error {
 }
 
 // Delete removes the specified element from the slice.
+//
+// Deprecated: this method is no longer used and will be removed in the next release.
 func (opts *ListOpts) Delete(key string) {
 	for i, k := range *opts.values {
 		if k == key {

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -141,15 +141,11 @@ func TestListOptsWithoutValidator(t *testing.T) {
 	if o.Get("baz") {
 		t.Error(`o.Get("baz") == true`)
 	}
-	o.Delete("foo")
-	if o.String() != "[bar bar]" {
-		t.Errorf("%s != [bar bar]", o.String())
+	if listOpts := o.GetSlice(); len(listOpts) != 3 || listOpts[0] != "foo" || listOpts[1] != "bar" || listOpts[2] != "bar" {
+		t.Errorf("Expected [[foo bar bar]], got [%v]", listOpts)
 	}
-	if listOpts := o.GetSlice(); len(listOpts) != 2 || listOpts[0] != "bar" || listOpts[1] != "bar" {
-		t.Errorf("Expected [[bar bar]], got [%v]", listOpts)
-	}
-	if mapListOpts := o.GetMap(); len(mapListOpts) != 1 {
-		t.Errorf("Expected [map[bar:{}]], got [%v]", mapListOpts)
+	if mapListOpts := o.GetMap(); len(mapListOpts) != 2 {
+		t.Errorf("Expected [map[bar:{} foo:{}]], got [%v]", mapListOpts)
 	}
 }
 
@@ -182,9 +178,8 @@ func TestListOptsWithValidator(t *testing.T) {
 	if o.Get("baz") {
 		t.Error(`o.Get("baz") == true`)
 	}
-	o.Delete("valid-option2=2")
-	if o.String() != "" {
-		t.Errorf(`%s != ""`, o.String())
+	if expected := "[valid-option2=2]"; o.String() != expected {
+		t.Errorf(`%s != %q`, o.String(), expected)
 	}
 }
 


### PR DESCRIPTION
relates to:

- https://github.com/moby/moby/pull/2829
- https://github.com/moby/moby/pull/7506




### opts: deprecate ListOpts.Delete()

This method was added as part of a refactor in [moby@1ba1138], at which time it was used to delete original values for "--host" and "--volume" after normalizing. This beccame redundant in [moby@6200002], which added specialized options that used a validate function, which both validated and normalized inputs.

It's no longer used, so let's mark it deprecated so that we can remove it.

[moby@1ba1138]: https://github.com/moby/moby/commit/1ba11384bf82f824b0efbab31aaca439cfba1b4f
[moby@6200002]: https://github.com/moby/moby/commit/6200002669874f3314856527fecd0c004060913c

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: opts: deprecate ListOpts.Delete()
```

**- A picture of a cute animal (not mandatory but encouraged)**

