### PR TITLE
docs: clarify repeated ENV changes with docker commit

### DIFF
--- a/docs/reference/commandline/container_commit.md
+++ b/docs/reference/commandline/container_commit.md
@@ -79,6 +79,20 @@ $ docker inspect -f "{{ .Config.Env }}" f5283438590d
 [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
 ```
 
+You can repeat `--change` to apply multiple Dockerfile instructions in the same commit. When you use repeated `ENV`
+instructions, each one updates the named variable while leaving the rest of the environment intact.
+
+```console
+$ docker commit \
+    --change "ENV DEBUG=true" \
+    --change "ENV LOG_LEVEL=debug" \
+    c3f279d17e0a svendowideit/testimage:version3
+
+$ docker inspect -f "{{ .Config.Env }}" svendowideit/testimage:version3
+
+[HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true LOG_LEVEL=debug]
+```
+
 ### Commit a container with new `CMD` and `EXPOSE` instructions
 
 ```console


### PR DESCRIPTION
**- What I did**

Clarified that `docker commit --change` can be repeated, and added an example showing how repeated `ENV` instructions update specific variables without replacing the rest of the environment.

Closes #169

**- How I did it**

Added a short explanatory paragraph and one focused console example to `docs/reference/commandline/container_commit.md`.

**- How to verify it**

- Read the updated `--change` section and confirm it now covers repeated `ENV` usage.
- `git diff --check`

**- Human readable description for the release notes**
```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

N/A
