### PR TITLE
test: cover service ps pretty output

### DIFF
--- a/cli/command/service/ps_test.go
+++ b/cli/command/service/ps_test.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/docker/cli/internal/test"
+	"github.com/docker/cli/internal/test/builders"
 	"github.com/docker/cli/opts"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/api/types/system"
@@ -12,6 +14,46 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
+
+func TestServicePsPrettyPrint(t *testing.T) {
+	const (
+		serviceID = "service-id"
+		taskID    = "sxabyp0obqokwekpun4rjo0b3"
+	)
+	apiClient := &fakeClient{
+		serviceListFunc: func(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
+			return client.ServiceListResult{
+				Items: []swarm.Service{newService(serviceID, "service-name")},
+			}, nil
+		},
+		taskListFunc: func(context.Context, client.TaskListOptions) (client.TaskListResult, error) {
+			return client.TaskListResult{
+				Items: []swarm.Task{*builders.Task(
+					builders.TaskID(taskID),
+					builders.TaskServiceID(serviceID),
+					builders.TaskNodeID("node-id"),
+					builders.TaskSlot(1),
+					builders.TaskDesiredState(swarm.TaskStateRunning),
+					builders.WithStatus(builders.TaskState(swarm.TaskStateRunning)),
+					builders.WithTaskSpec(builders.TaskImage("alpine:latest")),
+				)},
+			}, nil
+		},
+	}
+
+	cli := test.NewFakeCli(apiClient)
+	cmd := newPsCommand(cli)
+	cmd.SetArgs([]string{"--no-resolve", "service-name"})
+	assert.NilError(t, cmd.Execute())
+
+	output := cli.OutBuffer().String()
+	for _, expected := range []string{
+		"ID", "NAME", "IMAGE", "NODE", "DESIRED STATE", "CURRENT STATE",
+		taskID[:12], serviceID + ".1", "alpine:latest", "node-id", "Running",
+	} {
+		assert.Assert(t, strings.Contains(output, expected), "output does not contain %q:\n%s", expected, output)
+	}
+}
 
 func TestCreateFilter(t *testing.T) {
 	apiClient := &fakeClient{


### PR DESCRIPTION
Related to #201

**- What I did**

Added coverage for the default `docker service ps` table output, corresponding
to the remaining pretty-print item in #201.

**- How I did it**

The test drives the command with a fake service and representative task, uses
`--no-resolve`, and checks stable headings and identifying row values without
depending on volatile elapsed-time output.

AI assistance: OpenAI Codex helped draft the test. I reviewed the complete diff
and validation evidence and take responsibility for the contribution.

**- How to verify it**

Run the focused `TestServicePsPrettyPrint` test in `./cli/command/service`.
`gofmt -d cli/command/service/ps_test.go` and `git diff --check` are clean.

On this Windows checkout, the broader package run still has the existing
LF/CRLF golden-output failures in `TestServiceContextWrite`, `TestPrettyPrint`,
and `TestServiceListOrder`; the new test passes.

**- Human readable description for the release notes**

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**