### PR TITLE
builder: keep Windows default when daemon is unavailable

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -164,16 +164,27 @@ func (cli *DockerCli) BuildKitEnabled() (bool, error) {
 	}
 
 	si := cli.ServerInfo()
+	return defaultBuildKitEnabled(si, runtime.GOOS), nil
+}
+
+func defaultBuildKitEnabled(si ServerInfo, clientOSType string) bool {
 	if si.BuildkitVersion == build.BuilderBuildKit {
 		// The daemon advertised BuildKit as the preferred builder; this may
 		// be either a Linux daemon or a Windows daemon with experimental
 		// BuildKit support enabled.
-		return true, nil
+		return true
 	}
-
-	// otherwise, assume BuildKit is enabled for Linux, but disabled for
+	if si.OSType == "windows" {
+		return false
+	}
+	if si.OSType == "" && clientOSType == "windows" {
+		// If the daemon cannot be reached, keep the Windows client on the
+		// Windows / WCOW default instead of assuming a Linux daemon.
+		return false
+	}
+	// Otherwise, assume BuildKit is enabled for Linux, but disabled for
 	// Windows / WCOW, which does not yet support BuildKit by default.
-	return si.OSType != "windows", nil
+	return true
 }
 
 // HooksEnabled returns whether plugin hooks are enabled.

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -252,6 +252,18 @@ func TestDefaultBuildKitEnabled(t *testing.T) {
 	}
 }
 
+func TestBuildKitEnabledWithBuilderAlias(t *testing.T) {
+	cli := &DockerCli{
+		configFile: &configfile.ConfigFile{
+			Aliases: map[string]string{"builder": "buildx"},
+		},
+	}
+
+	enabled, err := cli.BuildKitEnabled()
+	assert.NilError(t, err)
+	assert.Check(t, enabled)
+}
+
 // Makes sure we don't hang forever on the initial connection.
 // https://github.com/docker/cli/issues/3652
 func TestInitializeFromClientHangs(t *testing.T) {

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/context/store"
 	"github.com/docker/cli/cli/flags"
+	"github.com/moby/moby/api/types/build"
 	"github.com/moby/moby/client"
 	"gotest.tools/v3/assert"
 )
@@ -201,6 +202,52 @@ func TestInitializeFromClient(t *testing.T) {
 			assert.NilError(t, err)
 			assert.DeepEqual(t, cli.ServerInfo(), tc.expectedServer)
 			assert.Equal(t, apiClient.negotiated, tc.negotiated)
+		})
+	}
+}
+
+func TestDefaultBuildKitEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverInfo ServerInfo
+		clientOS   string
+		expected   bool
+	}{
+		{
+			name:       "linux daemon",
+			serverInfo: ServerInfo{OSType: "linux"},
+			clientOS:   "windows",
+			expected:   true,
+		},
+		{
+			name:       "windows daemon",
+			serverInfo: ServerInfo{OSType: "windows"},
+			clientOS:   "linux",
+			expected:   false,
+		},
+		{
+			name:       "windows daemon advertised buildkit",
+			serverInfo: ServerInfo{OSType: "windows", BuildkitVersion: build.BuilderBuildKit},
+			clientOS:   "windows",
+			expected:   true,
+		},
+		{
+			name:       "unknown daemon on linux client",
+			serverInfo: ServerInfo{},
+			clientOS:   "linux",
+			expected:   true,
+		},
+		{
+			name:       "unknown daemon on windows client",
+			serverInfo: ServerInfo{},
+			clientOS:   "windows",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, defaultBuildKitEnabled(tc.serverInfo, tc.clientOS), tc.expected)
 		})
 	}
 }

