### PR TITLE
builder: preserve selected builder for docker bake

### DIFF
--- a/cmd/docker/builder.go
+++ b/cmd/docker/builder.go
@@ -136,7 +136,8 @@ func processBuilder(dockerCli command.Cli, cmd *cobra.Command, args, osargs []st
 	// is not being set in the command line or in the environment before
 	// setting the default context and keep "buildx install" behavior if being
 	// set (builder alias).
-	if forwarded && !useAlias && !hasBuilderName(args, os.Environ()) {
+	isBake := len(args) > 0 && args[0] == "bake"
+	if forwarded && !isBake && !useAlias && !hasBuilderName(args, os.Environ()) {
 		envs = append([]string{"BUILDX_BUILDER=" + dockerCli.CurrentContext()}, envs...)
 	}
 

--- a/cmd/docker/builder_test.go
+++ b/cmd/docker/builder_test.go
@@ -21,11 +21,12 @@ import (
 
 var pluginFilename = "docker-buildx"
 
-func TestBuildWithBuilder(t *testing.T) {
+func TestForwardedCommandWithBuilder(t *testing.T) {
 	ctx := t.Context()
-
 	testcases := []struct {
 		name         string
+		args         []string
+		expectedArgs []string
 		context      string
 		builder      string
 		alias        bool
@@ -33,25 +34,40 @@ func TestBuildWithBuilder(t *testing.T) {
 	}{
 		{
 			name:         "default",
+			args:         []string{"build", "."},
+			expectedArgs: []string{builderDefaultPlugin, "build", "."},
 			context:      "default",
 			alias:        false,
 			expectedEnvs: []string{"BUILDX_BUILDER=default"},
 		},
 		{
 			name:         "custom context",
+			args:         []string{"build", "."},
+			expectedArgs: []string{builderDefaultPlugin, "build", "."},
 			context:      "foo",
 			alias:        false,
 			expectedEnvs: []string{"BUILDX_BUILDER=foo"},
 		},
 		{
 			name:         "custom builder name",
+			args:         []string{"build", "."},
+			expectedArgs: []string{builderDefaultPlugin, "build", "."},
 			builder:      "mybuilder",
 			alias:        false,
 			expectedEnvs: nil,
 		},
 		{
 			name:         "buildx install",
+			args:         []string{"build", "."},
+			expectedArgs: []string{builderDefaultPlugin, "build", "."},
 			alias:        true,
+			expectedEnvs: nil,
+		},
+		{
+			name:         "bake with custom context",
+			args:         []string{"bake", "app"},
+			expectedArgs: []string{builderDefaultPlugin, "bake", "app"},
+			context:      "foo",
 			expectedEnvs: nil,
 		},
 	}
@@ -67,9 +83,7 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 			ctx2, cancel2 := context.WithCancel(ctx)
 			defer cancel2()
 
-			if tc.builder != "" {
-				t.Setenv("BUILDX_BUILDER", tc.builder)
-			}
+			t.Setenv("BUILDX_BUILDER", tc.builder)
 
 			var b bytes.Buffer
 			dockerCli, err := command.NewDockerCli(
@@ -103,7 +117,7 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 			}
 
 			tcmd := newDockerCommand(dockerCli)
-			tcmd.SetArgs([]string{"build", "."})
+			tcmd.SetArgs(tc.args)
 
 			cmd, args, err := tcmd.HandleGlobalFlags()
 			assert.NilError(t, err)
@@ -111,11 +125,17 @@ echo '{"SchemaVersion":"0.1.0","Vendor":"Docker Inc.","Version":"v0.6.3","ShortD
 			var envs []string
 			args, os.Args, envs, err = processBuilder(dockerCli, cmd, args, os.Args)
 			assert.NilError(t, err)
-			assert.DeepEqual(t, []string{builderDefaultPlugin, "build", "."}, args)
+			assert.DeepEqual(t, tc.expectedArgs, args)
+
 			if tc.expectedEnvs != nil {
 				assert.DeepEqual(t, tc.expectedEnvs, envs)
 			} else {
-				assert.Check(t, len(envs) == 0)
+				assert.Check(
+					t,
+					len(envs) == 0,
+					"unexpected environment variables: %v",
+					envs,
+				)
 			}
 		})
 	}


### PR DESCRIPTION
**- What I did**

Fixed top-level `docker bake` so it preserves the builder selected with
`docker buildx use`, instead of overriding it with the active Docker
context's implicit `docker`-driver builder.

The existing compatibility behavior for `docker build` remains unchanged.

Fixes #7125

**- How I did it**

Top-level `docker bake` is forwarded to `docker buildx bake`, but it was
also passing through the generic forwarded-command compatibility block
that injects:

```text
BUILDX_BUILDER=<current Docker context>
```

That override is intended for traditional `docker build` commands so they
continue using the current context builder and load results into the local
image store.

This change skips that environment-variable injection for top-level
`docker bake`, allowing Buildx to perform its normal selected-builder
resolution.

I also extended the existing table-driven test to cover different forwarded
commands and added a regression case for Bake with a custom Docker context.

**- How to verify it**

Automated validation performed:

- `TestForwardedCommandWithBuilder`
- Complete `cmd/docker` package tests
- Complete unit-test suite: 2,559 tests passed, 4 skipped
- `golangci-lint`: 0 issues
- ShellCheck

Manual verification used a non-default Docker context and a selected
`docker-container` builder.

Before the fix:

```text
docker bake        -> context builder / docker driver
docker buildx bake -> selected builder / docker-container driver
```

After the fix:

```text
docker bake        -> selected builder / docker-container driver
docker buildx bake -> selected builder / docker-container driver
docker build       -> context builder / docker driver
```

**- Human readable description for the release notes**

```markdown changelog
Make `docker bake` honor the builder selected with `docker buildx use`.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Not included.