### PR TITLE
cli/command/system: Fix missing components in version output

### DIFF
--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -137,6 +137,7 @@ func newServerVersion(sv client.ServerVersionResult) *serverVersion {
 		Os:            sv.Os,
 		Arch:          sv.Arch,
 		Experimental:  sv.Experimental, //nolint:staticcheck // ignore deprecated field.
+		Components:    make([]system.ComponentVersion, 0, len(sv.Components)),
 	}
 	foundEngine := false
 	for _, component := range sv.Components {
@@ -152,6 +153,7 @@ func newServerVersion(sv client.ServerVersionResult) *serverVersion {
 			out.Experimental = func() bool { b, _ := strconv.ParseBool(component.Details["Experimental"]); return b }()
 			out.BuildTime = reformatDate(component.Details["BuildTime"])
 		}
+		out.Components = append(out.Components, component)
 	}
 
 	if !foundEngine {


### PR DESCRIPTION
- fixup: https://github.com/docker/cli/pull/6648

The `Components` weren't actually copied to the output struct.


### Before

<img width="497" height="176" alt="image" src="https://github.com/user-attachments/assets/90cf1a0c-c5ce-4a15-bc5d-916232f9e649" />

### After

<img width="522" height="436" alt="image" src="https://github.com/user-attachments/assets/432bf7ce-5d58-496a-b6e4-be309d150be0" />

