### PR TITLE
image/tree: Fix untagged images in non-expanded view

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -111,6 +111,13 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) (int,
 			continue
 		}
 
+		if len(sortedTags) == 0 {
+			view.images = append(view.images, topImage{
+				Details:  topDetails,
+				Children: children,
+				created:  img.Created,
+			})
+		}
 		for _, tag := range sortedTags {
 			view.images = append(view.images, topImage{
 				Names:    []string{tag},


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/issues/6652

### image/tree: Fix untagged images in non-expanded view

In the expanded view there is a separate image entry per each tag.

Fix a bug which caused no entry to be added for untagged images.

```markdown changelog
Fix a bug causing `docker image ls --all` to not show untagged/dangling images.
```