### PR TITLE
completion: fix zsh __docker_plugins bad math expression

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -1551,32 +1551,18 @@ __docker_plugin_complete_ls_filters() {
 __docker_plugins() {
     [[ $PREFIX = -* ]] && return 1
     integer ret=1
-    local line s
+    local line name id
     declare -a lines plugins args
 
     filter=$1; shift
-    [[ $filter != "none" ]] && args=("-f $filter")
+    [[ $filter != "none" ]] && args=("-f" "$filter")
 
-    lines=(${(f)${:-"$(_call_program commands docker $docker_options plugin ls $args)"$'\n'}})
+    lines=(${(f)${:-"$(_call_program commands docker $docker_options plugin ls --format '{{.Name}}\t{{.ID}}' $args)"$'\n'}})
 
-    # Parse header line to find columns
-    local i=1 j=1 k header=${lines[1]}
-    declare -A begin end
-    while (( j < ${#header} - 1 )); do
-        i=$(( j + ${${header[$j,-1]}[(i)[^ ]]} - 1 ))
-        j=$(( i + ${${header[$i,-1]}[(i)  ]} - 1 ))
-        k=$(( j + ${${header[$j,-1]}[(i)[^ ]]} - 2 ))
-        begin[${header[$i,$((j-1))]}]=$i
-        end[${header[$i,$((j-1))]}]=$k
-    done
-    end[${header[$i,$((j-1))]}]=-1
-    lines=(${lines[2,-1]})
-
-    # Name
     for line in $lines; do
-        s="${line[${begin[NAME]},${end[NAME]}]%% ##}"
-        s="$s:${(l:7:: :::)${${line[${begin[TAG]},${end[TAG]}]}%% ##}}"
-        plugins=($plugins $s)
+        name="${line%%$'\t'*}"
+        id="${line#*$'\t'}"
+        plugins+=("${name//:/\\:}:$id")
     done
 
     _describe -t plugins-list "plugins" plugins "$@" && ret=0


### PR DESCRIPTION
The \TAG\ column no longer exists in \docker plugin ls\ output. When the \__docker_plugins\ function tried to extract the non-existent \TAG\ column, the header parser returned an empty string for \egin[TAG]\ and \end[TAG]\, which evaluated to \