### PR TITLE
cli/config/types: make AuthConfig an alias for registry.AuthConfig

### DIFF
--- a/cli/command/container/auth_config_utils.go
+++ b/cli/command/container/auth_config_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/moby/api/types/registry"
 )
 
 // readCredentials resolves auth-config from the current environment to be
@@ -22,7 +22,7 @@ import (
 // formatted, or when failing to read from the credentials store.
 //
 // A nil value is returned if neither option contained any credentials.
-func readCredentials(dockerCLI config.Provider) (creds map[string]types.AuthConfig, _ error) {
+func readCredentials(dockerCLI config.Provider) (creds map[string]registry.AuthConfig, _ error) {
 	if v, ok := os.LookupEnv("DOCKER_AUTH_CONFIG"); ok && v != "" {
 		// The results are expected to have been unmarshaled the same as
 		// when reading from a config-file, which includes decoding the

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -18,11 +18,11 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/config/configfile"
-	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/docker/cli/opts"
 	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/spf13/cobra"
@@ -239,7 +239,7 @@ func createContainer(ctx context.Context, dockerCli command.Cli, containerCfg *c
 	}
 
 	const dockerConfigPathInContainer = "/run/secrets/docker/config.json"
-	var apiSocketCreds map[string]types.AuthConfig
+	var apiSocketCreds map[string]registry.AuthConfig
 
 	if options.useAPISocket {
 		// We'll create two new mounts to handle this flag:

--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -11,7 +11,6 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
-	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/internal/commands"
 	"github.com/docker/cli/internal/oauth/manager"
 	"github.com/docker/cli/internal/registry"
@@ -283,7 +282,7 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCLI command.Cli) (msg st
 
 func storeCredentials(cfg *configfile.ConfigFile, authConfig registrytypes.AuthConfig) error {
 	creds := cfg.GetCredentialsStore(authConfig.ServerAddress)
-	if err := creds.Store(configtypes.AuthConfig{
+	if err := creds.Store(registrytypes.AuthConfig{
 		Username:      authConfig.Username,
 		Password:      authConfig.Password,
 		ServerAddress: authConfig.ServerAddress,

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/creack/pty"
-	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/prompt"
 	"github.com/docker/cli/internal/registry"
@@ -90,14 +89,14 @@ func TestLoginWithCredStoreCreds(t *testing.T) {
 func TestRunLogin(t *testing.T) {
 	testCases := []struct {
 		doc                 string
-		priorCredentials    map[string]configtypes.AuthConfig
+		priorCredentials    map[string]registrytypes.AuthConfig
 		input               loginOptions
-		expectedCredentials map[string]configtypes.AuthConfig
+		expectedCredentials map[string]registrytypes.AuthConfig
 		expectedErr         string
 	}{
 		{
 			doc: "valid auth from store",
-			priorCredentials: map[string]configtypes.AuthConfig{
+			priorCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      "a-password",
@@ -107,7 +106,7 @@ func TestRunLogin(t *testing.T) {
 			input: loginOptions{
 				serverAddress: "reg1",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      "a-password",
@@ -117,7 +116,7 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc: "expired auth from store",
-			priorCredentials: map[string]configtypes.AuthConfig{
+			priorCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      expiredPassword,
@@ -131,13 +130,13 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc:              "store valid username and password",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				serverAddress: "reg1",
 				user:          "my-username",
 				password:      "p2",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      "p2",
@@ -147,7 +146,7 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc: "unknown user w/ prior credentials",
-			priorCredentials: map[string]configtypes.AuthConfig{
+			priorCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      "a-password",
@@ -160,7 +159,7 @@ func TestRunLogin(t *testing.T) {
 				password:      "a-password",
 			},
 			expectedErr: errUnknownUser,
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "a-password",
 					Password:      "a-password",
@@ -170,24 +169,24 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc:              "unknown user w/o prior credentials",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				serverAddress: "reg1",
 				user:          unknownUser,
 				password:      "a-password",
 			},
 			expectedErr:         errUnknownUser,
-			expectedCredentials: map[string]configtypes.AuthConfig{},
+			expectedCredentials: map[string]registrytypes.AuthConfig{},
 		},
 		{
 			doc:              "store valid token",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				serverAddress: "reg1",
 				user:          "my-username",
 				password:      useToken,
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					IdentityToken: useToken,
@@ -197,7 +196,7 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc: "valid token from store",
-			priorCredentials: map[string]configtypes.AuthConfig{
+			priorCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					Password:      useToken,
@@ -207,7 +206,7 @@ func TestRunLogin(t *testing.T) {
 			input: loginOptions{
 				serverAddress: "reg1",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"reg1": {
 					Username:      "my-username",
 					IdentityToken: useToken,
@@ -217,12 +216,12 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc:              "no registry specified defaults to index server",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				user:     "my-username",
 				password: "my-password",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				registry.IndexServer: {
 					Username:      "my-username",
 					Password:      "my-password",
@@ -232,13 +231,13 @@ func TestRunLogin(t *testing.T) {
 		},
 		{
 			doc:              "registry-1.docker.io",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				serverAddress: "registry-1.docker.io",
 				user:          "my-username",
 				password:      "my-password",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"registry-1.docker.io": {
 					Username:      "my-username",
 					Password:      "my-password",
@@ -249,13 +248,13 @@ func TestRunLogin(t *testing.T) {
 		// Regression test for https://github.com/docker/cli/issues/5382
 		{
 			doc:              "sanitizes server address to remove repo",
-			priorCredentials: map[string]configtypes.AuthConfig{},
+			priorCredentials: map[string]registrytypes.AuthConfig{},
 			input: loginOptions{
 				serverAddress: "registry-1.docker.io/bork/test",
 				user:          "my-username",
 				password:      "a-password",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"registry-1.docker.io": {
 					Username:      "my-username",
 					Password:      "a-password",
@@ -266,7 +265,7 @@ func TestRunLogin(t *testing.T) {
 		// Regression test for https://github.com/docker/cli/issues/5382
 		{
 			doc: "updates credential if server address includes repo",
-			priorCredentials: map[string]configtypes.AuthConfig{
+			priorCredentials: map[string]registrytypes.AuthConfig{
 				"registry-1.docker.io": {
 					Username:      "my-username",
 					Password:      "a-password",
@@ -278,7 +277,7 @@ func TestRunLogin(t *testing.T) {
 				user:          "my-username",
 				password:      "new-password",
 			},
-			expectedCredentials: map[string]configtypes.AuthConfig{
+			expectedCredentials: map[string]registrytypes.AuthConfig{
 				"registry-1.docker.io": {
 					Username:      "my-username",
 					Password:      "new-password",
@@ -428,7 +427,7 @@ func TestLoginNonInteractive(t *testing.T) {
 					if serverAddress == "" {
 						serverAddress = "https://index.docker.io/v1/"
 					}
-					assert.NilError(t, cfg.GetCredentialsStore(serverAddress).Store(configtypes.AuthConfig{
+					assert.NilError(t, cfg.GetCredentialsStore(serverAddress).Store(registrytypes.AuthConfig{
 						Username:      "my-username",
 						Password:      "my-password",
 						ServerAddress: serverAddress,

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
-	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/moby/moby/api/pkg/authconfig"
 	"github.com/moby/moby/api/types/registry"
 	"gotest.tools/v3/assert"
@@ -60,7 +59,7 @@ func TestGetDefaultAuthConfig(t *testing.T) {
 	}
 	cfg := configfile.New("filename")
 	for _, authConfig := range testAuthConfigs {
-		assert.Check(t, cfg.GetCredentialsStore(authConfig.ServerAddress).Store(configtypes.AuthConfig{
+		assert.Check(t, cfg.GetCredentialsStore(authConfig.ServerAddress).Store(registry.AuthConfig{
 			Username:      authConfig.Username,
 			Password:      authConfig.Password,
 			ServerAddress: authConfig.ServerAddress,

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/moby/api/types/registry"
 )
 
 const (
@@ -109,7 +109,7 @@ func Path(p ...string) (string, error) {
 // a reader. It returns an error if configData is malformed.
 func LoadFromReader(configData io.Reader) (*configfile.ConfigFile, error) {
 	configFile := configfile.ConfigFile{
-		AuthConfigs: make(map[string]types.AuthConfig),
+		AuthConfigs: make(map[string]registry.AuthConfig),
 	}
 	err := configFile.LoadFromReader(configData)
 	return &configFile, err

--- a/cli/config/credentials/credentials.go
+++ b/cli/config/credentials/credentials.go
@@ -1,7 +1,7 @@
 package credentials
 
 import (
-	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/moby/api/types/registry"
 )
 
 // Store is the interface that any credentials store must implement.
@@ -9,9 +9,9 @@ type Store interface {
 	// Erase removes credentials from the store for a given server.
 	Erase(serverAddress string) error
 	// Get retrieves credentials from the store for a given server.
-	Get(serverAddress string) (types.AuthConfig, error)
+	Get(serverAddress string) (registry.AuthConfig, error)
 	// GetAll retrieves all the credentials from the store.
-	GetAll() (map[string]types.AuthConfig, error)
+	GetAll() (map[string]registry.AuthConfig, error)
 	// Store saves credentials in the store.
-	Store(authConfig types.AuthConfig) error
+	Store(authConfig registry.AuthConfig) error
 }

--- a/cli/config/credentials/file_store.go
+++ b/cli/config/credentials/file_store.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/moby/api/types/registry"
 )
 
 type store interface {
 	Save() error
-	GetAuthConfigs() map[string]types.AuthConfig
+	GetAuthConfigs() map[string]registry.AuthConfig
 	GetFilename() string
 }
 
@@ -40,7 +40,7 @@ func (c *fileStore) Erase(serverAddress string) error {
 }
 
 // Get retrieves credentials for a specific server from the file store.
-func (c *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
+func (c *fileStore) Get(serverAddress string) (registry.AuthConfig, error) {
 	authConfig, ok := c.file.GetAuthConfigs()[serverAddress]
 	if !ok {
 		// Maybe they have a legacy config file, we will iterate the keys converting
@@ -51,12 +51,12 @@ func (c *fileStore) Get(serverAddress string) (types.AuthConfig, error) {
 			}
 		}
 
-		authConfig = types.AuthConfig{}
+		authConfig = registry.AuthConfig{}
 	}
 	return authConfig, nil
 }
 
-func (c *fileStore) GetAll() (map[string]types.AuthConfig, error) {
+func (c *fileStore) GetAll() (map[string]registry.AuthConfig, error) {
 	return c.file.GetAuthConfigs(), nil
 }
 
@@ -77,7 +77,7 @@ var alreadyPrinted atomic.Bool
 
 // Store saves the given credentials in the file store. This function is
 // idempotent and does not update the file if credentials did not change.
-func (c *fileStore) Store(authConfig types.AuthConfig) error {
+func (c *fileStore) Store(authConfig registry.AuthConfig) error {
 	authConfigs := c.file.GetAuthConfigs()
 	if oldAuthConfig, ok := authConfigs[authConfig.ServerAddress]; ok && oldAuthConfig == authConfig {
 		// Credentials didn't change, so skip updating the configuration file.

--- a/cli/config/credentials/native_store_test.go
+++ b/cli/config/credentials/native_store_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker-credential-helpers/client"
 	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/moby/moby/api/types/registry"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -91,12 +91,12 @@ func mockCommandFn(args ...string) client.Program {
 }
 
 func TestNativeStoreAddCredentials(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{}}
+	f := &fakeStore{configs: map[string]registry.AuthConfig{}}
 	s := &nativeStore{
 		programFunc: mockCommandFn,
 		fileStore:   NewFileStore(f),
 	}
-	auth := types.AuthConfig{
+	auth := registry.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
 		ServerAddress: validServerAddress,
@@ -107,19 +107,19 @@ func TestNativeStoreAddCredentials(t *testing.T) {
 
 	actual, ok := f.GetAuthConfigs()[validServerAddress]
 	assert.Check(t, ok)
-	expected := types.AuthConfig{
+	expected := registry.AuthConfig{
 		ServerAddress: auth.ServerAddress,
 	}
 	assert.Check(t, is.DeepEqual(expected, actual))
 }
 
 func TestNativeStoreAddInvalidCredentials(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{}}
+	f := &fakeStore{configs: map[string]registry.AuthConfig{}}
 	s := &nativeStore{
 		programFunc: mockCommandFn,
 		fileStore:   NewFileStore(f),
 	}
-	err := s.Store(types.AuthConfig{
+	err := s.Store(registry.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
 		ServerAddress: invalidServerAddress,
@@ -129,7 +129,7 @@ func TestNativeStoreAddInvalidCredentials(t *testing.T) {
 }
 
 func TestNativeStoreGet(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {
 			Username: "foo@example.com",
 		},
@@ -141,7 +141,7 @@ func TestNativeStoreGet(t *testing.T) {
 	actual, err := s.Get(validServerAddress)
 	assert.NilError(t, err)
 
-	expected := types.AuthConfig{
+	expected := registry.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
 		ServerAddress: validServerAddress,
@@ -150,7 +150,7 @@ func TestNativeStoreGet(t *testing.T) {
 }
 
 func TestNativeStoreGetIdentityToken(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress2: {},
 	}}
 
@@ -161,7 +161,7 @@ func TestNativeStoreGetIdentityToken(t *testing.T) {
 	actual, err := s.Get(validServerAddress2)
 	assert.NilError(t, err)
 
-	expected := types.AuthConfig{
+	expected := registry.AuthConfig{
 		IdentityToken: "abcd1234",
 		ServerAddress: validServerAddress2,
 	}
@@ -169,7 +169,7 @@ func TestNativeStoreGetIdentityToken(t *testing.T) {
 }
 
 func TestNativeStoreGetAll(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {},
 	}}
 
@@ -180,7 +180,7 @@ func TestNativeStoreGetAll(t *testing.T) {
 	as, err := s.GetAll()
 	assert.NilError(t, err)
 	assert.Check(t, is.Len(as, 2))
-	expected := types.AuthConfig{
+	expected := registry.AuthConfig{
 		Username:      "foo",
 		Password:      "bar",
 		ServerAddress: "https://index.docker.io/v1",
@@ -192,7 +192,7 @@ func TestNativeStoreGetAll(t *testing.T) {
 }
 
 func TestNativeStoreGetMissingCredentials(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {},
 	}}
 
@@ -205,7 +205,7 @@ func TestNativeStoreGetMissingCredentials(t *testing.T) {
 }
 
 func TestNativeStoreGetInvalidAddress(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {},
 	}}
 
@@ -218,7 +218,7 @@ func TestNativeStoreGetInvalidAddress(t *testing.T) {
 }
 
 func TestNativeStoreErase(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {},
 	}}
 
@@ -232,7 +232,7 @@ func TestNativeStoreErase(t *testing.T) {
 }
 
 func TestNativeStoreEraseInvalidAddress(t *testing.T) {
-	f := &fakeStore{configs: map[string]types.AuthConfig{
+	f := &fakeStore{configs: map[string]registry.AuthConfig{
 		validServerAddress: {},
 	}}
 

--- a/cli/config/memorystore/store_test.go
+++ b/cli/config/memorystore/store_test.go
@@ -3,13 +3,13 @@ package memorystore
 import (
 	"testing"
 
-	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/moby/api/types/registry"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
 
 func TestMemoryStore(t *testing.T) {
-	config := map[string]types.AuthConfig{
+	config := map[string]registry.AuthConfig{
 		"https://example.test": {
 			Username:      "something-something",
 			ServerAddress: "https://example.test",
@@ -17,7 +17,7 @@ func TestMemoryStore(t *testing.T) {
 		},
 	}
 
-	fallbackConfig := map[string]types.AuthConfig{
+	fallbackConfig := map[string]registry.AuthConfig{
 		"https://only-in-file.example.test": {
 			Username:      "something-something",
 			ServerAddress: "https://only-in-file.example.test",
@@ -44,7 +44,7 @@ func TestMemoryStore(t *testing.T) {
 	})
 
 	t.Run("storing credentials in memory store should also be in defined fallback store", func(t *testing.T) {
-		err := memoryStore.Store(types.AuthConfig{
+		err := memoryStore.Store(registry.AuthConfig{
 			Username:      "not-in-store",
 			ServerAddress: "https://not-in-store.example.test",
 			Auth:          "not-in-store_token",
@@ -64,7 +64,7 @@ func TestMemoryStore(t *testing.T) {
 	})
 
 	t.Run("delete credentials should remove credentials from memory store and fallback store", func(t *testing.T) {
-		err := memoryStore.Store(types.AuthConfig{
+		err := memoryStore.Store(registry.AuthConfig{
 			Username:      "a-new-credential",
 			ServerAddress: "https://a-new-credential.example.test",
 			Auth:          "a-new-credential_token",
@@ -80,7 +80,7 @@ func TestMemoryStore(t *testing.T) {
 }
 
 func TestMemoryStoreWithoutFallback(t *testing.T) {
-	config := map[string]types.AuthConfig{
+	config := map[string]registry.AuthConfig{
 		"https://example.test": {
 			Username:      "something-something",
 			ServerAddress: "https://example.test",
@@ -103,7 +103,7 @@ func TestMemoryStoreWithoutFallback(t *testing.T) {
 	})
 
 	t.Run("case store credentials", func(t *testing.T) {
-		err := memoryStore.Store(types.AuthConfig{
+		err := memoryStore.Store(registry.AuthConfig{
 			Username:      "not-in-store",
 			ServerAddress: "https://not-in-store.example.test",
 			Auth:          "not-in-store_token",
@@ -117,7 +117,7 @@ func TestMemoryStoreWithoutFallback(t *testing.T) {
 	})
 
 	t.Run("delete credentials should remove credentials from memory store", func(t *testing.T) {
-		err := memoryStore.Store(types.AuthConfig{
+		err := memoryStore.Store(registry.AuthConfig{
 			Username:      "a-new-credential",
 			ServerAddress: "https://a-new-credential.example.test",
 			Auth:          "a-new-credential_token",

--- a/cli/config/types/authconfig.go
+++ b/cli/config/types/authconfig.go
@@ -1,17 +1,6 @@
 package types
 
+import "github.com/moby/moby/api/types/registry"
+
 // AuthConfig contains authorization information for connecting to a Registry
-type AuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Auth     string `json:"auth,omitempty"`
-
-	ServerAddress string `json:"serveraddress,omitempty"`
-
-	// IdentityToken is used to authenticate the user and get
-	// an access token for the registry.
-	IdentityToken string `json:"identitytoken,omitempty"`
-
-	// RegistryToken is a bearer token to be sent to a registry
-	RegistryToken string `json:"registrytoken,omitempty"`
-}
+type AuthConfig = registry.AuthConfig

--- a/internal/oauth/manager/manager.go
+++ b/internal/oauth/manager/manager.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/oauth"
 	"github.com/docker/cli/internal/oauth/api"
 	"github.com/docker/cli/internal/registry"
 	"github.com/docker/cli/internal/tui"
+	registrytypes "github.com/moby/moby/api/types/registry"
 	"github.com/morikuni/aec"
 	"github.com/sirupsen/logrus"
 
@@ -82,7 +82,7 @@ var ErrDeviceLoginStartFail = errors.New("failed to start device code flow login
 // tokens to create a Hub PAT which is returned to the caller.
 // The retrieved tokens are stored in the credentials store (under a separate
 // key), and the refresh token is concatenated with the client ID.
-func (m *OAuthManager) LoginDevice(ctx context.Context, w io.Writer) (*types.AuthConfig, error) {
+func (m *OAuthManager) LoginDevice(ctx context.Context, w io.Writer) (*registrytypes.AuthConfig, error) {
 	state, err := m.api.GetDeviceCode(ctx, m.audience)
 	if err != nil {
 		logrus.Debugf("failed to start device code login: %v", err)
@@ -149,7 +149,7 @@ func (m *OAuthManager) LoginDevice(ctx context.Context, w io.Writer) (*types.Aut
 		return nil, err
 	}
 
-	return &types.AuthConfig{
+	return &registrytypes.AuthConfig{
 		Username:      claims.Domain.Username,
 		Password:      pat,
 		ServerAddress: registry.IndexServer,
@@ -193,12 +193,12 @@ const (
 
 func (m *OAuthManager) storeTokensInStore(tokens api.TokenResponse, username string) error {
 	return errors.Join(
-		m.store.Store(types.AuthConfig{
+		m.store.Store(registrytypes.AuthConfig{
 			Username:      username,
 			Password:      tokens.AccessToken,
 			ServerAddress: accessTokenKey,
 		}),
-		m.store.Store(types.AuthConfig{
+		m.store.Store(registrytypes.AuthConfig{
 			Username:      username,
 			Password:      tokens.RefreshToken + ".." + m.clientID,
 			ServerAddress: refreshTokenKey,

--- a/internal/oauth/manager/manager_test.go
+++ b/internal/oauth/manager/manager_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/docker/cli/cli/config/credentials"
-	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/internal/oauth/api"
+	"github.com/moby/moby/api/types/registry"
 	"gotest.tools/v3/assert"
 )
 
@@ -69,7 +69,7 @@ func TestLoginDevice(t *testing.T) {
 			waitForDeviceToken: waitForDeviceToken,
 			getAutoPAT:         getAutoPat,
 		}
-		store := newStore(map[string]types.AuthConfig{})
+		store := newStore(map[string]registry.AuthConfig{})
 		manager := OAuthManager{
 			store:    credentials.NewFileStore(store),
 			audience: "https://hub.docker.com",
@@ -84,7 +84,7 @@ func TestLoginDevice(t *testing.T) {
 
 		assert.Equal(t, receivedAudience, "https://hub.docker.com")
 		assert.Equal(t, receivedState, expectedState)
-		assert.DeepEqual(t, authConfig, &types.AuthConfig{
+		assert.DeepEqual(t, authConfig, &registry.AuthConfig{
 			Username:      "bork!",
 			Password:      "a-pat",
 			ServerAddress: "https://index.docker.io/v1/",
@@ -114,7 +114,7 @@ func TestLoginDevice(t *testing.T) {
 			waitForDeviceToken: waitForDeviceToken,
 			getAutoPAT:         getAutoPAT,
 		}
-		store := newStore(map[string]types.AuthConfig{})
+		store := newStore(map[string]registry.AuthConfig{})
 		manager := OAuthManager{
 			clientID: "client-id",
 			store:    credentials.NewFileStore(store),
@@ -204,7 +204,7 @@ func TestLogout(t *testing.T) {
 				return nil
 			},
 		}
-		store := newStore(map[string]types.AuthConfig{
+		store := newStore(map[string]registry.AuthConfig{
 			"https://index.docker.io/v1/access-token": {
 				Password: validToken,
 			},
@@ -230,7 +230,7 @@ func TestLogout(t *testing.T) {
 				return errors.New("couldn't reach tenant")
 			},
 		}
-		store := newStore(map[string]types.AuthConfig{
+		store := newStore(map[string]registry.AuthConfig{
 			"https://index.docker.io/v1/access-token": {
 				Password: validToken,
 			},
@@ -257,7 +257,7 @@ func TestLogout(t *testing.T) {
 				return nil
 			},
 		}
-		store := newStore(map[string]types.AuthConfig{
+		store := newStore(map[string]registry.AuthConfig{
 			"https://index.docker.io/v1/access-token": {
 				Password: validToken,
 			},
@@ -284,7 +284,7 @@ func TestLogout(t *testing.T) {
 			return nil
 		}
 		a.revokeToken = revokeToken
-		store := newStore(map[string]types.AuthConfig{})
+		store := newStore(map[string]registry.AuthConfig{})
 		manager := OAuthManager{
 			store: credentials.NewFileStore(store),
 			api:   a,
@@ -343,14 +343,14 @@ func (t *testAPI) GetAutoPAT(_ context.Context, audience string, res api.TokenRe
 }
 
 type fakeStore struct {
-	configs map[string]types.AuthConfig
+	configs map[string]registry.AuthConfig
 }
 
 func (*fakeStore) Save() error {
 	return nil
 }
 
-func (f *fakeStore) GetAuthConfigs() map[string]types.AuthConfig {
+func (f *fakeStore) GetAuthConfigs() map[string]registry.AuthConfig {
 	return f.configs
 }
 
@@ -358,6 +358,6 @@ func (*fakeStore) GetFilename() string {
 	return "/tmp/docker-fakestore"
 }
 
-func newStore(auths map[string]types.AuthConfig) *fakeStore {
+func newStore(auths map[string]registry.AuthConfig) *fakeStore {
 	return &fakeStore{configs: auths}
 }


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/1642
- relates to  https://github.com/moby/buildkit/pull/800


The AuthConfig type was forked from the docker/docker API types in commit 27b2797f7deb3ca5b7f80371d825113deb1faca1 to reduce the dependency on the docker API types in BuildKit and Buildx (see [buildkit#800]). Now that the API is a separate module with minimal dependencies, this should no longer be a big concern, so this patch un-forks the type.

[buildkit#800]: https://github.com/moby/buildkit/pull/800

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

