### PR TITLE
completion/zsh: Allow multiple volumes of 'volume rm'

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -2533,7 +2533,7 @@ __docker_volume_subcommand() {
             _arguments $(__docker_arguments) \
                 $opts_help \
                 "($help -f --force)"{-f,--force}"[Force the removal of one or more volumes]" \
-                "($help -):volume:__docker_complete_volumes" && ret=0
+                "($help -)*:volumes:__docker_complete_volumes" && ret=0
             ;;
         (help)
             _arguments $(__docker_arguments) ":subcommand:__docker_volume_commands" && ret=0


### PR DESCRIPTION
It is possible to give more than one volume for `docker volume rm`.

---

**- How to verify it**

1. Create multiple volumes `for i in aaa bbb ccc; do docker run -v $i:/foo debian /bin/true; done`
1. Start a Zsh with the new completion file
2. Type `docker volume rm aaa ` and hit TAB. It should show `bbb` and `ccc` instead of `no more arguments`

**- Human readable description for the release notes**

```markdown changelog

```

