### PR TITLE
cmd/docker: print command error before running error hooks

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -517,6 +517,9 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		subCommand = ccmd
 		if err != nil || pluginmanager.IsPluginCommand(ccmd) {
 			err := tryPluginRun(ctx, dockerCli, cmd, args[0], envs)
+			if err != nil && !errdefs.IsNotFound(err) && !errdefs.IsCanceled(err) && err.Error() != "" {
+				_, _ = fmt.Fprintln(dockerCli.Err(), err)
+			}
 			if ccmd != nil && dockerCli.Out().IsTerminal() && dockerCli.HooksEnabled() && !errdefs.IsNotFound(err) {
 				errMessage := cmdErrorMessage(err)
 				pluginmanager.RunPluginHooks(ctx, dockerCli, cmd, ccmd, args, errMessage)
@@ -528,7 +531,7 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 				// For plugin not found we fall through to
 				// cmd.Execute() which deals with reporting
 				// "command not found" in a consistent way.
-				return err
+				return cli.StatusError{StatusCode: getExitCode(err)}
 			}
 		}
 	}

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -541,6 +541,9 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 	// which remain.
 	cmd.SetArgs(args)
 	err = cmd.ExecuteContext(ctx)
+	if err != nil && !errdefs.IsCanceled(err) && err.Error() != "" {
+		_, _ = fmt.Fprintln(dockerCli.Err(), err)
+	}
 
 	// If the command is being executed in an interactive terminal
 	// and hook are enabled, run the plugin hooks.
@@ -548,7 +551,11 @@ func runDocker(ctx context.Context, dockerCli *command.DockerCli) error {
 		pluginmanager.RunCLICommandHooks(ctx, dockerCli, cmd, subCommand, cmdErrorMessage(err))
 	}
 
-	return err
+	if err != nil {
+		return cli.StatusError{StatusCode: getExitCode(err)}
+	}
+
+	return nil
 }
 
 // hasCompletionArg returns true if a cobra completion arg request is found.


### PR DESCRIPTION
﻿fixes #6973

**- What I did**
Printed the command error to `dockerCli.Err()` before invoking plugin error hooks in `runDocker`.

**- How I did it**
Previously, `runDocker()` returned the command error to `main()`, which printed it to `os.Stderr` *after* `runDocker()` had already executed the plugin hooks (`RunCLICommandHooks`). This caused the "What's next:" hint to be printed before the command output/error.

By printing the error before executing the hooks and returning a `cli.StatusError` with the status code, the error is output first, followed by any hook suggestions ("What's next:"), and `main()` exits cleanly with the correct status code without duplicate output.

**- How to verify it**
Run a command that fails in an interactive terminal with error hooks enabled (e.g. `docker run --rm --env-file=./no-such-file alpine`).
Verify that the command error is printed before the "What's next:" section.

**- Description for the changelog**
```markdown changelog
Fix error hooks ("What's next:") being printed before command output on failures.
```
