### PR TITLE
docs: clarify docker context use affects all terminal sessions

### DIFF
--- a/cli/command/context/use.go
+++ b/cli/command/context/use.go
@@ -13,7 +13,7 @@ import (
 func newUseCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "use CONTEXT",
-		Short: "Set the current docker context",
+		Short: "Set the default docker context",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]

--- a/docs/reference/commandline/context.md
+++ b/docs/reference/commandline/context.md
@@ -15,7 +15,7 @@ Manage contexts
 | [`rm`](context_rm.md)           | Remove one or more contexts                                       |
 | [`show`](context_show.md)       | Print the name of the current context                             |
 | [`update`](context_update.md)   | Update a context                                                  |
-| [`use`](context_use.md)         | Set the current docker context                                    |
+| [`use`](context_use.md)         | Set the default docker context                                    |
 
 
 

--- a/docs/reference/commandline/context_use.md
+++ b/docs/reference/commandline/context_use.md
@@ -1,13 +1,63 @@
 # context use
 
 <!---MARKER_GEN_START-->
-Set the current docker context
+Set the default docker context
 
 
 <!---MARKER_GEN_END-->
 
 ## Description
 
-Set the default context to use, when `DOCKER_HOST`, `DOCKER_CONTEXT` environment
-variables and `--host`, `--context` global options aren't set.
-To disable usage of contexts, you can use the special `default` context.
+The `docker context use` command sets the default context for the Docker CLI.
+
+The `docker context use` command sets the Docker CLI’s default context by updating
+your CLI config (`~/.docker/config.json`). This change is persistent, affecting
+all shells and sessions that share that config, not just the current terminal.
+
+For one-off commands or per-shell usage, use `--context` or the `DOCKER_CONTEXT`
+environment variable instead.
+
+## Examples
+
+### Set the default (sticky) context
+
+This updates the CLI configuration and applies to new terminal sessions:
+
+```bash
+$ docker context use my-context
+my-context
+
+$ docker context show
+my-context
+```
+
+### Use a context for a single command
+
+Use the global `--context` flag to avoid changing the default:
+
+```bash
+$ docker --context my-context ps
+```
+
+### Use a context for the current shell session
+
+Set `DOCKER_CONTEXT` to override the configured default in the current shell:
+
+```bash
+$ export DOCKER_CONTEXT=my-context
+$ docker context show
+my-context
+```
+
+To stop overriding:
+
+```bash
+$ unset DOCKER_CONTEXT
+```
+
+### Switch back to the default context
+
+```bash
+$ docker context use default
+default
+```


### PR DESCRIPTION
Fixes #3064

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**
Clarified the behavior of `docker context use` in the CLI documentation.
The docs now explicitly mention that this command updates the Docker CLI configuration and therefore changes the default context globally (affecting all terminal sessions).

Added examples showing how to temporarily select a context using:
- the `DOCKER_CONTEXT` environment variable
- the `--context` flag for individual commands

**- How I did it**

Updated the documentation file:

docs/reference/commandline/context_use.md

Added explanation that `docker context use` modifies the CLI config and is therefore "sticky". Also added examples demonstrating safer alternatives for temporary context selection.


**- How to verify it**
1. Open the updated documentation page:
   docs/reference/commandline/context_use.md

2. Confirm the description explains that:
   - `docker context use` modifies the CLI config
   - the change affects all terminal sessions

3. Confirm examples exist for:
   - `docker --context <context>`
   - `export DOCKER_CONTEXT=<context>`
   
**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the section below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

![554131-istock-157135312-header](https://github.com/user-attachments/assets/7edd1d2c-f775-4c8f-994f-8641365c30eb)
