### PR TITLE
scripts/warn-outside-container: fix font representation

### DIFF
--- a/scripts/warn-outside-container
+++ b/scripts/warn-outside-container
@@ -10,16 +10,15 @@ if [ -z "${DISABLE_WARN_OUTSIDE_CONTAINER:-}" ]; then
 				;;
 			*)
 				(
-						echo
-						echo "\033[1mWARNING\033[0m: you are not in a container."
-						echo
-						echo 'Use "\033[1mmake dev\033[0m" to start an interactive development container,'
-						echo "use \"\033[1mmake -f docker.Makefile $target\033[0m\" to execute this target"
-						echo "in a container, or set \033[1mDISABLE_WARN_OUTSIDE_CONTAINER=1\033[0m to"
-						echo "disable this warning."
-						echo
-						echo "Press \033[1mCtrl+C\033[0m now to abort, or wait for the script to continue.."
-						echo
+						printf "\n"
+						printf "\033[1mWARNING\033[0m: you are not in a container.\n"
+						printf "\n"
+						printf 'Use "\033[1mmake dev\033[0m" to start an interactive development container,\n'
+						printf 'use "\033[1mmake -f docker.Makefile %s\033[0m" to execute this target\n' "$target"
+						printf "in a container, or set \033[1mDISABLE_WARN_OUTSIDE_CONTAINER=1\033[0m to\n"
+						printf "disable this warning.\n"
+						printf "\n"
+						printf "Press \033[1mCtrl+C\033[0m now to abort, or wait for the script to continue..\n"
 				) >&2
 				sleep 5
 				;;


### PR DESCRIPTION
- supersedes, closes https://github.com/docker/cli/pull/4211


Fixed font display in /scripts/warn-outside-container by replacing echo with POSIX-compatible prinf so that display works on any POSIX-compatible systems.

Fixes #6838 

<img width="528" height="600" alt="image" src="https://github.com/user-attachments/assets/a03640ff-cac5-4e22-b38c-3adff0a566ac" />
