### PR TITLE
opts: MountOpt: improve error for empty value

### DIFF
--- a/opts/mount.go
+++ b/opts/mount.go
@@ -22,6 +22,11 @@ type MountOpt struct {
 //
 //nolint:gocyclo
 func (m *MountOpt) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("value is empty")
+	}
+
 	csvReader := csv.NewReader(strings.NewReader(value))
 	fields, err := csvReader.Read()
 	if err != nil {

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -110,6 +110,10 @@ func TestMountOptErrors(t *testing.T) {
 		doc, value, expErr string
 	}{
 		{
+			doc:    "empty value",
+			expErr: "value is empty",
+		},
+		{
 			doc:    "missing tmpfs target",
 			value:  "type=tmpfs",
 			expErr: "target is required",


### PR DESCRIPTION
Before this patch:

    docker run --rm --mount "" busybox
    invalid argument "" for "--mount" flag: EOF

With this patch:

    docker run --rm --mount "" busybox
    invalid argument "" for "--mount" flag: value is empty

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

