### PR TITLE
cli/command: Avoid panics after client initialization errors

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -316,7 +316,11 @@ func newAPIClientFromEndpoint(ep docker.Endpoint, configFile *configfile.ConfigF
 		opts = append(opts, withCustomHeaders)
 	}
 	opts = append(opts, extraOpts...)
-	return client.New(opts...)
+	apiClient, err := client.New(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return apiClient, nil
 }
 
 func resolveDockerEndpoint(s store.Reader, contextName string) (docker.Endpoint, error) {

--- a/cli/command/cli_test.go
+++ b/cli/command/cli_test.go
@@ -132,6 +132,15 @@ func TestNewAPIClientFromFlagsWithAPIVersionFromEnv(t *testing.T) {
 	assert.Equal(t, apiclient.ClientVersion(), expectedVersion)
 }
 
+func TestNewAPIClientFromFlagsWithInvalidAPIVersionFromEnv(t *testing.T) {
+	t.Setenv("DOCKER_API_VERSION", "1")
+	t.Setenv("DOCKER_HOST", ":2375")
+
+	apiClient, err := NewAPIClientFromFlags(&flags.ClientOptions{}, &configfile.ConfigFile{})
+	assert.ErrorContains(t, err, "invalid API version")
+	assert.Check(t, apiClient == nil)
+}
+
 type fakeClient struct {
 	client.Client
 	pingFunc   func() (client.PingResult, error)


### PR DESCRIPTION

<!--
Make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Provide the following information:
-->

**- What I did**

When client.New rejects an invalid Docker host or other client option, it returns a nil concrete client with an error.

Returning that pointer directly as client.APIClient stores a typed-nil interface, so lazy version checks dereference it.

Return an error instead.


**- How I did it**

**- How to verify it**

**- Human readable description for the release notes**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section.

NOTE: Only fill this section if changes introduced in this PR are user-facing.
The PR must have a relevant impact/ label.
-->

```markdown changelog
Fix CLI panic when `DOCKER_HOST` or `-H` specifies an invalid host.
```

**- A picture of a cute animal (not mandatory but encouraged)**
