### PR TITLE
internal/prompt: Confirm: don't wrap stdIn

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -88,8 +88,18 @@ func Confirm(ctx context.Context, in io.Reader, out io.Writer, message string) (
 	_, _ = out.Write([]byte(message))
 
 	// On Windows, force the use of the regular OS stdin stream.
+	//
+	// StdStreams() may wrap stdin with windowsconsole.NewAnsiReader to
+	// emulate VT input on consoles that do not support it natively, but
+	// that wrapper has historically caused interactive prompts to hang
+	// or behave incorrectly.
+	//
+	// See:
+	// - https://github.com/moby/moby/issues/14336
+	// - https://github.com/moby/moby/issues/14210
+	// - https://github.com/moby/moby/pull/17738
 	if runtime.GOOS == "windows" {
-		in = streams.NewIn(os.Stdin)
+		in = os.Stdin
 	}
 
 	result := make(chan bool)


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/29288
- relates to https://github.com/docker/cli/pull/27


This was a remnant from when `PromptForConfirmation` accepted a `InStream`; it was added in [moby@30b8f08], which got left behind when [cli@37ccc00] updated its signature to accept a plain `io.Reader`.

While updating, also update the comment to provide more context on the reason we're unconditionally using `os.Stdin` on Windows.

[moby@30b8f08]: https://github.com/moby/moby/commit/30b8f084436a2a1d5e8523fcd2c5ea64cc805224
[cli@37ccc00]: https://github.com/docker/cli/commit/37ccc00d0e14461bcf29e98669773625dfed2fce

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
