### PR TITLE
container: don't copy stdin from a background TTY

### DIFF
--- a/cli/command/container/attach.go
+++ b/cli/command/container/attach.go
@@ -103,7 +103,7 @@ func RunAttach(ctx context.Context, dockerCLI command.Cli, containerID string, o
 
 	var in io.ReadCloser
 	if options.Stdin {
-		in = dockerCLI.In()
+		in = stdinForAttach(dockerCLI.In())
 	}
 
 	if opts.Proxy && !c.Config.Tty {

--- a/cli/command/container/background.go
+++ b/cli/command/container/background.go
@@ -1,0 +1,16 @@
+package container
+
+import (
+	"io"
+
+	"github.com/docker/cli/cli/streams"
+)
+
+// stdinForAttach returns stdin for hijacking, or nil when copying it would
+// spin (a background job whose stdin is still the controlling TTY).
+func stdinForAttach(in *streams.In) io.ReadCloser {
+	if stdinFromBackgroundJob(in) {
+		return nil
+	}
+	return in
+}

--- a/cli/command/container/background_test.go
+++ b/cli/command/container/background_test.go
@@ -1,0 +1,22 @@
+package container
+
+import (
+	"os"
+	"testing"
+
+	"github.com/docker/cli/cli/streams"
+	"gotest.tools/v3/assert"
+)
+
+func TestStdinForAttachNonTTY(t *testing.T) {
+	r, w, err := os.Pipe()
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	in := streams.NewIn(r)
+	got := stdinForAttach(in)
+	assert.Equal(t, got, in)
+}

--- a/cli/command/container/background_unix.go
+++ b/cli/command/container/background_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package container
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/docker/cli/cli/streams"
+)
+
+// stdinFromBackgroundJob reports whether stdin is a TTY whose foreground
+// process group is not us. Reading that TTY from a background job (for
+// example `docker run -i ... &`) produces SIGTTIN; the CLI catches every
+// signal for forwarding, so the default stop-in-background does not fire
+// and the read retries in a tight loop.
+func stdinFromBackgroundJob(in *streams.In) bool {
+	if in == nil || !in.IsTerminal() {
+		return false
+	}
+	fg, err := unix.IoctlGetInt(int(in.FD()), unix.TIOCGPGRP)
+	if err != nil {
+		return false
+	}
+	return unix.Getpgrp() != fg
+}

--- a/cli/command/container/background_windows.go
+++ b/cli/command/container/background_windows.go
@@ -1,0 +1,7 @@
+package container
+
+import "github.com/docker/cli/cli/streams"
+
+func stdinFromBackgroundJob(_ *streams.In) bool {
+	return false
+}

--- a/cli/command/container/exec.go
+++ b/cli/command/container/exec.go
@@ -144,7 +144,7 @@ func interactiveExec(ctx context.Context, dockerCli command.Cli, execOptions *cl
 	)
 
 	if execOptions.AttachStdin {
-		in = dockerCli.In()
+		in = stdinForAttach(dockerCli.In())
 	}
 	if execOptions.AttachStdout {
 		out = dockerCli.Out()

--- a/cli/command/container/run.go
+++ b/cli/command/container/run.go
@@ -277,7 +277,7 @@ func attachContainer(ctx context.Context, dockerCli command.Cli, containerID str
 		in        io.ReadCloser
 	)
 	if options.Stdin {
-		in = dockerCli.In()
+		in = stdinForAttach(dockerCli.In())
 	}
 	if options.Stdout {
 		out = dockerCli.Out()

--- a/cli/command/container/signals.go
+++ b/cli/command/container/signals.go
@@ -44,7 +44,7 @@ func ForwardAllSignals(ctx context.Context, apiClient client.ContainerAPIClient,
 				break
 			}
 		}
-		if sig == "" {
+		if sig == "" || sig == "TTIN" || sig == "TTOU" {
 			continue
 		}
 

--- a/cli/command/container/start.go
+++ b/cli/command/container/start.go
@@ -112,7 +112,7 @@ func RunStart(ctx context.Context, dockerCli command.Cli, opts *StartOptions) er
 		var in io.ReadCloser
 
 		if options.Stdin {
-			in = dockerCli.In()
+			in = stdinForAttach(dockerCli.In())
 		}
 
 		resp, errAttach := dockerCli.Client().ContainerAttach(ctx, c.Container.ID, options)


### PR DESCRIPTION
`docker run -i ... &` still has stdin pointed at the terminal. reading that from a background process group raises SIGTTIN, and because we catch every signal (to forward them) the default "stop in the background" never happens — the read just retries and the CLI sits at 100% cpu.

if we're not the foreground pgrp, skip the stdin copy. also stop forwarding TTIN/TTOU.

Fixes #6005