### PR TITLE
use stdlib's x509.SystemCertPool on Windows

### DIFF
--- a/cmd/docker-trust/internal/registry/registry.go
+++ b/cmd/docker-trust/internal/registry/registry.go
@@ -4,13 +4,13 @@ package registry
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/go-connections/tlsconfig"
 	"github.com/sirupsen/logrus"
 )
 
@@ -48,7 +48,7 @@ func loadTLSConfig(ctx context.Context, directory string, tlsConfig *tls.Config)
 		switch filepath.Ext(f.Name()) {
 		case ".crt":
 			if tlsConfig.RootCAs == nil {
-				systemPool, err := tlsconfig.SystemCertPool()
+				systemPool, err := x509.SystemCertPool()
 				if err != nil {
 					return invalidParam(fmt.Errorf("unable to get system cert pool: %w", err))
 				}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -4,6 +4,7 @@ package registry
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
@@ -74,7 +75,7 @@ func loadTLSConfig(ctx context.Context, directory string, tlsConfig *tls.Config)
 		switch filepath.Ext(f.Name()) {
 		case ".crt":
 			if tlsConfig.RootCAs == nil {
-				systemPool, err := tlsconfig.SystemCertPool()
+				systemPool, err := x509.SystemCertPool()
 				if err != nil {
 					return invalidParam(fmt.Errorf("unable to get system cert pool: %w", err))
 				}


### PR DESCRIPTION
relates to:

- https://github.com/docker/go-connections/pull/21
    - https://github.com/moby/moby/issues/12756
    - https://github.com/moby/moby/issues/15379
- https://github.com/docker/go-connections/pull/150
- https://github.com/containerd/containerd/pull/13128 

### use stdlib's x509.SystemCertPool on Windows

The `tlsconfig.SystemCertPool` utility in go-connections was added in
[docker/go-connections@55aadc3], at which time Go stdlib didn't support
system-pools ([x509.SystemCertPool]) on Windows, so an empty pool was
constructed.

Support for system pools on Windows originally added in Go 1.8 (through
[golang/go@05471e9]), but reverted, and re-implemented in Go 1.18 (through
[golang/go@3544082]).

Go 1.18 and up now implement this, but, unlike Linux, which uses a pure-Go
implementation, certificate validation is handled by the system:

> On macOS and Windows, certificate verification is handled by system APIs,
> but the package aims to apply consistent validation rules across operating
> systems.

On macOS and Windows, x509.SystemCertPool returns an empty Pool, with the
`systemPool` set to `true` (see [loadSystemRoots]). This must be considered
an implementation detail; custom CAs can be appended to this pool, and handled
as usual.

This patch removes the special handling on Windows, removing the dependency
on go-connections for this part.

[docker/go-connections@55aadc3]: https://github.com/docker/go-connections/commit/55aadc3cc561684699edcdd0921b9293c3ee6b49
[golang/go@05471e9]: https://github.com/golang/go/commit/05471e9ee64a300bd2dcc4582ee1043c055893bb
[golang/go@3544082]: https://github.com/golang/go/commit/3544082f75fd3d2df7af237ed9aef3ddd499ab9c
[x509.SystemCertPool]: https://pkg.go.dev/crypto/x509#SystemCertPool
[loadSystemRoots]: https://cs.opensource.google/go/go/+/refs/tags/go1.26.1:src/crypto/x509/root_windows.go;l=15-17



**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

