### PR TITLE
image/tree: Only show untagged images when --all flag is used

### DIFF
--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -111,7 +111,7 @@ func runTree(ctx context.Context, dockerCLI command.Cli, opts treeOptions) (int,
 			continue
 		}
 
-		if len(sortedTags) == 0 {
+		if opts.all && len(sortedTags) == 0 {
 			view.images = append(view.images, topImage{
 				Details:  topDetails,
 				Children: children,


### PR DESCRIPTION
- follow up to: https://github.com/docker/cli/pull/6657

### image/tree: Only show untagged images when --all flag is used

In non-expanded view, untagged images should only be displayed when the --all flag is explicitly provided by the user.

After https://github.com/docker/cli/pull/6657, untagged images were accidentally always shown in the non-expanded view regardless of the --all flag setting.