### PR TITLE
feat: automatically add socket's group when using `--use-api-socket`

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -255,12 +255,14 @@ func createContainer(ctx context.Context, dockerCLI command.Cli, containerCfg *c
 		}
 
 		// hard-code engine socket path until https://github.com/moby/moby/pull/43459 gives us a discovery mechanism
-		containerCfg.HostConfig.Mounts = append(containerCfg.HostConfig.Mounts, mount.Mount{
+		const dockerSocketPath = "/var/run/docker.sock"
+		hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{
 			Type:        mount.TypeBind,
-			Source:      "/var/run/docker.sock",
-			Target:      "/var/run/docker.sock",
+			Source:      dockerSocketPath,
+			Target:      dockerSocketPath,
 			BindOptions: &mount.BindOptions{},
 		})
+		addSocketGroup(&hostConfig.GroupAdd, dockerSocketPath)
 
 		/*
 

--- a/cli/command/container/use_api_socket_unix.go
+++ b/cli/command/container/use_api_socket_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package container
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+// addSocketGroup appends the GID of the socket file at path to groupAdd, so
+// non-root users can access the socket without an explicit --group-add flag.
+// Errors are silently ignored; this is best-effort.
+func addSocketGroup(groupAdd *[]string, path string) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	*groupAdd = append(*groupAdd, strconv.FormatUint(uint64(stat.Gid), 10))
+}

--- a/cli/command/container/use_api_socket_windows.go
+++ b/cli/command/container/use_api_socket_windows.go
@@ -1,0 +1,4 @@
+package container
+
+// addSocketGroup is a no-op on Windows.
+func addSocketGroup(_ *[]string, _ string) {}


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

The `--use-api-socket` flag is great, but it didn't account for the case when the container is executed as a non-root user that is not part of the socket's group:

```console
❯ docker run --rm --use-api-socket -u $(id -u):$(id -g) docker:cli docker version
Client:
 Version:           29.5.0
 API version:       1.54
 Go version:        go1.26.3
 Git commit:        98f1464
 Built:             Thu May 14 14:39:32 2026
 OS/Arch:           linux/amd64
 Context:           default
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

This PR makes it so that `--use-api-socket` will account for this case.

**- How I did it**

This PR improves the `--use-api-socket` flag so that it automatically discovers the socket's group and adds it, equivalent to manually passing `--group-add $(stat -c '%g' /var/run/docker.sock)`.

**- How to verify it**

```console
❯ build/docker run --rm --use-api-socket -u $(id -u):$(id -g) docker:cli docker version
Client:
 Version:           29.5.0
 API version:       1.54
 Go version:        go1.26.3
 Git commit:        98f1464
 Built:             Thu May 14 14:39:32 2026
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          29.5.1
  API version:      1.54 (minimum version 1.40)
  Go version:       go1.26.3
  Git commit:       dd24a3a
  Built:            Mon May 18 15:24:46 2026
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v2.2.3
  GitCommit:        77c84241c7cbdd9b4eca2591793e3d4f4317c590
 runc:
  Version:          1.3.5
  GitCommit:        v1.3.5-0-g488fc13e
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
Automatically add socket's group to container user when using `--use-api-socket`
```

**- A picture of a cute animal (not mandatory but encouraged)**

<img width="500" alt="Fossa" src="https://github.com/user-attachments/assets/d52e35f1-751d-457f-898a-357975d2dc59" />


