### PR TITLE
docs: clarify multiple --filter behavior in prune commands

### DIFF
--- a/docs/reference/commandline/container_prune.md
+++ b/docs/reference/commandline/container_prune.md
@@ -35,7 +35,19 @@ Total reclaimed space: 212 B
 ### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
-than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`).
+
+When multiple filters are provided, they are combined as follows:
+
+- Multiple filters with **different keys** are combined using AND logic.
+  A container must satisfy all filter conditions to be pruned.
+- Multiple filters with the **same key** are combined using OR logic.
+  A container is pruned if it matches any of the values for that key.
+
+For example, `--filter "label=foo" --filter "until=24h"` prunes containers
+that have the `foo` label **and** were created more than 24 hours ago.
+Conversely, `--filter "label=foo" --filter "label=bar"` prunes containers
+that have **either** the `foo` **or** `bar` label.
 
 The currently supported filters are:
 

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -58,7 +58,19 @@ Total reclaimed space: 16.43 MB
 ### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
-than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`).
+
+When multiple filters are provided, they are combined as follows:
+
+- Multiple filters with **different keys** are combined using AND logic.
+  An image must satisfy all filter conditions to be pruned.
+- Multiple filters with the **same key** are combined using OR logic.
+  An image is pruned if it matches any of the values for that key.
+
+For example, `--filter "label=foo" --filter "until=24h"` prunes images
+that have the `foo` label **and** were created more than 24 hours ago.
+Conversely, `--filter "label=foo" --filter "label=bar"` prunes images
+that have **either** the `foo` **or** `bar` label.
 
 The currently supported filters are:
 

--- a/docs/reference/commandline/network_prune.md
+++ b/docs/reference/commandline/network_prune.md
@@ -33,7 +33,19 @@ n2
 ### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
-than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`).
+
+When multiple filters are provided, they are combined as follows:
+
+- Multiple filters with **different keys** are combined using AND logic.
+  A network must satisfy all filter conditions to be pruned.
+- Multiple filters with the **same key** are combined using OR logic.
+  A network is pruned if it matches any of the values for that key.
+
+For example, `--filter "label=foo" --filter "until=24h"` prunes networks
+that have the `foo` label **and** were created more than 24 hours ago.
+Conversely, `--filter "label=foo" --filter "label=bar"` prunes networks
+that have **either** the `foo` **or** `bar` label.
 
 The currently supported filters are:
 

--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -97,7 +97,19 @@ Total reclaimed space: 13.5 MB
 ### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
-than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`).
+
+When multiple filters are provided, they are combined as follows:
+
+- Multiple filters with **different keys** are combined using AND logic.
+  An item must satisfy all filter conditions to be pruned.
+- Multiple filters with the **same key** are combined using OR logic.
+  An item is pruned if it matches any of the values for that key.
+
+For example, `--filter "label=foo" --filter "until=24h"` prunes items
+that have the `foo` label **and** were created more than 24 hours ago.
+Conversely, `--filter "label=foo" --filter "label=bar"` prunes items
+that have **either** the `foo` **or** `bar` label.
 
 The currently supported filters are:
 

--- a/docs/reference/commandline/volume_prune.md
+++ b/docs/reference/commandline/volume_prune.md
@@ -39,7 +39,19 @@ Use the `--all` flag to prune both unused anonymous and named volumes.
 ### <a name="filter"></a> Filtering (--filter)
 
 The filtering flag (`--filter`) format is of "key=value". If there is more
-than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`)
+than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "bif=baz"`).
+
+When multiple filters are provided, they are combined as follows:
+
+- Multiple filters with **different keys** are combined using AND logic.
+  A volume must satisfy all filter conditions to be pruned.
+- Multiple filters with the **same key** are combined using OR logic.
+  A volume is pruned if it matches any of the values for that key.
+
+For example, `--filter "label=foo" --filter "label=bar"` prunes volumes that
+have **either** the `foo` **or** `bar` label, while
+`--filter "label=foo" --filter "label!=bar"` prunes volumes that have the
+`foo` label **and** do not have the `bar` label.
 
 The currently supported filters are:
 


### PR DESCRIPTION
## Summary

- Adds documentation clarifying how multiple `--filter` flags interact in all prune commands (container, image, network, system, volume)
- Different filter keys (e.g., `--filter "label=foo" --filter "until=24h"`) are combined using **AND** logic: an item must satisfy all conditions to be pruned
- Multiple values for the same filter key (e.g., `--filter "label=foo" --filter "label=bar"`) are combined using **OR** logic: an item is pruned if it matches any of the values
- Includes concrete examples for each prune command to illustrate the behavior

This behavior is confirmed by the `Filters` type definition in the Docker client library, which documents: "A filter term is satisfied if any one of the values in the set is a match. An item matches the filters when all terms are satisfied."

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify the documented AND/OR behavior matches the `Filters` type contract in `vendor/github.com/moby/moby/client/filters.go`

Closes #5899