### PR TITLE
cli/grpc: add gRPC connections to the Docker Engine's API endpoint

### DIFF
--- a/cli/context/docker/load.go
+++ b/cli/context/docker/load.go
@@ -41,8 +41,9 @@ func WithTLSData(s store.Reader, contextName string, m EndpointMeta) (Endpoint, 
 	}, nil
 }
 
-// tlsConfig extracts a context docker endpoint TLS config
-func (ep *Endpoint) tlsConfig() (*tls.Config, error) {
+// TLSConfig extracts a context docker endpoint TLS config, or nil (without
+// error) when the endpoint has no TLS configuration.
+func (ep *Endpoint) TLSConfig() (*tls.Config, error) {
 	if ep.TLSData == nil && !ep.SkipTLSVerify {
 		// there is no specific tls config
 		return nil, nil
@@ -98,7 +99,7 @@ func (ep *Endpoint) ClientOpts() ([]client.Opt, error) {
 			// TODO(thaJeztah); make resolveDockerEndpoint and resolveDefaultDockerEndpoint not load TLS data,
 			//  and load TLS files lazily; see https://github.com/docker/cli/pull/1581
 			if !isSocket(ep.Host) {
-				tlsConfig, err := ep.tlsConfig()
+				tlsConfig, err := ep.TLSConfig()
 				if err != nil {
 					return nil, err
 				}

--- a/cli/grpc/grpc.go
+++ b/cli/grpc/grpc.go
@@ -11,10 +11,12 @@
 // [Connect] hides those transport details: it returns a [grpc.ClientConn]
 // reaching the daemon, whatever the transport of the current endpoint (unix
 // or npipe socket, tcp with or without TLS, or a connection helper such as
-// ssh://), falling back to the legacy upgrade endpoint for older daemons.
-// Note that the legacy endpoint only exposes the daemon's built-in gRPC
-// services: services published by daemon extensions require a daemon serving
-// gRPC natively.
+// ssh://), falling back to the legacy upgrade endpoint for older daemons —
+// or when an intermediary between the client and the daemon does not relay
+// HTTP/2 even though the daemon's API version advertises native support
+// (Docker Desktop's API proxy, at the time of writing). Note that the legacy
+// endpoint only exposes the daemon's built-in gRPC services: services
+// published by daemon extensions require a daemon serving gRPC natively.
 package grpc
 
 import (
@@ -29,8 +31,11 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/moby/moby/client/pkg/versions"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 )
 
 // nativeAPIVersion is the minimum API version where the daemon serves gRPC
@@ -87,9 +92,9 @@ func WithDialOptions(opts ...grpc.DialOption) Opt {
 }
 
 // Connect returns a gRPC client connection to the daemon of dockerCLI's
-// current endpoint. ctx is only used to query the daemon's API version; the
-// returned connection is lazy: it is not bound to ctx, and is only
-// established when the first RPC is made.
+// current endpoint. ctx bounds the daemon API version query and the probing
+// of native connections; the returned connection is not bound to it, and
+// behaves lazily afterwards.
 func Connect(ctx context.Context, dockerCLI DockerCLI, opts ...Opt) (*grpc.ClientConn, error) {
 	return Dial(ctx, dockerCLI.Client(), dockerCLI.DockerEndpoint(), opts...)
 }
@@ -105,9 +110,32 @@ func Dial(ctx context.Context, apiClient APIClient, ep docker.Endpoint, opts ...
 		return nil, fmt.Errorf("establishing gRPC connection to the daemon: %w", err)
 	}
 	if ping.APIVersion != "" && !versions.LessThan(ping.APIVersion, nativeAPIVersion) {
-		return dialNative(apiClient, ep, &cfg)
+		conn, err := dialNative(apiClient, ep, &cfg)
+		if err != nil {
+			return nil, err
+		}
+		if probeTransport(ctx, conn) == nil {
+			return conn, nil
+		}
+		// The daemon's API version advertises native gRPC support but the
+		// transport doesn't get through: an intermediary between the client
+		// and the daemon (Docker Desktop's API proxy, at the time of writing)
+		// may not relay HTTP/2. Fall back to the legacy upgrade endpoint.
+		_ = conn.Close()
 	}
 	return dialLegacy(apiClient, &cfg)
+}
+
+// probeTransport verifies conn actually reaches an HTTP/2 server. Any
+// RPC-level outcome — including Unimplemented from a daemon not serving the
+// health service — proves the transport; only transport-level failures
+// (codes.Unavailable) are reported.
+func probeTransport(ctx context.Context, conn *grpc.ClientConn) error {
+	_, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{})
+	if status.Code(err) == codes.Unavailable {
+		return err
+	}
+	return nil
 }
 
 // dialNative connects to a daemon serving gRPC natively on its API endpoint:

--- a/cli/grpc/grpc.go
+++ b/cli/grpc/grpc.go
@@ -1,0 +1,171 @@
+// Package grpc establishes gRPC client connections to the Docker Engine's
+// API endpoint.
+//
+// Alongside its HTTP API, the daemon serves gRPC services on the same
+// endpoint; this is, for example, how BuildKit's control API is exposed.
+// Daemons with API version 1.53 or later serve gRPC natively over HTTP/2:
+// cleartext HTTP/2 (h2c) on non-TLS connections, and ALPN-negotiated HTTP/2
+// on TLS connections. Older daemons only expose gRPC through the deprecated
+// "POST /grpc" HTTP/1.1 upgrade endpoint.
+//
+// [Connect] hides those transport details: it returns a [grpc.ClientConn]
+// reaching the daemon, whatever the transport of the current endpoint (unix
+// or npipe socket, tcp with or without TLS, or a connection helper such as
+// ssh://), falling back to the legacy upgrade endpoint for older daemons.
+// Note that the legacy endpoint only exposes the daemon's built-in gRPC
+// services: services published by daemon extensions require a daemon serving
+// gRPC natively.
+package grpc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/moby/moby/client"
+	"github.com/moby/moby/client/pkg/versions"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// nativeAPIVersion is the minimum API version where the daemon serves gRPC
+// natively over HTTP/2 on its API endpoint. Older daemons only expose gRPC
+// through the deprecated "POST /grpc" HTTP/1.1 upgrade endpoint.
+const nativeAPIVersion = "1.53"
+
+// defaultMaxMsgSize matches the message-size limits of the daemon's gRPC
+// server.
+const defaultMaxMsgSize = 16 << 20 // 16 MiB
+
+// dummyTarget is the pseudo-target of connections established through a
+// custom dialer; it only surfaces as the ":authority" header.
+const dummyTarget = "docker-engine"
+
+// APIClient is the subset of [client.APIClient] needed to establish a gRPC
+// connection to the daemon.
+type APIClient interface {
+	Ping(ctx context.Context, options client.PingOptions) (client.PingResult, error)
+	Dialer() func(context.Context) (net.Conn, error)
+	DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error)
+}
+
+// DockerCLI is the subset of the docker CLI (command.Cli) needed to establish
+// a gRPC connection to the daemon of its current endpoint.
+type DockerCLI interface {
+	Client() client.APIClient
+	DockerEndpoint() docker.Endpoint
+}
+
+type config struct {
+	dialMeta map[string][]string
+	dialOpts []grpc.DialOption
+}
+
+// Opt customizes how the connection is established.
+type Opt func(*config)
+
+// WithDialMeta sets metadata attached to the connection request when the
+// legacy upgrade endpoint is used. It has no effect on daemons serving gRPC
+// natively; use per-call gRPC metadata instead.
+func WithDialMeta(meta map[string][]string) Opt {
+	return func(cfg *config) {
+		cfg.dialMeta = meta
+	}
+}
+
+// WithDialOptions appends gRPC dial options to the defaults used when
+// establishing the connection.
+func WithDialOptions(opts ...grpc.DialOption) Opt {
+	return func(cfg *config) {
+		cfg.dialOpts = append(cfg.dialOpts, opts...)
+	}
+}
+
+// Connect returns a gRPC client connection to the daemon of dockerCLI's
+// current endpoint. ctx is only used to query the daemon's API version; the
+// returned connection is lazy: it is not bound to ctx, and is only
+// established when the first RPC is made.
+func Connect(ctx context.Context, dockerCLI DockerCLI, opts ...Opt) (*grpc.ClientConn, error) {
+	return Dial(ctx, dockerCLI.Client(), dockerCLI.DockerEndpoint(), opts...)
+}
+
+// Dial is like [Connect], for an API client and endpoint obtained separately.
+func Dial(ctx context.Context, apiClient APIClient, ep docker.Endpoint, opts ...Opt) (*grpc.ClientConn, error) {
+	cfg := config{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	ping, err := apiClient.Ping(ctx, client.PingOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("establishing gRPC connection to the daemon: %w", err)
+	}
+	if ping.APIVersion != "" && !versions.LessThan(ping.APIVersion, nativeAPIVersion) {
+		return dialNative(apiClient, ep, &cfg)
+	}
+	return dialLegacy(apiClient, &cfg)
+}
+
+// dialNative connects to a daemon serving gRPC natively on its API endpoint:
+// ALPN-negotiated HTTP/2 for TLS endpoints, cleartext HTTP/2 (h2c) over the
+// API client's own dialer otherwise. The client dialer covers unix and npipe
+// sockets, plain tcp, and connection helpers such as ssh://.
+func dialNative(apiClient APIClient, ep docker.Endpoint, cfg *config) (*grpc.ClientConn, error) {
+	if strings.HasPrefix(ep.Host, "tcp://") {
+		tlsCfg, err := ep.TLSConfig()
+		if err != nil {
+			return nil, err
+		}
+		if tlsCfg != nil {
+			return dialTLS(ep.Host, tlsCfg, cfg)
+		}
+	}
+	dialer := apiClient.Dialer()
+	return grpc.NewClient("passthrough:///"+dummyTarget, dialOptions(cfg,
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return dialer(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)...)
+}
+
+// dialTLS connects to a TLS API endpoint. The daemon only accepts HTTP/2 on
+// TLS connections through ALPN, so the TLS handshake is left to gRPC, which
+// adds "h2" to the offered ALPN protocols.
+func dialTLS(host string, tlsCfg *tls.Config, cfg *config) (*grpc.ClientConn, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	return grpc.NewClient(u.Host, dialOptions(cfg,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
+	)...)
+}
+
+// dialLegacy connects through the deprecated "POST /grpc" HTTP/1.1 upgrade
+// endpoint of daemons older than API v1.53: each connection upgrades an API
+// request to a raw stream carrying cleartext HTTP/2, whatever the underlying
+// transport. The upgrade request goes through the API client's regular
+// plumbing, so it carries the configured dial metadata as headers.
+func dialLegacy(apiClient APIClient, cfg *config) (*grpc.ClientConn, error) {
+	return grpc.NewClient("passthrough:///"+dummyTarget, dialOptions(cfg,
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return apiClient.DialHijack(ctx, "/grpc", "h2c", cfg.dialMeta)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)...)
+}
+
+func dialOptions(cfg *config, opts ...grpc.DialOption) []grpc.DialOption {
+	defaults := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultMaxMsgSize),
+			grpc.MaxCallSendMsgSize(defaultMaxMsgSize),
+		),
+	}
+	return append(append(defaults, opts...), cfg.dialOpts...)
+}

--- a/cli/grpc/grpc.go
+++ b/cli/grpc/grpc.go
@@ -51,7 +51,7 @@ const dummyTarget = "docker-engine"
 type APIClient interface {
 	Ping(ctx context.Context, options client.PingOptions) (client.PingResult, error)
 	Dialer() func(context.Context) (net.Conn, error)
-	DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error)
+	DialHijack(ctx context.Context, path, proto string, meta map[string][]string) (net.Conn, error)
 }
 
 // DockerCLI is the subset of the docker CLI (command.Cli) needed to establish

--- a/cli/grpc/grpc_test.go
+++ b/cli/grpc/grpc_test.go
@@ -1,0 +1,177 @@
+package grpc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/docker/cli/cli/context/docker"
+	"github.com/moby/moby/client"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+type fakeAPIClient struct {
+	apiVersion string
+	pingErr    error
+
+	dialer func(context.Context) (net.Conn, error)
+	hijack func(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error)
+
+	dialerCalled atomic.Bool
+	hijackCalled atomic.Bool
+	hijackURL    string
+	hijackProto  string
+	hijackMeta   map[string][]string
+}
+
+func (f *fakeAPIClient) Ping(context.Context, client.PingOptions) (client.PingResult, error) {
+	return client.PingResult{APIVersion: f.apiVersion}, f.pingErr
+}
+
+func (f *fakeAPIClient) Dialer() func(context.Context) (net.Conn, error) {
+	return func(ctx context.Context) (net.Conn, error) {
+		f.dialerCalled.Store(true)
+		return f.dialer(ctx)
+	}
+}
+
+func (f *fakeAPIClient) DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error) {
+	f.hijackCalled.Store(true)
+	f.hijackURL = url
+	f.hijackProto = proto
+	f.hijackMeta = meta
+	return f.hijack(ctx, url, proto, meta)
+}
+
+// startServer serves a gRPC health service on a loopback tcp socket, standing
+// in for the daemon's API endpoint, and returns its address.
+func startServer(t *testing.T, opts ...grpc.ServerOption) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	srv := grpc.NewServer(opts...)
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	go func() {
+		_ = srv.Serve(l)
+	}()
+	t.Cleanup(srv.Stop)
+	return l.Addr().String()
+}
+
+func checkHealth(t *testing.T, conn *grpc.ClientConn) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	resp, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{})
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal(resp.GetStatus(), healthpb.HealthCheckResponse_SERVING))
+}
+
+func TestDialNative(t *testing.T) {
+	addr := startServer(t)
+	apiClient := &fakeAPIClient{
+		apiVersion: "1.53",
+		dialer: func(context.Context) (net.Conn, error) {
+			return net.Dial("tcp", addr)
+		},
+	}
+
+	conn, err := Dial(t.Context(), apiClient, docker.Endpoint{
+		EndpointMeta: docker.EndpointMeta{Host: "unix:///var/run/docker.sock"},
+	})
+	assert.NilError(t, err)
+	defer conn.Close()
+
+	checkHealth(t, conn)
+	assert.Check(t, apiClient.dialerCalled.Load())
+	assert.Check(t, !apiClient.hijackCalled.Load())
+}
+
+func TestDialLegacy(t *testing.T) {
+	for _, apiVersion := range []string{"", "1.52"} {
+		t.Run("api-version-"+apiVersion, func(t *testing.T) {
+			addr := startServer(t)
+			meta := map[string][]string{"foo": {"bar"}}
+			apiClient := &fakeAPIClient{
+				apiVersion: apiVersion,
+				hijack: func(context.Context, string, string, map[string][]string) (net.Conn, error) {
+					return net.Dial("tcp", addr)
+				},
+			}
+
+			conn, err := Dial(t.Context(), apiClient, docker.Endpoint{
+				EndpointMeta: docker.EndpointMeta{Host: "unix:///var/run/docker.sock"},
+			}, WithDialMeta(meta))
+			assert.NilError(t, err)
+			defer conn.Close()
+
+			checkHealth(t, conn)
+			assert.Check(t, apiClient.hijackCalled.Load())
+			assert.Check(t, !apiClient.dialerCalled.Load())
+			assert.Check(t, is.Equal(apiClient.hijackURL, "/grpc"))
+			assert.Check(t, is.Equal(apiClient.hijackProto, "h2c"))
+			assert.Check(t, is.DeepEqual(apiClient.hijackMeta, meta))
+		})
+	}
+}
+
+func TestDialTLS(t *testing.T) {
+	cert := generateSelfSignedCert(t)
+	addr := startServer(t, grpc.Creds(credentials.NewServerTLSFromCert(&cert)))
+	apiClient := &fakeAPIClient{apiVersion: "1.53"}
+
+	conn, err := Dial(t.Context(), apiClient, docker.Endpoint{
+		EndpointMeta: docker.EndpointMeta{
+			Host: "tcp://" + addr,
+			// Self-signed server certificate; TLS with ALPN is still
+			// negotiated, which is what this test exercises.
+			SkipTLSVerify: true,
+		},
+	})
+	assert.NilError(t, err)
+	defer conn.Close()
+
+	checkHealth(t, conn)
+	assert.Check(t, !apiClient.dialerCalled.Load())
+	assert.Check(t, !apiClient.hijackCalled.Load())
+}
+
+func TestDialPingError(t *testing.T) {
+	apiClient := &fakeAPIClient{pingErr: errors.New("daemon unreachable")}
+	_, err := Dial(t.Context(), apiClient, docker.Endpoint{})
+	assert.ErrorContains(t, err, "daemon unreachable")
+}
+
+func generateSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NilError(t, err)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	assert.NilError(t, err)
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+	}
+}

