### PR TITLE
image: TestRunPushRespectsNoColorForAuxNotes: use table-test

### DIFF
--- a/cli/command/image/push_test.go
+++ b/cli/command/image/push_test.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -10,9 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/cli/internal/test"
-	"github.com/moby/moby/api/types/auxprogress"
 	"github.com/moby/moby/client"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
 
@@ -93,26 +89,50 @@ func TestNewPushCommandSuccess(t *testing.T) {
 }
 
 func TestRunPushRespectsNoColorForAuxNotes(t *testing.T) {
-	t.Setenv("NO_COLOR", "1")
-	cli := test.NewFakeCli(&fakeClient{
-		imagePushFunc: func(ref string, options client.ImagePushOptions) (client.ImagePushResponse, error) {
-			aux, err := json.Marshal(auxprogress.ManifestPushedInsteadOfIndex{
-				ManifestPushedInsteadOfIndex: true,
-				OriginalIndex:                ocispec.Descriptor{Digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111"},
-				SelectedManifest:             ocispec.Descriptor{Digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222"},
-			})
-			assert.NilError(t, err)
-			line := append([]byte(`{"aux":`), aux...)
-			line = append(line, '}', '\n')
-			return fakeStreamResult{ReadCloser: io.NopCloser(bytes.NewReader(line))}, nil
+	const (
+		originalDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		selectedDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+	response := `{"aux":{"manifestPushedInsteadOfIndex":true,"originalIndex":{"digest":"` + originalDigest + `"},"selectedManifest":{"digest":"` + selectedDigest + `"}}}` + "\n"
+
+	testCases := []struct {
+		name    string
+		noColor bool
+		hasANSI bool
+	}{
+		{
+			name:    "terminal",
+			hasANSI: true,
 		},
-	})
-	cli.Out().SetIsTerminal(true)
+		{
+			name:    "no-color",
+			noColor: true,
+			hasANSI: false,
+		},
+	}
 
-	err := runPush(t.Context(), cli, pushOptions{remote: "image:tag"})
-	assert.NilError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.noColor {
+				t.Setenv("NO_COLOR", "1")
+			} else {
+				t.Setenv("NO_COLOR", "")
+			}
 
-	out := cli.OutBuffer().String()
-	assert.Assert(t, strings.Contains(out, "sha256:1111111111111111111111111111111111111111111111111111111111111111 -> sha256:2222222222222222222222222222222222222222222222222222222222222222"))
-	assert.Assert(t, !strings.Contains(out, "\x1b["), "output should not contain ANSI escape codes, output: %s", out)
+			cli := test.NewFakeCli(&fakeClient{
+				imagePushFunc: func(ref string, options client.ImagePushOptions) (client.ImagePushResponse, error) {
+					return fakeStreamResult{ReadCloser: io.NopCloser(strings.NewReader(response))}, nil
+				},
+			})
+			cli.Out().SetIsTerminal(true)
+
+			assert.NilError(t, runPush(t.Context(), cli, pushOptions{remote: "example.com/image:tag"}))
+
+			out := cli.OutBuffer().String()
+			assert.Check(t, strings.Contains(out, "Not all multiplatform-content is present"))
+			assert.Check(t, strings.Contains(out, originalDigest))
+			assert.Check(t, strings.Contains(out, selectedDigest))
+			assert.Equal(t, tc.hasANSI, strings.Contains(out, "\x1b["))
+		})
+	}
 }


### PR DESCRIPTION
- follow-up to: https://github.com/docker/cli/pull/6957

**- How to verify it**

**- Human readable description for the release notes**

```markdown changelog
```
