### PR TITLE
fix(cmd/docker): prevent race between force-exit goroutine and plugin wait

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -344,6 +344,12 @@ func tryPluginRun(ctx context.Context, dockerCli command.Cli, cmd *cobra.Command
 	// notify the plugin via the PluginServer (or signal) as appropriate.
 	const exitLimit = 2
 
+	// forceExitCh is closed by the signal goroutine just before it SIGKILLs
+	// the plugin. The main goroutine checks this after plugincmd.Run() returns
+	// and owns the final os.Exit(1) call, keeping exit-code ownership in one
+	// place and avoiding a race between two concurrent os.Exit calls.
+	forceExitCh := make(chan struct{})
+
 	tryTerminatePlugin := func(force bool) {
 		// If stdin is a TTY, the kernel will forward
 		// signals to the subprocess because the shared
@@ -368,12 +374,12 @@ func tryPluginRun(ctx context.Context, dockerCli command.Cli, cmd *cobra.Command
 
 		// force the process to terminate if it hasn't already
 		if force {
+			// Close forceExitCh before Kill so the channel is guaranteed
+			// to be closed by the time plugincmd.Run() returns: the plugin
+			// can only exit after Kill() delivers SIGKILL, and Run() only
+			// returns after the process is reaped.
+			close(forceExitCh)
 			_ = plugincmd.Process.Kill()
-			_, _ = fmt.Fprint(dockerCli.Err(), "got 3 SIGTERM/SIGINTs, forcefully exiting\n")
-
-			// Restore terminal in case it was in raw mode.
-			restoreTerminal(dockerCli)
-			os.Exit(1)
 		}
 	}
 
@@ -397,10 +403,28 @@ func tryPluginRun(ctx context.Context, dockerCli command.Cli, cmd *cobra.Command
 				force = true
 			}
 			tryTerminatePlugin(force)
+			if force {
+				// Plugin has been killed; return to prevent further
+				// loop iterations from calling close(forceExitCh) again.
+				return
+			}
 		}
 	}()
 
 	if err := plugincmd.Run(); err != nil {
+		select {
+		case <-forceExitCh:
+			// We force-killed the plugin after 3 signals. Print the message
+			// and exit here so that exit-code ownership stays in the main
+			// goroutine and we avoid a race with any concurrent os.Exit call.
+			// Note: the deferred srv.Close() is already called by tryTerminatePlugin
+			// before forceExitCh is closed, so skipping it here is safe.
+			_, _ = fmt.Fprint(dockerCli.Err(), "got 3 SIGTERM/SIGINTs, forcefully exiting\n")
+			restoreTerminal(dockerCli)
+			os.Exit(1) //nolint:gocritic // exitAfterDefer: srv.Close() already called above
+		default:
+		}
+
 		statusCode := 1
 		exitErr, ok := err.(*exec.ExitError)
 		if !ok {


### PR DESCRIPTION
## Summary

- Fixes a race condition in `tryPluginRun` where two goroutines could both call `os.Exit` with different exit codes when force-killing a plugin after 3 SIGINT/SIGTERM signals
- Moves `os.Exit(1)` ownership to the main goroutine; the signal goroutine now only closes a channel and calls `Kill()`
- Adds a `return` after the force-kill to prevent additional signals from causing a `close` on an already-closed channel (panic)

**Root cause**: when a plugin ignored context cancellation and 3 SIGINTs were sent, the signal goroutine called `plugincmd.Process.Kill()` then `os.Exit(1)`. On a loaded runner, `plugincmd.Run()` in the main goroutine could return first — the SIGKILL'd plugin has `ws.ExitStatus() = -1`, leading to `os.Exit(-1)` = exit code **255** instead of **1**.

**Fix**: `forceExitCh` is closed before `Kill()`. Since the plugin can only die after SIGKILL is delivered and `Run()` only returns after the process is reaped, `forceExitCh` is guaranteed to be closed before `Run()` returns in the force-kill path. The main goroutine checks the channel and owns `os.Exit(1)`.

## Test plan

- [ ] Existing test `TestPluginSocketCommunication/detached/the_main_CLI_exits_after_3_signals` covers the fixed race — was flaky (exit code 255) on loaded CI runners with RC Docker on Alpine; should now be reliable
- [ ] No new tests required: the fix is a concurrency correctness change to existing behaviour with existing test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)