### PR TITLE
cli/compose: accept numeric cpus in stack deploy schema

### DIFF
--- a/cli/compose/loader/loader.go
+++ b/cli/compose/loader/loader.go
@@ -299,7 +299,8 @@ func Transform(source any, target any, additionalTransformers ...Transformer) er
 	config := &mapstructure.DecoderConfig{
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			createTransformHook(additionalTransformers...),
-			mapstructure.StringToTimeDurationHookFunc()),
+			mapstructure.StringToTimeDurationHookFunc(),
+			numberToStringHook()),
 		Result:   target,
 		Metadata: &data,
 	}
@@ -353,6 +354,28 @@ func createTransformHook(additionalTransformers ...Transformer) mapstructure.Dec
 			return data, nil
 		}
 		return transform(data)
+	}
+}
+
+// numberToStringHook lets numeric YAML/JSON values land in string fields
+// (notably deploy.resources.*.cpus, which compose config emits as numbers).
+func numberToStringHook() mapstructure.DecodeHookFunc {
+	return func(_ reflect.Type, to reflect.Type, data any) (any, error) {
+		if to.Kind() != reflect.String {
+			return data, nil
+		}
+		switch v := data.(type) {
+		case string:
+			return v, nil
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			return fmt.Sprint(v), nil
+		case float32:
+			return strconv.FormatFloat(float64(v), 'f', -1, 32), nil
+		case float64:
+			return strconv.FormatFloat(v, 'f', -1, 64), nil
+		default:
+			return data, nil
+		}
 	}
 }
 

--- a/cli/compose/loader/loader_test.go
+++ b/cli/compose/loader/loader_test.go
@@ -902,6 +902,37 @@ func TestInvalidResource(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "Additional property impossible is not allowed"))
 }
 
+func TestLoadNumericCPUs(t *testing.T) {
+	config, err := loadYAML(`
+version: "3.13"
+services:
+  foo:
+    image: busybox
+    deploy:
+      resources:
+        limits:
+          cpus: 0.5
+        reservations:
+          cpus: 1
+`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("0.5", config.Services[0].Deploy.Resources.Limits.NanoCPUs))
+	assert.Check(t, is.Equal("1", config.Services[0].Deploy.Resources.Reservations.NanoCPUs))
+
+	config, err = loadYAML(`
+version: "3.13"
+services:
+  foo:
+    image: busybox
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+`)
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("0.25", config.Services[0].Deploy.Resources.Limits.NanoCPUs))
+}
+
 func TestInvalidExternalAndDriverCombination(t *testing.T) {
 	_, err := loadYAML(`
 version: "3"

--- a/cli/compose/schema/data/config_schema_v3.0.json
+++ b/cli/compose/schema/data/config_schema_v3.0.json
@@ -268,7 +268,7 @@
       "id": "#/definitions/resource",
       "type": "object",
       "properties": {
-        "cpus": {"type": "string"},
+        "cpus": {"type": ["number", "string"]},
         "memory": {"type": "string"}
       },
       "additionalProperties": false

--- a/cli/compose/schema/data/config_schema_v3.1.json
+++ b/cli/compose/schema/data/config_schema_v3.1.json
@@ -297,7 +297,7 @@
       "id": "#/definitions/resource",
       "type": "object",
       "properties": {
-        "cpus": {"type": "string"},
+        "cpus": {"type": ["number", "string"]},
         "memory": {"type": "string"}
       },
       "additionalProperties": false

--- a/cli/compose/schema/data/config_schema_v3.10.json
+++ b/cli/compose/schema/data/config_schema_v3.10.json
@@ -391,7 +391,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -400,7 +400,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.11.json
+++ b/cli/compose/schema/data/config_schema_v3.11.json
@@ -391,7 +391,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -400,7 +400,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.12.json
+++ b/cli/compose/schema/data/config_schema_v3.12.json
@@ -392,7 +392,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -401,7 +401,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.13.json
+++ b/cli/compose/schema/data/config_schema_v3.13.json
@@ -399,7 +399,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -408,7 +408,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.2.json
+++ b/cli/compose/schema/data/config_schema_v3.2.json
@@ -343,7 +343,7 @@
       "id": "#/definitions/resource",
       "type": "object",
       "properties": {
-        "cpus": {"type": "string"},
+        "cpus": {"type": ["number", "string"]},
         "memory": {"type": "string"}
       },
       "additionalProperties": false

--- a/cli/compose/schema/data/config_schema_v3.3.json
+++ b/cli/compose/schema/data/config_schema_v3.3.json
@@ -391,7 +391,7 @@
       "id": "#/definitions/resource",
       "type": "object",
       "properties": {
-        "cpus": {"type": "string"},
+        "cpus": {"type": ["number", "string"]},
         "memory": {"type": "string"}
       },
       "additionalProperties": false

--- a/cli/compose/schema/data/config_schema_v3.4.json
+++ b/cli/compose/schema/data/config_schema_v3.4.json
@@ -398,7 +398,7 @@
       "id": "#/definitions/resource",
       "type": "object",
       "properties": {
-        "cpus": {"type": "string"},
+        "cpus": {"type": ["number", "string"]},
         "memory": {"type": "string"}
       },
       "additionalProperties": false

--- a/cli/compose/schema/data/config_schema_v3.5.json
+++ b/cli/compose/schema/data/config_schema_v3.5.json
@@ -363,7 +363,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false
@@ -371,7 +371,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.6.json
+++ b/cli/compose/schema/data/config_schema_v3.6.json
@@ -372,7 +372,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false
@@ -380,7 +380,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.7.json
+++ b/cli/compose/schema/data/config_schema_v3.7.json
@@ -388,7 +388,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false
@@ -396,7 +396,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.8.json
+++ b/cli/compose/schema/data/config_schema_v3.8.json
@@ -389,7 +389,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"}
               },
               "additionalProperties": false
@@ -397,7 +397,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/data/config_schema_v3.9.json
+++ b/cli/compose/schema/data/config_schema_v3.9.json
@@ -391,7 +391,7 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "pids": {"type": "integer"}
               },
@@ -400,7 +400,7 @@
             "reservations": {
               "type": "object",
               "properties": {
-                "cpus": {"type": "string"},
+                "cpus": {"type": ["number", "string"]},
                 "memory": {"type": "string"},
                 "generic_resources": {"$ref": "#/definitions/generic_resources"}
               },

--- a/cli/compose/schema/schema_test.go
+++ b/cli/compose/schema/schema_test.go
@@ -135,6 +135,29 @@ func TestValidatePorts(t *testing.T) {
 	}
 }
 
+func TestValidateNumericCPUs(t *testing.T) {
+	config := dict{
+		"services": dict{
+			"foo": dict{
+				"image": "busybox",
+				"deploy": dict{
+					"resources": dict{
+						"limits": dict{
+							"cpus": 0.5,
+						},
+						"reservations": dict{
+							"cpus": 1,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NilError(t, Validate(config, "3.13"))
+	assert.NilError(t, Validate(config, "3"))
+}
+
 func TestValidateUndefinedTopLevelOption(t *testing.T) {
 	config := dict{
 		"version": "3.0",


### PR DESCRIPTION
`docker compose config` writes `deploy.resources.*.cpus` as a number. `docker stack deploy` still uses the v3 schema, which only allowed a string, so piping one into the other dies with `cpus must be a string`.

Allow number or string in the schema, and stringify numbers on load so the existing NanoCPUs parser still works.

Fixes #5009