### PR TITLE
image ls: allow custom format in cli config

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -114,6 +114,16 @@ func runImages(ctx context.Context, dockerCLI command.Cli, options imagesOptions
 		}
 	}
 
+	format := options.format
+	if len(format) == 0 {
+		if len(dockerCLI.ConfigFile().ImagesFormat) > 0 && !options.quiet && !options.tree {
+			format = dockerCLI.ConfigFile().ImagesFormat
+			useTree = false
+		} else {
+			format = formatter.TableFormatKey
+		}
+	}
+
 	if useTree {
 		return runTree(ctx, dockerCLI, treeOptions{
 			images:   images,
@@ -121,15 +131,6 @@ func runImages(ctx context.Context, dockerCLI command.Cli, options imagesOptions
 			filters:  filters,
 			expanded: options.tree,
 		})
-	}
-
-	format := options.format
-	if len(format) == 0 {
-		if len(dockerCLI.ConfigFile().ImagesFormat) > 0 && !options.quiet {
-			format = dockerCLI.ConfigFile().ImagesFormat
-		} else {
-			format = formatter.TableFormatKey
-		}
 	}
 
 	imageCtx := formatter.ImageContext{

--- a/cli/command/image/testdata/list-command-success.format.golden
+++ b/cli/command/image/testdata/list-command-success.format.golden
@@ -1,1 +1,0 @@
-IMAGE   ID             DISK USAGE   CONTENT SIZE   EXTRA


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6663
- fixes https://github.com/docker/cli/issues/6672

Setting a custom format in the cli cofig should still be supported, and not produce an error when specifying "--tree". Specifyihg both "--tree" and "--format" still produces an error, but we could consider allowing "json" format in a future update.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Fix `docker image ls` ignoring a custom `imageFormat` from `docker.json`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

