### PR TITLE
container/ps: add HealthStatus formatter field

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -21,13 +21,14 @@ import (
 const (
 	defaultContainerTableFormat = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
 
-	namesHeader      = "NAMES"
-	commandHeader    = "COMMAND"
-	runningForHeader = "CREATED"
-	mountsHeader     = "MOUNTS"
-	localVolumes     = "LOCAL VOLUMES"
-	networksHeader   = "NETWORKS"
-	platformHeader   = "PLATFORM"
+	namesHeader        = "NAMES"
+	commandHeader      = "COMMAND"
+	runningForHeader   = "CREATED"
+	mountsHeader       = "MOUNTS"
+	localVolumes       = "LOCAL VOLUMES"
+	networksHeader     = "NETWORKS"
+	platformHeader     = "PLATFORM"
+	healthStatusHeader = "HEALTH STATUS"
 )
 
 // Platform wraps a [ocispec.Platform] to implement the stringer interface.
@@ -121,6 +122,7 @@ func NewContainerContext() *ContainerContext {
 		"LocalVolumes": localVolumes,
 		"Networks":     networksHeader,
 		"Platform":     platformHeader,
+		"HealthStatus": healthStatusHeader,
 	}
 	return &containerCtx
 }
@@ -350,6 +352,35 @@ func (c *ContainerContext) Networks() string {
 	}
 
 	return strings.Join(networks, ",")
+}
+
+// HealthStatus returns the container's health status (for example, "healthy","unhealthy", or "starting").
+// If no healthcheck is configured, an empty
+// string is returned.
+func (c *ContainerContext) HealthStatus() string {
+	if c.c.Health != nil && c.c.Health.Status != "" {
+		return string(c.c.Health.Status)
+	}
+
+	// Fallback for API versions before v1.52, which include health only in Status text;
+	// see https://github.com/moby/moby/pull/50281
+	// see https://github.com/moby/moby/blob/docker-v29.4.3/daemon/container/health.go#L18-L43
+	_, health, ok := strings.Cut(c.c.Status, "(")
+	if !ok || !strings.HasSuffix(health, ")") {
+		return ""
+	}
+
+	health = strings.TrimSuffix(health, ")")
+	health = strings.TrimPrefix(health, "health: ")
+
+	switch container.HealthStatus(health) {
+	case container.Healthy, container.Unhealthy, container.Starting:
+		return health
+	case container.NoHealthcheck:
+		return ""
+	default:
+		return ""
+	}
 }
 
 // DisplayablePorts returns formatted string representing open ports of container

--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -28,6 +28,7 @@ const (
 	localVolumes     = "LOCAL VOLUMES"
 	networksHeader   = "NETWORKS"
 	platformHeader   = "PLATFORM"
+	healthCheckHeader = "HEALTHCHECK"
 )
 
 // Platform wraps a [ocispec.Platform] to implement the stringer interface.
@@ -121,6 +122,7 @@ func NewContainerContext() *ContainerContext {
 		"LocalVolumes": localVolumes,
 		"Networks":     networksHeader,
 		"Platform":     platformHeader,
+		"HealthCheck": healthCheckHeader,
 	}
 	return &containerCtx
 }
@@ -350,6 +352,27 @@ func (c *ContainerContext) Networks() string {
 	}
 
 	return strings.Join(networks, ",")
