### PR TITLE
cli/config/configfile: normalize hostname when resolving auth

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -194,8 +194,7 @@ func RetrieveAuthTokenFromImage(cfg *configfile.ConfigFile, image string) (strin
 	if err != nil {
 		return "", err
 	}
-	configKey := getAuthConfigKey(reference.Domain(registryRef))
-	authConfig, err := cfg.GetAuthConfig(configKey)
+	authConfig, err := cfg.GetAuthConfig(reference.Domain(registryRef))
 	if err != nil {
 		return "", err
 	}
@@ -210,19 +209,4 @@ func RetrieveAuthTokenFromImage(cfg *configfile.ConfigFile, image string) (strin
 		IdentityToken: authConfig.IdentityToken,
 		RegistryToken: authConfig.RegistryToken,
 	})
-}
-
-// getAuthConfigKey special-cases using the full index address of the official
-// index as the AuthConfig key, and uses the (host)name[:port] for private indexes.
-//
-// It is similar to [registry.GetAuthConfigKey], but does not require on
-// [registrytypes.IndexInfo] as intermediate.
-//
-// [registry.GetAuthConfigKey]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/registry#GetAuthConfigKey
-// [registrytypes.IndexInfo]: https://pkg.go.dev/github.com/docker/docker@v28.3.3+incompatible/api/types/registry#IndexInfo
-func getAuthConfigKey(domainName string) string {
-	if domainName == "docker.io" || domainName == "index.docker.io" {
-		return authConfigKey
-	}
-	return domainName
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -20,6 +20,34 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// authConfigKey is the key used to store credentials for Docker Hub. It is
+// a copy of [registry.IndexServer].
+//
+// [registry.IndexServer]: https://pkg.go.dev/github.com/docker/docker@v28.5.1+incompatible/registry#IndexServer
+const authConfigKey = "https://index.docker.io/v1/"
+
+// getAuthConfigKey returns the canonical key used to look up stored
+// registry credentials for the given registry domain.
+//
+// For the official Docker Hub registry ("docker.io"), credentials are stored
+// under the historical full index address ("https://index.docker.io/v1/").
+//
+// For all other registries, the input is domainName to already be a normalized
+// hostname (optionally including ":port") and is returned unchanged.
+//
+// This function performs key normalization only; it does not validate or parse
+// the input.
+//
+// It is similar to [registry.GetAuthConfigKey] in the daemon.
+//
+// [registry.GetAuthConfigKey]: https://pkg.go.dev/github.com/docker/docker@v28.5.1+incompatible/registry#GetAuthConfigKey
+func getAuthConfigKey(domainName string) string {
+	if domainName == "docker.io" || domainName == "index.docker.io" {
+		return authConfigKey
+	}
+	return domainName
+}
+
 // ConfigFile ~/.docker/config.json file info
 type ConfigFile struct {
 	AuthConfigs          map[string]types.AuthConfig  `json:"auths"`
@@ -293,7 +321,7 @@ func decodeAuth(authStr string) (string, string, error) {
 func (configFile *ConfigFile) GetCredentialsStore(registryHostname string) credentials.Store {
 	store := credentials.NewFileStore(configFile)
 
-	if helper := getConfiguredCredentialStore(configFile, registryHostname); helper != "" {
+	if helper := getConfiguredCredentialStore(configFile, getAuthConfigKey(registryHostname)); helper != "" {
 		store = newNativeStore(configFile, helper)
 	}
 
@@ -358,7 +386,8 @@ var newNativeStore = func(configFile *ConfigFile, helperSuffix string) credentia
 
 // GetAuthConfig for a repository from the credential store
 func (configFile *ConfigFile) GetAuthConfig(registryHostname string) (types.AuthConfig, error) {
-	return configFile.GetCredentialsStore(registryHostname).Get(registryHostname)
+	acKey := getAuthConfigKey(registryHostname)
+	return configFile.GetCredentialsStore(acKey).Get(acKey)
 }
 
 // getConfiguredCredentialStore returns the credential helper configured for the


### PR DESCRIPTION
Previously, normalization was done before calling these functions, which required implementations to normalize before using.

Move the normalization into the GetAuthConfig, GetCredentialsStore, so that non-normalized hostnames will be able to resolve the correct auth.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
cli/config/configfile: `GetAuthConfig`, `GetCredentialsStore`: normalize hostname when resolving auth
```

**- A picture of a cute animal (not mandatory but encouraged)**

