### PR TITLE
update minimum go version to go1.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ shellcheck: ## run shellcheck validation
 .PHONY: fmt
 fmt: ## run gofumpt (if present) or gofmt
 	@if command -v gofumpt > /dev/null; then \
-		gofumpt -w -d -lang=1.23 . ; \
+		gofumpt -w -d -lang=1.24 . ; \
 	else \
 		go list -f {{.Dir}} ./... | xargs gofmt -w -s -d ; \
 	fi

--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package manager
 

--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package config
 

--- a/cli/command/container/completion.go
+++ b/cli/command/container/completion.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package container
 

--- a/cli/command/container/inspect.go
+++ b/cli/command/container/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package container
 

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -1,5 +1,5 @@
 // FIXME(vvoland): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package container
 

--- a/cli/command/context.go
+++ b/cli/command/context.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/context/completion.go
+++ b/cli/command/context/completion.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package context
 

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package context
 

--- a/cli/command/context/create_test.go
+++ b/cli/command/context/create_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package context
 

--- a/cli/command/context/inspect.go
+++ b/cli/command/context/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package context
 

--- a/cli/command/context/list.go
+++ b/cli/command/context/list.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package context
 

--- a/cli/command/context_test.go
+++ b/cli/command/context_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/defaultcontextstore.go
+++ b/cli/command/defaultcontextstore.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/defaultcontextstore_test.go
+++ b/cli/command/defaultcontextstore_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/custom.go
+++ b/cli/command/formatter/custom.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/displayutils.go
+++ b/cli/command/formatter/displayutils.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/formatter.go
+++ b/cli/command/formatter/formatter.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/formatter_test.go
+++ b/cli/command/formatter/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/reflect.go
+++ b/cli/command/formatter/reflect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/reflect_test.go
+++ b/cli/command/formatter/reflect_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package formatter
 

--- a/cli/command/idresolver/idresolver.go
+++ b/cli/command/idresolver/idresolver.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package idresolver
 

--- a/cli/command/image/inspect.go
+++ b/cli/command/image/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package image
 

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -1,4 +1,5 @@
-//go:build go1.23
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.24
 
 package image
 

--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package image
 

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package image
 

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package inspect
 

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package network
 

--- a/cli/command/network/inspect.go
+++ b/cli/command/network/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package network
 

--- a/cli/command/node/formatter_test.go
+++ b/cli/command/node/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package node
 

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package node
 

--- a/cli/command/plugin/formatter_test.go
+++ b/cli/command/plugin/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package plugin
 

--- a/cli/command/plugin/inspect.go
+++ b/cli/command/plugin/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package plugin
 

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package secret
 

--- a/cli/command/service/formatter_test.go
+++ b/cli/command/service/formatter_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package service
 

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package service
 

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package service
 

--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package service
 

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package service
 

--- a/cli/command/stack/loader.go
+++ b/cli/command/stack/loader.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package stack
 

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package system
 

--- a/cli/command/system/inspect.go
+++ b/cli/command/system/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package system
 

--- a/cli/command/system/pruner/pruner.go
+++ b/cli/command/system/pruner/pruner.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 // Package pruner registers "prune" functions to be included as part of
 // "docker system prune".

--- a/cli/command/telemetry_docker.go
+++ b/cli/command/telemetry_docker.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/trust/inspect.go
+++ b/cli/command/trust/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package trust
 

--- a/cli/command/utils.go
+++ b/cli/command/utils.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package command
 

--- a/cli/command/volume/inspect.go
+++ b/cli/command/volume/inspect.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package volume
 

--- a/cli/compose/interpolation/interpolation.go
+++ b/cli/compose/interpolation/interpolation.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package interpolation
 

--- a/cli/compose/interpolation/interpolation_test.go
+++ b/cli/compose/interpolation/interpolation_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package interpolation
 

--- a/cli/compose/loader/full-struct_test.go
+++ b/cli/compose/loader/full-struct_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/loader/interpolate.go
+++ b/cli/compose/loader/interpolate.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package loader
 

--- a/cli/compose/schema/schema.go
+++ b/cli/compose/schema/schema.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package schema
 

--- a/cli/compose/schema/schema_test.go
+++ b/cli/compose/schema/schema_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package schema
 

--- a/cli/compose/template/template.go
+++ b/cli/compose/template/template.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package template
 

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package template
 

--- a/cli/compose/types/types.go
+++ b/cli/compose/types/types.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package types
 

--- a/cli/config/memorystore/store.go
+++ b/cli/config/memorystore/store.go
@@ -1,4 +1,5 @@
-//go:build go1.23
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.24
 
 package memorystore
 

--- a/cli/context/store/metadata_test.go
+++ b/cli/context/store/metadata_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cli/context/store/metadatastore.go
+++ b/cli/context/store/metadatastore.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cli/context/store/storeconfig.go
+++ b/cli/context/store/storeconfig.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cli/context/store/storeconfig_test.go
+++ b/cli/context/store/storeconfig_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package store
 

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package main
 

--- a/internal/oauth/api/api.go
+++ b/internal/oauth/api/api.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package api
 

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package registry
 

--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package registry
 

--- a/internal/tui/chip.go
+++ b/internal/tui/chip.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/internal/tui/colors.go
+++ b/internal/tui/colors.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/internal/tui/count.go
+++ b/internal/tui/count.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/internal/tui/note.go
+++ b/internal/tui/note.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/internal/tui/output.go
+++ b/internal/tui/output.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/internal/tui/str.go
+++ b/internal/tui/str.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package tui
 

--- a/scripts/with-go-mod.sh
+++ b/scripts/with-go-mod.sh
@@ -25,7 +25,7 @@ else
 	tee "${ROOTDIR}/go.mod" >&2 <<- EOF
 		module github.com/docker/cli
 
-		go 1.23.0
+		go 1.24.0
 	EOF
 	trap 'rm -f "${ROOTDIR}/go.mod"' EXIT
 fi

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,5 +1,5 @@
 // FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
-//go:build go1.23
+//go:build go1.24
 
 package templates
 

--- a/vendor.mod
+++ b/vendor.mod
@@ -4,7 +4,7 @@ module github.com/docker/cli
 // There is no 'go.mod' file, as that would imply opting in for all the rules
 // around SemVer, which this repo cannot abide by as it uses CalVer.
 
-go 1.23.0
+go 1.24.0
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Various dependencies, including "golang.org/x/.."  started to update the minimum required version,so we should follow suit for the next release.

Note that the `//go:build` directives not necesserily have to be updated, but it's good to keep them in sync until we have a go.mod to control this.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: Update minimum go version to go1.24
```

**- A picture of a cute animal (not mandatory but encouraged)**

