### PR TITLE
docs, completion: remove deprecated "--kernel-memory" flags

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1929,7 +1929,6 @@ _docker_container_run_and_create() {
 		--ip
 		--ip6
 		--ipc
-		--kernel-memory
 		--label-file
 		--label -l
 		--link
@@ -2310,7 +2309,6 @@ _docker_container_update() {
 		--cpuset-cpus
 		--cpuset-mems
 		--cpu-shares -c
-		--kernel-memory
 		--memory -m
 		--memory-reservation
 		--memory-swap

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -226,7 +226,6 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l ip -d 'IPv4 
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l ip6 -d 'IPv6 address (e.g., 2001:db8::33)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l ipc -d 'IPC mode to use'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l isolation -d 'Container isolation technology'
-complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l kernel-memory -d 'Kernel memory limit'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s l -l label -d 'Set meta data on a container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l label-file -d 'Read in a line delimited file of labels'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l link -d 'Add link to another container'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -675,7 +675,6 @@ __docker_container_subcommand() {
         "($help)--cpu-rt-runtime=[Limit the CPU real-time runtime]:CPU real-time runtime in microseconds: "
         "($help)--cpuset-cpus=[CPUs in which to allow execution]:CPUs: "
         "($help)--cpuset-mems=[MEMs in which to allow execution]:MEMs: "
-        "($help)--kernel-memory=[Kernel memory limit in bytes]:Memory limit: "
         "($help -m --memory)"{-m=,--memory=}"[Memory limit]:Memory limit: "
         "($help)--memory-reservation=[Memory soft limit]:Memory limit: "
         "($help)--memory-swap=[Total memory limit with swap]:Memory limit: "
@@ -938,11 +937,7 @@ __docker_container_subcommand() {
                 "($help -)*: :->values" && ret=0
             case $state in
                 (values)
-                    if [[ ${words[(r)--kernel-memory*]} = (--kernel-memory*) ]]; then
-                        __docker_complete_stopped_containers && ret=0
-                    else
-                        __docker_complete_containers && ret=0
-                    fi
+                    __docker_complete_containers && ret=0
                     ;;
             esac
             ;;

--- a/docs/reference/commandline/container_update.md
+++ b/docs/reference/commandline/container_update.md
@@ -37,11 +37,6 @@ resources from their Docker host.  With a single command, you can place
 limits on a single container or on many. To specify more than one container,
 provide space-separated list of container names or IDs.
 
-With the exception of the `--kernel-memory` option, you can specify these
-options on a running or a stopped container. On kernel version older than
-4.6, you can only update `--kernel-memory` on a stopped container or on
-a running container with kernel memory initialized.
-
 > [!WARNING]
 > The `docker update` and `docker container update` commands are not supported
 > for Windows containers.
@@ -68,42 +63,6 @@ To update multiple resource configurations for multiple containers:
 ```console
 $ docker update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ```
-
-### <a name="kernel-memory"></a> Update a container's kernel memory constraints (--kernel-memory)
-
-You can update a container's kernel memory limit using the `--kernel-memory`
-option. On kernel version older than 4.6, this option can be updated on a
-running container only if the container was started with `--kernel-memory`.
-If the container was started without `--kernel-memory` you need to stop
-the container before updating kernel memory.
-
-> [!NOTE]
-> The `--kernel-memory` option has been deprecated since Docker 20.10.
-
-For example, if you started a container with this command:
-
-```console
-$ docker run -dit --name test --kernel-memory 50M ubuntu bash
-```
-
-You can update kernel memory while the container is running:
-
-```console
-$ docker update --kernel-memory 80M test
-```
-
-If you started a container without kernel memory initialized:
-
-```console
-$ docker run -dit --name test2 --memory 300M ubuntu bash
-```
-
-Update kernel memory of running container `test2` will fail. You need to stop
-the container before updating the `--kernel-memory` setting. The next time you
-start it, the container uses the new value.
-
-Kernel version newer than (include) 4.6 does not have this limitation, you
-can use `--kernel-memory` the same way as other options.
 
 ### <a name="restart"></a> Update a container's restart policy (--restart)
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -334,7 +334,6 @@ container:
 | `-m`, `--memory=""`        | Memory limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`. Minimum is 6M.                                                                                                                                                        |
 | `--memory-swap=""`         | Total memory limit (memory + swap, format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`.                                                                                                                                                  |
 | `--memory-reservation=""`  | Memory soft limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`.                                                                                                                                                                  |
-| `--kernel-memory=""`       | Kernel memory limit (format: `<number>[<unit>]`). Number is a positive integer. Unit can be one of `b`, `k`, `m`, or `g`. Minimum is 4M.                                                                                                                                                 |
 | `-c`, `--cpu-shares=0`     | CPU shares (relative weight)                                                                                                                                                                                                                                                             |
 | `--cpus=0.000`             | Number of CPUs. Number is a fractional number. 0.000 means no limit.                                                                                                                                                                                                                     |
 | `--cpu-period=0`           | Limit the CPU CFS (Completely Fair Scheduler) period                                                                                                                                                                                                                                     |
@@ -499,80 +498,6 @@ and require killing system processes to free memory. The `--oom-score-adj`
 parameter can be changed to select the priority of which containers will
 be killed when the system is out of memory, with negative scores making them
 less likely to be killed, and positive scores more likely.
-
-### Kernel memory constraints
-
-Kernel memory is fundamentally different than user memory as kernel memory can't
-be swapped out. The inability to swap makes it possible for the container to
-block system services by consuming too much kernel memory. Kernel memory includes：
-
- - stack pages
- - slab pages
- - sockets memory pressure
- - tcp memory pressure
-
-You can setup kernel memory limit to constrain these kinds of memory. For example,
-every process consumes some stack pages. By limiting kernel memory, you can
-prevent new processes from being created when the kernel memory usage is too high.
-
-Kernel memory is never completely independent of user memory. Instead, you limit
-kernel memory in the context of the user memory limit. Assume "U" is the user memory
-limit and "K" the kernel limit. There are three possible ways to set limits:
-
-<table>
-  <thead>
-    <tr>
-      <th>Option</th>
-      <th>Result</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="no-wrap"><strong>U != 0, K = inf</strong> (default)</td>
-      <td>
-        This is the standard memory limitation mechanism already present before using
-        kernel memory. Kernel memory is completely ignored.
-      </td>
-    </tr>
-    <tr>
-      <td class="no-wrap"><strong>U != 0, K &lt; U</strong></td>
-      <td>
-        Kernel memory is a subset of the user memory. This setup is useful in
-        deployments where the total amount of memory per-cgroup is overcommitted.
-        Overcommitting kernel memory limits is definitely not recommended, since the
-        box can still run out of non-reclaimable memory.
-        In this case, you can configure K so that the sum of all groups is
-        never greater than the total memory. Then, freely set U at the expense of
-        the system's service quality.
-      </td>
-    </tr>
-    <tr>
-      <td class="no-wrap"><strong>U != 0, K &gt; U</strong></td>
-      <td>
-        Since kernel memory charges are also fed to the user counter and reclamation
-        is triggered for the container for both kinds of memory. This configuration
-        gives the admin a unified view of memory. It is also useful for people
-        who just want to track kernel memory usage.
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-Examples:
-
-```console
-$ docker run -it -m 500M --kernel-memory 50M ubuntu:24.04 /bin/bash
-```
-
-We set memory and kernel memory, so the processes in the container can use
-500M memory in total, in this 500M memory, it can be 50M kernel memory tops.
-
-```console
-$ docker run -it --kernel-memory 50M ubuntu:24.04 /bin/bash
-```
-
-We set kernel memory without **-m**, so the processes in the container can
-use as much memory as they want, but they can only use 50M kernel memory.
 
 ### Swappiness constraint
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -50,7 +50,6 @@ docker-run - Create and run a new container from an image
 [**--ip6**[=*IPv6-ADDRESS*]]
 [**--ipc**[=*IPC*]]
 [**--isolation**[=*default*]]
-[**--kernel-memory**[=*KERNEL-MEMORY*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
@@ -409,15 +408,6 @@ is `hyperv`. Linux only supports `default`.
 
 **-l**, **--label** *key*=*value*
    Set metadata on the container (for example, **--label com.example.key=value**).
-
-**--kernel-memory**=*number*[*S*]
-   Kernel memory limit; *S* is an optional suffix which can be one of **b**, **k**, **m**, or **g**.
-
-   Constrains the kernel memory available to a container. If a limit of 0
-   is specified (not using **--kernel-memory**), the container's kernel memory
-   is not limited. If you specify a limit, it may be rounded up to a multiple
-   of the operating system's page size and the value can be very large,
-   millions of trillions.
 
 **--label-file**=[]
    Read in a line delimited file of labels

--- a/man/src/container/update.md
+++ b/man/src/container/update.md
@@ -4,25 +4,11 @@ resources from their Docker host.  With a single command, you can place
 limits on a single container or on many. To specify more than one container,
 provide space-separated list of container names or IDs.
 
-With the exception of the **--kernel-memory** option, you can specify these
-options on a running or a stopped container. On kernel version older than
-4.6, You can only update **--kernel-memory** on a stopped container or on
-a running container with kernel memory initialized.
-
 # OPTIONS
-
-## kernel-memory
-
-Kernel memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)
-
-Note that on kernel version older than 4.6, you can not update kernel memory on
-a running container if the container is started without kernel memory initialized,
-in this case, it can only be updated after it's stopped. The new setting takes
-effect when the container is started.
 
 ## memory
 
-Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
+Memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)
 
 Note that the memory should be smaller than the already set swap memory limit.
 If you want update a memory limit bigger than the already set swap memory limit,
@@ -51,41 +37,6 @@ To update multiple resource configurations for multiple containers:
 ```console
 $ docker container update --cpu-shares 512 -m 300M abebf7571666 hopeful_morse
 ```
-
-### Update a container's kernel memory constraints
-
-You can update a container's kernel memory limit using the **--kernel-memory**
-option. On kernel version older than 4.6, this option can be updated on a
-running container only if the container was started with **--kernel-memory**.
-If the container was started *without* **--kernel-memory** you need to stop
-the container before updating kernel memory.
-
-NOTE: The **--kernel-memory** option has been deprecated since Docker 20.10.
-
-For example, if you started a container with this command:
-
-```console
-$ docker run -dit --name test --kernel-memory 50M ubuntu bash
-```
-
-You can update kernel memory while the container is running:
-
-```console
-$ docker container update --kernel-memory 80M test
-```
-
-If you started a container *without* kernel memory initialized:
-
-```console
-$ docker run -dit --name test2 --memory 300M ubuntu bash
-```
-
-Update kernel memory of running container `test2` will fail. You need to stop
-the container before updating the **--kernel-memory** setting. The next time you
-start it, the container uses the new value.
-
-Kernel version newer than (include) 4.6 does not have this limitation, you
-can use `--kernel-memory` the same way as other options.
 
 ### Update a container's restart policy
 


### PR DESCRIPTION
- supersedes, closes https://github.com/docker/cli/pull/6922
- addresses, closes https://github.com/docker/docs/issues/24643
- relates to https://github.com/docker/docs/pull/24708


<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

