### PR TITLE
docs: update buildgc example config to use new buildkit v0.17 options

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -1076,11 +1076,11 @@ The following is a full example of the allowed configuration options on Linux:
   "builder": {
     "gc": {
       "enabled": true,
-      "defaultKeepStorage": "10GB",
+      "defaultReservedSpace": "10GB",
       "policy": [
-        { "keepStorage": "10GB", "filter": ["unused-for=2200h"] },
-        { "keepStorage": "50GB", "filter": ["unused-for=3300h"] },
-        { "keepStorage": "100GB", "all": true }
+        { "maxUsedSpace": "512MB", "keepDuration": "48h", "filter": [ "type=source.local" ] },
+        { "reservedSpace": "10GB", "maxUsedSpace": "100GB", "keepDuration": "1440h" },
+        { "reservedSpace": "50GB", "minFreeSpace": "20GB", "maxUsedSpace": "200GB", "all": true }
       ]
     }
   },


### PR DESCRIPTION
Signed-off-by: David Karlsson <35727626+dvdksn@users.noreply.github.com>

**- What I did**

Updated the example builder gc config in the dockerd reference to use the new
options introduced in buildkit v0.17.

**- How I did it**

Tested manually

A couple small inconsistencies I noticed when doing this:

- The `filter` field in `daemon.json` uses a single `=` to assign filters, whereas builder uses `==`, for example: `type==source.git.checkout`
- The size values in `daemon.json` are human-readable bytes. But BuildKit also allows percentage values. Attempting to set eg `"minFreeSpace": "20%"` results in config parse error.

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="726" height="519" alt="Screenshot 2025-10-27 at 14 43 05" src="https://github.com/user-attachments/assets/64323dab-99a8-4800-916a-1667bc9fdd21" />
