### PR TITLE
introduce bind create-host-path option, aligned with docker-compose

### DIFF
--- a/docs/reference/commandline/service_create.md
+++ b/docs/reference/commandline/service_create.md
@@ -452,7 +452,24 @@ The following options can only be used for bind mounts (`type=bind`):
         Read-only mounts are made recursively read-only if kernel is v5.12 or later.
         Otherwise the Engine raises an error.</li>
       </ul>
-      When the option is not specified, the default behavior correponds to setting <tt>enabled</tt>.
+      When the option is not specified, the default behavior corresponds to setting <tt>enabled</tt>.
+    </td>
+  </tr>
+  <tr>
+    <td><b>bind-create-host-path</b></td>
+    <td>
+      By default, mounts require the mount point to exist on host. This is a significant difference with
+      the <tt>volumes</tt> flag.   
+      Set <tt>bind-create-host-path</tt> to control the behavior of the engine regarding a non-existent
+      mount target.<br />
+      <br />
+      A value is one of:<br />
+      <br />
+      <ul>
+        <li><<tt>true</tt>: Create path on host if it doesn't exists.</li>
+        <li><<tt>false</tt>: Default behavior. If remote path doesn't exists, an error will be reported.</li>
+      </ul>
+      When the option is not specified, the default behavior corresponds to setting <tt>true</tt>.
     </td>
   </tr>
 </table>

--- a/opts/mount.go
+++ b/opts/mount.go
@@ -131,6 +131,15 @@ func (m *MountOpt) Set(value string) error {
 			default:
 				return fmt.Errorf(`invalid value for %s: %s (must be "enabled", "disabled", "writable", or "readonly")`, key, val)
 			}
+		case "bind-create-host-path":
+			switch val {
+			case "true":
+				bindOptions().CreateMountpoint = true
+			case "false":
+				bindOptions().CreateMountpoint = false
+			default:
+				return fmt.Errorf(`invalid value for %s: %s (must be "true" or "false")`, key, val)
+			}
 		case "volume-subpath":
 			volumeOptions().Subpath = val
 		case "volume-nocopy":

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -325,4 +325,19 @@ func TestMountOptSetBindRecursive(t *testing.T) {
 			},
 		}, m.Value()))
 	})
+
+	t.Run("create-host-path", func(t *testing.T) {
+		var m MountOpt
+		assert.NilError(t, m.Set("type=bind,source=/foo,target=/bar,bind-create-host-path=true"))
+		assert.Check(t, is.DeepEqual([]mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: "/foo",
+				Target: "/bar",
+				BindOptions: &mount.BindOptions{
+					CreateMountpoint: true,
+				},
+			},
+		}, m.Value()))
+	})
 }


### PR DESCRIPTION
**- What I did**

Introduce `bind-create-host-path` option to control engine behaviot regarding a missing mount point
See `create_host_path` attribute on https://github.com/compose-spec/compose-spec/blob/main/05-services.md#long-syntax-5

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
```markdown changelog
Introduce `bind-create-host-path` option to control engine behaviot regarding a missing mount point
```

**- A picture of a cute animal (not mandatory but encouraged)**

