### PR TITLE
scripts/with-go-mod: use correct minimum Go version

### DIFF
--- a/scripts/with-go-mod.sh
+++ b/scripts/with-go-mod.sh
@@ -25,7 +25,7 @@ else
 	tee "${ROOTDIR}/go.mod" >&2 <<- EOF
 		module github.com/docker/cli
 
-		go 1.24.0
+		go 1.25.0
 	EOF
 	trap 'rm -f "${ROOTDIR}/go.mod"' EXIT
 fi


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/6897

Follow-up to 8f7dc04070206b38aec41a7c643e53db20742232, which updated the minimum Go version in vendor.mod, but did not adjust this script.

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
