### PR TITLE
docker.Makefile: Use active context socket

### DIFF
--- a/docker.Makefile
+++ b/docker.Makefile
@@ -8,6 +8,7 @@
 DOCKER_CLI_MOUNTS ?= -v "$(CURDIR)":/go/src/github.com/docker/cli
 DOCKER_CLI_CONTAINER_NAME ?=
 DOCKER_CLI_GO_BUILD_CACHE ?= y
+DOCKER_SOCK ?= $(or $(patsubst unix://%,%,$(filter unix://%,$(shell docker context inspect --format '{{.Endpoints.docker.Host}}'))),/var/run/docker.sock)
 
 # Sets the name of the company that produced the windows binary.
 PACKAGER_NAME ?=
@@ -62,7 +63,7 @@ dynbinary: ## build dynamically linked binary
 .PHONY: dev
 dev: build_docker_image ## start a build container in interactive mode for in-container development
 	$(DOCKER_RUN) -it \
-		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+		--mount 'type=bind,src=$(DOCKER_SOCK),dst=/var/run/docker.sock' \
 		$(DEV_DOCKER_IMAGE_NAME)
 
 shell: dev ## alias for dev
@@ -134,14 +135,14 @@ test-e2e: test-e2e-local test-e2e-connhelper-ssh ## run all e2e tests
 test-e2e-local: build-e2e-image # run experimental e2e tests
 	docker run --rm $(ENVVARS) \
 		--mount type=bind,src=$(CURDIR)/build/coverage,dst=/tmp/coverage \
-		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+		--mount 'type=bind,src=$(DOCKER_SOCK),dst=/var/run/docker.sock' \
 		$(E2E_IMAGE_NAME)
 
 .PHONY: test-e2e-connhelper-ssh
 test-e2e-connhelper-ssh: build-e2e-image # run experimental SSH-connection helper e2e tests
 	docker run --rm $(ENVVARS) -e TEST_CONNHELPER=ssh \
 		--mount type=bind,src=$(CURDIR)/build/coverage,dst=/tmp/coverage \
-		--mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+		--mount 'type=bind,src=$(DOCKER_SOCK),dst=/var/run/docker.sock' \
 		$(E2E_IMAGE_NAME)
 
 .PHONY: help


### PR DESCRIPTION
The development and e2e containers hard-code /var/run/docker.sock, so rootless and other local contexts cannot expose their daemon socket. Resolve the active context's Docker endpoint and strip the unix scheme before using it as the bind source.

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
