### PR TITLE
docs: explain how to set bridge network driver options

### DIFF
--- a/docs/reference/commandline/network_create.md
+++ b/docs/reference/commandline/network_create.md
@@ -149,9 +149,10 @@ fails and Docker Engine returns an error.
 
 ### Bridge driver options
 
-When creating a custom `bridge` network, the following additional options can
-be passed. Some of these have equivalent flags that can be used on the dockerd
-command line or in `daemon.json` to configure the default bridge, `docker0`:
+When creating a custom `bridge` network, you can configure driver options using
+the `--opt` flag. Some of these options have equivalent flags that can be used
+on the dockerd command line or in `daemon.json` to configure the default bridge,
+`docker0`:
 
 | Network create option                            | Daemon option for `docker0` | Description                                           |
 |--------------------------------------------------|-----------------------------|-------------------------------------------------------|
@@ -161,6 +162,15 @@ command line or in `daemon.json` to configure the default bridge, `docker0`:
 | `com.docker.network.bridge.host_binding_ipv4`    | `--ip`                      | Default IP when binding container ports               |
 | `com.docker.network.driver.mtu`                  | `--mtu`                     | Set the containers network MTU                        |
 | `com.docker.network.container_iface_prefix`      | -                           | Set a custom prefix for container interfaces          |
+
+For example, to create a custom `bridge` network with IP masquerading disabled:
+
+```console
+$ docker network create \
+    --driver bridge \
+    --opt com.docker.network.bridge.enable_ip_masquerade=false \
+    no-masq-network
+```
 
 The following arguments can be passed to `docker network create` for any
 network driver, again with their approximate equivalents to Docker daemon


### PR DESCRIPTION
Supersedes #7075.

## What changed

Addresses @dvdksn's review feedback on #7075 for the **Bridge driver options** section of `docker network create`:

- Reworded the section intro to explain that driver options are set with the `--opt` flag (kept the existing note about the equivalent `docker0`/daemon flags, since the table's second column relies on that context).
- Removed the redundant `enable_ip_masquerade` paragraph, so the example now sits directly below the table as a general illustration of how to set a bridge driver option.

## Why

Follow-up to docker/docs#13861 and the review discussion on #7075. The existing table already lists `com.docker.network.bridge.enable_ip_masquerade`, but the section didn't show *how* driver options are actually passed on the command line.

## Validation

- `make mddocs` / `make yamldocs` — regenerated cleanly, no changes outside the reworked prose
- `git diff --check`

This is a documentation-only change; it does not change Docker CLI or daemon behavior.
