### PR TITLE
vendor: github.com/moby/moby api v1.55.0 and client v0.5.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -33,7 +33,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/moby/go-archive v0.2.0
 	github.com/moby/moby/api v1.55.0
-	github.com/moby/moby/client v0.5.0-rc.1
+	github.com/moby/moby/client v0.5.0
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/vendor.mod
+++ b/vendor.mod
@@ -32,7 +32,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/moby/go-archive v0.2.0
-	github.com/moby/moby/api v1.55.0-rc.1
+	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0-rc.1
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/swarmkit/v2 v2.1.2

--- a/vendor.sum
+++ b/vendor.sum
@@ -115,8 +115,8 @@ github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
 github.com/moby/moby/api v1.55.0/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.5.0-rc.1 h1:ubz6nHbWuDjYGPWVKMazn//Ac93T2+41IgOtrndMgHU=
-github.com/moby/moby/client v0.5.0-rc.1/go.mod h1:mw5zy3IR06oD8V7+LfHYtA+sVNsgnhdrb2um3bTFcUM=
+github.com/moby/moby/client v0.5.0 h1:5XhyPk2fuOWf6RlSFa3MkIIgDZkF25xToXW8Q/BH7cc=
+github.com/moby/moby/client v0.5.0/go.mod h1:rcVpF8ncl9vo5gaIBdol6CnbEtSj1uxMvEV/UrykF/s=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/vendor.sum
+++ b/vendor.sum
@@ -113,8 +113,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
-github.com/moby/moby/api v1.55.0-rc.1 h1:PizbkLn9OMoMIkNrcR/eNVOhNQnvR0zsJkrcePTYaeA=
-github.com/moby/moby/api v1.55.0-rc.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
+github.com/moby/moby/api v1.55.0/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
 github.com/moby/moby/client v0.5.0-rc.1 h1:ubz6nHbWuDjYGPWVKMazn//Ac93T2+41IgOtrndMgHU=
 github.com/moby/moby/client v0.5.0-rc.1/go.mod h1:mw5zy3IR06oD8V7+LfHYtA+sVNsgnhdrb2um3bTFcUM=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/moby/docker-image-spec/specs-go/v1
 github.com/moby/go-archive
 github.com/moby/go-archive/compression
 github.com/moby/go-archive/tarheader
-# github.com/moby/moby/api v1.55.0-rc.1
+# github.com/moby/moby/api v1.55.0
 ## explicit; go 1.24
 github.com/moby/moby/api/pkg/authconfig
 github.com/moby/moby/api/pkg/stdcopy

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -189,7 +189,7 @@ github.com/moby/moby/api/types/storage
 github.com/moby/moby/api/types/swarm
 github.com/moby/moby/api/types/system
 github.com/moby/moby/api/types/volume
-# github.com/moby/moby/client v0.5.0-rc.1
+# github.com/moby/moby/client v0.5.0
 ## explicit; go 1.24
 github.com/moby/moby/client
 github.com/moby/moby/client/internal


### PR DESCRIPTION
### vendor: github.com/moby/moby/api v1.55.0

  full diff: https://github.com/moby/moby/compare/api/v1.55.0-rc.1...api/v1.55.0



### vendor: github.com/moby/moby/client v0.5.0

  full diff: https://github.com/moby/moby/compare/client/v0.5.0-rc.1...client/v0.5.0