+}
+
+// HealthCheck returns the container's health status (for example, "healthy","unhealthy", or "starting").
+// If no healthcheck is configured, an empty
+// string is returned.
+func (c *ContainerContext) HealthCheck() string {
+	if c.c.Health != nil && c.c.Health.Status != "" {
+		return string(c.c.Health.Status)
+	}
+
+	// Fallback for daemons/API versions that include health only in Status text.
+	switch {
+	case strings.HasSuffix(c.c.Status, "(healthy)"):
+		return string(container.Healthy)
+	case strings.HasSuffix(c.c.Status, "(unhealthy)"):
+		return string(container.Unhealthy)
+	case strings.HasSuffix(c.c.Status, "(health: starting)"):
+		return string(container.Starting)
+	}
+
+	return ""
 }
 
 // DisplayablePorts returns formatted string representing open ports of container

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -494,6 +494,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthCheck":  "",
 			"ID":           "containerID1",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -511,6 +512,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthCheck":  "",
 			"ID":           "containerID2",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -528,6 +530,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthCheck":  "",
 			"ID":           "containerID3",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -615,6 +618,7 @@ func TestContainerBackCompat(t *testing.T) {
 		{field: "Image", expected: "docker.io/library/ubuntu"},
 		{field: "Command", expected: `"/bin/sh"`},
 		{field: "CreatedAt", expected: time.Unix(createdAtTime.Unix(), 0).String()},
+		{field: "HealthCheck", expected: ""},
 		{field: "RunningFor", expected: "12 months ago"},
 		{field: "Ports", expected: "8080/tcp"},
 		{field: "Status", expected: "running"},

--- a/cli/command/formatter/container_test.go
+++ b/cli/command/formatter/container_test.go
@@ -494,6 +494,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthStatus": "",
 			"ID":           "containerID1",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -511,6 +512,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthStatus": "",
 			"ID":           "containerID2",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -528,6 +530,7 @@ func TestContainerContextWriteJSON(t *testing.T) {
 		{
 			"Command":      `""`,
 			"CreatedAt":    expectedCreated,
+			"HealthStatus": "",
 			"ID":           "containerID3",
 			"Image":        "ubuntu",
 			"Labels":       "",
@@ -615,6 +618,7 @@ func TestContainerBackCompat(t *testing.T) {
 		{field: "Image", expected: "docker.io/library/ubuntu"},
 		{field: "Command", expected: `"/bin/sh"`},
 		{field: "CreatedAt", expected: time.Unix(createdAtTime.Unix(), 0).String()},
+		{field: "HealthStatus", expected: ""},
 		{field: "RunningFor", expected: "12 months ago"},
 		{field: "Ports", expected: "8080/tcp"},
 		{field: "Status", expected: "running"},

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -395,22 +395,22 @@ template.
 
 Valid placeholders for the Go template are listed below:
 
-| Placeholder   | Description                                                                                     |
-|:--------------|:------------------------------------------------------------------------------------------------|
-| `.ID`         | Container ID                                                                                    |
-| `.Image`      | Image ID                                                                                        |
-| `.Command`    | Quoted command                                                                                  |
-| `.CreatedAt`  | Time when the container was created.                                                            |
-| `.RunningFor` | Elapsed time since the container was started.                                                   |
-| `.Ports`      | Exposed ports.                                                                                  |
-| `.State`      | Container status (for example; "created", "running", "exited").                                 |
-| `.Status`     | Container status with details about duration and health-status.                                 |
-| `.Size`       | Container disk size.                                                                            |
-| `.Names`      | Container names.                                                                                |
-| `.Labels`     | All labels assigned to the container.                                                           |
-| `.Label`      | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
-| `.Mounts`     | Names of the volumes mounted in this container.                                                 |
-| `.Networks`   | Names of the networks attached to this container.                                               |
+| Placeholder     | Description                                                                                     |
+|:----------------|:------------------------------------------------------------------------------------------------|
+| `.ID`           | Container ID                                                                                    |
+| `.Image`        | Image ID                                                                                        |
+| `.Command`      | Quoted command                                                                                  |
+| `.CreatedAt`    | Time when the container was created.                                                            |
+| `.RunningFor`   | Elapsed time since the container was started.                                                   |
+| `.Ports`        | Exposed ports.                                                                                  |
+| `.State`        | Container status (for example; "created", "running", "exited").                                 |
+| `.Status`       | Container status with details about duration and health-status.                                 |
+| `.Size`         | Container disk size.                                                                            |
+| `.Names`        | Container names.                                                                                |
+| `.Labels`       | All labels assigned to the container.                                                           |
+| `.Label`        | Value of a specific label for this container. For example `'{{.Label "com.docker.swarm.cpu"}}'` |
+| `.Mounts`       | Names of the volumes mounted in this container.                                                 |
+| `.Networks`     | Names of the networks attached to this container.                                               |
 
 When using the `--format` option, the `ps` command will either output the data
 exactly as the template declares or, when using the `table` directive, includes

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -405,6 +405,7 @@ Valid placeholders for the Go template are listed below:
 | `.Ports`      | Exposed ports.                                                                                  |
 | `.State`      | Container status (for example; "created", "running", "exited").                                 |
 | `.Status`     | Container status with details about duration and health-status.                                 |
+| `.HealthCheck`| Container health status ("starting", "healthy", "unhealthy", or "none"; empty when unavailable).|
 | `.Size`       | Container disk size.                                                                            |
 | `.Names`      | Container names.                                                                                |
 | `.Labels`     | All labels assigned to the container.                                                           |

--- a/docs/reference/commandline/container_ls.md
+++ b/docs/reference/commandline/container_ls.md
@@ -405,6 +405,7 @@ Valid placeholders for the Go template are listed below:
 | `.Ports`        | Exposed ports.                                                                                  |
 | `.State`        | Container status (for example; "created", "running", "exited").                                 |
 | `.Status`       | Container status with details about duration and health-status.                                 |
+| `.HealthStatus` | Container health status ("starting", "healthy", "unhealthy"; empty when unavailable).           |
 | `.Size`         | Container disk size.                                                                            |
 | `.Names`        | Container names.                                                                                |
 | `.Labels`       | All labels assigned to the container.                                                           |


### PR DESCRIPTION
**- What I did**

Added a new `docker ps --format` placeholder: `.HealthStatus`, so users can print container health state directly as a dedicated field.

- Fixes #6203
- relates to https://github.com/moby/moby/pull/50281

**- How I did it**

- Added `HealthStatus()` to the container formatter context.
- Returned health directly from `c.c.Health.Status` when available.
- Added fallback parsing from `.Status` text for:
  - `(healthy)` -> `healthy`
  - `(unhealthy)` -> `unhealthy`
  - `(health: starting)` -> `starting`
- Updated docs in `docs/reference/commandline/container_ls.md` to include `.HealthStatus` in the format placeholders table.
- Added/updated unit tests in `cli/command/formatter/container_test.go`.

**- How to verify it**

1. Start dev shell:
   ```bash
   make -f docker.Makefile shell
   ```

2. Build the CLI binary:
   ```bash
   make binary
   ```

3. Run a container that stays in `starting` during the start period:
   ```bash
   docker rm -f hc-starting 2>/dev/null || true

   ./build/docker-linux-amd64 run -d --name hc-starting \
     --health-cmd='exit 1' \
     --health-start-period=2m \
     --health-interval=5s \
     --health-retries=1 \
     alpine sh -c 'sleep 300'
   ```

4. Verify formatter output:
   ```bash
   ./build/docker-linux-amd64 ps -a --filter name=hc-starting --format "table {{.Names}}\t{{.Status}}\t{{.HealthStatus}}"
   ```

Expected result:
- `STATUS` contains `(health: starting)`
- `HEALTHSTATUS` shows `starting`

**- Human readable description for the release notes**

```markdown changelog
`docker ps --format` now supports a `.HealthStatus` placeholder to print container health state (`starting`, `healthy`, `unhealthy`) as a dedicated field.
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img src="https://img.freepik.com/free-vector/cute-dolphin-cartoon-illustration_138676-3212.jpg?ga=GA1.1.1909937445.1776049133&semt=ais_hybrid&w=740&q=80"></img>

