### PR TITLE
cli/command: add WithAPIClientOptions option

### DIFF
--- a/cli/command/cli_options.go
+++ b/cli/command/cli_options.go
@@ -104,6 +104,16 @@ func WithInitializeClient(makeClient func(*DockerCli) (client.APIClient, error))
 	}
 }
 
+// WithAPIClientOptions configures additional [client.Opt] to use when
+// initializing the API client. These options have no effect if a custom
+// client is set (through [WithAPIClient] or [WithInitializeClient]).
+func WithAPIClientOptions(c ...client.Opt) CLIOption {
+	return func(cli *DockerCli) error {
+		cli.clientOpts = append(cli.clientOpts, c...)
+		return nil
+	}
+}
+
 // envOverrideHTTPHeaders is the name of the environment-variable that can be
 // used to set custom HTTP headers to be sent by the client. This environment
 // variable is the equivalent to the HttpHeaders field in the configuration


### PR DESCRIPTION
- [x] depends on / stacked on https://github.com/docker/cli/pull/6739

This option allows setting custom options to use when constructing the API client.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
cli/command: add WithAPIClientOptions option.
```

**- A picture of a cute animal (not mandatory but encouraged)**

