### PR TITLE
docs: add `swarm-external-secrets` to the list of available plugins in legacy plugins documentation

### DIFF
--- a/docs/extend/legacy_plugins.md
+++ b/docs/extend/legacy_plugins.md
@@ -80,6 +80,12 @@ The sections below provide an overview of available third-party plugins.
 | [HBM plugin](https://github.com/kassisol/hbm)                        | An authorization plugin that prevents from executing commands with certains parameters.                                                                                                                                                                                                                                              |
 | [Twistlock AuthZ Broker](https://github.com/twistlock/authz)         | A basic extendable authorization plugin that runs directly on the host or inside a container. This plugin allows you to define user policies that it evaluates during authorization. Basic authorization is provided if Docker daemon is started with the --tlsverify flag (username is extracted from the certificate common name). |
 
+### Secrets plugins
+
+| Plugin                                                                           | Description                                                                                                                                       |
+|:---------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Swarm External Secrets](https://github.com/sugar-org/swarm-external-secrets) | A Docker Swarm secrets plugin that integrates with multiple secret management providers including HashiCorp Vault, AWS Secrets Manager, and more. |
+
 ## Troubleshooting a plugin
 
 If you are having problems with Docker after loading a plugin, ask the authors


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Added a new "Secrets plugins" section to the Legacy Plugins documentation and included the `swarm-external-secrets` plugin. This highlights a community plugin that enables integrating Docker Swarm secrets with external providers like HashiCorp Vault, AWS Secrets Manager, and Azure Key Vault.

**- How I did it**

Modified `docs/extend/legacy_plugins.md` to include a new section and table detailing the `swarm-external-secrets` plugin right after the Authorization plugins section.


**- How to verify it**

View the modified `docs/extend/legacy_plugins.md` file to ensure the formatting is correct and verify the link to the [sugar-org/swarm-external-secrets ](https://github.com/sugar-org/swarm-external-secrets) project resolves successfully.

**- Human readable description for the release notes**


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
docs: add `swarm-external-secrets` to the list of available plugins in legacy plugins documentation
```

**- A picture of a cute animal (not mandatory but encouraged)**

