### PR TITLE
fix: use HumanSize for image list to avoid scientific notation

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -246,7 +246,7 @@ func (c *imageContext) CreatedAt() string {
 }
 
 func (c *imageContext) Size() string {
-	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
+	return units.HumanSize(float64(c.i.Size))
 }
 
 func (c *imageContext) Containers() string {


### PR DESCRIPTION
## Description

`docker image ls` reports image sizes near 1000 MB as `1e+03MB` instead of a human-readable value like `999.5MB`.

## Root cause

The `Size()` method in `cli/command/formatter/image.go` calls `units.HumanSizeWithPrecision(float64(c.i.Size), 3)`. The `%g` format verb with precision=3 uses 3 *significant digits*, so when a value like 999.5 rounds to 1000 (which requires 4 significant digits), Go's formatter falls back to scientific notation: `1e+03`.

## Fix

Switch to `units.HumanSize()` which uses precision=4 (the standard used by `SharedSize()`, `UniqueSize()`, and most other callers in this codebase). This avoids the scientific notation edge case while still producing compact, human-readable output.

**Before (precision=3):**
| Bytes | Output |
|-------|--------|
| 999,500,000 | `1e+03MB` |
| 999,900,000 | `1e+03MB` |

**After (precision=4 via HumanSize):**
| Bytes | Output |
|-------|--------|
| 999,500,000 | `999.5MB` |
| 999,900,000 | `999.9MB` |

Normal-range sizes remain unchanged (e.g. `796kB`, `1.5GB`).

Fixes #3091

- [x] I've verified the fix with a standalone reproduction of the formatting logic
- [x] The change is a single line: `HumanSizeWithPrecision(..., 3)` → `HumanSize(...)`
