### PR TITLE
docs(run): say list flags are repeated, not comma-separated

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -117,3 +117,12 @@ Create and run a new container from an image
 
 <!---MARKER_GEN_END-->
 
+## Description
+
+Options whose type is `list` take one value per flag. Repeat the flag to pass
+more than one value. A comma-separated string is a single item, not a list.
+
+```console
+$ docker run --dns 8.8.8.8 --dns 1.1.1.1 --rm alpine getent hosts docker.com
+```
+


### PR DESCRIPTION
`--dns list` in --help looks like a comma-separated string. it isn't — repeat the flag.

Fixes #2138