### PR TITLE
ci: add concurrency group to pr-review-trigger to prevent duplicate reviews

### DIFF
--- a/.github/workflows/pr-review-trigger.yml
+++ b/.github/workflows/pr-review-trigger.yml
@@ -7,8 +7,17 @@ on:
 
 permissions: {}
 
+# Deduplicate simultaneous pull_request events for the same fork PR.
+# When reviewers are requested at the same time, GitHub fires multiple
+# review_requested events. Without this group each event triggers a
+# separate review via workflow_run, producing duplicate reviews.
+concurrency:
+  group: pr-review-trigger-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   save-context:
+    if: github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - name: Save event context


### PR DESCRIPTION
Adds a concurrency group keyed by PR number to `pr-review-trigger.yml` to prevent
triplicate reviews when simultaneous `pull_request` events fire for the same fork PR
(e.g., multiple `review_requested` events when several reviewers are added at once).

Also skips Bot-type senders (Dependabot, Renovate) early to save Actions minutes.