### PR TITLE
[RFC] errors: introduce structured hints + apply audit-driven rewrites

### DIFF
--- a/cli-plugins/plugin/plugin.go
+++ b/cli-plugins/plugin/plugin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/cli/cli/debug"
+	"github.com/docker/cli/internal/hint"
 	"github.com/moby/moby/client"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -104,11 +106,18 @@ func Run(makeCmd func(command.Cli) *cobra.Command, meta metadata.Metadata, ops .
 			if stErr.StatusCode == 0 { // FIXME(thaJeztah): this should never be used with a zero status-code. Check if we do this anywhere.
 				stErr.StatusCode = 1
 			}
-			_, _ = fmt.Fprintln(dockerCLI.Err(), stErr)
+			printError(dockerCLI.Err(), stErr)
 			os.Exit(stErr.StatusCode)
 		}
-		_, _ = fmt.Fprintln(dockerCLI.Err(), err)
+		printError(dockerCLI.Err(), err)
 		os.Exit(1)
+	}
+}
+
+func printError(out io.Writer, err error) {
+	_, _ = fmt.Fprintln(out, err)
+	if h := hint.Of(err); h != "" {
+		_, _ = fmt.Fprintln(out, "\n"+h)
 	}
 }
 

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -82,6 +82,7 @@ func FlagErrorFunc(cmd *cobra.Command, err error) error {
 	}
 
 	return StatusError{
+		Cause:      err,
 		Status:     fmt.Sprintf("%s\n\nUsage:  %s\n\nRun '%s --help' for more information", err, cmd.UseLine(), cmd.CommandPath()),
 		StatusCode: 125,
 	}

--- a/cli/command/config/inspect.go
+++ b/cli/command/config/inspect.go
@@ -67,7 +67,7 @@ func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions)
 	}
 
 	if err := inspectFormatWrite(configCtx, opts.names, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 1, Status: err.Error()}
 	}
 	return nil
 }

--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/go-units"
 	"github.com/moby/go-archive"
 	"github.com/moby/moby/client"
@@ -242,7 +243,10 @@ func runCopy(ctx context.Context, dockerCli command.Cli, opts copyOptions) error
 	case acrossContainers:
 		return errors.New("copying between containers is not supported")
 	default:
-		return errors.New("must specify at least one container source")
+		return hint.Wrap(
+			errors.New("one argument must reference a container as 'CONTAINER:PATH'"),
+			"Use 'docker cp CONTAINER:SRC LOCAL' to copy from a container, or 'docker cp LOCAL CONTAINER:DEST' to copy into one.",
+		)
 	}
 }
 

--- a/cli/command/container/cp_test.go
+++ b/cli/command/container/cp_test.go
@@ -38,7 +38,7 @@ func TestRunCopyWithInvalidArguments(t *testing.T) {
 				source:      "./source",
 				destination: "./dest",
 			},
-			expectedErr: "must specify at least one container source",
+			expectedErr: "one argument must reference a container as 'CONTAINER:PATH'",
 		},
 	}
 	for _, testcase := range testcases {

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/docker/cli/cli/streams"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/docker/cli/opts"
 	"github.com/moby/moby/api/types/mount"
@@ -97,10 +98,7 @@ func newCreateCommand(dockerCLI command.Cli) *cobra.Command {
 
 func runCreate(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, options *createOptions, copts *containerOptions) error {
 	if err := validatePullOpt(options.pull); err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "create").Error(),
-			StatusCode: 125,
-		}
+		return statusErrorWithHelp(err, "create", 125)
 	}
 	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(dockerCLI.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
 	newEnv := make([]string, 0, len(proxyConfig))
@@ -119,10 +117,7 @@ func runCreate(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet,
 
 	containerCfg, err := parse(flags, copts, serverInfo.OSType)
 	if err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "create").Error(),
-			StatusCode: 125,
-		}
+		return statusErrorWithHelp(err, "create", 125)
 	}
 	id, err := createContainer(ctx, dockerCLI, containerCfg, options)
 	if err != nil {
@@ -188,7 +183,10 @@ func (cid *cidFile) Write(id string) error {
 		return nil
 	}
 	if _, err := cid.file.WriteString(id); err != nil {
-		return fmt.Errorf("failed to write the container ID (%s) to file: %w", id, err)
+		return hint.Wrap(
+			fmt.Errorf("container %s was created, but writing its ID to %s failed: %w", id, cid.path, err),
+			fmt.Sprintf("The container exists on the daemon. Run 'docker rm %s' to remove it, or note the ID for later use.", id),
+		)
 	}
 	cid.written = true
 	return nil

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/internal/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/container"
@@ -198,6 +199,25 @@ func TestCreateContainerImagePullPolicyInvalid(t *testing.T) {
 			assert.Check(t, is.ErrorContains(err, tc.ExpectedErrMsg))
 		})
 	}
