### PR TITLE
cli-plugins/manager: remove legacy system-wide cli-plugin path

### DIFF
--- a/cli-plugins/manager/manager_windows.go
+++ b/cli-plugins/manager/manager_windows.go
@@ -16,6 +16,5 @@ import (
 //
 // [ConfigFile.CLIPluginsExtraDirs]: https://pkg.go.dev/github.com/docker/cli@v26.1.4+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs
 var defaultSystemPluginDirs = []string{
-	filepath.Join(os.Getenv("ProgramData"), "Docker", "cli-plugins"),
 	filepath.Join(os.Getenv("ProgramFiles"), "Docker", "cli-plugins"),
 }


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/1760


commit 4d3a76d71e368b7ccff6184d2c65e588b543f293 updated the list of directories for discovering CLI plugins, adding `%ProgramFiles%\Docker\cli-plugins` for system-wide plugins.

For backward compatibility, the `%PROGRAMDATA%\Docker\cli-plugins` was kept, however, this location is no longer used, and not generally recommended for storing non-data content (such as CLI plugin binaries). From the [ProgramData] documentation:

> ProgramData specifies the path to the program-data folder (normally C:\ProgramData).
> Unlike the Program Files folder, this folder can be used by applications to store
> data for standard users, because it does not require elevated permissions.

It also mentions "It can’t contain any serviceable components.", effectively meaning that these paths should not contain data that is managed (through updates etc.), making it a poor choice for installing "system wide" CLI plugins.

This patch removes the path from the list, given that this location is no longer used by Docker Desktop, and the CLI-plugin API is considered an internal implementation (since 459c6082f87750d45c84cd9454f3fa4b6c5580d9).

[ProgramData]: https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-folderlocations-programdata

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Remove `%PROGRAMDATA%\Docker\cli-plugins` from the list of paths used for CLI plugins on Windows. This path was present for backward compatibility with old installation, but replaced by `%ProgramFiles%\Docker\cli-plugins`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

