### PR TITLE
docs(run): say --health-retries 0 is unset, default is 3

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1085,6 +1085,10 @@ for container healthchecks:
 | `--health-start-interval`  | Time between running the check during the start period                                 |
 | `--no-healthcheck`         | Disable any container-specified `HEALTHCHECK`                                          |
 
+`--health-retries` is consecutive failed checks before the container is marked
+`unhealthy`. The first check counts. The value must be 1 or higher; `0` is
+treated as unset and the daemon uses its default of 3.
+
 Example:
 
 ```console


### PR DESCRIPTION
`--health-retries` defaulting to 0 in the flag table makes it look like you can disable retries. The daemon ignores 0 and uses 3; the first probe already counts.

- Fixes docker/docs#10929