### PR TITLE
vendor: github.com/moby/moby/api v1.54.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -29,7 +29,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.20
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/api v1.54.0
-	github.com/moby/moby/client v0.2.3-rc.1
+	github.com/moby/moby/client v0.3.0
 	github.com/moby/patternmatcher v0.6.0
 	github.com/moby/swarmkit/v2 v2.1.1
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/vendor.sum
+++ b/vendor.sum
@@ -115,8 +115,8 @@ github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/moby/api v1.54.0 h1:7kbUgyiKcoBhm0UrWbdrMs7RX8dnwzURKVbZGy2GnL0=
 github.com/moby/moby/api v1.54.0/go.mod h1:8mb+ReTlisw4pS6BRzCMts5M49W5M7bKt1cJy/YbAqc=
-github.com/moby/moby/client v0.2.3-rc.1 h1:EJU7m5WunbgLw8ufo6TIxiLEpqXvBSzHhjXl9Z1B5jo=
-github.com/moby/moby/client v0.2.3-rc.1/go.mod h1:b3+CF2Ln9mr96ROGGjWx8cnVvkVBcOo69OoeIsralw0=
+github.com/moby/moby/client v0.3.0 h1:UUGL5okry+Aomj3WhGt9Aigl3ZOxZGqR7XPo+RLPlKs=
+github.com/moby/moby/client v0.3.0/go.mod h1:HJgFbJRvogDQjbM8fqc1MCEm4mIAGMLjXbgwoZp6jCQ=
 github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
 github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/swarmkit/v2 v2.1.1 h1:yvTJ8MMCc3f0qTA44J6R59EZ5yZawdYopkpuLk4+ICU=

--- a/vendor/github.com/moby/moby/client/client.go
+++ b/vendor/github.com/moby/moby/client/client.go
@@ -179,10 +179,7 @@ func NewClientWithOpts(ops ...Opt) (*Client, error) {
 // [WithAPIVersionFromEnv] to configure the client with a fixed API version
 // and disable API version negotiation.
 //
-//	cli, err := client.New(
-//		client.FromEnv,
-//		client.WithAPIVersionNegotiation(),
-//	)
+//	cli, err := client.New(client.FromEnv)
 func New(ops ...Opt) (*Client, error) {
 	hostURL, err := ParseHostURL(DefaultDockerHost)
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/moby/moby/api/types/storage
 github.com/moby/moby/api/types/swarm
 github.com/moby/moby/api/types/system
 github.com/moby/moby/api/types/volume
-# github.com/moby/moby/client v0.2.3-rc.1
+# github.com/moby/moby/client v0.3.0
 ## explicit; go 1.24.0
 github.com/moby/moby/client
 github.com/moby/moby/client/internal


### PR DESCRIPTION
### vendor: github.com/moby/moby/api v1.54.0

  full diff: https://github.com/moby/moby/compare/api/v1.54.0-rc.1...api/v1.54.0



### vendor: github.com/moby/moby/client v0.3.0

  full diff: https://github.com/moby/moby/compare/client/v0.2.3-rc.1...client/v0.3.0