### PR TITLE
cli/command/image: close ProgressReader

### DIFF
--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -315,9 +315,10 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 		buildCtx = dockerfileCtx
 	}
 
-	var body io.Reader
+	var body io.ReadCloser
 	if buildCtx != nil {
 		body = progress.NewProgressReader(buildCtx, progressOutput, 0, "", "Sending build context to Docker daemon")
+		defer func() { _ = body.Close() }()
 	}
 
 	configFile := dockerCli.ConfigFile()


### PR DESCRIPTION
progress.NewProgressReader implements io.ReadCloser. client.ImageBuild only requests an io.Reader, and there's some code in place to assert if the passed io.Reader was an io.ReadCloser, but let's make sure it's closed just in case.

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

