### PR TITLE
vendor: github.com/moby/moby/api v1.56.0 & client v0.6.0

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -34,7 +34,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.28
 	github.com/moby/go-archive v0.3.3
 	github.com/moby/moby/api v1.56.0
-	github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341
+	github.com/moby/moby/client v0.6.0
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/swarmkit/v2 v2.1.2
 	github.com/moby/sys/atomicwriter v0.1.0

--- a/vendor.mod
+++ b/vendor.mod
@@ -33,7 +33,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-runewidth v0.0.28
 	github.com/moby/go-archive v0.3.3
-	github.com/moby/moby/api v1.55.1-0.20260903164743-b9b109e4d341
+	github.com/moby/moby/api v1.56.0
 	github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341
 	github.com/moby/patternmatcher v0.6.1
 	github.com/moby/swarmkit/v2 v2.1.2

--- a/vendor.sum
+++ b/vendor.sum
@@ -88,8 +88,8 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.3.3 h1:OxxR9paxsluYi+zDUEXTTaIxtkK3viymW+Ka7vRhhME=
 github.com/moby/go-archive v0.3.3/go.mod h1:Npdv43fFqlhZW7Xo8fbm3ZMYFvAGNviUPqX21VERbcE=
-github.com/moby/moby/api v1.55.1-0.20260903164743-b9b109e4d341 h1:ooFZgSrQ/xRDfGves7imF3goa+32bEcJrcXIDlL/qpI=
-github.com/moby/moby/api v1.55.1-0.20260903164743-b9b109e4d341/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/moby/moby/api v1.56.0 h1:GQzua3NA599ASSIICx0iFgiJeO9YkdDARvQsm23ZZuQ=
+github.com/moby/moby/api v1.56.0/go.mod h1:sZ+THbVWkjOmBPPfbnzdD/G1LuIexWhqlSHHPTDQ1Uk=
 github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341 h1:/XUuyJxH/HXe5MBcQo+YG9hAtZTQNpWFeJ5PcxL+hs8=
 github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341/go.mod h1:odLstlZ6uSnfvAgVxMpvgmb8SUdd+siH2T0GBuxVAlM=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=

--- a/vendor.sum
+++ b/vendor.sum
@@ -90,8 +90,8 @@ github.com/moby/go-archive v0.3.3 h1:OxxR9paxsluYi+zDUEXTTaIxtkK3viymW+Ka7vRhhME
 github.com/moby/go-archive v0.3.3/go.mod h1:Npdv43fFqlhZW7Xo8fbm3ZMYFvAGNviUPqX21VERbcE=
 github.com/moby/moby/api v1.56.0 h1:GQzua3NA599ASSIICx0iFgiJeO9YkdDARvQsm23ZZuQ=
 github.com/moby/moby/api v1.56.0/go.mod h1:sZ+THbVWkjOmBPPfbnzdD/G1LuIexWhqlSHHPTDQ1Uk=
-github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341 h1:/XUuyJxH/HXe5MBcQo+YG9hAtZTQNpWFeJ5PcxL+hs8=
-github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341/go.mod h1:odLstlZ6uSnfvAgVxMpvgmb8SUdd+siH2T0GBuxVAlM=
+github.com/moby/moby/client v0.6.0 h1:AJjEB21QPbXSXjDsZorFBoDZPhMrfbpaPLgSMAW9Bgs=
+github.com/moby/moby/client v0.6.0/go.mod h1:OCo00wNRyA3m4lmJ228W3JbyCN4ZNNYjpOXiJydBdcQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/swarmkit/v2 v2.1.2 h1:1WDZAI6HVYNKdCG4zlXnTAPyLsLwuhRGWlHoOUf5Z6I=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/moby/moby/api/types/storage
 github.com/moby/moby/api/types/swarm
 github.com/moby/moby/api/types/system
 github.com/moby/moby/api/types/volume
-# github.com/moby/moby/client v0.5.2-0.20260903164743-b9b109e4d341
+# github.com/moby/moby/client v0.6.0
 ## explicit; go 1.24
 github.com/moby/moby/client
 github.com/moby/moby/client/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/moby/go-archive
 github.com/moby/go-archive/compression
 github.com/moby/go-archive/internal/archiveoptions
 github.com/moby/go-archive/tarheader
-# github.com/moby/moby/api v1.55.1-0.20260903164743-b9b109e4d341
+# github.com/moby/moby/api v1.56.0
 ## explicit; go 1.24
 github.com/moby/moby/api/pkg/authconfig
 github.com/moby/moby/api/pkg/stdcopy


### PR DESCRIPTION
### vendor: github.com/moby/moby/api v1.56.0

  full diff: https://github.com/moby/moby/compare/b9b109e4d341...api/v1.56.0



### vendor: github.com/moby/moby/client v0.6.0

  full diff: https://github.com/moby/moby/compare/b9b109e4d341...client/v0.6.0