### PR TITLE
cli/command/service: fix API version for memory-swap, memory-swappiness

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -905,9 +905,9 @@ func addServiceFlags(flags *pflag.FlagSet, options *serviceOptions, defaultFlagV
 	flags.Int64Var(&options.resources.limitPids, flagLimitPids, 0, "Limit maximum number of processes (default 0 = unlimited)")
 	flags.SetAnnotation(flagLimitPids, "version", []string{"1.41"})
 	flags.Var(&options.resources.swapBytes, flagSwapBytes, "Swap Bytes (-1 for unlimited)")
-	flags.SetAnnotation(flagLimitPids, "version", []string{"1.52"})
+	flags.SetAnnotation(flagSwapBytes, "version", []string{"1.52"})
 	flags.Int64Var(&options.resources.memSwappiness, flagMemSwappiness, -1, "Tune memory swappiness (0-100), -1 to reset to default")
-	flags.SetAnnotation(flagLimitPids, "version", []string{"1.52"})
+	flags.SetAnnotation(flagMemSwappiness, "version", []string{"1.52"})
 
 	flags.Var(&options.stopGrace, flagStopGracePeriod, flagDesc(flagStopGracePeriod, "Time to wait before force killing a container (ns|us|ms|s|m|h)"))
 	flags.Var(&options.replicas, flagReplicas, "Number of tasks")


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/23861#discussion_r2630641057
- introduced in https://github.com/docker/cli/pull/6619


These flags were added in 71828f27922684582edf30566ebf77df23a37f2b, but copy/pasted the annotation from `--limit-pids`.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

