### PR TITLE
connhelper: include ssh remote host in dummy client URL (fixes #5604)

### DIFF
--- a/cli/connhelper/connhelper.go
+++ b/cli/connhelper/connhelper.go
@@ -19,7 +19,7 @@ import (
 // ConnectionHelper allows to connect to a remote host with custom stream provider binary.
 type ConnectionHelper struct {
 	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
-	Host   string // dummy URL used for HTTP requests. e.g. "http://docker"
+	Host   string // dummy URL used for HTTP requests. e.g. "http://docker". For ssh connections, the dummy URL includes the remote hostname so that connection error messages refer to the host the user intends to connect to.
 }
 
 // GetConnectionHelper returns Docker-specific connection helper for the given URL.
@@ -61,11 +61,21 @@ func getConnectionHelper(daemonURL string, sshFlags []string) (*ConnectionHelper
 		if err != nil {
 			return nil, err
 		}
+
+		// The Host is a dummy URL used for the API client to build requests;
+		// the actual connection is made through the Dialer above. Using the
+		// remote hostname in the dummy URL makes sure that error messages
+		// (e.g. "Cannot connect to the Docker daemon at ...") mention the
+		// host the user configured, instead of a non-descriptive dummy domain.
+		host := sp.Host
+		if sp.Port != "" && sp.Port != "22" {
+			host = net.JoinHostPort(host, sp.Port)
+		}
 		return &ConnectionHelper{
 			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return commandconn.New(ctx, "ssh", sshArgs...)
 			},
-			Host: "http://docker.example.com",
+			Host: "http://" + host,
 		}, nil
 	}
 	// Future version may support plugins via ~/.docker/config.json. e.g. "dind"

--- a/cli/connhelper/connhelper_test.go
+++ b/cli/connhelper/connhelper_test.go
@@ -31,6 +31,48 @@ func TestSSHFlags(t *testing.T) {
 	}
 }
 
+func TestConnectionHelperHostIncludesRemoteHost(t *testing.T) {
+	testCases := []struct {
+		name      string
+		daemonURL string
+		expected  string
+	}{
+		{
+			name:      "ssh with user and default port",
+			daemonURL: "ssh://user@myserver.local",
+			expected:  "http://myserver.local",
+		},
+		{
+			name:      "ssh with custom port",
+			daemonURL: "ssh://user@myserver.local:2222",
+			expected:  "http://myserver.local:2222",
+		},
+		{
+			name:      "ssh with explicit default port",
+			daemonURL: "ssh://myserver.local:22",
+			expected:  "http://myserver.local",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			helper, err := GetConnectionHelper(tc.daemonURL)
+			assert.NilError(t, err)
+			assert.Assert(t, helper != nil)
+			assert.Equal(t, helper.Host, tc.expected,
+				"dummy Host URL must include the remote hostname so connection errors point to the daemon the user configured (docker/cli#5604)")
+			assert.Assert(t, helper.Dialer != nil)
+		})
+	}
+}
+
+func TestGetCommandConnectionHelperHost(t *testing.T) {
+	helper, err := GetCommandConnectionHelper("fake-command")
+	assert.NilError(t, err)
+	assert.Assert(t, helper != nil)
+	assert.Equal(t, helper.Host, "http://docker.example.com")
+}
+
 func TestDisablePseudoTerminalAllocation(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
## Description

When connecting to a daemon over `ssh://`, `ConnectionHelper.Host` is used as a dummy URL for the API client (Go's stdlib requires a valid hostname in requests). That dummy value — `http://docker.example.com` — also ends up in connection error messages, so a failed connection reports:

```
Error: Cannot connect to the Docker daemon at http://docker.example.com. Is the docker daemon running?
```

which makes users believe the client is trying to connect to `docker.example.com` instead of the remote host they configured. This was reported in #5604; as suggested there, this change makes the error mention the hostname the user actually provided.

**What this changes**

For ssh connections, the dummy URL now embeds the remote hostname (and the port, when non-default), so the error reads e.g.:

```
Error: Cannot connect to the Docker daemon at http://myserver.local. Is the docker daemon running?
```

The URL remains a pure dummy: the actual connection is established through the ssh `Dialer` (`docker system dial-stdio` over ssh), so request transport behavior is unchanged. Command-based connection helpers (`GetCommandConnectionHelper`) keep the generic dummy host since there is no meaningful hostname to surface.

**Tests**

Added `TestConnectionHelperHostIncludesRemoteHost` covering plain/user+host/custom-port/explicit-default-port ssh URLs, and `TestGetCommandConnectionHelperHost` pinning the generic dummy for command-based helpers. `go test ./cli/connhelper/...` passes.

**AI assistance disclosure**

This change was implemented with assistance from an AI coding agent (design direction informed by the discussion in #5604); the resulting code has been reviewed for correctness and follows the existing style of the package.

- fixes #5604

**Changelog**

```changelog
fix: make connection error messages for ssh-based connections point to the remote host the user configured instead of "docker.example.com"
```

**A picture of a cute animal (not mandatory but encouraged)**

![](https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg)