### PR TITLE
fix: default to unix scheme when DOCKER_HOST is a filesystem path

### DIFF
--- a/opts/hosts.go
+++ b/opts/hosts.go
@@ -57,7 +57,14 @@ func parseDockerDaemonHost(addr string) (string, error) {
 	proto, host, hasProto := strings.Cut(addr, "://")
 	if !hasProto && proto != "" {
 		host = proto
-		proto = "tcp"
+		// If the address looks like a filesystem path, default to "unix"
+		// rather than "tcp" to avoid confusing errors when the user sets
+		// DOCKER_HOST=/path/to/sock without a unix:// prefix.
+		if strings.HasPrefix(host, "/") || strings.HasPrefix(host, "./") {
+			proto = "unix"
+		} else {
+			proto = "tcp"
+		}
 	}
 
 	switch proto {

--- a/opts/hosts_test.go
+++ b/opts/hosts_test.go
@@ -79,6 +79,8 @@ func TestParseDockerDaemonHost(t *testing.T) {
 		"unix://":                     "unix://" + defaultUnixSocket,
 		"fd://":                       "fd://",
 		"fd://something":              "fd://something",
+		"/var/run/docker.sock":        "unix:///var/run/docker.sock",
+		"./run/docker.sock":           "unix://run/docker.sock",
 		"localhost:":                  "tcp://localhost:2375",
 		"localhost:5555":              "tcp://localhost:5555",
 		"localhost:5555/path":         "tcp://localhost:5555/path",


### PR DESCRIPTION
## Description

When `DOCKER_HOST` is set to a filesystem path without a `unix://` prefix (e.g. `DOCKER_HOST=/var/run/docker.sock`), the CLI produces a confusing error:

```
Cannot connect to the Docker daemon at tcp://localhost:2375/var/run/docker.sock. Is the docker daemon running?
```

The path gets misinterpreted as a TCP address because `parseDockerDaemonHost` defaults to the `tcp` protocol when no scheme is present.

## Root cause

In `opts/hosts.go`, `parseDockerDaemonHost` splits on `://` and defaults any scheme-less address to `tcp`:

```go
if !hasProto && proto != "" {
    host = proto
    proto = "tcp"  // always defaults to tcp
}
```

## Fix

When the scheme-less address starts with `/` or `./` (i.e. it's clearly a filesystem path), default to `unix` instead of `tcp`. This matches the user's intent and either connects successfully or produces a clear, relevant error.

**Before:**
```
$ DOCKER_HOST=/var/run/docker.sock docker version
Cannot connect to the Docker daemon at tcp://localhost:2375/var/run/docker.sock.
```

**After:**
```
$ DOCKER_HOST=/var/run/docker.sock docker version
# connects normally (equivalent to unix:///var/run/docker.sock)
```

## Testing

- Added test cases to `TestParseDockerDaemonHost` for `/var/run/docker.sock` and `./run/docker.sock`
- Verified the parsing logic with a standalone reproduction covering path, hostname, and explicit-scheme inputs
- Existing `tcp` and explicit `unix://` cases remain unchanged

Fixes #5846
