### PR TITLE
docs: fix typo in dockerd.md for 'replacement'

### DIFF
--- a/docs/reference/dockerd.md
+++ b/docs/reference/dockerd.md
@@ -610,7 +610,7 @@ $ sudo dockerd --add-runtime <runtime>=<path>
 
 Defining runtime arguments via the command line is not supported.
 
-For an example configuration for a runc drop-in replacment, see
+For an example configuration for a runc drop-in replacement, see
 [Alternative container runtimes > youki](https://docs.docker.com/engine/daemon/alternative-runtimes/#youki)
 
 ##### Configure the default container runtime


### PR DESCRIPTION
Fixed a typo in [dockerd](https://docs.docker.com/reference/cli/dockerd/#configure-runc-drop-in-replacements)

<img width="950" height="374" alt="image" src="https://github.com/user-attachments/assets/a55f7096-2a7c-4077-a88b-d2240fc2aa42" />
