### PR TITLE
cli/command/image: rm redundant TestPrintImageTreeNoWarningWhenRedirected

### DIFF
--- a/cli/command/image/tree_test.go
+++ b/cli/command/image/tree_test.go
@@ -157,17 +157,6 @@ func TestPrintImageTreeAnsiTty(t *testing.T) {
 	}
 }
 
-func TestPrintImageTreeNoWarningWhenRedirected(t *testing.T) {
-	cli := test.NewFakeCli(nil)
-	cli.Out().SetIsTerminal(false)
-	cli.Err().SetIsTerminal(false)
-
-	printImageTree(cli, treeView{images: []topImage{}})
-
-	errOut := cli.ErrBuffer().String()
-	assert.Check(t, !strings.Contains(errOut, "WARNING: This output is designed for human readability"), "stderr should not contain warning when output is redirected, got: %s", errOut)
-}
-
 func TestPrintImageTreeGolden(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
- follow-up to https://github.com/docker/cli/pull/6754

This is already covered by various tests using .golden files.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

