### PR TITLE
docker run, create: don't swallow connection errors during validate

### DIFF
--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -232,3 +232,7 @@ func (f *fakeClient) ContainerPause(ctx context.Context, containerID string, opt
 
 	return client.ContainerPauseResult{}, nil
 }
+
+func (*fakeClient) Ping(_ context.Context, _ client.PingOptions) (client.PingResult, error) {
+	return client.PingResult{}, nil
+}

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -112,7 +112,12 @@ func runCreate(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet,
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
-	containerCfg, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
+	serverInfo, err := dockerCli.Client().Ping(ctx, client.PingOptions{})
+	if err != nil {
+		return err
+	}
+
+	containerCfg, err := parse(flags, copts, serverInfo.OSType)
 	if err != nil {
 		return cli.StatusError{
 			Status:     withHelp(err, "create").Error(),

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -101,7 +101,12 @@ func runRun(ctx context.Context, dockerCli command.Cli, flags *pflag.FlagSet, ro
 		}
 	}
 	copts.env = *opts.NewListOptsRef(&newEnv, nil)
-	containerCfg, err := parse(flags, copts, dockerCli.ServerInfo().OSType)
+	serverInfo, err := dockerCli.Client().Ping(ctx, client.PingOptions{})
+	if err != nil {
+		return err
+	}
+
+	containerCfg, err := parse(flags, copts, serverInfo.OSType)
 	// just in case the parse does not exit
 	if err != nil {
 		return cli.StatusError{


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6694

Some validation steps done by `docker create` (and `docker run`) are platform- specific, and need to know the daemon's OS.

To get this information, the CLI.ServerInfo() method was used, which discards connection errors, resulting in an empty OS, which causes validation to fail with an "unknown server OS" error message.

This patch changes it to use the Client.Ping so that we can error when failing to connect.

We should look if we can reduce the platform-specific validation and parsing on the client-side, but at least this change should produce a more useful error.

Before this patch:

    DOCKER_HOST=tcp://example.invalid docker run -it --rm --device=/dev/dri alpine
    docker: unknown server OS:

    Run 'docker run --help' for more information

With this patch:

    DOCKER_HOST=tcp://example.invalid docker run -it --rm --device=/dev/dri alpine
    failed to connect to the docker API at tcp://example.invalid:2375: lookup example.invalid on 192.168.65.7:53: no such host

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

