### PR TITLE
show secrets and configs details in service inspect --pretty

### DIFF
--- a/cli/command/service/formatter.go
+++ b/cli/command/service/formatter.go
@@ -129,14 +129,26 @@ Mounts:
 {{- if .Configs}}
 Configs:
 {{- range $config := .Configs }}
- Target:	{{$config.File.Name}}
+ Target:	{{ if $config.File }}{{$config.File.Name}}{{ else }}[runtime]{{ end }}
   Source:	{{$config.ConfigName}}
+  ID:		{{$config.ConfigID}}
+{{- if $config.File }}
+  UID:		{{$config.File.UID}}
+  GID:		{{$config.File.GID}}
+  Mode:		{{$config.File.Mode}}
+{{- end }}
 {{- end }}{{ end }}
 {{- if .Secrets }}
 Secrets:
 {{- range $secret := .Secrets }}
- Target:	{{$secret.File.Name}}
+ Target:	{{ if $secret.File }}{{$secret.File.Name}}{{ else }}[runtime]{{ end }}
   Source:	{{$secret.SecretName}}
+  ID:		{{$secret.SecretID}}
+{{- if $secret.File }}
+  UID:		{{$secret.File.UID}}
+  GID:		{{$secret.File.GID}}
+  Mode:		{{$secret.File.Mode}}
+{{- end }}
 {{- end }}{{ end }}
 {{- if .HasLogDriver }}
 Log Driver:

--- a/cli/command/service/inspect_test.go
+++ b/cli/command/service/inspect_test.go
@@ -193,4 +193,58 @@ func TestPrettyPrintWithConfigsAndSecrets(t *testing.T) {
 	assert.Check(t, is.Contains(s, "Configs:"), "Pretty print missing configs")
 	assert.Check(t, is.Contains(s, "Secrets:"), "Pretty print missing secrets")
 	assert.Check(t, is.Contains(s, "Healthcheck:"), "Pretty print missing healthcheck")
+	assert.Check(t, is.Contains(s, "configtest.conf"), "Pretty print missing config name")
+	assert.Check(t, is.Contains(s, "mtc3i44r1awdoziy2iceg73z8"), "Pretty print missing config ID")
+	assert.Check(t, is.Contains(s, "secrettest.conf"), "Pretty print missing secret name")
+	assert.Check(t, is.Contains(s, "3hv39ehbbb4hdozo7spod9ftn"), "Pretty print missing secret ID")
+}
+
+func TestPrettyPrintWithRuntimeConfig(t *testing.T) {
+	b := new(bytes.Buffer)
+	endpointSpec := &swarm.EndpointSpec{Mode: "vip"}
+	two := uint64(2)
+
+	s := swarm.Service{
+		ID: "runtimeconfigservice",
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{Name: "runtime_svc"},
+			TaskTemplate: swarm.TaskSpec{
+				ContainerSpec: &swarm.ContainerSpec{
+					Image: "foo/bar:latest",
+					Configs: []*swarm.ConfigReference{
+						{
+							ConfigID:   "abc123",
+							ConfigName: "my-runtime-config",
+							Runtime:    &swarm.ConfigReferenceRuntimeTarget{},
+						},
+					},
+				},
+			},
+			Mode: swarm.ServiceMode{
+				Replicated: &swarm.ReplicatedService{Replicas: &two},
+			},
+			EndpointSpec: endpointSpec,
+		},
+		Endpoint: swarm.Endpoint{Spec: *endpointSpec},
+	}
+
+	ctx := formatter.Context{
+		Output: b,
+		Format: newFormat("pretty"),
+	}
+
+	err := inspectFormatWrite(ctx, []string{"runtimeconfigservice"},
+		func(ref string) (any, []byte, error) {
+			return s, nil, nil
+		},
+		func(ref string) (any, []byte, error) {
+			return network.Summary{}, nil, nil
+		},
+	)
+	assert.NilError(t, err)
+	output := b.String()
+	assert.Check(t, is.Contains(output, "Configs:"), "Pretty print missing configs")
+	assert.Check(t, is.Contains(output, "[runtime]"), "Pretty print should show [runtime] for configs without File target")
+	assert.Check(t, is.Contains(output, "my-runtime-config"), "Pretty print missing runtime config name")
+	assert.Check(t, is.Contains(output, "abc123"), "Pretty print missing runtime config ID")
 }

--- a/cli/command/service/testdata/service-inspect-pretty.golden
+++ b/cli/command/service/testdata/service-inspect-pretty.golden
@@ -11,9 +11,17 @@ ContainerSpec:
 Configs:
  Target:	/configtest.conf
   Source:	configtest.conf
+  ID:		mtc3i44r1awdoziy2iceg73z8
+  UID:		
+  GID:		
+  Mode:		----------
 Secrets:
  Target:	/secrettest.conf
   Source:	secrettest.conf
+  ID:		3hv39ehbbb4hdozo7spod9ftn
+  UID:		
+  GID:		
+  Mode:		----------
 Log Driver:
  Name:		driver
  LogOpts:


### PR DESCRIPTION
## summary
- show config/secret ID, UID, GID, and file mode in pretty-print output for `docker service inspect --pretty`
- handle runtime configs that have no file target without panicking (shows `[runtime]` instead)
- add test for runtime config rendering in pretty-print

## test plan
- ran full unit test suite for `cli/command/service/` - all 72 tests pass
- updated golden file for pretty-print output
- added `TestPrettyPrintWithRuntimeConfig` to verify runtime configs render correctly
- verified existing `TestPrettyPrintWithConfigsAndSecrets` still passes with new ID assertions

fixes #908