### PR TITLE
image/tree: Don't limit name width if non tty

### DIFF
--- a/cli/command/image/testdata/list-command-success.filters.golden
+++ b/cli/command/image/testdata/list-command-success.filters.golden
@@ -1,2 +1,1 @@
-                                                               Info ->  U In Use
 IMAGE   ID             DISK USAGE   CONTENT SIZE   EXTRA

--- a/cli/command/image/testdata/list-command-success.format.golden
+++ b/cli/command/image/testdata/list-command-success.format.golden
@@ -1,2 +1,1 @@
-                                                               Info ->  U In Use
 IMAGE   ID             DISK USAGE   CONTENT SIZE   EXTRA

--- a/cli/command/image/testdata/list-command-success.match-name.golden
+++ b/cli/command/image/testdata/list-command-success.match-name.golden
@@ -1,2 +1,1 @@
-                                                               Info ->  U In Use
 IMAGE   ID             DISK USAGE   CONTENT SIZE   EXTRA

--- a/cli/command/image/testdata/list-command-success.simple.golden
+++ b/cli/command/image/testdata/list-command-success.simple.golden
@@ -1,2 +1,1 @@
-                                                               Info ->  U In Use
 IMAGE   ID             DISK USAGE   CONTENT SIZE   EXTRA

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -233,6 +233,7 @@ func printImageTree(outs command.Streams, view treeView) {
 	isTerm := out.IsTerminal()
 
 	_, width := out.GetTtySize()
+	limitWidth := width == 0
 	if isTerm && width < 20 {
 		width = 20
 	}
@@ -242,7 +243,10 @@ func printImageTree(outs command.Streams, view treeView) {
 	untaggedColor := out.Color(tui.ColorTertiary)
 	titleColor := out.Color(tui.ColorTitle)
 
-	out.Println(generateLegend(out, width))
+	// Legend is right-aligned, so don't print it if the width is unlimited
+	if !limitWidth {
+		out.Println(generateLegend(out, width))
+	}
 
 	possibleChips := getPossibleChips(view)
 	columns := []imgColumn{


### PR DESCRIPTION
- address: https://github.com/docker/cli/issues/6650

Previously when no terminal was attached the width was assumed to be 80.
This is too short for most image names which truncated the names when output was redirect (for example to `grep`).

This disabled the name truncation if the terminal width can't be determined.

```markdown changelog
`docker image ls` no longer truncates the name width when output is redirect (e.g. for `grep`).
```