### PR TITLE
cli: use configured endpoint for proxy lookup

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -466,6 +466,16 @@ func (cli *DockerCli) DockerEndpoint() docker.Endpoint {
 	return cli.dockerEndpoint
 }
 
+// DaemonHost returns the configured daemon endpoint. For connection helpers,
+// the API client's host is an internal HTTP placeholder, so use the original
+// endpoint when it is available.
+func DaemonHost(cli Cli) string {
+	if host := cli.DockerEndpoint().Host; host != "" {
+		return host
+	}
+	return cli.Client().DaemonHost()
+}
+
 func (cli *DockerCli) getDockerEndPoint() (ep docker.Endpoint, err error) {
 	cn := cli.CurrentContext()
 	if cn == DefaultContextName {

--- a/cli/command/container/client_test.go
+++ b/cli/command/container/client_test.go
@@ -27,6 +27,7 @@ func (e fakeStreamResult) Close() error               { return e.ReadCloser.Clos
 
 type fakeClient struct {
 	client.Client
+	daemonHost              string
 	inspectFunc             func(string) (client.ContainerInspectResult, error)
 	execInspectFunc         func(execID string) (client.ExecInspectResult, error)
 	execCreateFunc          func(containerID string, options client.ExecCreateOptions) (client.ExecCreateResult, error)
@@ -53,6 +54,10 @@ type fakeClient struct {
 	containerCommitFunc     func(ctx context.Context, container string, options client.ContainerCommitOptions) (client.ContainerCommitResult, error)
 	containerPauseFunc      func(ctx context.Context, container string, options client.ContainerPauseOptions) (client.ContainerPauseResult, error)
 	Version                 string
+}
+
+func (f *fakeClient) DaemonHost() string {
+	return f.daemonHost
 }
 
 func (f *fakeClient) ContainerList(_ context.Context, options client.ContainerListOptions) (client.ContainerListResult, error) {

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -102,7 +102,7 @@ func runCreate(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet,
 			StatusCode: 125,
 		}
 	}
-	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(dockerCLI.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
+	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(command.DaemonHost(dockerCLI), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
 	newEnv := make([]string, 0, len(proxyConfig))
 	for k, v := range proxyConfig {
 		if v == nil {

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/context/docker"
 	"github.com/docker/cli/internal/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/moby/moby/api/types/container"
@@ -309,6 +310,33 @@ func TestCreateContainerWithProxyConfig(t *testing.T) {
 	cmd.SetArgs([]string{"image:tag"})
 	err := cmd.Execute()
 	assert.NilError(t, err)
+}
+
+func TestCreateContainerWithSSHHostProxyConfig(t *testing.T) {
+	const (
+		sshHost   = "ssh://daemon.example.com"
+		dummyHost = "http://docker.example.com"
+	)
+
+	fakeCLI := test.NewFakeCli(&fakeClient{
+		daemonHost: dummyHost,
+		createContainerFunc: func(options client.ContainerCreateOptions) (client.ContainerCreateResult, error) {
+			assert.Check(t, is.Contains(options.Config.Env, "HTTP_PROXY=http://ssh-proxy.example.com"))
+			return client.ContainerCreateResult{}, nil
+		},
+	})
+	fakeCLI.SetDockerEndpoint(docker.Endpoint{EndpointMeta: docker.EndpointMeta{Host: sshHost}})
+	fakeCLI.SetConfigFile(&configfile.ConfigFile{
+		Proxies: map[string]configfile.ProxyConfig{
+			"default": {HTTPProxy: "http://default-proxy.example.com"},
+			sshHost:   {HTTPProxy: "http://ssh-proxy.example.com"},
+		},
+	})
+
+	cmd := newCreateCommand(fakeCLI)
+	cmd.SetOut(io.Discard)
+	cmd.SetArgs([]string{"image:tag"})
+	assert.NilError(t, cmd.Execute())
 }
 
 type fakeNotFound struct{}

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -91,7 +91,7 @@ func runRun(ctx context.Context, dockerCLI command.Cli, flags *pflag.FlagSet, ro
 			StatusCode: 125,
 		}
 	}
-	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(dockerCLI.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
+	proxyConfig := dockerCLI.ConfigFile().ParseProxyConfig(command.DaemonHost(dockerCLI), opts.ConvertKVStringsToMapWithNil(copts.env.GetSlice()))
 	newEnv := []string{}
 	for k, v := range proxyConfig {
 		if v == nil {

--- a/cli/command/image/build.go
+++ b/cli/command/image/build.go
@@ -434,7 +434,7 @@ func imageBuildOptions(dockerCli command.Cli, options buildOptions) client.Image
 		CgroupParent:   options.cgroupParent,
 		ShmSize:        options.shmSize.Value(),
 		Ulimits:        options.ulimits.GetList(),
-		BuildArgs:      configFile.ParseProxyConfig(dockerCli.Client().DaemonHost(), opts.ConvertKVStringsToMapWithNil(options.buildArgs.GetSlice())),
+		BuildArgs:      configFile.ParseProxyConfig(command.DaemonHost(dockerCli), opts.ConvertKVStringsToMapWithNil(options.buildArgs.GetSlice())),
 		Labels:         opts.ConvertKVStringsToMap(options.labels.GetSlice()),
 		CacheFrom:      options.cacheFrom,
 		SecurityOpt:    options.securityOpt,


### PR DESCRIPTION
**- What I did**

Use the configured Docker endpoint, rather than a connection helper's internal HTTP placeholder, when selecting per-daemon proxy configuration for container create/run and image build.

Fixes #5797.

**- How I did it**

Added a shared daemon-host resolver that prefers the original endpoint and falls back to the API client's host for test and compatibility paths. Added a regression covering an SSH endpoint whose API client uses `http://docker.example.com` internally.

**- How to verify it**

```console
TZ=UTC ./scripts/with-go-mod.sh go test ./cli/command ./cli/command/container ./cli/command/image -count=1
```

Configure distinct `default` and `ssh://daemon.example.com` entries under `proxies`, then create or run a container through that SSH context. The container receives the SSH endpoint's proxy values.

**- Human readable description for the release notes**

```markdown changelog
Use per-daemon proxy configuration for SSH Docker contexts.
```

**- A picture of a cute animal (not mandatory but encouraged)**

Not included.
