### PR TITLE
Fix: Remove inconsistent human readability warning from docker images

### DIFF
--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -211,6 +211,6 @@ func printAmbiguousHint(stdErr io.Writer, matchName string) {
 		"save",
 		"tag":
 
-		_, _ = fmt.Fprintf(stdErr, "\nNo images found matching %q: did you mean \"docker image %[1]s\"?\n", matchName)
+		_, _ = fmt.Fprintf(stdErr, "No images found matching %q: did you mean \"docker image %[1]s\"?\n", matchName)
 	}
 }

--- a/cli/command/image/testdata/list-command-ambiguous.golden
+++ b/cli/command/image/testdata/list-command-ambiguous.golden
@@ -1,3 +1,1 @@
-WARNING: This output is designed for human readability. For machine-readable output, please use --format.
-
 No images found matching "ls": did you mean "docker image ls"?

--- a/cli/command/image/tree.go
+++ b/cli/command/image/tree.go
@@ -6,14 +6,12 @@ package image
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
 	"github.com/containerd/platforms"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/formatter"
-	"github.com/docker/cli/cli/streams"
 	"github.com/docker/cli/internal/tui"
 	"github.com/docker/go-units"
 	imagetypes "github.com/moby/moby/api/types/image"
@@ -233,10 +231,6 @@ func getPossibleChips(view treeView) (chips []imageChip) {
 }
 
 func printImageTree(outs command.Streams, view treeView) {
-	if streamRedirected(outs.Out()) {
-		_, _ = fmt.Fprintln(outs.Err(), "WARNING: This output is designed for human readability. For machine-readable output, please use --format.")
-	}
-
 	out := tui.NewOutput(outs.Out())
 	isTerm := out.IsTerminal()
 
@@ -563,18 +557,4 @@ func widestFirstColumnValue(headers []imgColumn, images []topImage) int {
 		}
 	}
 	return width
-}
-
-func streamRedirected(s *streams.Out) bool {
-	fd := s.FD()
-	if os.Stdout.Fd() != fd {
-		return true
-	}
-
-	fi, err := os.Stdout.Stat()
-	if err != nil {
-		return true
-	}
-
-	return fi.Mode()&os.ModeCharDevice == 0
 }

--- a/cli/command/image/tree_test.go
+++ b/cli/command/image/tree_test.go
@@ -157,6 +157,17 @@ func TestPrintImageTreeAnsiTty(t *testing.T) {
 	}
 }
 
+func TestPrintImageTreeNoWarningWhenRedirected(t *testing.T) {
+	cli := test.NewFakeCli(nil)
+	cli.Out().SetIsTerminal(false)
+	cli.Err().SetIsTerminal(false)
+
+	printImageTree(cli, treeView{images: []topImage{}})
+
+	errOut := cli.ErrBuffer().String()
+	assert.Check(t, !strings.Contains(errOut, "WARNING: This output is designed for human readability"), "stderr should not contain warning when output is redirected, got: %s", errOut)
+}
+
 func TestPrintImageTreeGolden(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
### What I did

* **Removed Warning:** Removed the warning message printed to stderr when `docker images` output is redirected (non-TTY). This involved removing the logic in `tree.go` and the unused `streamRedirected` helper function.
* **Formatting Polish:** Removed a leading newline in `list.go` (in the "ambiguous argument" hint).
* *Context:* Previously, the warning message consumed the first line of stderr. After removing the warning, the ambiguous argument error started with an awkward blank line. I removed this leading newline to ensure clean output.



### Why I did it

* **Inconsistency:** `docker images` was the only list command (unlike `docker ps`, `docker volume ls`, etc.) to emit this warning when piped. This change aligns behavior across the CLI.
* **Pipeline Stability:** The warning interferes with standard command-line pipelines (e.g., `docker images | grep ...`) and complicates parsing for users who have relied on this behavior for years.
* **Cleaner Output:** Removing the warning and the redundant newline ensures stderr remains clean and focused on actual errors or hints, rather than noise.

### How I verified it

* **New Test:** Added `TestPrintImageTreeNoWarningWhenRedirected` in `tree_test.go` to ensure no warning is emitted on redirection.
* **Existing Tests:** Updated `list-command-ambiguous.golden` to match the cleaner output (verified that the leading blank line is gone).
* **CI:** Verified all unit tests and linters pass in the `dev-container` environment.

### Related Issue

Closes #6749