### PR TITLE
docs(stop): say --timeout 0 is immediate SIGKILL

### DIFF
--- a/cli/command/container/restart.go
+++ b/cli/command/container/restart.go
@@ -46,9 +46,14 @@ func newRestartCommand(dockerCLI command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.signal, "signal", "s", "", "Signal to send to the container")
 	flags.IntVarP(&opts.timeout, "timeout", "t", 0, "Seconds to wait before killing the container")
+	// 0 is only the Go zero value. Omitting the flag leaves timeout unset
+	// so the daemon uses the container or daemon default. Hide "0" from
+	// --help / generated docs.
+	flags.Lookup("timeout").DefValue = ""
 
 	// The --time option is deprecated, but kept for backward compatibility.
 	flags.IntVar(&opts.timeout, "time", 0, "Seconds to wait before killing the container (deprecated: use --timeout)")
+	flags.Lookup("time").DefValue = ""
 	_ = flags.MarkDeprecated("time", "use --timeout instead")
 
 	_ = cmd.RegisterFlagCompletionFunc("signal", completeSignals)

--- a/cli/command/container/stop.go
+++ b/cli/command/container/stop.go
@@ -46,9 +46,14 @@ func newStopCommand(dockerCLI command.Cli) *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.signal, "signal", "s", "", "Signal to send to the container")
 	flags.IntVarP(&opts.timeout, "timeout", "t", 0, "Seconds to wait before killing the container")
+	// 0 is only the Go zero value. Omitting the flag leaves timeout unset
+	// so the daemon uses the container or daemon default. Hide "0" from
+	// --help / generated docs (pflag already omits it in usage).
+	flags.Lookup("timeout").DefValue = ""
 
 	// The --time option is deprecated, but kept for backward compatibility.
 	flags.IntVar(&opts.timeout, "time", 0, "Seconds to wait before killing the container (deprecated: use --timeout)")
+	flags.Lookup("time").DefValue = ""
 	_ = flags.MarkDeprecated("time", "use --timeout instead")
 
 	_ = cmd.RegisterFlagCompletionFunc("signal", completeSignals)

