### PR TITLE
Allow the external CAs to be removed entirely using the CL (carry 1179)

### DIFF
--- a/cli/command/swarm/opts.go
+++ b/cli/command/swarm/opts.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -99,7 +100,9 @@ func (m *ExternalCAOption) Set(value string) error {
 		return err
 	}
 
-	m.values = append(m.values, parsed)
+	if parsed != nil {
+		m.values = append(m.values, parsed)
+	}
 	return nil
 }
 
@@ -112,8 +115,10 @@ func (*ExternalCAOption) Type() string {
 func (m *ExternalCAOption) String() string {
 	externalCAs := make([]string, 0, len(m.values))
 	for _, externalCA := range m.values {
-		repr := fmt.Sprintf("%s: %s", externalCA.Protocol, externalCA.URL)
-		externalCAs = append(externalCAs, repr)
+		if externalCA != nil {
+			repr := fmt.Sprintf("%s: %s", externalCA.Protocol, externalCA.URL)
+			externalCAs = append(externalCAs, repr)
+		}
 	}
 	return strings.Join(externalCAs, ", ")
 }
@@ -161,6 +166,9 @@ func (p *PEMFile) Contents() string {
 func parseExternalCA(caSpec string) (*swarm.ExternalCA, error) {
 	csvReader := csv.NewReader(strings.NewReader(caSpec))
 	fields, err := csvReader.Read()
+	if err == io.EOF {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cli/command/swarm/opts_test.go
+++ b/cli/command/swarm/opts_test.go
@@ -3,6 +3,7 @@ package swarm
 import (
 	"testing"
 
+	"github.com/moby/moby/api/types/swarm"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -43,10 +44,6 @@ func TestExternalCAOptionErrors(t *testing.T) {
 		expectedError string
 	}{
 		{
-			externalCA:    "",
-			expectedError: "EOF",
-		},
-		{
 			externalCA:    "anything",
 			expectedError: "invalid field 'anything' must be a key=value pair",
 		},
@@ -71,34 +68,112 @@ func TestExternalCAOptionErrors(t *testing.T) {
 
 func TestExternalCAOption(t *testing.T) {
 	testCases := []struct {
-		externalCA string
-		expected   string
+		externalCAs    []string
+		expected       []*swarm.ExternalCA
+		expectedString string
 	}{
 		{
-			externalCA: "protocol=cfssl,url=anything",
-			expected:   "cfssl: anything",
+			externalCAs:    []string{""},
+			expected:       nil,
+			expectedString: "",
 		},
 		{
-			externalCA: "protocol=CFSSL,url=anything",
-			expected:   "cfssl: anything",
+			externalCAs: []string{"protocol=cfssl,url=anything"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "anything",
+					Options:  make(map[string]string),
+				},
+			},
+			expectedString: "cfssl: anything",
 		},
 		{
-			externalCA: "protocol=Cfssl,url=https://example.com",
-			expected:   "cfssl: https://example.com",
+			externalCAs: []string{"protocol=CFSSL,url=anything"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "anything",
+					Options:  make(map[string]string),
+				},
+			},
+			expectedString: "cfssl: anything",
 		},
 		{
-			externalCA: "protocol=Cfssl,url=https://example.com,foo=bar",
-			expected:   "cfssl: https://example.com",
+			externalCAs: []string{"protocol=Cfssl,url=https://example.com"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example.com",
+					Options:  make(map[string]string),
+				},
+			},
+			expectedString: "cfssl: https://example.com",
 		},
 		{
-			externalCA: "protocol=Cfssl,url=https://example.com,foo=bar,foo=baz",
-			expected:   "cfssl: https://example.com",
+			externalCAs: []string{"protocol=Cfssl,url=https://example.com,foo=bar"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example.com",
+					Options: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+			expectedString: "cfssl: https://example.com",
+		},
+		{
+			externalCAs: []string{"protocol=Cfssl,url=https://example.com,foo=bar,foo=baz"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example.com",
+					Options: map[string]string{
+						"foo": "baz",
+					},
+				},
+			},
+			expectedString: "cfssl: https://example.com",
+		},
+		{
+			externalCAs: []string{"", "protocol=Cfssl,url=https://example.com"},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example.com",
+					Options:  make(map[string]string),
+				},
+			},
+			expectedString: "cfssl: https://example.com",
+		},
+		{
+			externalCAs: []string{
+				"protocol=Cfssl,url=https://example.com",
+				"protocol=Cfssl,url=https://example2.com",
+			},
+			expected: []*swarm.ExternalCA{
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example.com",
+					Options:  make(map[string]string),
+				},
+				{
+					Protocol: swarm.ExternalCAProtocolCFSSL,
+					URL:      "https://example2.com",
+					Options:  make(map[string]string),
+				},
+			},
+			expectedString: "cfssl: https://example.com, cfssl: https://example2.com",
 		},
 	}
 	for _, tc := range testCases {
 		opt := &ExternalCAOption{}
-		assert.NilError(t, opt.Set(tc.externalCA))
-		assert.Check(t, is.Equal(tc.expected, opt.String()))
+		for _, extCA := range tc.externalCAs {
+			assert.NilError(t, opt.Set(extCA))
+		}
+		assert.Check(t, is.DeepEqual(tc.expected, opt.Value()))
+		assert.Check(t, is.Equal(tc.expectedString, opt.String()))
 	}
 }
 


### PR DESCRIPTION
- rebase of https://github.com/docker/cli/pull/1179 in case we still needed it


Allow setting --external-ca to an empty string, to allow for removing all external CAs entirely.  This will help for instance if rotating from a fully external CA to an internal CA (if the CA's cert and key are already in the swarm for instance).

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->
```markdown changelog


```

**- A picture of a cute animal (not mandatory but encouraged)**

