### PR TITLE
feat: return error when service update triggers rollback

### DIFF
--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -138,6 +138,10 @@ func ServiceProgress(ctx context.Context, apiClient client.APIClient, serviceID 
 			if message != nil {
 				_ = progressOut.WriteProgress(*message)
 			}
+			if rollback {
+				// Exit with error when update was rolled back
+				return fmt.Errorf("service update rolled back: %s", res.Service.UpdateStatus.Message)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
Return error when service update triggers rollback

When a service update fails and triggers a rollback, the command now
exits with code 1 instead of 0.

Fixes #6752

**- What I did**
Modified the `ServiceProgress` function to return an error when a service update is rolled back, instead of returning success (nil)

**- How I did it**
Added a check for the `rollback` flag after service convergence. When `rollback` is true, the function now returns an error instead of nil, which causes the CLI to exit with code 1.

**- How to verify it**
1. Deploy a stack with a healthy service
2. Update the service with a configuration that will fail (e.g., failing healthcheck)
3. The service will rollback automatically
4. Verify the command exits with code 1 instead of 0

Test setup:
- Use the docker-compose.yml from issue #6752
- First deploy with `exit 0` in healthcheck
- Then deploy with `exit 1` in healthcheck to trigger rollback
- Check exit code with `echo $?`

**- Human readable description for the release notes**
```markdown changelog
- Fix `docker stack deploy` to exit with error code 1 when service update triggers rollback
```

**- A picture of a cute animal (not mandatory but encouraged)**
