### PR TITLE
cmd: report unknown command before unknown flag

### DIFF
--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -186,6 +186,10 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	cmd.SetOut(dockerCli.Out())
 	commands.AddCommands(cmd, dockerCli)
 
+	// Stop root flag parsing at the first non-flag so a misspelled command
+	// followed by flags is reported as an unknown command, not "unknown flag".
+	cmd.Flags().SetInterspersed(false)
+
 	visitAll(cmd, setValidateArgs(dockerCli))
 
 	// flags must be the top-level command flags, not cmd.Flags()

--- a/cmd/docker/docker.go
+++ b/cmd/docker/docker.go
@@ -186,10 +186,6 @@ func newDockerCommand(dockerCli *command.DockerCli) *cli.TopLevelCommand {
 	cmd.SetOut(dockerCli.Out())
 	commands.AddCommands(cmd, dockerCli)
 
-	// Stop root flag parsing at the first non-flag so a misspelled command
-	// followed by flags is reported as an unknown command, not "unknown flag".
-	cmd.Flags().SetInterspersed(false)
-
 	visitAll(cmd, setValidateArgs(dockerCli))
 
 	// flags must be the top-level command flags, not cmd.Flags()
@@ -206,8 +202,38 @@ func setFlagErrorFunc(dockerCli command.Cli, cmd *cobra.Command) {
 		if err := isSupported(cmd, dockerCli); err != nil {
 			return err
 		}
+		if cmd == cmd.Root() {
+			if rewritten := unknownCommandInsteadOfFlag(cmd, err); rewritten != nil {
+				return rewritten
+			}
+		}
 		return flagErrorFunc(cmd, err)
 	})
+}
+
+// unknownCommandInsteadOfFlag rewrites "unknown flag" to "unknown command"
+// when the first leftover arg isn't a docker subcommand. That way
+// `docker iamges --filter` matches `docker iamges` instead of complaining
+// about --filter. `--help` after a bogus name still works because it is a
+// known flag and never reaches FlagErrorFunc.
+func unknownCommandInsteadOfFlag(cmd *cobra.Command, err error) error {
+	msg := err.Error()
+	if !strings.HasPrefix(msg, "unknown flag:") && !strings.HasPrefix(msg, "unknown shorthand flag:") {
+		return nil
+	}
+	args := cmd.Flags().Args()
+	if len(args) == 0 {
+		return nil
+	}
+	name := args[0]
+	if strings.HasPrefix(name, "-") {
+		return nil
+	}
+	found, _, _ := cmd.Find([]string{name})
+	if found != nil && found != cmd {
+		return nil
+	}
+	return fmt.Errorf("docker: unknown command: docker %s\n\nRun 'docker --help' for more information", name)
 }
 
 func setupHelpCommand(dockerCli command.Cli, rootCmd, helpCmd *cobra.Command) {

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -93,12 +93,19 @@ func TestExitStatusForInvalidSubcommand(t *testing.T) {
 }
 
 func TestUnknownCommandWithFlag(t *testing.T) {
-	err := runCliCommand(t, nil, nil, "iamges", "--filter")
+	err := runCliCommand(t, discard, nil, "iamges", "--filter")
 	assert.Check(t, is.ErrorContains(err, "docker: unknown command: docker iamges"))
 	assert.Check(t, is.ErrorContains(err, "docker --help"))
 
-	err = runCliCommand(t, nil, nil, "iamges", "-f")
+	err = runCliCommand(t, discard, nil, "iamges", "-f")
 	assert.Check(t, is.ErrorContains(err, "docker: unknown command: docker iamges"))
+}
+
+func TestUnknownCommandWithHelpFlag(t *testing.T) {
+	var b bytes.Buffer
+	err := runCliCommand(t, discard, &b, "nonexistent", "--help")
+	assert.NilError(t, err)
+	assert.Check(t, is.Contains(b.String(), "Usage:"))
 }
 
 func TestVersion(t *testing.T) {

--- a/cmd/docker/docker_test.go
+++ b/cmd/docker/docker_test.go
@@ -92,6 +92,15 @@ func TestExitStatusForInvalidSubcommand(t *testing.T) {
 	assert.Check(t, is.ErrorContains(err, "docker: unknown command: docker invalid"))
 }
 
+func TestUnknownCommandWithFlag(t *testing.T) {
+	err := runCliCommand(t, nil, nil, "iamges", "--filter")
+	assert.Check(t, is.ErrorContains(err, "docker: unknown command: docker iamges"))
+	assert.Check(t, is.ErrorContains(err, "docker --help"))
+
+	err = runCliCommand(t, nil, nil, "iamges", "-f")
+	assert.Check(t, is.ErrorContains(err, "docker: unknown command: docker iamges"))
+}
+
 func TestVersion(t *testing.T) {
 	var b bytes.Buffer
 	err := runCliCommand(t, nil, &b, "--version")


### PR DESCRIPTION
`docker iamges --filter` was coming back as `unknown flag: --filter` because the root command kept parsing flags after the first token.

stop at the first non-flag so this matches `docker iamges` and says the command is unknown.

Fixes #4550