### PR TITLE
docs: fix typo in run reference examples

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1222,7 +1222,7 @@ starting a container, you can override the `USER` instruction by passing the
 -u="", --user="": Sets the username or UID used and optionally the groupname or GID for the specified command.
 ```
 
-The followings examples are all valid:
+The following examples are all valid:
 
 ```text
 --user=[ user | user:group | uid | uid:gid | user:gid | uid:group ]


### PR DESCRIPTION
**- What I did**

- Fixed the `followings` typo in the `docker run` reference examples sentence.
- Related issue: N/A (trivial docs typo fix).
- Guideline alignment: docs-only change in a single source docs file with no behavior changes.

**- How I did it**

- Replaced `followings` with `following` in `docs/reference/run.md`.

**- How to verify it**

- Confirm the sentence now reads `The following examples are all valid:`.
- Not run locally; this is a docs-only wording change.

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

N/A
