### PR TITLE
docs: contrast image ls and image prune filter keys

### DIFF
--- a/docs/reference/commandline/image_ls.md
+++ b/docs/reference/commandline/image_ls.md
@@ -150,6 +150,12 @@ The currently supported filters are:
 * since (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filter images created since given id or references
 * reference (pattern of an image reference) - filter images whose reference matches the specified pattern
 
+These keys are **not** the same set as `docker image prune --filter`. Prune
+supports `until` and `label` / `label!=...`, but not `dangling`, `before`,
+`since`, or `reference`. Negative label filters (`label!=...`) work with prune
+but not with `docker image ls`, so you cannot always preview prune matches with
+`image ls`. See [docker image prune](image_prune.md#filter).
+
 #### Show untagged images (dangling)
 
 ```console

--- a/docs/reference/commandline/image_prune.md
+++ b/docs/reference/commandline/image_prune.md
@@ -77,6 +77,10 @@ The currently supported filters are:
 * until (`<timestamp>`) - only remove images created before given timestamp
 * label (`label=<key>`, `label=<key>=<value>`, `label!=<key>`, or `label!=<key>=<value>`) - only remove images with (or without, in case `label!=...` is used) the specified labels.
 
+`docker image ls --filter` uses a different key set (`dangling`, `label`,
+`before`, `since`, `reference`) and does not accept `until` or `label!=...`.
+Do not assume the two commands share filter syntax.
+
 The `until` filter can be Unix timestamps, date formatted
 timestamps, or Go duration strings supported by [ParseDuration](https://pkg.go.dev/time#ParseDuration) (e.g. `10m`, `1h30m`) computed
 relative to the daemon machine’s time. Supported formats for date


### PR DESCRIPTION
image ls and image prune both grow --filter flags, but the allowed keys never matched. Easy to assume until or reference works everywhere.

Called out the split on both pages.

Fixes #3696