### PR TITLE
update to go1.26.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
         name: Update Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
       -
         name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
       -
         name: Test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -96,7 +96,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
       -
         name: Run gocompat check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   # which causes it to fallback to go1.17 semantics.
   #
   # TODO(thaJeztah): update "usetesting" settings to enable go1.24 features once our minimum version is go1.24
-  go: "1.26.3"
+  go: "1.26.4"
 
   timeout: 5m
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG BASE_VARIANT=alpine
 ARG ALPINE_VERSION=3.23
 ARG BASE_DEBIAN_DISTRO=bookworm
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # XX_VERSION specifies the version of the xx utility to use.
 # It must be a valid tag in the docker.io/tonistiigi/xx image repository.

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.lint
+++ b/dockerfiles/Dockerfile.lint
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository

--- a/dockerfiles/Dockerfile.vendor
+++ b/dockerfiles/Dockerfile.vendor
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.4
 
 # ALPINE_VERSION sets the version of the alpine base image to use, including for the golang image.
 # It must be a supported tag in the docker.io/library/alpine image repository


### PR DESCRIPTION
- https://github.com/golang/go/issues?q=milestone%3AGo1.26.4+label%3ACherryPickApproved
- full diff: https://github.com/golang/go/compare/go1.26.3...go1.26.4

**- Description for the changelog**

```markdown changelog
Update Go runtime to [1.26.4](https://go.dev/doc/devel/release#go1.26.4)
```

  This release include 3 security fixes following the security policy:

  - mime: quadratic complexity in WordDecoder.DecodeHeader

      Decoding a maliciously-crafted MIME header containing many invalid
     encoded-words could consume excessive CPU.
     The MIME decoder now better handles this case.

      Thanks to p4p3r (https://hackerone.com/p4p3r_hak) for reporting this issue.

      This is CVE-2026-42504 and Go issue https://go.dev/issue/79217.

  - net/textproto: arbitrary input are included in errors without any escaping

      When returning errors, functions in the net/textproto package would
     include its input as part of the error, without any escaping. Note that
     said input is often controlled by external parties when using this
     package naturally. For example, a net/http client uses ReadMIMEHeader
     when parsing the headers it receive from a server.

      As a result, an attacker could inject arbitrary content into the error.
     Practically, this can result in an attacker injecting misleading
     content, terminal control bytes, etc. into a victim's output or logs.

      This is CVE-2026-42507 and Go issue https://go.dev/issue/79346

  - crypto/x509: split candidate hostname only once

      (*x509.Certificate).VerifyHostname previously called matchHostnames in a loop
     over all DNS Subject Alternative Name (SAN) entries. This caused
     strings.Split(host, ".") to execute repeatedly on the same input hostname.

      With a large DNS SAN list, verification costs scaled quadratically based on the
     number of SAN entries multiplied by the hostname's label count. Because
     x509.Verify validates hostnames before building the certificate chain, this
     overhead occurred even for untrusted certificates.

      Thanks to Jakub Ciolek (https://ciolek.dev) for reporting this issue.

      This is CVE-2026-27145 and https://go.dev/issue/79694.

  View the release notes for more information: https://go.dev/doc/devel/release#go1.26.4