### PR TITLE
cli/command/registry: fix "docker logout docker.io" leaving credentials behind

### DIFF
--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -60,6 +60,11 @@ func runLogout(ctx context.Context, dockerCLI command.Cli, serverAddress string)
 		// the tries below are kept for backward compatibility where a user could have
 		// saved the registry in one of the following format.
 		regsToLogout = append(regsToLogout, hostnameAddress, "http://"+hostnameAddress, "https://"+hostnameAddress)
+		// "docker login docker.io" stores credentials under the full index
+		// address, so look for that key as well.
+		if hostnameAddress == registry.DefaultNamespace || hostnameAddress == registry.IndexHostname {
+			regsToLogout = append(regsToLogout, registry.IndexServer)
+		}
 	}
 
 	if isDefaultRegistry {

--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -60,8 +60,10 @@ func runLogout(ctx context.Context, dockerCLI command.Cli, serverAddress string)
 		// the tries below are kept for backward compatibility where a user could have
 		// saved the registry in one of the following format.
 		regsToLogout = append(regsToLogout, hostnameAddress, "http://"+hostnameAddress, "https://"+hostnameAddress)
-		// "docker login docker.io" stores credentials under the full index
-		// address, so look for that key as well.
+		// Credentials for the default registry are stored under the full index
+		// address, which is the key "docker login docker.io" writes to. The
+		// hostnames below are the ones that getAuthConfigKey in
+		// cli/config/configfile maps to that key.
 		if hostnameAddress == registry.DefaultNamespace || hostnameAddress == registry.IndexHostname {
 			regsToLogout = append(regsToLogout, registry.IndexServer)
 		}

--- a/cli/command/registry/logout_test.go
+++ b/cli/command/registry/logout_test.go
@@ -1,0 +1,49 @@
+package registry
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/internal/test"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestLogoutRemovesCredentialsStoredByLogin verifies that logging out with the
+// same argument that was used to log in removes the stored credentials.
+//
+// "docker.io" is normalized to [registry.IndexServer] when logging in, so
+// logout must apply the same normalization to find the entry again.
+func TestLogoutRemovesCredentialsStoredByLogin(t *testing.T) {
+	for _, serverAddress := range []string{
+		"",
+		"docker.io",
+		"index.docker.io",
+		"https://index.docker.io/v1/",
+		"myreg.example.com",
+	} {
+		name := serverAddress
+		if name == "" {
+			name = "no server address"
+		}
+		t.Run(name, func(t *testing.T) {
+			configFile := configfile.New(filepath.Join(t.TempDir(), "config.json"))
+			cli := test.NewFakeCli(&fakeClient{})
+			cli.SetConfigFile(configFile)
+
+			err := runLogin(context.Background(), cli, loginOptions{
+				serverAddress: serverAddress,
+				user:          "my-username",
+				password:      "my-password",
+			})
+			assert.NilError(t, err)
+			assert.Assert(t, is.Len(configFile.AuthConfigs, 1), "login did not store credentials")
+
+			err = runLogout(context.Background(), cli, serverAddress)
+			assert.NilError(t, err)
+			assert.Check(t, is.Len(configFile.AuthConfigs, 0))
+		})
+	}
+}

--- a/cli/command/registry/logout_test.go
+++ b/cli/command/registry/logout_test.go
@@ -14,8 +14,9 @@ import (
 // TestLogoutRemovesCredentialsStoredByLogin verifies that logging out with the
 // same argument that was used to log in removes the stored credentials.
 //
-// "docker.io" is normalized to [registry.IndexServer] when logging in, so
-// logout must apply the same normalization to find the entry again.
+// Credentials for the default registry are stored under
+// [registry.IndexServer] regardless of the spelling passed to "docker login",
+// so logout has to look for that key as well to find them again.
 func TestLogoutRemovesCredentialsStoredByLogin(t *testing.T) {
 	for _, serverAddress := range []string{
 		"",


### PR DESCRIPTION
**- What I did**

Fixed `docker logout docker.io` silently leaving the credentials in `config.json`. It printed `Removing login credentials for docker.io`, returned no error and exited 0, but nothing was removed.

`docker.io` is the name the docs use for Docker Hub, so this is the spelling a user is most likely to reach for. `docker logout` with no argument, and `docker logout https://index.docker.io/v1/`, both work — only the namespace form is affected.

**- How I did it**

`runLogin` resolves the default registry before storing:

```go
if opts.serverAddress != "" && opts.serverAddress != registry.DefaultNamespace {
	serverAddress = opts.serverAddress
} else {
	serverAddress = registry.IndexServer
}
```

so `docker login docker.io` stores under `https://index.docker.io/v1/`.

`runLogout` only treats an *empty* server address as the default registry, so for `docker.io` it takes the `!isDefaultRegistry` branch and builds `regsToLogout` as `docker.io`, `http://docker.io`, `https://docker.io`. None of those keys exist, and `fileStore.Erase` returns `nil` for a key that is not present:

```go
func (c *fileStore) Erase(serverAddress string) error {
	if _, exists := c.file.GetAuthConfigs()[serverAddress]; !exists {
		// nothing to do; no credentials found for the given serverAddress
		return nil
	}
	...
```

so every removal "succeeds", `errs` stays empty, and the success message is printed.

This patch appends `registry.IndexServer` to `regsToLogout` when logging out of the default registry by namespace or index hostname. The existing lookups are left in place, so credentials stored under a legacy key are still removed.

**- How to verify it**

`cli/command/registry/logout.go` had no test file at all. This PR adds one that drives the real `runLogin` / `runLogout` round-trip for the spellings a user can pass:

```console
$ go test ./cli/command/registry/ -run TestLogoutRemovesCredentialsStoredByLogin -v
```

On master exactly one subtest fails:

```
--- FAIL: TestLogoutRemovesCredentialsStoredByLogin/docker.io
    logout_test.go:46: assertion failed: expected
    map[https://index.docker.io/v1/:{my-username my-password  https://index.docker.io/v1/  }]
    (length 1) to have length 0
--- PASS: TestLogoutRemovesCredentialsStoredByLogin/no_server_address
--- PASS: TestLogoutRemovesCredentialsStoredByLogin/index.docker.io
--- PASS: TestLogoutRemovesCredentialsStoredByLogin/https://index.docker.io/v1/
--- PASS: TestLogoutRemovesCredentialsStoredByLogin/myreg.example.com
```

With the fix all five pass.

End to end, with a config file holding the entry `docker login docker.io` writes and no credential helper configured:

```console
$ export DOCKER_CONFIG=$(mktemp -d)
$ echo '{"auths":{"https://index.docker.io/v1/":{"auth":"bXl1c2VyOm15cGFzc3dvcmQ="}}}' > $DOCKER_CONFIG/config.json
$ docker logout docker.io
Removing login credentials for docker.io
$ echo $?
0
$ jq -r '.auths | keys[]' $DOCKER_CONFIG/config.json
https://index.docker.io/v1/
```

The same sequence built from this branch leaves `.auths` empty. In both cases the output and the exit status are identical, which is what makes this one easy to miss.

**- One thing I deliberately did not change**

There is a second, larger reading of this asymmetry, and I would rather ask than guess.

`runLogin` treats `docker.io` as the default registry for *everything*, including the OAuth device-code flow. `runLogout` does not, so `isDefaultRegistry` stays false and this block is skipped:

```go
if isDefaultRegistry {
	store := dockerCLI.ConfigFile().GetCredentialsStore(registry.IndexServer)
	if err := manager.NewManager(store).Logout(ctx); err != nil {
		...
```

That means `docker logout docker.io` also never reaches `OAuthManager.Logout`, so the refresh token is neither erased nor revoked with the tenant. Aligning the condition in `runLogout` with the one in `runLogin` would fix both at once:

```go
if serverAddress == "" || serverAddress == registry.DefaultNamespace {
	serverAddress = registry.IndexServer
	isDefaultRegistry = true
}
```

I kept this PR to the narrow fix because that version also changes the address printed in the output message and drops the legacy `http://` / `https://` lookups for this input. Happy to switch to it if you prefer the symmetry — the test above covers either shape.

**- Human readable description for the release notes**

```markdown changelog
Fix `docker logout docker.io` reporting success without removing the stored credentials
```
