### PR TITLE
e2e/image: add private registry pull/push regression test

### DIFF
--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -3,9 +3,19 @@ services:
   registry:
     image: 'registry:3'
 
+  private-registry:
+    image: 'registry:3'
+    environment:
+      - REGISTRY_HTTP_ADDR=0.0.0.0:5001
+      - REGISTRY_AUTH=htpasswd
+      - REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm
+      - REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd
+    volumes:
+      - ./e2e/testdata/registry/auth:/auth:ro
+
   engine:
       image: 'docker:${ENGINE_VERSION:-29}-dind'
       privileged: true
-      command: ['--insecure-registry=registry:5000', '--experimental']
+      command: ['--insecure-registry=registry:5000', '--insecure-registry=private-registry:5001', '--experimental']
       environment:
         - DOCKER_TLS_CERTDIR=

--- a/e2e/compose-env.yaml
+++ b/e2e/compose-env.yaml
@@ -5,6 +5,10 @@ services:
 
   private-registry:
     image: 'registry:3'
+    networks:
+      default:
+        aliases:
+          - privateregistry
     environment:
       - REGISTRY_HTTP_ADDR=0.0.0.0:5001
       - REGISTRY_AUTH=htpasswd
@@ -16,6 +20,6 @@ services:
   engine:
       image: 'docker:${ENGINE_VERSION:-29}-dind'
       privileged: true
-      command: ['--insecure-registry=registry:5000', '--insecure-registry=private-registry:5001', '--experimental']
+      command: ['--insecure-registry=registry:5000', '--insecure-registry=privateregistry:5001', '--experimental']
       environment:
         - DOCKER_TLS_CERTDIR=

--- a/e2e/image/private_test.go
+++ b/e2e/image/private_test.go
@@ -1,0 +1,74 @@
+package image
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/e2e/internal/fixtures"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+)
+
+const privateRegistryPrefix = "private-registry:5001"
+
+// Regression test for https://github.com/docker/cli/issues/5963
+func TestPullPushPrivateRepository(t *testing.T) {
+	t.Parallel()
+
+	dir := fixtures.SetupConfigFile(t)
+	t.Cleanup(dir.Remove)
+	emptyConfigDir := t.TempDir()
+
+	sourceImage := fixtures.AlpineImage
+	privateImage := privateRegistryPrefix + "/private/alpine:test-private-pull-push"
+
+	icmd.RunCommand("docker", "pull", sourceImage).Assert(t, icmd.Success)
+	t.Cleanup(func() {
+		icmd.RunCommand("docker", "image", "rm", "-f", privateImage).Assert(t, icmd.Success)
+	})
+
+	icmd.RunCommand("docker", "tag", sourceImage, privateImage).Assert(t, icmd.Success)
+
+	pushNoAuth := icmd.RunCmd(
+		icmd.Command("docker", "push", privateImage),
+		fixtures.WithConfig(emptyConfigDir),
+	)
+	pushNoAuth.Assert(t, icmd.Expected{ExitCode: 1})
+	assertAuthDenied(t, pushNoAuth)
+
+	pushWithAuth := icmd.RunCmd(
+		icmd.Command("docker", "push", privateImage),
+		fixtures.WithConfig(dir.Path()),
+	)
+	pushWithAuth.Assert(t, icmd.Success)
+	assert.Check(t, strings.Contains(pushWithAuth.Combined(), "The push refers to repository ["+privateImage+"]"), pushWithAuth.Combined())
+
+	icmd.RunCommand("docker", "image", "rm", "-f", privateImage).Assert(t, icmd.Success)
+
+	pullNoAuth := icmd.RunCmd(
+		icmd.Command("docker", "pull", privateImage),
+		fixtures.WithConfig(emptyConfigDir),
+	)
+	pullNoAuth.Assert(t, icmd.Expected{ExitCode: 1})
+	assertAuthDenied(t, pullNoAuth)
+
+	pullWithAuth := icmd.RunCmd(
+		icmd.Command("docker", "pull", privateImage),
+		fixtures.WithConfig(dir.Path()),
+	)
+	pullWithAuth.Assert(t, icmd.Success)
+	assert.Check(t, strings.Contains(pullWithAuth.Combined(), privateImage), pullWithAuth.Combined())
+}
+
+func assertAuthDenied(t *testing.T, result *icmd.Result) {
+	t.Helper()
+	output := result.Combined()
+
+	assert.Check(t,
+		strings.Contains(output, "requested access to the resource is denied") ||
+			strings.Contains(output, "no basic auth credentials") ||
+			strings.Contains(output, "unauthorized") ||
+			strings.Contains(output, "authentication required"),
+		output,
+	)
+}

