### PR TITLE
cli/command: DockerCli: store API-client options as field

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -60,6 +60,7 @@ type Cli interface {
 type DockerCli struct {
 	configFile         *configfile.ConfigFile
 	options            *cliflags.ClientOptions
+	clientOpts         []client.Opt
 	in                 *streams.In
 	out                *streams.Out
 	err                *streams.Out
@@ -72,7 +73,6 @@ type DockerCli struct {
 	dockerEndpoint     docker.Endpoint
 	contextStoreConfig *store.Config
 	initTimeout        time.Duration
-	userAgent          string
 	res                telemetryResource
 
 	// baseCtx is the base context used for internal operations. In the future
@@ -533,8 +533,7 @@ func (cli *DockerCli) initialize() error {
 			return
 		}
 		if cli.client == nil {
-			ops := []client.Opt{client.WithUserAgent(cli.userAgent)}
-			if cli.client, cli.initErr = newAPIClientFromEndpoint(cli.dockerEndpoint, cli.configFile, ops...); cli.initErr != nil {
+			if cli.client, cli.initErr = newAPIClientFromEndpoint(cli.dockerEndpoint, cli.configFile, cli.clientOpts...); cli.initErr != nil {
 				return
 			}
 		}

--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -221,7 +221,7 @@ func WithUserAgent(userAgent string) CLIOption {
 		if userAgent == "" {
 			return errors.New("user agent cannot be blank")
 		}
-		cli.userAgent = userAgent
+		cli.clientOpts = append(cli.clientOpts, client.WithUserAgent(userAgent))
 		return nil
 	}
 }


### PR DESCRIPTION
Use a more generic "clientOptions" field to store options to apply when constructing the API client, instead of a dedicated field for user-agent.


**- A picture of a cute animal (not mandatory but encouraged)**

