### PR TITLE
cli/command/service: fix panic when removing duplicate values

### DIFF
--- a/cli/command/service/opts.go
+++ b/cli/command/service/opts.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -687,15 +688,13 @@ func (options *serviceOptions) makeEnv() ([]string, error) {
 	}
 	currentEnv := make([]string, 0, len(envVariables))
 	for _, env := range envVariables { // need to process each var, in order
-		k, _, _ := strings.Cut(env, "=")
-		for i, current := range currentEnv { // remove duplicates
-			if current == env {
-				continue // no update required, may hide this behind flag to preserve order of envVariables
-			}
-			if strings.HasPrefix(current, k+"=") {
-				currentEnv = append(currentEnv[:i], currentEnv[i+1:]...)
-			}
+		if slices.Contains(currentEnv, env) {
+			continue // no update required, may hide this behind flag to preserve order of envVariables
 		}
+		k, _, _ := strings.Cut(env, "=")
+		currentEnv = slices.DeleteFunc(currentEnv, func(current string) bool { // remove duplicates
+			return strings.HasPrefix(current, k+"=")
+		})
 		currentEnv = append(currentEnv, env)
 	}
 

--- a/cli/command/service/opts_test.go
+++ b/cli/command/service/opts_test.go
@@ -373,3 +373,49 @@ func TestToServiceSysCtls(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(service.TaskTemplate.ContainerSpec.Sysctls, expected))
 }
