### PR TITLE
Add linux/riscv64 to bin-image-cross release target

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -190,6 +190,7 @@ target "bin-image-cross" {
     "linux/arm/v7",
     "linux/arm64",
     "linux/ppc64le",
+    "linux/riscv64",
     "linux/s390x",
     "windows/amd64",
     "windows/arm64"


### PR DESCRIPTION
**- What I did**

Added `linux/riscv64` to the `bin-image-cross` target's platform list in `docker-bake.hcl`, so that official release images include riscv64 binaries.

**- How I did it**

One-line addition to `docker-bake.hcl`. `linux/riscv64` is already present in the `_platforms` variable (line 38) and used by the `cross`, `dynbinary-cross`, and `plugins-cross` targets — CI already builds riscv64 binaries. They are simply excluded from the release image because `bin-image-cross` has its own hardcoded platform list.

**- How to verify it**

1. Run `docker buildx bake bin-image-cross --print` and confirm `linux/riscv64` appears in the platforms list
2. All other Docker stack components already ship riscv64 release binaries: [runc](https://github.com/opencontainers/runc/releases) (since v1.1.8), [containerd](https://github.com/containerd/containerd/releases) (v2.2.2), [BuildKit](https://github.com/moby/buildkit/releases) (v0.28.0), [BuildX](https://github.com/docker/buildx/releases) (v0.32.1), [Compose](https://github.com/docker/compose/releases) (v5.1.0)
3. I maintain [docker-for-riscv64](https://github.com/gounthar/docker-for-riscv64) which has shipped Docker CLI riscv64 binaries across 117+ releases, tested on native hardware (BananaPi F3, SpacemiT K1, rv64gc, Debian Trixie)

**- Human readable description for the release notes**

```markdown changelog
```

**- A picture of a cute animal (not mandatory but encouraged)**

🐧 (a riscv penguin)

Closes #6857