### PR TITLE
compose/loader: keep TCP+UDP when merging same published port

### DIFF
--- a/cli/compose/loader/merge.go
+++ b/cli/compose/loader/merge.go
@@ -129,9 +129,19 @@ func toServicePortConfigsMap(s any) (map[any]any, error) {
 	}
 	m := map[any]any{}
 	for _, p := range ports {
-		m[p.Published] = p
+		// Key by published port + protocol so TCP and UDP on the same host
+		// port (e.g. 443/tcp and 443/udp) do not collapse when merging files.
+		m[servicePortMergeKey(p)] = p
 	}
 	return m, nil
+}
+
+func servicePortMergeKey(p types.ServicePortConfig) string {
+	proto := p.Protocol
+	if proto == "" {
+		proto = "tcp"
+	}
+	return fmt.Sprintf("%d/%s", p.Published, proto)
 }
 
 func toServiceVolumeConfigsMap(s any) (map[any]any, error) {
@@ -176,7 +186,10 @@ func toServicePortConfigsSlice(dst reflect.Value, m map[any]any) error {
 		s = append(s, v.(types.ServicePortConfig))
 	}
 	slices.SortFunc(s, func(a, b types.ServicePortConfig) int {
-		return cmp.Compare(a.Published, b.Published)
+		if n := cmp.Compare(a.Published, b.Published); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Protocol, b.Protocol)
 	})
 	dst.Set(reflect.ValueOf(s))
 	return nil

--- a/cli/compose/loader/merge_test.go
+++ b/cli/compose/loader/merge_test.go
@@ -301,6 +301,30 @@ func TestLoadMultipleServicePorts(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "same_published_tcp_and_udp",
+			portBase: map[string]any{
+				"ports": []any{
+					"443:443",
+					"443:443/udp",
+				},
+			},
+			portOverride: map[string]any{},
+			expected: []types.ServicePortConfig{
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    443,
+					Protocol:  "tcp",
+				},
+				{
+					Mode:      "ingress",
+					Published: 443,
+					Target:    443,
+					Protocol:  "udp",
+				},
+			},
+		},
 	}
 
 	for _, tc := range portsCases {


### PR DESCRIPTION
`docker stack config -c base.yml -c override.yml` was dropping one of the twin entries when you publish the same host port as both TCP and UDP. Merge used only the published port as the map key, so the second protocol stomped the first even if the override didn't touch `ports`.

Key by `published/protocol` instead. Test covers 443/tcp + 443/udp surviving a no-op override merge.

Fixes #6223