### PR TITLE
docs: mention build cache in docker system prune description

### DIFF
--- a/docs/reference/commandline/system_prune.md
+++ b/docs/reference/commandline/system_prune.md
@@ -18,7 +18,13 @@ Remove unused data
 ## Description
 
 Remove all unused containers, networks, images (both dangling and unused),
-and optionally, volumes.
+unused [build cache](https://docs.docker.com/build/cache/), and optionally,
+volumes.
+
+Build cache is always eligible for pruning with this command (including BuildKit
+cache mounts created with `RUN --mount=type=cache`). Use
+[`docker builder prune`](builder_prune.md) if you only want to reclaim build
+cache without removing containers, networks, or images.
 
 ## Examples
 


### PR DESCRIPTION
The description for `docker system prune` only mentioned containers, networks, images, and volumes. The interactive warning (and actual behavior) also removes unused build cache, including BuildKit cache mounts.

Pulled that into the description and pointed at `docker builder prune` for cache-only cleanup.

Related to moby/moby#50141