### PR TITLE
docs(man): note docker build uses BuildKit by default

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -36,6 +36,10 @@ docker-build - Build an image from a Dockerfile
 PATH | URL | -
 
 # DESCRIPTION
+**docker build** uses BuildKit by default. The flags listed in this page
+include options that only apply to the legacy builder. For the current
+BuildKit option set, see **docker buildx build**(1).
+
 This will read the Dockerfile from the directory specified in **PATH**.
 It also sends any other files and directories found in the current
 directory to the Docker daemon. The contents of this directory would


### PR DESCRIPTION
the man page still reads like the old builder. one paragraph up top pointing at buildx.

Fixes #1503