### PR TITLE
docs: docs: improve documentation for "prune" commands specifying 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,8 @@ For more information, see https://www.bis.doc.gov
 docker/cli is licensed under the Apache License, Version 2.0. See
 [LICENSE](https://github.com/docker/docker/blob/master/LICENSE) for the full
 license text.
+
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.


### PR DESCRIPTION
## Description

### Description

This got in through the docs.docker.com feedback form;

> The line " If there is more than one filter, then pass multiple flags (e.g., --filter "foo=bar" --filter "bif=baz")" unfortun

## Changes Made

- docs: Added contributing section

Fixes #5899
