### PR TITLE
image/tree: Fix dangling filter condition

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -116,7 +116,7 @@ func runImages(ctx context.Context, dockerCLI command.Cli, options imagesOptions
 	}
 	images := res.Items
 	if !options.all {
-		if _, ok := filters["dangling"]; ok {
+		if _, ok := filters["dangling"]; !ok {
 			images = slices.DeleteFunc(images, isDangling)
 		}
 	}


### PR DESCRIPTION
- follow up to: https://github.com/docker/cli/pull/6574

The logic for applying the dangling filter when `--all` is not used was inverted. The filter was being applied when the dangling filter was present, but it should be applied when the dangling filter is NOT present.