### PR TITLE
docs: clarify 64 KiB response-body buffer in authz plugin docs

### DIFF
--- a/docs/extend/plugins_authorization.md
+++ b/docs/extend/plugins_authorization.md
@@ -86,6 +86,31 @@ passed to the authorization plugins. For commands that return chunked HTTP
 response, such as `logs` and `events`, only the HTTP request is sent to the
 authorization plugins.
 
+### Response body size and partial buffering
+
+The internal buffer that holds the response body between the daemon's HTTP
+handler and the plugin's response authorization callback (`responseModifier`,
+defined in [`pkg/authorization/response.go`](https://github.com/moby/moby/blob/master/pkg/authorization/response.go))
+has a fixed capacity of 64 KiB (`maxBufferSize`).
+
+For most non-streaming endpoints the full response is buffered for plugin
+inspection regardless of total size, because Go's `encoding/json` encoder
+serializes the complete payload into a single underlying write. The
+streaming-response exclusion noted above (for example, `logs` and `events`)
+is the practical effect of this 64 KiB threshold combined with the
+`io.WriteFlusher` write pattern used by streaming handlers, where each write
+is immediately drained to the client and is therefore no longer available
+for plugin inspection by the time the handler returns.
+
+> [!NOTE]
+> Plugins that depend on `ResponseBody` inspection for redaction or
+> content-filtering should restrict their policies to endpoints whose
+> response is produced as a single write (typical of REST-style API
+> responses). For commands whose responses are streamed or are likely to
+> exceed the buffer through multiple writes, do not rely on `ResponseBody`
+> for security-relevant decisions; perform the filtering in a separate
+> layer in front of the daemon.
+
 During request/response processing, some authorization flows might
 need to do additional queries to the Docker daemon. To complete such flows,
 plugins can call the daemon API similar to a regular user. To enable these


### PR DESCRIPTION
## What

Adds a new **"Response body size and partial buffering"** subsection to `docs/extend/plugins_authorization.md` documenting the 64 KiB `maxBufferSize` constant in the daemon's internal `responseModifier` ([`pkg/authorization/response.go`](https://github.com/moby/moby/blob/master/pkg/authorization/response.go) in `moby/moby`) and its practical implications for plugins that use `ResponseBody` inspection.

## Why

The existing docs (lines 81–87) tell plugin authors that streaming endpoints such as `logs` and `events` send only the HTTP request to authorization plugins, but don't explain the underlying mechanism. As a result, plugin authors building response-body redaction or content-filtering can be surprised when the same effect happens on non-listed endpoints whose response is produced through multiple writes that exceed the buffer, or whose handler uses `io.WriteFlusher`.

This is not a behavior change — the 64 KiB buffer is observable from the public `moby` source. The PR is documentation catching up to existing behavior.

## How

- Inserts a new \`###\` subsection right after the existing "chunked HTTP response" paragraph (line 87 in \`master\`).
- 25 lines added, 0 removed.
- Uses the existing \`> [!NOTE]\` callout syntax ([introduced to this file in \`f1befab\`](https://github.com/docker/cli/commit/f1befab) on 2024-08-16).
- No content removed, no other section modified.

## Who's affected

Plugin authors and operations teams running authorization plugins that depend on \`ResponseBody\` for security decisions on large or streaming responses. For redaction-style plugins, the new section recommends performing filtering in a separate layer in front of the daemon when the endpoint is likely to exceed 64 KiB or stream chunked output.

## Verification

The numbers and behaviors described in the new subsection were derived directly from a read of \`pkg/authorization/response.go\` at moby \`master\`:

- \`maxBufferSize = 64 * 1024\` at \`pkg/authorization/response.go\` line 50.
- \`responseModifier.Write\` at line 117–128 calls \`Flush()\` when \`len(rm.body) + len(b) > maxBufferSize\`.
- \`responseModifier.FlushAll\` at line 167–197 writes the buffer to the underlying \`http.ResponseWriter\` and then drains the buffer slice.
- \`pkg/ioutils/writeflusher.go\` \`WriteFlusher.Write\` calls \`Flush()\` after every underlying write.
- \`pkg/authorization/middleware.go\` invokes \`AuthZResponse\` after the handler returns.