### PR TITLE
docs(logout): say no SERVER means Docker Hub

### DIFF
--- a/cli/command/registry/logout.go
+++ b/cli/command/registry/logout.go
@@ -22,7 +22,7 @@ func newLogoutCommand(dockerCLI command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout [SERVER]",
 		Short: "Log out from a registry",
-		Long:  "Log out from a registry.\nIf no server is specified, the default is defined by the daemon.",
+		Long:  "Log out from a registry.\nIf no server is specified, log out of Docker Hub.",
 		Args:  cli.RequiresMaxArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var serverAddress string

--- a/docs/reference/commandline/logout.md
+++ b/docs/reference/commandline/logout.md
@@ -2,14 +2,21 @@
 
 <!---MARKER_GEN_START-->
 Log out from a registry.
-If no server is specified, the default is defined by the daemon.
+If no server is specified, log out of Docker Hub.
 
 
 <!---MARKER_GEN_END-->
 
+## Description
+
+With no argument, `docker logout` removes credentials for Docker Hub
+(`https://index.docker.io/v1/`). It does not consult the daemon for a
+default registry. Pass a server to log out of a private registry.
+
 ## Examples
 
 ```console
+$ docker logout
 $ docker logout localhost:8080
 ```
 


### PR DESCRIPTION
the generated help said the default registry comes from the daemon. the client always logs out of Docker Hub when you omit SERVER.