### PR TITLE
registry: treat basic-auth 401 as unauthorized

### DIFF
--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs/pkg/errhttp"
 	"github.com/containerd/log"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -67,11 +68,7 @@ func loginV2(ctx context.Context, authConfig *registry.AuthConfig, endpoint APIE
 
 	if resp.StatusCode != http.StatusOK {
 		// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
-		err := fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
-		if resp.StatusCode == http.StatusUnauthorized {
-			return "", unauthorizedErr{err}
-		}
-		return "", err
+		return "", fmt.Errorf("login attempt to %s failed with status: %d %s: %w", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode), errhttp.ToNative(resp.StatusCode))
 	}
 
 	return credentialAuthConfig.IdentityToken, nil

--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -67,7 +67,11 @@ func loginV2(ctx context.Context, authConfig *registry.AuthConfig, endpoint APIE
 
 	if resp.StatusCode != http.StatusOK {
 		// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
-		return "", fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
+		err := fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return "", unauthorizedErr{err}
+		}
+		return "", err
 	}
 
 	return credentialAuthConfig.IdentityToken, nil

--- a/internal/registry/auth_test.go
+++ b/internal/registry/auth_test.go
@@ -1,0 +1,40 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/registry"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+func TestLoginV2BasicAuthUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "alice" || pass != "secret" {
+			w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+			http.Error(w, "401 Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	assert.NilError(t, err)
+	endpoint := APIEndpoint{URL: u}
+	ctx := context.Background()
+
+	_, err = loginV2(ctx, &registry.AuthConfig{Username: "alice", Password: "wrong"}, endpoint, "docker-test")
+	assert.ErrorContains(t, err, "401")
+	assert.Check(t, errdefs.IsUnauthorized(err))
+
+	token, err := loginV2(ctx, &registry.AuthConfig{Username: "alice", Password: "secret"}, endpoint, "docker-test")
+	assert.NilError(t, err)
+	assert.Check(t, is.Equal("", token))
+}

--- a/internal/registry/auth_test.go
+++ b/internal/registry/auth_test.go
@@ -33,6 +33,7 @@ func TestLoginV2BasicAuthUnauthorized(t *testing.T) {
 	_, err = loginV2(ctx, &registry.AuthConfig{Username: "alice", Password: "wrong"}, endpoint, "docker-test")
 	assert.ErrorContains(t, err, "401")
 	assert.Check(t, errdefs.IsUnauthorized(err))
+	assert.Check(t, is.ErrorType(err, errdefs.IsUnauthorized))
 
 	token, err := loginV2(ctx, &registry.AuthConfig{Username: "alice", Password: "secret"}, endpoint, "docker-test")
 	assert.NilError(t, err)

--- a/vendor.mod
+++ b/vendor.mod
@@ -14,6 +14,7 @@ tool (
 require (
 	dario.cat/mergo v1.0.2
 	github.com/containerd/errdefs v1.0.0
+	github.com/containerd/errdefs/pkg v0.3.0
 	github.com/containerd/log v0.1.0
 	github.com/containerd/platforms v1.0.0-rc.5
 	github.com/creack/pty v1.1.24
@@ -75,7 +76,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
-	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/docker/go-events v0.0.0-20260608200158-dbf6103125a4 // indirect
 	github.com/docker/go-metrics v0.1.0 // indirect


### PR DESCRIPTION
daemon-less `docker login` was turning a 401 into a plain error, so `Auth()` tried the next endpoint. against a Basic-Auth registry that can print `Login Succeeded` for a wrong password (the HTTP fallback answering 200).

mark 401 as unauthorized and stop.

Fixes #7237