### PR TITLE
opts: MountOpt: relax client-side validation of mount target

### DIFF
--- a/opts/mount.go
+++ b/opts/mount.go
@@ -175,10 +175,6 @@ func (m *MountOpt) Set(value string) error {
 		return errors.New("type is required")
 	}
 
-	if mount.Target == "" {
-		return errors.New("target is required")
-	}
-
 	if mount.VolumeOptions != nil && mount.Type != mounttypes.TypeVolume {
 		return fmt.Errorf("cannot mix 'volume-*' options with mount type '%s'", mount.Type)
 	}

--- a/opts/mount_test.go
+++ b/opts/mount_test.go
@@ -114,21 +114,6 @@ func TestMountOptErrors(t *testing.T) {
 			expErr: "value is empty",
 		},
 		{
-			doc:    "missing tmpfs target",
-			value:  "type=tmpfs",
-			expErr: "target is required",
-		},
-		{
-			doc:    "missing bind target",
-			value:  "type=bind",
-			expErr: "target is required",
-		},
-		{
-			doc:    "missing volume target",
-			value:  "type=volume,source=/foo",
-			expErr: "target is required",
-		},
-		{
 			doc:    "invalid key=value",
 			value:  "type=volume,target=/foo,bogus=foo",
 			expErr: "unexpected key 'bogus' in 'bogus=foo'",


### PR DESCRIPTION
The daemon already validates the target, so we don't have to validate if a target is set. Instead, we can ignore empty targets, but produce an error if a target option was set, but set to an empty value.

With this patch applied, omitting a target option is ignored by the CLI, but still invalidated by the daemon if the given mount-type requires a mount target;

    docker run --rm --mount type=bind,src=/var/run/docker.sock alpine
    docker: Error response from daemon: invalid mount config for type "bind": field Target must not be empty

    docker run --rm --mount type=bind,src=/var/run/docker.sock,dst=../foo alpine
    docker: Error response from daemon: invalid mount config for type "bind": invalid mount path: '../foo' mount path must be absolute

When passing a target option (`target`, `dst`, or `destination`), the CLI produces an error if the value is empty;

    docker run --rm --mount type=bind,src=/var/run/docker.sock,dst= alpine
    invalid argument "type=bind,src=/var/run/docker.sock,dst=" for "--mount" flag: invalid value for 'dst': mount target must be a non-empty value


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

