### PR TITLE
docs: clarify --add-host example uses two terminals

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1290,10 +1290,17 @@ The following example shows how the special `host-gateway` value works. The
 example runs an HTTP server that serves a file from host to container over the
 `host.docker.internal` hostname, which resolves to the host's internal IP.
 
+In one terminal, create the file and start an HTTP server:
+
 ```console
 $ echo "hello from host!" > ./hello
 $ python3 -m http.server 8000
 Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
+```
+
+In another terminal, run a container that connects to the HTTP server:
+
+```console
 $ docker run \
   --add-host host.docker.internal=host-gateway \
   curlimages/curl -s host.docker.internal:8000/hello


### PR DESCRIPTION
Fixes #5558.

## Summary
- clarify that the example requires two terminals
- keep the existing example intact, but split the steps so the HTTP server can keep running while the container connects to it
- avoid introducing a more complex or platform-specific replacement command

## Validation
- `git diff --check`
