### PR TITLE
cmd/docker: print command error before running plugin hooks

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -546,7 +546,20 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 	// If the command is being executed in an interactive terminal
 	// and hook are enabled, run the plugin hooks.
 	if subCommand != nil && dockerCli.Out().IsTerminal() && dockerCli.HooksEnabled() {
-		pluginmanager.RunCLICommandHooks(ctx, dockerCli, cmd, subCommand, cmdErrorMessage(err))
+		errMessage := cmdErrorMessage(err)
+
+		// If the command produced an error that has yet to be printed,
+		// print it before running hooks, so that hook output (such as
+		// "What's next" hints) is shown after the error message instead
+		// of before it. The error is replaced with a silent error that
+		// only carries the exit-code, so that main does not print the
+		// error a second time.
+		if err != nil && !errdefs.IsCanceled(err) && err.Error() != "" {
+			_, _ = fmt.Fprintln(dockerCli.Err(), err)
+			err = cli.StatusError{StatusCode: getExitCode(err)}
+		}
+
+		pluginmanager.RunCLICommandHooks(ctx, dockerCli, cmd, subCommand, errMessage)
 	}
 
 	return err


### PR DESCRIPTION
**- What I did**

Fixes https://github.com/docker/cli/issues/6973 — when a command fails and a plugin `error-hook` (or hook) produces a "What's next" hint, the hint was printed _before_ the command's error message:

```console
$ docker run --rm --env-file=./no-such-file alpine

What's next:
    Debug this container error with Gordon → docker ai "help me fix this container error"
docker: open ./no-such-file: no such file or directory

Run 'docker run --help' for more information
```

**- How I did it**

The cobra tree runs with `SilenceErrors: true`, so the error is only printed by `main()` _after_ `runDocker()` returns, while plugin hooks run inside `runDocker()` right after `cmd.ExecuteContext()` — hence the inverted order.

In `runDocker()`, before invoking the hooks I now print the pending (non-canceled, non-silent) command error to stderr, and replace the returned error with a bare `cli.StatusError` carrying the exit code only, so `main()` doesn't print it a second time. Canceled and signal-terminated errors (which print nothing) pass through untouched, and exit codes are unchanged.

**- How to verify it**

Repro for that area is in the issue. I verified end-to-end with a stub hook plugin (`docker-demo` CLI plugin answering `docker-cli-plugin-hooks` with a fixed next-steps template) configured with `"error-hooks": "run"`, `DOCKER_CLI_HOOKS=true`, under a pty:

Before (current `master` build):

```console
$ docker run --rm --env-file=./no-such-file alpine

What's next:
    Try the --debug flag to diagnose (fake hook hint)
docker: --env-file: open ./no-such-file: no such file or directory

Run 'docker run --help' for more information
```

After (this patch):

```console
$ docker run --rm --env-file=./no-such-file alpine
docker: --env-file: open ./no-such-file: no such file or directory

Run 'docker run --help' for more information

What's next:
    Try the --debug flag to diagnose (fake hook hint)
```

- Exit code is 125 both before and after (same as unpatched).
- Success-case hooks still print after command output (verified with a `hooks: context` config on `docker context ls`).
- `go test ./cmd/docker/... ./cli-plugins/...` passes.

```markdown changelog
Fixed plugin hook messages (e.g. "What's next" hints) being printed before the command's error message when a command fails
```
