### PR TITLE
fix: add background execution to python http server example

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1292,12 +1292,13 @@ example runs an HTTP server that serves a file from host to container over the
 
 ```console
 $ echo "hello from host!" > ./hello
-$ python3 -m http.server 8000
+$ python3 -m http.server 8000 &
 Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
 $ docker run \
   --add-host host.docker.internal=host-gateway \
   curlimages/curl -s host.docker.internal:8000/hello
 hello from host!
+$ kill %1  # Stop the HTTP server
 ```
 
 The `--add-host` flag also accepts a `:` separator, for example:


### PR DESCRIPTION
## 修復內容

修復 docker/cli#5558：--add-host 範例無法正常運作的問題

### 問題
python3 HTTP 伺服器佔用前景，導致用戶無法在同樣的終端機執行 docker run 命令。

### 解決方案
1. 在 python3 命令後加入 `&` 讓它在背景執行
2. 添加 `kill %1` 來停止 HTTP 伺服器

### 修改檔案
- `docs/reference/commandline/container_run.md`

### 修改內容
```diff
- $ python3 -m http.server 8000
+ $ python3 -m http.server 8000 &
  Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
  $ docker run \
    --add-host host.docker.internal=host-gateway \
    curlimages/curl -s host.docker.internal:8000/hello
  hello from host!
+ $ kill %1  # Stop the HTTP server
```

### 關聯 Issue
Fixes #5558