### PR TITLE
version: keep consistent RFC3339 BuildTime for --format json

### DIFF
--- a/cli/command/system/info.go
+++ b/cli/command/system/info.go
@@ -88,7 +88,7 @@ func runInfo(ctx context.Context, cmd *cobra.Command, dockerCli command.Cli, opt
 			// Don't pass a dockerCLI to newClientVersion(), because we currently
 			// don't include negotiated API version, and want to avoid making an
 			// API connection when only printing the Client section.
-			clientVersion: newClientVersion(dockerCli.CurrentContext(), nil),
+			clientVersion: newClientVersion(dockerCli.CurrentContext(), nil, true),
 			Debug:         debug.IsEnabled(),
 		},
 		Info: &system.Info{},

--- a/cli/command/system/version.go
+++ b/cli/command/system/version.go
@@ -108,13 +108,17 @@ type serverVersion struct {
 // passed as argument, additional information is included (API version),
 // which may invoke an API connection. Pass nil to omit the additional
 // information.
-func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
+func newClientVersion(contextName string, dockerCli command.Cli, prettyTime bool) clientVersion {
+	buildTime := version.BuildTime
+	if prettyTime {
+		buildTime = reformatDate(buildTime)
+	}
 	v := clientVersion{
 		Version:           version.Version,
 		DefaultAPIVersion: client.MaxAPIVersion,
 		GoVersion:         runtime.Version(),
 		GitCommit:         version.GitCommit,
-		BuildTime:         reformatDate(version.BuildTime),
+		BuildTime:         buildTime,
 		Os:                runtime.GOOS,
 		Arch:              arch(),
 		Context:           contextName,
@@ -128,7 +132,7 @@ func newClientVersion(contextName string, dockerCli command.Cli) clientVersion {
 	return v
 }
 
-func newServerVersion(sv client.ServerVersionResult) *serverVersion {
+func newServerVersion(sv client.ServerVersionResult, prettyTime bool) *serverVersion {
 	out := &serverVersion{
 		Platform:      sv.Platform,
 		Version:       sv.Version,
@@ -145,13 +149,16 @@ func newServerVersion(sv client.ServerVersionResult) *serverVersion {
 			foundEngine = true
 			buildTime, ok := component.Details["BuildTime"]
 			if ok {
-				component.Details["BuildTime"] = reformatDate(buildTime)
+				if prettyTime {
+					buildTime = reformatDate(buildTime)
+					component.Details["BuildTime"] = buildTime
+				}
+				out.BuildTime = buildTime
 			}
 			out.GitCommit = component.Details["GitCommit"]
 			out.GoVersion = component.Details["GoVersion"]
 			out.KernelVersion = component.Details["KernelVersion"]
 			out.Experimental = func() bool { b, _ := strconv.ParseBool(component.Details["Experimental"]); return b }()
-			out.BuildTime = buildTime
 		}
 		out.Components = append(out.Components, component)
 	}
@@ -193,6 +200,16 @@ func newVersionCommand(dockerCLI command.Cli) *cobra.Command {
 	return cmd
 }
 
+
+func isJSONVersionFormat(format string) bool {
+	switch format {
+	case formatter.JSONFormatKey, formatter.JSONFormat:
+		return true
+	default:
+		return false
+	}
+}
+
 func reformatDate(buildTime string) string {
 	t, errTime := time.Parse(time.RFC3339Nano, buildTime)
 	if errTime == nil {
@@ -216,12 +233,14 @@ func runVersion(ctx context.Context, dockerCLI command.Cli, opts *versionOptions
 		return cli.StatusError{StatusCode: 64, Status: err.Error()}
 	}
 
+	// Keep RFC3339 BuildTime strings for JSON; reformat to ANSIC only for human templates.
+	prettyTime := !isJSONVersionFormat(opts.format)
 	vd := versionInfo{
-		Client: newClientVersion(dockerCLI.CurrentContext(), dockerCLI),
+		Client: newClientVersion(dockerCLI.CurrentContext(), dockerCLI, prettyTime),
 	}
 	sv, err := dockerCLI.Client().ServerVersion(ctx, client.ServerVersionOptions{})
 	if err == nil {
-		vd.Server = newServerVersion(sv)
+		vd.Server = newServerVersion(sv, prettyTime)
 	}
 	if err2 := prettyPrintVersion(dockerCLI.Out(), vd, tmpl); err2 != nil && err == nil {
 		err = err2


### PR DESCRIPTION
`docker version --format json` was mixing timestamp layouts in one document: Client / component Details used ANSIC via `reformatDate`, while `Server.BuildTime` kept the raw RFC3339 value from the Engine component (and never got the reformatted string).

For `json` / `{{json .}}`, skip reformatting so BuildTime fields stay ISO-8601. Default human output is unchanged (ANSIC), and `Server.BuildTime` now matches the Engine component detail after reformat.

Fixes #6727