### PR TITLE
Removed EOL Flocker plugin reference from plugin documentations.

### DIFF
--- a/docs/extend/plugin_api.md
+++ b/docs/extend/plugin_api.md
@@ -21,7 +21,7 @@ which registers itself by placing a file on the daemon host in one of the plugin
 directories described in [Plugin discovery](#plugin-discovery).
 
 Plugins have human-readable names, which are short, lowercase strings. For
-example, `flocker` or `weave`.
+example, `myplugin`.
 
 Plugins can run inside or outside containers. Currently running them outside
 containers is recommended.
@@ -45,12 +45,12 @@ spec files can be located either under `/etc/docker/plugins` or `/usr/lib/docker
 
 The name of the file (excluding the extension) determines the plugin name.
 
-For example, the `flocker` plugin might create a Unix socket at
-`/run/docker/plugins/flocker.sock`.
+For example, a plugin named `myplugin` might create a Unix socket at
+`/run/docker/plugins/myplugin.sock`.
 
 You can define each plugin into a separated subdirectory if you want to isolate definitions from each other.
-For example, you can create the `flocker` socket under `/run/docker/plugins/flocker/flocker.sock` and only
-mount `/run/docker/plugins/flocker` inside the `flocker` container.
+For example, you can create the `myplugin` socket under `/run/docker/plugins/myplugin/myplugin.sock` and only
+mount `/run/docker/plugins/myplugin` inside the `myplugin` container.
 
 Docker always searches for Unix sockets in `/run/docker/plugins` first. It checks for spec or json files under
 `/etc/docker/plugins` and `/usr/lib/docker/plugins` if the socket doesn't exist. The directory scan stops as

--- a/docs/extend/plugins_volume.md
+++ b/docs/extend/plugins_volume.md
@@ -45,7 +45,7 @@ accepts a volume name and path on the host, and the `--volume-driver` flag
 accepts a driver type.
 
 ```console
-$ docker volume create --driver=flocker volumename
+$ docker volume create --driver=myplugin volumename
 
 $ docker container run -it --volume volumename:/data busybox sh
 ```
@@ -61,11 +61,18 @@ separated by a colon (`:`) character.
 - The `Mountpoint` is the path on the host (v1) or in the plugin (v2) where the
   volume has been made available.
 
-### `volumedriver`
+### `--volume-driver`
 
-Specifying a `volumedriver` in conjunction with a `volumename` allows you to
-use plugins such as [Flocker](https://github.com/ScatterHQ/flocker) to manage
-volumes external to a single host, such as those on EBS.
+Specifying the `--volume-driver` flag together with a volume name (using
+`--volume`) allows you to use plugins to manage volumes for the container.
+
+The `--volume-driver` flag is used as a default for all volumes created for
+the container, including anonymous volumes. Use the [`--mount`] flag with
+the [`volume-driver`] option to specify the driver to use for each volume
+individually.
+
+[`--mount`]: https://docs.docker.com/reference/cli/docker/container/run/#mount
+[`volume-driver`]: https://docs.docker.com/engine/storage/volumes/#start-a-container-which-creates-a-volume-using-a-volume-driver
 
 ## Create a VolumeDriver
 


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->
Closes #6783

**- What I did**
I removed references of the Flocker plugin from the plugin documentations.

**- How I did it**
Manually check references of this plugin throughout the codebase.

**- How to verify it**

**- Human readable description for the release notes**
<!--

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

Removed references of the EOL Flocker plugin from the plugin documentations.

```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

