### PR TITLE
Improve clarity of environment variables description

### DIFF
--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -114,8 +114,7 @@ Options:
 
 ### Environment variables
 
-The following list of environment variables are supported by the `docker` command
-line:
+The following environment variables control the behavior of the `docker` command-line client:
 
 | Variable                      | Description                                                                                                                                                                                                                                                       |
 | :---------------------------- |:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary

Improved the clarity of the environment variables section description.

### Changes

Changed the environment variables section description from:
> The following list of environment variables are supported by the `docker` command line:

To:
> The following environment variables control the behavior of the `docker` command-line client:

This change:
- Makes it clearer that these variables **control** Docker's behavior, not just that they are "supported"
- Uses the more precise term "command-line client" instead of "command line"
- Fixes the grammatical issue with "The following list...are supported" (subject-verb agreement)

## Related Issue
https://github.com/docker/docs/pull/23620

Signed-off-by: Andrew Hopp <andrew.hopp@me.com>