### PR TITLE
improve validation of "--detach-keys" options

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -70,6 +70,14 @@ func newAttachCommand(dockerCLI command.Cli) *cobra.Command {
 
 // RunAttach executes an `attach` command
 func RunAttach(ctx context.Context, dockerCLI command.Cli, containerID string, opts *AttachOptions) error {
+	detachKeys := opts.DetachKeys
+	if detachKeys == "" {
+		detachKeys = dockerCLI.ConfigFile().DetachKeys
+	}
+	if err := validateDetachKeys(detachKeys); err != nil {
+		return err
+	}
+
 	apiClient := dockerCLI.Client()
 
 	// request channel to wait for client
@@ -83,11 +91,6 @@ func RunAttach(ctx context.Context, dockerCLI command.Cli, containerID string, o
 
 	if err := dockerCLI.In().CheckTty(!opts.NoStdin, c.Config.Tty); err != nil {
 		return err
-	}
-
-	detachKeys := dockerCLI.ConfigFile().DetachKeys
-	if opts.DetachKeys != "" {
-		detachKeys = opts.DetachKeys
 	}
 
 	options := client.ContainerAttachOptions{

--- a/cli/command/container/attach_test.go
+++ b/cli/command/container/attach_test.go
@@ -28,6 +28,14 @@ func TestNewAttachCommandErrors(t *testing.T) {
 			},
 		},
 		{
+			name:          "invalid-detach-keys",
+			args:          []string{"--detach-keys", "shift-b", "5cb5bb5e4a3b"},
+			expectedError: "invalid detach keys (shift-b):",
+			containerInspectFunc: func(containerID string) (client.ContainerInspectResult, error) {
+				return client.ContainerInspectResult{}, errors.New("something went wrong")
+			},
+		},
+		{
 			name:          "client-stopped",
 			args:          []string{"5cb5bb5e4a3b"},
 			expectedError: "cannot attach to a stopped container",

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -248,5 +248,8 @@ func parseExec(execOpts ExecOptions, configFile *configfile.ConfigFile) (*client
 	} else {
 		execOptions.DetachKeys = configFile.DetachKeys
 	}
+	if err := validateDetachKeys(execOpts.DetachKeys); err != nil {
+		return nil, err
+	}
 	return execOptions, nil
 }

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -140,6 +140,14 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		config.StdinOnce = false
 	}
 
+	detachKeys := runOpts.detachKeys
+	if detachKeys == "" {
+		detachKeys = dockerCli.ConfigFile().DetachKeys
+	}
+	if err := validateDetachKeys(runOpts.detachKeys); err != nil {
+		return err
+	}
+
 	containerID, err := createContainer(ctx, dockerCli, containerCfg, &runOpts.createOptions)
 	if err != nil {
 		return toStatusError(err)
@@ -172,11 +180,6 @@ func runContainer(ctx context.Context, dockerCli command.Cli, runOpts *runOption
 		}()
 	}
 	if attach {
-		detachKeys := dockerCli.ConfigFile().DetachKeys
-		if runOpts.detachKeys != "" {
-			detachKeys = runOpts.detachKeys
-		}
-
 		// ctx should not be cancellable here, as this would kill the stream to the container
 		// and we want to keep the stream open until the process in the container exits or until
 		// the user forcefully terminates the CLI.

--- a/cli/command/container/run_test.go
+++ b/cli/command/container/run_test.go
@@ -34,6 +34,11 @@ func TestRunValidateFlags(t *testing.T) {
 			args:        []string{"--attach", "stdin", "--detach", "myimage"},
 			expectedErr: "conflicting options: cannot specify both --attach and --detach",
 		},
+		{
+			name:        "with invalid --detach-keys",
+			args:        []string{"--detach-keys", "shift-a", "myimage"},
+			expectedErr: "invalid detach keys (shift-a):",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := newRunCommand(test.NewFakeCli(&fakeClient{}))

--- a/cli/command/container/start_test.go
+++ b/cli/command/container/start_test.go
@@ -1,0 +1,38 @@
+package container
+
+import (
+	"io"
+	"testing"
+
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestStartValidateFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "with invalid --detach-keys",
+			args:        []string{"--detach-keys", "shift-a", "myimage"},
+			expectedErr: "invalid detach keys (shift-a):",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newStartCommand(test.NewFakeCli(&fakeClient{}))
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if tc.expectedErr != "" {
+				assert.Check(t, is.ErrorContains(err, tc.expectedErr))
+			} else {
+				assert.Check(t, is.Nil(err))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this change, the detach-keys were not validated, and the code either fell back to the default sequence, or returned an obscure error if the invalid sequence would produce an error on the daemon;

Before this patch:

    docker run -it --rm --detach-keys=shift-a,b busybox
    unable to upgrade to tcp, received 400

With this patch:

    docker run -it --rm --detach-keys=shift-a,b busybox
    invalid detach keys (shift-a,b): Unknown character: 'shift-a'

Note that the "unable to upgrade to tcp, received 400" error is still something to be looked into; the client currently discards error messages coming from the daemon.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Improve validation of `--detach-keys` command-line options
```

**- A picture of a cute animal (not mandatory but encouraged)**

