### PR TITLE
docs: fix grammar in run reference

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1222,7 +1222,7 @@ starting a container, you can override the `USER` instruction by passing the
 -u="", --user="": Sets the username or UID used and optionally the groupname or GID for the specified command.
 ```
 
-The followings examples are all valid:
+The following examples are all valid:
 
 ```text
 --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]


### PR DESCRIPTION
**- What I did**

- Fixed the sentence "The followings examples are all valid" to "The following examples are all valid" in `docs/reference/run.md`.

**- How I did it**

- Updated the wording in the run reference without changing behavior.

**- How to verify it**

- Review the rendered sentence in `docs/reference/run.md`.
- No code paths changed.

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
