### PR TITLE
[28.x backport] Dockerfile: update golangci-lint to v2.5.0

### DIFF
--- a/cli/command/formatter/tabwriter/tabwriter.go
+++ b/cli/command/formatter/tabwriter/tabwriter.go
@@ -12,7 +12,7 @@
 
 // based on https://github.com/golang/go/blob/master/src/text/tabwriter/tabwriter.go Last modified 690ac40 on 31 Jan
 
-//nolint:gocyclo,nakedret,unused // ignore linting errors, so that we can stick close to upstream
+//nolint:gocyclo,gofumpt,nakedret,unused // ignore linting errors, so that we can stick close to upstream
 package tabwriter
 
 import (

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -6,7 +6,8 @@ ARG GO_VERSION=1.24.8
 # It must be a supported tag in the docker.io/library/alpine image repository
 # that's also available as alpine image variant for the Golang version used.
 ARG ALPINE_VERSION=3.21
-ARG GOLANGCI_LINT_VERSION=v2.1.5
+# GOLANGCI_LINT_VERSION sets the version of the golangci/golangci-lint image to use.
+ARG GOLANGCI_LINT_VERSION=v2.5.0
 
 FROM golangci/golangci-lint:${GOLANGCI_LINT_VERSION}-alpine AS golangci-lint
 


### PR DESCRIPTION
- backport https://github.com/docker/cli/pull/6557
- relates to https://github.com/docker/cli/pull/6556

(cherry picked from commit 5ad9fbdef7551f0b829f7ed17f55145cce31a03b)


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

