### PR TITLE
cli/streams: Out, In: preserve original os.File when available

### DIFF
--- a/cli/streams/in.go
+++ b/cli/streams/in.go
@@ -3,6 +3,7 @@ package streams
 import (
 	"errors"
 	"io"
+	"os"
 
 	"github.com/moby/term"
 )
@@ -14,7 +15,8 @@ type In struct {
 	cs commonStream
 }
 
-// NewIn returns a new [In] from an [io.ReadCloser].
+// NewIn returns a new [In] from an [io.ReadCloser]. If in is an [*os.File],
+// a reference is kept to the file, and accessible through [In.File].
 func NewIn(in io.ReadCloser) *In {
 	return &In{
 		in: in,
@@ -25,6 +27,13 @@ func NewIn(in io.ReadCloser) *In {
 // FD returns the file descriptor number for this stream.
 func (i *In) FD() uintptr {
 	return i.cs.fd
+}
+
+// File returns the underlying *os.File if the stream was constructed from one.
+// If the stream was created from a non-file (e.g., a pipe, buffer, or wrapper),
+// the returned boolean will be false.
+func (i *In) File() (*os.File, bool) {
+	return i.cs.file()
 }
 
 // Read implements the [io.Reader] interface.

--- a/cli/streams/out.go
+++ b/cli/streams/out.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"io"
+	"os"
 
 	"github.com/moby/term"
 )
@@ -14,7 +15,8 @@ type Out struct {
 	cs  commonStream
 }
 
-// NewOut returns a new [Out] from an [io.Writer].
+// NewOut returns a new [Out] from an [io.Writer]. If out is an [*os.File],
+// a reference is kept to the file, and accessible through [Out.File].
 func NewOut(out io.Writer) *Out {
 	return &Out{
 		out: out,
@@ -25,6 +27,13 @@ func NewOut(out io.Writer) *Out {
 // FD returns the file descriptor number for this stream.
 func (o *Out) FD() uintptr {
 	return o.cs.FD()
+}
+
+// File returns the underlying *os.File if the stream was constructed from one.
+// If the stream was created from a non-file (e.g., a pipe, buffer, or wrapper),
+// the returned boolean will be false.
+func (o *Out) File() (*os.File, bool) {
+	return o.cs.file()
 }
 
 // Write writes to the output stream.

--- a/cli/streams/stream.go
+++ b/cli/streams/stream.go
@@ -11,14 +11,21 @@ import (
 )
 
 func newCommonStream(stream any) commonStream {
+	var f *os.File
+	if v, ok := stream.(*os.File); ok {
+		f = v
+	}
+
 	fd, tty := term.GetFdInfo(stream)
 	return commonStream{
+		f:   f,
 		fd:  fd,
 		tty: tty,
 	}
 }
 
 type commonStream struct {
+	f     *os.File
 	fd    uintptr
 	tty   bool
 	state *term.State
@@ -26,6 +33,9 @@ type commonStream struct {
 
 // FD returns the file descriptor number for this stream.
 func (s *commonStream) FD() uintptr { return s.fd }
+
+// file returns the underlying *os.File if the stream was constructed from one.
+func (s *commonStream) file() (*os.File, bool) { return s.f, s.f != nil }
 
 // isTerminal returns whether this stream is connected to a terminal.
 func (s *commonStream) isTerminal() bool { return s.tty }


### PR DESCRIPTION
Preserve the original *os.File, if available, and add a File() method
    to return it did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Go SDK: cli/streams: Out, In: preserve original os.File when available
```

**- A picture of a cute animal (not mandatory but encouraged)**

