### PR TITLE
remove uses of deprecated go-archive consts

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -480,7 +480,7 @@ func Compress(buildCtx io.ReadCloser) (io.ReadCloser, error) {
 	pipeReader, pipeWriter := io.Pipe()
 
 	go func() {
-		compressWriter, err := compression.CompressStream(pipeWriter, archive.Gzip)
+		compressWriter, err := compression.CompressStream(pipeWriter, compression.Gzip)
 		if err != nil {
 			_ = pipeWriter.CloseWithError(err)
 		}


### PR DESCRIPTION
relates to

- https://github.com/moby/moby/pull/51777
- https://github.com/moby/go-archive/pull/10
- https://github.com/moby/go-archive/pull/7



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