--- a/cli/grpc/grpc_test.go
+++ b/cli/grpc/grpc_test.go
@@ -102,6 +102,59 @@ func TestDialNative(t *testing.T) {
 	assert.Check(t, !apiClient.hijackCalled.Load())
 }
 
+// startHTTP1Server answers any connection with a plain HTTP/1.1 response,
+// standing in for an intermediary that does not relay HTTP/2 (e.g. Docker
+// Desktop's API proxy).
+func startHTTP1Server(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				buf := make([]byte, 1024)
+				_, _ = c.Read(buf)
+				_, _ = c.Write([]byte("HTTP/1.1 505 HTTP Version Not Supported\r\nContent-Length: 0\r\n\r\n"))
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() { _ = l.Close() })
+	return l.Addr().String()
+}
+
+func TestDialNativeFallsBackToLegacy(t *testing.T) {
+	// The daemon advertises native support but an HTTP/1.1-only intermediary
+	// sits on the endpoint: the probe fails at transport level and the
+	// connection falls back to the legacy upgrade endpoint.
+	http1Addr := startHTTP1Server(t)
+	grpcAddr := startServer(t)
+	apiClient := &fakeAPIClient{
+		apiVersion: "1.53",
+		dialer: func(context.Context) (net.Conn, error) {
+			return net.Dial("tcp", http1Addr)
+		},
+		hijack: func(context.Context, string, string, map[string][]string) (net.Conn, error) {
+			return net.Dial("tcp", grpcAddr)
+		},
+	}
+
+	conn, err := Dial(t.Context(), apiClient, docker.Endpoint{
+		EndpointMeta: docker.EndpointMeta{Host: "unix:///var/run/docker.sock"},
+	})
+	assert.NilError(t, err)
+	defer conn.Close()
+
+	checkHealth(t, conn)
+	assert.Check(t, apiClient.dialerCalled.Load())
+	assert.Check(t, apiClient.hijackCalled.Load())
+	assert.Check(t, is.Equal(apiClient.hijackURL, "/grpc"))
+}
+
 func TestDialLegacy(t *testing.T) {
 	for _, apiVersion := range []string{"", "1.52"} {
 		t.Run("api-version-"+apiVersion, func(t *testing.T) {

--- a/cli/grpc/grpc_test.go
+++ b/cli/grpc/grpc_test.go
@@ -30,7 +30,7 @@ type fakeAPIClient struct {
 	pingErr    error
 
 	dialer func(context.Context) (net.Conn, error)
-	hijack func(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error)
+	hijack func(ctx context.Context, path, proto string, meta map[string][]string) (net.Conn, error)
 
 	dialerCalled atomic.Bool
 	hijackCalled atomic.Bool
@@ -50,12 +50,12 @@ func (f *fakeAPIClient) Dialer() func(context.Context) (net.Conn, error) {
 	}
 }
 
-func (f *fakeAPIClient) DialHijack(ctx context.Context, url, proto string, meta map[string][]string) (net.Conn, error) {
+func (f *fakeAPIClient) DialHijack(ctx context.Context, path, proto string, meta map[string][]string) (net.Conn, error) {
 	f.hijackCalled.Store(true)
-	f.hijackURL = url
+	f.hijackURL = path
 	f.hijackProto = proto
 	f.hijackMeta = meta
-	return f.hijack(ctx, url, proto, meta)
+	return f.hijack(ctx, path, proto, meta)
 }
 
 // startServer serves a gRPC health service on a loopback tcp socket, standing

--- a/vendor.mod
+++ b/vendor.mod
@@ -64,6 +64,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
+	google.golang.org/grpc v1.82.1
 	gotest.tools/v3 v3.5.2
 	tags.cncf.io/container-device-interface v1.1.0
 )
@@ -108,6 +109,5 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/vendor/google.golang.org/grpc/health/client.go
+++ b/vendor/google.golang.org/grpc/health/client.go
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/internal/backoff"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	backoffStrategy = backoff.DefaultExponential
+	backoffFunc     = func(ctx context.Context, retries int) bool {
+		d := backoffStrategy.Backoff(retries)
+		timer := time.NewTimer(d)
+		select {
+		case <-timer.C:
+			return true
+		case <-ctx.Done():
+			timer.Stop()
+			return false
+		}
+	}
+)
+
+func init() {
+	internal.HealthCheckFunc = clientHealthCheck
+}
+
+const healthCheckMethod = "/grpc.health.v1.Health/Watch"
+
+// This function implements the protocol defined at:
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md
+func clientHealthCheck(ctx context.Context, newStream func(string) (any, error), setConnectivityState func(connectivity.State, error), service string) error {
+	tryCnt := 0
+
+retryConnection:
+	for {
+		// Backs off if the connection has failed in some way without receiving a message in the previous retry.
+		if tryCnt > 0 && !backoffFunc(ctx, tryCnt-1) {
+			return nil
+		}
+		tryCnt++
+
+		if ctx.Err() != nil {
+			return nil
+		}
+		setConnectivityState(connectivity.Connecting, nil)
+		rawS, err := newStream(healthCheckMethod)
+		if err != nil {
+			continue retryConnection
+		}
+
+		s, ok := rawS.(grpc.ClientStream)
+		// Ideally, this should never happen. But if it happens, the server is marked as healthy for LBing purposes.
+		if !ok {
+			setConnectivityState(connectivity.Ready, nil)
+			return fmt.Errorf("newStream returned %v (type %T); want grpc.ClientStream", rawS, rawS)
+		}
+
+		if err = s.SendMsg(&healthpb.HealthCheckRequest{Service: service}); err != nil && err != io.EOF {
+			// Stream should have been closed, so we can safely continue to create a new stream.
+			continue retryConnection
+		}
+		s.CloseSend()
+
+		resp := new(healthpb.HealthCheckResponse)
+		for {
+			err = s.RecvMsg(resp)
+
+			// Reports healthy for the LBing purposes if health check is not implemented in the server.
+			if status.Code(err) == codes.Unimplemented {
+				setConnectivityState(connectivity.Ready, nil)
+				return err
+			}
+
+			// Reports unhealthy if server's Watch method gives an error other than UNIMPLEMENTED.
+			if err != nil {
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but received health check RPC error: %v", err))
+				continue retryConnection
+			}
+
+			// As a message has been received, removes the need for backoff for the next retry by resetting the try count.
+			tryCnt = 0
+			if resp.Status == healthpb.HealthCheckResponse_SERVING {
+				setConnectivityState(connectivity.Ready, nil)
+			} else {
+				setConnectivityState(connectivity.TransientFailure, fmt.Errorf("connection active but health check failed. status=%s", resp.Status))
+			}
+		}
+	}
+}

--- a/vendor/google.golang.org/grpc/health/logging.go
+++ b/vendor/google.golang.org/grpc/health/logging.go
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import "google.golang.org/grpc/grpclog"
+
+var logger = grpclog.Component("health_service")

--- a/vendor/google.golang.org/grpc/health/producer.go
+++ b/vendor/google.golang.org/grpc/health/producer.go
@@ -1,0 +1,106 @@
+/*
+ *
+ * Copyright 2024 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package health
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/internal"
+	"google.golang.org/grpc/status"
+)
+
+func init() {
+	producerBuilderSingleton = &producerBuilder{}
+	internal.RegisterClientHealthCheckListener = registerClientSideHealthCheckListener
+}
+
+type producerBuilder struct{}
+
+var producerBuilderSingleton *producerBuilder
+
+// Build constructs and returns a producer and its cleanup function.
+func (*producerBuilder) Build(cci any) (balancer.Producer, func()) {
+	p := &healthServiceProducer{
+		cc:     cci.(grpc.ClientConnInterface),
+		cancel: func() {},
+	}
+	return p, func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.cancel()
+	}
+}
+
+type healthServiceProducer struct {
+	// The following fields are initialized at build time and read-only after
+	// that and therefore do not need to be guarded by a mutex.
+	cc grpc.ClientConnInterface
+
+	mu     sync.Mutex
+	cancel func()
+}
+
+// registerClientSideHealthCheckListener accepts a listener to provide server
+// health state via the health service.
+func registerClientSideHealthCheckListener(ctx context.Context, sc balancer.SubConn, serviceName string, listener func(balancer.SubConnState)) func() {
+	pr, closeFn := sc.GetOrBuildProducer(producerBuilderSingleton)
+	p := pr.(*healthServiceProducer)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cancel()
+	if listener == nil {
+		return closeFn
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+
+	go p.startHealthCheck(ctx, sc, serviceName, listener)
+	return closeFn
+}
+
+func (p *healthServiceProducer) startHealthCheck(ctx context.Context, sc balancer.SubConn, serviceName string, listener func(balancer.SubConnState)) {
+	newStream := func(method string) (any, error) {
+		return p.cc.NewStream(ctx, &grpc.StreamDesc{ServerStreams: true}, method)
+	}
+
+	setConnectivityState := func(state connectivity.State, err error) {
+		listener(balancer.SubConnState{
+			ConnectivityState: state,
+			ConnectionError:   err,
+		})
+	}
+
+	// Call the function through the internal variable as tests use it for
+	// mocking.
+	err := internal.HealthCheckFunc(ctx, newStream, setConnectivityState, serviceName)
+	if err == nil {
+		return
+	}
+	if status.Code(err) == codes.Unimplemented {
+		logger.Errorf("Subchannel health check is unimplemented at server side, thus health check is disabled for SubConn %p", sc)
+	} else {
+		logger.Errorf("Health checking failed for SubConn %p: %v", sc, err)
+	}
+}

--- a/vendor/google.golang.org/grpc/health/server.go
+++ b/vendor/google.golang.org/grpc/health/server.go
@@ -1,0 +1,187 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package health provides a service that exposes server's health and it must be
+// imported to enable support for client-side health checks.
+package health
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// maxAllowedServices defines the maximum number of resources a List
+	// operation can return. An error is returned if the number of services
+	// exceeds this limit.
+	maxAllowedServices = 100
+)
+
+// Server implements `service Health`.
+type Server struct {
+	healthgrpc.UnimplementedHealthServer
+	mu sync.RWMutex
+	// If shutdown is true, it's expected all serving status is NOT_SERVING, and
+	// will stay in NOT_SERVING.
+	shutdown bool
+	// statusMap stores the serving status of the services this Server monitors.
+	statusMap map[string]healthpb.HealthCheckResponse_ServingStatus
+	updates   map[string]map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus
+}
+
+// NewServer returns a new Server.
+func NewServer() *Server {
+	return &Server{
+		statusMap: map[string]healthpb.HealthCheckResponse_ServingStatus{"": healthpb.HealthCheckResponse_SERVING},
+		updates:   make(map[string]map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus),
+	}
+}
+
+// Check implements `service Health`.
+func (s *Server) Check(_ context.Context, in *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if servingStatus, ok := s.statusMap[in.Service]; ok {
+		return &healthpb.HealthCheckResponse{
+			Status: servingStatus,
+		}, nil
+	}
+	return nil, status.Error(codes.NotFound, "unknown service")
+}
+
+// List implements `service Health`.
+func (s *Server) List(_ context.Context, _ *healthpb.HealthListRequest) (*healthpb.HealthListResponse, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.statusMap) > maxAllowedServices {
+		return nil, status.Errorf(codes.ResourceExhausted, "server health list exceeds maximum capacity: %d", maxAllowedServices)
+	}
+
+	statusMap := make(map[string]*healthpb.HealthCheckResponse, len(s.statusMap))
+	for k, v := range s.statusMap {
+		statusMap[k] = &healthpb.HealthCheckResponse{Status: v}
+	}
+
+	return &healthpb.HealthListResponse{Statuses: statusMap}, nil
+}
+
+// Watch implements `service Health`.
+func (s *Server) Watch(in *healthpb.HealthCheckRequest, stream healthgrpc.Health_WatchServer) error {
+	service := in.Service
+	// update channel is used for getting service status updates.
+	update := make(chan healthpb.HealthCheckResponse_ServingStatus, 1)
+	s.mu.Lock()
+	// Puts the initial status to the channel.
+	if servingStatus, ok := s.statusMap[service]; ok {
+		update <- servingStatus
+	} else {
+		update <- healthpb.HealthCheckResponse_SERVICE_UNKNOWN
+	}
+
+	// Registers the update channel to the correct place in the updates map.
+	if _, ok := s.updates[service]; !ok {
+		s.updates[service] = make(map[healthgrpc.Health_WatchServer]chan healthpb.HealthCheckResponse_ServingStatus)
+	}
+	s.updates[service][stream] = update
+	defer func() {
+		s.mu.Lock()
+		delete(s.updates[service], stream)
+		s.mu.Unlock()
+	}()
+	s.mu.Unlock()
+
+	var lastSentStatus healthpb.HealthCheckResponse_ServingStatus = -1
+	for {
+		select {
+		// Status updated. Sends the up-to-date status to the client.
+		case servingStatus := <-update:
+			if lastSentStatus == servingStatus {
+				continue
+			}
+			lastSentStatus = servingStatus
+			err := stream.Send(&healthpb.HealthCheckResponse{Status: servingStatus})
+			if err != nil {
+				return status.Error(codes.Canceled, "Stream has ended.")
+			}
+		// Context done. Removes the update channel from the updates map.
+		case <-stream.Context().Done():
+			return status.Error(codes.Canceled, "Stream has ended.")
+		}
+	}
+}
+
+// SetServingStatus is called when need to reset the serving status of a service
+// or insert a new service entry into the statusMap.
+func (s *Server) SetServingStatus(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		logger.Infof("health: status changing for %s to %v is ignored because health service is shutdown", service, servingStatus)
+		return
+	}
+
+	s.setServingStatusLocked(service, servingStatus)
+}
+
+func (s *Server) setServingStatusLocked(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+	s.statusMap[service] = servingStatus
+	for _, update := range s.updates[service] {
+		// Clears previous updates, that are not sent to the client, from the channel.
+		// This can happen if the client is not reading and the server gets flow control limited.
+		select {
+		case <-update:
+		default:
+		}
+		// Puts the most recent update to the channel.
+		update <- servingStatus
+	}
+}
+
+// Shutdown sets all serving status to NOT_SERVING, and configures the server to
+// ignore all future status changes.
+//
+// This changes serving status for all services. To set status for a particular
+// services, call SetServingStatus().
+func (s *Server) Shutdown() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shutdown = true
+	for service := range s.statusMap {
+		s.setServingStatusLocked(service, healthpb.HealthCheckResponse_NOT_SERVING)
+	}
+}
+
+// Resume sets all serving status to SERVING, and configures the server to
+// accept all future status changes.
+//
+// This changes serving status for all services. To set status for a particular
+// services, call SetServingStatus().
+func (s *Server) Resume() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.shutdown = false
+	for service := range s.statusMap {
+		s.setServingStatusLocked(service, healthpb.HealthCheckResponse_SERVING)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -464,6 +464,7 @@ google.golang.org/grpc/experimental/balancer/weight
 google.golang.org/grpc/experimental/stats
 google.golang.org/grpc/grpclog
 google.golang.org/grpc/grpclog/internal
+google.golang.org/grpc/health
 google.golang.org/grpc/health/grpc_health_v1
 google.golang.org/grpc/internal
 google.golang.org/grpc/internal/backoff


### PR DESCRIPTION
**- What I did**

Added a `cli/grpc` package providing a single way to establish a gRPC client connection to the daemon's API endpoint, for CLI plugins consuming the daemon's gRPC services (BuildKit's control API today, services published by daemon extensions — moby/moby#53021 — tomorrow).

`Connect()` (or the lower-level `Dial()`) hides the transport details of the current docker context:

- native HTTP/2 for daemons with API ≥ v1.53: h2c over the API client's own dialer (unix/npipe sockets, plain tcp, `ssh://` and other connection helpers), or an ALPN-negotiated TLS handshake for `tcp://` endpoints with TLS material;
- fallback to the deprecated `POST /grpc` HTTP/1.1 upgrade endpoint for older daemons, as buildx currently hand-rolls.

Also exports `Endpoint.TLSConfig()` in `cli/context/docker` (previously private), needed for the ALPN path.

`google.golang.org/grpc` moves from indirect to direct dependency.

**- How I did it**

Daemon API version is probed with a plain `Ping`; the connection is then established with `grpc.NewClient` using either a custom dialer (h2c, legacy upgrade) or gRPC's TLS credentials (ALPN). See the package documentation for details.

**Note — capability signal in Ping**
Native connections are probed with a health-check RPC before being returned, because the API version alone cannot be trusted: an intermediary may not relay HTTP/2 even when the daemon advertises native support (Docker Desktop's API proxy today — its engine reports API 1.55 while only the legacy upgrade path gets through). The probe costs one round-trip per `Connect` on the native path. If the daemon ever exposes an explicit capability signal in the `Ping` response (e.g. a `Builder-Version`-style header advertising native gRPC, which an intermediary that doesn't relay HTTP/2 would strip or rewrite), it should replace both the version gate and the probe.

**- How to verify it**

`go test ./cli/grpc/...` covers the three paths (h2c over the client dialer, TLS+ALPN, legacy hijack fallback) against a real gRPC server.

**- Human readable description for the release notes**

<!--
Suggested changelog entry, to be restored with the relevant impact/, kind/
and area/ labels by a maintainer (I don't have label permissions):

    Add a cli/grpc package for CLI plugins to establish gRPC connections
    to the Docker Engine's API endpoint.

Milestone to set: 29.8.0 (per validate-milestone).
-->

```markdown changelog
```

Created with: Claude Code

