### PR TITLE
network: add --mac-address support to `docker network connect`

### DIFF
--- a/docs/reference/commandline/network_connect.md
+++ b/docs/reference/commandline/network_connect.md
@@ -14,6 +14,7 @@ Connect a container to a network
 | `--ip6`             | `ip`          | `<nil>` | IPv6 address (e.g., `2001:db8::33`)                                                     |
 | [`--link`](#link)   | `list`        |         | Add link to another container                                                           |
 | `--link-local-ip`   | `ipSlice`     |         | Add a link-local address for the container                                              |
+| `--mac-address`     | `string`      |         | MAC address for the container on this network (e.g., 92:d0:c6:0a:29:33)                 |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
- relates to https://github.com/moby/moby/issues/51796


# Add `--mac-address` support to `docker network connect`

Closes https://github.com/moby/moby/issues/51796

This change adds support for specifying a MAC address when connecting an existing container to a network using `docker network connect`, bringing feature parity with `docker run --network`.

The flag follows the same behavior as existing network-related options such as `--ip` and `--ip6`. The MAC address is parsed and validated client-side, then forwarded to the daemon via `EndpointSettings.MacAddress`.

This is particularly useful for macvlan networks, where explicit MAC address assignment is a common requirement.

**Note:** This change requires a companion update in `moby/moby` for the daemon to actually apply the MAC address during network connection.

---

## What I did

- Added a `--mac-address` flag to `docker network connect`  
- Implemented MAC address parsing and validation  
- Passed the MAC address through `EndpointSettings.MacAddress` to the daemon  

---

## How I did it

- Introduced a new CLI flag consistent with existing network flags  
- Validated input using `net.ParseMAC`  
- Converted the value to `network.HardwareAddr` before sending it to the API  
- Ensured invalid MAC addresses are rejected before making the API call  

---

## How to verify it

```bash
docker network create -d macvlan \
  --subnet=192.168.70.0/24 \
  --gateway=192.168.70.1 \
  -o parent=<interface> test-macvlan

docker run -d --name mysql3 mysql:8.0

docker network connect \
  --mac-address 02:42:ac:70:00:28 \
  test-macvlan mysql3

docker inspect mysql3 | jq '.[0].NetworkSettings.Networks."test-macvlan".MacAddress'
