### PR TITLE
docs: fix storage driver wording

### DIFF
--- a/man/src/volume.md
+++ b/man/src/volume.md
@@ -1,5 +1,5 @@
 The `docker volume` command has subcommands for managing data volumes. A data
-volume is a specially-designated directory that by-passes storage driver
+volume is a specially-designated directory that bypasses storage driver
 management.
 
 Data volumes persist data independent of a container's life cycle. When you


### PR DESCRIPTION
**- What I did**

Fixed a typo in `man/src/volume.md` by changing `by-passes` to `bypasses`.

**- How I did it**

Updated one wording-only line in the volume command documentation.

**- How to verify it**

Review the sentence in `man/src/volume.md`; no behavior changes or command output changes are involved.

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

Not included.
