### PR TITLE
cli/command/image/build: remove deprecated utilities and consts

### DIFF
--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -272,17 +272,6 @@ func GetContextFromLocalDir(localDir, dockerfileName string) (string, string, er
 	return localDir, relDockerfile, err
 }
 
-// ResolveAndValidateContextPath uses the given context directory for a `docker build`
-// and returns the absolute path to the context directory.
-//
-// Deprecated: this utility was used internally and will be removed in the next
-// release. Use [DetectContextType] to detect the context-type, and use
-// [GetContextFromLocalDir], [GetContextFromLocalDir], [GetContextFromGitURL],
-// or [GetContextFromURL] instead.
-func ResolveAndValidateContextPath(givenContextDir string) (string, error) {
-	return resolveAndValidateContextPath(givenContextDir)
-}
-
 // resolveAndValidateContextPath uses the given context directory for a `docker build`
 // and returns the absolute path to the context directory.
 func resolveAndValidateContextPath(givenContextDir string) (string, error) {

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -111,15 +111,6 @@ func detectArchiveReader(input io.ReadCloser) (rc io.ReadCloser, ok bool, err er
 	return newReadCloserWrapper(buf, func() error { return input.Close() }), isArchive(magic), nil
 }
 
-// WriteTempDockerfile writes a Dockerfile stream to a temporary file with a
-// name specified by defaultDockerfileName and returns the path to the
-// temporary directory containing the Dockerfile.
-//
-// Deprecated: this utility was only used internally, and will be removed in the next release.
-func WriteTempDockerfile(rc io.ReadCloser) (dockerfileDir string, err error) {
-	return writeTempDockerfile(rc)
-}
-
 // writeTempDockerfile writes a Dockerfile stream to a temporary file with a
 // name specified by defaultDockerfileName and returns the path to the
 // temporary directory containing the Dockerfile.

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -201,14 +201,6 @@ func GetContextFromReader(rc io.ReadCloser, dockerfileName string) (out io.ReadC
 	}), defaultDockerfileName, nil
 }
 
-// IsArchive checks for the magic bytes of a tar or any supported compression
-// algorithm.
-//
-// Deprecated: this utility was used internally and will be removed in the next release.
-func IsArchive(header []byte) bool {
-	return isArchive(header)
-}
-
 // isArchive checks for the magic bytes of a tar or any supported compression
 // algorithm.
 func isArchive(header []byte) bool {

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -95,17 +95,6 @@ func filepathMatches(matcher *patternmatcher.PatternMatcher, file string) (bool,
 	return matcher.MatchesOrParentMatches(file)
 }
 
-// DetectArchiveReader detects whether the input stream is an archive or a
-// Dockerfile and returns a buffered version of input, safe to consume in lieu
-// of input. If an archive is detected, ok is set to true, and to false
-// otherwise, in which case it is safe to assume input represents the contents
-// of a Dockerfile.
-//
-// Deprecated: this utility was only used internally, and will be removed in the next release.
-func DetectArchiveReader(input io.ReadCloser) (rc io.ReadCloser, ok bool, err error) {
-	return detectArchiveReader(input)
-}
-
 // detectArchiveReader detects whether the input stream is an archive or a
 // Dockerfile and returns a buffered version of input, safe to consume in lieu
 // of input. If an archive is detected, ok is set to true, and to false

--- a/cli/command/image/build/context.go
+++ b/cli/command/image/build/context.go
@@ -25,11 +25,6 @@ import (
 	"github.com/moby/patternmatcher"
 )
 
-// DefaultDockerfileName is the Default filename with Docker commands, read by docker build
-//
-// Deprecated: this const is no longer used and will be removed in the next release.
-const DefaultDockerfileName string = "Dockerfile"
-
 const (
 	// defaultDockerfileName is the Default filename with Docker commands, read by docker build
 	defaultDockerfileName string = "Dockerfile"


### PR DESCRIPTION
relates to:

- https://github.com/docker/cli/pull/6550
- https://github.com/docker/cli/pull/6561

### cli/command/image/build: remove deprecated IsArchive utility

It was deprecated in 64be664e858d6ebcf0a119e349f6667ef67e7a83

### cli/command/image/build: remove deprecated DefaultDockerfileName const

It was deprecated in f24bb4bc76ae9c02e9df9d5bfccff5ee7e3a9ef9

### cli/command/image/build: remove deprecated DetectArchiveReader util

It was deprecated in c52fa073cd14498d060f0d8d99e9909737b729b5

### cli/command/image/build: remove deprecated WriteTempDockerfile util

It was deprecated in 6e1ff0bec1c87913c3cb58e2499fbf549fb3221f

### cli/command/image/build: remove deprecated ResolveAndValidateContextPath util

It was deprecated in 0f2f9e9c41f10997aad8c370fe1193d7a744


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
- cli/command/image/build: remove deprecated `IsArchive` utility
- cli/command/image/build: remove deprecated `DefaultDockerfileName` const
- cli/command/image/build: remove deprecated `DetectArchiveReader` util
- cli/command/image/build: remove deprecated `WriteTempDockerfile` util
- cli/command/image/build: remove deprecated `ResolveAndValidateContextPath` util
```

**- A picture of a cute animal (not mandatory but encouraged)**

