### PR TITLE
gha: Grant PR review permissions required by v2.0.3

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,6 +18,6 @@ jobs:
       issues: write # Create security incident issues if secrets detected
       checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
-      actions: read # Download artifacts from trigger workflow
+      actions: write # Required since v2.0.3 — review-lock cache cleanup and feedback artifacts
     with:
       trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}


### PR DESCRIPTION
`docker-agent-action` v2.0.3 requires callers of its reusable PR review workflow to grant `actions: write` for review-lock cache cleanup and feedback artifacts. Earlier releases required only `actions: read`. See:

https://github.com/docker/docker-agent-action#pr-review-workflow

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
