### PR TITLE
context: cap TLS reads during zip import

### DIFF
--- a/cli/context/store/io_utils.go
+++ b/cli/context/store/io_utils.go
@@ -16,14 +16,14 @@ func (l *limitedReader) Read(p []byte) (n int, err error) {
 	if l.N < 0 {
 		return 0, errors.New("read exceeds the defined limit")
 	}
-	if l.N == 0 {
-		return 0, io.EOF
-	}
 	// have to cap N + 1 otherwise we won't hit limit err
 	if int64(len(p)) > l.N+1 {
 		p = p[0 : l.N+1]
 	}
 	n, err = l.R.Read(p)
 	l.N -= int64(n)
+	if l.N < 0 {
+		return n, errors.New("read exceeds the defined limit")
+	}
 	return n, err
 }

--- a/cli/context/store/io_utils_test.go
+++ b/cli/context/store/io_utils_test.go
@@ -21,4 +21,8 @@ func TestLimitReaderReadAll(t *testing.T) {
 	r = strings.NewReader("Test")
 	_, err = io.ReadAll(&limitedReader{R: r, N: 2})
 	assert.Error(t, err, "read exceeds the defined limit")
+
+	r = strings.NewReader("Tes")
+	_, err = io.ReadAll(&limitedReader{R: r, N: 2})
+	assert.Error(t, err, "read exceeds the defined limit")
 }

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -478,7 +478,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 			if err != nil {
 				return err
 			}
-			data, err := io.ReadAll(f)
+			data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
 			defer f.Close()
 			if err != nil {
 				return err

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -211,6 +211,46 @@ func TestImportZip(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestImportZipRejectsOversizedTLSFile(t *testing.T) {
+	testDir := t.TempDir()
+	zf := path.Join(testDir, "test.zip")
+
+	f, err := os.Create(zf)
+	assert.NilError(t, err)
+	defer f.Close()
+	w := zip.NewWriter(f)
+
+	meta, err := json.Marshal(Metadata{
+		Endpoints: map[string]any{
+			"ep1": endpoint{Foo: "bar"},
+		},
+		Metadata: context{Bar: "baz"},
+		Name:     "source",
+	})
+	assert.NilError(t, err)
+
+	mf, err := w.Create(metaFile)
+	assert.NilError(t, err)
+	_, err = mf.Write(meta)
+	assert.NilError(t, err)
+
+	tlsFile, err := w.Create(path.Join("tls", "docker", "ca.pem"))
+	assert.NilError(t, err)
+	_, err = tlsFile.Write(bytes.Repeat([]byte{0}, int(maxAllowedFileSizeToImport)+1))
+	assert.NilError(t, err)
+
+	err = w.Close()
+	assert.NilError(t, err)
+
+	source, err := os.Open(zf)
+	assert.NilError(t, err)
+	defer source.Close()
+	var r io.Reader = source
+	s := New(testDir, testCfg)
+	err = Import("zipOversizedTLS", s, r)
+	assert.ErrorContains(t, err, "read exceeds the defined limit")
+}
+
 func TestImportZipInvalid(t *testing.T) {
 	testDir := t.TempDir()
 	zf := path.Join(testDir, "test.zip")


### PR DESCRIPTION
**- What I did**

Applied the existing context-import decompressed read limit to TLS entries in zip context archives.

Fixes #6917

**- How I did it**

- wrapped zip `tls/` entry reads with `limitedReader`, matching `meta.json`
- tightened `limitedReader` so it probes the underlying reader at the zero-remaining boundary and reports data beyond the limit
- added regressions for oversized compressed TLS entries and the exact limit-plus-one reader boundary

**- How to verify it**

```bash
GO111MODULE=auto GOPATH=<temp-gopath> go test github.com/docker/cli/cli/context/store -run 'TestImportZipRejectsOversizedTLSFile|TestLimitReaderReadAll' -count=1
GO111MODULE=auto GOPATH=<temp-gopath> go test github.com/docker/cli/cli/context/store -count=1
GO111MODULE=auto GOPATH=<temp-gopath> go test github.com/docker/cli/cli/context/store github.com/docker/cli/cli/command/context -count=1
git diff --check
```

**- Human readable description for the release notes**

```markdown changelog
`docker context import` now enforces the decompressed size limit for TLS material in zip archives.
```
