### PR TITLE
cli: allManagementSubCommands: improve handling of plugin stubs

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -350,13 +350,10 @@ func orchestratorSubCommands(cmd *cobra.Command) []*cobra.Command {
 func allManagementSubCommands(cmd *cobra.Command) []*cobra.Command {
 	cmds := []*cobra.Command{}
 	for _, sub := range cmd.Commands() {
-		if isPlugin(sub) {
-			if invalidPluginReason(sub) == "" {
-				cmds = append(cmds, sub)
-			}
+		if invalidPluginReason(sub) != "" {
 			continue
 		}
-		if sub.IsAvailableCommand() && sub.HasSubCommands() {
+		if sub.IsAvailableCommand() && (isPlugin(sub) || sub.HasSubCommands()) {
 			cmds = append(cmds, sub)
 		}
 	}


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6605


The allManagementSubCommands function is used to present plugin-commands in the docker --help output; these commands are included in the "management commands" section, but for plugins we don't know if they have sub-commands.

However, plugin stubs may be hidden (for placeholders that are not yet loaded), or not be runnable, which was previously ignored.

This patch treats plugin-stubs the same as other commands, with the exception of checking if they have subcommands (which is not yet known for plugin-stubs).

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

