### PR TITLE
docs(man): --file can sit outside the build context

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -54,12 +54,11 @@ set as the **URL**, the repository is cloned locally and then sent as the contex
 
 # OPTIONS
 **-f**, **--file** *PATH/Dockerfile*
-   Path to the Dockerfile to use. If the path is a relative path and you are
-   building from a local directory, then the path must be relative to that
-   directory. If you are building from a remote URL pointing to either a
-   tarball or a Git repository, then the path must be relative to the root of
-   the remote context. In all cases, the file must be within the build context.
-   The default is *Dockerfile*.
+   Path to the Dockerfile to use. A relative path is resolved from the
+   current working directory, not from the build context. The file does
+   not have to live inside the context. When the context is a remote Git
+   repository or tarball, **-f** is relative to the root of that remote
+   context. The default is *Dockerfile*.
 
 **--squash** *true*|*false*
    **Experimental Only**


### PR DESCRIPTION
The docker-build man page still said `-f` has to live inside the context. That hasn't been true since the Dockerfile-outside-context change, and it's the default BuildKit builder now.

Relative `-f` is from the current working directory. Remote git/tar contexts still resolve it from the remote root.

- Fixes #1549