--- a/e2e/image/private_test.go
+++ b/e2e/image/private_test.go
@@ -10,7 +10,7 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
-const privateRegistryPrefix = "private-registry:5001"
+const privateRegistryPrefix = "privateregistry:5001"
 
 // Regression test for https://github.com/docker/cli/issues/5963
 func TestPullPushPrivateRepository(t *testing.T) {
@@ -66,6 +66,9 @@ func TestPullPushPrivateRepository(t *testing.T) {
 func assertAuthDenied(t *testing.T, result *icmd.Result) {
 	t.Helper()
 	output := result.Combined()
+	if isPrivateRegistryTransient(output) {
+		t.Fatalf("private registry unavailable while expecting auth failure: %s", output)
+	}
 
 	assert.Check(t,
 		strings.Contains(output, "requested access to the resource is denied") ||
@@ -79,21 +82,31 @@ func assertAuthDenied(t *testing.T, result *icmd.Result) {
 func runWithPrivateRegistryRetry(t *testing.T, cmd icmd.Cmd, opts ...icmd.CmdOp) *icmd.Result {
 	t.Helper()
 
-	deadline := time.Now().Add(60 * time.Second)
+	deadline := time.Now().Add(90 * time.Second)
 	for {
 		result := icmd.RunCmd(cmd, opts...)
 		output := result.Combined()
-		if strings.Contains(output, "lookup private-registry") ||
-			strings.Contains(output, "lookup registry") ||
-			strings.Contains(output, "no such host") ||
-			strings.Contains(output, "server misbehaving") ||
-			strings.Contains(output, "Temporary failure in name resolution") {
+		if isPrivateRegistryTransient(output) {
 			if time.Now().Before(deadline) {
-				t.Logf("waiting for registry DNS to become available: %s", output)
+				t.Logf("waiting for private registry availability: %s", output)
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}
 		}
 		return result
 	}
+}
+
+func isPrivateRegistryTransient(output string) bool {
+	return strings.Contains(output, "lookup privateregistry") ||
+		strings.Contains(output, "lookup registry") ||
+		strings.Contains(output, "no such host") ||
+		strings.Contains(output, "server misbehaving") ||
+		strings.Contains(output, "Temporary failure in name resolution") ||
+		strings.Contains(output, "connection refused") ||
+		strings.Contains(output, "i/o timeout") ||
+		strings.Contains(output, "TLS handshake timeout") ||
+		strings.Contains(output, "context deadline exceeded") ||
+		strings.Contains(output, "connection reset by peer") ||
+		strings.Contains(output, "unexpected EOF")
 }

--- a/e2e/image/private_test.go
+++ b/e2e/image/private_test.go
@@ -3,6 +3,7 @@ package image
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/cli/e2e/internal/fixtures"
 	"gotest.tools/v3/assert"
@@ -29,14 +30,14 @@ func TestPullPushPrivateRepository(t *testing.T) {
 
 	icmd.RunCommand("docker", "tag", sourceImage, privateImage).Assert(t, icmd.Success)
 
-	pushNoAuth := icmd.RunCmd(
+	pushNoAuth := runWithPrivateRegistryRetry(t,
 		icmd.Command("docker", "push", privateImage),
 		fixtures.WithConfig(emptyConfigDir),
 	)
 	pushNoAuth.Assert(t, icmd.Expected{ExitCode: 1})
 	assertAuthDenied(t, pushNoAuth)
 
-	pushWithAuth := icmd.RunCmd(
+	pushWithAuth := runWithPrivateRegistryRetry(t,
 		icmd.Command("docker", "push", privateImage),
 		fixtures.WithConfig(dir.Path()),
 	)
@@ -45,14 +46,14 @@ func TestPullPushPrivateRepository(t *testing.T) {
 
 	icmd.RunCommand("docker", "image", "rm", "-f", privateImage).Assert(t, icmd.Success)
 
-	pullNoAuth := icmd.RunCmd(
+	pullNoAuth := runWithPrivateRegistryRetry(t,
 		icmd.Command("docker", "pull", privateImage),
 		fixtures.WithConfig(emptyConfigDir),
 	)
 	pullNoAuth.Assert(t, icmd.Expected{ExitCode: 1})
 	assertAuthDenied(t, pullNoAuth)
 
-	pullWithAuth := icmd.RunCmd(
+	pullWithAuth := runWithPrivateRegistryRetry(t,
 		icmd.Command("docker", "pull", privateImage),
 		fixtures.WithConfig(dir.Path()),
 	)
@@ -71,4 +72,24 @@ func assertAuthDenied(t *testing.T, result *icmd.Result) {
 			strings.Contains(output, "authentication required"),
 		output,
 	)
+}
+
+func runWithPrivateRegistryRetry(t *testing.T, cmd *icmd.Cmd, opts ...func(*icmd.Cmd)) *icmd.Result {
+	t.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		result := icmd.RunCmd(cmd, opts...)
+		output := result.Combined()
+		if strings.Contains(output, "lookup private-registry") ||
+			strings.Contains(output, "no such host") ||
+			strings.Contains(output, "server misbehaving") {
+			if time.Now().Before(deadline) {
+				t.Logf("waiting for private registry DNS to become available: %s", output)
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+		}
+		return result
+	}
 }

--- a/e2e/image/private_test.go
+++ b/e2e/image/private_test.go
@@ -23,7 +23,9 @@ func TestPullPushPrivateRepository(t *testing.T) {
 	sourceImage := fixtures.AlpineImage
 	privateImage := privateRegistryPrefix + "/private/alpine:test-private-pull-push"
 
-	icmd.RunCommand("docker", "pull", sourceImage).Assert(t, icmd.Success)
+	runWithPrivateRegistryRetry(t,
+		icmd.Command("docker", "pull", sourceImage),
+	).Assert(t, icmd.Success)
 	t.Cleanup(func() {
 		icmd.RunCommand("docker", "image", "rm", "-f", privateImage).Assert(t, icmd.Success)
 	})
@@ -74,18 +76,20 @@ func assertAuthDenied(t *testing.T, result *icmd.Result) {
 	)
 }
 
-func runWithPrivateRegistryRetry(t *testing.T, cmd *icmd.Cmd, opts ...func(*icmd.Cmd)) *icmd.Result {
+func runWithPrivateRegistryRetry(t *testing.T, cmd icmd.Cmd, opts ...icmd.CmdOp) *icmd.Result {
 	t.Helper()
 
-	deadline := time.Now().Add(30 * time.Second)
+	deadline := time.Now().Add(60 * time.Second)
 	for {
 		result := icmd.RunCmd(cmd, opts...)
 		output := result.Combined()
 		if strings.Contains(output, "lookup private-registry") ||
+			strings.Contains(output, "lookup registry") ||
 			strings.Contains(output, "no such host") ||
-			strings.Contains(output, "server misbehaving") {
+			strings.Contains(output, "server misbehaving") ||
+			strings.Contains(output, "Temporary failure in name resolution") {
 			if time.Now().Before(deadline) {
-				t.Logf("waiting for private registry DNS to become available: %s", output)
+				t.Logf("waiting for registry DNS to become available: %s", output)
 				time.Sleep(500 * time.Millisecond)
 				continue
 			}

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -24,7 +24,7 @@ func SetupConfigFile(t *testing.T) fs.Dir {
 		"registry:5000": {
 			"auth": "ZWlhaXM6cGFzc3dvcmQK"
 		},
-		"private-registry:5001": {
+		"privateregistry:5001": {
 			"auth": "ZTJlOnBhc3N3b3Jk"
 		}
 	}}`), fs.WithDir("trust", fs.WithDir("private")))

--- a/e2e/internal/fixtures/fixtures.go
+++ b/e2e/internal/fixtures/fixtures.go
@@ -23,6 +23,9 @@ func SetupConfigFile(t *testing.T) fs.Dir {
 	"auths": {
 		"registry:5000": {
 			"auth": "ZWlhaXM6cGFzc3dvcmQK"
+		},
+		"private-registry:5001": {
+			"auth": "ZTJlOnBhc3N3b3Jk"
 		}
 	}}`), fs.WithDir("trust", fs.WithDir("private")))
 	return *dir

--- a/e2e/testdata/registry/auth/htpasswd
+++ b/e2e/testdata/registry/auth/htpasswd
@@ -1,0 +1,1 @@
+e2e:$2y$05$UozlY7.SA2NMcojF.qocv.W9Q4rsr75uLMW.mVEsAPx90BVeMgveC


### PR DESCRIPTION
- fixes: https://github.com/docker/cli/issues/5965

## Summary
- add authenticated private-registry service to the e2e compose stack
- add fixture auth config for private-registry:5001
- add TestPullPushPrivateRepository to verify unauthenticated pull/push fails and authenticated pull/push succeeds
- add htpasswd test credentials for the private registry

## Context
- regression coverage for private repository auth behavior
- refs #5963, #5965

## Notes
- change is limited to e2e test infrastructure and tests; no production CLI behavior changes