### PR TITLE
loader: Fix preservation of multiple protocols on one port

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -116,7 +116,11 @@ func toServicePortConfigsMap(s any) (map[any]any, error) {
 	}
 	m := map[any]any{}
 	for _, p := range ports {
-		m[p.Published] = p
+		protocol := "tcp"
+		if p.Protocol != "" {
+			protocol = p.Protocol
+		}
+		m[fmt.Sprintf("%d%s", p.Published, protocol)] = p
 	}
 	return m, nil
 }

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -848,6 +848,8 @@ func TestLoadMultipleConfigs(t *testing.T) {
 				"ports": []any{
 					"8080:80",
 					"9090:90",
+					"53:53/tcp",
+					"53:53/udp",
 				},
 				"labels": []any{
 					"foo=bar",
@@ -925,6 +927,18 @@ func TestLoadMultipleConfigs(t *testing.T) {
 					},
 				},
 				Ports: []types.ServicePortConfig{
+					{
+						Mode:      "ingress",
+						Target:    53,
+						Published: 53,
+						Protocol:  "tcp",
+					},
+					{
+						Mode:      "ingress",
+						Target:    53,
+						Published: 53,
+						Protocol:  "udp",
+					},
 					{
 						Target:    81,
 						Published: 8080,


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

Fixes #2407.

**- What I did**
I fixed a bug in the configuration loader,  where ports with the same number but different protocols (e.g., 53:53/tcp and 53:53/udp) would overwrite each other instead of being preserved as separate port configurations. 

**- How I did it**

Modified `toServicePortConfigsMap` in `merge.go` to use a composite key that includes both the published port number and protocol (e.g., "53tcp", "53udp") instead of just the port number. This ensures that ports with the same number but different protocols are treated as distinct entries in the map and won't overwrite each other during the merge process.

**- How to verify it**
I added a test case in that defines the same port (53) with both TCP and UDP protocols. The test verifies that both port configurations are properly loaded and preserved in the resulting service configuration, confirming that neither gets overwritten during the merge process. Alternativeley follow the steps to reproduce of #2407.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
loader: Fix preservation of multiple protocols on one port

```

