### PR TITLE
connhelper: return original daemonURL for ssh host

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -65,7 +65,7 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return commandconn.New(ctx, "ssh", sshArgs...)
 			},
-			Host: "http://docker.example.com",
+			Host: daemonURL,
 		}, nil
 	}
 	// Future version may support plugins via ~/.docker/config.json. e.g. "dind"

--- a/cli/connhelper/connhelper_test.go
+++ b/cli/connhelper/connhelper_test.go
@@ -61,3 +61,10 @@ func TestDisablePseudoTerminalAllocation(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConnectionHelper(t *testing.T) {
+	helper, err := GetConnectionHelper("ssh://user@1.2.3.4")
+	assert.NilError(t, err)
+	assert.Assert(t, helper != nil)
+	assert.Equal(t, helper.Host, "ssh://user@1.2.3.4")
+}


### PR DESCRIPTION
**- What I did**
Fixed connection helper for SSH scheme to return the original daemonURL as the Host instead of the hardcoded dummy "http://docker.example.com". This fixes #6164.

**- How I did it**
Modified `getConnectionHelper` in `cli/connhelper/connhelper.go` to return `Host: daemonURL` under `u.Scheme == "ssh"`. The URL parser and client transport will correctly cut the scheme and host, preserving the correct host for DaemonHost() and matching proxy settings (like `NO_PROXY`), while keeping connection setup via SSH dialer intact.

**- How to verify it**
Added a unit test `TestGetConnectionHelper` in `cli/connhelper/connhelper_test.go` verifying that the Host field matches the original SSH daemon URL.

**- Human readable description for the release notes**
```markdown changelog
connhelper: return original daemonURL for ssh host to resolve incorrect host reporting and proxy matching issues.
```