### PR TITLE
docs: prefer alpine over debian in container run examples

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1023,7 +1023,7 @@ streams of the container to a pseudo terminal, creating an interactive terminal
 session for the container. See [Allocate a pseudo-TTY](#tty) for more examples.
 
 ```console
-$ docker run -it debian
+$ docker run -it alpine
 root@10a3e71492b0:/# factor 90
 90: 2 3 3 5
 root@10a3e71492b0:/# exit
@@ -1058,11 +1058,11 @@ your terminal to the I/O streams of the container. Allocating a pseudo-TTY to
 the container means that you get access to input and output feature that TTY
 devices provide.
 
-For example, the following command runs the `passwd` command in a `debian`
+For example, the following command runs the `passwd` command in an `alpine`
 container, to set a new password for the `root` user.
 
 ```console
-$ docker run -i debian passwd root
+$ docker run -i alpine passwd root
 New password: karjalanpiirakka9
 Retype new password: karjalanpiirakka9
 passwd: password updated successfully
@@ -1074,7 +1074,7 @@ text. However, if you try the same thing but also adding the `-t` flag, the
 password is hidden:
 
 ```console
-$ docker run -it debian passwd root
+$ docker run -it alpine passwd root
 New password:
 Retype new password:
 passwd: password updated successfully
@@ -1332,7 +1332,7 @@ Specify `--ulimit` with a soft and hard limit in the format
 `<type>=<soft limit>[:<hard limit>]`. For example:
 
 ```console
-$ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
+$ docker run --ulimit nofile=1024:1024 --rm alpine sh -c "ulimit -n"
 1024
 ```
 


### PR DESCRIPTION
Partial pass on the example-image cleanup: a handful of container run samples still pulled debian for nothing special.

Swapped those to alpine. Left debian where multi-tag/layer demos need it (pull docs, etc.).

Fixes #4902