### PR TITLE
cli/command/registry: preserve all whitespace in secrets

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -144,8 +144,8 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 		}
 	}
 
-	argPassword = strings.TrimSpace(argPassword)
-	if argPassword == "" {
+	isEmpty := strings.TrimSpace(argPassword) == ""
+	if isEmpty {
 		restoreInput, err := prompt.DisableInputEcho(cli.In())
 		if err != nil {
 			return registrytypes.AuthConfig{}, err

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -339,6 +339,56 @@ func TestRunLogin(t *testing.T) {
 				},
 			},
 		},
+		{
+			doc:              "password with leading and trailing spaces",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				password:      "  my password with spaces  ",
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					Password:      "  my password with spaces  ",
+					ServerAddress: "reg1",
+				},
+			},
+		},
+		{
+			doc:              "password stdin with line-endings",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			stdIn:            "  my password with spaces  \r\n",
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				passwordStdin: true,
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					Password:      "  my password with spaces  ",
+					ServerAddress: "reg1",
+				},
+			},
+		},
+		{
+			doc:              "password stdin with multiple line-endings",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			stdIn:            "  my password\nwith spaces  \r\n\r\n",
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				passwordStdin: true,
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					Password:      "  my password\nwith spaces  \r\n",
+					ServerAddress: "reg1",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6782
- updates https://github.com/docker/cli/commit/a21a5f42433267052441cdb7ebe7604dfcc7f159 /  https://github.com/docker/cli/pull/5550

### cli/command/registry: preserve all whitespace in secrets

Preserve all whitespace and treat the secret as an opaque value,
leaving it to the registry to (in)validate. We still check for
empty values in some places.

This partially reverts a21a5f42433267052441cdb7ebe7604dfcc7f159,
but checks for empty (whitespace-only) passwords without mutating
the value.

This better aligns with [NIST SP 800-63B §5.1.1.2], which describes
that the value should be treated as opaque, preserving any other whitespace,
including newlines. Note that trimming whitespace may still happen elsewhere
(see [NIST SP 800-63B (revision 4) §3.1.1.2]);
> Verifiers **MAY** make limited allowances for mistyping (e.g., removing
> leading and trailing whitespace characters before verification, allowing
> the verification of passwords with differing cases for the leading character)

[NIST SP 800-63B §5.1.1.2]: https://pages.nist.gov/800-63-3/sp800-63b.html#memsecretver
[NIST SP 800-63B (revision 4) §3.1.1.2]: https://pages.nist.gov/800-63-4/sp800-63b.html#passwordver


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Preserve leading and trailing whitespace when storing registry passwords.
```

**- A picture of a cute animal (not mandatory but encouraged)**

