### PR TITLE
cli/command/service: preserve mount order on force update

### DIFF
--- a/cli/command/service/update.go
+++ b/cli/command/service/update.go
@@ -352,8 +352,10 @@ func updateService(ctx context.Context, apiClient client.NetworkAPIClient, flags
 	if err := updateIsolation(flagIsolation, &cspec.Isolation); err != nil {
 		return err
 	}
-	if err := updateMounts(flags, &cspec.Mounts); err != nil {
-		return err
+	if anyChanged(flags, flagMountAdd, flagMountRemove) {
+		if err := updateMounts(flags, &cspec.Mounts); err != nil {
+			return err
+		}
 	}
 
 	updateSysCtls(flags, &task.ContainerSpec.Sysctls)

--- a/cli/command/service/update_test.go
+++ b/cli/command/service/update_test.go
@@ -250,6 +250,32 @@ func TestUpdateMounts(t *testing.T) {
 	assert.Check(t, is.Equal("/tokeep", mounts[1].Target))
 }
 
+func TestUpdateServiceForcePreservesMountOrder(t *testing.T) {
+	flags := newUpdateCommand(nil).Flags()
+	assert.NilError(t, flags.Set("force", "true"))
+
+	spec := &swarm.ServiceSpec{
+		TaskTemplate: swarm.TaskSpec{
+			ContainerSpec: &swarm.ContainerSpec{
+				Mounts: []mount.Mount{
+					{Type: mount.TypeVolume, Source: "z-volume", Target: "/data/z"},
+					{Type: mount.TypeVolume, Source: "a-volume", Target: "/data/a"},
+					{Type: mount.TypeVolume, Source: "m-volume", Target: "/data/m"},
+				},
+			},
+		},
+	}
+
+	err := updateService(context.Background(), nil, flags, spec)
+	assert.NilError(t, err)
+	assert.Equal(t, spec.TaskTemplate.ForceUpdate, uint64(1))
+	assert.DeepEqual(t, spec.TaskTemplate.ContainerSpec.Mounts, []mount.Mount{
+		{Type: mount.TypeVolume, Source: "z-volume", Target: "/data/z"},
+		{Type: mount.TypeVolume, Source: "a-volume", Target: "/data/a"},
+		{Type: mount.TypeVolume, Source: "m-volume", Target: "/data/m"},
+	})
+}
+
 func TestUpdateMountsWithDuplicateMounts(t *testing.T) {
 	flags := newUpdateCommand(nil).Flags()
 	flags.Set("mount-add", "type=volume,source=vol4,target=/toadd")


### PR DESCRIPTION
**- What I did**

Fixed `docker service update --force` so it preserves the existing service mount order when no mount options are supplied.

This prevents a subsequent identical `docker stack deploy` from detecting a mount-order difference and unnecessarily rolling the service again.

Fixes #7226

**- How I did it**

Changed `updateService()` to call `updateMounts()` only when `--mount-add` or `--mount-rm` was explicitly changed.

Added a regression test that performs a force-only update and verifies that:

- `ForceUpdate` is incremented.
- The existing mount order remains unchanged.

**- How to verify it**

Run:

```console
go test -mod=vendor ./cli/command/service -run '^TestUpdateServiceForcePreservesMountOrder$' -count=1
go test -mod=vendor ./cli/command/service -run '^TestUpdate' -count=1
```

The regression test, all service update tests, and the complete service package passed locally in a disposable container environment.

**- Human readable description for the release notes**

```markdown changelog
Preserve service mount order during forced updates to avoid an unnecessary rollout on the next stack deploy.
```

<img width="474" height="598" alt="OIP" src="https://github.com/user-attachments/assets/43982322-69f3-4f30-b835-3e8fa5fabadd" />

