### PR TITLE
cli/context/store: cap tls file size on zip import

### DIFF
--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -474,24 +474,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 			}
 			importedMetaFile = true
 		} else if strings.HasPrefix(zf.Name, "tls/") {
-			// Reject entries whose advertised uncompressed size exceeds
-			// the per-file cap without decompressing, to avoid allocating
-			// gigabytes for a zip bomb (see #6917).
-			if zf.UncompressedSize64 > uint64(maxAllowedFileSizeToImport) {
-				return invalidParameter(fmt.Errorf("%s: tls file exceeds maximum allowed size", zf.Name))
-			}
-			f, err := zf.Open()
-			if err != nil {
-				return err
-			}
-			// Defense in depth in case the zip header is spoofed.
-			data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
-			defer f.Close()
-			if err != nil {
-				return err
-			}
-			err = importEndpointTLS(&tlsData, zf.Name, data)
-			if err != nil {
+			if err := importTLSEntry(zf, &tlsData); err != nil {
 				return err
 			}
 		}
@@ -500,6 +483,26 @@ func importZip(name string, s Writer, reader io.Reader) error {
 		return invalidParameter(errors.New("invalid context: no metadata found"))
 	}
 	return s.ResetTLSMaterial(name, &tlsData)
+}
+
+func importTLSEntry(zf *zip.File, tlsData *ContextTLSData) error {
+	// Reject entries whose advertised uncompressed size exceeds
+	// the per-file cap without decompressing, to avoid allocating
+	// gigabytes for a zip bomb (see #6917).
+	if zf.UncompressedSize64 > uint64(maxAllowedFileSizeToImport) {
+		return invalidParameter(fmt.Errorf("%s: tls file exceeds maximum allowed size", zf.Name))
+	}
+	f, err := zf.Open()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	// Defense in depth in case the zip header is spoofed.
+	data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
+	if err != nil {
+		return err
+	}
+	return importEndpointTLS(tlsData, zf.Name, data)
 }
 
 func parseMetadata(data []byte, name string) (Metadata, error) {

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -474,11 +474,18 @@ func importZip(name string, s Writer, reader io.Reader) error {
 			}
 			importedMetaFile = true
 		} else if strings.HasPrefix(zf.Name, "tls/") {
+			// Reject entries whose advertised uncompressed size exceeds
+			// the per-file cap without decompressing, to avoid allocating
+			// gigabytes for a zip bomb (see #6917).
+			if zf.UncompressedSize64 > uint64(maxAllowedFileSizeToImport) {
+				return invalidParameter(fmt.Errorf("%s: tls file exceeds maximum allowed size", zf.Name))
+			}
 			f, err := zf.Open()
 			if err != nil {
 				return err
 			}
-			data, err := io.ReadAll(f)
+			// Defense in depth in case the zip header is spoofed.
+			data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
 			defer f.Close()
 			if err != nil {
 				return err

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -211,6 +211,41 @@ func TestImportZip(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+// TestImportZipTLSTooLarge verifies that a TLS entry whose uncompressed
+// size exceeds the per-file limit is rejected instead of being read into
+// memory unbounded (zip-bomb protection, see issue #6917).
+func TestImportZipTLSTooLarge(t *testing.T) {
+	meta, err := json.Marshal(Metadata{
+		Endpoints: map[string]any{
+			"ep1": endpoint{Foo: "bar"},
+		},
+		Metadata: context{Bar: "baz"},
+		Name:     "source",
+	})
+	assert.NilError(t, err)
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	mf, err := w.Create("meta.json")
+	assert.NilError(t, err)
+	_, err = mf.Write(meta)
+	assert.NilError(t, err)
+
+	tf, err := w.Create(path.Join("tls", "docker", "ca.pem"))
+	assert.NilError(t, err)
+	// Write well over the per-file cap; zeros compress to a tiny archive
+	// so the outer archive-size cap is not hit first.
+	oversized := make([]byte, 2*maxAllowedFileSizeToImport)
+	_, err = tf.Write(oversized)
+	assert.NilError(t, err)
+	assert.NilError(t, w.Close())
+
+	s := New(t.TempDir(), testCfg)
+	err = Import("zipBomb", s, bytes.NewReader(buf.Bytes()))
+	assert.ErrorContains(t, err, "tls file exceeds maximum allowed size")
+}
+
 func TestImportZipInvalid(t *testing.T) {
 	testDir := t.TempDir()
 	zf := path.Join(testDir, "test.zip")


### PR DESCRIPTION
### What I did

Wrap the `io.ReadAll` call for `tls/*` entries in `importZip` with the existing `limitedReader`, and add a fast-fail check against `zf.UncompressedSize64` before opening the entry. Fixes #6917.

### How I did it

The `meta.json` branch a few lines above already uses `&limitedReader{R: f, N: maxAllowedFileSizeToImport}`; the `tls/` branch was still calling `io.ReadAll(f)` directly, which is unbounded after flate has decompressed. A compressed archive that fits under the outer 10 MiB cap can trivially decompress to multi-GB TLS entries and take the CLI out with an OOM.

Primary guard is the header check: if `UncompressedSize64` exceeds the cap we bail out before calling `zf.Open()`, so no decompression happens at all for a well-formed zip bomb. The `limitedReader` wrapper stays as defense-in-depth for the case where the header lies about the declared size.

### How to verify it

Added `TestImportZipTLSTooLarge` in `cli/context/store/store_test.go`: it builds an in-memory zip whose `tls/docker/ca.pem` entry is `2 * maxAllowedFileSizeToImport` zero bytes (compresses to ~10 KiB, so the outer archive limit is not what's catching it), and asserts that `Import` rejects it with the expected error. Also ran `go vet` and `go build` on linux and windows.

Local `go test ./cli/context/store/` passes aside from an unrelated pre-existing `TestImportZip` TempDir cleanup flake on Windows (open handle on `test.zip`), which reproduces on master without these changes.