### PR TITLE
container rm: suppress forced not found errors

### DIFF
--- a/cli/command/container/rm.go
+++ b/cli/command/container/rm.go
@@ -88,7 +88,6 @@ func runRm(ctx context.Context, dockerCLI command.Cli, opts *rmOptions) error {
 	for _, name := range opts.containers {
 		if err := <-errChan; err != nil {
 			if opts.force && errdefs.IsNotFound(err) {
-				_, _ = fmt.Fprintln(dockerCLI.Err(), err)
 				continue
 			}
 			errs = append(errs, err)

--- a/cli/command/container/rm_test.go
+++ b/cli/command/container/rm_test.go
@@ -52,6 +52,7 @@ func TestRemoveForce(t *testing.T) {
 			} else {
 				assert.NilError(t, err)
 			}
+			assert.Equal(t, cli.ErrBuffer().String(), "")
 			sort.Strings(removed)
 			assert.DeepEqual(t, removed, []string{"mycontainer", "nosuchcontainer"})
 		})


### PR DESCRIPTION
**- What I did**

Fixes #7076.

Suppresses stderr output for `docker rm --force` when the daemon reports that a container was not found. The command already treats that case as non-fatal; this makes the output match the successful exit status and the existing `docker network rm -f` behavior.

**- How I did it**

Removed the stderr write in the `--force` + not-found branch, and added a regression assertion to `TestRemoveForce`.

**- How to verify it**

`./scripts/with-go-mod.sh go test ./cli/command/container`

**- Human readable description for the release notes**

```markdown changelog
Suppress the “No such container” error when `docker rm --force` succeeds for a nonexistent container.
```