+
+func TestMakeEnv(t *testing.T) {
+	tests := []struct {
+		doc      string
+		env      []string
+		expected []string
+	}{
+		{
+			doc:      "no duplicates",
+			env:      []string{"one=1", "two=2"},
+			expected: []string{"one=1", "two=2"},
+		},
+		{
+			doc:      "same variable repeated",
+			env:      []string{"one=1", "one=1"},
+			expected: []string{"one=1"},
+		},
+		{
+			doc:      "same variable repeated, then overridden",
+			env:      []string{"one=1", "one=1", "one=2"},
+			expected: []string{"one=2"},
+		},
+		{
+			doc:      "repeated variable last",
+			env:      []string{"one=1", "two=2", "two=2"},
+			expected: []string{"one=1", "two=2"},
+		},
+		{
+			doc:      "last value wins",
+			env:      []string{"one=1", "two=2", "one=3"},
+			expected: []string{"two=2", "one=3"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.doc, func(t *testing.T) {
+			o := newServiceOptions()
+			for _, env := range tc.env {
+				assert.NilError(t, o.env.Set(env))
+			}
+			actual, err := o.makeEnv()
+			assert.NilError(t, err)
+			assert.Check(t, is.DeepEqual(tc.expected, actual))
+		})
+	}
+}

--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -1213,11 +1213,9 @@ func updateHosts(flags *pflag.FlagSet, hosts *[]string) error {
 			if rm.IPAddr != "" && rm.IPAddr != ip {
 				continue
 			}
-			for i, h := range hostNames {
-				if h == rm.Host {
-					hostNames = append(hostNames[:i], hostNames[i+1:]...)
-				}
-			}
+			hostNames = slices.DeleteFunc(hostNames, func(h string) bool {
+				return h == rm.Host
+			})
 		}
 		if len(hostNames) > 0 {
 			newHosts = append(newHosts, fmt.Sprintf("%s %s", ip, strings.Join(hostNames, " ")))

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -1727,3 +1727,18 @@ func TestUpdateUlimits(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateHostsRemoveRepeatedHost(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	flags.Set("host-rm", "host1")
+
+	//nolint:dupword // ignore "Duplicate words (host1) found"
+	hosts := []string{"127.0.0.1 host1 host1 host2", "127.0.0.2 host2 host1 host1"}
+
+	err := updateHosts(flags, &hosts)
+	assert.NilError(t, err)
+
+	// All occurrences of `host1` should be removed, also if the same host
+	// is listed multiple times in the same entry.
+	assert.Check(t, is.DeepEqual([]string{"127.0.0.1 host2", "127.0.0.2 host2"}, hosts))
+}


### PR DESCRIPTION
**- What I did**

Fixed a panic in `docker service create` / `docker service update` when the same environment variable is passed more than once, and the same bug class in `updateHosts`.

Both `(*serviceOptions).makeEnv` and `updateHosts` removed elements from a slice with `s = append(s[:i], s[i+1:]...)` *while ranging over that same slice*. The range expression is evaluated once, so after a removal the loop keeps using the original length: it reads stale elements that shifted down, skips a live element, and can slice past the end of the shrunken slice, which panics.

In `makeEnv` there was a second problem feeding the first: the `continue` for the "no update required" case continued the **inner** loop instead of skipping the re-append, so an env var passed twice with the same value was stored twice — contradicting the `// remove duplicates` comment. A third occurrence with a different value then tried to remove both copies and ran off the end:

```
$ docker service create --env A=1 --env A=1 --env A=2 --name repro nginx
panic: runtime error: slice bounds out of range [2:1]

goroutine 1 [running]:
github.com/docker/cli/cli/command/service.(*serviceOptions).makeEnv(...)
	/go/src/github.com/docker/cli/cli/command/service/opts.go:696
github.com/docker/cli/cli/command/service.(*serviceOptions).ToService(...)
	/go/src/github.com/docker/cli/cli/command/service/opts.go:715
```

`makeEnv` is the first statement of `ToService`, so this happens before any API call — no daemon is needed to hit it, and the same applies to an `--env-file` that lists a variable twice.

`updateHosts` has the same defect when a hostname appears more than once in a single entry: `--host-rm` either leaves a copy behind or panics with `slice bounds out of range`. To be upfront about the impact: the CLI itself does not produce such entries, so reaching that one needs a spec written through the API or swarmkit directly. It is fixed here because it is literally the same bug two files apart, not because I can show it from the CLI.

**- How I did it**

Replaced both hand-rolled removal loops with `slices.DeleteFunc`, which removes every match in a single pass and cannot leave a stale index behind. In `makeEnv` the "already present, unchanged" check moved out to the top of the outer loop, which is where the original `continue` comment was clearly aiming — so an exact repeat is now skipped instead of appended twice. Behaviour is otherwise unchanged: vars are still processed in order and the last value for a key still wins.

I also swept the rest of the tree for the same pattern. The only other in-place removals are `stats.remove` (`cli/command/container/stats_helpers.go`) and `ListOpts.Delete` (`opts/opts.go`); neither removes inside a range over the slice it mutates, so both are correct and are left alone.

**- How to verify it**

Before this change, on `master`:

```
$ go build -o dockercli ./cmd/docker
$ ./dockercli service create --env A=1 --env A=1 --env A=2 --name repro nginx
panic: runtime error: slice bounds out of range [2:1]
```

(also reproducible with `printf 'A=1\nA=1\nA=2\n' > /tmp/e && ./dockercli service create --env-file /tmp/e ...`)

After it, the command proceeds normally and the service gets a single `A=2`.

`makeEnv` had no test coverage at all, so this adds `TestMakeEnv` covering the repeat, repeat-then-override, repeat-at-last-position and no-duplicate cases, plus `TestUpdateHostsRemoveRepeatedHost` for the `--host-rm` side. Both fail on `master` (the override case and the host case panic) and pass with the fix:

```
$ go test ./cli/command/service/... 
ok  	github.com/docker/cli/cli/command/service
ok  	github.com/docker/cli/cli/command/service/internal/genericresource
ok  	github.com/docker/cli/cli/command/service/progress
```

The existing `TestUpdateHosts*` tests are untouched and still pass, and `golangci-lint run ./cli/command/service/...` is clean.

**- Human readable description for the release notes**

I left the changelog block below empty on purpose: `check-changelog` fails a PR that fills it without an `impact/` label, and labels are maintainer-applied. If you'd like it in the release notes, the line I'd suggest is:

Happy to move that into the block once a label is applied.

```markdown changelog
Fix `docker service create` and `docker service update` panicking when the same environment variable is passed more than once.
```