### PR TITLE
docs(history): use the pulled platform in the --platform example

### DIFF
--- a/docs/reference/commandline/image_history.md
+++ b/docs/reference/commandline/image_history.md
@@ -102,7 +102,7 @@ and shows its history.
 $ docker image pull --quiet --platform=linux/riscv64 alpine
 docker.io/library/alpine:latest
 
-$ docker image history --platform=linux/s390x alpine
+$ docker image history --platform=linux/riscv64 alpine
 IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
 beefdbd8a1da   3 weeks ago   /bin/sh -c #(nop)  CMD ["/bin/sh"]              0B
 <missing>      3 weeks ago   /bin/sh -c #(nop) ADD file:ba2637314e600db5a…   8.46MB


### PR DESCRIPTION
the example pulled linux/riscv64 then ran history against linux/s390x. swapped the history command to match the pull.