### PR TITLE
cli-plugins/hooks: fix max message enforcement

### DIFF
--- a/cli/command/volume/prune.go
+++ b/cli/command/volume/prune.go
@@ -57,7 +57,7 @@ func newPruneCommand(dockerCLI command.Cli) *cobra.Command {
 	flags.BoolVarP(&options.all, "all", "a", false, "Remove all unused volumes, not just anonymous ones")
 	flags.SetAnnotation("all", "version", []string{"1.42"})
 	flags.BoolVarP(&options.force, "force", "f", false, "Do not prompt for confirmation")
-	flags.Var(&options.filter, "filter", `Provide filter values (e.g. "label=<label>")`)
+	flags.Var(&options.filter, "filter", `Provide filter values (e.g. "label=<label>" or "label!=<label>")`)
 
 	return cmd
 }

--- a/cli/command/volume/prune_test.go
+++ b/cli/command/volume/prune_test.go
@@ -101,6 +101,15 @@ func TestVolumePruneSuccess(t *testing.T) {
 				return client.VolumePruneResult{}, nil
 			},
 		},
+		{
+			name:  "label-not-filter",
+			args:  []string{"--filter", "label!=foobar"},
+			input: "y",
+			pruneFunc: func(opts client.VolumePruneOptions) (client.VolumePruneResult, error) {
+				assert.Check(t, is.DeepEqual(opts.Filters["label!"], map[string]bool{"foobar": true}))
+				return client.VolumePruneResult{}, nil
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cli/command/volume/testdata/volume-prune-success.label-not-filter.golden
+++ b/cli/command/volume/testdata/volume-prune-success.label-not-filter.golden
@@ -1,0 +1,2 @@
+WARNING! This will remove anonymous local volumes not used by at least one container.
+Are you sure you want to continue? [y/N] Total reclaimed space: 0B


### PR DESCRIPTION
The --filter flag description for 'docker volume prune' only mentioned 'label=<label>' but not 'label!=<label>', even though the label! filter is supported and handled correctly by the underlying PruneFilters function.

This commit:
- Updates the --filter flag description to include label!=<label>
- Adds a unit test for the label! filter to match the existing label filter test

Fixes #6918

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
