### PR TITLE
docs: contrast docker export with docker save

### DIFF
--- a/docs/reference/commandline/container_export.md
+++ b/docs/reference/commandline/container_export.md
@@ -18,6 +18,12 @@ Export a container's filesystem as a tar archive
 
 ## Description
 
+`docker export` writes the container's current filesystem as a flat tar
+archive. It does not include image layers, tags, or history, so the
+result is not a `docker save` image and cannot be loaded with
+`docker load`. Use [`docker import`](image_import.md) to turn the
+archive into a new image.
+
 The `docker export` command doesn't export the contents of volumes associated
 with the container. If a volume is mounted on top of an existing directory in
 the container, `docker export` exports the contents of the underlying

--- a/docs/reference/commandline/image_save.md
+++ b/docs/reference/commandline/image_save.md
@@ -23,6 +23,10 @@ Produces a tarred repository to the standard output stream.
 Contains all parent layers, and all tags + versions, or specified `repo:tag`, for
 each argument provided.
 
+This is not the same as [`docker export`](container_export.md), which
+archives a container's filesystem without image layers or tags. Use
+`docker load` to restore a `docker save` archive.
+
 ## Examples
 
 ### Create a backup that can then be used with `docker load`.


### PR DESCRIPTION
both write a tar, so they're easy to mix up. export is a container rootfs (import if you want an image back); save keeps layers and tags (load).