### PR TITLE
.gitattributes: force LF for golden and testdata pem files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,5 +10,9 @@ vendor.sum linguist-language=Go-Checksums
 # without extensions, so we need to force
 scripts/** text=auto eol=lf
 
+# golden files and testdata certificates are compared byte-for-byte by tests
+*.golden text eol=lf
+*.pem text eol=lf
+
 # shell scripts should always have LF
 *.sh text eol=lf


### PR DESCRIPTION
**- What I did**

Made `.gitattributes` check out `*.golden` and `*.pem` with LF endings.

**- How I did it**

`gotest.tools/v3/golden` compares byte-for-byte and strips CRLF from the value under test only, never from the golden file, so a CRLF golden can never match. Its doc comment recommends fixing that in `.gitattributes`. The existing `* text=auto` exempts `*.go`, `scripts/**` and `*.sh`, but not the 222 `.golden` files or `cli/command/testdata/ca.pem`. On a Windows checkout with `core.autocrlf=true`, 220 of those 223 arrive as CRLF. The other three are empty.

The blobs are already LF, so no file content changes here. Only the checkout does.

`* text=auto eol=lf` was added in 2bd4e95bf1 and reverted in 4a6ab2b37d ("fix: binary file line endings"). This rule is scoped to the two extensions that tests compare byte-for-byte.

**- How to verify it**

On Windows with `core.autocrlf=true`, running what CI runs:

```
go test $(go list ./... | grep -vE '^github.com/docker/cli/e2e/')

before: 35 ok, 28 FAIL
after:  46 ok, 17 FAIL
```

go1.26.5 windows/amd64, 90 packages listed, 63 of them with tests. I have only run this on Windows. No line-ending mismatch is left in the output. The 17 that remain fail for other reasons, among them `syscall.Kill` in three `_test.go` files, `os.Symlink` privileges and `unix://` endpoints built from a `C:\` temp path.

**- Human readable description for the release notes**

Not user-facing.

```markdown changelog

```
