### PR TITLE
scripts/build/.variables: don't use "netgo" when building Windows binaries

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -102,6 +102,15 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     # compiling statically with CGO enabled requires osusergo and netgo to be set.
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo netgo"
 fi
+# XXX: Disable netgo on Windows and use Windows system resolver instead.
+#
+# go1.19 and newer added support for netgo on Windows (https://go.dev/doc/go1.19#net),
+# which may not respect VPN adaptors (such as Twingate) due to resolver ordering,
+# resulting in queries being sent through the local network adapter instead of the
+# VPN tunnel. See https://github.com/docker/cli/issues/6665
+if [ "$(go env GOOS)" = "windows" ]; then
+    GO_BUILDTAGS=$(echo "$GO_BUILDTAGS" | sed 's/\(^\| \)netgo\( \|$\)/\1/g')
+fi
 if [ -n "$GO_STRIP" ]; then
     # if stripping enabled and building with llvm < 12 against darwin/amd64
     # platform, it will fail with:


### PR DESCRIPTION
relates to:

- fixes https://github.com/docker/cli/issues/6665
- (likely) introduced in https://github.com/docker/cli/pull/6631
- related: https://github.com/moby/moby/pull/45603



### scripts/build/.variables: don't use "netgo" when building Windows binaries

commit 880ef756b76a09d9c8f1ef2b4994265ebb2a1bc8 fixed static builds with CGO, which included setting the `netgo` build-tag for static builds.

Starting with go1.19, the Go runtime on Windows now supports the `netgo` build- flag to use a native Go DNS resolver. Prior to that version, the build-flag only had an effect on non-Windows platforms. From the go1.19 release notes: https://go.dev/doc/go1.19#net

> Resolver.PreferGo is now implemented on Windows and Plan 9. It previously
> only worked on Unix platforms. Combined with Dialer.Resolver and Resolver.Dial,
> it's now possible to write portable programs and be in control of all DNS name
> lookups when dialing.
>
> The net package now has initial support for the netgo build tag on Windows.
> When used, the package uses the Go DNS client (as used by Resolver.PreferGo)
> instead of asking Windows for DNS results. The upstream DNS server it discovers
> from Windows may not yet be correct with complex system network configurations,
> however.

This originally caused issues in the daemon, because the pure-go implementation did not respect file-based resolution (`C:\Windows\System32\Drivers\etc\hosts`), resulting in `localhost` not being resolvable, and custom entries in `.etc/hosts` not being used.

That specific problem was resolved in go1.22 (through [golang/go@33d4a51]), but other limitations may still apply, and resolver ordering may not respect VPN adaptors (such as Twingate) and queries sent through the local network adapter instead of the VPN tunnel, resulting in DNS resolution failures;

    Get "https://example.com:2376/v1.52/containers/json": dial tcp: lookup example.com: i/o timeout

This patch unsets the `netgo` option when (cross-)compiling for Windows, similar to the patch used for the daemon (see [moby/moby@53d1b12]).

[golang/go@33d4a51]: https://github.com/golang/go/commit/33d4a5105cf2b2d549922e909e9239a48b8cefcc
[moby/moby@53d1b12]: https://github.com/moby/moby/commit/53d1b12bc014b4243e9439fc2610eb4ef863659f

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

