### PR TITLE
Fix various typos in code and documentation

### DIFF
--- a/cli-plugins/manager/error.go
+++ b/cli-plugins/manager/error.go
@@ -28,7 +28,7 @@ func (e *pluginError) Unwrap() error {
 	return e.cause
 }
 
-// MarshalText marshalls the pluginError into a textual form.
+// MarshalText marshals the pluginError into a textual form.
 func (e *pluginError) MarshalText() (text []byte, err error) {
 	return []byte(e.cause.Error()), nil
 }

--- a/cli-plugins/manager/manager.go
+++ b/cli-plugins/manager/manager.go
@@ -172,7 +172,7 @@ func ListPlugins(dockerCli config.Provider, rootcmd *cobra.Command) ([]Plugin, e
 }
 
 // PluginRunCommand returns an [os/exec.Cmd] which when [os/exec.Cmd.Run] will execute the named plugin.
-// The rootcmd argument is referenced to determine the set of builtin commands in order to detect conficts.
+// The rootcmd argument is referenced to determine the set of builtin commands in order to detect conflicts.
 // The error returned satisfies the [errdefs.IsNotFound] predicate if no plugin was found or if the first candidate plugin was invalid somehow.
 func PluginRunCommand(dockerCli config.Provider, name string, rootcmd *cobra.Command) (*exec.Cmd, error) {
 	// This uses the full original args, not the args which may

--- a/cli-plugins/manager/manager_test.go
+++ b/cli-plugins/manager/manager_test.go
@@ -89,7 +89,7 @@ func TestListPluginCandidatesEmpty(t *testing.T) {
 // Regression test for https://github.com/docker/cli/issues/5643.
 // Check that inaccessible directories that come before accessible ones are ignored
 // and do not prevent the latter from being processed.
-func TestListPluginCandidatesInaccesibleDir(t *testing.T) {
+func TestListPluginCandidatesInaccessibleDir(t *testing.T) {
 	dir := fs.NewDir(t, t.Name(),
 		fs.WithDir("no-perm", fs.WithMode(0)),
 		fs.WithDir("plugins",

--- a/cli-plugins/socket/socket.go
+++ b/cli-plugins/socket/socket.go
@@ -93,7 +93,7 @@ func (pl *PluginServer) Addr() net.Addr {
 // Close ensures that the server is no longer accepting new connections and
 // closes all existing connections. Existing connections will receive [io.EOF].
 //
-// The error value is that of the underlying [net.Listner.Close] call.
+// The error value is that of the underlying [net.Listener.Close] call.
 func (pl *PluginServer) Close() error {
 	if pl == nil {
 		return nil

--- a/cli-plugins/socket/socket_test.go
+++ b/cli-plugins/socket/socket_test.go
@@ -47,7 +47,7 @@ func TestPluginServer(t *testing.T) {
 		select {
 		case err := <-done:
 			if !errors.Is(err, io.EOF) {
-				t.Fatalf("exepcted EOF error, got: %v", err)
+				t.Fatalf("expected EOF error, got: %v", err)
 			}
 		case <-time.After(10 * time.Millisecond):
 		}

--- a/docs/reference/commandline/stack_ps.md
+++ b/docs/reference/commandline/stack_ps.md
@@ -189,14 +189,14 @@ also shows the non-truncated task IDs, and error-messages, as can be seen below:
 $ docker stack ps --no-trunc voting
 
 ID                          NAME                  IMAGE                                                                                                                 NODE   DESIRED STATE  CURREN STATE           ERROR  PORTS
-xim5bcqtgk1bxqz91jzo4a1s5   voting_worker.1       dockersamples/examplevotingapp_worker:latest@sha256:3e4ddf59c15f432280a2c0679c4fc5a2ee5a797023c8ef0d3baf7b1385e9fed   node2  Running        Runnin 32 minutes ago
-q7yik0ks1in6kv32gg6y6yjf7   voting_result.1       dockersamples/examplevotingapp_result:before@sha256:83b56996e930c292a6ae5187fda84dd6568a19d97cdb933720be15c757b7463   node1  Running        Runnin 32 minutes ago
-rx5yo0866nfxc58zf4irsss6n   voting_vote.1         dockersamples/examplevotingapp_vote:before@sha256:8e64b182c87de902f2b72321c89b4af4e2b942d76d0b772532ff27ec4c6ebf6     node3  Running        Runnin 32 minutes ago
-tz6j82jnwrx7n2offljp3mn03   voting_db.1           postgres:9.4@sha256:6046af499eae34d2074c0b53f9a8b404716d415e4a03e68bc1d2f8064f2b027                                   node1  Running        Runnin 32 minutes ago
-w48spazhbmxcmbjfi54gs7x90   voting_redis.1        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node2  Running        Runnin 32 minutes ago
-6jj1m02freg1n3z9n1evrzsbl   voting_visualizer.1   dockersamples/visualizer:stable@sha256:f924ad66c8e94b10baaf7bdb9cd491ef4e982a1d048a56a17e02bf5945401e5                node1  Running        Runnin 32 minutes ago
-kqgdmededccbhz2wuc0e9hx7g   voting_vote.2         dockersamples/examplevotingapp_vote:before@sha256:8e64b182c87de902f2b72321c89b4af4e2b942d76d0b772532ff27ec4c6ebf6     node2  Running        Runnin 32 minutes ago
-t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Runnin 32 minutes ago
+xim5bcqtgk1bxqz91jzo4a1s5   voting_worker.1       dockersamples/examplevotingapp_worker:latest@sha256:3e4ddf59c15f432280a2c0679c4fc5a2ee5a797023c8ef0d3baf7b1385e9fed   node2  Running        Running 32 minutes ago
+q7yik0ks1in6kv32gg6y6yjf7   voting_result.1       dockersamples/examplevotingapp_result:before@sha256:83b56996e930c292a6ae5187fda84dd6568a19d97cdb933720be15c757b7463   node1  Running        Running 32 minutes ago
+rx5yo0866nfxc58zf4irsss6n   voting_vote.1         dockersamples/examplevotingapp_vote:before@sha256:8e64b182c87de902f2b72321c89b4af4e2b942d76d0b772532ff27ec4c6ebf6     node3  Running        Running 32 minutes ago
+tz6j82jnwrx7n2offljp3mn03   voting_db.1           postgres:9.4@sha256:6046af499eae34d2074c0b53f9a8b404716d415e4a03e68bc1d2f8064f2b027                                   node1  Running        Running 32 minutes ago
+w48spazhbmxcmbjfi54gs7x90   voting_redis.1        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node2  Running        Running 32 minutes ago
+6jj1m02freg1n3z9n1evrzsbl   voting_visualizer.1   dockersamples/visualizer:stable@sha256:f924ad66c8e94b10baaf7bdb9cd491ef4e982a1d048a56a17e02bf5945401e5                node1  Running        Running 32 minutes ago
+kqgdmededccbhz2wuc0e9hx7g   voting_vote.2         dockersamples/examplevotingapp_vote:before@sha256:8e64b182c87de902f2b72321c89b4af4e2b942d76d0b772532ff27ec4c6ebf6     node2  Running        Running 32 minutes ago
+t72q3z038jehe1wbh9gdum076   voting_redis.2        redis:alpine@sha256:9cd405cd1ec1410eaab064a1383d0d8854d1ef74a54e1e4a92fb4ec7bdc3ee7                                   node3  Running        Running 32 minutes ago
 ```
 
 ### <a name="quiet"></a> Only display task IDs (-q, --quiet)

--- a/man/src/image/ls.md
+++ b/man/src/image/ls.md
@@ -86,7 +86,7 @@ Repository entries separated by a colon for all images:
 
     docker image ls --format "{{.ID}}: {{.Repository}}"
     77af4d6b9913: <none>
-    b6fa739cedf5: committ
+    b6fa739cedf5: commit
     78a85c484bad: ipbabble
     30557a29d5ab: docker
     5ed6274db6ce: <none>
@@ -100,7 +100,7 @@ To list all images with their repository and tag in a table format you can use:
     docker image ls --format "table {{.ID}}\t{{.Repository}}\t{{.Tag}}"
     IMAGE ID            REPOSITORY                TAG
     77af4d6b9913        <none>                    <none>
-    b6fa739cedf5        committ                   latest
+    b6fa739cedf5        commit                   latest
     78a85c484bad        ipbabble                  <none>
     30557a29d5ab        docker                    latest
     5ed6274db6ce        <none>                    <none>


### PR DESCRIPTION
Fixes #6814

  **- What I did**

  Fixed various typos in the codebase and documentation.

  **- How I did it**

  Used the `typos` CLI tool to find typos and manually verified each fix.

  **- Files changed:**

  | File | Line | Typo | Fix |
  |------|------|------|-----|
  | `cli-plugins/socket/socket_test.go` | 50 | `exepcted` | `expected` |
  | `cli-plugins/socket/socket.go` | 96 | `Listner` | `Listener` |
  | `cli-plugins/manager/error.go` | 31 | `marshalls` | `marshals` |
  | `cli-plugins/manager/manager.go` | 175 | `conficts` | `conflicts` |
  | `cli-plugins/manager/manager_test.go` | 92 | `Inaccesible` | `Inaccessible` |
  | `man/src/image/ls.md` | 89, 103 | `committ` | `commit` |
  | `docs/reference/commandline/stack_ps.md` | 192-199 | `Runnin` | `Running` (8 instances) |

  **- How to verify it**

  N/A (typo fixes)

  **- Description for the changelog**

  ```text
  typo: Fix various typos in code and documentation
  ```