### PR TITLE
chore: update broken link to restrucured docker desktop documentation

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1282,7 +1282,7 @@ connect to services running on the host machine.
 
 It's conventional to use `host.docker.internal` as the hostname referring to
 `host-gateway`. Docker Desktop automatically resolves this hostname, see
-[Explore networking features](https://docs.docker.com/desktop/features/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host).
+[Explore networking features](https://docs.docker.com/desktop/features/networking/networking-how-tos/#i-want-to-connect-from-a-container-to-a-service-on-the-host).
 
 The following example shows how the special `host-gateway` value works. The
 example runs an HTTP server that serves a file from host to container over the


### PR DESCRIPTION
This resulted in a test failure that was overlooked when the documentation was restructured in docker/docs. Implemented a hotfix in https://github.com/docker/docs/pull/23666 - this PR changes the canonical source.