### PR TITLE
cli/command: make TestSetGoDebug more predictable

### DIFF
--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -358,6 +358,7 @@ func TestSetGoDebug(t *testing.T) {
 		assert.Equal(t, "val1,val2", os.Getenv("GODEBUG"))
 	})
 	t.Run("GODEBUG in context metadata can set env", func(t *testing.T) {
+		t.Setenv("GODEBUG", "")
 		meta := store.Metadata{
 			Metadata: DockerContext{
 				AdditionalFields: map[string]any{


### PR DESCRIPTION
Prevent the test from failing if GODEBUG is set in the current environment.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

