### PR TITLE
fix: use actual daemon URL for proxy lookup in SSH connections

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -65,7 +65,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return commandconn.New(ctx, "ssh", sshArgs...)
 			},
-			Host: "http://docker.example.com",
+			Host: daemonURL,
 		}, nil
 	}
 	// Future version may support plugins via ~/.docker/config.json. e.g. "dind"
@@ -74,6 +74,8 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 }
 
 // GetCommandConnectionHelper returns Docker-specific connection helper constructed from an arbitrary command.
+// Note: Host is set to a default value since we don't have information about the target daemon.
+// Users should configure proxies for this default host in their config.json if needed.
 func GetCommandConnectionHelper(cmd string, flags ...string) (*ConnectionHelper, error) {
 	return &ConnectionHelper{
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {


### PR DESCRIPTION
## Problem
When configuring proxies in `~/.docker/config.json`, users had to use a hardcoded dummy host `http://docker.example.com` because SSH connections used this dummy URL instead of the actual daemon URL.

Example that used to fail:
```json
{
  "proxies": {
    "ssh://user@host.com": {
      "httpProxy": "http://proxy.example.com:3128"
    }
  }
}
```

Users had to work around this by configuring proxies with the dummy host:
```json
{
  "proxies": {
    "http://docker.example.com": {
      "httpProxy": "http://proxy.example.com:3128"
    }
  }
}
```

## Solution
Use the actual daemon URL from the endpoint configuration instead of the hardcoded `http://docker.example.com`.

Now users can configure proxies with their actual SSH endpoint URLs:
```json
{
  "proxies": {
    "ssh://user@host.com": {
      "httpProxy": "http://proxy.example.com:3128"
    }
  }
}
```

## Changes
- Modified SSH connection helper to use the actual `daemonURL` for the `Host` field
- Added clarifying comment for command connection helper (which still uses a default since we don't have endpoint information)

The fix is minimal and only affects SSH connections, allowing proxy lookup to work with the actual configured endpoint URLs.

Fixes: #7046