### PR TITLE
Fix: run plugin hooks on command failure, not just success

### DIFF
--- a/cli-plugins/manager/hooks_test.go
+++ b/cli-plugins/manager/hooks_test.go
@@ -51,12 +51,15 @@ func TestGetNaiveFlags(t *testing.T) {
 
 func TestPluginMatch(t *testing.T) {
 	testCases := []struct {
-		commandString string
-		pluginConfig  map[string]string
-		expectedMatch string
-		expectedOk    bool
+		doc             string
+		commandString   string
+		pluginConfig    map[string]string
+		cmdErrorMessage string
+		expectedMatch   string
+		expectedOk      bool
 	}{
 		{
+			doc:           "hooks prefix match",
 			commandString: "image ls",
 			pluginConfig: map[string]string{
 				"hooks": "image",
@@ -65,6 +68,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    true,
 		},
 		{
+			doc:           "hooks no match",
 			commandString: "context ls",
 			pluginConfig: map[string]string{
 				"hooks": "build",
@@ -73,6 +77,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    false,
 		},
 		{
+			doc:           "hooks exact match",
 			commandString: "context ls",
 			pluginConfig: map[string]string{
 				"hooks": "context ls",
@@ -81,6 +86,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    true,
 		},
 		{
+			doc:           "hooks first match wins",
 			commandString: "image ls",
 			pluginConfig: map[string]string{
 				"hooks": "image ls,image",
@@ -89,6 +95,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    true,
 		},
 		{
+			doc:           "hooks empty string",
 			commandString: "image ls",
 			pluginConfig: map[string]string{
 				"hooks": "",
@@ -97,6 +104,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    false,
 		},
 		{
+			doc:           "hooks partial token no match",
 			commandString: "image inspect",
 			pluginConfig: map[string]string{
 				"hooks": "image i",
@@ -105,6 +113,7 @@ func TestPluginMatch(t *testing.T) {
 			expectedOk:    false,
 		},
 		{
+			doc:           "hooks prefix token match",
 			commandString: "image inspect",
 			pluginConfig: map[string]string{
 				"hooks": "image",
@@ -112,12 +121,140 @@ func TestPluginMatch(t *testing.T) {
 			expectedMatch: "image",
 			expectedOk:    true,
 		},
+		{
+			doc:           "error-hooks match on error",
+			commandString: "build",
+			pluginConfig: map[string]string{
+				"error-hooks": "build",
+			},
+			cmdErrorMessage: "exit status 1",
+			expectedMatch:   "build",
+			expectedOk:      true,
+		},
+		{
+			doc:           "error-hooks no match on success",
+			commandString: "build",
+			pluginConfig: map[string]string{
+				"error-hooks": "build",
+			},
+			cmdErrorMessage: "",
+			expectedMatch:   "",
+			expectedOk:      false,
+		},
+		{
+			doc:           "error-hooks prefix match on error",
+			commandString: "compose up",
+			pluginConfig: map[string]string{
+				"error-hooks": "compose",
+			},
+			cmdErrorMessage: "exit status 1",
+			expectedMatch:   "compose",
+			expectedOk:      true,
+		},
+		{
+			doc:           "error-hooks no match for wrong command",
+			commandString: "pull",
+			pluginConfig: map[string]string{
+				"error-hooks": "build",
+			},
+			cmdErrorMessage: "exit status 1",
+			expectedMatch:   "",
+			expectedOk:      false,
+		},
+		{
+			doc:           "hooks takes precedence over error-hooks",
+			commandString: "build",
+			pluginConfig: map[string]string{
+				"hooks":       "build",
+				"error-hooks": "build",
+			},
+			cmdErrorMessage: "exit status 1",
+			expectedMatch:   "build",
+			expectedOk:      true,
+		},
+		{
+			doc:           "hooks fires on success even with error-hooks configured",
+			commandString: "build",
+			pluginConfig: map[string]string{
+				"hooks":       "build",
+				"error-hooks": "build",
+			},
+			cmdErrorMessage: "",
+			expectedMatch:   "build",
+			expectedOk:      true,
+		},
+		{
+			doc:           "error-hooks with multiple commands",
+			commandString: "compose up",
+			pluginConfig: map[string]string{
+				"error-hooks": "build,compose up,pull",
+			},
+			cmdErrorMessage: "exit status 1",
+			expectedMatch:   "compose up",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range testCases {
-		match, ok := pluginMatch(tc.pluginConfig, tc.commandString)
-		assert.Equal(t, ok, tc.expectedOk)
-		assert.Equal(t, match, tc.expectedMatch)
+		t.Run(tc.doc, func(t *testing.T) {
+			match, ok := pluginMatch(tc.pluginConfig, tc.commandString, tc.cmdErrorMessage)
+			assert.Equal(t, ok, tc.expectedOk)
+			assert.Equal(t, match, tc.expectedMatch)
+		})
+	}
+}
+
+func TestMatchHookConfig(t *testing.T) {
+	testCases := []struct {
+		doc             string
+		configuredHooks string
+		subCmd          string
+		expectedMatch   string
+		expectedOk      bool
+	}{
+		{
+			doc:             "empty config",
+			configuredHooks: "",
+			subCmd:          "build",
+			expectedMatch:   "",
+			expectedOk:      false,
+		},
+		{
+			doc:             "exact match",
+			configuredHooks: "build",
+			subCmd:          "build",
+			expectedMatch:   "build",
+			expectedOk:      true,
+		},
+		{
+			doc:             "prefix match",
+			configuredHooks: "image",
+			subCmd:          "image ls",
+			expectedMatch:   "image",
+			expectedOk:      true,
+		},
+		{
+			doc:             "comma-separated match",
+			configuredHooks: "pull,build,push",
+			subCmd:          "build",
+			expectedMatch:   "build",
+			expectedOk:      true,
+		},
+		{
+			doc:             "no match",
+			configuredHooks: "pull,push",
+			subCmd:          "build",
+			expectedMatch:   "",
+			expectedOk:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.doc, func(t *testing.T) {
+			match, ok := matchHookConfig(tc.configuredHooks, tc.subCmd)
+			assert.Equal(t, ok, tc.expectedOk)
+			assert.Equal(t, match, tc.expectedMatch)
+		})
 	}
 }
 
@@ -170,21 +307,37 @@ func TestRunPluginHooksPassesErrorMessage(t *testing.T) {
 	RunPluginHooks(context.Background(), provider, root, sub, []string{"build"}, "exit status 1")
 }
 
-func TestInvokeAndCollectHooksForwardsErrorMessage(t *testing.T) {
+func TestRunPluginHooksErrorHooks(t *testing.T) {
 	cfg := configfile.New("")
 	cfg.Plugins = map[string]map[string]string{
-		"nonexistent": {"hooks": "build"},
+		"test-plugin": {"error-hooks": "build"},
+	}
+	provider := &fakeConfigProvider{cfg: cfg}
+	root := &cobra.Command{Use: "docker"}
+	sub := &cobra.Command{Use: "build"}
+	root.AddCommand(sub)
+
+	// Should not panic — error-hooks with error message
+	RunPluginHooks(context.Background(), provider, root, sub, []string{"build"}, "exit status 1")
+
+	// Should not panic — error-hooks with no error (should be skipped)
+	RunPluginHooks(context.Background(), provider, root, sub, []string{"build"}, "")
+}
+
+func TestInvokeAndCollectHooksErrorHooksSkippedOnSuccess(t *testing.T) {
+	cfg := configfile.New("")
+	cfg.Plugins = map[string]map[string]string{
+		"nonexistent": {"error-hooks": "build"},
 	}
 	root := &cobra.Command{Use: "docker"}
 	sub := &cobra.Command{Use: "build"}
 	root.AddCommand(sub)
 
-	// Plugin binary doesn't exist — invokeAndCollectHooks skips it
-	// gracefully and returns empty. Verifies the error message path
-	// doesn't cause issues when forwarded through the call chain.
+	// On success, error-hooks should not match, so the plugin
+	// binary is never looked up and no results are returned.
 	result := invokeAndCollectHooks(
 		context.Background(), cfg, root, sub,
-		"build", map[string]string{}, "exit status 1",
+		"build", map[string]string{}, "",
 	)
 	assert.Check(t, is.Len(result, 0))
 }

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -163,6 +163,31 @@ func TestGetExitCode(t *testing.T) {
 	})
 }
 
+func TestCmdErrorMessage(t *testing.T) {
+	t.Run("nil error returns empty string", func(t *testing.T) {
+		assert.Equal(t, cmdErrorMessage(nil), "")
+	})
+
+	t.Run("generic error returns error message", func(t *testing.T) {
+		assert.Equal(t, cmdErrorMessage(errors.New("something broke")), "something broke")
+	})
+
+	t.Run("StatusError with Status field", func(t *testing.T) {
+		err := dockercli.StatusError{Status: "build failed", StatusCode: 1}
+		assert.Equal(t, cmdErrorMessage(err), "build failed")
+	})
+
+	t.Run("StatusError with only exit code falls back to generic message", func(t *testing.T) {
+		err := dockercli.StatusError{StatusCode: 42}
+		assert.Equal(t, cmdErrorMessage(err), "exited with code 42")
+	})
+
+	t.Run("wrapped error preserves message", func(t *testing.T) {
+		err := fmt.Errorf("wrapper: %w", errors.New("inner failure"))
+		assert.Equal(t, cmdErrorMessage(err), "wrapper: inner failure")
+	})
+}
+
 func TestVisitAll(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
 	sub1 := &cobra.Command{Use: "sub1"}


### PR DESCRIPTION
### This PR is part of a trilogy:
1. [docker/cli](https://github.com/docker/cli/pull/6794) **<-- you are here**
2. [docker/ai](https://github.com/docker/ai/pull/384)
3. [docker/pinata](https://github.com/docker/pinata/pull/39356)

---

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Closes https://github.com/docker/gordon/issues/125
**- What I did**

Enabled CLI plugin hooks to fire on command failure, not just success. Previously, when a plugin-delegated command like `docker build` (buildx) or `docker compose up` failed, the hooks system was skipped entirely. This meant plugins like `ai`, `scout`, and `debug` could never show "What's next:" hints for failed builds or compose errors — exactly when users would benefit most from a suggestion like `docker ai "fix my problem"`.

Additionally, introduced a new `error-hooks` plugin configuration key that lets plugins opt in to error-only hooks, separate from the existing `hooks` key that fires on every invocation.

**- How I did it**

Three coordinated changes:

1. **`cli-plugins/manager/hooks.go`** — Extended `RunPluginHooks` to accept a `cmdErrorMessage` string and forward it to `runHooks` (previously hardcoded to `""`). Refactored `pluginMatch` to check both `hooks` (always fires) and `error-hooks` (fires only when `cmdErrorMessage` is non-empty). Extracted a new `matchHookConfig` helper to deduplicate the comma-separated hook matching logic.

2. **`cmd/docker/docker.go`** — Moved the `RunPluginHooks` call out of the `if err == nil` block so hooks fire regardless of plugin exit status. The error message is extracted the same way the native command path (`RunCLICommandHooks`) already does. Hooks are still skipped for "not found" errors (i.e., unknown commands) to avoid false triggers.

3. **`*_test.go`** — Added comprehensive tests for:
   - `pluginMatch` with the new `cmdErrorMessage` parameter and `error-hooks` configuration
   - The new `matchHookConfig` helper
   - `RunPluginHooks` integration tests verifying both success and failure paths
   - `invokeAndCollectHooks` edge cases (no plugins, cancelled context, error-hooks skipped on success)
   - `getExitCode` covering `StatusError`, wrapped errors, and signal termination

---

**- How to verify it**

These two PRs work together:
- **[docker/cli#6794](https://github.com/docker/cli/pull/6794)** — Makes plugin hooks fire on command failure and adds `error-hooks` config
- **[docker/ai#384](https://github.com/docker/ai/pull/384)** — Registers the `ai` plugin's hook handler to show "ask Gordon" hints when commands fail

### 1. Build the custom CLI binary

```bash
git clone https://github.com/docker/cli.git
cd cli
gh pr checkout https://github.com/docker/cli/pull/6794
make -f docker.Makefile build
# Binary: ./build/docker
```

### 2. Build and install the custom `docker-ai` plugin

> **Note:** `task cli:install` is currently broken due to a `dotenv` issue in an unrelated Taskfile. Run the build steps directly instead.

```bash
git clone https://github.com/docker/ai.git
cd ai
gh pr checkout https://github.com/docker/ai/pull/384
cd cli
go build -trimpath -ldflags="-s -w" -o docker-ai .
ln -sf "$PWD/docker-ai" ~/.docker/cli-plugins/docker-ai
```

### 3. Configure hooks in `~/.docker/config.json`

Add the `features` and `plugins` keys (merge with your existing config):

```json
{
  "features": {
    "hooks": "true"
  },
  "plugins": {
    "ai": {
      "hooks": "run",
      "error-hooks": "build,buildx build,compose"
    }
  }
}
```

> **Important:** `error-hooks` must include both `"build"` and `"buildx build"`. `docker build` and `docker buildx build` produce different command strings internally, and the hook matching is a prefix token match — `"buildx build"` won't match a bare `docker build`. Use `"compose"` (not `"compose up"`) because flags like `-f` appear between `compose` and `up` in the args, breaking the positional match.

### 4. Test the full flow

**Failing build (the main use case):**
```bash
echo "FROM nonexistent:image" > /tmp/Dockerfile
~/path/to/cli/build/docker build /tmp
# Expected output after the build error:
#   What's next:
#     Debug this build failure with Gordon → docker ai "help me fix this build failure"
```

**Failing run:**
```bash
~/path/to/cli/build/docker run nonexistent:image
# Expected:
#   What's next:
#     Debug this container error with Gordon → docker ai "help me fix this container error"
```

**Failing compose:**
```bash
cat > /tmp/docker-compose.yml <<'EOF'
services:
  broken:
    image: nonexistent:image
EOF
~/path/to/cli/build/docker compose -f /tmp/docker-compose.yml up
# Expected:
#   What's next:
#     Debug this Compose error with Gordon → docker ai "help me fix this compose error"
```

**Successful build (error-hooks should NOT fire):**
```bash
~/path/to/cli/build/docker build -t test .
# Expected: build succeeds, NO Gordon hints shown
# (error-hooks only fire on failure)
```

**Successful run (regular hooks fire, but plugin returns nothing):**
```bash
~/path/to/cli/build/docker run --rm hello-world
# Expected: run succeeds, no hints shown
# (ai plugin returns nothing when CommandError is empty)
```

### 5. Run the tests

```bash
# CLI plugin hooks tests
cd cli
go test ./cli-plugins/manager/... ./cmd/docker/...

# AI plugin hooks tests
cd ai/cli
go test ./commands/... -run Hook
```

### 6. Restore original plugin when done

```bash
ln -sf /Applications/Docker.app/Contents/Resources/cli-plugins/docker-ai \
  ~/.docker/cli-plugins/docker-ai
```

And remove the `features`/`plugins` keys from `~/.docker/config.json` if you don't want hooks active.

---

**- Human readable description for the release notes**

```markdown changelog
CLI plugin hooks now fire on command failure (not just success), and plugins can use "error-hooks" to show hints only when commands fail.
```