### PR TITLE
docs(manifest annotate): list common OS/arch/variant values

### DIFF
--- a/docs/reference/commandline/manifest_annotate.md
+++ b/docs/reference/commandline/manifest_annotate.md
@@ -16,3 +16,15 @@ Add additional information to a local image manifest
 
 <!---MARKER_GEN_END-->
 
+## Description
+
+`--os`, `--arch`, and `--variant` take OCI platform values, not distro nicknames
+like `armhf` or `armv7`.
+
+Common `--os` values are `linux` and `windows`. Common `--arch` values are
+`amd64`, `arm64`, `arm`, `386`, `ppc64le`, `s390x`, and `riscv64`.
+
+`--variant` is mostly for 32-bit ARM. An `armhf` / `armv7` image is
+`--arch arm --variant v7`. `arm64` usually has no variant (or `v8`).
+
+


### PR DESCRIPTION
`--arch armv7` isn't a thing — it's `--arch arm --variant v7`. Added the usual OS/arch names and that armhf mapping.

- Fixes docker/docs#10254