### PR TITLE
formatter: Sort labels for stable output

### DIFF
--- a/cli/command/config/formatter.go
+++ b/cli/command/config/formatter.go
@@ -1,7 +1,11 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.25
+
 package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -102,6 +106,7 @@ func (c *configContext) Labels() string {
 	for k, v := range mapLabels {
 		joinLabels = append(joinLabels, k+"="+v)
 	}
+	slices.Sort(joinLabels)
 	return strings.Join(joinLabels, ",")
 }
 

--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -1,7 +1,11 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.25
+
 package formatter
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -104,6 +108,7 @@ func (c *volumeContext) Labels() string {
 	for k, v := range c.v.Labels {
 		joinLabels = append(joinLabels, k+"="+v)
 	}
+	slices.Sort(joinLabels)
 	return strings.Join(joinLabels, ",")
 }
 

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -48,9 +48,7 @@ func TestVolumeContext(t *testing.T) {
 	for _, c := range cases {
 		ctx = c.volumeCtx
 		v := c.call()
-		if strings.Contains(v, ",") {
-			test.CompareMultipleValues(t, v, c.expValue)
-		} else if v != c.expValue {
+		if v != c.expValue {
 			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
 		}
 	}

--- a/cli/command/network/formatter.go
+++ b/cli/command/network/formatter.go
@@ -1,6 +1,10 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.25
+
 package network
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -115,6 +119,7 @@ func (c *networkContext) Labels() string {
 	for k, v := range c.n.Labels {
 		joinLabels = append(joinLabels, k+"="+v)
 	}
+	slices.Sort(joinLabels)
 	return strings.Join(joinLabels, ",")
 }
 

--- a/cli/command/network/formatter_test.go
+++ b/cli/command/network/formatter_test.go
@@ -68,9 +68,7 @@ func TestNetworkContext(t *testing.T) {
 	for _, c := range cases {
 		ctx = c.networkCtx
 		v := c.call()
-		if strings.Contains(v, ",") {
-			test.CompareMultipleValues(t, v, c.expValue)
-		} else if v != c.expValue {
+		if v != c.expValue {
 			t.Fatalf("Expected %s, was %s\n", c.expValue, v)
 		}
 	}

--- a/cli/command/secret/formatter.go
+++ b/cli/command/secret/formatter.go
@@ -1,7 +1,11 @@
+// FIXME(thaJeztah): remove once we are a module; the go:build directive prevents go from downgrading language version to go1.16:
+//go:build go1.25
+
 package secret
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -109,6 +113,7 @@ func (c *secretContext) Labels() string {
 	for k, v := range mapLabels {
 		joinLabels = append(joinLabels, k+"="+v)
 	}
+	slices.Sort(joinLabels)
 	return strings.Join(joinLabels, ",")
 }
 


### PR DESCRIPTION
- related to: https://github.com/docker/cli/pull/6073

Several Labels() methods iterated over maps without sorting, producing non-deterministic output.

In early versions of Go, map iteration order happened to be stable in practice, so the original code appeared to work correctly. Since Go 1.12, the runtime intentionally randomizes map iteration order, making the output unpredictable between runs.

The API response produces sorted labels and the container formatter already sorted its labels (changed in 5ee17eef).

Apply the same fix to the volume, network, config, and secret formatters, and update tests to assert exact ordering instead of using order-independent comparison.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog
Sort labels in `volume`, `network`, `config`, and `secret` formatters for deterministic output.
```

**- A picture of a cute animal (not mandatory but encouraged)**

