### PR TITLE
Revert "e2e/container: Skip umask test until engine support"

### DIFF
--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -112,6 +112,7 @@ func TestRunWithCgroupNamespace(t *testing.T) {
 
 func TestRunUmask(t *testing.T) {
 	environment.SkipIfDaemonNotLinux(t)
+	skip.If(t, versions.LessThan(environment.DaemonAPIVersion(t), "1.56"))
 
 	testCases := []struct {
 		name     string

--- a/e2e/container/run_test.go
+++ b/e2e/container/run_test.go
@@ -112,7 +112,6 @@ func TestRunWithCgroupNamespace(t *testing.T) {
 
 func TestRunUmask(t *testing.T) {
 	environment.SkipIfDaemonNotLinux(t)
-	t.Skip("FIXME: un-skip once e2e tests v29.8.0")
 
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
This reverts commit 45a3e0bc2aece19bb2970905231b97dc3a86568b.

The 29.8.0 is out now so the CI should work