### PR TITLE
registry: normalize server address to lowercase for credential lookup

### DIFF
--- a/cli/command/registry/login.go
+++ b/cli/command/registry/login.go
@@ -320,6 +320,7 @@ func loginWithDeviceCodeFlow(ctx context.Context, dockerCLI command.Cli) (msg st
 }
 
 func storeCredentials(cfg *configfile.ConfigFile, authConfig registrytypes.AuthConfig) error {
+	authConfig.ServerAddress = strings.ToLower(authConfig.ServerAddress)
 	creds := cfg.GetCredentialsStore(authConfig.ServerAddress)
 	if err := creds.Store(configtypes.AuthConfig{
 		Username:      authConfig.Username,

--- a/cli/command/registry/login_test.go
+++ b/cli/command/registry/login_test.go
@@ -150,6 +150,28 @@ func TestRunLogin(t *testing.T) {
 			},
 		},
 		{
+			doc: "mixed-case server address updates lowercase credential key",
+			priorCredentials: map[string]configtypes.AuthConfig{
+				"myregistry.example.com": {
+					Username:      "my-username",
+					Password:      "old-password",
+					ServerAddress: "myregistry.example.com",
+				},
+			},
+			input: loginOptions{
+				serverAddress: "MyRegistry.Example.com",
+				user:          "my-username",
+				password:      "new-password",
+			},
+			expectedCredentials: map[string]configtypes.AuthConfig{
+				"myregistry.example.com": {
+					Username:      "my-username",
+					Password:      "new-password",
+					ServerAddress: "myregistry.example.com",
+				},
+			},
+		},
+		{
 			doc: "unknown user w/ prior credentials",
 			priorCredentials: map[string]configtypes.AuthConfig{
 				"reg1": {

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
@@ -60,6 +61,10 @@ func runLogout(ctx context.Context, dockerCLI command.Cli, serverAddress string)
 		// the tries below are kept for backward compatibility where a user could have
 		// saved the registry in one of the following format.
 		regsToLogout = append(regsToLogout, hostnameAddress, "http://"+hostnameAddress, "https://"+hostnameAddress)
+		// Also try lowercase variants for backward compatibility with case-insensitive
+		// login normalization in getAuthConfigKey and storeCredentials.
+		lowercaseAddress := strings.ToLower(hostnameAddress)
+		regsToLogout = append(regsToLogout, lowercaseAddress, "http://"+lowercaseAddress, "https://"+lowercaseAddress)
 	}
 
 	if isDefaultRegistry {

--- a/cli/command/registry/logout_test.go
+++ b/cli/command/registry/logout_test.go
@@ -1,0 +1,48 @@
+package registry
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	configtypes "github.com/docker/cli/cli/config/types"
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+)
+
+func TestRunLogoutMixedCaseServerAddress(t *testing.T) {
+	cfg := configfile.New(filepath.Join(t.TempDir(), "config.json"))
+	cli := test.NewFakeCli(nil)
+	cli.SetConfigFile(cfg)
+
+	const serverAddress = "myregistry.example.com"
+	assert.NilError(t, cfg.GetCredentialsStore(serverAddress).Store(configtypes.AuthConfig{
+		Username:      "my-username",
+		Password:      "my-password",
+		ServerAddress: serverAddress,
+	}))
+
+	assert.NilError(t, runLogout(context.Background(), cli, "MyRegistry.Example.com"))
+	credentials, err := cfg.GetAllCredentials()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, credentials, map[string]configtypes.AuthConfig{})
+}
+
+func TestRunLogoutUpperCaseServerAddress(t *testing.T) {
+	cfg := configfile.New(filepath.Join(t.TempDir(), "config.json"))
+	cli := test.NewFakeCli(nil)
+	cli.SetConfigFile(cfg)
+
+	const serverAddress = "MYREGISTRY.EXAMPLE.COM"
+	assert.NilError(t, cfg.GetCredentialsStore(serverAddress).Store(configtypes.AuthConfig{
+		Username:      "my-username",
+		Password:      "my-password",
+		ServerAddress: serverAddress,
+	}))
+
+	assert.NilError(t, runLogout(context.Background(), cli, serverAddress))
+	credentials, err := cfg.GetAllCredentials()
+	assert.NilError(t, err)
+	assert.DeepEqual(t, credentials, map[string]configtypes.AuthConfig{})
+}

--- a/cli/command/registry_test.go
+++ b/cli/command/registry_test.go
@@ -109,7 +109,8 @@ func TestRetrieveAuthTokenFromImage(t *testing.T) {
 		"localhost": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="},
 		"localhost:5000": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="},
 		"registry-1.docker.io": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="},
-		"registry.hub.docker.com": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="}
+		"registry.hub.docker.com": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="},
+		"registry.example.com": {"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="}
 	}
 }`
 	cfg := configfile.ConfigFile{}
@@ -156,6 +157,10 @@ func TestRetrieveAuthTokenFromImage(t *testing.T) {
 			// FIXME(thaJeztah): registry.hub.docker.com is stored separate from other URLs used for docker hub's registry
 			prefix:          "registry.hub.docker.com",
 			expectedAuthCfg: registry.AuthConfig{Username: "username", Password: "password", ServerAddress: "registry.hub.docker.com"},
+		},
+		{
+			prefix:          "Registry.Example.com",
+			expectedAuthCfg: registry.AuthConfig{Username: "username", Password: "password", ServerAddress: "registry.example.com"},
 		},
 		{
 			prefix:          "[::1]",

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -42,6 +42,7 @@ const authConfigKey = "https://index.docker.io/v1/"
 //
 // [registry.GetAuthConfigKey]: https://pkg.go.dev/github.com/docker/docker@v28.5.1+incompatible/registry#GetAuthConfigKey
 func getAuthConfigKey(domainName string) string {
+	domainName = strings.ToLower(domainName)
 	if domainName == "docker.io" || domainName == "index.docker.io" {
 		return authConfigKey
 	}

--- a/cli/config/configfile/file_test.go
+++ b/cli/config/configfile/file_test.go
@@ -15,6 +15,20 @@ import (
 	"gotest.tools/v3/golden"
 )
 
+func TestGetAuthConfigKey(t *testing.T) {
+	tests := map[string]string{
+		"MyRegistry.Example.com": "myregistry.example.com",
+		"DOCKER.IO":              authConfigKey,
+		"Index.Docker.IO":        authConfigKey,
+	}
+
+	for domainName, expected := range tests {
+		t.Run(domainName, func(t *testing.T) {
+			assert.Equal(t, getAuthConfigKey(domainName), expected)
+		})
+	}
+}
+
 func TestEncodeAuth(t *testing.T) {
 	newAuthConfig := &types.AuthConfig{Username: "ken", Password: "test"}
 	authStr := encodeAuth(newAuthConfig)


### PR DESCRIPTION
Closes #2753

**- What I did**

Registry login credentials were stored/looked-up under a case-sensitive
key. If the hostname's case used at `docker login` differs from the
case used in an image reference at push/pull time (e.g.
`docker login Test.Registry.org` then
`docker push Test.Registry.org/img`), authentication fails even though
credentials for that registry exist.

Root cause: `distribution/reference` does not lowercase the domain
component of a reference (only the repository path must be lowercase),
so the same registry hostname can produce different credential-store
keys depending on how it was typed.

This revisits the approach from #2782 (2020, closed unmerged by the
stale bot, but previously reviewed and approved) and adapts it to the
current codebase, which has changed substantially since then (device-
flow login, new credential-store abstraction, content trust moved to
the separate `cmd/docker-trust` binary).

**- How I did it**

Normalize the server address to lowercase at:
- `docker login` / `docker logout`, before it's used as a
  credential-store key
- `RetrieveAuthTokenFromImage`, which resolves auth for an image
  reference and is shared by push, pull, service create/update, stack
  deploy, and plugin install
- `getAuthConfigKey` in `cli/config/configfile`, the canonical
  credential-lookup key used by `GetAuthConfig`, as defense-in-depth
  for any other caller

**- How to verify it**

Added/extended unit tests covering mixed-case server addresses for
login, logout, image-reference auth resolution, and the config-file
lookup key. `go build ./...` and the affected package tests pass.

**- Description for the changelog**

Registry login/logout and image push/pull now resolve stored
credentials case-insensitively by registry hostname.