### PR TITLE
docs: clarify byte units for size-based ulimits (memlock)

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1370,7 +1370,21 @@ $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
 | `stack`      | Maximum stack size (`RLIMIT_STACK`)                       |
 
 Docker sends the values to the appropriate OS `syscall` and doesn't perform any byte conversion.
-Take this into account when setting the values.
+For limits that describe a size, such as `memlock`, `data`, and `fsize`, values
+are in bytes, following the semantics of the Linux `setrlimit(2)` syscall.
+Values must be plain integers, and don't support unit suffixes such as `k`,
+`m`, or `g`.
+
+> [!NOTE]
+> The `ulimit` shell builtin reports some of these limits in different units.
+> For example, `ulimit -l` reports the `memlock` limit in kilobytes, so a limit
+> of 64 MiB set with `--ulimit memlock=67108864:67108864` is reported as
+> `65536`:
+>
+> ```console
+> $ docker run --ulimit memlock=67108864:67108864 --rm debian sh -c "ulimit -l"
+> 65536
+> ```
 
 #### For `nproc` usage
 

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -740,7 +740,15 @@ any options, the systems uses the following options:
    Without this argument the command will be run as root in the container.
 
 **--ulimit**=[]
-    Ulimit options
+   Ulimit options, in the format `<type>=<soft limit>[:<hard limit>]`, for
+   example `--ulimit nofile=1024:1024`.
+
+   Limits that describe a size, such as `memlock`, `data`, and `fsize`, are
+   specified in bytes, as used by the Linux setrlimit(2) syscall. Values must
+   be plain integers, and don't support unit suffixes such as `k`, `m`, or
+   `g`. Note that the `ulimit` builtin of the shell reports some of these
+   limits in different units, for example, `ulimit -l` reports the `memlock`
+   limit in kilobytes.
 
 **-v**|**--volume**[=*[[HOST-DIR:]CONTAINER-DIR[:OPTIONS]]*]
    Create a bind mount. If you specify, ` -v /HOST-DIR:/CONTAINER-DIR`, Docker


### PR DESCRIPTION
**- What I did**

Documented the units for size-based `--ulimit` values.

The values of `--ulimit` options are passed to the `setrlimit(2)` syscall as-is, so size-based limits such as `memlock`, `data`, and `fsize` are expressed in bytes. The `ulimit` shell builtin, however, reports several of these limits in kilobytes, so `--ulimit memlock=4096` produces a limit that `ulimit -l` reports as `4`. That's counter-intuitive for users expecting the same units as the shell, and it wasn't documented. Values must also be plain integers; unit suffixes such as `k`, `m`, or `g` aren't supported.

This PR only clarifies the documentation and doesn't change any behavior. Accepting human-friendly suffixes (for example `--ulimit memlock=64m`) could be a follow-up enhancement if maintainers think it's worthwhile, but that changes option parsing and deserves its own discussion.

Fixes #5799

**- How I did it**

- Extended the `--ulimit` section in `docs/reference/commandline/container_run.md`: documented that size-based limits are in bytes (following `setrlimit(2)` semantics) and that values must be plain integers without unit suffixes, and added a note with a `memlock` example showing the byte value (`67108864` = 64 MiB) next to the corresponding `ulimit -l` output (`65536`, in kilobytes).
- Expanded the terse `--ulimit` entry in `man/docker-run.1.md` with the same information.

**- How to verify it**

Documentation-only change; review the rendered Markdown. The documented behavior can be verified with:

```console
$ docker run --ulimit memlock=67108864:67108864 --rm debian sh -c "ulimit -l"
65536
```

**- Human readable description for the release notes**

```markdown changelog

```
