### PR TITLE
cli/command/container: fix use of generics

### DIFF
--- a/cli/command/container/stats.go
+++ b/cli/command/container/stats.go
@@ -145,7 +145,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 			eh.setHandler(events.ActionCreate, func(e events.Message) {
 				if s := NewStats(e.Actor.ID); cStats.add(s) {
 					waitFirst.Add(1)
-					log.G(ctx).WithFields(map[string]any{
+					log.G(ctx).WithFields(log.Fields{
 						"event":     e.Action,
 						"container": e.Actor.ID,
 					}).Debug("collecting stats for container")
@@ -157,7 +157,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 		eh.setHandler(events.ActionStart, func(e events.Message) {
 			if s := NewStats(e.Actor.ID); cStats.add(s) {
 				waitFirst.Add(1)
-				log.G(ctx).WithFields(map[string]any{
+				log.G(ctx).WithFields(log.Fields{
 					"event":     e.Action,
 					"container": e.Actor.ID,
 				}).Debug("collecting stats for container")
@@ -167,7 +167,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 
 		if !options.All {
 			eh.setHandler(events.ActionDie, func(e events.Message) {
-				log.G(ctx).WithFields(map[string]any{
+				log.G(ctx).WithFields(log.Fields{
 					"event":     e.Action,
 					"container": e.Actor.ID,
 				}).Debug("stop collecting stats for container")
@@ -232,7 +232,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 		for _, ctr := range cs.Items {
 			if s := NewStats(ctr.ID); cStats.add(s) {
 				waitFirst.Add(1)
-				log.G(ctx).WithFields(map[string]any{
+				log.G(ctx).WithFields(log.Fields{
 					"container": ctr.ID,
 				}).Debug("collecting stats for container")
 				go collect(ctx, s, apiClient, !options.NoStream, waitFirst)
@@ -255,7 +255,7 @@ func RunStats(ctx context.Context, dockerCLI command.Cli, options *StatsOptions)
 		for _, ctr := range options.Containers {
 			if s := NewStats(ctr); cStats.add(s) {
 				waitFirst.Add(1)
-				log.G(ctx).WithFields(map[string]any{
+				log.G(ctx).WithFields(log.Fields{
 					"container": ctr,
 				}).Debug("collecting stats for container")
 				go collect(ctx, s, apiClient, !options.NoStream, waitFirst)


### PR DESCRIPTION
- follow-up to / introduced in https://github.com/docker/cli/pull/6582

This was introduced in dad1d367c8fb0165d36bd2f2210d1ef0803f33d5, which did not add a `//go:build` constraint to enable the use of generics (`any`).

Which causes an error when used;

 could not import github.com/docker/cli/cli/command/container (-: # github.com/docker/cli/cli/command/container
 /Users/thajeztah/go/pkg/mod/github.com/docker/cli@v29.0.0-rc.2+incompatible/cli/command/container/stats.go:148:39: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

