### PR TITLE
cli-plugins/hooks: fix max-message off-by-one

### DIFF
--- a/cli-plugins/hooks/template.go
+++ b/cli-plugins/hooks/template.go
@@ -40,7 +40,7 @@ func ParseTemplate(hookTemplate string, cmd *cobra.Command) ([]string, error) {
 		}
 		out = b.String()
 	}
-	if n := strings.Count(out, "\n"); n > maxMessages {
+	if n := strings.Count(out, "\n") + 1; n > maxMessages {
 		return nil, fmt.Errorf("hook template contains too many messages (%d): maximum is %d", n, maxMessages)
 	}
 	return strings.SplitN(out, "\n", maxMessages), nil

--- a/cli-plugins/hooks/template_test.go
+++ b/cli-plugins/hooks/template_test.go
@@ -1,6 +1,7 @@
 package hooks_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docker/cli/cli-plugins/hooks"
@@ -122,4 +123,11 @@ func TestParseTemplate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseTemplateTooManyMessages(t *testing.T) {
+	testCmd := &cobra.Command{Use: "pull"}
+
+	_, err := hooks.ParseTemplate(strings.Repeat("line\n", 10)+"line", testCmd)
+	assert.Error(t, err, "hook template contains too many messages (11): maximum is 10")
 }


### PR DESCRIPTION
Fixes #7005

## What changed

This updates `cli-plugins/hooks.ParseTemplate()` to enforce the 10-message limit on the actual number of rendered messages instead of on the number of newline separators alone.

It also adds a regression test for the 11-line case.

## Why it changed

The current implementation rejects only when `strings.Count(out, "\n") > maxMessages` and then returns `strings.SplitN(out, "\n", maxMessages)`.

That makes the guard off by one: output with 10 newline characters contains 11 messages, but is still accepted. The extra rendered line is then folded into the last returned element.

## Impact

Templates that render to more than 10 messages are now rejected consistently, including the 11-line / 10-newline case.

Valid templates keep the existing split behavior.

## Root cause

The limit check counted separators instead of messages.

## Validation

- `GOPATH=$(mktemp -d) GO111MODULE=off go test github.com/docker/cli/cli-plugins/hooks` via a temporary GOPATH layout rooted at this checkout
