### PR TITLE
[28.x backport] Dockerfile: bump gotest.tools/gotestsum v1.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG GOVERSIONINFO_VERSION=v1.4.1
 
 # GOTESTSUM_VERSION sets the version of gotestsum to install in the dev container.
 # It must be a valid tag in the https://github.com/gotestyourself/gotestsum repository.
-ARG GOTESTSUM_VERSION=v1.12.3
+ARG GOTESTSUM_VERSION=v1.13.0
 
 # BUILDX_VERSION sets the version of buildx to use for the e2e tests.
 # It must be a tag in the docker.io/docker/buildx-bin image repository

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 FROM golang AS gotestsum
 # GOTESTSUM_VERSION sets the version of gotestsum to install in the dev container.
 # It must be a valid tag in the https://github.com/gotestyourself/gotestsum repository.
-ARG GOTESTSUM_VERSION=v1.12.3
+ARG GOTESTSUM_VERSION=v1.13.0
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=tmpfs,target=/go/src/ \


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6552


full diff: https://github.com/gotestyourself/gotestsum/compare/v1.12.3...v1.13.0


(cherry picked from commit f8b1b8d165688b4048fbff7f98d3687ef18af8e8)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

