### PR TITLE
docs: fix reuse wording in image build docs

### DIFF
--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -113,7 +113,7 @@ COPY failed: forbidden path outside the build context: ../../some-dir ()
 ```
 
 BuildKit on the other hand strips leading relative paths that traverse outside
-of the build context. Re-using the previous example, the path `COPY
+of the build context. Reusing the previous example, the path `COPY
 ../../some-dir .` evaluates to `COPY some-dir .` with BuildKit.
 
 ## Examples


### PR DESCRIPTION
## Summary

Fix the wording in the image build docs by changing `Re-using` to `Reusing`.

## Related issue

N/A, trivial docs wording fix.

## Guideline alignment

Single-file documentation-only change with no behavior impact.

## Validation/testing note

Not run; docs-only change.