### PR TITLE
docs(cp): clarify -a sets ownership to the container user

### DIFF
--- a/cli/command/container/cp.go
+++ b/cli/command/container/cp.go
@@ -159,7 +159,7 @@ container source to stdout.`,
 
 	flags := cmd.Flags()
 	flags.BoolVarP(&opts.followLink, "follow-link", "L", false, "Always follow symlinks in SRC_PATH")
-	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Archive mode (copy all uid/gid information)")
+	flags.BoolVarP(&opts.copyUIDGID, "archive", "a", false, "Set file ownership to the container user (default preserves source uid/gid)")
 	flags.BoolVarP(&opts.quiet, "quiet", "q", false, "Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached")
 	return cmd
 }

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -169,7 +169,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from commit' -a '(__fish_pri
 
 # cp
 complete -c docker -f -n '__fish_docker_no_subcommand' -a cp -d "Copy files/folders between a container and the local filesystem"
-complete -c docker -A -f -n '__fish_seen_subcommand_from cp' -s a -l archive -d 'Archive mode (copy all uid/gid information)'
+complete -c docker -A -f -n '__fish_seen_subcommand_from cp' -s a -l archive -d 'Set file ownership to the container user (default preserves source uid/gid)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from cp' -s L -l follow-link -d 'Always follow symlinks in SRC_PATH'
 complete -c docker -A -f -n '__fish_seen_subcommand_from cp' -l help -d 'Print usage'
 

--- a/docs/reference/commandline/container_cp.md
+++ b/docs/reference/commandline/container_cp.md
@@ -16,7 +16,7 @@ container source to stdout.
 
 | Name                  | Type   | Default | Description                                                                                                  |
 |:----------------------|:-------|:--------|:-------------------------------------------------------------------------------------------------------------|
-| `-a`, `--archive`     | `bool` |         | Archive mode (copy all uid/gid information)                                                                  |
+| `-a`, `--archive`     | `bool` |         | Set file ownership to the container user (default preserves source uid/gid)                                                                  |
 | `-L`, `--follow-link` | `bool` |         | Always follow symlinks in SRC_PATH                                                                           |
 | `-q`, `--quiet`       | `bool` |         | Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached |
 

--- a/docs/reference/commandline/cp.md
+++ b/docs/reference/commandline/cp.md
@@ -16,7 +16,7 @@ container source to stdout.
 
 | Name                  | Type   | Default | Description                                                                                                  |
 |:----------------------|:-------|:--------|:-------------------------------------------------------------------------------------------------------------|
-| `-a`, `--archive`     | `bool` |         | Archive mode (copy all uid/gid information)                                                                  |
+| `-a`, `--archive`     | `bool` |         | Set file ownership to the container user (default preserves source uid/gid)                                                                  |
 | `-L`, `--follow-link` | `bool` |         | Always follow symlinks in SRC_PATH                                                                           |
 | `-q`, `--quiet`       | `bool` |         | Suppress progress output during copy. Progress output is automatically suppressed if no terminal is attached |
 


### PR DESCRIPTION
`docker cp -a` was documented as "copy all uid/gid information", which reads like it preserves source ownership. Looking at the daemon path (`copyUIDGID` → `applyTarCopyUserOptions`), `-a` actually remaps ownership to the container user; without it, source uid/gid from the tar are kept.

Updated the flag help and the generated reference text to match that.

Fixes #6870