### PR TITLE
cli/registry: support password dash stdin

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -62,7 +62,7 @@ func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 
 	flags.StringVarP(&opts.user, "username", "u", "", "Username")
-	flags.StringVarP(&opts.password, "password", "p", "", "Password or Personal Access Token (PAT)")
+	flags.StringVarP(&opts.password, "password", "p", "", `Password or Personal Access Token (PAT), or "-" to read from stdin`)
 	flags.BoolVar(&opts.passwordStdin, "password-stdin", false, "Take the Password or Personal Access Token (PAT) from stdin")
 
 	return cmd
@@ -72,8 +72,8 @@ func newLoginCommand(dockerCLI command.Cli) *cobra.Command {
 //
 // TODO(thaJeztah); combine with verifyLoginOptions, but this requires rewrites of many tests.
 func verifyLoginFlags(flags *pflag.FlagSet, opts loginOptions) error {
-	if flags.Changed("password-stdin") {
-		if flags.Changed("password") {
+	if flags.Changed("password-stdin") || opts.password == "-" {
+		if flags.Changed("password") && opts.password != "-" {
 			return errors.New("conflicting options: cannot specify both --password and --password-stdin")
 		}
 		if !flags.Changed("username") {
@@ -122,6 +122,11 @@ func readSecretFromStdin(r io.Reader) (string, error) {
 }
 
 func verifyLoginOptions(dockerCLI command.Streams, opts *loginOptions) error {
+	if opts.password == "-" {
+		opts.password = ""
+		opts.passwordStdin = true
+	}
+
 	if opts.password != "" {
 		_, _ = fmt.Fprintln(dockerCLI.Err(), "WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
 	}

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -340,6 +340,57 @@ func TestRunLogin(t *testing.T) {
 			},
 		},
 		{
+			doc:              "password dash reads password from stdin",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			stdIn:            "my password\r\n",
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				password:      "-",
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					Password:      "my password",
+					ServerAddress: "reg1",
+				},
+			},
+		},
+		{
+			doc:              "password dash empty stdin",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				password:      "-",
+			},
+			expectedErr: `password is empty`,
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					ServerAddress: "reg1",
+				},
+			},
+		},
+		{
+			doc:              "password dash and password stdin read password from stdin",
+			priorCredentials: map[string]configtypes.AuthConfig{},
+			stdIn:            "my password\r\n",
+			input: loginOptions{
+				serverAddress: "reg1",
+				user:          "my-username",
+				password:      "-",
+				passwordStdin: true,
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"reg1": {
+					Username:      "my-username",
+					Password:      "my password",
+					ServerAddress: "reg1",
+				},
+			},
+		},
+		{
 			doc:              "password with leading and trailing spaces",
 			priorCredentials: map[string]configtypes.AuthConfig{},
 			input: loginOptions{
@@ -397,7 +448,7 @@ func TestRunLogin(t *testing.T) {
 			cfg := configfile.New(filepath.Join(tmpDir, "config.json"))
 			cli := test.NewFakeCli(&fakeClient{})
 			cli.SetConfigFile(cfg)
-			if tc.input.passwordStdin {
+			if tc.input.passwordStdin || tc.input.password == "-" || tc.stdIn != "" {
 				if tc.expectedErr == "TEST_READ_ERR" {
 					cli.SetIn(streams.NewIn(io.NopCloser(iotest.ErrReader(errors.New(tc.expectedErr)))))
 				} else {
@@ -633,6 +684,21 @@ func TestLoginValidateFlags(t *testing.T) {
 			expectedErr: `conflicting options: cannot specify both --password and --password-stdin`,
 		},
 		{
+			name:        "password stdin and password dash without stdin",
+			args:        []string{"--password-stdin", "--username", "my-username", "--password", "-"},
+			expectedErr: `password is empty`,
+		},
+		{
+			name:        "password dash without username",
+			args:        []string{"--password", "-"},
+			expectedErr: `the --password-stdin option requires --username to be set`,
+		},
+		{
+			name:        "short password dash without username",
+			args:        []string{"-p", "-"},
+			expectedErr: `the --password-stdin option requires --username to be set`,
+		},
+		{
 			name:        "empty --password",
 			args:        []string{"--password", ""},
 			expectedErr: `password is empty`,
@@ -657,4 +723,11 @@ func TestLoginValidateFlags(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoginHelpDocumentsPasswordDash(t *testing.T) {
+	cmd := newLoginCommand(test.NewFakeCli(&fakeClient{}))
+	flag := cmd.Flags().Lookup("password")
+	assert.Check(t, flag != nil)
+	assert.Check(t, is.Contains(flag.Usage, `"-"`))
 }

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -6,11 +6,11 @@ Defaults to Docker Hub if no server is specified.
 
 ### Options
 
-| Name                                         | Type     | Default | Description                                                 |
-|:---------------------------------------------|:---------|:--------|:------------------------------------------------------------|
-| `-p`, `--password`                           | `string` |         | Password or Personal Access Token (PAT)                     |
-| [`--password-stdin`](#password-stdin)        | `bool`   |         | Take the Password or Personal Access Token (PAT) from stdin |
-| [`-u`](#username), [`--username`](#username) | `string` |         | Username                                                    |
+| Name                                         | Type     | Default | Description                                                        |
+|:---------------------------------------------|:---------|:--------|:-------------------------------------------------------------------|
+| `-p`, `--password`                           | `string` |         | Password or Personal Access Token (PAT), or `-` to read from stdin |
+| [`--password-stdin`](#password-stdin)        | `bool`   |         | Take the Password or Personal Access Token (PAT) from stdin        |
+| [`-u`](#username), [`--username`](#username) | `string` |         | Username                                                           |
 
 
 <!---MARKER_GEN_END-->
@@ -242,6 +242,13 @@ The following example reads a password from a file, and passes it to the
 
 ```console
 $ cat ~/my_password.txt | docker login --username foo --password-stdin
+```
+
+You can also pass `-` as the value for `--password` or `-p` to read the
+password from `STDIN`.
+
+```console
+$ cat ~/my_password.txt | docker login --username foo --password -
 ```
 
 ## Related commands


### PR DESCRIPTION
## What

Support for `docker login --password -` and `docker login -p -` to read the password or PAT from stdin, matching the existing `--password-stdin` behavior, and following the common CLI convention that `-` means stdin.

The tradeoff is that `-` can no longer be used as a literal password value through `--password`.

## Validation

```console
make -f docker.Makefile test-unit
```

&

```console
docker run --rm -v "$PWD":/src -w /src golang:1.25 ./scripts/with-go-mod.sh go test -mod=mod ./cli/command/registry -run 'TestRunLogin/password_dash|TestLoginHelpDocumentsPasswordDash|TestLoginValidateFlags/(password_dash|short_password_dash|password_stdin_and_password_dash|conflicting_options)'
```

## Note

- I searched for prior Docker CLI issues and PRs rejecting this behavior and did not find one.
- Figured an issue was not needed for this and that it could be discussed in an MR instead given the low cost to just write it.
- No strong feelings if rejected.



**- Human readable description for the release notes**


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
The `--password` flag on `docker login` now accepts `-` to pass the password through STDIN as alternative to `--password-stdin`
```
