### PR TITLE
feat: add blkio device options to docker container update

### DIFF
--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -43,7 +43,13 @@ type updateOptions struct {
 
 // newUpdateCommand creates a new cobra.Command for "docker container update".
 func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
-	var options updateOptions
+	options := &updateOptions{
+		blkioWeightDevice: opts.NewWeightdeviceOpt(opts.ValidateWeightDevice),
+		deviceReadBps:     opts.NewThrottledeviceOpt(opts.ValidateThrottleBpsDevice),
+		deviceReadIOps:    opts.NewThrottledeviceOpt(opts.ValidateThrottleIOpsDevice),
+		deviceWriteBps:    opts.NewThrottledeviceOpt(opts.ValidateThrottleBpsDevice),
+		deviceWriteIOps:   opts.NewThrottledeviceOpt(opts.ValidateThrottleIOpsDevice),
+	}
 
 	cmd := &cobra.Command{
 		Use:   "update [OPTIONS] CONTAINER [CONTAINER...]",
@@ -52,7 +58,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.containers = args
 			options.nFlag = cmd.Flags().NFlag()
-			return runUpdate(cmd.Context(), dockerCLI, &options)
+			return runUpdate(cmd.Context(), dockerCLI, options)
 		},
 		Annotations: map[string]string{
 			"aliases": "docker container update, docker update",

--- a/cli/command/container/update.go
+++ b/cli/command/container/update.go
@@ -17,6 +17,7 @@ import (
 
 type updateOptions struct {
 	blkioWeight        uint16
+	blkioWeightDevice  opts.WeightdeviceOpt
 	cpuPeriod          int64
 	cpuQuota           int64
 	cpuRealtimePeriod  int64
@@ -24,6 +25,10 @@ type updateOptions struct {
 	cpusetCpus         string
 	cpusetMems         string
 	cpuShares          int64
+	deviceReadBps      opts.ThrottledeviceOpt
+	deviceWriteBps     opts.ThrottledeviceOpt
+	deviceReadIOps     opts.ThrottledeviceOpt
+	deviceWriteIOps    opts.ThrottledeviceOpt
 	memory             opts.MemBytes
 	memoryReservation  opts.MemBytes
 	memorySwap         opts.MemSwapBytes
@@ -58,6 +63,7 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 
 	flags := cmd.Flags()
 	flags.Uint16Var(&options.blkioWeight, "blkio-weight", 0, `Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)`)
+	flags.Var(&options.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flags.Int64Var(&options.cpuPeriod, "cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 	flags.Int64Var(&options.cpuQuota, "cpu-quota", 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	flags.Int64Var(&options.cpuRealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")
@@ -67,6 +73,10 @@ func newUpdateCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.StringVar(&options.cpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flags.StringVar(&options.cpusetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
 	flags.Int64VarP(&options.cpuShares, "cpu-shares", "c", 0, "CPU shares (relative weight)")
+	flags.Var(&options.deviceReadBps, "device-read-bps", "Limit read rate (bytes per second) from a device")
+	flags.Var(&options.deviceReadIOps, "device-read-iops", "Limit read rate (IO per second) from a device")
+	flags.Var(&options.deviceWriteBps, "device-write-bps", "Limit write rate (bytes per second) to a device")
+	flags.Var(&options.deviceWriteIOps, "device-write-iops", "Limit write rate (IO per second) to a device")
 	flags.VarP(&options.memory, "memory", "m", "Memory limit")
 	flags.Var(&options.memoryReservation, "memory-reservation", "Memory soft limit")
 	flags.Var(&options.memorySwap, "memory-swap", `Swap limit equal to memory plus swap: -1 to enable unlimited swap`)
@@ -110,19 +120,24 @@ func runUpdate(ctx context.Context, dockerCli command.Cli, options *updateOption
 
 	updateConfig := client.ContainerUpdateOptions{
 		Resources: &containertypes.Resources{
-			BlkioWeight:        options.blkioWeight,
-			CpusetCpus:         options.cpusetCpus,
-			CpusetMems:         options.cpusetMems,
-			CPUShares:          options.cpuShares,
-			Memory:             options.memory.Value(),
-			MemoryReservation:  options.memoryReservation.Value(),
-			MemorySwap:         options.memorySwap.Value(),
-			CPUPeriod:          options.cpuPeriod,
-			CPUQuota:           options.cpuQuota,
-			CPURealtimePeriod:  options.cpuRealtimePeriod,
-			CPURealtimeRuntime: options.cpuRealtimeRuntime,
-			NanoCPUs:           options.cpus.Value(),
-			PidsLimit:          pidsLimit,
+			BlkioWeight:          options.blkioWeight,
+			BlkioWeightDevice:    options.blkioWeightDevice.GetList(),
+			BlkioDeviceReadBps:   options.deviceReadBps.GetList(),
+			BlkioDeviceWriteBps:  options.deviceWriteBps.GetList(),
+			BlkioDeviceReadIOps:  options.deviceReadIOps.GetList(),
+			BlkioDeviceWriteIOps: options.deviceWriteIOps.GetList(),
+			CpusetCpus:           options.cpusetCpus,
+			CpusetMems:           options.cpusetMems,
+			CPUShares:            options.cpuShares,
+			Memory:               options.memory.Value(),
+			MemoryReservation:    options.memoryReservation.Value(),
+			MemorySwap:           options.memorySwap.Value(),
+			CPUPeriod:            options.cpuPeriod,
+			CPUQuota:             options.cpuQuota,
+			CPURealtimePeriod:    options.cpuRealtimePeriod,
+			CPURealtimeRuntime:   options.cpuRealtimeRuntime,
+			NanoCPUs:             options.cpus.Value(),
+			PidsLimit:            pidsLimit,
 		},
 		RestartPolicy: &restartPolicy,
 	}

--- a/docs/reference/commandline/container_update.md
+++ b/docs/reference/commandline/container_update.md
@@ -12,6 +12,7 @@ Update configuration of one or more containers
 | Name                                               | Type      | Default | Description                                                                  |
 |:---------------------------------------------------|:----------|:--------|:-----------------------------------------------------------------------------|
 | `--blkio-weight`                                   | `uint16`  | `0`     | Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0) |
+| `--blkio-weight-device`                            | `list`    |         | Block IO weight (relative device weight)                                     |
 | `--cpu-period`                                     | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) period                             |
 | `--cpu-quota`                                      | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) quota                              |
 | `--cpu-rt-period`                                  | `int64`   | `0`     | Limit the CPU real-time period in microseconds                               |
@@ -20,6 +21,10 @@ Update configuration of one or more containers
 | `--cpus`                                           | `decimal` |         | Number of CPUs                                                               |
 | `--cpuset-cpus`                                    | `string`  |         | CPUs in which to allow execution (0-3, 0,1)                                  |
 | `--cpuset-mems`                                    | `string`  |         | MEMs in which to allow execution (0-3, 0,1)                                  |
+| `--device-read-bps`                                | `list`    |         | Limit read rate (bytes per second) from a device                             |
+| `--device-read-iops`                               | `list`    |         | Limit read rate (IO per second) from a device                                |
+| `--device-write-bps`                               | `list`    |         | Limit write rate (bytes per second) to a device                              |
+| `--device-write-iops`                              | `list`    |         | Limit write rate (IO per second) to a device                                 |
 | [`-m`](#memory), [`--memory`](#memory)             | `bytes`   | `0`     | Memory limit                                                                 |
 | `--memory-reservation`                             | `bytes`   | `0`     | Memory soft limit                                                            |
 | `--memory-swap`                                    | `bytes`   | `0`     | Swap limit equal to memory plus swap: -1 to enable unlimited swap            |

--- a/docs/reference/commandline/update.md
+++ b/docs/reference/commandline/update.md
@@ -9,22 +9,27 @@ Update configuration of one or more containers
 
 ### Options
 
-| Name                   | Type      | Default | Description                                                                  |
-|:-----------------------|:----------|:--------|:-----------------------------------------------------------------------------|
-| `--blkio-weight`       | `uint16`  | `0`     | Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0) |
-| `--cpu-period`         | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) period                             |
-| `--cpu-quota`          | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) quota                              |
-| `--cpu-rt-period`      | `int64`   | `0`     | Limit the CPU real-time period in microseconds                               |
-| `--cpu-rt-runtime`     | `int64`   | `0`     | Limit the CPU real-time runtime in microseconds                              |
-| `-c`, `--cpu-shares`   | `int64`   | `0`     | CPU shares (relative weight)                                                 |
-| `--cpus`               | `decimal` |         | Number of CPUs                                                               |
-| `--cpuset-cpus`        | `string`  |         | CPUs in which to allow execution (0-3, 0,1)                                  |
-| `--cpuset-mems`        | `string`  |         | MEMs in which to allow execution (0-3, 0,1)                                  |
-| `-m`, `--memory`       | `bytes`   | `0`     | Memory limit                                                                 |
-| `--memory-reservation` | `bytes`   | `0`     | Memory soft limit                                                            |
-| `--memory-swap`        | `bytes`   | `0`     | Swap limit equal to memory plus swap: -1 to enable unlimited swap            |
-| `--pids-limit`         | `int64`   | `0`     | Tune container pids limit (set -1 for unlimited)                             |
-| `--restart`            | `string`  |         | Restart policy to apply when a container exits                               |
+| Name                    | Type      | Default | Description                                                                  |
+|:------------------------|:----------|:--------|:-----------------------------------------------------------------------------|
+| `--blkio-weight`        | `uint16`  | `0`     | Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0) |
+| `--blkio-weight-device` | `list`    |         | Block IO weight (relative device weight)                                     |
+| `--cpu-period`          | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) period                             |
+| `--cpu-quota`           | `int64`   | `0`     | Limit CPU CFS (Completely Fair Scheduler) quota                              |
+| `--cpu-rt-period`       | `int64`   | `0`     | Limit the CPU real-time period in microseconds                               |
+| `--cpu-rt-runtime`      | `int64`   | `0`     | Limit the CPU real-time runtime in microseconds                              |
+| `-c`, `--cpu-shares`    | `int64`   | `0`     | CPU shares (relative weight)                                                 |
+| `--cpus`                | `decimal` |         | Number of CPUs                                                               |
+| `--cpuset-cpus`         | `string`  |         | CPUs in which to allow execution (0-3, 0,1)                                  |
+| `--cpuset-mems`         | `string`  |         | MEMs in which to allow execution (0-3, 0,1)                                  |
+| `--device-read-bps`     | `list`    |         | Limit read rate (bytes per second) from a device                             |
+| `--device-read-iops`    | `list`    |         | Limit read rate (IO per second) from a device                                |
+| `--device-write-bps`    | `list`    |         | Limit write rate (bytes per second) to a device                              |
+| `--device-write-iops`   | `list`    |         | Limit write rate (IO per second) to a device                                 |
+| `-m`, `--memory`        | `bytes`   | `0`     | Memory limit                                                                 |
+| `--memory-reservation`  | `bytes`   | `0`     | Memory soft limit                                                            |
+| `--memory-swap`         | `bytes`   | `0`     | Swap limit equal to memory plus swap: -1 to enable unlimited swap            |
+| `--pids-limit`          | `int64`   | `0`     | Tune container pids limit (set -1 for unlimited)                             |
+| `--restart`             | `string`  |         | Restart policy to apply when a container exits                               |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
- [x] depends on https://github.com/docker/cli/pull/7051

Closes #3325

Related to https://github.com/moby/moby/pull/52651

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Add 5 options to `docker container update` to control the device blkio throttle.

**- How I did it**

I simply added the same options from the create command to the update command to be able to pass the blkio device arguments for the update.

**- How to verify it**

The current version of the moby/moby library does not forward those arguments even though they exist in the struct.

You need to set the moby/moby version to the one in https://github.com/moby/moby/pull/52651 and then create a docker container with a certain blkio device throttle configuration and then update it using docker container update. Then you can inspect the container for those new values.

**- Human readable description for the release notes**


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
docker container update can now update the blkio device weights/IOPs
```

**- A picture of a cute animal (not mandatory but encouraged)**
