### PR TITLE
fix: flaky `TestPrunePromptTermination` test

### DIFF
--- a/internal/test/cmd.go
+++ b/internal/test/cmd.go
@@ -27,8 +27,11 @@ func TerminatePrompt(ctx context.Context, t *testing.T, cmd *cobra.Command, cli 
 	}))
 	cli.SetOut(outStream)
 
-	r, _, err := os.Pipe()
+	r, w, err := os.Pipe()
 	assert.NilError(t, err)
+
+	// Keep the write end alive for the duration of the test.
+	defer w.Close()
 	cli.SetIn(streams.NewIn(r))
 
 	notifyCtx, notifyCancel := context.WithCancel(ctx)


### PR DESCRIPTION
<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

Addressed #5802

**- How I did it**

I kept the write end of the pipe alive for the duration of the test with

```go
defer w.Close()
```

**- How to verify it**

```
# without the changes from this branch: fails most runs
# with the changes from this branch: 0 failures
GOGC=1 GOMEMLIMIT=8MiB go test ./cli/command/container/ -run TestContainerPrunePromptTermination -count=40 -v
```

|                         | GC forced (`GOGC=1 GOMEMLIMIT=8MiB`) | GC off (`GOGC=off`) |
| ----------------------- | ------------------------------------ | ------------------- |
| **without this change** | **33 of 40 fail**                    | 0 of 40 fail        |
| **with this change**    | **0 of 40 fail**                     | 0 of 40 fail        |