### PR TITLE
cli/command: PromptUserForCredentials: don't mutate cli

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -97,17 +97,22 @@ func GetDefaultAuthConfig(cfg *configfile.ConfigFile, checkCredStore bool, serve
 // If defaultUsername is not empty, the username prompt includes that username
 // and the user can hit enter without inputting a username  to use that default
 // username.
-func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword, defaultUsername, serverAddress string) (registrytypes.AuthConfig, error) {
+func PromptUserForCredentials(ctx context.Context, cli Streams, argUser, argPassword, defaultUsername, serverAddress string) (registrytypes.AuthConfig, error) {
 	// On Windows, force the use of the regular OS stdin stream.
+	//
+	// StdStreams() may wrap stdin with windowsconsole.NewAnsiReader to
+	// emulate VT input on consoles that do not support it natively, but
+	// that wrapper has historically caused interactive prompts to hang
+	// or behave incorrectly.
 	//
 	// See:
 	// - https://github.com/moby/moby/issues/14336
 	// - https://github.com/moby/moby/issues/14210
 	// - https://github.com/moby/moby/pull/17738
-	//
-	// TODO(thaJeztah): we need to confirm if this special handling is still needed, as we may not be doing this in other places.
+	stdIn := cli.In()
 	if runtime.GOOS == "windows" {
-		cli.SetIn(streams.NewIn(os.Stdin))
+		// TODO(thaJeztah); change to io.Reader and skip wrapping once prompt.DisableInputEcho no longer requires a streams.In
+		stdIn = streams.NewIn(os.Stdin)
 	}
 
 	argUser = strings.TrimSpace(argUser)
@@ -132,7 +137,7 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 		}
 
 		var err error
-		argUser, err = prompt.ReadInput(ctx, cli.In(), cli.Out(), msg)
+		argUser, err = prompt.ReadInput(ctx, stdIn, cli.Out(), msg)
 		if err != nil {
 			return registrytypes.AuthConfig{}, err
 		}
@@ -146,7 +151,7 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 
 	isEmpty := strings.TrimSpace(argPassword) == ""
 	if isEmpty {
-		restoreInput, err := prompt.DisableInputEcho(cli.In())
+		restoreInput, err := prompt.DisableInputEcho(stdIn)
 		if err != nil {
 			return registrytypes.AuthConfig{}, err
 		}
@@ -166,7 +171,7 @@ func PromptUserForCredentials(ctx context.Context, cli Cli, argUser, argPassword
 				"To create a PAT, visit " + aec.Underline.Apply("https://app.docker.com/settings") + "\n\n")
 		}
 
-		argPassword, err = prompt.ReadInput(ctx, cli.In(), cli.Out(), "Password: ")
+		argPassword, err = prompt.ReadInput(ctx, stdIn, cli.Out(), "Password: ")
 		if err != nil {
 			return registrytypes.AuthConfig{}, err
 		}


### PR DESCRIPTION
PromptUserForCredentials accepted a Cli as argument so that it could swap the input stream on Windows (cli.SetIn).

Given that we only require this swap for the duration of this function (if needed at all), we can use a local variable that either uses cli.In() or os.Stdin (on Windows).

We currently still need to wrap the os.Stdin into a streams.In, but can use the raw os.Stdin (and/or cli.In().File()) once prompt.DisableInputEcho is updated.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
