### PR TITLE
cli/context/store: limit decompressed size of TLS files on zip import

### DIFF
--- a/cli/context/store/io_utils.go
+++ b/cli/context/store/io_utils.go
@@ -5,6 +5,8 @@ import (
 	"io"
 )
 
+var errLimitExceeded = errors.New("read exceeds the defined limit")
+
 // limitedReader is a fork of [io.LimitedReader] to override Read.
 type limitedReader struct {
 	R io.Reader
@@ -14,10 +16,7 @@ type limitedReader struct {
 // Read is a fork of [io.LimitedReader.Read] that returns an error when limit exceeded.
 func (l *limitedReader) Read(p []byte) (n int, err error) {
 	if l.N < 0 {
-		return 0, errors.New("read exceeds the defined limit")
-	}
-	if l.N == 0 {
-		return 0, io.EOF
+		return 0, errLimitExceeded
 	}
 	// have to cap N + 1 otherwise we won't hit limit err
 	if int64(len(p)) > l.N+1 {
@@ -25,5 +24,12 @@ func (l *limitedReader) Read(p []byte) (n int, err error) {
 	}
 	n, err = l.R.Read(p)
 	l.N -= int64(n)
+	if l.N < 0 {
+		// The limit must take precedence over the underlying error: a reader
+		// is allowed to return data together with [io.EOF], and returning that
+		// EOF here would make [io.ReadAll] report success for content that was
+		// silently truncated.
+		return n, errLimitExceeded
+	}
 	return n, err
 }

--- a/cli/context/store/io_utils_test.go
+++ b/cli/context/store/io_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"gotest.tools/v3/assert"
 )
@@ -20,5 +21,18 @@ func TestLimitReaderReadAll(t *testing.T) {
 
 	r = strings.NewReader("Test")
 	_, err = io.ReadAll(&limitedReader{R: r, N: 2})
+	assert.Error(t, err, "read exceeds the defined limit")
+
+	// exceeding the limit must error even when a read lands exactly on
+	// the limit before the remaining data is reached
+	r = strings.NewReader("Test")
+	_, err = io.ReadAll(&limitedReader{R: iotest.OneByteReader(r), N: 2})
+	assert.Error(t, err, "read exceeds the defined limit")
+
+	// a reader is allowed to return data together with io.EOF; the limit
+	// must still be reported, otherwise io.ReadAll treats the truncated
+	// content as a successful read
+	r = strings.NewReader("Tes")
+	_, err = io.ReadAll(&limitedReader{R: iotest.DataErrReader(r), N: 2})
 	assert.Error(t, err, "read exceeds the defined limit")
 }

--- a/cli/context/store/store.go
+++ b/cli/context/store/store.go
@@ -478,7 +478,7 @@ func importZip(name string, s Writer, reader io.Reader) error {
 			if err != nil {
 				return err
 			}
-			data, err := io.ReadAll(f)
+			data, err := io.ReadAll(&limitedReader{R: f, N: maxAllowedFileSizeToImport})
 			defer f.Close()
 			if err != nil {
 				return err

--- a/cli/context/store/store_test.go
+++ b/cli/context/store/store_test.go
@@ -236,6 +236,46 @@ func TestImportZipInvalid(t *testing.T) {
 	assert.ErrorContains(t, err, "unexpected context file")
 }
 
+func TestImportZipTLSDataTooLarge(t *testing.T) {
+	testDir := t.TempDir()
+	zf := path.Join(testDir, "test.zip")
+
+	f, err := os.Create(zf)
+	assert.NilError(t, err)
+	defer f.Close()
+	w := zip.NewWriter(f)
+
+	meta, err := json.Marshal(Metadata{
+		Endpoints: map[string]any{
+			"ep1": endpoint{Foo: "bar"},
+		},
+		Metadata: context{Bar: "baz"},
+		Name:     "source",
+	})
+	assert.NilError(t, err)
+	mf, err := w.Create("meta.json")
+	assert.NilError(t, err)
+	_, err = mf.Write(meta)
+	assert.NilError(t, err)
+
+	// a highly compressible TLS entry that inflates beyond the allowed
+	// import size, even though the zip file itself stays well under it
+	tf, err := w.Create(path.Join("tls", "docker", "ca.pem"))
+	assert.NilError(t, err)
+	_, err = tf.Write(make([]byte, 2*maxAllowedFileSizeToImport))
+	assert.NilError(t, err)
+	err = w.Close()
+	assert.NilError(t, err)
+
+	source, err := os.Open(zf)
+	assert.NilError(t, err)
+	defer source.Close()
+	var r io.Reader = source
+	s := New(testDir, testCfg)
+	err = Import("zipTLSTooLarge", s, r)
+	assert.ErrorContains(t, err, "exceeds the defined limit")
+}
+
 func TestCorruptMetadata(t *testing.T) {
 	tempDir := t.TempDir()
 	s := New(tempDir, testCfg)


### PR DESCRIPTION
**- What I did**

Fixed a memory exhaustion issue in `docker context import` with zip archives (fixes #6917).

The `meta.json` entry of an imported zip archive is read through `limitedReader` (10MB cap), but `tls/` entries were read with a bare `io.ReadAll`. Only the *compressed* archive size was capped, so a small crafted zip containing a highly compressible TLS entry could decompress to gigabytes and OOM the CLI.

**- How I did it**

Read TLS entries in `importZip` through the same `limitedReader` already used for `meta.json`.

That alone wasn't sufficient: `limitedReader` had two ways of silently *truncating* content rather than rejecting it, both of which made the cap ineffective because `io.ReadAll` treats `io.EOF` as success.

- The `l.N == 0` branch returned `io.EOF` once the budget was used up. Reachable whenever a read lands exactly on the remaining budget — deterministic for zip imports, since flate delivers 32KiB chunks that divide the 10MB cap evenly.
- A reader is permitted to return data together with `io.EOF`. When such a read crossed the limit, that `io.EOF` was returned as-is and the limit error was never observed by the caller. (Thanks to the Copilot review for catching this second one.)

The limit error now takes precedence over the underlying error as soon as the budget goes negative. True end-of-data still returns a clean `io.EOF` from the underlying reader.

**- How to verify it**

```
go test ./cli/context/store/
```

Regression tests:
- `TestImportZipTLSDataTooLarge` — imports a zip whose TLS entry inflates past the cap while the archive itself stays well under it, and asserts the import errors.
- `TestLimitReaderReadAll` gains two cases: an `iotest.OneByteReader` that lands a read exactly on the limit with data remaining, and an `iotest.DataErrReader` that returns data together with `io.EOF` on the read that crosses the limit. Both assert the limit error is surfaced; both fail against the previous `limitedReader`.

**- Human readable description for the release notes**

Left the block below empty because the changelog check requires a matching `impact/` label, which I can't set. Suggested note if a maintainer wants this in the release notes:

> Fix `docker context import` allocating unbounded memory for TLS files contained in zip archives

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**

🦦
