### PR TITLE
[DNM] manifest inspect: add some debug logs

### DIFF
--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/types"
 	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -69,10 +70,12 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	// Try a local manifest list first
+	logrus.WithFields(logrus.Fields{"name": namedRef}).Debug("trying local manifest")
 	localManifestList, err := newManifestStore(dockerCli).GetList(namedRef)
 	if err == nil {
 		return printManifestList(dockerCli, namedRef, localManifestList, opts)
 	}
+	logrus.WithFields(logrus.Fields{"name": namedRef}).Debug("trying remote manifest")
 
 	// Next try a remote manifest
 	registryClient := newRegistryClient(dockerCli, opts.insecure)
@@ -82,6 +85,7 @@ func runInspect(ctx context.Context, dockerCli command.Cli, opts inspectOptions)
 	}
 
 	// Finally try a remote manifest list
+	logrus.WithFields(logrus.Fields{"name": namedRef}).Debug("trying remote manifest list")
 	manifestList, err := registryClient.GetManifestList(ctx, namedRef)
 	if err != nil {
 		return err

--- a/internal/registry/service.go
+++ b/internal/registry/service.go
@@ -67,7 +67,7 @@ func (s *Service) Auth(ctx context.Context, authConfig *registry.AuthConfig, use
 			// Try next endpoint
 			log.G(ctx).WithFields(log.Fields{
 				"error":    err,
-				"endpoint": endpoint,
+				"endpoint": endpoint.URL,
 			}).Infof("Error logging in to endpoint, trying next endpoint")
 			lastErr = err
 			continue

--- a/internal/registryclient/client.go
+++ b/internal/registryclient/client.go
@@ -161,26 +161,24 @@ func (c *client) getHTTPTransportForRepoEndpoint(ctx context.Context, repoEndpoi
 // GetManifest returns an ImageManifest for the reference
 func (c *client) GetManifest(ctx context.Context, ref reference.Named) (manifesttypes.ImageManifest, error) {
 	var result manifesttypes.ImageManifest
-	fetch := func(ctx context.Context, repo distribution.Repository, ref reference.Named) (bool, error) {
+	err := c.iterateEndpoints(ctx, ref, func(fetchCtx context.Context, repo distribution.Repository, ref reference.Named) (bool, error) {
 		var err error
-		result, err = fetchManifest(ctx, repo, ref)
+		logrus.WithFields(logrus.Fields{"ref": ref}).Debug("fetching manifest")
+		result, err = fetchManifest(fetchCtx, repo, ref)
 		return result.Ref != nil, err
-	}
-
-	err := c.iterateEndpoints(ctx, ref, fetch)
+	})
 	return result, err
 }
 
 // GetManifestList returns a list of ImageManifest for the reference
 func (c *client) GetManifestList(ctx context.Context, ref reference.Named) ([]manifesttypes.ImageManifest, error) {
 	result := []manifesttypes.ImageManifest{}
-	fetch := func(ctx context.Context, repo distribution.Repository, ref reference.Named) (bool, error) {
+	err := c.iterateEndpoints(ctx, ref, func(ctx context.Context, repo distribution.Repository, ref reference.Named) (bool, error) {
 		var err error
+		logrus.WithFields(logrus.Fields{"ref": ref}).Debug("fetching manifest list")
 		result, err = fetchList(ctx, repo, ref)
 		return len(result) > 0, err
-	}
-
-	err := c.iterateEndpoints(ctx, ref, fetch)
+	})
 	return result, err
 }
 


### PR DESCRIPTION
Output;

```bash
time docker --debug manifest inspect debian:testing
time="2026-01-23T09:57:32Z" level=debug msg="trying local manifest" name="docker.io/library/debian:testing"
time="2026-01-23T09:57:32Z" level=debug msg="trying remote manifest" name="docker.io/library/debian:testing"
time="2026-01-23T09:57:32Z" level=debug msg="resolved endpoints for docker.io/library/debian:testing" endpoints="[https://registry-1.docker.io]"
time="2026-01-23T09:57:33Z" level=debug msg="fetching manifest" ref="docker.io/library/debian:testing"
time="2026-01-23T09:57:34Z" level=debug msg="manifestlist for: docker.io/library/debian:testing" mediaType=application/vnd.oci.image.index.v1+json payload="{\"manifests\":[{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"amd64\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"c5f3180659db80fb676e09bd8bfd992e3df68cac\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"amd64\",\"os\":\"linux\"},\"size\":1021},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"amd64\",\"vnd.docker.reference.digest\":\"sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:cc0c3abefacef503a707041ce6b9d36e45e2d5b9b39949623666b96582fa773c\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"arm32v7\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"b316b19b1c840c4f1fb5eb57d8d555ed04c5de77\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"arm\",\"os\":\"linux\",\"variant\":\"v7\"},\"size\":1037},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"arm32v7\",\"vnd.docker.reference.digest\":\"sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:a51c6aee7170fc28ca16a4cd74b43b033f95a90a17127c2b93f8dd06035b2da7\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"arm64v8\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"abba7ba5b7934fde6ebf5689d222898e7435ccfd\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"arm64\",\"os\":\"linux\",\"variant\":\"v8\"},\"size\":1041},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"arm64v8\",\"vnd.docker.reference.digest\":\"sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:4ab958db466d089dfe5aeb95dce7dd9a9e5edc0cd3b859d99d61e186d7dc7c89\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"i386\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"f54aec0e27e84ce626538d4ec0f78527e25d58df\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"386\",\"os\":\"linux\"},\"size\":1017},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"i386\",\"vnd.docker.reference.digest\":\"sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:235d7d2392334db190c9bccced822b51737cf685b96937d4f4d03f9f1f806ce5\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"ppc64le\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"1a1e9aafc3e0ffe247d4d9eb8edcb1cf5bc5eb28\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"ppc64le\",\"os\":\"linux\"},\"size\":1025},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"ppc64le\",\"vnd.docker.reference.digest\":\"sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:9ae89e56c7b2c48aa84f5363fa9ddcd916665dc7bfbaa90d78dc893d59d70d67\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"riscv64\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"41591d96d31c2344dc9cfc08693a5cdd1a81bc65\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"riscv64\",\"os\":\"linux\"},\"size\":1025},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"riscv64\",\"vnd.docker.reference.digest\":\"sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:3e35ac00160e7f2f8f1b12fd6f1ac9a59f87b64dbcb7994901d7b8ddf4b90e55\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"s390x\",\"org.opencontainers.image.base.name\":\"scratch\",\"org.opencontainers.image.created\":\"2026-01-12T00:00:00Z\",\"org.opencontainers.image.revision\":\"277feb856b3aa444512a443d704549f6c28edc01\",\"org.opencontainers.image.source\":\"https:\\/\\/github.com\\/debuerreotype\\/docker-debian-artifacts.git\",\"org.opencontainers.image.url\":\"https:\\/\\/hub.docker.com\\/_\\/debian\",\"org.opencontainers.image.version\":\"testing\"},\"digest\":\"sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"s390x\",\"os\":\"linux\"},\"size\":1021},{\"annotations\":{\"com.docker.official-images.bashbrew.arch\":\"s390x\",\"vnd.docker.reference.digest\":\"sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a\",\"vnd.docker.reference.type\":\"attestation-manifest\"},\"digest\":\"sha256:35933b4972c173eacdf795d212e4c944a855fb7a6891e72f0bd006a8854b6fa6\",\"mediaType\":\"application\\/vnd.oci.image.manifest.v1+json\",\"platform\":{\"architecture\":\"unknown\",\"os\":\"unknown\"},\"size\":562}],\"mediaType\":\"application\\/vnd.oci.image.index.v1+json\",\"schemaVersion\":2}"
time="2026-01-23T09:57:34Z" level=debug msg="not continuing on error (*errors.errorString) docker.io/library/debian:testing is a manifest list"
time="2026-01-23T09:57:34Z" level=debug msg="trying remote manifest list" name="docker.io/library/debian:testing"
time="2026-01-23T09:57:34Z" level=debug msg="resolved endpoints for docker.io/library/debian:testing" endpoints="[https://registry-1.docker.io]"
time="2026-01-23T09:57:34Z" level=debug msg="fetching manifest list" ref="docker.io/library/debian:testing"
time="2026-01-23T09:57:35Z" level=debug msg="pulling manifest" digest="sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9"
time="2026-01-23T09:57:37Z" level=debug msg="pulling manifest" digest="sha256:cc0c3abefacef503a707041ce6b9d36e45e2d5b9b39949623666b96582fa773c"
time="2026-01-23T09:57:38Z" level=debug msg="pulling manifest" digest="sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4"
time="2026-01-23T09:57:39Z" level=debug msg="pulling manifest" digest="sha256:a51c6aee7170fc28ca16a4cd74b43b033f95a90a17127c2b93f8dd06035b2da7"
time="2026-01-23T09:57:40Z" level=debug msg="pulling manifest" digest="sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018"
time="2026-01-23T09:57:41Z" level=debug msg="pulling manifest" digest="sha256:4ab958db466d089dfe5aeb95dce7dd9a9e5edc0cd3b859d99d61e186d7dc7c89"
time="2026-01-23T09:57:42Z" level=debug msg="pulling manifest" digest="sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7"
time="2026-01-23T09:57:43Z" level=debug msg="pulling manifest" digest="sha256:235d7d2392334db190c9bccced822b51737cf685b96937d4f4d03f9f1f806ce5"
time="2026-01-23T09:57:44Z" level=debug msg="pulling manifest" digest="sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86"
time="2026-01-23T09:57:46Z" level=debug msg="pulling manifest" digest="sha256:9ae89e56c7b2c48aa84f5363fa9ddcd916665dc7bfbaa90d78dc893d59d70d67"
time="2026-01-23T09:57:47Z" level=debug msg="pulling manifest" digest="sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721"
time="2026-01-23T09:57:48Z" level=debug msg="pulling manifest" digest="sha256:3e35ac00160e7f2f8f1b12fd6f1ac9a59f87b64dbcb7994901d7b8ddf4b90e55"
time="2026-01-23T09:57:49Z" level=debug msg="pulling manifest" digest="sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a"
time="2026-01-23T09:57:50Z" level=debug msg="pulling manifest" digest="sha256:35933b4972c173eacdf795d212e4c944a855fb7a6891e72f0bd006a8854b6fa6"
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1021,
         "digest": "sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:cc0c3abefacef503a707041ce6b9d36e45e2d5b9b39949623666b96582fa773c",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1037,
         "digest": "sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4",
         "platform": {
            "architecture": "arm",
            "os": "linux",
            "variant": "v7"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:a51c6aee7170fc28ca16a4cd74b43b033f95a90a17127c2b93f8dd06035b2da7",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1041,
         "digest": "sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018",
         "platform": {
            "architecture": "arm64",
            "os": "linux",
            "variant": "v8"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:4ab958db466d089dfe5aeb95dce7dd9a9e5edc0cd3b859d99d61e186d7dc7c89",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1017,
         "digest": "sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7",
         "platform": {
            "architecture": "386",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:235d7d2392334db190c9bccced822b51737cf685b96937d4f4d03f9f1f806ce5",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1025,
         "digest": "sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:9ae89e56c7b2c48aa84f5363fa9ddcd916665dc7bfbaa90d78dc893d59d70d67",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1025,
         "digest": "sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721",
         "platform": {
            "architecture": "riscv64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:3e35ac00160e7f2f8f1b12fd6f1ac9a59f87b64dbcb7994901d7b8ddf4b90e55",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 1021,
         "digest": "sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 562,
         "digest": "sha256:35933b4972c173eacdf795d212e4c944a855fb7a6891e72f0bd006a8854b6fa6",
         "platform": {
            "architecture": "unknown",
            "os": "unknown"
         }
      }
   ]
}

real	0m18.963s
user	0m0.390s
sys	0m0.215s
```

So.. what happens is that it finds that it's a manifest-list, not an image; 

```console
time="2026-01-23T09:57:34Z" level=debug msg="not continuing on error (*errors.errorString) docker.io/library/debian:testing is a manifest list"
```

Then it goes fetching the manifest-list, for which it pulls each image manifest referenced separately. 🙈 😂 

I'm not sure _why_ this logic is there, because the information it prints is already in the manifest list it fetched. Maybe the code was written to account for the _local_ manifest list, in which case, it would probably have to collect the individual image manifests as stored locally and/or fetched from a registry?

This is the output of the first (manifest list) payload (collapsed) after formatting;

<details>

```json
{
  "manifests": [
    {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "amd64",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "c5f3180659db80fb676e09bd8bfd992e3df68cac",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      },
      "size": 1021
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "amd64",
        "vnd.docker.reference.digest": "sha256:839158022a02ea738be200fcd45637be892ef04f169befd01022388fccca91c9",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:cc0c3abefacef503a707041ce6b9d36e45e2d5b9b39949623666b96582fa773c",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm32v7",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "b316b19b1c840c4f1fb5eb57d8d555ed04c5de77",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v7"
      },
      "size": 1037
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm32v7",
        "vnd.docker.reference.digest": "sha256:6c91078e6c9496cb6fa4d2c9f76b38749e480bca37486a09aae4123ecc4cc8d4",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:a51c6aee7170fc28ca16a4cd74b43b033f95a90a17127c2b93f8dd06035b2da7",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm64v8",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "abba7ba5b7934fde6ebf5689d222898e7435ccfd",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      },
      "size": 1041
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm64v8",
        "vnd.docker.reference.digest": "sha256:87bb3e9e37ee950840fbe32bec3df2688592b20cfcf8e880934c68d8e4dd7018",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:4ab958db466d089dfe5aeb95dce7dd9a9e5edc0cd3b859d99d61e186d7dc7c89",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "i386",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "f54aec0e27e84ce626538d4ec0f78527e25d58df",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "386",
        "os": "linux"
      },
      "size": 1017
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "i386",
        "vnd.docker.reference.digest": "sha256:7185eed61fc5173c9efa8d433377fa7f57b10e6930744de70574af050955eac7",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:235d7d2392334db190c9bccced822b51737cf685b96937d4f4d03f9f1f806ce5",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "ppc64le",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "1a1e9aafc3e0ffe247d4d9eb8edcb1cf5bc5eb28",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "ppc64le",
        "os": "linux"
      },
      "size": 1025
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "ppc64le",
        "vnd.docker.reference.digest": "sha256:20b6d1b0d69fcc436d67059f8131daaa55b77d028b10fc4ded0094bb7c67de86",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:9ae89e56c7b2c48aa84f5363fa9ddcd916665dc7bfbaa90d78dc893d59d70d67",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "riscv64",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "41591d96d31c2344dc9cfc08693a5cdd1a81bc65",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "riscv64",
        "os": "linux"
      },
      "size": 1025
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "riscv64",
        "vnd.docker.reference.digest": "sha256:9ff2e758e9cd9cc6ea5302e339ac3ed9bf8fc63a0b9d105af3a5a7d1edd0b721",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:3e35ac00160e7f2f8f1b12fd6f1ac9a59f87b64dbcb7994901d7b8ddf4b90e55",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "s390x",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2026-01-12T00:00:00Z",
        "org.opencontainers.image.revision": "277feb856b3aa444512a443d704549f6c28edc01",
        "org.opencontainers.image.source": "https://github.com/debuerreotype/docker-debian-artifacts.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/debian",
        "org.opencontainers.image.version": "testing"
      },
      "digest": "sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "s390x",
        "os": "linux"
      },
      "size": 1021
    }, {
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "s390x",
        "vnd.docker.reference.digest": "sha256:4de667dc1a88d02d44b629182c2d7477f480c1f71473d5370d829d9d1a942b6a",
        "vnd.docker.reference.type": "attestation-manifest"
      },
      "digest": "sha256:35933b4972c173eacdf795d212e4c944a855fb7a6891e72f0bd006a8854b6fa6",
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "platform": {
        "architecture": "unknown",
        "os": "unknown"
      },
      "size": 562
    }
  ],
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "schemaVersion": 2
}
```


</details>





**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

