### PR TITLE
container: allow an empty --cidfile path from mktemp

### DIFF
--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -198,13 +198,20 @@ func newCIDFile(cidPath string) (*cidFile, error) {
 	if cidPath == "" {
 		return &cidFile{}, nil
 	}
-	if _, err := os.Stat(cidPath); err == nil {
-		return nil, errors.New("container ID file found, make sure the other container isn't running or delete " + cidPath)
-	}
-
-	f, err := os.Create(cidPath)
+	// mktemp (and similar) create an empty file first. Only refuse the path
+	// when it already holds a container ID from another run.
+	f, err := os.OpenFile(cidPath, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the container ID file: %w", err)
+	}
+	st, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("failed to create the container ID file: %w", err)
+	}
+	if st.Size() > 0 {
+		_ = f.Close()
+		return nil, errors.New("container ID file found, make sure the other container isn't running or delete " + cidPath)
 	}
 
 	return &cidFile{path: cidPath, file: f}, nil

--- a/cli/command/container/create.go
+++ b/cli/command/container/create.go
@@ -200,7 +200,7 @@ func newCIDFile(cidPath string) (*cidFile, error) {
 	}
 	// mktemp (and similar) create an empty file first. Only refuse the path
 	// when it already holds a container ID from another run.
-	f, err := os.OpenFile(cidPath, os.O_RDWR|os.O_CREATE, 0o644)
+	f, err := os.OpenFile(cidPath, os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the container ID file: %w", err)
 	}

--- a/cli/command/container/create_test.go
+++ b/cli/command/container/create_test.go
@@ -37,9 +37,25 @@ func TestCIDFileNoOPWithNoFilename(t *testing.T) {
 func TestNewCIDFileWhenFileAlreadyExists(t *testing.T) {
 	tempfile := fs.NewFile(t, "test-cid-file")
 	defer tempfile.Remove()
+	assert.NilError(t, os.WriteFile(tempfile.Path(), []byte("already-running"), 0o644))
 
 	_, err := newCIDFile(tempfile.Path())
 	assert.ErrorContains(t, err, "container ID file found")
+}
+
+func TestNewCIDFileWhenEmptyFileExists(t *testing.T) {
+	tempfile := fs.NewFile(t, "test-cid-file")
+	defer tempfile.Remove()
+
+	file, err := newCIDFile(tempfile.Path())
+	assert.NilError(t, err)
+
+	assert.NilError(t, file.Write("id"))
+	assert.NilError(t, file.Close())
+
+	actual, err := os.ReadFile(tempfile.Path())
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("id", string(actual)))
 }
 
 func TestCIDFileCloseWithNoWrite(t *testing.T) {


### PR DESCRIPTION
`--cidfile` currently errors if the path already exists, even when the file is empty.

that's a pain with `mktemp`, which creates the file first:

```
t=$(mktemp)
docker run --rm --cidfile=$t debian
```

only refuse the path if it already has content (another container's id). empty files get reused.

Fixes #5954