### PR TITLE
cli/connhelper/commandcon: remove warn logs

### DIFF
--- a/cli/connhelper/commandconn/commandconn.go
+++ b/cli/connhelper/commandconn/commandconn.go
@@ -233,11 +233,9 @@ func (c *commandConn) Close() error {
 	defer c.closing.Store(false)
 
 	if err := c.CloseRead(); err != nil {
-		logrus.Warnf("commandConn.Close: CloseRead: %v", err)
 		return err
 	}
 	if err := c.CloseWrite(); err != nil {
-		logrus.Warnf("commandConn.Close: CloseWrite: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
These were originally added in 6f61cf053afc927379cfef91d241539c36d070f6, but at the time, the error wasn't returned. Now that it is, we shouldn't log _and_ return the error.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

