### PR TITLE
docs(run): map --ulimit names to bash ulimit flags

### DIFF
--- a/docs/reference/commandline/container_run.md
+++ b/docs/reference/commandline/container_run.md
@@ -1351,23 +1351,23 @@ $ docker run --ulimit nofile=1024:1024 --rm debian sh -c "ulimit -n"
 
 #### Supported options for `--ulimit`:
 
-| Option       | Description                                               |
-|:-------------|:----------------------------------------------------------|
-| `core`       | Maximum size of core files created (`RLIMIT_CORE`)        |
-| `cpu`        | CPU time limit in seconds (`RLIMIT_CPU`)                  |
-| `data`       | Maximum data segment size (`RLIMIT_DATA`)                 |
-| `fsize`      | Maximum file size (`RLIMIT_FSIZE`)                        |
-| `locks`      | Maximum number of file locks (`RLIMIT_LOCKS`)             |
-| `memlock`    | Maximum locked-in-memory address space (`RLIMIT_MEMLOCK`) |
-| `msgqueue`   | Maximum bytes in POSIX message queues (`RLIMIT_MSGQUEUE`) |
-| `nice`       | Maximum nice priority adjustment (`RLIMIT_NICE`)          |
-| `nofile`     | Maximum number of open file descriptors (`RLIMIT_NOFILE`) |
-| `nproc`      | Maximum number of processes available (`RLIMIT_NPROC`)    |
-| `rss`        | Maximum resident set size (`RLIMIT_RSS`)                  |
-| `rtprio`     | Maximum real-time scheduling priority (`RLIMIT_RTPRIO`)   |
-| `rttime`     | Maximum real-time execution time (`RLIMIT_RTTIME`)        |
-| `sigpending` | Maximum number of pending signals (`RLIMIT_SIGPENDING`)   |
-| `stack`      | Maximum stack size (`RLIMIT_STACK`)                       |
+| Option       | bash `ulimit` | Description                                               |
+|:-------------|:--------------|:----------------------------------------------------------|
+| `core`       | `-c`          | Maximum size of core files created (`RLIMIT_CORE`)        |
+| `cpu`        | `-t`          | CPU time limit in seconds (`RLIMIT_CPU`)                  |
+| `data`       | `-d`          | Maximum data segment size (`RLIMIT_DATA`)                 |
+| `fsize`      | `-f`          | Maximum file size (`RLIMIT_FSIZE`)                        |
+| `locks`      | `-x`          | Maximum number of file locks (`RLIMIT_LOCKS`)             |
+| `memlock`    | `-l`          | Maximum locked-in-memory address space (`RLIMIT_MEMLOCK`) |
+| `msgqueue`   | `-q`          | Maximum bytes in POSIX message queues (`RLIMIT_MSGQUEUE`) |
+| `nice`       | `-e`          | Maximum nice priority adjustment (`RLIMIT_NICE`)          |
+| `nofile`     | `-n`          | Maximum number of open file descriptors (`RLIMIT_NOFILE`) |
+| `nproc`      | `-u`          | Maximum number of processes available (`RLIMIT_NPROC`)    |
+| `rss`        | `-m`          | Maximum resident set size (`RLIMIT_RSS`)                  |
+| `rtprio`     | `-r`          | Maximum real-time scheduling priority (`RLIMIT_RTPRIO`)   |
+| `rttime`     |               | Maximum real-time execution time (`RLIMIT_RTTIME`)        |
+| `sigpending` | `-i`          | Maximum number of pending signals (`RLIMIT_SIGPENDING`)   |
+| `stack`      | `-s`          | Maximum stack size (`RLIMIT_STACK`)                       |
 
 Docker sends the values to the appropriate OS `syscall` and doesn't perform any byte conversion.
 Take this into account when setting the values.


### PR DESCRIPTION
The --ulimit table already lists nofile / nproc but not the bash ulimit -n letters. Added that column (rttime has no flag).

- Fixes docker/docs#13099