### PR TITLE
cli/command: add missing "go:build" comments

### DIFF
--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -1,4 +1,4 @@
-// FIXME(vvoland): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
 //go:build go1.24
 
 package container

--- a/cli/command/container/tty.go
+++ b/cli/command/container/tty.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.24
+
 package container
 
 import (

--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -1,3 +1,6 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.24
+
 package progress
 
 import (


### PR DESCRIPTION
- fixes https://github.com/docker/cli/issues/6852
- fixes https://github.com/docker/cli/issues/6877
- relates to https://github.com/docker/cli/pull/6791
- relates to https://github.com/docker/cli/pull/4723

### cli/command: add missing "go:build" comments

- commit e8dc2fce32f2b0cfc6e5e04599bcdab363dbc022 modernized loops to range over int, which requires go1.22 or later.
- commit 85ebca52fd8d711dc0303e6872392bb2b03e0bea modernized code to use stdlib min/max, which requires go1.21 or later.


**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: Add missing build-tag, which could cause `cannot range over 10 (untyped int constant)`  when importing the `cli/command` package.
```

**- A picture of a cute animal (not mandatory but encouraged)**

