### PR TITLE
cli/command: TestGetDefaultAuthConfig: cleanup test file

### DIFF
--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -3,6 +3,7 @@ package command_test
 import (
 	"bytes"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
@@ -58,7 +59,9 @@ func TestGetDefaultAuthConfig(t *testing.T) {
 			expectedAuthConfig: testAuthConfigs[1],
 		},
 	}
-	cfg := configfile.New("filename")
+
+	tmpDir := t.TempDir()
+	cfg := configfile.New(filepath.Join(tmpDir, "cli-config.json"))
 	for _, authConfig := range testAuthConfigs {
 		assert.Check(t, cfg.GetCredentialsStore(authConfig.ServerAddress).Store(configtypes.AuthConfig{
 			Username:      authConfig.Username,


### PR DESCRIPTION
Prevent a `cli/command/filename` file being left behind after running tests.


**- A picture of a cute animal (not mandatory but encouraged)**