+}
+
+func TestCreateContainerPreservesHintedParseError(t *testing.T) {
+	flags, copts := setupRunFlags()
+	assert.NilError(t, flags.Parse([]string{"--pid=container:", "image"}))
+
+	dockerCli := test.NewFakeCli(&fakeClient{})
+	err := runCreate(
+		context.TODO(),
+		dockerCli,
+		flags,
+		&createOptions{},
+		copts,
+	)
+
+	statusErr := cli.StatusError{}
+	assert.Check(t, errors.As(err, &statusErr))
+	assert.Check(t, statusErr.Cause != nil)
+	assert.Equal(t, hint.Of(err), "Valid forms are 'host' or 'container:<name|id>'.")
 }
 
 func TestCreateContainerValidateFlags(t *testing.T) {

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/opts"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -115,7 +116,10 @@ func RunExec(ctx context.Context, dockerCLI command.Cli, containerIDorName strin
 
 	execID := response.ID
 	if execID == "" {
-		return errors.New("exec ID empty")
+		return hint.Wrap(
+			errors.New("the Docker daemon returned an empty response when creating the exec session"),
+			"This is unexpected — please report it at https://github.com/moby/moby/issues with the daemon version ('docker version') and the command you ran.",
+		)
 	}
 
 	if options.Detach {

--- a/cli/command/container/exec_test.go
+++ b/cli/command/container/exec_test.go
@@ -195,7 +195,7 @@ func TestRunExec(t *testing.T) {
 		{
 			doc:           "missing exec ID",
 			options:       NewExecOptions(),
-			expectedError: "exec ID empty",
+			expectedError: "the Docker daemon returned an empty response when creating the exec session",
 			client:        &fakeClient{},
 		},
 	}

--- a/cli/command/container/export.go
+++ b/cli/command/container/export.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/hint"
 	"github.com/moby/moby/client"
 	"github.com/moby/sys/atomicwriter"
 	"github.com/spf13/cobra"
@@ -49,13 +50,16 @@ func runExport(ctx context.Context, dockerCLI command.Cli, opts exportOptions) e
 	var output io.Writer
 	if opts.output == "" {
 		if dockerCLI.Out().IsTerminal() {
-			return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
+			return hint.Wrap(
+				errors.New("refusing to write a binary tar archive to the terminal"),
+				"Use '-o FILE' to write to a file, or redirect stdout, e.g. 'docker container export CONTAINER > out.tar'.",
+			)
 		}
 		output = dockerCLI.Out()
 	} else {
 		writer, err := atomicwriter.New(opts.output, 0o600)
 		if err != nil {
-			return fmt.Errorf("failed to export container: %w", err)
+			return fmt.Errorf("cannot open output file %q: %w", opts.output, err)
 		}
 		defer writer.Close()
 		output = writer

--- a/cli/command/container/export_test.go
+++ b/cli/command/container/export_test.go
@@ -44,6 +44,6 @@ func TestContainerExportOutputToIrregularFile(t *testing.T) {
 	cmd.SetErr(io.Discard)
 	cmd.SetArgs([]string{"-o", "/dev/random", "container"})
 
-	const expected = `failed to export container: cannot write to a character device file`
+	const expected = `cannot open output file "/dev/random": cannot write to a character device file`
 	assert.Error(t, cmd.Execute(), expected)
 }

--- a/cli/command/container/opts.go
+++ b/cli/command/container/opts.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/internal/lazyregexp"
 	"github.com/docker/cli/internal/volumespec"
 	"github.com/docker/cli/opts"
@@ -517,22 +518,34 @@ func parse(flags *pflag.FlagSet, copts *containerOptions, serverOS string) (*con
 
 	pidMode := container.PidMode(copts.pidMode)
 	if !pidMode.Valid() {
-		return nil, errors.New("--pid: invalid PID mode")
+		return nil, hint.Wrap(
+			fmt.Errorf("invalid --pid mode %q", copts.pidMode),
+			"Valid forms are 'host' or 'container:<name|id>'.",
+		)
 	}
 
 	utsMode := container.UTSMode(copts.utsMode)
 	if !utsMode.Valid() {
-		return nil, errors.New("--uts: invalid UTS mode")
+		return nil, hint.Wrap(
+			fmt.Errorf("invalid --uts mode %q", copts.utsMode),
+			"The only valid form is 'host'.",
+		)
 	}
 
 	usernsMode := container.UsernsMode(copts.usernsMode)
 	if !usernsMode.Valid() {
-		return nil, errors.New("--userns: invalid USER mode")
+		return nil, hint.Wrap(
+			fmt.Errorf("invalid --userns mode %q", copts.usernsMode),
+			"The only valid form is 'host'.",
+		)
 	}
 
 	cgroupnsMode := container.CgroupnsMode(copts.cgroupnsMode)
 	if !cgroupnsMode.Valid() {
-		return nil, errors.New("--cgroupns: invalid CGROUP mode")
+		return nil, hint.Wrap(
+			fmt.Errorf("invalid --cgroupns mode %q", copts.cgroupnsMode),
+			"Valid forms are 'private' or 'host'.",
+		)
 	}
 
 	restartPolicy, err := opts.ParseRestartPolicy(copts.restartPolicy)
@@ -920,7 +933,10 @@ func convertToStandardNotation(ports []string) ([]string, error) {
 func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]string, error) {
 	loggingOptsMap := opts.ConvertKVStringsToMap(loggingOpts)
 	if loggingDriver == "none" && len(loggingOpts) > 0 {
-		return map[string]string{}, fmt.Errorf("invalid logging opts for driver %s", loggingDriver)
+		return map[string]string{}, hint.Wrap(
+			errors.New("log driver \"none\" accepts no --log-opt entries"),
+			"Remove the --log-opt flag(s) or choose a different --log-driver.",
+		)
 	}
 	return loggingOptsMap, nil
 }
@@ -984,7 +1000,7 @@ func parseStorageOpts(storageOpts []string) (map[string]string, error) {
 	for _, option := range storageOpts {
 		k, v, ok := strings.Cut(option, "=")
 		if !ok {
-			return nil, errors.New("invalid storage option")
+			return nil, fmt.Errorf("invalid --storage-opt value %q: expected key=value", option)
 		}
 		m[k] = v
 	}
@@ -1095,12 +1111,12 @@ func validateLinuxPath(val string, validator func(string) bool) (string, error) 
 	var mode string
 
 	if strings.Count(val, ":") > 2 {
-		return val, fmt.Errorf("bad format for path: %s", val)
+		return val, fmt.Errorf("invalid --device %q: too many ':' separators, expected [host-path:]container-path[:mode]", val)
 	}
 
 	split := strings.SplitN(val, ":", 3)
 	if split[0] == "" {
-		return val, fmt.Errorf("bad format for path: %s", val)
+		return val, fmt.Errorf("invalid --device %q: host path before ':' is empty, expected [host-path:]container-path[:mode]", val)
 	}
 	switch len(split) {
 	case 1:

--- a/cli/command/container/opts_test.go
+++ b/cli/command/container/opts_test.go
@@ -767,7 +767,7 @@ func TestParseModes(t *testing.T) {
 	args := []string{"--pid=container:", "img", "cmd"}
 	assert.NilError(t, flags.Parse(args))
 	_, err := parse(flags, copts, runtime.GOOS)
-	assert.ErrorContains(t, err, "--pid: invalid PID mode")
+	assert.ErrorContains(t, err, "invalid --pid mode")
 
 	// pid ok
 	_, hostconfig, _, err := parseRun([]string{"--pid=host", "img", "cmd"})
@@ -778,7 +778,7 @@ func TestParseModes(t *testing.T) {
 
 	// uts ko
 	_, _, _, err = parseRun([]string{"--uts=container:", "img", "cmd"}) //nolint:dogsled
-	assert.ErrorContains(t, err, "--uts: invalid UTS mode")
+	assert.ErrorContains(t, err, "invalid --uts mode")
 
 	// uts ok
 	_, hostconfig, _, err = parseRun([]string{"--uts=host", "img", "cmd"})
@@ -923,8 +923,8 @@ func TestParseHealth(t *testing.T) {
 
 func TestParseLoggingOpts(t *testing.T) {
 	// logging opts ko
-	if _, _, _, err := parseRun([]string{"--log-driver=none", "--log-opt=anything", "img", "cmd"}); err == nil || err.Error() != "invalid logging opts for driver none" {
-		t.Fatalf("Expected an error with message 'invalid logging opts for driver none', got %v", err)
+	if _, _, _, err := parseRun([]string{"--log-driver=none", "--log-opt=anything", "img", "cmd"}); err == nil || !strings.HasPrefix(err.Error(), "log driver \"none\" accepts no --log-opt entries") {
+		t.Fatalf("Expected an error stating that 'none' accepts no --log-opt entries, got %v", err)
 	}
 	// logging opts ok
 	_, hostconfig, _, err := parseRun([]string{"--log-driver=syslog", "--log-opt=something", "img", "cmd"})
@@ -1034,22 +1034,24 @@ func TestValidateDevice(t *testing.T) {
 		"/hostPath:/containerPath:rw",
 		"/hostPath:/containerPath:mrw",
 	}
+	const emptyHostMsg = `: host path before ':' is empty, expected [host-path:]container-path[:mode]`
+	const tooManyMsg = `: too many ':' separators, expected [host-path:]container-path[:mode]`
 	invalid := map[string]string{
-		"":        "bad format for path: ",
+		"":        `invalid --device ""` + emptyHostMsg,
 		"./":      "./ is not an absolute path",
 		"../":     "../ is not an absolute path",
 		"/:../":   "../ is not an absolute path",
 		"/:path":  "path is not an absolute path",
-		":":       "bad format for path: :",
+		":":       `invalid --device ":"` + emptyHostMsg,
 		"/tmp:":   " is not an absolute path",
-		":test":   "bad format for path: :test",
-		":/test":  "bad format for path: :/test",
+		":test":   `invalid --device ":test"` + emptyHostMsg,
+		":/test":  `invalid --device ":/test"` + emptyHostMsg,
 		"tmp:":    " is not an absolute path",
-		":test:":  "bad format for path: :test:",
-		"::":      "bad format for path: ::",
-		":::":     "bad format for path: :::",
-		"/tmp:::": "bad format for path: /tmp:::",
-		":/tmp::": "bad format for path: :/tmp::",
+		":test:":  `invalid --device ":test:"` + emptyHostMsg,
+		"::":      `invalid --device "::"` + emptyHostMsg,
+		":::":     `invalid --device ":::"` + tooManyMsg,
+		"/tmp:::": `invalid --device "/tmp:::"` + tooManyMsg,
+		":/tmp::": `invalid --device ":/tmp::"` + tooManyMsg,
 		"path:ro": "ro is not an absolute path",
 		"path:rr": "rr is not an absolute path",
 		"a:/b:ro": "bad mode specified: ro",

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -86,10 +86,7 @@ func newRunCommand(dockerCLI command.Cli) *cobra.Command {
 
 func runRun(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, ropts *runOptions, copts *containerOptions) error {
 	if err := validatePullOpt(ropts.pull); err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "run").Error(),
-			StatusCode: 125,
-		}
+		return statusErrorWithHelp(err, "run", 125)
 	}
 	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(dockerCLI.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
 	newEnv := []string{}
@@ -109,10 +106,7 @@ func runRun(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, ro
 	containerCfg, err := parse(flags, copts, serverInfo.OSType)
 	// just in case the parse does not exit
 	if err != nil {
-		return cli.StatusError{
-			Status:     withHelp(err, "run").Error(),
-			StatusCode: 125,
-		}
+		return statusErrorWithHelp(err, "run", 125)
 	}
 	return runContainer(ctx, dockerCLI, ropts, copts, containerCfg)
 }
@@ -319,6 +313,14 @@ func withHelp(err error, commandName string) error {
 	return fmt.Errorf("docker: %w\n\nRun 'docker %s --help' for more information", err, commandName)
 }
 
+func statusErrorWithHelp(err error, commandName string, statusCode int) cli.StatusError {
+	return cli.StatusError{
+		Cause:      err,
+		Status:     withHelp(err, commandName).Error(),
+		StatusCode: statusCode,
+	}
+}
+
 // toStatusError attempts to detect specific error-conditions to assign
 // an appropriate exit-code for situations where the problem originates
 // from the container. It returns [cli.StatusError] with the original
@@ -333,24 +335,12 @@ func toStatusError(err error) error {
 	errMsg := err.Error()
 
 	if strings.Contains(errMsg, "executable file not found") || strings.Contains(errMsg, "no such file or directory") || strings.Contains(errMsg, "system cannot find the file specified") {
-		return cli.StatusError{
-			Cause:      err,
-			Status:     withHelp(err, "run").Error(),
-			StatusCode: 127,
-		}
+		return statusErrorWithHelp(err, "run", 127)
 	}
 
 	if strings.Contains(errMsg, syscall.EACCES.Error()) || strings.Contains(errMsg, syscall.EISDIR.Error()) {
-		return cli.StatusError{
-			Cause:      err,
-			Status:     withHelp(err, "run").Error(),
-			StatusCode: 126,
-		}
+		return statusErrorWithHelp(err, "run", 126)
 	}
 
-	return cli.StatusError{
-		Cause:      err,
-		Status:     withHelp(err, "run").Error(),
-		StatusCode: 125,
-	}
+	return statusErrorWithHelp(err, "run", 125)
 }

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/opts"
 	containertypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
@@ -92,7 +93,10 @@ func runUpdate(ctx context.Context, dockerCli command.Cli, options *updateOption
 	var err error
 
 	if options.nFlag == 0 {
-		return errors.New("you must provide one or more flags when using this command")
+		return hint.Wrap(
+			errors.New("no resource flags supplied — nothing to update"),
+			"Pass at least one tunable flag (for example --memory, --cpus, --restart). Run 'docker container update --help' for the full list.",
+		)
 	}
 
 	var restartPolicy containertypes.RestartPolicy

--- a/cli/command/context/create.go
+++ b/cli/command/context/create.go
@@ -85,7 +85,7 @@ func runCreate(dockerCLI command.Cli, name string, opts createOptions) error {
 
 func createNewContext(contextStore store.ReaderWriter, name string, opts createOptions) error {
 	if opts.endpoint == nil {
-		return errors.New("docker endpoint configuration is required")
+		return errors.New("no docker endpoint configured: set one with --docker, or copy from an existing context with --from")
 	}
 	dockerEP, dockerTLS, err := getDockerEndpointMetadataAndTLS(contextStore, opts.endpoint)
 	if err != nil {

--- a/cli/command/context/export.go
+++ b/cli/command/context/export.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/context/store"
+	"github.com/docker/cli/internal/hint"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,10 @@ func writeTo(dockerCli command.Cli, reader io.Reader, dest string) error {
 	var printDest bool
 	if dest == "-" {
 		if dockerCli.Out().IsTerminal() {
-			return errors.New("cowardly refusing to export to a terminal, specify a file path")
+			return hint.Wrap(
+				errors.New("exported context is a binary tar stream and would corrupt the terminal"),
+				"Pass a file path as the second argument, or redirect stdout (e.g. 'docker context export NAME > file.dockercontext').",
+			)
 		}
 		writer = dockerCli.Out()
 	} else {

--- a/cli/command/context/options.go
+++ b/cli/command/context/options.go
@@ -100,7 +100,7 @@ func getDockerEndpoint(contextStore store.Reader, config map[string]string) (doc
 		if ep, ok := metadata.Endpoints[docker.DockerEndpoint].(docker.EndpointMeta); ok {
 			return docker.Endpoint{EndpointMeta: ep}, nil
 		}
-		return docker.Endpoint{}, fmt.Errorf("unable to get endpoint from context %q", contextName)
+		return docker.Endpoint{}, fmt.Errorf("context %q has no docker endpoint configured", contextName)
 	}
 	tlsData, err := context.TLSDataFromFiles(config[keyCA], config[keyCert], config[keyKey])
 	if err != nil {

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -261,7 +261,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 			_, _ = fmt.Fprintln(dockerCli.Err(), progBuff)
 		}
 	default:
-		return fmt.Errorf("unable to prepare context: path %q not found", options.context)
+		return fmt.Errorf("build context %q is not a supported form: expected '-' for stdin, an existing directory, a Git URL, or an HTTP(S) URL", options.context)
 	}
 
 	// read from a directory into tar archive
@@ -356,7 +356,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 	aux := func(msg jsonstream.JSONMessage) {
 		var result buildtypes.Result
 		if err := json.Unmarshal(*msg.Aux, &result); err != nil {
-			_, _ = fmt.Fprintf(dockerCli.Err(), "Failed to parse aux message: %s", err)
+			_, _ = fmt.Fprintf(dockerCli.Err(), "could not read image ID from daemon response; the image was built, but --iidfile and -q output will be empty: %s", err)
 		} else {
 			imageID = result.ID
 		}
@@ -373,7 +373,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 			if options.quiet {
 				_, _ = fmt.Fprintf(dockerCli.Err(), "%s%s", progBuff, buildBuff)
 			}
-			return cli.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
+			return cli.StatusError{Cause: err, Status: jerr.Message, StatusCode: jerr.Code}
 		}
 		return err
 	}
@@ -387,7 +387,7 @@ func runBuild(ctx context.Context, dockerCli command.Cli, options buildOptions) 
 
 	if options.imageIDFile != "" {
 		if imageID == "" {
-			return fmt.Errorf("server did not provide an image ID. Cannot write %s", options.imageIDFile)
+			return fmt.Errorf("image was built, but --iidfile %q was not written: the daemon did not return an image ID", options.imageIDFile)
 		}
 		if err := os.WriteFile(options.imageIDFile, []byte(imageID), 0o666); err != nil {
 			return err

--- a/cli/command/image/build/context_detect.go
+++ b/cli/command/image/build/context_detect.go
@@ -29,7 +29,7 @@ func DetectContextType(specifiedContext string) (ContextType, error) {
 	case urlutil.IsURL(specifiedContext):
 		return ContextTypeRemote, nil
 	default:
-		return "", fmt.Errorf("unable to prepare context: path %q not found", specifiedContext)
+		return "", fmt.Errorf("build context %q is not a supported form: expected '-' for stdin, an existing directory, a Git URL, or an HTTP(S) URL", specifiedContext)
 	}
 }
 

--- a/cli/command/image/list.go
+++ b/cli/command/image/list.go
@@ -161,7 +161,7 @@ func shouldUseTree(options imagesOptions) (bool, error) {
 	}
 	if options.showDigests {
 		if options.tree {
-			return false, errors.New("--show-digest is not yet supported with --tree")
+			return false, errors.New("--digests is not yet supported with --tree")
 		}
 		return false, nil
 	}

--- a/cli/command/image/load.go
+++ b/cli/command/image/load.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/internal/jsonstream"
 	"github.com/moby/moby/client"
 	"github.com/moby/sys/sequential"
@@ -61,7 +62,10 @@ func runLoad(ctx context.Context, dockerCli command.Cli, opts loadOptions) error
 		// To avoid getting stuck, verify that a tar file is given either in
 		// the input flag or through stdin and if not display an error message and exit.
 		if dockerCli.In().IsTerminal() {
-			return errors.New("requested load from stdin, but stdin is empty")
+			return hint.Wrap(
+				errors.New("no input given: stdin is a terminal, not a tar archive"),
+				"Pipe a tar archive into 'docker image load', or pass one with '-i FILE'.",
+			)
 		}
 	default:
 		// We use sequential.Open to use sequential file access on Windows, avoiding

--- a/cli/command/image/load_test.go
+++ b/cli/command/image/load_test.go
@@ -30,7 +30,7 @@ func TestNewLoadCommandErrors(t *testing.T) {
 			name:          "input-to-terminal",
 			args:          []string{},
 			isTerminalIn:  true,
-			expectedError: "requested load from stdin, but stdin is empty",
+			expectedError: "stdin is a terminal, not a tar archive",
 		},
 		{
 			name:          "pull-error",

--- a/cli/command/image/save.go
+++ b/cli/command/image/save.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/completion"
+	"github.com/docker/cli/internal/hint"
 	"github.com/moby/moby/client"
 	"github.com/moby/sys/atomicwriter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -70,13 +71,16 @@ func runSave(ctx context.Context, dockerCLI command.Cli, opts saveOptions) error
 	var output io.Writer
 	if opts.output == "" {
 		if dockerCLI.Out().IsTerminal() {
-			return errors.New("cowardly refusing to save to a terminal. Use the -o flag or redirect")
+			return hint.Wrap(
+				errors.New("refusing to write a binary tar archive to the terminal"),
+				"Use '-o FILE' to write to a file, or redirect stdout, e.g. 'docker image save IMAGE > image.tar'.",
+			)
 		}
 		output = dockerCLI.Out()
 	} else {
 		writer, err := atomicwriter.New(opts.output, 0o600)
 		if err != nil {
-			return fmt.Errorf("failed to save image: %w", err)
+			return fmt.Errorf("cannot open output file %q: %w", opts.output, err)
 		}
 		defer writer.Close()
 		output = writer

--- a/cli/command/image/save_test.go
+++ b/cli/command/image/save_test.go
@@ -30,7 +30,7 @@ func TestNewSaveCommandErrors(t *testing.T) {
 			name:          "output to terminal",
 			args:          []string{"output", "file", "arg1"},
 			isTerminal:    true,
-			expectedError: "cowardly refusing to save to a terminal. Use the -o flag or redirect",
+			expectedError: "refusing to write a binary tar archive to the terminal",
 		},
 		{
 			name:          "ImageSave fail",
@@ -44,12 +44,12 @@ func TestNewSaveCommandErrors(t *testing.T) {
 		{
 			name:          "output directory does not exist",
 			args:          []string{"-o", "fake-dir/out.tar", "arg1"},
-			expectedError: `failed to save image: invalid output path: stat fake-dir: no such file or directory`,
+			expectedError: `cannot open output file "fake-dir/out.tar": invalid output path: stat fake-dir: no such file or directory`,
 		},
 		{
 			name:          "output file is irregular",
 			args:          []string{"-o", "/dev/null", "arg1"},
-			expectedError: `failed to save image: cannot write to a character device file`,
+			expectedError: `cannot open output file "/dev/null": cannot write to a character device file`,
 		},
 		{
 			name:          "invalid platform",

--- a/cli/command/inspect/inspector.go
+++ b/cli/command/inspect/inspector.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/templates"
 	"github.com/sirupsen/logrus"
 )
@@ -76,7 +77,7 @@ func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFu
 	}
 	inspector, err := NewTemplateInspectorFromString(out, tmplStr)
 	if err != nil {
-		return cli.StatusError{StatusCode: 64, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 64, Status: err.Error()}
 	}
 
 	var errs []error
@@ -98,6 +99,7 @@ func Inspect(out io.Writer, references []string, tmplStr string, getRef GetRefFu
 
 	if err := errors.Join(errs...); err != nil {
 		return cli.StatusError{
+			Cause:      err,
 			StatusCode: 1,
 			Status:     err.Error(),
 		}
@@ -112,7 +114,7 @@ func (i *TemplateInspector) Inspect(typedElement any, rawElement []byte) error {
 	buffer := new(bytes.Buffer)
 	if err := i.tmpl.Execute(buffer, typedElement); err != nil {
 		if rawElement == nil {
-			return fmt.Errorf("template parsing error: %w", err)
+			return fmt.Errorf("--format template failed during execution: %w", err)
 		}
 		return i.tryRawInspectFallback(rawElement)
 	}
@@ -136,7 +138,10 @@ func (i *TemplateInspector) tryRawInspectFallback(rawElement []byte) error {
 
 	tmplMissingKey := i.tmpl.Option("missingkey=error")
 	if err := tmplMissingKey.Execute(buffer, raw); err != nil {
-		return fmt.Errorf("template parsing error: %w", err)
+		return hint.Wrap(
+			fmt.Errorf("--format template failed during execution: %w", err),
+			"Check that field names referenced in the template match the JSON output of 'docker inspect' without --format.",
+		)
 	}
 
 	i.buffer.Write(buffer.Bytes())

--- a/cli/command/inspect/inspector_test.go
+++ b/cli/command/inspect/inspector_test.go
@@ -62,7 +62,7 @@ func TestTemplateInspectorTemplateError(t *testing.T) {
 		t.Fatal("Expected error got nil")
 	}
 
-	if !strings.HasPrefix(err.Error(), "template parsing error") {
+	if !strings.HasPrefix(err.Error(), "--format template failed during execution") {
 		t.Fatalf("Expected template error, got %v", err)
 	}
 }
@@ -98,7 +98,7 @@ func TestTemplateInspectorRawFallbackError(t *testing.T) {
 		t.Fatal("Expected error got nil")
 	}
 
-	if !strings.HasPrefix(err.Error(), "template parsing error") {
+	if !strings.HasPrefix(err.Error(), "--format template failed during execution") {
 		t.Fatalf("Expected template error, got %v", err)
 	}
 }

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/manifest/store"
+	"github.com/docker/cli/internal/hint"
 	"github.com/docker/cli/internal/registryclient"
 	"github.com/moby/moby/api/types/registry"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -162,7 +163,10 @@ func runManifestAnnotate(dockerCLI command.Cli, opts annotateOptions) error {
 	}
 
 	if !isValidOSArch(imageManifest.Descriptor.Platform.OS, imageManifest.Descriptor.Platform.Architecture) {
-		return fmt.Errorf("manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
+		return hint.Wrap(
+			fmt.Errorf("unsupported os/arch combination %s/%s for manifest entry %s", imageManifest.Descriptor.Platform.OS, imageManifest.Descriptor.Platform.Architecture, opts.image),
+			"Set --os and --arch to a supported pair (for example linux/amd64, linux/arm64, or windows/amd64).",
+		)
 	}
 	return manifestStore.Save(targetRef, imgRef, imageManifest)
 }

--- a/cli/command/manifest/annotate_test.go
+++ b/cli/command/manifest/annotate_test.go
@@ -63,7 +63,7 @@ func TestManifestAnnotate(t *testing.T) {
 	cmd.Flags().Set("os-version", "1")
 	cmd.Flags().Set("os-features", "feature1")
 	cmd.Flags().Set("variant", "v7")
-	expectedError = "manifest entry for image has unsupported os/arch combination"
+	expectedError = "unsupported os/arch combination"
 	assert.ErrorContains(t, cmd.Execute(), expectedError)
 
 	cmd.Flags().Set("arch", "arm")

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -281,7 +281,10 @@ func mountBlobs(ctx context.Context, client registryclient.RegistryClient, ref r
 		case nil:
 		case registryclient.ErrBlobCreated:
 			if blob.os != "windows" {
-				return fmt.Errorf("error mounting %s to %s", blob.canonical, ref)
+				return fmt.Errorf(
+					"blob %s was uploaded to %s instead of mounted from the source repository; cross-repository blob mount is required for %s manifests: %w",
+					blob.canonical, ref, blob.os, err,
+				)
 			}
 		default:
 			return err

--- a/cli/command/network/connect.go
+++ b/cli/command/network/connect.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net"
 	"net/netip"
 	"strings"
@@ -92,7 +92,7 @@ func convertDriverOpt(options []string) (map[string]string, error) {
 		// TODO(thaJeztah): we should probably not accept whitespace here (both for key and value).
 		k = strings.TrimSpace(k)
 		if !ok || k == "" {
-			return nil, errors.New("invalid key/value pair format in driver options")
+			return nil, fmt.Errorf("invalid --driver-opt value %q: expected key=value", opt)
 		}
 		driverOpt[k] = strings.TrimSpace(v)
 	}

--- a/cli/command/network/create.go
+++ b/cli/command/network/create.go
@@ -154,7 +154,7 @@ func createIPAMConfig(options ipamOptions) (*network.IPAM, error) {
 				return nil, err
 			}
 			if ok1 || ok2 {
-				return nil, errors.New("multiple overlapping subnet configuration is not supported")
+				return nil, fmt.Errorf("--subnet %s overlaps with --subnet %s", s, k)
 			}
 		}
 		sn, err := netip.ParsePrefix(s)

--- a/cli/command/network/create_test.go
+++ b/cli/command/network/create_test.go
@@ -71,7 +71,7 @@ func TestNetworkCreateErrors(t *testing.T) {
 				"gateway":  "255.0.255.0", // FIXME(thaJeztah): this used to accept a CIDR ("255.0.0.0/24")
 				"subnet":   "10.1.2.0/23,10.1.3.248/30",
 			},
-			expectedError: "multiple overlapping subnet configuration is not supported",
+			expectedError: "overlaps with --subnet",
 		},
 		{
 			args: []string{"toto"},

--- a/cli/command/node/inspect.go
+++ b/cli/command/node/inspect.go
@@ -71,7 +71,7 @@ func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions)
 	}
 
 	if err := inspectFormatWrite(nodeCtx, opts.nodeIds, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 1, Status: err.Error()}
 	}
 	return nil
 }

--- a/cli/command/secret/inspect.go
+++ b/cli/command/secret/inspect.go
@@ -65,7 +65,7 @@ func runSecretInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOp
 	}
 
 	if err := inspectFormatWrite(secretCtx, opts.names, getRef); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 1, Status: err.Error()}
 	}
 	return nil
 }

--- a/cli/command/service/inspect.go
+++ b/cli/command/service/inspect.go
@@ -94,7 +94,7 @@ func runInspect(ctx context.Context, dockerCLI command.Cli, opts inspectOptions)
 	}
 
 	if err := inspectFormatWrite(serviceCtx, opts.refs, getRef, getNetwork); err != nil {
-		return cli.StatusError{StatusCode: 1, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 1, Status: err.Error()}
 	}
 	return nil
 }

--- a/cli/command/system/events.go
+++ b/cli/command/system/events.go
@@ -60,6 +60,7 @@ func runEvents(ctx context.Context, dockerCLI command.Cli, options *eventsOption
 	tmpl, err := makeTemplate(options.format)
 	if err != nil {
 		return cli.StatusError{
+			Cause:      err,
 			StatusCode: 64,
 			Status:     "Error parsing format: " + err.Error(),
 		}

--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -209,7 +209,7 @@ func prettyPrintInfo(streams command.Streams, info dockerInfo) error {
 	}
 
 	if len(info.ServerErrors) > 0 || len(info.ClientErrors) > 0 {
-		return errors.New("errors pretty printing info")
+		return errors.New("one or more errors occurred while collecting system info; see ERROR lines above")
 	}
 	return nil
 }
@@ -493,6 +493,7 @@ func formatInfo(output io.Writer, info dockerInfo, format string) error {
 	tmpl, err := templates.Parse(format)
 	if err != nil {
 		return cli.StatusError{
+			Cause:      err,
 			StatusCode: 64,
 			Status:     "template parsing error: " + err.Error(),
 		}

--- a/cli/command/system/info_test.go
+++ b/cli/command/system/info_test.go
@@ -362,7 +362,7 @@ func TestPrettyPrintInfo(t *testing.T) {
 			prettyGolden:   "docker-info-errors",
 			jsonGolden:     "docker-info-errors",
 			warningsGolden: "docker-info-errors-stderr",
-			expectedError:  "errors pretty printing info",
+			expectedError:  "one or more errors occurred while collecting system info; see ERROR lines above",
 		},
 		{
 			doc: "bad security info",
@@ -374,7 +374,7 @@ func TestPrettyPrintInfo(t *testing.T) {
 			prettyGolden:   "docker-info-badsec",
 			jsonGolden:     "docker-info-badsec",
 			warningsGolden: "docker-info-badsec-stderr",
-			expectedError:  "errors pretty printing info",
+			expectedError:  "one or more errors occurred while collecting system info; see ERROR lines above",
 		},
 		{
 			doc: "info with devices",

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -213,7 +213,7 @@ func runVersion(ctx context.Context, dockerCLI command.Cli, opts *versionOptions
 	var err error
 	tmpl, err := newVersionTemplate(opts.format)
 	if err != nil {
-		return cli.StatusError{StatusCode: 64, Status: err.Error()}
+		return cli.StatusError{Cause: err, StatusCode: 64, Status: err.Error()}
 	}
 
 	vd := versionInfo{

--- a/cli/command/volume/update.go
+++ b/cli/command/volume/update.go
@@ -2,7 +2,7 @@ package volume
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -52,7 +52,7 @@ func runUpdate(ctx context.Context, dockerCli command.Cli, volumeID, availabilit
 	}
 
 	if res.Volume.ClusterVolume == nil {
-		return errors.New("can only update cluster volumes")
+		return fmt.Errorf("volume %q is not a cluster volume; only cluster volumes can be updated", volumeID)
 	}
 
 	if flags.Changed("availability") {

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -24,6 +24,7 @@ import (
 	cliflags "github.com/docker/cli/cli/flags"
 	"github.com/docker/cli/cli/version"
 	platformsignals "github.com/docker/cli/cmd/docker/internal/signals"
+	"github.com/docker/cli/internal/hint"
 	"github.com/moby/moby/client/pkg/versions"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -48,6 +49,9 @@ func main() {
 	if err != nil && !errdefs.IsCanceled(err) {
 		if err.Error() != "" {
 			_, _ = fmt.Fprintln(os.Stderr, err)
+			if h := hint.Of(err); h != "" {
+				_, _ = fmt.Fprintln(os.Stderr, "\n"+h)
+			}
 		}
 		os.Exit(getExitCode(err))
 	}

--- a/internal/hint/hint.go
+++ b/internal/hint/hint.go
@@ -1,0 +1,47 @@
+// Package hint attaches actionable user guidance to errors.
+//
+// A hint describes what the user can do about a failure ("Run
+// 'docker rm foo' to remove it.") and is rendered separately from the
+// error's message by the top-level error handler. It is not part of
+// [error.Error], so substring matching on the error message stays
+// stable as hints are added or reworded.
+//
+// Use [Wrap] to attach a hint at the call site, and [Of] (or
+// [errors.As] against [Hinter]) to extract it for rendering.
+package hint
+
+import "errors"
+
+// Hinter is implemented by errors that carry actionable user guidance.
+type Hinter interface {
+	Hint() string
+}
+
+type errWithHint struct {
+	error
+	hint string
+}
+
+func (e *errWithHint) Hint() string  { return e.hint }
+func (e *errWithHint) Unwrap() error { return e.error }
+
+// Wrap attaches actionable guidance to err. It returns nil if err is
+// nil. The hint does not appear in the wrapped error's [error.Error]
+// output; it is read out of the chain by the top-level renderer via
+// [Of] (or [errors.As] against [Hinter]).
+func Wrap(err error, hint string) error {
+	if err == nil {
+		return nil
+	}
+	return &errWithHint{error: err, hint: hint}
+}
+
+// Of returns the first hint in the error chain, or "" if none of the wrapped
+// errors implement [Hinter].
+func Of(err error) string {
+	var h Hinter
+	if errors.As(err, &h) {
+		return h.Hint()
+	}
+	return ""
+}

--- a/internal/hint/hint_test.go
+++ b/internal/hint/hint_test.go
@@ -1,0 +1,50 @@
+package hint
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestWrap_NilError(t *testing.T) {
+	assert.Assert(t, Wrap(nil, "irrelevant") == nil)
+}
+
+func TestWrap_PreservesMessage(t *testing.T) {
+	err := Wrap(errors.New("bad input"), "Try --help.")
+	assert.Equal(t, err.Error(), "bad input")
+}
+
+func TestWrap_HintReadable(t *testing.T) {
+	err := Wrap(errors.New("bad input"), "Try --help.")
+
+	var h Hinter
+	assert.Assert(t, errors.As(err, &h))
+	assert.Equal(t, h.Hint(), "Try --help.")
+}
+
+func TestOf_FindsHint(t *testing.T) {
+	base := Wrap(errors.New("bad input"), "Try --help.")
+	wrapped := fmt.Errorf("context: %w", base)
+
+	assert.Equal(t, Of(wrapped), "Try --help.")
+}
+
+func TestOf_NoHint(t *testing.T) {
+	assert.Equal(t, Of(errors.New("plain")), "")
+	assert.Equal(t, Of(nil), "")
+}
+
+func TestOf_FindsHintInJoinedError(t *testing.T) {
+	err := errors.Join(errors.New("plain"), Wrap(errors.New("bad input"), "Try --help."))
+
+	assert.Equal(t, Of(err), "Try --help.")
+}
+
+func TestUnwrap(t *testing.T) {
+	base := errors.New("bad input")
+	err := Wrap(base, "Try --help.")
+	assert.Assert(t, errors.Is(err, base))
+}


### PR DESCRIPTION
## What I did

Two things, packaged together so the abstraction is motivated by concrete improvements rather than argued in the abstract:

1. **Introduces `internal/hint`** — a small (~50-line) package that attaches actionable user guidance to errors. The hint is exposed via a `Hinter` interface, walked out of the error chain by the top-level renderer in `cmd/docker/docker.go`, and printed on its own line. Hints are **not** part of `err.Error()`, so substring assertions on error messages stay stable as hints are added or reworded.

2. **Applies 31 error-message rewrites** flagged by an end-to-end audit of CLI error quality across 11 command areas. The rewrites are organised around the patterns that surfaced most often:

   - **Factual / wrong-noun fixes** — messages that misdirected users to the wrong layer or named things that didn't exist (e.g. `image load` claiming "stdin is empty" when the actual guard checks `IsTerminal()`; `image list` referencing the internal field name `--show-digest` instead of the user-facing `--digests` flag; `inspect` calling template execution failures "parsing errors").
   - **Partial success surfaced** — operations that succeeded with a follow-up failure now say so, preventing wasted retries (`container create` cidfile write; `image build` aux-message decode and missing image ID for `--iidfile`).
   - **Refusal reasons explained** — TTY-refusal messages for binary tar output now state why instead of using "cowardly".
   - **Echo-the-value / name-the-flag** — validation errors include what the user typed and the expected form (the `--pid`/`--uts`/`--userns`/`--cgroupns` family, `--device`, `--storage-opt`, `--driver-opt`, `--subnet`, etc.).
   - **Internal jargon replaced** — `container exec`'s `"exec ID empty"` (an internal API field) replaced with daemon-anomaly framing.
   - **Cause preserved** — `manifest push` ErrBlobCreated now wrapped via `%w` and described correctly.

## How I did it

**The mechanism.** A 50-line internal package + a 4-line addition to the top-level error renderer. Usage:

```go
return hint.Wrap(
    fmt.Errorf("invalid --pid mode %q", val),
    "Valid forms are 'host' or 'container:<name|id>'.",
)
```

The `cmd/docker` renderer walks the chain via `errors.As` for any `Hinter` and prints the hint after the error. Errors without a hint are unaffected — the migration is fully incremental, no flag day.

**The rewrites.** Driven by an audit over the user-facing error inventory (215 errors across container, image, network, volume, context, system, registry, manifest, builder, inspect). Review flagged 32 entries as needing improvement; rewrite produced 31 rewrites + 1 keep-original; an editorial pass approved 29 outright and flagged 3 for cross-entry consistency tweaks (which are folded in).

15 of the rewrites have an explicit hint and use `hint.Wrap`; the rest are message-only changes.

## How to verify

- `make test` — the test suite is updated where assertions referenced the old wordings.
- Manually trigger a few of the rewritten errors:
  ```
  docker image save alpine               # writes to terminal -> binary-tar refusal with reason + hint
  docker image load                       # stdin is a TTY -> states the actual condition + hint
  docker run --pid=hsot alpine            # echoes the bad value + lists valid forms
  docker network create --subnet=10.0.0.0/24 --subnet=10.0.0.128/25 net  # names both overlapping subnets
  docker volume update some-non-cluster-volume  # names the volume + the constraint
  ```
- Compare `err.Error()` to substring-based test expectations to confirm hints are not part of the message string (they render on their own line).

## Why internal-only

Keeps API surface small while we iterate. If buildx/compose/scout adopt the same `Hinter` interface independently, errors flowing through docker CLI's renderer Just Work via duck-typing — they don't need to import the same package, just match the interface shape. Promotion to public is a rename when the convention proves out.

## Out of scope (intentional)

- **`withHelp` in `container/run.go`** still uses `\n\n` for its `--help` suggestion. Pre-existing pattern, untouched in this PR — natural follow-up to migrate to `hint.Wrap` once the mechanism lands.
- **Stderr-write error sites** (18 per the inventory). They bypass the central renderer entirely; addressing them needs separate consolidation work.
- **Catalog / identity-based error matching** (à la sentinel `var ErrFoo = ...` patterns). The current shape is a strict subset of what a catalog would provide; if it's wanted later, `Wrap` can sit underneath without breaking call sites.
- **One known nit deferred** — `context create`'s "no docker endpoint configured: set one with `--docker`, or copy from an existing context with `--from`" reads slightly off because `--docker` takes a structured `key=value` value rather than a single thing to "set". Happy to refine if reviewers prefer different wording.

## Related

- #1986 — broader feature request for better error messages around `docker create network` and similar; this PR doesn't close it but addresses the pattern.
- The `[RFC]` framing in the title follows the convention of #1683 (standardise exit-codes) — small enough abstraction that splitting RFC-doc and implementation would feel ceremonial, but big enough to want maintainer sign-off on the approach before going through detailed review.

## Asks of reviewers

Marked as **draft** intentionally. Before deep-diving on each individual rewrite, I'd appreciate feedback on:

1. **Is `internal/hint` the right shape?** Or would you rather see it inlined into `cli/error.go` next to `StatusError`, or a different abstraction entirely?
2. **The `hint.Wrap(err, "hint")` vs `\n\n<hint>` migration boundary** — should this PR also migrate `withHelp`, or is keeping that as a follow-up clearer?
3. **Any rewrites I shouldn't have shipped** — the audit's bar was "concrete user-visible benefit", but reviewers closer to specific commands may have context I missed (e.g. `manifest/push`'s ErrBlobCreated wording uses domain terms that may or may not be appropriate).

<!--
Changelog block intentionally omitted; the PR is user-facing but the
appropriate `impact/` label is for maintainers to set. Happy to add a
release-note line once the label is applied.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)