### PR TITLE
docs(tag): align short description with SOURCE then TARGET order

### DIFF
--- a/cli/command/image/tag.go
+++ b/cli/command/image/tag.go
@@ -12,7 +12,7 @@ import (
 func newTagCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
-		Short: "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
+		Short: "Create TARGET_IMAGE as a new tag for SOURCE_IMAGE",
 		Args:  cli.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := dockerCLI.Client().ImageTag(cmd.Context(), client.ImageTagOptions{

--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -57,7 +57,7 @@ The base command for the Docker CLI.
 | [`stop`](stop.md)             | Stop one or more running containers                                           |
 | [`swarm`](swarm.md)           | Manage Swarm                                                                  |
 | [`system`](system.md)         | Manage Docker                                                                 |
-| [`tag`](tag.md)               | Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE                         |
+| [`tag`](tag.md)               | Create TARGET_IMAGE as a new tag for SOURCE_IMAGE                         |
 | [`top`](top.md)               | Display the running processes of a container                                  |
 | [`unpause`](unpause.md)       | Unpause all processes within one or more containers                           |
 | [`update`](update.md)         | Update configuration of one or more containers                                |

--- a/docs/reference/commandline/image.md
+++ b/docs/reference/commandline/image.md
@@ -18,7 +18,7 @@ Manage images
 | [`push`](image_push.md)       | Upload an image to a registry                                            |
 | [`rm`](image_rm.md)           | Remove one or more images                                                |
 | [`save`](image_save.md)       | Save one or more images to a tar archive (streamed to STDOUT by default) |
-| [`tag`](image_tag.md)         | Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE                    |
+| [`tag`](image_tag.md)         | Create TARGET_IMAGE as a new tag for SOURCE_IMAGE                    |
 
 
 

--- a/docs/reference/commandline/image_tag.md
+++ b/docs/reference/commandline/image_tag.md
@@ -1,7 +1,7 @@
 # tag
 
 <!---MARKER_GEN_START-->
-Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+Create TARGET_IMAGE as a new tag for SOURCE_IMAGE
 
 ### Aliases
 

--- a/docs/reference/commandline/tag.md
+++ b/docs/reference/commandline/tag.md
@@ -1,7 +1,7 @@
 # docker tag
 
 <!---MARKER_GEN_START-->
-Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE
+Create TARGET_IMAGE as a new tag for SOURCE_IMAGE
 
 ### Aliases
 


### PR DESCRIPTION
The short help used to lead with TARGET_IMAGE while `docker tag` itself is SOURCE then TARGET, which is easy to flip when you're skimming.

Reworded to keep the same meaning but match the argument order.

Fixes #3674