### PR TITLE
vendor: docker/go-units: avoid scientific notation in image size (1e+03MB)

### DIFF
--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -58,7 +58,13 @@ func CustomSize(format string, size float64, base float64, _map []string) string
 // instead of 4 digit precision used in units.HumanSize.
 func HumanSizeWithPrecision(size float64, precision int) string {
 	size, unit := getSizeAndUnit(size, 1000.0, decimapAbbrs)
-	return fmt.Sprintf("%.*g%s", precision, size, unit)
+	// Use %g format, but avoid scientific notation edge case
+	// (e.g., 999.5MB displaying as "1e+03MB" instead of "1000MB")
+	result := fmt.Sprintf("%.*g%s", precision, size, unit)
+	if strings.ContainsAny(result, "eE") {
+		result = fmt.Sprintf("%.0f%s", size, unit)
+	}
+	return result
 }
 
 // HumanSize returns a human-readable approximation of a size


### PR DESCRIPTION
## Description

When `docker image ls` shows an image with size between ~999.5MB and 999.9MB, the size is displayed as `1e+03MB` instead of `1000MB`. This happens because Go's `%g` format switches to scientific notation when the rounded value reaches the next unit boundary.

## Root Cause

`units.HumanSizeWithPrecision` in `github.com/docker/go-units` uses `%.*g` format. For a size of `999517084` bytes with precision 3:
- Value rounds to `1000` (3 significant digits)
- Exponent (3) >= precision (3) → Go switches to `%e` → `1e+03MB`

## Fix

After formatting with `%.*g`, check if the result contains scientific notation (`e`/`E`). If so, reformat using `%.0f` to produce clean output like `1000MB`.

Upstream PR: https://github.com/docker/go-units/pull/53

## Before/After

| Size | Before | After |
|------|--------|-------|
| 999517084 bytes | `1e+03MB` | `1000MB` |
| 999500000 bytes | `1e+03MB` | `1000MB` |
| 1000000000 bytes | `1GB` | `1GB` (unchanged) |

Fixes #3091