### PR TITLE
update to go1.25.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
         name: Update Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.2"
+          go-version: "1.25.3"
       -
         name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.2"
+          go-version: "1.25.3"
       -
         name: Test
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   # which causes it to fallback to go1.17 semantics.
   #
   # TODO(thaJeztah): update "usetesting" settings to enable go1.24 features once our minimum version is go1.24
-  go: "1.25.2"
+  go: "1.25.3"
 
   timeout: 5m
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_VARIANT=alpine
 ARG ALPINE_VERSION=3.22
 ARG BASE_DEBIAN_DISTRO=bookworm
 
-ARG GO_VERSION=1.25.2
+ARG GO_VERSION=1.25.3
 
 # XX_VERSION specifies the version of the xx utility to use.
 # It must be a valid tag in the docker.io/tonistiigi/xx image repository.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 variable "GO_VERSION" {
-    default = "1.25.2"
+    default = "1.25.3"
 }
 variable "VERSION" {
     default = ""

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.2
+ARG GO_VERSION=1.25.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.2
+ARG GO_VERSION=1.25.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.2
+ARG GO_VERSION=1.25.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/e2e/testdata/Dockerfile.gencerts
+++ b/e2e/testdata/Dockerfile.gencerts
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.25.2
+ARG GO_VERSION=1.25.3
 
 FROM golang:${GO_VERSION}-alpine AS generated
 ENV GOTOOLCHAIN=local


### PR DESCRIPTION
This release addresses breakage caused by a security patch included in
Go 1.25.2 and 1.24.8, which enforced overly restrictive validation on
the parsing of X.509 certificates. We've removed those restrictions
while maintaining the security fix that the initial release addressed.

- https://github.com/golang/go/issues?q=milestone%3AGo1.25.3+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.25.2...go1.25.3

**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.25.3](https://go.dev/doc/devel/release#go1.25.3)
```