### PR TITLE
e2e: use docker v29.x dind as default

### DIFF
--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -4,7 +4,7 @@ services:
     image: 'registry:3'
 
   engine:
-      image: 'docker:${ENGINE_VERSION:-28}-dind'
+      image: 'docker:${ENGINE_VERSION:-29}-dind'
       privileged: true
       command: ['--insecure-registry=registry:5000', '--experimental']
       environment:

--- a/e2e/testdata/Dockerfile.connhelper-ssh
+++ b/e2e/testdata/Dockerfile.connhelper-ssh
@@ -2,16 +2,13 @@
 
 # ENGINE_VERSION is the version of the (docker-in-docker) Docker Engine to
 # test against.
-ARG ENGINE_VERSION=28
+ARG ENGINE_VERSION=29
 
 FROM docker:${ENGINE_VERSION}-dind
 
 # the openssh-client update is needed for security reasons when using docker:23.0-dind, currently maintained as an lts by mirantis
 RUN apk --no-cache add openssl openssh-client openssh-server shadow && \
  apk --no-cache upgrade openssl openssh-client openssh-server &&  \
-  # TODO(krissetto): `groupadd` can be removed once we only test against moby >= v24
-  # see https://github.com/docker-library/docker/pull/470
-  groupadd -f docker && \
   useradd --create-home --shell /bin/sh --password $(head -c32 /dev/urandom | base64) penguin && \
   usermod -aG docker penguin && \
   ssh-keygen -A


### PR DESCRIPTION
Also remove groupadd which looks to be redundant now.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

