### PR TITLE
docs: fix --add-host example to work in a single terminal session

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1291,12 +1291,8 @@ example runs an HTTP server that serves a file from host to container over the
 `host.docker.internal` hostname, which resolves to the host's internal IP.
 
 ```console
-$ echo "hello from host!" > ./hello
-$ python3 -m http.server 8000
-Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
-$ docker run \
-  --add-host host.docker.internal=host-gateway \
-  curlimages/curl -s host.docker.internal:8000/hello
+$ printf 'HTTP/1.1 200 OK\r\n\r\nhello from host!\n' | nc -l 8000 & disown
+$ docker run --add-host host.docker.internal=host-gateway curlimages/curl -s host.docker.internal:8000
 hello from host!
 ```
 


### PR DESCRIPTION
## Problem

The current `--add-host` example in the `container_run.md` docs uses `python3 -m http.server 8000` which runs in the foreground, blocking the terminal. The user cannot run the subsequent `docker run` command in the same session. This was reported in #5558.

## Solution

Replace the Python HTTP server with `nc` (netcat) which can be backgrounded with `& disown`, allowing the entire example to run in a single terminal session.

This approach was suggested by @thaJeztah in [this comment](https://github.com/docker/cli/issues/5558#issuecomment-2826655766).

### Additional benefits
- Removes the dependency on Python being installed on the host
- Simpler, more portable example
- Works on macOS, Linux (nc is typically pre-installed)

Fixes #5558
