### PR TITLE
chore: migrate cagent-action to docker-agent-action (v2.0.0)

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -9,12 +9,6 @@ permissions: {}
 
 jobs:
   save-context:
-    if: >
-      github.event.comment.user.login != 'docker-agent' &&
-      github.event.comment.user.login != 'docker-agent[bot]' &&
-      github.event.comment.user.type != 'Bot' &&
-      !contains(github.event.comment.body, '<!-- cagent-review -->') &&
-      !contains(github.event.comment.body, '<!-- cagent-review-reply -->')
     runs-on: ubuntu-latest
     steps:
       - name: Save event context

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,15 +11,7 @@ permissions:
 
 jobs:
   review:
-    if: |
-      (github.event_name == 'issue_comment' &&
-       github.event.comment.user.login != 'docker-agent' &&
-       github.event.comment.user.login != 'docker-agent[bot]' &&
-       github.event.comment.user.type != 'Bot' &&
-       !contains(github.event.comment.body, '<!-- cagent-review -->') &&
-       !contains(github.event.comment.body, '<!-- cagent-review-reply -->')) ||
-      github.event.workflow_run.conclusion == 'success'
-    uses: docker/cagent-action/.github/workflows/review-pr.yml@367a30ddb41e0156459d03750f508eac03f3c38a  # v1.5.5
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@e96a4bb40cac114f64358621e1d08346c8eadc8c # v2.0.1
     permissions:
       contents: read # Read repository files and PR diffs
       pull-requests: write # Post review comments


### PR DESCRIPTION
## Summary

`docker/cagent-action` has moved to a new repository: `docker/docker-agent-action`.
GitHub Actions `uses:` references must be updated explicitly, so this PR migrates all references and pins them to [v2.0.0](https://github.com/docker/docker-agent-action/releases/tag/v2.0.0).

- **New repository**: `docker/docker-agent-action`
- **Pinned commit**: `3c0fa9d282c3f84d08dfd70ab0a28b151d11db70`
- **Version**: `v2.0.0`

ℹ️ The old `docker/cagent-action` repo remains functional, so there is no deadline — merge whenever convenient. New features and fixes land in the new repo, which is where you'll want to be going forward.

> Auto-generated by the [migrate-consumers](https://github.com/docker/docker-agent-action/actions/runs/28023540082) workflow.