### PR TITLE
docs: Update DCO identity guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ Then you just add a line to every git commit message:
 
     Signed-off-by: Joe Smith <joe.smith@email.com>
 
-Use your real name (sorry, no pseudonyms or anonymous contributions.)
+Use a known identity (sorry, no anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.


### PR DESCRIPTION
The DCO policy used here appears to have been derived from the Linux kernel's guidance. In 2023, that guidance changed to relax the "real name" requirement to a "known identity".

The DCO sign-off identifies the person certifying that they have the right to submit a contribution. The previous wording required a "real name" and rejected pseudonyms, which could discourage contributors whose preferred or community name is the identity by which they can be known.

The requirement is not anonymity: the identity in the sign-off must be known enough for the project to follow up about the contribution if a question arises. It does not require a legal name or a government-issued identity. Use the clarified wording from the Linux kernel so known pseudonyms and preferred names remain acceptable while anonymous contributions remain excluded.

This also reflects concerns raised in the CNCF community about whether "real name" means a legal name, a government-issued identity, or a public identity that is sufficient to identify and contact a contributor. The discussion emphasized that attribution and future accountability do not require publishing a legal identity, and that strict public-name rules can exclude people who cannot safely contribute under that name.

Source: https://github.com/cncf/foundation/issues/383
Source: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d4563201f33a022fc035
