### PR TITLE
docs: point --progress and other Buildx-only flags to buildx build

### DIFF
--- a/docs/reference/commandline/image_build.md
+++ b/docs/reference/commandline/image_build.md
@@ -72,6 +72,11 @@ behavior in BuildKit. For information about features and flags that are common
 between the legacy builder and BuildKit, such as `--tag` and `--target`, refer
 to the documentation for [`docker buildx build`](https://docs.docker.com/reference/cli/docker/buildx/build/).
 
+Flags that only exist in Buildx/BuildKit, such as
+[`--progress`](https://docs.docker.com/reference/cli/docker/buildx/build/#progress)
+(`auto`, `plain`, `tty`, `rawjson`), are also documented on that page — not in
+the legacy option table above.
+
 ### Build context with the legacy builder
 
 The build context is the positional argument you pass when invoking the build


### PR DESCRIPTION
The legacy builder option list doesn't include --progress (and similar Buildx-only flags), which is why man/reference searches miss them even though default docker build uses Buildx.

Added an explicit pointer to the buildx build page for those flags.

Fixes #4024