### PR TITLE
cli/command/formatter: add CreatedAt to volume list output

### DIFF
--- a/cli/command/formatter/volume.go
+++ b/cli/command/formatter/volume.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/volume"
@@ -75,6 +76,7 @@ func newVolumeContext() *volumeContext {
 		"Links":        linksHeader,
 		"Size":         SizeHeader,
 		"Status":       statusHeader,
+		"CreatedAt":    CreatedAtHeader,
 	}
 	return &volumeCtx
 }
@@ -147,6 +149,21 @@ func (c *volumeContext) Availability() string {
 	}
 
 	return string(c.v.ClusterVolume.Spec.Availability)
+}
+
+// CreatedAt returns the time the volume was created, formatted the same way as
+// the "CreatedAt" field of other list commands (e.g. "docker ps", "docker network ls").
+// It returns an empty string if the daemon did not report a creation time, and
+// the raw value as reported by the daemon if it cannot be parsed.
+func (c *volumeContext) CreatedAt() string {
+	if c.v.CreatedAt == "" {
+		return ""
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, c.v.CreatedAt)
+	if err != nil {
+		return c.v.CreatedAt
+	}
+	return createdAt.String()
 }
 
 func (c *volumeContext) Status() string {

--- a/cli/command/formatter/volume_test.go
+++ b/cli/command/formatter/volume_test.go
@@ -43,6 +43,15 @@ func TestVolumeContext(t *testing.T) {
 		{volumeContext{
 			v: volume.Volume{Labels: map[string]string{"label1": "value1", "label2": "value2"}},
 		}, "label1=value1,label2=value2", ctx.Labels},
+		{volumeContext{
+			v: volume.Volume{},
+		}, "", ctx.CreatedAt},
+		{volumeContext{
+			v: volume.Volume{CreatedAt: "2016-06-07T20:31:11.853781916Z"},
+		}, "2016-06-07 20:31:11.853781916 +0000 UTC", ctx.CreatedAt},
+		{volumeContext{
+			v: volume.Volume{CreatedAt: "not-a-timestamp"},
+		}, "not-a-timestamp", ctx.CreatedAt},
 	}
 
 	for _, c := range cases {
@@ -143,12 +152,12 @@ foobar_bar
 
 func TestVolumeContextWriteJSON(t *testing.T) {
 	volumes := []volume.Volume{
-		{Driver: "foo", Name: "foobar_baz"},
+		{Driver: "foo", Name: "foobar_baz", CreatedAt: "2016-06-07T20:31:11.853781916Z"},
 		{Driver: "bar", Name: "foobar_bar"},
 	}
 	expectedJSONs := []map[string]any{
-		{"Availability": "N/A", "Driver": "foo", "Group": "N/A", "Labels": "", "Links": "N/A", "Mountpoint": "", "Name": "foobar_baz", "Scope": "", "Size": "N/A", "Status": "N/A"},
-		{"Availability": "N/A", "Driver": "bar", "Group": "N/A", "Labels": "", "Links": "N/A", "Mountpoint": "", "Name": "foobar_bar", "Scope": "", "Size": "N/A", "Status": "N/A"},
+		{"Availability": "N/A", "CreatedAt": "2016-06-07 20:31:11.853781916 +0000 UTC", "Driver": "foo", "Group": "N/A", "Labels": "", "Links": "N/A", "Mountpoint": "", "Name": "foobar_baz", "Scope": "", "Size": "N/A", "Status": "N/A"},
+		{"Availability": "N/A", "CreatedAt": "", "Driver": "bar", "Group": "N/A", "Labels": "", "Links": "N/A", "Mountpoint": "", "Name": "foobar_bar", "Scope": "", "Size": "N/A", "Status": "N/A"},
 	}
 	out := bytes.NewBufferString("")
 	err := VolumeWrite(Context{Format: "{{json .}}", Output: out}, volumes)

--- a/docs/reference/commandline/volume_ls.md
+++ b/docs/reference/commandline/volume_ls.md
@@ -160,6 +160,7 @@ Valid placeholders for the Go template are listed below:
 | `.Mountpoint` | The mount point of the volume on the host                                             |
 | `.Labels`     | All labels assigned to the volume                                                     |
 | `.Label`      | Value of a specific label for this volume. For example `{{.Label "project.version"}}` |
+| `.CreatedAt`  | Time when the volume was created                                                      |
 
 When using the `--format` option, the `volume ls` command will either
 output the data exactly as the template declares or, when using the


### PR DESCRIPTION
- What I did

Added a `CreatedAt` placeholder to `docker volume ls --format`, which fixes #3871.

Containers, images and networks all expose `CreatedAt` in their list output, but volumes did not, even though the API has returned a `CreatedAt` field for volumes since API v1.42. As a result, the creation time was not reachable from `docker volume ls --format '{{.CreatedAt}}'` or `docker volume ls --format json`, and consumers had to fall back to `docker volume inspect` per volume.

- How I did it

Added a `CreatedAt()` method to `volumeContext` and registered the `CREATED AT` header, mirroring the other list formatters.

The API returns the value as an RFC3339 string, so it's parsed and rendered with `time.Time.String()`, matching what `docker ps`, `docker images` and `docker network ls` already emit for `{{.CreatedAt}}`. Two edge cases are handled explicitly:

- the field is `omitempty` in the API, so an empty string is returned when the daemon doesn't report a creation time (rather than a zero time)
- an unparsable value is passed through as-is rather than swallowed

The default table format is unchanged; this only adds a placeholder.

- How to verify it

```console
$ docker volume create foo
$ docker volume ls --format json
{"Availability":"N/A","CreatedAt":"2026-08-02 21:04:11 +0000 UTC","Driver":"local","Group":"N/A","Labels":"","Links":"N/A","Mountpoint":"/var/lib/docker/volumes/foo/_data","Name":"foo","Scope":"local","Size":"N/A","Status":"N/A"}

$ docker volume ls --format 'table {{.Name}}\t{{.CreatedAt}}'
VOLUME NAME   CREATED AT
foo           2026-08-02 21:04:11 +0000 UTC
```

Unit tests were extended to cover the populated, empty and unparsable cases:

```console
$ go test ./cli/command/formatter/ -run Volume -v
```

- Description for the changelog

Add a `CreatedAt` placeholder to the `docker volume ls --format` output.

- A picture of a cute animal (not mandatory but encouraged)

🦫