--- a/docs/reference/commandline/container_restart.md
+++ b/docs/reference/commandline/container_restart.md
@@ -12,7 +12,7 @@ Restart one or more containers
 | Name                                      | Type     | Default | Description                                  |
 |:------------------------------------------|:---------|:--------|:---------------------------------------------|
 | [`-s`](#signal), [`--signal`](#signal)    | `string` |         | Signal to send to the container              |
-| [`-t`](#timeout), [`--timeout`](#timeout) | `int`    | `0`     | Seconds to wait before killing the container |
+| [`-t`](#timeout), [`--timeout`](#timeout) | `int`    |         | Seconds to wait before killing the container |
 
 
 <!---MARKER_GEN_END-->
@@ -50,8 +50,7 @@ If you set `--timeout` to `-1`, no timeout is applied, and the daemon
 waits indefinitely for the container to exit.
 
 `--timeout 0` is not the same as omitting the flag. It skips the graceful
-wait and sends `SIGKILL` immediately. The `0` in the options table is
-the flag's zero value; it is not the daemon default.
+wait and sends `SIGKILL` immediately.
 
 If you omit `--timeout`, the CLI does not send a timeout. The daemon
 then uses the container's [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)

--- a/docs/reference/commandline/container_restart.md
+++ b/docs/reference/commandline/container_restart.md
@@ -49,7 +49,12 @@ with a `SIGKILL` signal.
 If you set `--timeout` to `-1`, no timeout is applied, and the daemon
 waits indefinitely for the container to exit.
 
-The default timeout can be specified using the [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)
-option when creating the container. If no default is configured for the container,
-the Daemon determines the default, and is 10 seconds for Linux containers, and
-30 seconds for Windows containers.
+`--timeout 0` is not the same as omitting the flag. It skips the graceful
+wait and sends `SIGKILL` immediately. The `0` in the options table is
+the flag's zero value; it is not the daemon default.
+
+If you omit `--timeout`, the CLI does not send a timeout. The daemon
+then uses the container's [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)
+if one was set, otherwise the daemon-wide
+[`default-stop-timeout`](https://docs.docker.com/reference/cli/dockerd/#default-container-stop-timeout)
+(10 seconds on Linux, 30 seconds on Windows).

--- a/docs/reference/commandline/container_stop.md
+++ b/docs/reference/commandline/container_stop.md
@@ -55,7 +55,12 @@ with a `SIGKILL` signal.
 If you set `--timeout` to `-1`, no timeout is applied, and the daemon
 waits indefinitely for the container to exit.
 
-The default timeout can be specified using the [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)
-option when creating the container. If no default is configured for the container,
-the Daemon determines the default, and is 10 seconds for Linux containers, and
-30 seconds for Windows containers.
+`--timeout 0` is not the same as omitting the flag. It skips the graceful
+wait and sends `SIGKILL` immediately. The `0` in the options table is
+the flag's zero value; it is not the daemon default.
+
+If you omit `--timeout`, the CLI does not send a timeout. The daemon
+then uses the container's [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)
+if one was set, otherwise the daemon-wide
+[`default-stop-timeout`](https://docs.docker.com/reference/cli/dockerd/#default-container-stop-timeout)
+(10 seconds on Linux, 30 seconds on Windows).

--- a/docs/reference/commandline/container_stop.md
+++ b/docs/reference/commandline/container_stop.md
@@ -12,7 +12,7 @@ Stop one or more running containers
 | Name                                      | Type     | Default | Description                                  |
 |:------------------------------------------|:---------|:--------|:---------------------------------------------|
 | [`-s`](#signal), [`--signal`](#signal)    | `string` |         | Signal to send to the container              |
-| [`-t`](#timeout), [`--timeout`](#timeout) | `int`    | `0`     | Seconds to wait before killing the container |
+| [`-t`](#timeout), [`--timeout`](#timeout) | `int`    |         | Seconds to wait before killing the container |
 
 
 <!---MARKER_GEN_END-->
@@ -56,8 +56,7 @@ If you set `--timeout` to `-1`, no timeout is applied, and the daemon
 waits indefinitely for the container to exit.
 
 `--timeout 0` is not the same as omitting the flag. It skips the graceful
-wait and sends `SIGKILL` immediately. The `0` in the options table is
-the flag's zero value; it is not the daemon default.
+wait and sends `SIGKILL` immediately.
 
 If you omit `--timeout`, the CLI does not send a timeout. The daemon
 then uses the container's [`--stop-timeout`](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout)

--- a/docs/reference/commandline/restart.md
+++ b/docs/reference/commandline/restart.md
@@ -12,7 +12,7 @@ Restart one or more containers
 | Name              | Type     | Default | Description                                  |
 |:------------------|:---------|:--------|:---------------------------------------------|
 | `-s`, `--signal`  | `string` |         | Signal to send to the container              |
-| `-t`, `--timeout` | `int`    | `0`     | Seconds to wait before killing the container |
+| `-t`, `--timeout` | `int`    |         | Seconds to wait before killing the container |
 
 
 <!---MARKER_GEN_END-->

--- a/docs/reference/commandline/stop.md
+++ b/docs/reference/commandline/stop.md
@@ -12,7 +12,7 @@ Stop one or more running containers
 | Name              | Type     | Default | Description                                  |
 |:------------------|:---------|:--------|:---------------------------------------------|
 | `-s`, `--signal`  | `string` |         | Signal to send to the container              |
-| `-t`, `--timeout` | `int`    | `0`     | Seconds to wait before killing the container |
+| `-t`, `--timeout` | `int`    |         | Seconds to wait before killing the container |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
the options table shows `--timeout` defaulting to 0, which reads like stop just kills the container. omitting the flag still uses the container `--stop-timeout` or the daemon default; `--timeout 0` is the immediate SIGKILL.

same note on restart.