### PR TITLE
fix(volume/prune): document and test label! filter support

### DIFF
--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -57,7 +57,7 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused volumes, not just anonymous ones")
 	flags.SetAnnotation("all", "version", []string{"1.42"})
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
-	flags.Var(&options.filter, "filter", `Provide filter values (e.g. "label=<label>")`)
+	flags.Var(&options.filter, "filter", `Provide filter values (e.g. "label=<label>" or "label!=<label>")`)
 
 	return cmd
 }

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -101,6 +101,15 @@ func TestVolumePruneSuccess(t *testing.T) {
 				return client.VolumePruneResult{}, nil
 			},
 		},
+		{
+			name:  "label-not-filter",
+			args:  []string{"--filter", "label!=foobar"},
+			input: "y",
+			pruneFunc: func(opts client.VolumePruneOptions) (client.VolumePruneResult, error) {
+				assert.Check(t, is.DeepEqual(opts.Filters["label!"], map[string]bool{"foobar": true}))
+				return client.VolumePruneResult{}, nil
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/command/volume/testdata/volume-prune-success.label-not-filter.golden
+++ b/cli/command/volume/testdata/volume-prune-success.label-not-filter.golden
@@ -1,0 +1,2 @@
+WARNING! This will remove anonymous local volumes not used by at least one container.
+Are you sure you want to continue? [y/N] Total reclaimed space: 0B


### PR DESCRIPTION
## What does this PR do?

The `--filter` flag description for `docker volume prune` only mentioned
`label=<label>` but not `label!=<label>`, making it inconsistent with
`docker system prune` which documents both forms.

The `label!` filter already works correctly via the shared `PruneFilters`
function — it was just undocumented and untested at the volume prune level.

## Changes

- Updated `--filter` flag description to include `label!=<label>` example
- Added unit test for `label!` filter to match the existing `label` filter test

## How to test 
Fixes #6918