### PR TITLE
service/progress: stop truncating task error messages

### DIFF
--- a/cli/command/service/progress/progress.go
+++ b/cli/command/service/progress/progress.go
@@ -268,16 +268,10 @@ func writeOverallProgress(progressOut progress.Output, numerator, denominator in
 }
 
 func truncError(errMsg string) string {
-	// Remove newlines from the error, which corrupt the output.
-	errMsg = strings.ReplaceAll(errMsg, "\n", " ")
-
-	// Limit the length to 75 characters, so that even on narrow terminals
-	// this will not overflow to the next line.
-	const maxWidth = 75
-	if len(errMsg) > maxWidth {
-		errMsg = errMsg[:maxWidth-1] + "…"
-	}
-	return errMsg
+	// Remove newlines from the error, which corrupt the single-line progress UI.
+	// Keep the full message otherwise — truncating to a fixed width (e.g. 75
+	// runes) hid the useful part of long swarm task errors (issue #7176).
+	return strings.ReplaceAll(errMsg, "\n", " ")
 }
 
 type replicatedProgressUpdater struct {


### PR DESCRIPTION
Swarm task errors in service scale/update progress were capped at 75 characters, so long failures (like a full missing bind path) got ellipsized right where you needed the details.

Still collapse newlines so the progress line stays single-line, but don't cut the message short.

Fixes #7176