--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -12,7 +13,6 @@ import (
 	pluginmanager "github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/metadata"
 	"github.com/docker/cli/cli/command"
-	"github.com/moby/moby/api/types/build"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -44,6 +44,10 @@ func newBuilderError(errorMsg string, pluginLoadErr error) error {
 		return fmt.Errorf("%w\n\n%s", pluginLoadErr, errorMsg)
 	}
 	return errors.New(errorMsg)
+}
+
+func isWindowsBuilderDefault(si command.ServerInfo, clientOSType string) bool {
+	return si.OSType == "windows" || (si.OSType == "" && clientOSType == "windows")
 }
 
 //nolint:gocyclo
@@ -85,11 +89,15 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 		return args, osargs, nil, nil
 	}
 
-	if !useBuilder {
+	if !useBuilder && !buildKitDisabled {
 		// Builder is not explicitly configured as an alias for buildx.
 		// Detect whether we should use BuildKit, or fallback to the
 		// legacy builder.
-		if si := dockerCli.ServerInfo(); si.BuildkitVersion != build.BuilderBuildKit && si.OSType == "windows" {
+		buildKitEnabled, err := dockerCli.BuildKitEnabled()
+		if err != nil {
+			return args, osargs, nil, err
+		}
+		if !buildKitEnabled {
 			// The daemon didn't advertise BuildKit as the preferred builder,
 			// so use the legacy builder, which is still the default for
 			// Windows / WCOW.
@@ -102,7 +110,7 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 		// is deprecated. For Windows / WCOW, BuildKit is still experimental,
 		// so we don't print this warning, even if the daemon advertised that
 		// it supports BuildKit.
-		if dockerCli.ServerInfo().OSType != "windows" {
+		if !isWindowsBuilderDefault(dockerCli.ServerInfo(), runtime.GOOS) {
 			_, _ = fmt.Fprintf(dockerCli.Err(), "%s\n\n", buildkitDisabledWarning)
 		}
 		return args, osargs, nil, nil

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -129,6 +129,46 @@ func (*fakeClient) Ping(context.Context, client.PingOptions) (client.PingResult,
 	return client.PingResult{OSType: "linux"}, nil
 }
 
+func TestIsWindowsBuilderDefault(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverInfo command.ServerInfo
+		clientOS   string
+		expected   bool
+	}{
+		{
+			name:       "windows daemon",
+			serverInfo: command.ServerInfo{OSType: "windows"},
+			clientOS:   "linux",
+			expected:   true,
+		},
+		{
+			name:       "linux daemon",
+			serverInfo: command.ServerInfo{OSType: "linux"},
+			clientOS:   "windows",
+			expected:   false,
+		},
+		{
+			name:       "unknown daemon on windows client",
+			serverInfo: command.ServerInfo{},
+			clientOS:   "windows",
+			expected:   true,
+		},
+		{
+			name:       "unknown daemon on linux client",
+			serverInfo: command.ServerInfo{},
+			clientOS:   "linux",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, isWindowsBuilderDefault(tc.serverInfo, tc.clientOS), tc.expected)
+		})
+	}
+}
+
 func TestBuildkitDisabled(t *testing.T) {
 	ctx := t.Context()
 

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -129,6 +129,14 @@ func (*fakeClient) Ping(context.Context, client.PingOptions) (client.PingResult,
 	return client.PingResult{OSType: "linux"}, nil
 }
 
+type fakeWindowsClient struct {
+	client.Client
+}
+
+func (*fakeWindowsClient) Ping(context.Context, client.PingOptions) (client.PingResult, error) {
+	return client.PingResult{OSType: "windows"}, nil
+}
+
 func TestIsWindowsBuilderDefault(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -207,6 +215,42 @@ func TestBuildkitDisabled(t *testing.T) {
 		0: output.Suffix("DEPRECATED: The legacy builder is deprecated and will be removed in a future release."),
 		1: output.Suffix("BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0"),
 	})
+}
+
+func TestBuildkitDisabledWithWindowsDaemonSkipsWarning(t *testing.T) {
+	ctx := t.Context()
+
+	t.Setenv("DOCKER_BUILDKIT", "0")
+
+	dir := fs.NewDir(t, t.Name(),
+		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0o777)),
+	)
+	defer dir.Remove()
+
+	b := bytes.NewBuffer(nil)
+
+	dockerCli, err := command.NewDockerCli(
+		command.WithBaseContext(ctx),
+		command.WithAPIClient(&fakeWindowsClient{}),
+		command.WithInputStream(discard),
+		command.WithCombinedStreams(b),
+	)
+	assert.NilError(t, err)
+	assert.NilError(t, dockerCli.Initialize(flags.NewClientOptions()))
+	dockerCli.ConfigFile().CLIPluginsExtraDirs = []string{dir.Path()}
+
+	tcmd := newDockerCommand(dockerCli)
+	tcmd.SetArgs([]string{"build", "."})
+
+	cmd, args, err := tcmd.HandleGlobalFlags()
+	assert.NilError(t, err)
+
+	var envs []string
+	args, os.Args, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{"build", "."}, args)
+	assert.Check(t, len(envs) == 0)
+	assert.Equal(t, b.String(), "")
 }
 
 func TestBuilderBroken(t *testing.T) {

--- a/cmd/docker/builder_windows_test.go
+++ b/cmd/docker/builder_windows_test.go
@@ -1,5 +1,61 @@
 package main
 
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/flags"
+	"github.com/moby/moby/client"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
 func init() {
 	pluginFilename = pluginFilename + ".exe"
+}
+
+type failingPingClient struct {
+	client.Client
+}
+
+func (*failingPingClient) Ping(context.Context, client.PingOptions) (client.PingResult, error) {
+	return client.PingResult{}, errors.New("daemon unavailable")
+}
+
+func TestBuildWithUnavailableDaemonUsesWindowsLegacyDefault(t *testing.T) {
+	ctx := t.Context()
+
+	dir := fs.NewDir(t, t.Name(),
+		fs.WithFile(pluginFilename, `#!/bin/sh exit 1`, fs.WithMode(0o777)),
+	)
+	defer dir.Remove()
+
+	b := bytes.NewBuffer(nil)
+
+	dockerCli, err := command.NewDockerCli(
+		command.WithBaseContext(ctx),
+		command.WithAPIClient(&failingPingClient{}),
+		command.WithInputStream(discard),
+		command.WithCombinedStreams(b),
+	)
+	assert.NilError(t, err)
+	assert.NilError(t, dockerCli.Initialize(flags.NewClientOptions()))
+	dockerCli.ConfigFile().CLIPluginsExtraDirs = []string{dir.Path()}
+
+	tcmd := newDockerCommand(dockerCli)
+	tcmd.SetArgs([]string{"build", "."})
+
+	cmd, args, err := tcmd.HandleGlobalFlags()
+	assert.NilError(t, err)
+
+	var envs []string
+	args, os.Args, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{"build", "."}, args)
+	assert.Check(t, len(envs) == 0)
+	assert.Equal(t, b.String(), "")
 }


### PR DESCRIPTION
**- What I did**

Kept the Windows/WCOW default builder behavior when a Windows Docker CLI client cannot read daemon OSType because the daemon is unavailable.

Fixes #6855

**- How I did it**

- moved the default BuildKit decision behind a helper that can distinguish daemon OSType from client OS fallback
- treats unknown daemon OSType on a Windows client like the Windows/WCOW default instead of assuming a Linux daemon
- updated builder forwarding to use `BuildKitEnabled()` for the default decision
- kept explicit `DOCKER_BUILDKIT=1`, advertised BuildKit, and Linux daemon-unavailable behavior unchanged
- added portable helper tests plus a Windows-only regression for the unavailable-daemon path

**- How to verify it**

```bash
GO111MODULE=auto GOPATH=<temp-gopath> go test github.com/docker/cli/cli/command github.com/docker/cli/cmd/docker -count=1
git diff --check
```

**- Human readable description for the release notes**

```markdown changelog
Avoid incorrectly warning Windows users to install Buildx when `docker build` cannot read daemon OSType.
```
