### PR TITLE
formatter: add raw byte sizes for images

### DIFF
--- a/cli/command/formatter/image.go
+++ b/cli/command/formatter/image.go
@@ -194,16 +194,19 @@ type imageContext struct {
 func newImageContext() *imageContext {
 	imageCtx := imageContext{}
 	imageCtx.Header = SubHeaderContext{
-		"ID":           imageIDHeader,
-		"Repository":   repositoryHeader,
-		"Tag":          tagHeader,
-		"Digest":       digestHeader,
-		"CreatedSince": CreatedSinceHeader,
-		"CreatedAt":    CreatedAtHeader,
-		"Size":         SizeHeader,
-		"Containers":   containersHeader,
-		"SharedSize":   sharedSizeHeader,
-		"UniqueSize":   uniqueSizeHeader,
+		"ID":              imageIDHeader,
+		"Repository":      repositoryHeader,
+		"Tag":             tagHeader,
+		"Digest":          digestHeader,
+		"CreatedSince":    CreatedSinceHeader,
+		"CreatedAt":       CreatedAtHeader,
+		"Size":            SizeHeader,
+		"SizeBytes":       "SIZE BYTES",
+		"Containers":      containersHeader,
+		"SharedSize":      sharedSizeHeader,
+		"SharedSizeBytes": "SHARED SIZE BYTES",
+		"UniqueSize":      uniqueSizeHeader,
+		"UniqueSizeBytes": "UNIQUE SIZE BYTES",
 	}
 	return &imageCtx
 }
@@ -249,6 +252,10 @@ func (c *imageContext) Size() string {
 	return units.HumanSizeWithPrecision(float64(c.i.Size), 3)
 }
 
+func (c *imageContext) SizeBytes() *int64 {
+	return optionalImageSize(c.i.Size)
+}
+
 func (c *imageContext) Containers() string {
 	if c.i.Containers == -1 {
 		return "N/A"
@@ -263,9 +270,27 @@ func (c *imageContext) SharedSize() string {
 	return units.HumanSize(float64(c.i.SharedSize))
 }
 
+func (c *imageContext) SharedSizeBytes() *int64 {
+	return optionalImageSize(c.i.SharedSize)
+}
+
 func (c *imageContext) UniqueSize() string {
 	if c.i.Size == -1 || c.i.SharedSize == -1 {
 		return "N/A"
 	}
 	return units.HumanSize(float64(c.i.Size - c.i.SharedSize))
+}
+
+func (c *imageContext) UniqueSizeBytes() *int64 {
+	if c.i.Size == -1 || c.i.SharedSize == -1 {
+		return nil
+	}
+	return optionalImageSize(c.i.Size - c.i.SharedSize)
+}
+
+func optionalImageSize(size int64) *int64 {
+	if size == -1 {
+		return nil
+	}
+	return &size
 }

--- a/cli/command/formatter/image_test.go
+++ b/cli/command/formatter/image_test.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +13,34 @@ import (
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
+
+func TestImageContextJSONIncludesRawSizes(t *testing.T) {
+	images := []image.Summary{
+		{ID: "available", RepoTags: []string{"example:latest"}, Size: 20_000, SharedSize: 5_000},
+		{ID: "unavailable", RepoTags: []string{"example:unknown"}, Size: -1, SharedSize: -1},
+	}
+	var out bytes.Buffer
+	err := ImageWrite(ImageContext{
+		Context: Context{Format: NewImageFormat("json", false, false), Output: &out},
+	}, images)
+	assert.NilError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	assert.Equal(t, len(lines), 2)
+
+	var available map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(lines[0]), &available))
+	assert.Equal(t, available["Size"], "20kB")
+	assert.Equal(t, available["SizeBytes"], float64(20_000))
+	assert.Equal(t, available["SharedSizeBytes"], float64(5_000))
+	assert.Equal(t, available["UniqueSizeBytes"], float64(15_000))
+
+	var unavailable map[string]any
+	assert.NilError(t, json.Unmarshal([]byte(lines[1]), &unavailable))
+	assert.Equal(t, unavailable["SizeBytes"], nil)
+	assert.Equal(t, unavailable["SharedSizeBytes"], nil)
+	assert.Equal(t, unavailable["UniqueSizeBytes"], nil)
+}
 
 func TestImageContext(t *testing.T) {
 	imageID := test.RandomID()

--- a/docs/reference/commandline/image_ls.md
+++ b/docs/reference/commandline/image_ls.md
@@ -300,7 +300,12 @@ Valid placeholders for the Go template are listed below:
 | `.Digest`       | Image digest                             |
 | `.CreatedSince` | Elapsed time since the image was created |
 | `.CreatedAt`    | Time when the image was created          |
-| `.Size`         | Image disk size                          |
+| `.Size`         | Image disk size, formatted for humans    |
+| `.SizeBytes`    | Image disk size in bytes                 |
+| `.SharedSize`   | Shared image disk size, formatted for humans |
+| `.SharedSizeBytes` | Shared image disk size in bytes       |
+| `.UniqueSize`   | Unique image disk size, formatted for humans |
+| `.UniqueSizeBytes` | Unique image disk size in bytes       |
 
 When using the `--format` option, the `image` command will either
 output the data exactly as the template declares or, when using the
@@ -343,8 +348,11 @@ b6fa739cedf5        committ                   latest
 
 To list all images in JSON format, use the `json` directive:
 
+Raw byte fields are JSON numbers. When Docker does not provide a size value,
+the corresponding raw field is `null`.
+
 ```console
 $ docker images --format json
-{"Containers":"N/A","CreatedAt":"2021-03-04 03:24:42 +0100 CET","CreatedSince":"5 days ago","Digest":"\u003cnone\u003e","ID":"4dd97cefde62","Repository":"ubuntu","SharedSize":"N/A","Size":"72.9MB","Tag":"latest","UniqueSize":"N/A"}
-{"Containers":"N/A","CreatedAt":"2021-02-17 22:19:54 +0100 CET","CreatedSince":"2 weeks ago","Digest":"\u003cnone\u003e","ID":"28f6e2705743","Repository":"alpine","SharedSize":"N/A","Size":"5.61MB","Tag":"latest","UniqueSize":"N/A"}
+{"Containers":"N/A","CreatedAt":"2021-03-04 03:24:42 +0100 CET","CreatedSince":"5 days ago","Digest":"\u003cnone\u003e","ID":"4dd97cefde62","Repository":"ubuntu","SharedSize":"N/A","SharedSizeBytes":null,"Size":"72.9MB","SizeBytes":72900000,"Tag":"latest","UniqueSize":"N/A","UniqueSizeBytes":null}
+{"Containers":"N/A","CreatedAt":"2021-02-17 22:19:54 +0100 CET","CreatedSince":"2 weeks ago","Digest":"\u003cnone\u003e","ID":"28f6e2705743","Repository":"alpine","SharedSize":"N/A","SharedSizeBytes":null,"Size":"5.61MB","SizeBytes":5610000,"Tag":"latest","UniqueSize":"N/A","UniqueSizeBytes":null}
 ```


### PR DESCRIPTION
**- What I did**

Added exact `SizeBytes`, `SharedSizeBytes`, and `UniqueSizeBytes` values to the image formatter. Related to #5300.

**- How I did it**

`docker image ls --format json` currently returns rounded strings such as `"72.9MB"` or `"N/A"`. The new fields expose the underlying byte counts as JSON numbers, or `null` when unavailable. Existing human-readable fields remain unchanged.

**- How to verify it**

Run:

```console
GOCACHE=/private/tmp/docker-cli-go-cache ./scripts/with-go-mod.sh go test ./cli/command/formatter
```

The formatter test verifies exact values, unique-size calculation, unavailable values, and preservation of the existing `Size` output.

**- Human readable description for the release notes**

```markdown changelog

```
