### PR TITLE
image push: respect NO_COLOR in aux notes

### DIFF
--- a/cli/command/image/push.go
+++ b/cli/command/image/push.go
@@ -131,18 +131,18 @@ To push the complete multi-platform image, remove the --platform flag.
 	}()
 
 	if opts.quiet {
-		err = jsonstream.Display(ctx, responseBody, streams.NewOut(io.Discard), jsonstream.WithAuxCallback(handleAux()))
+		err = jsonstream.Display(ctx, responseBody, streams.NewOut(io.Discard), jsonstream.WithAuxCallback(handleAux(out)))
 		if err == nil {
 			_, _ = fmt.Fprintln(dockerCli.Out(), ref.String())
 		}
 		return err
 	}
-	return jsonstream.Display(ctx, responseBody, dockerCli.Out(), jsonstream.WithAuxCallback(handleAux()))
+	return jsonstream.Display(ctx, responseBody, dockerCli.Out(), jsonstream.WithAuxCallback(handleAux(out)))
 }
 
 var notes []string
 
-func handleAux() func(jm jsonstream.JSONMessage) {
+func handleAux(out tui.Output) func(jm jsonstream.JSONMessage) {
 	return func(jm jsonstream.JSONMessage) {
 		b := []byte(*jm.Aux)
 
@@ -150,8 +150,8 @@ func handleAux() func(jm jsonstream.JSONMessage) {
 		err := json.Unmarshal(b, &stripped)
 		if err == nil && stripped.ManifestPushedInsteadOfIndex {
 			note := fmt.Sprintf("Not all multiplatform-content is present and only the available single-platform image was pushed\n%s -> %s",
-				aec.RedF.Apply(stripped.OriginalIndex.Digest.String()),
-				aec.GreenF.Apply(stripped.SelectedManifest.Digest.String()),
+				out.Color(aec.RedF).Apply(stripped.OriginalIndex.Digest.String()),
+				out.Color(aec.GreenF).Apply(stripped.SelectedManifest.Digest.String()),
 			)
 			notes = append(notes, note)
 		}

--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -1,13 +1,19 @@
 package image
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
+	"github.com/moby/moby/api/types/auxprogress"
 	"github.com/moby/moby/client"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
 
@@ -85,4 +91,31 @@ func TestNewPushCommandSuccess(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunPushRespectsNoColorForAuxNotes(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	cli := test.NewFakeCli(&fakeClient{
+		imagePushFunc: func(ref string, options client.ImagePushOptions) (client.ImagePushResponse, error) {
+			aux, err := json.Marshal(auxprogress.ManifestPushedInsteadOfIndex{
+				ManifestPushedInsteadOfIndex: true,
+				OriginalIndex:                ocispec.Descriptor{Digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
+				SelectedManifest:             ocispec.Descriptor{Digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
+			})
+			assert.NilError(t, err)
+			line := append([]byte(`{"aux":`), aux...)
+			line = append(line, '}', '\n')
+			return fakeStreamResult{ReadCloser: io.NopCloser(bytes.NewReader(line))}, nil
+		},
+	})
+	cli.Out().SetIsTerminal(true)
+	notes = nil
+	t.Cleanup(func() { notes = nil })
+
+	err := runPush(context.Background(), cli, pushOptions{remote: "image:tag"})
+	assert.NilError(t, err)
+
+	out := cli.OutBuffer().String()
+	assert.Assert(t, strings.Contains(out, "sha256:1111111111111111111111111111111111111111111111111111111111111111 -> sha256:2222222222222222222222222222222222222222222222222222222222222222"))
+	assert.Assert(t, !strings.Contains(out, "\x1b["), "output should not contain ANSI escape codes, output: %s", out)
 }


### PR DESCRIPTION
## Summary
- route `docker image push` aux-note coloring through `tui.Output`
- respect `NO_COLOR` when rendering the digest mapping note
- add a regression test covering terminal output with `NO_COLOR=1`

## Why
Fixes `docker image push` emitting ANSI color codes in aux-note output even when `NO_COLOR` is set.

Fixes #6890

## Testing
- added regression test: `TestRunPushRespectsNoColorForAuxNotes`
- local static check: `git diff --check`
- full Go test execution was not available locally in this environment because `go` is not installed in PATH here; CI should validate compile/test behavior

```markdown changelog
`docker image push` now respects `NO_COLOR`
```
