### PR TITLE
scripts/build: set grpcnotrace build-tag to reduce binary size

### DIFF
--- a/scripts/build/.variables
+++ b/scripts/build/.variables
@@ -98,6 +98,16 @@ fi
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$(go env GOOS)" = "linux" ]; then
     GO_LDFLAGS="$GO_LDFLAGS -linkmode external -extldflags -static"
 fi
+
+# We only import google.golang.org/grpc as an indirect dependency, and
+# do not make gRPC connections.
+#
+# grpcnotrace avoids importing golang.org/x/net/trace, which in turn enables
+# dead code elimination, which can reduce binary size when tracing is not needed.
+#
+# see https://github.com/grpc/grpc-go/blob/v1.81.1/trace_notrace.go#L23-L25
+GO_BUILDTAGS="$GO_BUILDTAGS grpcnotrace"
+
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     # compiling statically with CGO enabled requires osusergo and netgo to be set.
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo netgo"


### PR DESCRIPTION
Reduces the binary size (39810466 - 39289106 => 521360 (521 kb)

We only import google.golang.org/grpc as an indirect dependency, and do not make gRPC connections.

grpcnotrace avoids importing golang.org/x/net/trace, which in turn enables dead code elimination, which can yield 10-15% improvements in binary size when tracing is not needed.

see https://github.com/grpc/grpc-go/blob/v1.81.1/trace_notrace.go#L23-L25

Before:

    ls -l ./build/docker-darwin-arm64
    -rwxr-xr-x  1 thajeztah  staff  39810466 May 22 11:44 ./build/docker-darwin-arm64*
    ls -lh ./build/docker-darwin-arm64
    -rwxr-xr-x  1 thajeztah  staff    38M May 22 11:44 ./build/docker-darwin-arm64*

After:

    ls -l ./build/docker-darwin-arm64
    -rwxr-xr-x  1 thajeztah  staff  39289106 May 22 11:45 ./build/docker-darwin-arm64*
    ls -lh ./build/docker-darwin-arm64
    -rwxr-xr-x  1 thajeztah  staff    37M May 22 11:45 ./build/docker-darwin-arm64*

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
