### PR TITLE
cli/compose/loader: don't drop tcp port when udp uses same published port

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -123,6 +123,14 @@ func toServiceConfigObjConfigsMap(s any) (map[any]any, error) {
 	return m, nil
 }
 
+// servicePortKey identifies a port during a merge; the same published
+// port may be exposed for both tcp and udp, so the protocol is part of
+// the identity.
+type servicePortKey struct {
+	published uint32
+	protocol  string
+}
+
 func toServicePortConfigsMap(s any) (map[any]any, error) {
 	ports, ok := s.([]types.ServicePortConfig)
 	if !ok {
@@ -130,7 +138,13 @@ func toServicePortConfigsMap(s any) (map[any]any, error) {
 	}
 	m := map[any]any{}
 	for _, p := range ports {
-		m[p.Published] = p
+		protocol := p.Protocol
+		if protocol == "" {
+			// long syntax allows the protocol to be omitted, in which
+			// case it defaults to tcp
+			protocol = "tcp"
+		}
+		m[servicePortKey{published: p.Published, protocol: protocol}] = p
 	}
 	return m, nil
 }
@@ -172,7 +186,12 @@ func toServicePortConfigsSlice(dst reflect.Value, m map[any]any) error {
 	for _, v := range m {
 		s = append(s, v.(types.ServicePortConfig))
 	}
-	sort.Slice(s, func(i, j int) bool { return s[i].Published < s[j].Published })
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].Published != s[j].Published {
+			return s[i].Published < s[j].Published
+		}
+		return s[i].Protocol < s[j].Protocol
+	})
 	dst.Set(reflect.ValueOf(s))
 	return nil
 }

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -281,6 +281,58 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 			},
 		},
 		{
+			name: "same_published_different_protocol",
+			portBase: map[string]any{
+				"ports": []any{
+					"443:443",
+					"443:443/udp",
+				},
+			},
+			portOverride: map[string]any{},
+			expected: []types.ServicePortConfig{
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    443,
+					Protocol:  "tcp",
+				},
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    443,
+					Protocol:  "udp",
+				},
+			},
+		},
+		{
+			name: "override_same_published_different_protocol",
+			portBase: map[string]any{
+				"ports": []any{
+					"443:443",
+					"443:443/udp",
+				},
+			},
+			portOverride: map[string]any{
+				"ports": []any{
+					"443:8443/udp",
+				},
+			},
+			expected: []types.ServicePortConfig{
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    443,
+					Protocol:  "tcp",
+				},
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    8443,
+					Protocol:  "udp",
+				},
+			},
+		},
+		{
 			name: "override_same_published",
 			portBase: map[string]any{
 				"ports": []any{


### PR DESCRIPTION
**- What I did**

Fixed `docker stack config` / `docker stack deploy` silently dropping a port entry when merging multiple compose files where a service publishes the same port on both tcp and udp (e.g. `443:443` and `443:443/udp`). The entry was lost even when the override file did not define any ports.

Fixes #6223

**- How I did it**

During merge, ports were indexed by their published port only, so the tcp and udp entries for the same published port collided and the later one overwrote the earlier one. The merge key now includes the protocol (an omitted protocol is treated as tcp, matching the long-syntax default), and the sort of the merged result uses the protocol as a tie-breaker so the output order is deterministic.

**- How to verify it**

```bash
# compose.yaml
services:
  web:
    image: caddy
    ports:
      - "80:80"
      - "443:443"
      - "443:443/udp"

# compose.override.yaml
services:
  web:
    environment:
      FOO: bar
```

`docker stack config -c compose.yaml -c compose.override.yaml` now returns all three ports; previously the `443:443/tcp` entry was missing. Regression tests added in `cli/compose/loader/merge_test.go` (`go test ./cli/compose/loader/ -run TestLoadMultipleServicePorts`).

**- Human readable description for the release notes**

```markdown changelog
Fix `docker stack config` dropping a port when merging compose files that publish the same port on both tcp and udp
```