### PR TITLE
Fix docker login treating 401 Unauthorized as success for Basic-Auth …

### DIFF
--- a/internal/registry/auth.go
+++ b/internal/registry/auth.go
@@ -65,6 +65,9 @@ func loginV2(ctx context.Context, authConfig *registry.AuthConfig, endpoint APIE
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", unauthorizedErr{fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))}
+	}
 	if resp.StatusCode != http.StatusOK {
 		// TODO(dmcgowan): Attempt to further interpret result, status code and error code string
 		return "", fmt.Errorf("login attempt to %s failed with status: %d %s", endpointStr, resp.StatusCode, http.StatusText(resp.StatusCode))


### PR DESCRIPTION
…registries

When the Docker daemon is not running, docker login falls back to a client-side authentication path. For Basic-Auth registries (those that respond with WWW-Authenticate: Basic without Bearer-token challenge), a 401 Unauthorized response was being treated as a successful login instead of a failure.

The issue was in loginV2() which returned a generic error for non-200 status codes, but did not specifically mark 401 responses as unauthorized errors. This caused errdefs.IsUnauthorized() to return false, and the error was not properly propagated as an authentication failure.

This fix adds an explicit check for http.StatusUnauthorized and returns an unauthorizedErr wrapper so that the error is correctly identified as an authentication failure.

Fixes: docker/cli#7237

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog

```

**- A picture of a cute animal (not mandatory but encouraged)**
