### PR TITLE
fix(scripts/build): fix date formatting issue on different OS

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -13,13 +13,23 @@ PLATFORM=${PLATFORM:-}
 VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null || echo "unknown-version" )}
 GITCOMMIT=${GITCOMMIT:-$(git rev-parse --short HEAD 2> /dev/null || true)}
 
-if [ "$(uname)" = "Darwin" ]; then
-    # Using BSD date (macOS), which doesn't suppoort the --date option
-    # date -jf "<input format>" "<input value>" +"<output format>" (https://unix.stackexchange.com/a/86510)
-    BUILDTIME=${BUILDTIME:-$(TZ=UTC date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
-else
-    # Using GNU date (Linux)
-    BUILDTIME=${BUILDTIME:-$(TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")}
+# Try GNU date syntax first (Linux), fallback to BSD date syntax (macOS) if failed
+BUILDTIME_SET=false
+if [ -z "${BUILDTIME:-}" ]; then
+    # Try GNU date syntax
+    TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1 && {
+        BUILDTIME=$(TZ=UTC date -u --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")
+        BUILDTIME_SET=true
+    }
+fi
+
+if [ -z "${BUILDTIME:-}" ] && [ "$BUILDTIME_SET" = false ]; then
+    # Fallback to BSD date syntax
+    echo "GNU date syntax not supported, fallback to BSD date syntax"
+    TZ=UTC date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1 && {
+        BUILDTIME=$(TZ=UTC date -jf "%s" "${SOURCE_DATE_EPOCH:-$(date +%s)}" +"%Y-%m-%dT%H:%M:%SZ")
+        BUILDTIME_SET=true
+    }
 fi
 
 case "$VERSION" in


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
The `date` command on my macOS is GNU-style, so I submitted this PR.

**- How I did it**
Fix this issue by trying GNU/BSD command style one by one

**- How to verify it**
`make binary`

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

