### PR TITLE
docs: say --tls still loads ~/.docker/ca.pem

### DIFF
--- a/docs/reference/commandline/docker.md
+++ b/docs/reference/commandline/docker.md
@@ -86,6 +86,11 @@ The base command for the Docker CLI.
 
 ## Description
 
+`--tls` turns on TLS for the client. The CLI still loads `--tlscacert`
+(default `~/.docker/ca.pem`) and errors if that file is missing. It does
+not use the system CA pool. Without `--tlsverify`, the daemon certificate
+is not verified.
+
 Depending on your Docker system configuration, you may be required to preface
 each `docker` command with `sudo`. To avoid having to use `sudo` with the
 `docker` command, your system administrator can create a Unix group called

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -38,9 +38,13 @@ unix://[/path/to/socket] to use.
 
 **--tls**=*true*|*false*
   Use TLS; implied by --tlsverify. Default is false.
+  The client still loads --tlscacert (default ~/.docker/ca.pem) and
+  errors if that file is missing. It does not fall back to the system
+  CA pool. Without --tlsverify the daemon certificate is not verified.
 
 **--tlscacert**=*~/.docker/ca.pem*
-  Trust certs signed only by this CA.
+  Trust certs signed only by this CA. Always used when TLS is on,
+  including --tls without --tlsverify.
 
 **--tlscert**=*~/.docker/cert.pem*
   Path to TLS certificate file.


### PR DESCRIPTION
`--tls` was documented as if it used the public CA pool. The client still opens `--tlscacert` (default `~/.docker/ca.pem`) and errors if that file is missing, even when `--tlsverify` is off.

Fixes #2468