### PR TITLE
fix: restore os.Args after plugin completion and fix error return

### DIFF
--- a/cli-plugins/manager/cobra.go
+++ b/cli-plugins/manager/cobra.go
@@ -45,8 +45,7 @@ func AddPluginCommandStubs(dockerCLI config.Provider, rootCmd *cobra.Command) (e
 				RunE: func(cmd *cobra.Command, args []string) error {
 					flags := rootCmd.PersistentFlags()
 					flags.SetOutput(nil)
-					perr := flags.Parse(args)
-					if perr != nil {
+					if err := flags.Parse(args); err != nil {
 						return err
 					}
 					if flags.Changed("help") {
@@ -60,7 +59,11 @@ func AddPluginCommandStubs(dockerCLI config.Provider, rootCmd *cobra.Command) (e
 					cargs := []string{p.Path, cobra.ShellCompRequestCmd, p.Name} //nolint:prealloc // no need to over-complicate things.
 					cargs = append(cargs, args...)
 					cargs = append(cargs, toComplete)
+					origArgs := os.Args
 					os.Args = cargs
+					defer func() {
+						os.Args = origArgs
+					}()
 					runCommand, runErr := PluginRunCommand(dockerCLI, p.Name, cmd)
 					if runErr != nil {
 						return nil, cobra.ShellCompDirectiveError

--- a/cli-plugins/manager/cobra_test.go
+++ b/cli-plugins/manager/cobra_test.go
@@ -1,8 +1,12 @@
 package manager
 
 import (
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/docker/cli/internal/test"
 	"github.com/spf13/cobra"
 	"gotest.tools/v3/assert"
 )
@@ -23,4 +27,59 @@ func TestPluginResourceAttributesEnvvar(t *testing.T) {
 
 	env = appendPluginResourceAttributesEnvvar(nil, cmd, Plugin{Name: "compose"})
 	assert.DeepEqual(t, []string{"OTEL_RESOURCE_ATTRIBUTES=a.b.c=foo,docker.cli.cobra.command_path=docker%20compose"}, env)
+}
+
+func TestPluginStubRunEReturnsParseError(t *testing.T) {
+	cmd, err := preparePluginStubCommand(t)
+	assert.NilError(t, err)
+
+	err = cmd.RunE(cmd, []string{"--definitely-not-a-real-flag"})
+	assert.ErrorContains(t, err, "unknown flag: --definitely-not-a-real-flag")
+}
+
+func TestPluginStubCompletionRestoresOSArgs(t *testing.T) {
+	cmd, err := preparePluginStubCommand(t)
+	assert.NilError(t, err)
+
+	savedArgs := os.Args
+	t.Cleanup(func() { os.Args = savedArgs })
+
+	originalArgs := []string{"docker", "image", "ls"}
+	os.Args = append([]string(nil), originalArgs...)
+
+	_, directive := cmd.ValidArgsFunction(cmd, []string{"--all"}, "alp")
+	assert.Equal(t, directive, cobra.ShellCompDirectiveError)
+	assert.DeepEqual(t, os.Args, originalArgs)
+}
+
+func preparePluginStubCommand(t *testing.T) (*cobra.Command, error) {
+	t.Helper()
+	pluginCommandStubsOnce = sync.Once{}
+
+	tmpDir := t.TempDir()
+	const cliPlugin = `#!/bin/sh
+printf '%s' '{"SchemaVersion":"0.1.0"}'
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "docker-testplugin"), []byte(cliPlugin), 0o777); err != nil {
+		return nil, err
+	}
+
+	cli := test.NewFakeCli(nil)
+	cli.ConfigFile().CLIPluginsExtraDirs = []string{tmpDir}
+
+	root := &cobra.Command{Use: "docker"}
+	root.PersistentFlags().Bool("debug", false, "")
+
+	if err := AddPluginCommandStubs(cli, root); err != nil {
+		return nil, err
+	}
+
+	cmd, _, err := root.Find([]string{"testplugin"})
+	if err != nil {
+		return nil, err
+	}
+	if cmd == nil {
+		return nil, os.ErrNotExist
+	}
+	return cmd, nil
 }


### PR DESCRIPTION
**- What I did**

Fix two issues in the plugin manager:

1. Fix error return value: The plugin stub was returning the wrong error variable when flag parsing failed
2. Restore os.Args after plugin completion: The global os.Args was being modified during plugin completion but not restored, which could cause side effects in subsequent code

**- How I did it**

1. Changed the error return from `err` to `perr` when flag parsing fails
2. Added code to save the original `os.Args` before modification and use `defer` to restore it
3. Added comprehensive tests to verify both fixes

**- Files changed:**

| File | Change |
|------|--------|
| `cli-plugins/manager/cobra.go` | Fix error return + restore os.Args |
| `cli-plugins/manager/cobra_test.go` | Add regression tests |

**- How to verify it**

The new tests verify both scenarios.

**- Description for the changelog**

```text
Fix os.Args restoration and error handling in plugin manager
```

Fixes #6816