### PR TITLE
update to go1.26.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
         name: Update Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: false
       -
         name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: false
       -
         name: Test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -96,7 +96,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
           cache: false
       -
         name: Run gocompat check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   # which causes it to fallback to go1.17 semantics.
   #
   # TODO(thaJeztah): update "usetesting" settings to enable go1.24 features once our minimum version is go1.24
-  go: "1.26.2"
+  go: "1.26.3"
 
   timeout: 5m
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_VARIANT=alpine
 ARG ALPINE_VERSION=3.23
 ARG BASE_DEBIAN_DISTRO=bookworm
 
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 # XX_VERSION specifies the version of the xx utility to use.
 # It must be a valid tag in the docker.io/tonistiigi/xx image repository.

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.2
+ARG GO_VERSION=1.26.3
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.26.3+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.2...go1.26.3

**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.26.3](https://go.dev/doc/devel/release#go1.26.3)
```


```
This release include 11 security fixes:

- cmd/go: malicious module proxy can bypass checksum database

    A malicious module proxy could exploit a flaw in the go command's
    validation of module checksums to bypass checksum database validation.

    This vulnerability affects any user using an untrusted module proxy
    (GOMODPROXY) or checksum database (GOSUMDB).

    A malicious module proxy can serve altered versions of the Go toolchain.
    When selecting a different version of the Go toolchain than the
    currently installed toolchain (due to the GOTOOLCHAIN environment variable,
    or a go.work or go.mod with a toolchain line), the go command will download
    and execute a toolchain provided by the module proxy. A malicious module
    proxy can bypass checksum database validation for this downloaded
    toolchain.

    Since this vulnerability affects the security of toolchain downloads,
    setting GOTOOLCHAIN to a fixed version is not sufficient. You must upgrade
    your base Go toolchain.

    The go tool always validates the hash of a toolchain before executing it,
    so fixed versions will refuse to execute any cached, altered versions of the
    toolchain.

    The go tool trusts go.sum files to contain accurate hashes of the current
    module's dependencies. A malicious proxy exploiting this vulnerability to
    serve an altered module will have caused an incorrect hash to be recorded
    in the go.sum. Users who have configured a non-trusted GOPROXY can determine
    if they have been affected by running "rm go.sum ; go mod tidy ; go mod verify",
    which will revalidate all dependencies of the current module.

    The specific flaw in more detail:

    The go command consults the checksum database to validate downloaded modules,
    when a module is not listed in the go.sum file. It verifies that the module hash
    reported by the checksum database matches the hash of the downloaded module.
    If, however, the checksum database returns a successful response that contains
    no entry for the module, the go command incorrectly permitted validation to succeed.

    A module proxy may mirror or proxy the checksum database, in which case the go
    command will not connect to the checksum database directly. Checksums reported
    by the checksum database are cryptographically signed, so a malicious proxy
    cannot alter the reported checksum for a module. However, a proxy which returns
    an empty checksum response, or a checksum response for an unrelated module,
    could cause the go command to proceed as if a downloaded module has been validated.

    The go command now properly checks checksum database responses to ensure
    that the expected module signature is present, not just that if a signature is
    present it matches the expectation.

    Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

    This is CVE-2026-42501 and Go issue https://go.dev/issue/79070.

- net/http/httputil: ReverseProxy forwards queries with more than urlmaxqueryparams parameters

    When used with a Rewrite function, or a Director function which parses query parameters,
    ReverseProxy sanitizes the forwarded request to remove query parameters which are not
    parsed by url.ParseQuery. ReverseProxy did not take ParseQuery's limit on the total number
    of query parameters (controlled by GODEBUG=urlmaxqueryparams=N) into account.
    This could permit ReverseProxy to forward a request containing a query parameter
    that was not visible to the Rewrite function.

    For example, the query "a1=x&a2=x&...&a10000=x&hidden=y" could forward the parameter
    "hidden=y" while hiding it from the proxy's Rewrite function.

    ReverseProxy now avoids forwarding parameters that exceed the ParseQuery limit.

    This is CVE-2026-39825 and Go issue https://go.dev/issue/78948.

- net: panic in Dial and LookupPort when handling NUL byte on Windows

    The Dial and LookupPort functions would panic on Windows when provided
    with an input containing a NUL (0). These functions now return an error
    rather than panicking.

    This is CVE-2026-39836 and Go issue https://go.dev/issue/79006.

- net/mail: quadratic string concatenation in consumePhrase

    Pathological inputs could cause DoS through consumePhrase
    when parsing an email address according to RFC 5322.

    This is CVE-2026-42499 and Go issue https://go.dev/issue/78987.

- net/mail: quadratic string concatentation in consumeComment

    Well-crafted inputs reaching ParseAddress, ParseAddressList,
    and ParseDate were able to trigger excessive CPU exhaustion
    and memory allocations.

    This is CVE-2026-39820 and Go issue https://go.dev/issue/78566.

- cmd/go: "go bug" follows symlinks in predictable temporary filenames

    The "go bug" command wrote to two files with predictable names in
    the system temporary directory (for example, "/tmp").

    An attacker with access to the temporary directory could create a
    symlink in one of these names, causing "go bug" to overwrite the
    target of the symlink.

    The "go bug" command now uses os.MkdirTemp to create a safe
    working directory.

    Thanks to Harshit Gupta (Mr HAX) for reporting this issue.

    This is CVE-2026-39819 and Go issue https://go.dev/issue/78584.

- cmd/go: "go tool pack" does not sanitize output paths

    The "go tool pack" subcommand is a minimal version of the Unix ar utility.
    It is used by the compiler as an internal tool with known-good inputs.

    The "pack" subcommand did not sanitize output filenames.
    When invoked to extract a malicious archive file, it could write
    files to arbitrary locations on the filesystem.

    The "pack" subcommand now refuses to extract files with names
    containing any directory components.

    Thanks to Harshit Gupta (Mr HAX) for reporting this issue.

    This is CVE-2026-39817 and Go issue https://go.dev/issue/78778.

- net/http: infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE

    When processing HTTP/2 SETTINGS frames, transport will enter an infinite loop of
    writing CONTINUATION frames if it receives a SETTINGS_MAX_FRAME_SIZE with a
    value of 0.

    This allows potential DoS against a client by a malicious server. HTTP/2
    transport now properly checks that the received SETTINGS_MAX_FRAME_SIZE is
    valid.

    Thanks to Marwan Atia (marwansamir688@gmail.com) for reporting this issue.

    This is CVE-2026-33814 and Go issue https://go.dev/issue/78476.

- html/template: escaper bypass leads to XSS

    If a trusted template author were to write a
    tag containing an empty type attribute or a type
    attribute with an ASCII whitespace, the execution of
    the template would incorrectly escape any data passed
    into the block.

    Thanks to Mundur (https://github.com/M0nd0R) for reporting this issue.

    This is CVE-2026-39826 and Go issue https://go.dev/issue/78981.

- net: crash when handling long CNAME response

    When using LookupCNAME with the cgo DNS resolver,
    a very long CNAME response could trigger a double-free of C memory
    and a crash. The double-free has been fixed.

    Thanks to hamayanhamayan for reporting this issue.

    This is CVE-2026-33811 and Go issue https://go.dev/issue/78803.

- html/template: bypass of meta content URL escaping causes XSS

    CVE-2026-27142 fixed a vulnerability in which URLs were not
    correctly escaped inside of a tag's attribute.
    If the URL content were to insert ASCII whitespaces around the
    = rune inside of the attribute, the escaper would
    fail to similarly escape it, leading to XSS.

    Dynamic inputs to a tag's attribute are now
    whitespace sanitized prior to escaping.

    Thanks to Samy Ghannad for reporting this issue.
```