### PR TITLE
cli/command/container: improve CID-file errors

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -177,8 +177,8 @@ func (cid *cidFile) Close() error {
 	if cid.written {
 		return nil
 	}
-	if err := os.Remove(cid.path); err != nil {
-		return fmt.Errorf("failed to remove the CID file '%s': %w", cid.path, err)
+	if err := os.Remove(cid.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove the CID file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
### cli/command/container: cidFile.Write: include CID in error message

Include the container-ID in the error message when failing to write the ID to a file, so that the user can still find the ID of the container that was created.

### cli/command/container: ignore "not found" error on cidfile.Close

Ignore errors when trying to remove a CID-file that no longer exists;
also remove the path from the custom error as os.Remove already returns
a os.PathError, which includes the path.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

